### PR TITLE
refactor: Consolidate duplicated generator logic into GeneratorUtils

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GlobalOptionsBaseGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GlobalOptionsBaseGenerator.cs
@@ -88,85 +88,19 @@ public class GlobalOptionsBaseGenerator : ICodeGenerator
     private static void GenerateProperty(StringBuilder sb, CliOptionDefinition option)
     {
         // XML documentation
-        if (!string.IsNullOrEmpty(option.Description))
-        {
-            sb.AppendLine("    /// <summary>");
-            sb.AppendLine($"    /// {EscapeXmlComment(option.Description)}");
-            sb.AppendLine("    /// </summary>");
-        }
+        GeneratorUtils.GenerateXmlDocumentation(sb, option.Description);
 
         // Validation attributes
         if (option.ValidationConstraints is not null)
         {
-            GenerateValidationAttributes(sb, option.ValidationConstraints);
+            GeneratorUtils.GenerateValidationAttributes(sb, option.ValidationConstraints);
         }
 
         // Command attribute
-        var attribute = GetAttributeString(option);
+        var attribute = GeneratorUtils.GenerateCliAttributeString(option);
         sb.AppendLine($"    [{attribute}]");
 
         // Property
         sb.AppendLine($"    public virtual {option.CSharpType} {option.PropertyName} {{ get; set; }}");
     }
-
-    private static void GenerateValidationAttributes(StringBuilder sb, CliValidationConstraints constraints)
-    {
-        if (constraints.MinValue.HasValue || constraints.MaxValue.HasValue)
-        {
-            var min = constraints.MinValue ?? int.MinValue;
-            var max = constraints.MaxValue ?? int.MaxValue;
-            sb.AppendLine($"    [Range({min}, {max})]");
-        }
-
-        if (!string.IsNullOrEmpty(constraints.Pattern))
-        {
-            sb.AppendLine($"    [RegularExpression(@\"{constraints.Pattern}\")]");
-        }
-    }
-
-    private static string GetAttributeString(CliOptionDefinition option)
-    {
-        if (option.IsFlag)
-        {
-            // Use CliFlag for boolean flags
-            var parts = new List<string> { $"\"{option.SwitchName}\"" };
-
-            if (!string.IsNullOrEmpty(option.ShortForm))
-            {
-                parts.Add($"ShortForm = \"{option.ShortForm}\"");
-            }
-
-            return $"CliFlag({string.Join(", ", parts)})";
-        }
-
-        // Use CliOption for value options
-        var optionParts = new List<string> { $"\"{option.SwitchName}\"" };
-
-        if (!string.IsNullOrEmpty(option.ShortForm))
-        {
-            optionParts.Add($"ShortForm = \"{option.ShortForm}\"");
-        }
-
-        if (option.ValueSeparator == "=")
-        {
-            optionParts.Add("Format = OptionFormat.EqualsSeparated");
-        }
-        else if (option.ValueSeparator == ":")
-        {
-            optionParts.Add("Format = OptionFormat.ColonSeparated");
-        }
-        else if (option.ValueSeparator != " " && !string.IsNullOrEmpty(option.ValueSeparator))
-        {
-            optionParts.Add($"CustomSeparator = \"{option.ValueSeparator}\"");
-        }
-
-        if (option.AcceptsMultipleValues)
-        {
-            optionParts.Add("AllowMultiple = true");
-        }
-
-        return $"CliOption({string.Join(", ", optionParts)})";
-    }
-
-    private static string EscapeXmlComment(string text) => GeneratorUtils.EscapeXmlComment(text);
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -65,12 +65,7 @@ public class OptionsClassGenerator : ICodeGenerator
         sb.AppendLine();
 
         // XML documentation
-        if (!string.IsNullOrEmpty(command.Description))
-        {
-            sb.AppendLine("/// <summary>");
-            sb.AppendLine($"/// {EscapeXmlComment(command.Description)}");
-            sb.AppendLine("/// </summary>");
-        }
+        GeneratorUtils.GenerateXmlDocumentation(sb, command.Description, "");
 
         // Class attributes
         sb.AppendLine("[ExcludeFromCodeCoverage]");
