### PR TITLE
fix: Improve exception handling patterns

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -284,8 +284,8 @@ internal class ModuleExecutor : IModuleExecutor
             }
             catch (Exception alwaysRunEx)
             {
-                _logger.LogDebug("AlwaysRun module {ModuleName} threw after late start: {ExceptionType}",
-                    moduleType.Name, alwaysRunEx.GetType().Name);
+                _logger.LogWarning(alwaysRunEx, "AlwaysRun module {ModuleName} failed after late start",
+                    moduleType.Name);
             }
         }
         else if (ShouldWaitForAlwaysRunModule(moduleState))
@@ -300,8 +300,10 @@ internal class ModuleExecutor : IModuleExecutor
             }
             catch (Exception alwaysRunEx)
             {
-                _logger.LogDebug("AlwaysRun module {ModuleName} threw: {ExceptionType}",
-                    moduleType.Name, alwaysRunEx.GetType().Name);
+                _logger.LogWarning(alwaysRunEx, "AlwaysRun module {ModuleName} failed",
+                    moduleType.Name);
+
+                // Access Exception property to observe the exception and prevent TaskScheduler.UnobservedTaskException
                 _ = moduleTask.Exception;
             }
         }


### PR DESCRIPTION
## Summary

- Changed AlwaysRun module failure logging from Debug to Warning level for better visibility when modules fail during pipeline execution
- Added explanatory comment for the intentional `_ = moduleTask.Exception` pattern that prevents `TaskScheduler.UnobservedTaskException`

## Changes

### ModuleExecutor.cs
- **Lines 285-289**: Changed `LogDebug` to `LogWarning` for AlwaysRun modules that fail after late start, also passing the exception object for full stack trace logging
- **Lines 301-307**: Changed `LogDebug` to `LogWarning` for AlwaysRun modules that fail during normal execution, added comment explaining why `_ = moduleTask.Exception` is intentional (to observe the exception and prevent `TaskScheduler.UnobservedTaskException`)

### Note on GitCommandRunner.cs
The `RunCommandsOrNull` method already has proper exception logging in place (logging at Debug level before returning null), so no changes were needed there.

## Test plan

- [x] Build succeeds with `dotnet build`
- [ ] Verify AlwaysRun module failures are now logged at Warning level
- [ ] Verify exception observation comment is clear and helpful

Closes #1423