### PR TITLE
refactor: Improve build module quality - remove incorrect attribute and fix null reference

### DIFF
--- a/src/ModularPipelines.Build/Modules/DependabotCommitsModule.cs
+++ b/src/ModularPipelines.Build/Modules/DependabotCommitsModule.cs
@@ -26,7 +26,7 @@ public class DependabotCommitsModule : Module<List<string>>
             });
 
         var commits = commitsSinceRelease
-            .Where(x => x.Author.Login.StartsWith("dependabot") || x.Author.Login.StartsWith("renovate-bot"))
+            .Where(x => x.Author?.Login.StartsWith("dependabot") == true || x.Author?.Login.StartsWith("renovate-bot") == true)
             .Select(x => x.Commit.Message.Split(Environment.NewLine))
             .Select(x => x.FirstOrDefault())
             .OfType<string>()

--- a/src/ModularPipelines.Build/Modules/LocalMachine/UploadPackagesToLocalNuGetModule.cs
+++ b/src/ModularPipelines.Build/Modules/LocalMachine/UploadPackagesToLocalNuGetModule.cs
@@ -12,7 +12,6 @@ namespace ModularPipelines.Build.Modules.LocalMachine;
 [DependsOn<AddLocalNugetSourceModule>]
 [DependsOn<PackagePathsParserModule>]
 [DependsOn<CreateLocalNugetFolderModule>]
-[RunOnLinuxOnly]
 public class UploadPackagesToLocalNuGetModule : Module<CommandResult[]>
 {
     public override async Task<CommandResult[]?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- Remove `[RunOnLinuxOnly]` attribute from `UploadPackagesToLocalNuGetModule` - local NuGet development works on any platform, the attribute was misleading (Fixes #1651)
- Add null-conditional operator for `Author` in `DependabotCommitsModule` LINQ query - GitHub API can return commits where Author is null (Fixes #1647)

## Test plan
- [x] Verified changes compile successfully (GitHub project builds)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.ai/code)