@@ -133,7 +128,7 @@ public class OptionsClassGenerator : ICodeGenerator
 
             foreach (var opt in requiredOptions)
             {
-                var attr = GetAttributeString(opt);
+                var attr = GeneratorUtils.GenerateCliAttributeString(opt);
                 parameters.Add($"    [property: {attr}] {opt.CSharpType.TrimEnd('?')} {opt.PropertyName}");
                 existingNames.Add(opt.PropertyName);
             }
@@ -162,94 +157,25 @@ public class OptionsClassGenerator : ICodeGenerator
     private static void GenerateProperty(StringBuilder sb, CliOptionDefinition option)
     {
         // XML documentation
-        if (!string.IsNullOrEmpty(option.Description))
-        {
-            sb.AppendLine("    /// <summary>");
-            sb.AppendLine($"    /// {EscapeXmlComment(option.Description)}");
-            sb.AppendLine("    /// </summary>");
-        }
+        GeneratorUtils.GenerateXmlDocumentation(sb, option.Description);
 
         // Validation attributes
         if (option.ValidationConstraints is not null)
         {
-            GenerateValidationAttributes(sb, option.ValidationConstraints);
+            GeneratorUtils.GenerateValidationAttributes(sb, option.ValidationConstraints);
         }
 
         // Command attribute
-        var attribute = GetAttributeString(option);
+        var attribute = GeneratorUtils.GenerateCliAttributeString(option);
         sb.AppendLine($"    [{attribute}]");
 
         // Property
         sb.AppendLine($"    public {option.CSharpType} {option.PropertyName} {{ get; set; }}");
     }
 
-    private static void GenerateValidationAttributes(StringBuilder sb, CliValidationConstraints constraints)
-    {
-        if (constraints.MinValue.HasValue || constraints.MaxValue.HasValue)
-        {
-            var min = constraints.MinValue ?? int.MinValue;
-            var max = constraints.MaxValue ?? int.MaxValue;
-            sb.AppendLine($"    [Range({min}, {max})]");
-        }
-
-        if (!string.IsNullOrEmpty(constraints.Pattern))
-        {
-            sb.AppendLine($"    [RegularExpression(@\"{constraints.Pattern}\")]");
-        }
-    }
-
-    private static string GetAttributeString(CliOptionDefinition option)
-    {
-        if (option.IsFlag)
-        {
-            // Use CliFlag for boolean flags
-            var parts = new List<string> { $"\"{option.SwitchName}\"" };
-
-            if (!string.IsNullOrEmpty(option.ShortForm))
-            {
-                parts.Add($"ShortForm = \"{option.ShortForm}\"");
-            }
-
-            return $"CliFlag({string.Join(", ", parts)})";
-        }
-
-        // Use CliOption for value options
-        var optionParts = new List<string> { $"\"{option.SwitchName}\"" };
-
-        if (!string.IsNullOrEmpty(option.ShortForm))
-        {
-            optionParts.Add($"ShortForm = \"{option.ShortForm}\"");
-        }
-
-        if (option.ValueSeparator == "=")
-        {
-            optionParts.Add("Format = OptionFormat.EqualsSeparated");
-        }
-        else if (option.ValueSeparator == ":")
-        {
-            optionParts.Add("Format = OptionFormat.ColonSeparated");
-        }
-        else if (option.ValueSeparator != " " && !string.IsNullOrEmpty(option.ValueSeparator))
-        {
-            optionParts.Add($"CustomSeparator = \"{option.ValueSeparator}\"");
-        }
-
-        if (option.AcceptsMultipleValues)
-        {
-            optionParts.Add("AllowMultiple = true");
-        }
-
-        return $"CliOption({string.Join(", ", optionParts)})";
-    }
-
     private static void GeneratePositionalArgument(StringBuilder sb, CliPositionalArgument positional)
     {
-        if (!string.IsNullOrEmpty(positional.Description))
-        {
-            sb.AppendLine("    /// <summary>");
-            sb.AppendLine($"    /// {EscapeXmlComment(positional.Description)}");
-            sb.AppendLine("    /// </summary>");
-        }
+        GeneratorUtils.GenerateXmlDocumentation(sb, positional.Description);
 
         var attrString = GetPositionalAttributeString(positional);
         sb.AppendLine($"    [{attrString}]");
@@ -282,6 +208,4 @@ public class OptionsClassGenerator : ICodeGenerator
 
         return $"CliArgument({string.Join(", ", parts)})";
     }
