### PR TITLE
refactor: Replace magic numbers with named constants

### DIFF
--- a/src/ModularPipelines.Build/BuildConstants.cs
+++ b/src/ModularPipelines.Build/BuildConstants.cs
@@ -1,7 +1,15 @@
 namespace ModularPipelines.Build;
 
+/// <summary>
+/// Constants used for build configuration.
+/// </summary>
 public static class BuildConstants
 {
     public const string Owner = "thomhurst";
     public const string RepositoryName = "ModularPipelines";
+
+    /// <summary>
+    /// The target framework for running tests.
+    /// </summary>
+    public const string TestFramework = "net10.0";
 }

--- a/src/ModularPipelines.Build/Modules/RunUnitTestsModule.cs
+++ b/src/ModularPipelines.Build/Modules/RunUnitTestsModule.cs
@@ -30,7 +30,7 @@ public class RunUnitTestsModule : Module<CommandResult[]>, IRetryable<CommandRes
             {
                 Project = unitTestProjectFile.Path,
                 NoBuild = true,
-                Framework = "net10.0",
+                Framework = BuildConstants.TestFramework,
                 Arguments = ["--coverage", "--coverage-output-format", "cobertura"],
                 Configuration = Configuration.Release,
                 EnvironmentVariables = new Dictionary<string, string?>

--- a/src/ModularPipelines/Constants/ConcurrencyConstants.cs
+++ b/src/ModularPipelines/Constants/ConcurrencyConstants.cs
@@ -1,0 +1,12 @@
+namespace ModularPipelines.Constants;
+
+/// <summary>
+/// Constants used for concurrency and parallelism configuration.
+/// </summary>
+internal static class ConcurrencyConstants
+{
+    /// <summary>
+    /// The multiplier applied to ProcessorCount to calculate default maximum parallelism.
+    /// </summary>
+    public const int ParallelismMultiplier = 4;
+}

--- a/src/ModularPipelines/Constants/LoggingConstants.cs
+++ b/src/ModularPipelines/Constants/LoggingConstants.cs
@@ -1,0 +1,27 @@
+namespace ModularPipelines.Constants;
+
+/// <summary>
+/// Constants used for logging and output formatting.
+/// </summary>
+internal static class LoggingConstants
+{
+    /// <summary>
+    /// The string used to mask secret values in logs.
+    /// </summary>
+    public const string SecretMask = "**********";
+
+    /// <summary>
+    /// The string used to mask command arguments when they should not be displayed.
+    /// </summary>
+    public const string CommandMask = "********";
+
+    /// <summary>
+    /// Default maximum body size (4KB) for HTTP logging.
+    /// </summary>
+    public const int DefaultMaxBodySizeToLog = 4096;
+
+    /// <summary>
+    /// Full logging maximum body size (64KB) for HTTP logging.
+    /// </summary>
+    public const int FullLoggingMaxBodySize = 65536;
+}

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Initialization.Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Constants;
 
 namespace ModularPipelines.Engine;
 
@@ -30,7 +31,7 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         {
             if (input.Contains(secret))
             {
-                stringBuilder.Replace(secret, "**********");
+                stringBuilder.Replace(secret, LoggingConstants.SecretMask);
             }
         }
 

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using ModularPipelines.Constants;
 using ModularPipelines.Engine;
 using ModularPipelines.Enums;
 using ModularPipelines.Helpers;
@@ -130,7 +131,7 @@ internal class CommandLogger : ICommandLogger
         }
         else
         {
-            Logger.LogInformation("{Timestamp}Command: {WorkingDirectory}> ********",
+            Logger.LogInformation("{Timestamp}Command: {WorkingDirectory}> " + LoggingConstants.CommandMask,
                 timestamp,
                 workingDirectory);
         }

--- a/src/ModularPipelines/Options/ConcurrencyOptions.cs
+++ b/src/ModularPipelines/Options/ConcurrencyOptions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Constants;
 
 namespace ModularPipelines.Options;
 
@@ -22,7 +23,7 @@ public record ConcurrencyOptions
     /// options.Concurrency.MaxParallelism = int.MaxValue;
     /// </code>
     /// </example>
-    public int MaxParallelism { get; set; } = Environment.ProcessorCount * 4;
+    public int MaxParallelism { get; set; } = Environment.ProcessorCount * ConcurrencyConstants.ParallelismMultiplier;
 
     /// <summary>
     /// Gets or sets the maximum number of CPU-intensive modules that can execute concurrently.

--- a/src/ModularPipelines/Options/HttpLoggingOptions.cs
+++ b/src/ModularPipelines/Options/HttpLoggingOptions.cs
@@ -1,3 +1,5 @@
+using ModularPipelines.Constants;
+
 namespace ModularPipelines.Options;
 
 /// <summary>
@@ -67,7 +69,7 @@ public record HttpLoggingOptions
     /// Bodies larger than this will be truncated with a message indicating the full size.
     /// Set to 0 or negative to disable truncation.
     /// </summary>
-    public int MaxBodySizeToLog { get; init; } = 4096;
+    public int MaxBodySizeToLog { get; init; } = LoggingConstants.DefaultMaxBodySizeToLog;
 
     /// <summary>
     /// Default logging options (all logging enabled, 4KB body limit).
@@ -132,6 +134,6 @@ public record HttpLoggingOptions
         LogResponseBody = true,
         LogStatusCode = true,
         LogDuration = true,
-        MaxBodySizeToLog = 65536,
+        MaxBodySizeToLog = LoggingConstants.FullLoggingMaxBodySize,
     };
 }


### PR DESCRIPTION
## Summary

- Created `LoggingConstants` class with `SecretMask`, `CommandMask`, `DefaultMaxBodySizeToLog`, and `FullLoggingMaxBodySize` constants
- Created `ConcurrencyConstants` class with `ParallelismMultiplier` constant
- Added `TestFramework` constant to existing `BuildConstants` class
- Updated all usages to reference the named constants instead of hardcoded values

## Files Changed

**Core Library (`src/ModularPipelines/`):**
- `Constants/LoggingConstants.cs` - New file with logging-related constants
- `Constants/ConcurrencyConstants.cs` - New file with concurrency-related constants
- `Engine/SecretObfuscator.cs` - Uses `LoggingConstants.SecretMask`
- `Logging/CommandLogger.cs` - Uses `LoggingConstants.CommandMask`
- `Options/HttpLoggingOptions.cs` - Uses `LoggingConstants.DefaultMaxBodySizeToLog` and `FullLoggingMaxBodySize`
- `Options/ConcurrencyOptions.cs` - Uses `ConcurrencyConstants.ParallelismMultiplier`

**Build Project (`src/ModularPipelines.Build/`):**
- `BuildConstants.cs` - Added `TestFramework` constant
- `Modules/RunUnitTestsModule.cs` - Uses `BuildConstants.TestFramework`

## Test plan

- [x] Core library builds successfully with named constants
- [x] All magic numbers replaced with descriptive constant names
- [x] Constants are appropriately scoped (internal for core library, public for build)

Fixes #1457

🤖 Generated with [Claude Code](https://claude.com/claude-code)