### PR TITLE
fix: support open generic types in DependsOnAllModulesInheritingFrom

### DIFF
--- a/src/ModularPipelines/Extensions/TypeExtensions.cs
+++ b/src/ModularPipelines/Extensions/TypeExtensions.cs
@@ -6,7 +6,35 @@ internal static class TypeExtensions
 {
     public static bool IsOrInheritsFrom(this Type type, Type otherType)
     {
-        return type == otherType || type.IsSubclassOf(otherType);
+        if (type == otherType || type.IsSubclassOf(otherType))
+        {
+            return true;
+        }
+
+        // Handle open generic types (e.g., typeof(Step1Module<>))
+        if (otherType.IsGenericTypeDefinition)
+        {
+            return type.IsSubclassOfOpenGeneric(otherType);
+        }
+
+        return false;
+    }
+
+    private static bool IsSubclassOfOpenGeneric(this Type type, Type openGenericType)
+    {
+        var current = type;
+
+        while (current != null && current != typeof(object))
+        {
+            if (current.IsGenericType && current.GetGenericTypeDefinition() == openGenericType)
+            {
+                return true;
+            }
+
+            current = current.BaseType;
+        }
+
+        return false;
     }
 
     public static string GetRealTypeName(this Type type)


### PR DESCRIPTION
## Summary
- Fixes #1337 where `DependsOnAllModulesInheritingFrom(typeof(Step1Module<>))` with open generic types didn't work
- The `IsOrInheritsFrom` method now correctly handles open generic type definitions by walking up the inheritance chain and comparing `GetGenericTypeDefinition()`

## Problem
When using an open generic type like `typeof(Step1Module<>)`:
```csharp
[DependsOnAllModulesInheritingFrom(typeof(Step1Module<>))]
public abstract class Step2Module<T> : Module<T>;
```

Modules inheriting from `Step1Module<int>` were not detected as dependencies because `Type.IsSubclassOf()` returns `false` when comparing closed generics to open generic definitions.

## Solution
Modified `TypeExtensions.IsOrInheritsFrom` to:
1. Detect when `otherType` is an open generic (`Type.IsGenericTypeDefinition`)
2. Walk up the inheritance chain comparing `GetGenericTypeDefinition()` for matches

## Test plan
- [x] Added regression test `DependsOnAllModulesInheritingFrom_Works_With_Open_Generic_Types`
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)