### PR TITLE
Use TaskCompletionSource in SubModule

### DIFF
--- a/src/ModularPipelines/Modules/ModuleBase.cs
+++ b/src/ModularPipelines/Modules/ModuleBase.cs
@@ -142,7 +142,7 @@ public abstract partial class ModuleBase : ITypeDiscriminator
             {
                 if (existingSubModule.Status == Status.Successful && existingSubModule is SubModule<T> typedSubmodule)
                 {
-                    return typedSubmodule.Task;
+                    return typedSubmodule.SubModuleResultTaskCompletionSource.Task;
                 }
 
                 if (existingSubModule.Status is Status.NotYetStarted or Status.Processing)

--- a/test/ModularPipelines.TestHelpers/TestHostSettings.cs
+++ b/test/ModularPipelines.TestHelpers/TestHostSettings.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using ModularPipelines.Enums;
+﻿using ModularPipelines.Enums;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace ModularPipelines.TestHelpers;
@@ -9,4 +8,5 @@ public record TestHostSettings
     public CommandLogging CommandLogging { get; init; } = CommandLogging.Input | CommandLogging.Error;
     public LogLevel LogLevel { get; init; } = LogLevel.Warning;
     public bool ClearLogProviders { get; init; } = true;
+    public bool ShowProgressInConsole { get; init; } = false;
 }

--- a/test/ModularPipelines.TestHelpers/TestPipelineHostBuilder.cs
+++ b/test/ModularPipelines.TestHelpers/TestPipelineHostBuilder.cs
@@ -21,7 +21,7 @@ public static class TestPipelineHostBuilder
                 collection.Configure<PipelineOptions>(opt =>
                 {
                     opt.DefaultCommandLogging = testHostSettings.CommandLogging;
-                    opt.ShowProgressInConsole = false;
+                    opt.ShowProgressInConsole = testHostSettings.ShowProgressInConsole;
                     opt.PrintResults = false;
                     opt.PrintLogo = false;
                     opt.PrintDependencyChains = false;

--- a/test/ModularPipelines.UnitTests/SubModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/SubModuleTests.cs
@@ -233,6 +233,21 @@ public class SubModuleTests : TestBase
     }
 
     [Test]
+    public async Task Submodule_With_Progress()
+    {
+        var module = await RunModule<SubModulesWithReturnTypeModule>(new TestHostSettings { ShowProgressInConsole = true });
+
+        var results = await module;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(results.ModuleResultType).IsEqualTo(ModuleResultType.Success);
+            await Assert.That(results.Value).IsEquivalentCollectionTo(new List<string> { "1", "2", "3" });
+            await Assert.That(module.SubModuleRunCount).IsEqualTo(3);
+        }
+    }
+
+    [Test]
     public async Task Submodule_With_Return_Type_Does_Not_Fail_And_Runs_Once()
     {
         var module = await RunModule<SubModulesWithReturnTypeModule>();


### PR DESCRIPTION
The `ProgressPrinter` listens on `OnSubModuleCreated`
https://github.com/thomhurst/ModularPipelines/blob/fecd8440e4f2b9bc2ada0f2a68c0212c631c108d/src/ModularPipelines/Helpers/ProgressPrinter.cs#L244

which is invoked before the submodule is executed
https://github.com/thomhurst/ModularPipelines/blob/fecd8440e4f2b9bc2ada0f2a68c0212c631c108d/src/ModularPipelines/Modules/ModuleBase.cs#L158-L160

and thus the `CallbackTask` is `null`.
https://github.com/thomhurst/ModularPipelines/blob/fecd8440e4f2b9bc2ada0f2a68c0212c631c108d/src/ModularPipelines/Helpers/ProgressPrinter.cs#L273

Using a `TaskCompletionSource` just like in `ModuleBase` avoids the NRE.

https://github.com/thomhurst/ModularPipelines/blob/fecd8440e4f2b9bc2ada0f2a68c0212c631c108d/src/ModularPipelines/Modules/ModuleBase.cs#L210