### PR TITLE
refactor: Add error handling for file parsing and zip creation

### DIFF
--- a/src/ModularPipelines/Context/Zip.cs
+++ b/src/ModularPipelines/Context/Zip.cs
@@ -18,6 +18,11 @@ internal class Zip : IZip
 
         ZipFile.CreateFromDirectory(folder.Path, outputPath, compressionLevel, false);
 
+        if (!System.IO.File.Exists(outputPath))
+        {
+            throw new InvalidOperationException($"Failed to create zip file at '{outputPath}'.");
+        }
+
         return new File(outputPath);
     }
 

--- a/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
+++ b/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
@@ -70,8 +70,16 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
 
         if (File.Exists(path))
         {
-            var contents = await File.ReadAllTextAsync(path).ConfigureAwait(false);
-            return TimeSpan.Parse(contents);
+            try
+            {
+                var contents = await File.ReadAllTextAsync(path).ConfigureAwait(false);
+                return TimeSpan.Parse(contents);
+            }
+            catch (FormatException)
+            {
+                // File contains malformed content - return default fallback
+                return TimeSpan.FromMinutes(2);
+            }
         }
 
         // Some default fallback. We can't estimate for now so we'll estimate next time.


### PR DESCRIPTION
## Summary
- **FileSystemModuleEstimatedTimeProvider**: Add try/catch around `TimeSpan.Parse` to gracefully handle malformed content by returning the default fallback value (2 minutes)
- **Zip.ZipFolder**: Verify zip file was created successfully after calling `ZipFile.CreateFromDirectory` and throw `InvalidOperationException` if the file does not exist

## Test plan
- [ ] Build succeeds
- [ ] Verify `GetEstimatedTimeAsync` returns fallback for malformed file content
- [ ] Verify `ZipFolder` throws exception when file creation fails

Fixes #1635
Fixes #1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)