### PR TITLE
fix: Add bounds checking for array/list access

### DIFF
--- a/src/ModularPipelines.Git/GitCommitMapper.cs
+++ b/src/ModularPipelines.Git/GitCommitMapper.cs
@@ -4,9 +4,19 @@ namespace ModularPipelines.Git;
 
 public class GitCommitMapper : IGitCommitMapper
 {
+    private const int ExpectedLineCount = 10;
+
     public GitCommit Map(string commandLineOutput)
     {
         var lines = commandLineOutput.Split(GitConstants.DotNetLineSeparator, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
+
+        if (lines.Count < ExpectedLineCount)
+        {
+            throw new ArgumentException(
+                $"Git commit output is malformed. Expected at least {ExpectedLineCount} lines but received {lines.Count}. " +
+                $"Output: {commandLineOutput}",
+                nameof(commandLineOutput));
+        }
 
         return new GitCommit
         {

--- a/src/ModularPipelines/Logging/StackTraceModuleDetector.cs
+++ b/src/ModularPipelines/Logging/StackTraceModuleDetector.cs
@@ -81,17 +81,26 @@ internal class StackTraceModuleDetector : IStackTraceModuleDetector
         if (getLoggerFrame != null)
         {
             var getLoggerFrameIndex = stackFrames.IndexOf(getLoggerFrame);
-            var nextFrame = stackFrames[getLoggerFrameIndex + 1];
-            var type = nextFrame.GetMethod()?.ReflectedType;
+            var nextFrameIndex = getLoggerFrameIndex + 1;
 
-            if (type != null)
+            if (nextFrameIndex >= stackFrames.Count)
             {
-                if (cacheKey != null)
-                {
-                    _typeCache.TryAdd(cacheKey, type);
-                }
+                // No frame after get_Logger, fall through to next strategy
+            }
+            else
+            {
+                var nextFrame = stackFrames[nextFrameIndex];
+                var type = nextFrame.GetMethod()?.ReflectedType;
 
-                return type;
+                if (type != null)
+                {
+                    if (cacheKey != null)
+                    {
+                        _typeCache.TryAdd(cacheKey, type);
+                    }
+
+                    return type;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Added bounds checking in `GitCommitMapper.cs` to validate that git commit output contains at least 10 lines before accessing array indices, throwing a descriptive `ArgumentException` if the output is malformed
- Added bounds checking in `StackTraceModuleDetector.cs` to verify that the next frame index is within bounds before accessing the stack frames array, gracefully falling through to the next strategy if bounds are exceeded

## Test Plan

- [ ] Verify the solution builds successfully
- [ ] Verify existing tests pass
- [ ] Manual testing: `GitCommitMapper` should throw a descriptive error when receiving malformed git output instead of `IndexOutOfRangeException`
- [ ] Manual testing: `StackTraceModuleDetector` should gracefully handle edge cases where the stack trace ends unexpectedly

Closes #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)