### PR TITLE
feat: Change ReadLinesAsync to return IAsyncEnumerable<string>

### DIFF
--- a/src/ModularPipelines.Build/Modules/FindProjectDependenciesModule.cs
+++ b/src/ModularPipelines.Build/Modules/FindProjectDependenciesModule.cs
@@ -17,11 +17,14 @@ public class FindProjectDependenciesModule : Module<FindProjectDependenciesModul
 
         foreach (var file in projects.Value!)
         {
-            var contents = await file.ReadLinesAsync(cancellationToken);
-
-            foreach (var projectReferenceLine in contents.Where(x => x.Contains("<ProjectReference")))
+            await foreach (var line in file.ReadLinesAsync(cancellationToken))
             {
-                var name = projectReferenceLine.Split('\\').Last().Split('"').First();
+                if (!line.Contains("<ProjectReference"))
+                {
+                    continue;
+                }
+
+                var name = line.Split('\\').Last().Split('"').First();
 
                 var project = projects.Value!.FirstOrDefault(x => x.Name == name);
 

--- a/src/ModularPipelines/FileSystem/File.cs
+++ b/src/ModularPipelines/FileSystem/File.cs
@@ -40,11 +40,12 @@ public class File : IEquatable<File>
         return System.IO.File.ReadAllTextAsync(Path, cancellationToken);
     }
 
-    public Task<string[]> ReadLinesAsync(CancellationToken cancellationToken = default)
+    /// <inheritdoc cref="System.IO.File.ReadLinesAsync(string,System.Threading.CancellationToken)"/>
+    public IAsyncEnumerable<string> ReadLinesAsync(CancellationToken cancellationToken = default)
     {
         ModuleLogger.Current.LogInformation("Reading File: {Path}", this);
 
-        return System.IO.File.ReadAllLinesAsync(Path, cancellationToken);
+        return System.IO.File.ReadLinesAsync(Path, cancellationToken);
     }
 
     public Task<byte[]> ReadBytesAsync(CancellationToken cancellationToken = default)

--- a/test/ModularPipelines.UnitTests/FileTests.cs
+++ b/test/ModularPipelines.UnitTests/FileTests.cs
@@ -105,7 +105,7 @@ public class FileTests : TestBase
         file.Create();
 
         var plainText = await file.ReadAsync();
-        var lines = await file.ReadLinesAsync();
+        var lines = await ToListAsync(file.ReadLinesAsync());
         var bytes = await file.ReadBytesAsync();
         var stream = await file.GetStream().ToMemoryStreamAsync();
 
@@ -126,7 +126,7 @@ public class FileTests : TestBase
         await file.WriteAsync($"Hello{Environment.NewLine}world");
 
         var plainText = await file.ReadAsync();
-        var lines = await file.ReadLinesAsync();
+        var lines = await ToListAsync(file.ReadLinesAsync());
         var bytes = await file.ReadBytesAsync();
         var stream = await file.GetStream().ToMemoryStreamAsync();
 
@@ -152,7 +152,7 @@ public class FileTests : TestBase
         ]);
 
         var plainText = await file.ReadAsync();
-        var lines = await file.ReadLinesAsync();
+        var lines = await ToListAsync(file.ReadLinesAsync());
 
         using (Assert.Multiple())
         {
@@ -352,5 +352,15 @@ public class FileTests : TestBase
         await System.IO.File.WriteAllTextAsync(path, "Foo bar!");
 
         return new File(path);
+    }
+
+    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source, CancellationToken cancellationToken = default)
+    {
+        var list = new List<T>();
+        await foreach (var item in source.WithCancellation(cancellationToken))
+        {
+            list.Add(item);
+        }
+        return list;
     }
 }


### PR DESCRIPTION
## Summary

- Changed `File.ReadLinesAsync()` to return `IAsyncEnumerable<string>` instead of `Task<string[]>` to match the standard .NET `File.ReadLinesAsync` API
- Uses `System.IO.File.ReadLinesAsync` internally for streaming line reading
- Updated `FindProjectDependenciesModule` to use `await foreach` pattern
- Added `ToListAsync` helper method in tests for compatibility

## Why

This change aligns the API with the standard .NET `File.ReadLinesAsync` method, which returns `IAsyncEnumerable<string>` for memory-efficient streaming of large files.

Reference: https://learn.microsoft.com/en-us/dotnet/api/system.io.file.readlinesasync

## Test plan

- [x] Core library builds successfully
- [x] Unit tests build successfully
- [ ] All unit tests pass (verify in CI)

Closes #1339

🤖 Generated with [Claude Code](https://claude.com/claude-code)