### PR TITLE
docs: Complete XML documentation for IHex, IHasher interfaces and CommandLineToolOptions.Tool

### DIFF
--- a/src/ModularPipelines/Context/IHasher.cs
+++ b/src/ModularPipelines/Context/IHasher.cs
@@ -7,7 +7,7 @@ public interface IHasher
     /// </summary>
     /// <param name="input">The input to hash.</param>
     /// <param name="hashType">The encoded string output format.</param>
-    /// <returns></returns>
+    /// <returns>The hashed string.</returns>
     string Sha1(string input, HashType hashType = HashType.Hex);
 
     /// <summary>
@@ -15,7 +15,7 @@ public interface IHasher
     /// </summary>
     /// <param name="input">The input to hash.</param>
     /// <param name="hashType">The encoded string output format.</param>
-    /// <returns></returns>
+    /// <returns>The hashed string.</returns>
     string Sha256(string input, HashType hashType = HashType.Hex);
 
     /// <summary>
@@ -23,15 +23,15 @@ public interface IHasher
     /// </summary>
     /// <param name="input">The input to hash.</param>
     /// <param name="hashType">The encoded string output format.</param>
-    /// <returns></returns>
+    /// <returns>The hashed string.</returns>
     string Sha384(string input, HashType hashType = HashType.Hex);
 
     /// <summary>
     /// Hashes the input to an Sha512 encoded string.
     /// </summary>
-    /// <param name="input"></param>
+    /// <param name="input">The input to hash.</param>
     /// <param name="hashType">The encoded string output format.</param>
-    /// <returns></returns>
+    /// <returns>The hashed string.</returns>
     string Sha512(string input, HashType hashType = HashType.Hex);
 
     /// <summary>
@@ -39,6 +39,6 @@ public interface IHasher
     /// </summary>
     /// <param name="input">The input to hash.</param>
     /// <param name="hashType">The encoded string output format.</param>
-    /// <returns></returns>
+    /// <returns>The hashed string.</returns>
     string Md5(string input, HashType hashType = HashType.Hex);
 }

--- a/src/ModularPipelines/Context/IHex.cs
+++ b/src/ModularPipelines/Context/IHex.cs
@@ -8,7 +8,7 @@ public interface IHex
     /// Converts a string to a hex encoded string.
     /// </summary>
     /// <param name="input">The string to convert to a hex.</param>
-    /// <returns></returns>
+    /// <returns>The hex encoded string.</returns>
     string ToHex(string input) => ToHex(input, Encoding.UTF8);
 
     /// <summary>
@@ -16,21 +16,21 @@ public interface IHex
     /// </summary>
     /// <param name="input">The string to convert to a hex.</param>
     /// <param name="encoding">The string encoding.</param>
-    /// <returns></returns>
+    /// <returns>The hex encoded string.</returns>
     string ToHex(string input, Encoding encoding);
 
     /// <summary>
     /// Converts a byte sequence to a hex encoded string.
     /// </summary>
     /// <param name="bytes">The byte array to convert to a hex.</param>
-    /// <returns></returns>
+    /// <returns>The hex encoded string.</returns>
     string ToHex(IEnumerable<byte> bytes);
 
     /// <summary>
     /// Converts a hex encoded string to a decoded standard string.
     /// </summary>
     /// <param name="hexInput">The hex string to decode.</param>
-    /// <returns></returns>
+    /// <returns>The decoded string.</returns>
     string FromHex(string hexInput) => FromHex(hexInput, Encoding.UTF8);
 
     /// <summary>
@@ -38,6 +38,6 @@ public interface IHex
     /// </summary>
     /// <param name="hexInput">The hex string to decode.</param>
     /// <param name="encoding">The string encoding.</param>
-    /// <returns></returns>
+    /// <returns>The decoded string.</returns>
     string FromHex(string hexInput, Encoding encoding);
 }

--- a/src/ModularPipelines/Options/CommandLineToolOptions.cs
+++ b/src/ModularPipelines/Options/CommandLineToolOptions.cs
@@ -17,6 +17,9 @@ public record CommandLineToolOptions : CommandLineOptions
         Arguments = arguments;
     }
 
+    /// <summary>
+    /// Gets the command line tool to execute.
+    /// </summary>
     public string Tool { get; init; }
 
     public string[]? CommandParts { get; init; }


### PR DESCRIPTION
## Summary
- Complete missing `<returns>` tags in IHex and IHasher interfaces
- Add XML documentation to CommandLineToolOptions.Tool property

## Changes
- `IHex.cs`: Add descriptions to all 5 `<returns>` tags for ToHex and FromHex methods
- `IHasher.cs`: Add descriptions to all 5 `<returns>` tags for hash methods, fix incomplete `<param name="input">` tag
- `CommandLineToolOptions.cs`: Add `<summary>` documentation to Tool property

## Test plan
- [ ] Build verification passes
- [ ] XML documentation generation works

Fixes #1582, fixes #1595

🤖 Generated with [Claude Code](https://claude.com/claude-code)