### PR TITLE
fix: Render Spectre.Console markup in console output

### DIFF
--- a/src/ModularPipelines/ConsoleWriter.cs
+++ b/src/ModularPipelines/ConsoleWriter.cs
@@ -1,9 +1,22 @@
 using System.Diagnostics.CodeAnalysis;
+using Spectre.Console;
 
 namespace ModularPipelines;
 
 [ExcludeFromCodeCoverage]
 internal class ConsoleWriter : IConsoleWriter
 {
-    public void LogToConsole(string value) => Console.WriteLine(value);
+    public void LogToConsole(string value)
+    {
+        try
+        {
+            AnsiConsole.MarkupLine(value);
+        }
+        catch (InvalidOperationException)
+        {
+            // Fall back to plain console output if markup parsing fails
+            // (e.g., unbalanced or invalid markup characters)
+            Console.WriteLine(value);
+        }
+    }
 }

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -38,24 +38,11 @@ internal static class DependencyInjectionSetup
 
                 builder.AddSpectreConsole(config =>
                 {
-                    config.ConfigureProfile(LogLevel.Information, profile =>
+                    config.ConfigureProfiles(profile =>
                     {
-                        profile.ConfigureOptions<Vertical.SpectreLogger.Rendering.ExceptionRenderer.Options>(options =>
-                        {
-                            options.MaxStackFrames = int.MaxValue;
-                        });
-                    });
+                        // Enable Spectre.Console markup rendering in log messages
+                        profile.PreserveMarkupInFormatStrings = true;
 
-                    config.ConfigureProfile(LogLevel.Warning, profile =>
-                    {
-                        profile.ConfigureOptions<Vertical.SpectreLogger.Rendering.ExceptionRenderer.Options>(options =>
-                        {
-                            options.MaxStackFrames = int.MaxValue;
-                        });
-                    });
-
-                    config.ConfigureProfile(LogLevel.Error, profile =>
-                    {
                         profile.ConfigureOptions<Vertical.SpectreLogger.Rendering.ExceptionRenderer.Options>(options =>
                         {
                             options.MaxStackFrames = int.MaxValue;


### PR DESCRIPTION
## Summary

- Fixed Spectre.Console markup tags like `[bold]`, `[cyan]`, etc. being displayed as plain text instead of being rendered as formatted output
- Changed `ConsoleWriter.LogToConsole` to use `AnsiConsole.MarkupLine()` instead of `Console.WriteLine()`, with a fallback for invalid markup
- Enabled `PreserveMarkupInFormatStrings` in the Vertical.SpectreLogger configuration to allow markup in log messages to be rendered

## Problem

Console output was showing raw markup tags instead of rendering them:
```
[12:39:03 Info] [bold]Build System:[/] [cyan]Unknown[/]
[bold cyan]▶[/] CleanProjectsModule
```

Instead of showing properly formatted, colored output.

## Solution

Two changes were needed:

1. **ConsoleWriter.cs**: Changed from `Console.WriteLine(value)` to `AnsiConsole.MarkupLine(value)` with a try-catch fallback for invalid markup
2. **DependencyInjectionSetup.cs**: Added `PreserveMarkupInFormatStrings = true` to the Vertical.SpectreLogger configuration to preserve Spectre markup in log message format strings

## Test plan

- [x] Build the ModularPipelines project successfully
- [ ] Run a sample pipeline and verify markup is rendered correctly (e.g., colored text, bold headers)
- [ ] Verify the fallback works when invalid markup is passed (should output plain text)

Closes #1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)