### PR TITLE
fix: Replace exception flow control with early return and add CancellationToken to HTTP formatters

### DIFF
--- a/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
+++ b/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
 using ModularPipelines.Build.Attributes;
@@ -93,7 +94,9 @@ public class FormatMarkdownModule : Module<CommandResult>, ISkippable, IAlwaysRu
         await GitHelpers.CommitAndPush(context, branchTriggeringPullRequest, "Formatting Markdown", _gitHubSettings.Value.StandardToken!,
             cancellationToken);
 
-        // Fail this run - The git push will trigger a new run
-        throw new Exception("Formatting Markdown. This run will abort. Another run will trigger with the formatted markdown.");
+        // Log that we're completing early - the git push will trigger a new run
+        context.Logger.LogInformation("Formatting Markdown complete. The git push will trigger a new run with the formatted markdown.");
+
+        return null;
     }
 }

--- a/src/ModularPipelines/Http/HttpRequestFormatter.cs
+++ b/src/ModularPipelines/Http/HttpRequestFormatter.cs
@@ -40,12 +40,12 @@ internal class HttpRequestFormatter : IHttpRequestFormatter
         "application/javascript",
     };
 
-    public Task<string> FormatAsync(HttpRequestMessage request)
+    public Task<string> FormatAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
     {
-        return FormatAsync(request, HttpLoggingOptions.Default);
+        return FormatAsync(request, HttpLoggingOptions.Default, cancellationToken);
     }
 
-    public async Task<string> FormatAsync(HttpRequestMessage request, HttpLoggingOptions options)
+    public async Task<string> FormatAsync(HttpRequestMessage request, HttpLoggingOptions options, CancellationToken cancellationToken = default)
     {
         var sb = new StringBuilder();
 
@@ -60,7 +60,7 @@ internal class HttpRequestFormatter : IHttpRequestFormatter
 
         if (options.LogRequestBody)
         {
-            await AppendBodyAsync(sb, request.Content, options.MaxBodySizeToLog).ConfigureAwait(false);
+            await AppendBodyAsync(sb, request.Content, options.MaxBodySizeToLog, cancellationToken).ConfigureAwait(false);
         }
 
         return sb.ToString();
@@ -95,7 +95,7 @@ internal class HttpRequestFormatter : IHttpRequestFormatter
         }
     }
 
-    private static async Task AppendBodyAsync(StringBuilder sb, HttpContent? content, int maxBodySize)
+    private static async Task AppendBodyAsync(StringBuilder sb, HttpContent? content, int maxBodySize, CancellationToken cancellationToken)
     {
         sb.AppendLine("Body");
 
@@ -114,7 +114,7 @@ internal class HttpRequestFormatter : IHttpRequestFormatter
             return;
         }
 
-        var body = await content.ReadAsStringAsync().ConfigureAwait(false);
+        var body = await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(body))
         {

--- a/src/ModularPipelines/Http/HttpResponseFormatter.cs
+++ b/src/ModularPipelines/Http/HttpResponseFormatter.cs
@@ -40,12 +40,12 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
         "application/javascript",
     };
 
-    public Task<string> FormatAsync(HttpResponseMessage response)
+    public Task<string> FormatAsync(HttpResponseMessage response, CancellationToken cancellationToken = default)
     {
-        return FormatAsync(response, HttpLoggingOptions.Default);
+        return FormatAsync(response, HttpLoggingOptions.Default, cancellationToken);
     }
 
-    public async Task<string> FormatAsync(HttpResponseMessage response, HttpLoggingOptions options)
+    public async Task<string> FormatAsync(HttpResponseMessage response, HttpLoggingOptions options, CancellationToken cancellationToken = default)
     {
         var sb = new StringBuilder();
 
@@ -60,7 +60,7 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
 
         if (options.LogResponseBody)
         {
-            await AppendBodyAsync(sb, response.Content, options.MaxBodySizeToLog).ConfigureAwait(false);
+            await AppendBodyAsync(sb, response.Content, options.MaxBodySizeToLog, cancellationToken).ConfigureAwait(false);
         }
 
         return sb.ToString();
@@ -95,7 +95,7 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
         }
     }
 
-    private static async Task AppendBodyAsync(StringBuilder sb, HttpContent? content, int maxBodySize)
+    private static async Task AppendBodyAsync(StringBuilder sb, HttpContent? content, int maxBodySize, CancellationToken cancellationToken)
     {
         sb.AppendLine("Body");
 
@@ -114,7 +114,7 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
             return;
         }
 
-        var body = await content.ReadAsStringAsync().ConfigureAwait(false);
+        var body = await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(body))
         {

--- a/src/ModularPipelines/Http/IHttpRequestFormatter.cs
+++ b/src/ModularPipelines/Http/IHttpRequestFormatter.cs
@@ -11,14 +11,16 @@ internal interface IHttpRequestFormatter
     /// Formats an HTTP request message as a string.
     /// </summary>
     /// <param name="request">The HTTP request to format.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A formatted string representation of the request.</returns>
-    Task<string> FormatAsync(HttpRequestMessage request);
+    Task<string> FormatAsync(HttpRequestMessage request, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Formats an HTTP request message as a string with logging options.
     /// </summary>
     /// <param name="request">The HTTP request to format.</param>
     /// <param name="options">Options controlling what parts of the request to include.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A formatted string representation of the request.</returns>
-    Task<string> FormatAsync(HttpRequestMessage request, HttpLoggingOptions options);
+    Task<string> FormatAsync(HttpRequestMessage request, HttpLoggingOptions options, CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Http/IHttpResponseFormatter.cs
+++ b/src/ModularPipelines/Http/IHttpResponseFormatter.cs
@@ -11,14 +11,16 @@ internal interface IHttpResponseFormatter
     /// Formats an HTTP response message as a string.
     /// </summary>
     /// <param name="response">The HTTP response to format.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A formatted string representation of the response.</returns>
-    Task<string> FormatAsync(HttpResponseMessage response);
+    Task<string> FormatAsync(HttpResponseMessage response, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Formats an HTTP response message as a string with logging options.
     /// </summary>
     /// <param name="response">The HTTP response to format.</param>
     /// <param name="options">Options controlling what parts of the response to include.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A formatted string representation of the response.</returns>
-    Task<string> FormatAsync(HttpResponseMessage response, HttpLoggingOptions options);
+    Task<string> FormatAsync(HttpResponseMessage response, HttpLoggingOptions options, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary
- FormatMarkdownModule: Replace exception throwing with proper early return and informational log message
- HTTP formatters: Add CancellationToken parameter to ReadAsStringAsync calls for proper cancellation support

## Changes
- `FormatMarkdownModule.cs`: Replace `throw new Exception(...)` with `return null;` and log message
- `IHttpRequestFormatter.cs`, `IHttpResponseFormatter.cs`: Add CancellationToken parameter to interface methods
- `HttpRequestFormatter.cs`, `HttpResponseFormatter.cs`: Pass CancellationToken to ReadAsStringAsync calls

## Test plan
- [ ] Build verification passes
- [ ] Existing tests continue to pass

Fixes #1637, fixes #1605

🤖 Generated with [Claude Code](https://claude.com/claude-code)