### PR TITLE
refactor: Replace int.Parse with TryParse for safe parsing

### DIFF
--- a/src/ModularPipelines.Build/Attributes/SkipIfDependencyPullRequest.cs
+++ b/src/ModularPipelines.Build/Attributes/SkipIfDependencyPullRequest.cs
@@ -1,4 +1,4 @@
-﻿using ModularPipelines.Attributes;
+using ModularPipelines.Attributes;
 using ModularPipelines.Context;
 using ModularPipelines.GitHub.Extensions;
 
@@ -15,9 +15,18 @@ public class SkipIfDependencyPullRequest : MandatoryRunConditionAttribute
             return true;
         }
 
-        var prNumber = int.Parse(gitHubEnvironmentVariables.RefName!.Split('/').First());
+        var refNamePart = gitHubEnvironmentVariables.RefName?.Split('/').FirstOrDefault();
+        if (!int.TryParse(refNamePart, out var prNumber))
+        {
+            return true;
+        }
 
-        var pr = await pipelineContext.GitHub().Client.PullRequest.Get(int.Parse(gitHubEnvironmentVariables.RepositoryId!), prNumber);
+        if (!long.TryParse(gitHubEnvironmentVariables.RepositoryId, out var repositoryId))
+        {
+            return true;
+        }
+
+        var pr = await pipelineContext.GitHub().Client.PullRequest.Get(repositoryId, prNumber);
 
         return pr.Labels.All(x => x.Name != "dependencies");
     }

--- a/src/ModularPipelines.Build/Modules/CreateReleaseModule.cs
+++ b/src/ModularPipelines.Build/Modules/CreateReleaseModule.cs
@@ -53,7 +53,13 @@ public class CreateReleaseModule : Module<Release>, ISkippable, IIgnoreFailures
     {
         var versionInfoResult = context.GetModule<NugetVersionGeneratorModule, string>();
 
-        return await context.GitHub().Client.Repository.Release.Create(long.Parse(context.GitHub().EnvironmentVariables.RepositoryId!),
+        var repositoryIdString = context.GitHub().EnvironmentVariables.RepositoryId;
+        if (!long.TryParse(repositoryIdString, out var repositoryId))
+        {
+            throw new InvalidOperationException($"Failed to parse RepositoryId '{repositoryIdString}' as a valid long integer.");
+        }
+
+        return await context.GitHub().Client.Repository.Release.Create(repositoryId,
             new NewRelease($"v{versionInfoResult.Value}")
             {
                 Name = versionInfoResult.Value,


### PR DESCRIPTION
## Summary
- Replace unsafe `int.Parse`/`long.Parse` with `TryParse` for proper error handling in build modules
- **SkipIfDependencyPullRequest**: Handle invalid `RefName` and `RepositoryId` gracefully by returning `true` (skip the check) instead of throwing `FormatException`
- **CreateReleaseModule**: Throw clear `InvalidOperationException` with context if `RepositoryId` parsing fails

## Test plan
- [ ] Verify build compiles successfully (note: pre-existing `Sourcy` source generator issues exist in `FindProjectsModule.cs` unrelated to this change)
- [ ] Manual testing: If `RefName` or `RepositoryId` are invalid/missing, the PR check is skipped gracefully
- [ ] Manual testing: If `RepositoryId` is invalid in CreateReleaseModule, a clear error is thrown

Fixes #1641
Fixes #1642

🤖 Generated with [Claude Code](https://claude.com/claude-code)