### PR TITLE
feat: Defer exception printing until after pipeline results table

### DIFF
--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -68,6 +68,7 @@ internal static class DependencyInjectionSetup
         services
             .AddSingleton<IConsolePrinter, ConsolePrinter>()
             .AddSingleton<IAfterPipelineLogger, AfterPipelineLogger>()
+            .AddSingleton<IExceptionBuffer, ExceptionBuffer>()
             .AddSingleton<ISecondaryExceptionContainer, SecondaryExceptionContainer>()
             .AddSingleton<IPipelineContextProvider, ModuleContextProvider>()
             .AddSingleton<IDependencyChainProvider, DependencyChainProvider>()

--- a/src/ModularPipelines/Logging/ExceptionBuffer.cs
+++ b/src/ModularPipelines/Logging/ExceptionBuffer.cs
@@ -1,0 +1,35 @@
+using System.Collections.Concurrent;
+
+namespace ModularPipelines.Logging;
+
+internal class ExceptionBuffer : IExceptionBuffer
+{
+    private readonly ConcurrentQueue<string> _exceptionMessages = new();
+
+    public bool HasExceptions => !_exceptionMessages.IsEmpty;
+
+    public void AddExceptionMessage(string message)
+    {
+        _exceptionMessages.Enqueue(message);
+    }
+
+    public void FlushExceptions()
+    {
+        if (_exceptionMessages.IsEmpty)
+        {
+            return;
+        }
+
+        // Add a separator to clearly indicate deferred exceptions
+        Console.WriteLine();
+        Console.WriteLine("========== Deferred Exceptions ==========");
+        Console.WriteLine();
+
+        while (_exceptionMessages.TryDequeue(out var message))
+        {
+            Console.WriteLine(message);
+        }
+
+        Console.WriteLine();
+    }
+}

--- a/src/ModularPipelines/Logging/IExceptionBuffer.cs
+++ b/src/ModularPipelines/Logging/IExceptionBuffer.cs
@@ -1,0 +1,25 @@
+namespace ModularPipelines.Logging;
+
+/// <summary>
+/// Buffers exceptions and console output that would normally be printed immediately,
+/// allowing them to be printed after the pipeline results table.
+/// </summary>
+internal interface IExceptionBuffer
+{
+    /// <summary>
+    /// Adds an exception message to the buffer to be printed later.
+    /// </summary>
+    /// <param name="message">The exception message to buffer.</param>
+    void AddExceptionMessage(string message);
+
+    /// <summary>
+    /// Prints all buffered exception messages to the console.
+    /// Should be called after the pipeline results table has been printed.
+    /// </summary>
+    void FlushExceptions();
+
+    /// <summary>
+    /// Gets whether there are any buffered exceptions.
+    /// </summary>
+    bool HasExceptions { get; }
+}

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -41,6 +41,7 @@ internal class ModuleLogger<T> : ModuleLogger, IModuleLogger, ILogger<T>
     private readonly ISecretObfuscator _secretObfuscator;
     private readonly IConsoleWriter _consoleWriter;
     private readonly ISmartCollapsableLoggingStringBlockProvider _collapsableLoggingStringBlockProvider;
+    private readonly IExceptionBuffer _exceptionBuffer;
 
     private List<StringOrLogEvent> _stringOrLogEvents = new();
 
@@ -51,12 +52,14 @@ internal class ModuleLogger<T> : ModuleLogger, IModuleLogger, ILogger<T>
         IModuleLoggerContainer moduleLoggerContainer,
         ISecretObfuscator secretObfuscator,
         IConsoleWriter consoleWriter,
-        ISmartCollapsableLoggingStringBlockProvider collapsableLoggingStringBlockProvider)
+        ISmartCollapsableLoggingStringBlockProvider collapsableLoggingStringBlockProvider,
+        IExceptionBuffer exceptionBuffer)
     {
         _defaultLogger = defaultLogger;
         _secretObfuscator = secretObfuscator;
         _consoleWriter = consoleWriter;
         _collapsableLoggingStringBlockProvider = collapsableLoggingStringBlockProvider;
+        _exceptionBuffer = exceptionBuffer;
         moduleLoggerContainer.AddLogger(this);
 
         Disposer.RegisterOnShutdown(this);
@@ -176,8 +179,8 @@ internal class ModuleLogger<T> : ModuleLogger, IModuleLogger, ILogger<T>
         }
         catch (Exception e)
         {
-            Console.WriteLine(e);
-            Console.WriteLine($"{logLevel}: {eventId} - {state}{exception}");
+            _exceptionBuffer.AddExceptionMessage(e.ToString());
+            _exceptionBuffer.AddExceptionMessage($"{logLevel}: {eventId} - {state}{exception}");
         }
     }
 


### PR DESCRIPTION
When the pipeline fails and exceptions are thrown, they can appear mixed with the final results output table, making everything difficult to read. This change introduces an exception buffer that collects exceptions during pipeline execution and prints them after the results table has been fully rendered.

- Add IExceptionBuffer interface and ExceptionBuffer implementation
- Update ModuleLogger to buffer exceptions instead of printing directly
- Modify ExecutionOrchestrator to flush buffered exceptions after results
- Register ExceptionBuffer as singleton in DI container

This ensures clean, readable output with exceptions always appearing after the pipeline results table.