### PR TITLE
fix: Use proper path APIs in Folder.CopyTo() instead of string replacement

### DIFF
--- a/src/ModularPipelines/FileSystem/Folder.cs
+++ b/src/ModularPipelines/FileSystem/Folder.cs
@@ -111,12 +111,16 @@ public class Folder : IEquatable<Folder>
 
         foreach (var dirPath in Directory.EnumerateDirectories(this, "*", SearchOption.AllDirectories))
         {
-            Directory.CreateDirectory(dirPath.Replace(this, targetPath));
+            var relativePath = System.IO.Path.GetRelativePath(this, dirPath);
+            var newPath = System.IO.Path.Combine(targetPath, relativePath);
+            Directory.CreateDirectory(newPath);
         }
 
-        foreach (var newPath in Directory.EnumerateFiles(this, "*", SearchOption.AllDirectories))
+        foreach (var filePath in Directory.EnumerateFiles(this, "*", SearchOption.AllDirectories))
         {
-            System.IO.File.Copy(newPath, newPath.Replace(this, targetPath), true);
+            var relativePath = System.IO.Path.GetRelativePath(this, filePath);
+            var newPath = System.IO.Path.Combine(targetPath, relativePath);
+            System.IO.File.Copy(filePath, newPath, true);
         }
 
         ModuleLogger.Current.LogInformation("Copying Folder: {Source} > {Destination}", this, targetPath);


### PR DESCRIPTION
## Summary

- Replaced brittle string replacement (`dirPath.Replace(this, targetPath)`) with proper path APIs (`Path.GetRelativePath()` and `Path.Combine()`)
- Fixes correctness and security issues when source path contains the same substring multiple times
- The previous implementation could corrupt paths in edge cases

## Changes

**Before:**
```csharp
Directory.CreateDirectory(dirPath.Replace(this, targetPath));
System.IO.File.Copy(newPath, newPath.Replace(this, targetPath), true);
```

**After:**
```csharp
var relativePath = System.IO.Path.GetRelativePath(this, dirPath);
var newPath = System.IO.Path.Combine(targetPath, relativePath);
Directory.CreateDirectory(newPath);
```

Fixes #1453

## Test plan

- [ ] Build succeeds
- [ ] Existing tests pass
- [ ] The fix correctly handles edge cases where source path contains repeated substrings

🤖 Generated with [Claude Code](https://claude.com/claude-code)