### PR TITLE
refactor: Apply SRP to ModuleExecutor and ModuleScheduler

### DIFF
--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -147,6 +147,17 @@ internal static class DependencyInjectionSetup
             .AddSingleton<IAttributeEventInvoker, AttributeEventInvoker>()
             .AddSingleton<IRegistrationEventExecutor, RegistrationEventExecutor>()
 
+            // Module execution components (SRP extraction from ModuleExecutor)
+            .AddSingleton<Engine.Execution.IModuleResultRegistrar, Engine.Execution.ModuleResultRegistrar>()
+            .AddSingleton<Engine.Execution.IParallelLimitHandler, Engine.Execution.ParallelLimitHandler>()
+            .AddSingleton<Engine.Execution.IDependencyWaiter, Engine.Execution.DependencyWaiter>()
+            .AddSingleton<Engine.Execution.IModuleLifecycleEventInvoker, Engine.Execution.ModuleLifecycleEventInvoker>()
+            .AddSingleton<Engine.Execution.IModuleRunner, Engine.Execution.ModuleRunner>()
+            .AddSingleton<Engine.Execution.IAlwaysRunHandler, Engine.Execution.AlwaysRunHandler>()
+
+            // Module scheduling components (SRP extraction from ModuleScheduler)
+            .AddSingleton<Engine.Scheduling.IModuleConstraintEvaluator, Engine.Scheduling.ModuleConstraintEvaluator>()
+
             // Metrics collection
             .AddSingleton<IMetricsCollector, MetricsCollector>()
 

