### PR TITLE
fix: Remove redundant directory creation and use HttpClient from DownloadOptions

### DIFF
--- a/src/ModularPipelines/Context/Downloader.cs
+++ b/src/ModularPipelines/Context/Downloader.cs
@@ -60,6 +60,7 @@ internal class Downloader : IDownloader
         var response = await _http.SendAsync(new HttpOptions(request)
         {
             LoggingType = options.LoggingType,
+            HttpClient = options.HttpClient,
         }, cancellationToken).ConfigureAwait(false);
 
         return response.EnsureSuccessStatusCode();

--- a/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
+++ b/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
@@ -30,8 +30,6 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
             directoryInfo.Create();
         }
 
-        directoryInfo.Create();
-
         var paths = directoryInfo
             .EnumerateFiles("*.txt", SearchOption.TopDirectoryOnly)
             .Where(x => x.Name.StartsWith($"Mod-{moduleType.FullName}"))


### PR DESCRIPTION
## Summary
- FileSystemModuleEstimatedTimeProvider: Remove duplicate directory creation call
- Downloader: Pass HttpClient from DownloadOptions to HttpOptions

## Changes
- `FileSystemModuleEstimatedTimeProvider.cs`: Remove redundant `directoryInfo.Create()` call that was already handled by conditional check above
- `Downloader.cs`: Add `HttpClient = options.HttpClient` to HttpOptions so custom HttpClient instances are actually used

## Test plan
- [ ] Build verification passes
- [ ] Existing tests continue to pass

Fixes #1588, fixes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)