### PR TITLE
Avoid duplicate logs on CommandException with wrong status code

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -172,7 +172,7 @@ public sealed class Command(ICommandLogger commandLogger) : ICommand
             
             throw new CommandException(inputToLog, e.ExitCode, stopwatch.Elapsed, standardOutput, standardError, e);
         }
-        catch (Exception e) when (e is not CommandExecutionException or CommandException)
+        catch (Exception e) when (e is not CommandExecutionException and not CommandException)
         {
             standardOutput = options.OutputLoggingManipulator == null ? standardOutputStringBuilder.ToString() : options.OutputLoggingManipulator(standardOutputStringBuilder.ToString());
             standardError = options.OutputLoggingManipulator == null ? standardErrorStringBuilder.ToString() : options.OutputLoggingManipulator(standardErrorStringBuilder.ToString());


### PR DESCRIPTION
At the moment, when a command fails, the result is logged twice (once with a "wrong" exit code). This is because the condition in the catch clause matches `CommandException` even if it shouldn't.

See the following example:

```cs
public class Module1 : Module
{
    protected override async Task<IDictionary<string, object>?> ExecuteAsync(IPipelineContext context, CancellationToken cancellationToken)
    {
        await context.Bash.Command(new BashCommandOptions("fail"));
        return await NothingAsync();
    }
}
```

It currently produces this output:

```
----------Module1 - Error! CommandException Start----------
[4:12:23 PM Info] ---Executing Command---
repro> bash -c fail
[4:12:23 PM Info] ---Exit Code----
127
[4:12:23 PM Info] ---Duration---
1ms
[4:12:23 PM Info] ---Command Result---

[4:12:23 PM Info] ---Command Error---
bash: line 1: fail: command not found

[4:12:23 PM Info] ---Executing Command---
repro> bash -c fail
[4:12:23 PM Info] ---Exit Code----
-1
[4:12:23 PM Info] ---Duration---
3ms
[4:12:23 PM Info] ---Command Result---

[4:12:23 PM Info] ---Command Error---
bash: line 1: fail: command not found

[4:12:23 PM Fail] Module Failed after 00:00:00.0134119
```

That is quite misleading as it suggests that the command is run twice