-
-    private static string EscapeXmlComment(string text) => GeneratorUtils.EscapeXmlComment(text);
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
@@ -138,7 +138,7 @@ public class ServiceImplementationGenerator : ICodeGenerator
             StringComparer.OrdinalIgnoreCase);
 
         var nonCollidingRootCommands = rootCommands
-            .Where(c => !subDomainNames.Contains(GenerateMethodName(c)))
+            .Where(c => !subDomainNames.Contains(GeneratorUtils.GenerateMethodNameFromCommandParts(c.CommandParts)))
             .ToList();
 
         if (nonCollidingRootCommands.Count > 0)
@@ -162,7 +162,7 @@ public class ServiceImplementationGenerator : ICodeGenerator
 
     private static void GenerateMethod(StringBuilder sb, CliCommandDefinition command, CliToolDefinition tool)
     {
-        var methodName = GenerateMethodName(command);
+        var methodName = GeneratorUtils.GenerateMethodNameFromCommandParts(command.CommandParts);
         var hasRequiredParams = command.RequiredOptions.Count > 0 ||
                                 command.PositionalArguments.Any(p => p.IsRequired);
 
@@ -189,15 +189,5 @@ public class ServiceImplementationGenerator : ICodeGenerator
         }
 
         sb.AppendLine("    }");
-    }
-
-    private static string GenerateMethodName(CliCommandDefinition command)
-    {
-        // Convert command parts to method name
-        // e.g., ["container", "create"] -> "ContainerCreate"
-        // Handle hyphens within parts (e.g., "build-server" -> "BuildServer")
-        return string.Join("", command.CommandParts
-            .SelectMany(p => p.Split('-', StringSplitOptions.RemoveEmptyEntries))
-            .Select(p => char.ToUpperInvariant(p[0]) + p[1..].ToLowerInvariant()));
     }
 }


### PR DESCRIPTION
## Summary
- Moved shared code generation logic from 4 generator files to `GeneratorUtils.cs`
- Added 4 new utility methods: `GenerateCliAttributeString()`, `GenerateValidationAttributes()`, `GenerateXmlDocumentation()`, `GenerateMethodNameFromCommandParts()`, and `GenerateMethodNameFromLastCommandPart()`
- Reduced ~80 lines of duplicated code across `OptionsClassGenerator.cs`, `GlobalOptionsBaseGenerator.cs`, `ServiceInterfaceGenerator.cs`, `ServiceImplementationGenerator.cs`, and `SubDomainClassGenerator.cs`

## Details
The following duplicated logic has been consolidated:

| Method | Description | Previously Duplicated In |
|--------|-------------|--------------------------|
| `GenerateCliAttributeString()` | Generates CliFlag/CliOption attribute strings | OptionsClassGenerator, GlobalOptionsBaseGenerator |
| `GenerateValidationAttributes()` | Generates Range/RegularExpression attributes | OptionsClassGenerator, GlobalOptionsBaseGenerator |
| `GenerateXmlDocumentation()` | Generates XML summary blocks | All 5 generator files |
| `GenerateMethodNameFromCommandParts()` | Converts command parts to PascalCase method name | ServiceInterfaceGenerator, ServiceImplementationGenerator |
| `GenerateMethodNameFromLastCommandPart()` | Generates method name from last command segment | SubDomainClassGenerator |

Fixes #1456

## Test plan
- [x] Build succeeds: `dotnet build tools/ModularPipelines.OptionsGenerator`
- [ ] All existing tests pass
- [ ] Generated code output is identical (no behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)