### PR TITLE
fix: Replace ContinueWith with async/await to prevent unobserved task exceptions

### DIFF
--- a/src/ModularPipelines/Modules/Module.cs
+++ b/src/ModularPipelines/Modules/Module.cs
@@ -337,20 +337,21 @@ public abstract partial class Module<T> : ModuleBase<T>
         try
         {
             await Task.Delay(Timeout, cancellationToken);
-            
-            if (!executeAsyncTask.IsCompleted)
-            {
-                if (ModuleRunType == ModuleRunType.OnSuccessfulDependencies)
-                {
-                    Context.EngineCancellationToken.Token.ThrowIfCancellationRequested();
-                }
-
-                throw new ModuleTimeoutException(this);
-            }
         }
         catch (OperationCanceledException)
         {
-            // Task was cancelled, which is expected when the main task completes
+            // Task was cancelled because main task completed, this is expected
+            return;
+        }
+        
+        if (!executeAsyncTask.IsCompleted)
+        {
+            if (ModuleRunType == ModuleRunType.OnSuccessfulDependencies)
+            {
+                Context.EngineCancellationToken.Token.ThrowIfCancellationRequested();
+            }
+
+            throw new ModuleTimeoutException(this);
         }
     }
 


### PR DESCRIPTION


- Refactored Module.cs to use async MonitorTimeoutAsync method instead of ContinueWith
- Updated ProgressPrinter.cs to use Task.Run with async/await pattern
- Added proper exception handling to prevent unobserved task exceptions
- All task exceptions are now properly observed and handled

This fixes the "unobserved task exception" errors that were occurring when tasks were failing or being cancelled, particularly in test scenarios.

🤖 Generated with [Claude Code](https://claude.ai/code)