### PR TITLE
fix: Add null checks for reflection calls

### DIFF
--- a/src/ModularPipelines/Engine/OptionsProvider.cs
+++ b/src/ModularPipelines/Engine/OptionsProvider.cs
@@ -39,7 +39,15 @@ internal class OptionsProvider : IOptionsProvider
 
         foreach (var option in types.Select(t => _serviceProvider.GetService(typeof(IOptions<>).MakeGenericType(t))))
         {
-            yield return option!.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)!.GetValue(option);
+            if (option is null)
+            {
+                continue;
+            }
+
+            var valueProperty = option.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)
+                ?? throw new InvalidOperationException($"Property 'Value' not found on type '{option.GetType().Name}'.");
+
+            yield return valueProperty.GetValue(option);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replace null-forgiving operators (`!`) with explicit null checks and descriptive `InvalidOperationException` messages in reflection-based method/property lookups
- Affected files:
  - `ModuleExecutor.cs`: Added null checks for `GetMethod`, `Invoke`, `GetProperty`, and `GetValue` reflection calls in `ExecuteTypedModule` method
  - `OptionsProvider.cs`: Added null check for service resolution and property access via reflection in `GetOptions` method

## Test plan

- [ ] Build the solution to verify no compilation errors
- [ ] Run unit tests to ensure reflection-based execution still works correctly
- [ ] The changes only add validation - if reflection succeeds as before, behavior is unchanged
- [ ] If reflection fails, descriptive error messages now help diagnose the issue

Closes #1420

🤖 Generated with [Claude Code](https://claude.com/claude-code)