--- a/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
@@ -1,0 +1,94 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Logging;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for handling AlwaysRun modules that must complete even after pipeline failure.
+/// </summary>
+internal class AlwaysRunHandler : IAlwaysRunHandler
+{
+    private readonly IModuleRunner _moduleRunner;
+    private readonly ILogger<AlwaysRunHandler> _logger;
+
+    public AlwaysRunHandler(
+        IModuleRunner moduleRunner,
+        ILogger<AlwaysRunHandler> logger)
+    {
+        _moduleRunner = moduleRunner;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task WaitForAlwaysRunModulesAsync(IModuleScheduler scheduler, IReadOnlyList<IModule> modules)
+    {
+        var alwaysRunModules = modules.Where(x => x.ModuleRunType == ModuleRunType.AlwaysRun).ToList();
+        _logger.LogDebug("Found {Count} AlwaysRun modules", alwaysRunModules.Count);
+
+        foreach (var module in alwaysRunModules)
+        {
+            await WaitForSingleAlwaysRunModuleAsync(scheduler, module).ConfigureAwait(false);
+        }
+    }
+
+    private async Task WaitForSingleAlwaysRunModuleAsync(IModuleScheduler scheduler, IModule module)
+    {
+        var moduleType = module.GetType();
+        var moduleState = scheduler.GetModuleState(moduleType);
+        var moduleTask = scheduler.GetModuleCompletionTask(moduleType);
+
+        if (moduleTask == null || moduleState == null)
+        {
+            return;
+        }
+
+        // If the AlwaysRun module is still pending (never started), execute it now
+        // Skip dependency waiting to prevent deadlocks - dependencies may never complete
+        if (moduleState.State == ModuleExecutionState.Pending)
+        {
+            _logger.LogDebug("Starting pending AlwaysRun module: {ModuleName}", moduleType.Name);
+
+            try
+            {
+                await _moduleRunner.ExecuteWithoutDependencyWaitAsync(moduleState, scheduler, CancellationToken.None).ConfigureAwait(false);
+                _logger.LogDebug("AlwaysRun module {ModuleName} completed after late start", moduleType.Name);
+            }
+            catch (Exception alwaysRunEx)
+            {
+                _logger.LogWarning(alwaysRunEx, "AlwaysRun module {ModuleName} failed after late start",
+                    moduleType.Name);
+            }
+        }
+        else if (ShouldWaitForAlwaysRunModule(moduleState))
+        {
+            _logger.LogDebug("Awaiting AlwaysRun module: {ModuleName} (State={State})",
+                moduleType.Name, moduleState.State);
+
+            try
+            {
+                await moduleTask.ConfigureAwait(false);
+                _logger.LogDebug("AlwaysRun module {ModuleName} completed", moduleType.Name);
+            }
+            catch (Exception alwaysRunEx)
+            {
+                _logger.LogWarning(alwaysRunEx, "AlwaysRun module {ModuleName} failed",
+                    moduleType.Name);
+
+                // Access Exception property to observe the exception and prevent TaskScheduler.UnobservedTaskException
+                _ = moduleTask.Exception;
+            }
+        }
+        else
+        {
+            _logger.LogDebug("Skipping AlwaysRun module {ModuleName} (State={State})",
+                moduleType.Name, moduleState.State);
+        }
+    }
+
+    private static bool ShouldWaitForAlwaysRunModule(ModuleState moduleState)
+    {
+        return moduleState.State == ModuleExecutionState.Executing || moduleState.State == ModuleExecutionState.Completed;
+    }
+}

--- a/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
@@ -1,0 +1,71 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Exceptions;
+using ModularPipelines.Logging;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for waiting for module dependencies to complete before execution.
+/// </summary>
+internal class DependencyWaiter : IDependencyWaiter
+{
+    private readonly ISecondaryExceptionContainer _secondaryExceptionContainer;
+    private readonly IModuleLoggerContainer _loggerContainer;
+
+    public DependencyWaiter(
+        ISecondaryExceptionContainer secondaryExceptionContainer,
+        IModuleLoggerContainer loggerContainer)
+    {
+        _secondaryExceptionContainer = secondaryExceptionContainer;
+        _loggerContainer = loggerContainer;
+    }
+
+    /// <inheritdoc />
+    public async Task WaitForDependenciesAsync(ModuleState moduleState, IModuleScheduler scheduler, IServiceProvider scopedServiceProvider)
+    {
+        var dependencies = ModuleDependencyResolver.GetDependencies(moduleState.ModuleType);
+
+        foreach (var (dependencyType, ignoreIfNotRegistered) in dependencies)
+        {
+            var dependencyTask = scheduler.GetModuleCompletionTask(dependencyType);
+
+            if (dependencyTask != null)
+            {
+                try
+                {
+                    await dependencyTask.ConfigureAwait(false);
+                }
+                catch (Exception e) when (moduleState.Module.ModuleRunType == ModuleRunType.AlwaysRun)
+                {
+                    var depLogger = GetOrCreateLogger(moduleState.ModuleType, scopedServiceProvider);
+                    _secondaryExceptionContainer.RegisterException(new AlwaysRunPostponedException(
+                        $"{dependencyType.Name} threw an exception when {moduleState.ModuleType.Name} was waiting for it as a dependency",
+                        e));
+                    depLogger.LogError(e, "Ignoring Exception due to 'AlwaysRun' set");
+                }
+            }
+            else if (!ignoreIfNotRegistered)
+            {
+                var message = $"Module '{moduleState.ModuleType.Name}' depends on '{dependencyType.Name}', " +
+                              $"but '{dependencyType.Name}' has not been registered in the pipeline.\n\n" +
+                              $"Suggestions:\n" +
+                              $"  1. Add '.AddModule<{dependencyType.Name}>()' to your pipeline configuration before '.AddModule<{moduleState.ModuleType.Name}>()'\n" +
+                              $"  2. Use '[DependsOn<{dependencyType.Name}>(ignoreIfNotRegistered: true)]' if this dependency is optional\n" +
+                              $"  3. Check for typos in the dependency type name\n" +
+                              $"  4. Verify that '{dependencyType.Name}' is in a project referenced by your pipeline project";
+                throw new ModuleNotRegisteredException(message, null);
+            }
+        }
+    }
+
+    private IModuleLogger GetOrCreateLogger(Type moduleType, IServiceProvider scopedServiceProvider)
+    {
+        var loggerType = typeof(ModuleLogger<>).MakeGenericType(moduleType);
+        return _loggerContainer.GetLogger(loggerType)
+            ?? (IModuleLogger)scopedServiceProvider.GetRequiredService(loggerType);
+    }
+}

--- a/src/ModularPipelines/Engine/Execution/IAlwaysRunHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/IAlwaysRunHandler.cs
@@ -1,0 +1,16 @@
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for handling AlwaysRun modules that must complete even after pipeline failure.
+/// </summary>
+internal interface IAlwaysRunHandler
+{
+    /// <summary>
+    /// Waits for all AlwaysRun modules to complete, executing any that are still pending.
+    /// </summary>
+    /// <param name="scheduler">The scheduler managing module execution.</param>
+    /// <param name="modules">All modules in the pipeline.</param>
+    Task WaitForAlwaysRunModulesAsync(IModuleScheduler scheduler, IReadOnlyList<IModule> modules);
+}

--- a/src/ModularPipelines/Engine/Execution/IDependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/IDependencyWaiter.cs
@@ -1,0 +1,16 @@
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for waiting for module dependencies to complete before execution.
+/// Handles AlwaysRun modules that should continue despite dependency failures.
+/// </summary>
+internal interface IDependencyWaiter
+{
+    /// <summary>
+    /// Waits for all dependencies of the specified module to complete.
+    /// </summary>
+    /// <param name="moduleState">The state of the module waiting for dependencies.</param>
+    /// <param name="scheduler">The scheduler to get dependency completion tasks from.</param>
+    /// <param name="scopedServiceProvider">The scoped service provider for logging.</param>
+    Task WaitForDependenciesAsync(ModuleState moduleState, IModuleScheduler scheduler, IServiceProvider scopedServiceProvider);
+}

--- a/src/ModularPipelines/Engine/Execution/IModuleLifecycleEventInvoker.cs
+++ b/src/ModularPipelines/Engine/Execution/IModuleLifecycleEventInvoker.cs
@@ -1,0 +1,39 @@
+using ModularPipelines.Models;
+
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for invoking module lifecycle events (Ready, Start, End, Failed, Skipped).
+/// </summary>
+internal interface IModuleLifecycleEventInvoker
+{
+    /// <summary>
+    /// Invokes the OnModuleReady lifecycle event.
+    /// Called when a module's dependencies are satisfied and it's about to execute.
+    /// </summary>
+    Task InvokeReadyEventAsync(ModuleLifecycleContext context);
+
+    /// <summary>
+    /// Invokes the OnModuleStart lifecycle event.
+    /// Called when a module begins execution.
+    /// </summary>
+    Task InvokeStartEventAsync(ModuleLifecycleContext context);
+
+    /// <summary>
+    /// Invokes the OnModuleEnd lifecycle event.
+    /// Called when a module completes successfully.
+    /// </summary>
+    Task InvokeEndEventAsync(ModuleLifecycleContext context, Enums.Status status, IModuleResult result);
+
+    /// <summary>
+    /// Invokes the OnModuleFailed lifecycle event.
+    /// Called when a module throws an exception.
+    /// </summary>
+    Task InvokeFailedEventAsync(ModuleLifecycleContext context, Exception exception);
+
+    /// <summary>
+    /// Invokes the OnModuleSkipped lifecycle event.
+    /// Called when a module is skipped.
+    /// </summary>
+    Task InvokeSkippedEventAsync(ModuleLifecycleContext context, Enums.Status status, SkipDecision skipReason);
+}

--- a/src/ModularPipelines/Engine/Execution/IModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Execution/IModuleResultRegistrar.cs
@@ -1,0 +1,26 @@
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for registering module execution results.
+/// Handles successful results, failed results, and terminated results for cancelled modules.
+/// </summary>
+internal interface IModuleResultRegistrar
+{
+    /// <summary>
+    /// Registers a terminated result for a module that was cancelled before completion.
+    /// </summary>
+    /// <param name="module">The module instance.</param>
+    /// <param name="moduleType">The type of the module.</param>
+    /// <param name="exception">The exception that caused termination.</param>
+    void RegisterTerminatedResult(IModule module, Type moduleType, Exception exception);
+
+    /// <summary>
+    /// Registers terminated results for all modules that were cancelled before they started.
+    /// </summary>
+    /// <param name="modules">The list of all modules.</param>
+    /// <param name="exception">The exception that caused pipeline termination.</param>
+    void RegisterTerminatedResultsForCancelledModules(IReadOnlyList<IModule> modules, Exception exception);
+}

--- a/src/ModularPipelines/Engine/Execution/IModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/IModuleRunner.cs
@@ -1,0 +1,25 @@
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for executing a single module with proper scoping, dependency waiting,
+/// lifecycle events, and result registration.
+/// </summary>
+internal interface IModuleRunner
+{
+    /// <summary>
+    /// Executes a module, waiting for its dependencies first.
+    /// </summary>
+    /// <param name="moduleState">The state of the module to execute.</param>
+    /// <param name="scheduler">The scheduler managing module execution.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ExecuteAsync(ModuleState moduleState, IModuleScheduler scheduler, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Executes a module without waiting for dependencies.
+    /// Used for late-started AlwaysRun modules where dependencies may never complete.
+    /// </summary>
+    /// <param name="moduleState">The state of the module to execute.</param>
+    /// <param name="scheduler">The scheduler managing module execution.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ExecuteWithoutDependencyWaitAsync(ModuleState moduleState, IModuleScheduler scheduler, CancellationToken cancellationToken);
+}

--- a/src/ModularPipelines/Engine/Execution/IParallelLimitHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/IParallelLimitHandler.cs
@@ -1,0 +1,23 @@
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for managing parallel execution limits.
+/// Handles both custom parallel limiters (via ParallelLimiterAttribute) and
+/// execution type limits (CPU-intensive, IO-intensive).
+/// </summary>
+internal interface IParallelLimitHandler
+{
+    /// <summary>
+    /// Acquires a parallel limit semaphore for the specified module type.
+    /// </summary>
+    /// <param name="moduleType">The type of the module.</param>
+    /// <returns>A disposable that releases the semaphore when disposed.</returns>
+    Task<IDisposable> AcquireParallelLimitAsync(Type moduleType);
+
+    /// <summary>
+    /// Acquires an execution type limit semaphore for the specified module state.
+    /// </summary>
+    /// <param name="moduleState">The module state containing execution type information.</param>
+    /// <returns>A disposable that releases the semaphore when disposed.</returns>
+    Task<IDisposable> AcquireExecutionTypeLimitAsync(ModuleState moduleState);
+}

--- a/src/ModularPipelines/Engine/Execution/ModuleLifecycleContext.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleLifecycleContext.cs
@@ -1,0 +1,68 @@
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Context information required for invoking module lifecycle events.
+/// </summary>
+internal class ModuleLifecycleContext
+{
+    public ModuleLifecycleContext(
+        IModule module,
+        Type moduleType,
+        IReadOnlyList<Attribute> moduleAttributes,
+        DateTimeOffset startTime,
+        IPipelineContext pipelineContext,
+        IServiceProvider scopedServiceProvider,
+        CancellationToken cancellationToken)
+    {
+        Module = module;
+        ModuleType = moduleType;
+        ModuleAttributes = moduleAttributes;
+        StartTime = startTime;
+        PipelineContext = pipelineContext;
+        ScopedServiceProvider = scopedServiceProvider;
+        CancellationToken = cancellationToken;
+    }
+
+    /// <summary>
+    /// Gets the module instance.
+    /// </summary>
+    public IModule Module { get; }
+
+    /// <summary>
+    /// Gets the module type.
+    /// </summary>
+    public Type ModuleType { get; }
+
+    /// <summary>
+    /// Gets the module's custom attributes.
+    /// </summary>
+    public IReadOnlyList<Attribute> ModuleAttributes { get; }
+
+    /// <summary>
+    /// Gets the start time of the module execution.
+    /// </summary>
+    public DateTimeOffset StartTime { get; }
+
+    /// <summary>
+    /// Gets the pipeline context.
+    /// </summary>
+    public IPipelineContext PipelineContext { get; }
+
+    /// <summary>
+    /// Gets the scoped service provider for this module execution.
+    /// </summary>
+    public IServiceProvider ScopedServiceProvider { get; }
+
+    /// <summary>
+    /// Gets the cancellation token.
+    /// </summary>
+    public CancellationToken CancellationToken { get; }
+
+    /// <summary>
+    /// Gets or sets the ready time (when dependencies were satisfied).
+    /// </summary>
+    public DateTimeOffset? ReadyTime { get; set; }
+}

--- a/src/ModularPipelines/Engine/Execution/ModuleLifecycleEventInvoker.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleLifecycleEventInvoker.cs
@@ -1,0 +1,147 @@
+using ModularPipelines.Context;
+using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Models;
+
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for invoking module lifecycle events.
+/// </summary>
+internal class ModuleLifecycleEventInvoker : IModuleLifecycleEventInvoker
+{
+    private readonly IModuleAttributeEventService _attributeEventService;
+    private readonly IAttributeEventInvoker _attributeEventInvoker;
+    private readonly IMetricsCollector _metricsCollector;
+    private readonly IModuleMetadataRegistry _metadataRegistry;
+
+    public ModuleLifecycleEventInvoker(
+        IModuleAttributeEventService attributeEventService,
+        IAttributeEventInvoker attributeEventInvoker,
+        IMetricsCollector metricsCollector,
+        IModuleMetadataRegistry metadataRegistry)
+    {
+        _attributeEventService = attributeEventService;
+        _attributeEventInvoker = attributeEventInvoker;
+        _metricsCollector = metricsCollector;
+        _metadataRegistry = metadataRegistry;
+    }
+
+    /// <inheritdoc />
+    public async Task InvokeReadyEventAsync(ModuleLifecycleContext context)
+    {
+        var receivers = _attributeEventService.GetReadyReceivers(context.ModuleType);
+        if (receivers.Count == 0)
+        {
+            return;
+        }
+
+        var readyTime = context.ReadyTime ?? context.StartTime;
+        var pipelineStartTime = _metricsCollector.GetPipelineStartTime() ?? readyTime;
+
+        var eventContext = new ModuleReadyContext(
+            context.Module,
+            context.ModuleType,
+            context.ModuleAttributes,
+            readyTime,
+            pipelineStartTime,
+            context.PipelineContext,
+            context.ScopedServiceProvider,
+            _metadataRegistry,
+            context.CancellationToken);
+
+        await _attributeEventInvoker.InvokeReadyReceiversAsync(receivers, eventContext).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task InvokeStartEventAsync(ModuleLifecycleContext context)
+    {
+        var receivers = _attributeEventService.GetStartReceivers(context.ModuleType);
+        if (receivers.Count == 0)
+        {
+            return;
+        }
+
+        var eventContext = new ModuleEventContext(
+            context.Module,
+            context.ModuleType,
+            context.ModuleAttributes,
+            context.StartTime,
+            Enums.Status.Processing,
+            context.PipelineContext,
+            context.ScopedServiceProvider,
+            _metadataRegistry,
+            context.CancellationToken);
+
+        await _attributeEventInvoker.InvokeStartReceiversAsync(receivers, eventContext).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task InvokeEndEventAsync(ModuleLifecycleContext context, Enums.Status status, IModuleResult result)
+    {
+        var receivers = _attributeEventService.GetEndReceivers(context.ModuleType);
+        if (receivers.Count == 0)
+        {
+            return;
+        }
+
+        var eventContext = new ModuleEventContext(
+            context.Module,
+            context.ModuleType,
+            context.ModuleAttributes,
+            context.StartTime,
+            status,
+            context.PipelineContext,
+            context.ScopedServiceProvider,
+            _metadataRegistry,
+            context.CancellationToken);
+
+        await _attributeEventInvoker.InvokeEndReceiversAsync(receivers, eventContext, (ModuleResult)result).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task InvokeFailedEventAsync(ModuleLifecycleContext context, Exception exception)
+    {
+        var receivers = _attributeEventService.GetFailureReceivers(context.ModuleType);
+        if (receivers.Count == 0)
+        {
+            return;
+        }
+
+        var eventContext = new ModuleEventContext(
+            context.Module,
+            context.ModuleType,
+            context.ModuleAttributes,
+            context.StartTime,
+            Enums.Status.Failed,
+            context.PipelineContext,
+            context.ScopedServiceProvider,
+            _metadataRegistry,
+            context.CancellationToken);
+
+        await _attributeEventInvoker.InvokeFailureReceiversAsync(receivers, eventContext, exception).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task InvokeSkippedEventAsync(ModuleLifecycleContext context, Enums.Status status, SkipDecision skipReason)
+    {
+        var receivers = _attributeEventService.GetSkippedReceivers(context.ModuleType);
+        if (receivers.Count == 0)
+        {
+            return;
+        }
+
+        var eventContext = new ModuleEventContext(
+            context.Module,
+            context.ModuleType,
+            context.ModuleAttributes,
+            context.StartTime,
+            status,
+            context.PipelineContext,
+            context.ScopedServiceProvider,
+            _metadataRegistry,
+            context.CancellationToken);
+
+        await _attributeEventInvoker.InvokeSkippedReceiversAsync(receivers, eventContext, skipReason).ConfigureAwait(false);
+    }
+}

--- a/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Helpers;
+using ModularPipelines.Logging;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for registering module execution results.
+/// </summary>
+internal class ModuleResultRegistrar : IModuleResultRegistrar
+{
+    private readonly IModuleResultRegistry _resultRegistry;
+    private readonly ILogger<ModuleResultRegistrar> _logger;
+
+    public ModuleResultRegistrar(
+        IModuleResultRegistry resultRegistry,
+        ILogger<ModuleResultRegistrar> logger)
+    {
+        _resultRegistry = resultRegistry;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public void RegisterTerminatedResult(IModule module, Type moduleType, Exception exception)
+    {
+        var resultType = module.ResultType;
+
+        // Create execution context with PipelineTerminated status
+        var contextType = typeof(ModuleExecutionContext<>).MakeGenericType(resultType);
+        var executionContext = (ModuleExecutionContext)Activator.CreateInstance(contextType, module, moduleType)!;
+        executionContext.Status = Enums.Status.PipelineTerminated;
+        executionContext.Exception = exception;
+
+        // Create ModuleResult<T> with the exception
+        var resultGenericType = typeof(ModuleResult<>).MakeGenericType(resultType);
+        var result = (IModuleResult)Activator.CreateInstance(
+            resultGenericType,
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            null,
+            new object[] { exception, executionContext },
+            null)!;
+
+        _resultRegistry.RegisterResult(moduleType, result);
+    }
+
+    /// <inheritdoc />
+    public void RegisterTerminatedResultsForCancelledModules(IReadOnlyList<IModule> modules, Exception exception)
+    {
+        foreach (var module in modules)
+        {
+            var moduleType = module.GetType();
+
+            // Check if a result was already registered for this module
+            if (_resultRegistry.GetResult(moduleType) != null)
+            {
+                continue;
+            }
+
+            _logger.LogDebug(
+                "Registering PipelineTerminated result for cancelled module {ModuleName}",
+                MarkupFormatter.FormatModuleName(moduleType.Name));
+
+            RegisterTerminatedResult(module, moduleType, exception);
+        }
+    }
+}

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -1,0 +1,278 @@
+using System.Reflection;
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModularPipelines.Context;
+using ModularPipelines.Events;
+using ModularPipelines.Helpers;
+using ModularPipelines.Logging;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for executing a single module with proper scoping and coordination.
+/// </summary>
+internal class ModuleRunner : IModuleRunner
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IModuleExecutionPipeline _executionPipeline;
+    private readonly IModuleLoggerContainer _loggerContainer;
+    private readonly IPipelineSetupExecutor _pipelineSetupExecutor;
+    private readonly IMediator _mediator;
+    private readonly ISafeModuleEstimatedTimeProvider _moduleEstimatedTimeProvider;
+    private readonly IModuleDisposer _moduleDisposer;
+    private readonly IModuleResultRegistry _resultRegistry;
+    private readonly IOptions<PipelineOptions> _pipelineOptions;
+    private readonly ILogger<ModuleRunner> _logger;
+    private readonly IDependencyWaiter _dependencyWaiter;
+    private readonly IParallelLimitHandler _parallelLimitHandler;
+    private readonly IModuleLifecycleEventInvoker _lifecycleEventInvoker;
+    private readonly IModuleResultRegistrar _resultRegistrar;
+
+    public ModuleRunner(
+        IServiceProvider serviceProvider,
+        IModuleExecutionPipeline executionPipeline,
+        IModuleLoggerContainer loggerContainer,
+        IPipelineSetupExecutor pipelineSetupExecutor,
+        IMediator mediator,
+        ISafeModuleEstimatedTimeProvider moduleEstimatedTimeProvider,
+        IModuleDisposer moduleDisposer,
+        IModuleResultRegistry resultRegistry,
+        IOptions<PipelineOptions> pipelineOptions,
+        ILogger<ModuleRunner> logger,
+        IDependencyWaiter dependencyWaiter,
+        IParallelLimitHandler parallelLimitHandler,
+        IModuleLifecycleEventInvoker lifecycleEventInvoker,
+        IModuleResultRegistrar resultRegistrar)
+    {
+        _serviceProvider = serviceProvider;
+        _executionPipeline = executionPipeline;
+        _loggerContainer = loggerContainer;
+        _pipelineSetupExecutor = pipelineSetupExecutor;
+        _mediator = mediator;
+        _moduleEstimatedTimeProvider = moduleEstimatedTimeProvider;
+        _moduleDisposer = moduleDisposer;
+        _resultRegistry = resultRegistry;
+        _pipelineOptions = pipelineOptions;
+        _logger = logger;
+        _dependencyWaiter = dependencyWaiter;
+        _parallelLimitHandler = parallelLimitHandler;
+        _lifecycleEventInvoker = lifecycleEventInvoker;
+        _resultRegistrar = resultRegistrar;
+    }
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(ModuleState moduleState, IModuleScheduler scheduler, CancellationToken cancellationToken)
+    {
+        return ExecuteCore(moduleState, scheduler, cancellationToken, skipDependencyWait: false);
+    }
+
+    /// <inheritdoc />
+    public Task ExecuteWithoutDependencyWaitAsync(ModuleState moduleState, IModuleScheduler scheduler, CancellationToken cancellationToken)
+    {
+        return ExecuteCore(moduleState, scheduler, cancellationToken, skipDependencyWait: true);
+    }
+
+    private async Task ExecuteCore(
+        ModuleState moduleState,
+        IModuleScheduler scheduler,
+        CancellationToken cancellationToken,
+        bool skipDependencyWait)
+    {
+        var module = moduleState.Module;
+        var moduleType = moduleState.ModuleType;
+        var moduleName = MarkupFormatter.FormatModuleName(moduleType.Name);
+
+        // Create a scope to resolve scoped services like IPipelineContext and ModuleLogger<T>
+        var scope = _serviceProvider.CreateAsyncScope();
+        await using (scope.ConfigureAwait(false))
+        {
+            try
+            {
+                // Check if the module can proceed with execution
+                // Returns false if constraints (e.g., NotInParallel) prevent execution
+                if (!scheduler.MarkModuleStarted(moduleType))
+                {
+                    _logger.LogDebug("Module {ModuleName} deferred due to constraint check failure", moduleName);
+                    return; // Module will be rescheduled by the scheduler
+                }
+
+                _logger.LogDebug("{Icon} Starting module {ModuleName}", MarkupFormatter.PlayIcon, moduleName);
+
+                if (!skipDependencyWait)
+                {
+                    await _dependencyWaiter.WaitForDependenciesAsync(moduleState, scheduler, scope.ServiceProvider).ConfigureAwait(false);
+                }
+                else
+                {
+                    _logger.LogDebug("Skipping dependency wait for late-started AlwaysRun module: {ModuleName}", moduleName);
+                }
+
+                await ExecuteModuleWithPipeline(moduleState, scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
+
+                scheduler.MarkModuleCompleted(moduleType, true);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Module {ModuleName} failed", moduleName);
+                scheduler.MarkModuleCompleted(moduleType, false, ex);
+
+                // Register a PipelineTerminated result for this module if no result was registered yet
+                if (moduleState.Result == null)
+                {
+                    _resultRegistrar.RegisterTerminatedResult(module, moduleType, ex);
+                }
+
+                if (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
+                {
+                    throw;
+                }
+            }
+        }
+    }
+
+    private async Task ExecuteModuleWithPipeline(ModuleState moduleState, IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
+    {
+        var module = moduleState.Module;
+        var moduleType = moduleState.ModuleType;
+
+        var pipelineContext = scopedServiceProvider.GetRequiredService<IPipelineContext>();
+
+        // Create module-specific context
+        var executionContext = CreateExecutionContext(module, moduleType);
+        var logger = GetOrCreateLogger(moduleType, scopedServiceProvider);
+        var moduleContext = new ModuleContext(pipelineContext, module, executionContext, logger);
+
+        // Set up logging
+        ModuleLogger.Values.Value = logger;
+
+        // Before module hooks
+        await _pipelineSetupExecutor.OnBeforeModuleStartAsync(moduleState).ConfigureAwait(false);
+
+        var estimatedDuration = await _moduleEstimatedTimeProvider.GetModuleEstimatedTimeAsync(moduleType).ConfigureAwait(false);
+        await _mediator.Publish(new ModuleStartedNotification(moduleState, estimatedDuration)).ConfigureAwait(false);
+
+        using var semaphoreHandle = await _parallelLimitHandler.AcquireParallelLimitAsync(moduleType).ConfigureAwait(false);
+        using var executionTypeHandle = await _parallelLimitHandler.AcquireExecutionTypeLimitAsync(moduleState).ConfigureAwait(false);
+
+        // Track start time for lifecycle events
+        var startTime = DateTimeOffset.UtcNow;
+        var moduleAttributes = moduleType.GetCustomAttributes(inherit: true).OfType<Attribute>().ToList();
+
+        var lifecycleContext = new ModuleLifecycleContext(
+            module,
+            moduleType,
+            moduleAttributes,
+            startTime,
+            pipelineContext,
+            scopedServiceProvider,
+            cancellationToken)
+        {
+            ReadyTime = moduleState.ReadyTime ?? startTime
+        };
+
+        try
+        {
+            // Invoke OnModuleReady lifecycle event (dependencies satisfied, about to execute)
+            await _lifecycleEventInvoker.InvokeReadyEventAsync(lifecycleContext).ConfigureAwait(false);
+
+            // Invoke OnModuleStart lifecycle event
+            await _lifecycleEventInvoker.InvokeStartEventAsync(lifecycleContext).ConfigureAwait(false);
+
+            // Execute via the ModuleExecutionPipeline using reflection to handle the generic type
+            var result = await ExecuteTypedModule(module, executionContext, moduleContext, cancellationToken).ConfigureAwait(false);
+
+            moduleState.Result = result;
+            _resultRegistry.RegisterResult(moduleType, result);
+
+            if (executionContext.Status == Enums.Status.Skipped)
+            {
+                // Invoke OnModuleSkipped lifecycle event
+                await _lifecycleEventInvoker.InvokeSkippedEventAsync(lifecycleContext, Enums.Status.Skipped, executionContext.SkipResult!).ConfigureAwait(false);
+
+                await _mediator.Publish(new ModuleSkippedNotification(moduleState, executionContext.SkipResult)).ConfigureAwait(false);
+                return;
+            }
+
+            await _moduleEstimatedTimeProvider.SaveModuleTimeAsync(moduleType, executionContext.Duration).ConfigureAwait(false);
+            await _pipelineSetupExecutor.OnAfterModuleEndAsync(moduleState).ConfigureAwait(false);
+
+            // Invoke OnModuleEnd lifecycle event
+            await _lifecycleEventInvoker.InvokeEndEventAsync(lifecycleContext, executionContext.Status, result).ConfigureAwait(false);
+
+            var isSuccessful = executionContext.Status == Enums.Status.Successful;
+            await _mediator.Publish(new ModuleCompletedNotification(moduleState, isSuccessful)).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Even when an exception is thrown, we need to register the result if one was set
+            if (executionContext.ExecutionTask.IsCompleted && !executionContext.ExecutionTask.IsFaulted && !executionContext.ExecutionTask.IsCanceled)
+            {
+                var result = executionContext.ExecutionTask.Result;
+                moduleState.Result = result;
+                _resultRegistry.RegisterResult(moduleType, result);
+            }
+
+            // Invoke OnModuleFailed lifecycle event
+            await _lifecycleEventInvoker.InvokeFailedEventAsync(lifecycleContext, ex).ConfigureAwait(false);
+
+            throw;
+        }
+        finally
+        {
+            // Store execution context results in module state
+            moduleState.SkipResult = executionContext.SkipResult;
+
+            if (!_pipelineOptions.Value.ShowProgressInConsole)
+            {
+                await _moduleDisposer.DisposeAsync(moduleState).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private ModuleExecutionContext CreateExecutionContext(IModule module, Type moduleType)
+    {
+        var resultType = module.ResultType;
+        var contextType = typeof(ModuleExecutionContext<>).MakeGenericType(resultType);
+        return (ModuleExecutionContext)Activator.CreateInstance(contextType, module, moduleType)!;
+    }
+
+    private async Task<IModuleResult> ExecuteTypedModule(
+        IModule module,
+        ModuleExecutionContext executionContext,
+        IModuleContext moduleContext,
+        CancellationToken cancellationToken)
+    {
+        var resultType = module.ResultType;
+
+        var executeMethodInfo = typeof(IModuleExecutionPipeline).GetMethod(nameof(IModuleExecutionPipeline.ExecuteAsync))
+            ?? throw new InvalidOperationException($"Method '{nameof(IModuleExecutionPipeline.ExecuteAsync)}' not found on type '{nameof(IModuleExecutionPipeline)}'.");
+
+        var executeMethod = executeMethodInfo.MakeGenericMethod(resultType);
+
+        var invokeResult = executeMethod.Invoke(_executionPipeline, new object[] { module, executionContext, moduleContext, cancellationToken })
+            ?? throw new InvalidOperationException($"Invocation of '{nameof(IModuleExecutionPipeline.ExecuteAsync)}' returned null.");
+
+        var task = (Task)invokeResult;
+        await task.ConfigureAwait(false);
+
+        var resultProperty = task.GetType().GetProperty("Result")
+            ?? throw new InvalidOperationException($"Property 'Result' not found on task type '{task.GetType().Name}'.");
+
+        var resultValue = resultProperty.GetValue(task)
+            ?? throw new InvalidOperationException($"Property 'Result' returned null for task type '{task.GetType().Name}'.");
+
+        return (IModuleResult)resultValue;
+    }
+
+    private IModuleLogger GetOrCreateLogger(Type moduleType, IServiceProvider scopedServiceProvider)
+    {
+        var loggerType = typeof(ModuleLogger<>).MakeGenericType(moduleType);
+        return _loggerContainer.GetLogger(loggerType)
+            ?? (IModuleLogger)scopedServiceProvider.GetRequiredService(loggerType);
+    }
+}

--- a/src/ModularPipelines/Engine/Execution/ParallelLimitHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/ParallelLimitHandler.cs
@@ -1,0 +1,62 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
+using ModularPipelines.Helpers;
+using ModularPipelines.Interfaces;
+using ModularPipelines.Logging;
+
+namespace ModularPipelines.Engine.Execution;
+
+/// <summary>
+/// Responsible for managing parallel execution limits.
+/// </summary>
+internal class ParallelLimitHandler : IParallelLimitHandler
+{
+    private readonly IParallelLimitProvider _parallelLimitProvider;
+    private readonly ILogger<ParallelLimitHandler> _logger;
+
+    public ParallelLimitHandler(
+        IParallelLimitProvider parallelLimitProvider,
+        ILogger<ParallelLimitHandler> logger)
+    {
+        _parallelLimitProvider = parallelLimitProvider;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IDisposable> AcquireParallelLimitAsync(Type moduleType)
+    {
+        var parallelLimitAttributeType =
+            moduleType.GetCustomAttributes<ParallelLimiterAttribute>().FirstOrDefault()?.Type;
+
+        if (parallelLimitAttributeType != null)
+        {
+            _logger.LogDebug(
+                "Module {ModuleName} acquiring parallel limit from {LimiterType}",
+                MarkupFormatter.FormatModuleName(moduleType.Name),
+                parallelLimitAttributeType.Name);
+
+            return await _parallelLimitProvider.GetLock(parallelLimitAttributeType).WaitAsync().ConfigureAwait(false);
+        }
+
+        return NoOpDisposable.Instance;
+    }
+
+    /// <inheritdoc />
+    public async Task<IDisposable> AcquireExecutionTypeLimitAsync(ModuleState moduleState)
+    {
+        var executionTypeLock = _parallelLimitProvider.GetExecutionTypeLock(moduleState.ExecutionType);
+
+        if (executionTypeLock != null)
+        {
+            _logger.LogDebug(
+                "Module {ModuleName} waiting for {ExecutionType} execution slot",
+                MarkupFormatter.FormatModuleName(moduleState.ModuleType.Name),
+                moduleState.ExecutionType);
+
+            return await executionTypeLock.WaitAsync().ConfigureAwait(false);
+        }
+
+        return NoOpDisposable.Instance;
+    }
+}

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -1,88 +1,57 @@
-using System.Reflection;
-using Mediator;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using ModularPipelines.Attributes;
-using ModularPipelines.Attributes.Events;
-using ModularPipelines.Context;
 using ModularPipelines.Engine.Attributes;
-using ModularPipelines.Engine.Dependencies;
-using ModularPipelines.Events;
-using ModularPipelines.Exceptions;
+using ModularPipelines.Engine.Execution;
 using ModularPipelines.Helpers;
-using ModularPipelines.Logging;
-using ModularPipelines.Models;
+using ModularPipelines.Interfaces;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 
 namespace ModularPipelines.Engine;
 
+/// <summary>
+/// Orchestrates the execution of a collection of modules using eager parallel scheduling.
+/// Delegates to specialized components for individual responsibilities.
+/// </summary>
+/// <remarks>
+/// This class follows the Single Responsibility Principle by focusing solely on orchestration.
+/// Individual responsibilities are delegated to:
+/// - <see cref="IModuleRunner"/>: Executes individual modules
+/// - <see cref="IAlwaysRunHandler"/>: Handles AlwaysRun module completion
+/// - <see cref="IModuleResultRegistrar"/>: Registers module results
+/// </remarks>
 internal class ModuleExecutor : IModuleExecutor
 {
-    private readonly IPipelineSetupExecutor _pipelineSetupExecutor;
-    private readonly IOptions<PipelineOptions> _pipelineOptions;
-    private readonly ISafeModuleEstimatedTimeProvider _moduleEstimatedTimeProvider;
-    private readonly IModuleDisposer _moduleDisposer;
-    private readonly IEnumerable<IModule> _allModules;
-    private readonly ISecondaryExceptionContainer _secondaryExceptionContainer;
-    private readonly IParallelLimitProvider _parallelLimitProvider;
-    private readonly IMediator _mediator;
-    private readonly ILogger<ModuleExecutor> _logger;
     private readonly IModuleSchedulerFactory _schedulerFactory;
-    private readonly IModuleExecutionPipeline _executionPipeline;
-    private readonly IServiceProvider _serviceProvider;
-    private readonly IModuleLoggerContainer _loggerContainer;
-    private readonly EngineCancellationToken _engineCancellationToken;
-    private readonly IModuleResultRegistry _resultRegistry;
+    private readonly IModuleRunner _moduleRunner;
+    private readonly IAlwaysRunHandler _alwaysRunHandler;
+    private readonly IModuleResultRegistrar _resultRegistrar;
+    private readonly IParallelLimitProvider _parallelLimitProvider;
     private readonly IRegistrationEventExecutor _registrationEventExecutor;
-    private readonly IModuleAttributeEventService _attributeEventService;
-    private readonly IAttributeEventInvoker _attributeEventInvoker;
-    private readonly IModuleMetadataRegistry _metadataRegistry;
     private readonly IMetricsCollector _metricsCollector;
+    private readonly IOptions<PipelineOptions> _pipelineOptions;
+    private readonly ILogger<ModuleExecutor> _logger;
 
     public ModuleExecutor(
-        IPipelineSetupExecutor pipelineSetupExecutor,
-        IOptions<PipelineOptions> pipelineOptions,
-        ISafeModuleEstimatedTimeProvider moduleEstimatedTimeProvider,
-        IModuleDisposer moduleDisposer,
-        IEnumerable<IModule> allModules,
-        ISecondaryExceptionContainer secondaryExceptionContainer,
-        IParallelLimitProvider parallelLimitProvider,
-        IMediator mediator,
-        ILogger<ModuleExecutor> logger,
         IModuleSchedulerFactory schedulerFactory,
-        IModuleExecutionPipeline executionPipeline,
-        IServiceProvider serviceProvider,
-        IModuleLoggerContainer loggerContainer,
-        EngineCancellationToken engineCancellationToken,
-        IModuleResultRegistry resultRegistry,
+        IModuleRunner moduleRunner,
+        IAlwaysRunHandler alwaysRunHandler,
+        IModuleResultRegistrar resultRegistrar,
+        IParallelLimitProvider parallelLimitProvider,
         IRegistrationEventExecutor registrationEventExecutor,
-        IModuleAttributeEventService attributeEventService,
-        IAttributeEventInvoker attributeEventInvoker,
-        IModuleMetadataRegistry metadataRegistry,
-        IMetricsCollector metricsCollector)
+        IMetricsCollector metricsCollector,
+        IOptions<PipelineOptions> pipelineOptions,
+        ILogger<ModuleExecutor> logger)
     {
-        _pipelineSetupExecutor = pipelineSetupExecutor;
-        _pipelineOptions = pipelineOptions;
-        _moduleEstimatedTimeProvider = moduleEstimatedTimeProvider;
-        _moduleDisposer = moduleDisposer;
-        _allModules = allModules;
-        _secondaryExceptionContainer = secondaryExceptionContainer;
-        _parallelLimitProvider = parallelLimitProvider;
-        _mediator = mediator;
-        _logger = logger;
         _schedulerFactory = schedulerFactory;
-        _executionPipeline = executionPipeline;
-        _serviceProvider = serviceProvider;
-        _loggerContainer = loggerContainer;
-        _engineCancellationToken = engineCancellationToken;
-        _resultRegistry = resultRegistry;
+        _moduleRunner = moduleRunner;
+        _alwaysRunHandler = alwaysRunHandler;
+        _resultRegistrar = resultRegistrar;
+        _parallelLimitProvider = parallelLimitProvider;
         _registrationEventExecutor = registrationEventExecutor;
-        _attributeEventService = attributeEventService;
-        _attributeEventInvoker = attributeEventInvoker;
-        _metadataRegistry = metadataRegistry;
         _metricsCollector = metricsCollector;
+        _pipelineOptions = pipelineOptions;
+        _logger = logger;
     }
 
     /// <summary>
@@ -111,7 +80,7 @@ internal class ModuleExecutor : IModuleExecutor
 
             if (scheduler != null)
             {
-                await WaitForAlwaysRunModulesAsync(scheduler, modules).ConfigureAwait(false);
+                await _alwaysRunHandler.WaitForAlwaysRunModulesAsync(scheduler, modules).ConfigureAwait(false);
             }
 
             _logger.LogDebug("Outer catch block rethrowing exception");
@@ -167,7 +136,7 @@ internal class ModuleExecutor : IModuleExecutor
         // Register PipelineTerminated results for modules that were cancelled before they started
         if (firstException != null)
         {
-            RegisterTerminatedResultsForCancelledModules(modules, firstException);
+            _resultRegistrar.RegisterTerminatedResultsForCancelledModules(modules, firstException);
         }
 
         RethrowFirstExceptionIfPresent(firstException);
@@ -211,7 +180,7 @@ internal class ModuleExecutor : IModuleExecutor
                 {
                     try
                     {
-                        await ExecuteModule(moduleState, scheduler, ct).ConfigureAwait(false);
+                        await _moduleRunner.ExecuteAsync(moduleState, scheduler, ct).ConfigureAwait(false);
                     }
                     catch (Exception ex) when (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                     {
@@ -247,533 +216,5 @@ internal class ModuleExecutor : IModuleExecutor
             _logger.LogDebug("Rethrowing first exception: {ExceptionType}", firstException.GetType().Name);
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(firstException).Throw();
         }
-    }
-
-    private async Task WaitForAlwaysRunModulesAsync(IModuleScheduler scheduler, IReadOnlyList<IModule> modules)
-    {
-        var alwaysRunModules = modules.Where(x => x.ModuleRunType == ModuleRunType.AlwaysRun).ToList();
-        _logger.LogDebug("Found {Count} AlwaysRun modules", alwaysRunModules.Count);
-
-        foreach (var module in alwaysRunModules)
-        {
-            await WaitForSingleAlwaysRunModuleAsync(scheduler, module).ConfigureAwait(false);
-        }
-    }
-
-    private async Task WaitForSingleAlwaysRunModuleAsync(IModuleScheduler scheduler, IModule module)
-    {
-        var moduleType = module.GetType();
-        var moduleState = scheduler.GetModuleState(moduleType);
-        var moduleTask = scheduler.GetModuleCompletionTask(moduleType);
-
-        if (moduleTask == null || moduleState == null)
-        {
-            return;
-        }
-
-        // If the AlwaysRun module is still pending (never started), execute it now
-        // Skip dependency waiting to prevent deadlocks - dependencies may never complete
-        if (moduleState.State == ModuleExecutionState.Pending)
-        {
-            _logger.LogDebug("Starting pending AlwaysRun module: {ModuleName}", moduleType.Name);
-
-            try
-            {
-                await ExecuteModuleCore(moduleState, scheduler, CancellationToken.None, skipDependencyWait: true).ConfigureAwait(false);
-                _logger.LogDebug("AlwaysRun module {ModuleName} completed after late start", moduleType.Name);
-            }
-            catch (Exception alwaysRunEx)
-            {
-                _logger.LogWarning(alwaysRunEx, "AlwaysRun module {ModuleName} failed after late start",
-                    moduleType.Name);
-            }
-        }
-        else if (ShouldWaitForAlwaysRunModule(moduleState))
-        {
-            _logger.LogDebug("Awaiting AlwaysRun module: {ModuleName} (State={State})",
-                moduleType.Name, moduleState.State);
-
-            try
-            {
-                await moduleTask.ConfigureAwait(false);
-                _logger.LogDebug("AlwaysRun module {ModuleName} completed", moduleType.Name);
-            }
-            catch (Exception alwaysRunEx)
-            {
-                _logger.LogWarning(alwaysRunEx, "AlwaysRun module {ModuleName} failed",
-                    moduleType.Name);
-
-                // Access Exception property to observe the exception and prevent TaskScheduler.UnobservedTaskException
-                _ = moduleTask.Exception;
-            }
-        }
-        else
-        {
-            _logger.LogDebug("Skipping AlwaysRun module {ModuleName} (State={State})",
-                moduleType.Name, moduleState.State);
-        }
-    }
-
-    private static bool ShouldWaitForAlwaysRunModule(ModuleState moduleState)
-    {
-        return moduleState.State == ModuleExecutionState.Executing || moduleState.State == ModuleExecutionState.Completed;
-    }
-
-    private Task ExecuteModule(ModuleState moduleState, IModuleScheduler scheduler, CancellationToken cancellationToken)
-    {
-        return ExecuteModuleCore(moduleState, scheduler, cancellationToken, skipDependencyWait: false);
-    }
-
-    private async Task ExecuteModuleCore(
-        ModuleState moduleState,
-        IModuleScheduler scheduler,
-        CancellationToken cancellationToken,
-        bool skipDependencyWait)
-    {
-        var module = moduleState.Module;
-        var moduleType = moduleState.ModuleType;
-        var moduleName = MarkupFormatter.FormatModuleName(moduleType.Name);
-
-        // Create a scope to resolve scoped services like IPipelineContext and ModuleLogger<T>
-        var scope = _serviceProvider.CreateAsyncScope();
-        await using (scope.ConfigureAwait(false))
-        {
-            try
-            {
-                // Check if the module can proceed with execution
-                // Returns false if constraints (e.g., NotInParallel) prevent execution
-                if (!scheduler.MarkModuleStarted(moduleType))
-                {
-                    _logger.LogDebug("Module {ModuleName} deferred due to constraint check failure", moduleName);
-                    return; // Module will be rescheduled by the scheduler
-                }
-
-                _logger.LogDebug("{Icon} Starting module {ModuleName}", MarkupFormatter.PlayIcon, moduleName);
-
-                if (!skipDependencyWait)
-                {
-                    await WaitForDependenciesAsync(moduleState, scheduler, scope.ServiceProvider).ConfigureAwait(false);
-                }
-                else
-                {
-                    _logger.LogDebug("Skipping dependency wait for late-started AlwaysRun module: {ModuleName}", moduleName);
-                }
-
-                await ExecuteModuleWithPipeline(moduleState, scope.ServiceProvider, cancellationToken).ConfigureAwait(false);
-
-                scheduler.MarkModuleCompleted(moduleType, true);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Module {ModuleName} failed", moduleName);
-                scheduler.MarkModuleCompleted(moduleType, false, ex);
-
-                // Register a PipelineTerminated result for this module if no result was registered yet
-                // This happens when the module was waiting for a dependency that failed
-                if (moduleState.Result == null)
-                {
-                    RegisterTerminatedResult(module, moduleType, ex);
-                }
-
-                if (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
-                {
-                    throw;
-                }
-            }
-        }
-    }
-
-    private async Task ExecuteModuleWithPipeline(ModuleState moduleState, IServiceProvider scopedServiceProvider, CancellationToken cancellationToken)
-    {
-        var module = moduleState.Module;
-        var moduleType = moduleState.ModuleType;
-
-        var pipelineContext = scopedServiceProvider.GetRequiredService<IPipelineContext>();
-
-        // Create module-specific context
-        var executionContext = CreateExecutionContext(module, moduleType);
-        var logger = GetOrCreateLogger(moduleType, scopedServiceProvider);
-        var moduleContext = new ModuleContext(pipelineContext, module, executionContext, logger);
-
-        // Set up logging
-        ModuleLogger.Values.Value = logger;
-
-        // Before module hooks
-        await _pipelineSetupExecutor.OnBeforeModuleStartAsync(moduleState).ConfigureAwait(false);
-
-        var estimatedDuration = await _moduleEstimatedTimeProvider.GetModuleEstimatedTimeAsync(moduleType).ConfigureAwait(false);
-        await _mediator.Publish(new ModuleStartedNotification(moduleState, estimatedDuration)).ConfigureAwait(false);
-
-        using var semaphoreHandle = await WaitForParallelLimiter(moduleType).ConfigureAwait(false);
-        using var executionTypeHandle = await WaitForExecutionTypeLimiter(moduleState).ConfigureAwait(false);
-
-        // Track start time for lifecycle events
-        var startTime = DateTimeOffset.UtcNow;
-        var moduleAttributes = moduleType.GetCustomAttributes(inherit: true).OfType<Attribute>().ToList();
-
-        try
-        {
-            // Invoke OnModuleReady lifecycle event (dependencies satisfied, about to execute)
-            await InvokeReadyEventAsync(module, moduleType, moduleAttributes, moduleState.ReadyTime ?? startTime, pipelineContext, scopedServiceProvider, cancellationToken).ConfigureAwait(false);
-
-            // Invoke OnModuleStart lifecycle event
-            await InvokeStartEventAsync(module, moduleType, moduleAttributes, startTime, pipelineContext, scopedServiceProvider, cancellationToken).ConfigureAwait(false);
-
-            // Execute via the ModuleExecutionPipeline using reflection to handle the generic type
-            var result = await ExecuteTypedModule(module, executionContext, moduleContext, cancellationToken).ConfigureAwait(false);
-
-            moduleState.Result = result;
-            _resultRegistry.RegisterResult(moduleType, result);
-
-            if (executionContext.Status == Enums.Status.Skipped)
-            {
-                // Invoke OnModuleSkipped lifecycle event
-                await InvokeSkippedEventAsync(module, moduleType, moduleAttributes, startTime, Enums.Status.Skipped, pipelineContext, scopedServiceProvider, executionContext.SkipResult!, cancellationToken).ConfigureAwait(false);
-
-                await _mediator.Publish(new ModuleSkippedNotification(moduleState, executionContext.SkipResult)).ConfigureAwait(false);
-                return;
-            }
-
-            await _moduleEstimatedTimeProvider.SaveModuleTimeAsync(moduleType, executionContext.Duration).ConfigureAwait(false);
-            await _pipelineSetupExecutor.OnAfterModuleEndAsync(moduleState).ConfigureAwait(false);
-
-            // Invoke OnModuleEnd lifecycle event
-            await InvokeEndEventAsync(module, moduleType, moduleAttributes, startTime, executionContext.Status, pipelineContext, scopedServiceProvider, result, cancellationToken).ConfigureAwait(false);
-
-            var isSuccessful = executionContext.Status == Enums.Status.Successful;
-            await _mediator.Publish(new ModuleCompletedNotification(moduleState, isSuccessful)).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            // Even when an exception is thrown, we need to register the result if one was set
-            // The ModuleExecutionPipeline sets the result before throwing
-            // Check IsCompleted instead of IsCompletedSuccessfully to handle all completion states
-            if (executionContext.ExecutionTask.IsCompleted && !executionContext.ExecutionTask.IsFaulted && !executionContext.ExecutionTask.IsCanceled)
-            {
-                var result = executionContext.ExecutionTask.Result;
-                moduleState.Result = result;
-                _resultRegistry.RegisterResult(moduleType, result);
-            }
-
-            // Invoke OnModuleFailed lifecycle event
-            await InvokeFailedEventAsync(module, moduleType, moduleAttributes, startTime, pipelineContext, scopedServiceProvider, ex, cancellationToken).ConfigureAwait(false);
-
-            throw;
-        }
-        finally
-        {
-            // Store execution context results in module state
-            moduleState.SkipResult = executionContext.SkipResult;
-
-            if (!_pipelineOptions.Value.ShowProgressInConsole)
-            {
-                await _moduleDisposer.DisposeAsync(moduleState).ConfigureAwait(false);
-            }
-        }
-    }
-
-    private ModuleExecutionContext CreateExecutionContext(IModule module, Type moduleType)
-    {
-        // Use reflection to create the typed execution context
-        var resultType = module.ResultType;
-        var contextType = typeof(ModuleExecutionContext<>).MakeGenericType(resultType);
-        return (ModuleExecutionContext) Activator.CreateInstance(contextType, module, moduleType)!;
-    }
-
-    private async Task<IModuleResult> ExecuteTypedModule(
-        IModule module,
-        ModuleExecutionContext executionContext,
-        IModuleContext moduleContext,
-        CancellationToken cancellationToken)
-    {
-        var resultType = module.ResultType;
-
-        // Use reflection to call the generic ExecuteAsync method
-        var executeMethodInfo = typeof(IModuleExecutionPipeline).GetMethod(nameof(IModuleExecutionPipeline.ExecuteAsync))
-            ?? throw new InvalidOperationException($"Method '{nameof(IModuleExecutionPipeline.ExecuteAsync)}' not found on type '{nameof(IModuleExecutionPipeline)}'.");
-
-        var executeMethod = executeMethodInfo.MakeGenericMethod(resultType);
-
-        var invokeResult = executeMethod.Invoke(_executionPipeline, new object[] { module, executionContext, moduleContext, cancellationToken })
-            ?? throw new InvalidOperationException($"Invocation of '{nameof(IModuleExecutionPipeline.ExecuteAsync)}' returned null.");
-
-        var task = (Task)invokeResult;
-        await task.ConfigureAwait(false);
-
-        // Get the result from the completed task
-        var resultProperty = task.GetType().GetProperty("Result")
-            ?? throw new InvalidOperationException($"Property 'Result' not found on task type '{task.GetType().Name}'.");
-
-        var resultValue = resultProperty.GetValue(task)
-            ?? throw new InvalidOperationException($"Property 'Result' returned null for task type '{task.GetType().Name}'.");
-
-        return (IModuleResult)resultValue;
-    }
-
-    private async Task<IDisposable> WaitForParallelLimiter(Type moduleType)
-    {
-        var parallelLimitAttributeType =
-            moduleType.GetCustomAttributes<ParallelLimiterAttribute>().FirstOrDefault()?.Type;
-
-        if (parallelLimitAttributeType != null)
-        {
-            return await _parallelLimitProvider.GetLock(parallelLimitAttributeType).WaitAsync().ConfigureAwait(false);
-        }
-
-        return NoOpDisposable.Instance;
-    }
-
-    private async Task<IDisposable> WaitForExecutionTypeLimiter(ModuleState moduleState)
-    {
-        var executionTypeLock = _parallelLimitProvider.GetExecutionTypeLock(moduleState.ExecutionType);
-
-        if (executionTypeLock != null)
-        {
-            _logger.LogDebug(
-                "Module {ModuleName} waiting for {ExecutionType} execution slot",
-                MarkupFormatter.FormatModuleName(moduleState.ModuleType.Name),
-                moduleState.ExecutionType);
-
-            return await executionTypeLock.WaitAsync().ConfigureAwait(false);
-        }
-
-        return NoOpDisposable.Instance;
-    }
-
-    private async Task WaitForDependenciesAsync(ModuleState moduleState, IModuleScheduler scheduler, IServiceProvider scopedServiceProvider)
-    {
-        var dependencies = ModuleDependencyResolver.GetDependencies(moduleState.ModuleType);
-
-        foreach (var (dependencyType, ignoreIfNotRegistered) in dependencies)
-        {
-            var dependencyTask = scheduler.GetModuleCompletionTask(dependencyType);
-
-            if (dependencyTask != null)
-            {
-                try
-                {
-                    await dependencyTask.ConfigureAwait(false);
-                }
-                catch (Exception e) when (moduleState.Module.ModuleRunType == ModuleRunType.AlwaysRun)
-                {
-                    var depLogger = GetOrCreateLogger(moduleState.ModuleType, scopedServiceProvider);
-                    _secondaryExceptionContainer.RegisterException(new AlwaysRunPostponedException(
-                        $"{dependencyType.Name} threw an exception when {moduleState.ModuleType.Name} was waiting for it as a dependency",
-                        e));
-                    depLogger.LogError(e, "Ignoring Exception due to 'AlwaysRun' set");
-                }
-            }
-            else if (!ignoreIfNotRegistered)
-            {
-                var message = $"Module '{moduleState.ModuleType.Name}' depends on '{dependencyType.Name}', " +
-                              $"but '{dependencyType.Name}' has not been registered in the pipeline.\n\n" +
-                              $"Suggestions:\n" +
-                              $"  1. Add '.AddModule<{dependencyType.Name}>()' to your pipeline configuration before '.AddModule<{moduleState.ModuleType.Name}>()'\n" +
-                              $"  2. Use '[DependsOn<{dependencyType.Name}>(ignoreIfNotRegistered: true)]' if this dependency is optional\n" +
-                              $"  3. Check for typos in the dependency type name\n" +
-                              $"  4. Verify that '{dependencyType.Name}' is in a project referenced by your pipeline project";
-                throw new ModuleNotRegisteredException(message, null);
-            }
-        }
-    }
-
-    private IModuleLogger GetOrCreateLogger(Type moduleType, IServiceProvider scopedServiceProvider)
-    {
-        var loggerType = typeof(ModuleLogger<>).MakeGenericType(moduleType);
-        return _loggerContainer.GetLogger(loggerType)
-            ?? (IModuleLogger) scopedServiceProvider.GetRequiredService(loggerType);
-    }
-
-    private void RegisterTerminatedResultsForCancelledModules(IReadOnlyList<IModule> modules, Exception exception)
-    {
-        foreach (var module in modules)
-        {
-            var moduleType = module.GetType();
-
-            // Check if a result was already registered for this module
-            if (_resultRegistry.GetResult(moduleType) != null)
-            {
-                continue;
-            }
-
-            _logger.LogDebug("Registering PipelineTerminated result for cancelled module {ModuleName}",
-                MarkupFormatter.FormatModuleName(moduleType.Name));
-
-            RegisterTerminatedResult(module, moduleType, exception);
-        }
-    }
-
-    private void RegisterTerminatedResult(IModule module, Type moduleType, Exception exception)
-    {
-        var resultType = module.ResultType;
-
-        // Create execution context with PipelineTerminated status
-        var contextType = typeof(ModuleExecutionContext<>).MakeGenericType(resultType);
-        var executionContext = (ModuleExecutionContext) Activator.CreateInstance(contextType, module, moduleType)!;
-        executionContext.Status = Enums.Status.PipelineTerminated;
-        executionContext.Exception = exception;
-
-        // Create ModuleResult<T> with the exception
-        var resultGenericType = typeof(ModuleResult<>).MakeGenericType(resultType);
-        var result = (IModuleResult) Activator.CreateInstance(
-            resultGenericType,
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
-            null,
-            new object[] { exception, executionContext },
-            null)!;
-
-        _resultRegistry.RegisterResult(moduleType, result);
-    }
-
-    private async Task InvokeReadyEventAsync(
-        IModule module,
-        Type moduleType,
-        IReadOnlyList<Attribute> moduleAttributes,
-        DateTimeOffset readyTime,
-        IPipelineContext pipelineContext,
-        IServiceProvider scopedServiceProvider,
-        CancellationToken cancellationToken)
-    {
-        var receivers = _attributeEventService.GetReadyReceivers(moduleType);
-        if (receivers.Count == 0)
-        {
-            return;
-        }
-
-        var pipelineStartTime = _metricsCollector.GetPipelineStartTime() ?? readyTime;
-
-        var eventContext = new ModuleReadyContext(
-            module,
-            moduleType,
-            moduleAttributes,
-            readyTime,
-            pipelineStartTime,
-            pipelineContext,
-            scopedServiceProvider,
-            _metadataRegistry,
-            cancellationToken);
-
-        await _attributeEventInvoker.InvokeReadyReceiversAsync(receivers, eventContext).ConfigureAwait(false);
-    }
-
-    private async Task InvokeStartEventAsync(
-        IModule module,
-        Type moduleType,
-        IReadOnlyList<Attribute> moduleAttributes,
-        DateTimeOffset startTime,
-        IPipelineContext pipelineContext,
-        IServiceProvider scopedServiceProvider,
-        CancellationToken cancellationToken)
-    {
-        var receivers = _attributeEventService.GetStartReceivers(moduleType);
-        if (receivers.Count == 0)
-        {
-            return;
-        }
-
-        var eventContext = new ModuleEventContext(
-            module,
-            moduleType,
-            moduleAttributes,
-            startTime,
-            Enums.Status.Processing,
-            pipelineContext,
-            scopedServiceProvider,
-            _metadataRegistry,
-            cancellationToken);
-
-        await _attributeEventInvoker.InvokeStartReceiversAsync(receivers, eventContext).ConfigureAwait(false);
-    }
-
-    private async Task InvokeEndEventAsync(
-        IModule module,
-        Type moduleType,
-        IReadOnlyList<Attribute> moduleAttributes,
-        DateTimeOffset startTime,
-        Enums.Status status,
-        IPipelineContext pipelineContext,
-        IServiceProvider scopedServiceProvider,
-        IModuleResult result,
-        CancellationToken cancellationToken)
-    {
-        var receivers = _attributeEventService.GetEndReceivers(moduleType);
-        if (receivers.Count == 0)
-        {
-            return;
-        }
-
-        var eventContext = new ModuleEventContext(
-            module,
-            moduleType,
-            moduleAttributes,
-            startTime,
-            status,
-            pipelineContext,
-            scopedServiceProvider,
-            _metadataRegistry,
-            cancellationToken);
-
-        await _attributeEventInvoker.InvokeEndReceiversAsync(receivers, eventContext, (ModuleResult)result).ConfigureAwait(false);
-    }
-
-    private async Task InvokeFailedEventAsync(
-        IModule module,
-        Type moduleType,
-        IReadOnlyList<Attribute> moduleAttributes,
-        DateTimeOffset startTime,
-        IPipelineContext pipelineContext,
-        IServiceProvider scopedServiceProvider,
-        Exception exception,
-        CancellationToken cancellationToken)
-    {
-        var receivers = _attributeEventService.GetFailureReceivers(moduleType);
-        if (receivers.Count == 0)
-        {
-            return;
-        }
-
-        var eventContext = new ModuleEventContext(
-            module,
-            moduleType,
-            moduleAttributes,
-            startTime,
-            Enums.Status.Failed,
-            pipelineContext,
-            scopedServiceProvider,
-            _metadataRegistry,
-            cancellationToken);
-
-        await _attributeEventInvoker.InvokeFailureReceiversAsync(receivers, eventContext, exception).ConfigureAwait(false);
-    }
-
-    private async Task InvokeSkippedEventAsync(
-        IModule module,
-        Type moduleType,
-        IReadOnlyList<Attribute> moduleAttributes,
-        DateTimeOffset startTime,
-        Enums.Status status,
-        IPipelineContext pipelineContext,
-        IServiceProvider scopedServiceProvider,
-        SkipDecision skipReason,
-        CancellationToken cancellationToken)
-    {
-        var receivers = _attributeEventService.GetSkippedReceivers(moduleType);
-        if (receivers.Count == 0)
-        {
-            return;
-        }
-
-        var eventContext = new ModuleEventContext(
-            module,
-            moduleType,
-            moduleAttributes,
-            startTime,
-            status,
-            pipelineContext,
-            scopedServiceProvider,
-            _metadataRegistry,
-            cancellationToken);
-
-        await _attributeEventInvoker.InvokeSkippedReceiversAsync(receivers, eventContext, skipReason).ConfigureAwait(false);
     }
 }

--- a/src/ModularPipelines/Engine/ModuleSchedulerFactory.cs
+++ b/src/ModularPipelines/Engine/ModuleSchedulerFactory.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Engine.Scheduling;
 using ModularPipelines.Options;
 
 namespace ModularPipelines.Engine;
@@ -15,23 +16,26 @@ internal class ModuleSchedulerFactory : IModuleSchedulerFactory
     private readonly IOptions<SchedulerOptions> _schedulerOptions;
     private readonly IModuleDependencyRegistry _dependencyRegistry;
     private readonly IMetricsCollector _metricsCollector;
+    private readonly IModuleConstraintEvaluator _constraintEvaluator;
 
     public ModuleSchedulerFactory(
         ILogger<ModuleScheduler> logger,
         TimeProvider timeProvider,
         IOptions<SchedulerOptions> schedulerOptions,
         IModuleDependencyRegistry dependencyRegistry,
-        IMetricsCollector metricsCollector)
+        IMetricsCollector metricsCollector,
+        IModuleConstraintEvaluator constraintEvaluator)
     {
         _logger = logger;
         _timeProvider = timeProvider;
         _schedulerOptions = schedulerOptions;
         _dependencyRegistry = dependencyRegistry;
         _metricsCollector = metricsCollector;
+        _constraintEvaluator = constraintEvaluator;
     }
 
     public IModuleScheduler Create()
     {
-        return new ModuleScheduler(_logger, _timeProvider, _schedulerOptions, _dependencyRegistry, _metricsCollector);
+        return new ModuleScheduler(_logger, _timeProvider, _schedulerOptions, _dependencyRegistry, _metricsCollector, _constraintEvaluator);
     }
 }

--- a/src/ModularPipelines/Engine/Scheduling/IModuleConstraintEvaluator.cs
+++ b/src/ModularPipelines/Engine/Scheduling/IModuleConstraintEvaluator.cs
@@ -1,0 +1,26 @@
+namespace ModularPipelines.Engine.Scheduling;
+
+/// <summary>
+/// Responsible for evaluating module execution constraints such as
+/// NotInParallel attributes and lock key conflicts.
+/// </summary>
+internal interface IModuleConstraintEvaluator
+{
+    /// <summary>
+    /// Determines if a module can be queued for execution given the currently active modules.
+    /// This is called during the scheduling phase before a module is put in the queue.
+    /// </summary>
+    /// <param name="moduleState">The module to evaluate.</param>
+    /// <param name="activeModules">Modules that are currently queued or executing.</param>
+    /// <returns>True if the module can be queued, false if constraints prevent it.</returns>
+    bool CanQueue(ModuleState moduleState, IEnumerable<ModuleState> activeModules);
+
+    /// <summary>
+    /// Determines if a module can start execution given the currently executing modules.
+    /// This is called at the execution boundary, just before a module begins running.
+    /// </summary>
+    /// <param name="moduleState">The module to evaluate.</param>
+    /// <param name="executingModules">Modules that are currently executing.</param>
+    /// <returns>True if the module can start execution, false if constraints prevent it.</returns>
+    bool CanStartExecution(ModuleState moduleState, IEnumerable<ModuleState> executingModules);
+}

--- a/src/ModularPipelines/Engine/Scheduling/ModuleConstraintEvaluator.cs
+++ b/src/ModularPipelines/Engine/Scheduling/ModuleConstraintEvaluator.cs
@@ -1,0 +1,133 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Helpers;
+
+namespace ModularPipelines.Engine.Scheduling;
+
+/// <summary>
+/// Evaluates module execution constraints (NotInParallel, lock keys).
+/// </summary>
+internal class ModuleConstraintEvaluator : IModuleConstraintEvaluator
+{
+    private readonly ILogger<ModuleConstraintEvaluator> _logger;
+
+    public ModuleConstraintEvaluator(ILogger<ModuleConstraintEvaluator> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public bool CanQueue(ModuleState moduleState, IEnumerable<ModuleState> activeModules)
+    {
+        var activeList = activeModules.ToList();
+
+        // Check lock key conflicts
+        if (!CheckLockKeyConstraints(moduleState, activeList, logBlocking: false))
+        {
+            return false;
+        }
+
+        // Check sequential execution constraints
+        if (!CheckSequentialConstraints(moduleState, activeList, logBlocking: false))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public bool CanStartExecution(ModuleState moduleState, IEnumerable<ModuleState> executingModules)
+    {
+        var executingList = executingModules.ToList();
+
+        // Primary constraint check: verify no executing module has conflicting lock keys
+        if (!CheckLockKeyConstraints(moduleState, executingList, logBlocking: true))
+        {
+            return false;
+        }
+
+        // Secondary check: sequential execution constraints
+        if (!CheckSequentialConstraints(moduleState, executingList, logBlocking: true))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool CheckLockKeyConstraints(ModuleState moduleState, List<ModuleState> otherModules, bool logBlocking)
+    {
+        if (moduleState.RequiredLockKeys.Length == 0)
+        {
+            return true;
+        }
+
+        foreach (var other in otherModules)
+        {
+            if (other == moduleState)
+            {
+                continue;
+            }
+
+            if (other.RequiredLockKeys.Length == 0)
+            {
+                continue;
+            }
+
+            var intersection = other.RequiredLockKeys.Intersect(moduleState.RequiredLockKeys).ToArray();
+            if (intersection.Length > 0)
+            {
+                if (logBlocking)
+                {
+                    _logger.LogDebug(
+                        "Module {ModuleName} BLOCKED - {OtherModule} has conflicting keys [{Keys}]",
+                        MarkupFormatter.FormatModuleName(moduleState.ModuleType.Name),
+                        MarkupFormatter.FormatModuleName(other.ModuleType.Name),
+                        string.Join(", ", intersection));
+                }
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private bool CheckSequentialConstraints(ModuleState moduleState, List<ModuleState> otherModules, bool logBlocking)
+    {
+        var otherActiveModules = otherModules.Where(m => m != moduleState).ToList();
+
+        // If this module requires sequential execution, no other modules can be active
+        if (moduleState.RequiresSequentialExecution && otherActiveModules.Count > 0)
+        {
+            if (logBlocking)
+            {
+                _logger.LogDebug(
+                    "Sequential module {ModuleName} blocked - {Count} modules already active",
+                    MarkupFormatter.FormatModuleName(moduleState.ModuleType.Name),
+                    otherActiveModules.Count);
+            }
+
+            return false;
+        }
+
+        // If any other active module requires sequential execution, this module is blocked
+        foreach (var other in otherActiveModules)
+        {
+            if (other.RequiresSequentialExecution)
+            {
+                if (logBlocking)
+                {
+                    _logger.LogDebug(
+                        "Module {ModuleName} blocked by sequential module {SequentialModule}",
+                        MarkupFormatter.FormatModuleName(moduleState.ModuleType.Name),
+                        MarkupFormatter.FormatModuleName(other.ModuleType.Name));
+                }
+
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- Extract 6 single-responsibility components from ModuleExecutor (779→218 lines, 21→9 dependencies):
  - `IModuleResultRegistrar`: Registers module execution results
  - `IParallelLimitHandler`: Manages parallel execution semaphore
  - `IDependencyWaiter`: Waits for module dependencies to complete
  - `IModuleLifecycleEventInvoker`: Invokes module lifecycle hooks
  - `IModuleRunner`: Executes individual modules with retry/timeout
  - `IAlwaysRunHandler`: Handles AlwaysRun modules after pipeline failure
- Extract `IModuleConstraintEvaluator` from ModuleScheduler for NotInParallel and lock key constraint evaluation

## Benefits
- **Improved testability**: Each component can be unit tested in isolation
- **Better maintainability**: Smaller, focused classes are easier to understand and modify
- **Enhanced extensibility**: Components can be replaced or extended via DI

## Test Plan
- [x] All existing unit tests pass (388 passed)
- [x] Build succeeds with no errors
- [x] Code follows existing patterns and conventions

Closes #1421

🤖 Generated with [Claude Code](https://claude.com/claude-code)