### PR TITLE
Fix a bug where Folder.GetFiles(string globPattern) was returning the…

### DIFF
--- a/src/ModularPipelines.Build/ReleaseNotes.md
+++ b/src/ModularPipelines.Build/ReleaseNotes.md
@@ -1,0 +1,1 @@
+- Fix a bug where Folder.GetFiles(string globPattern) was returning the wrong relative paths

--- a/src/ModularPipelines/FileSystem/Folder.cs
+++ b/src/ModularPipelines/FileSystem/Folder.cs
@@ -141,7 +141,7 @@ public class Folder : IEquatable<Folder>
             .AddInclude(globPattern)
             .Execute(new DirectoryInfoWrapper(DirectoryInfo))
             .Files
-            .Select(x => new File(x.Path))
+            .Select(x => new File(System.IO.Path.Combine(this, x.Path)))
             .Distinct();
     }
 


### PR DESCRIPTION
… wrong relative paths