### PR TITLE
refactor: Fix documentation grammar and improve exception handling

### DIFF
--- a/src/ModularPipelines.Git/GitInformation.cs
+++ b/src/ModularPipelines.Git/GitInformation.cs
@@ -112,8 +112,12 @@ internal class GitInformation : IGitInformation, IInitializer
                 .FirstOrDefault(x => x.StartsWith("HEAD branch:"))
                 ?.Split("HEAD branch: ")[1];
         }
-        catch
+        catch (Exception ex)
         {
+            // Fallback: If 'git remote show origin' fails (e.g., no remote configured, network issues,
+            // or shallow clone), try parsing origin/HEAD reference instead. This provides a best-effort
+            // approach to determine the default branch in various git repository states.
+            logger.LogDebug(ex, "Failed to get default branch from 'git remote show origin', falling back to origin/HEAD");
             var output = await GetOutput(command, logger, new GitRevParseOptions
             {
                 Arguments = ["origin/HEAD"],

--- a/src/ModularPipelines/Options/HttpOptions.cs
+++ b/src/ModularPipelines/Options/HttpOptions.cs
@@ -19,7 +19,7 @@ public record HttpOptions(HttpRequestMessage HttpRequestMessage)
     public bool ThrowOnNonSuccessStatusCode { get; set; }
 
     /// <summary>
-    /// Gets and sets the logging for the HTTP request.
+    /// Gets or sets the logging for the HTTP request.
     /// Controls which handlers are used (Request, Response, StatusCode, Duration).
     /// For fine-grained control over what gets logged within those handlers, use <see cref="LogSettings"/>.
     /// </summary>


### PR DESCRIPTION
## Summary

- Fix grammatical error in `HttpOptions.LoggingType` documentation: "Gets and sets" -> "Gets or sets" (Fixes #1616)
- Add logging and explanatory comment to `GetDefaultBranchName` catch block in `GitInformation.cs` (Fixes #1617)
  - The empty catch was intentional fallback behavior when `git remote show origin` fails
  - Now properly documented with a comment explaining the fallback strategy
  - Added `LogDebug` call to log the exception at Debug level

## Test plan

- [ ] Verify `HttpOptions.cs` documentation grammar is corrected
- [ ] Verify `GitInformation.cs` catch block now has proper logging and documentation
- [ ] Build succeeds for both `ModularPipelines` and `ModularPipelines.Git` projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)