### PR TITLE
test: Improve test module return types and document external URL

### DIFF
--- a/test/ModularPipelines.UnitTests/AfterPipelineLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/AfterPipelineLoggerTests.cs
@@ -10,19 +10,19 @@ namespace ModularPipelines.UnitTests;
 
 public class AfterPipelineLoggerTests
 {
-    private class AfterPipelineLoggingModule : Module<IDictionary<string, object>?>
+    private class AfterPipelineLoggingModule : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             context.LogOnPipelineEnd("Blah!");
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 
-    private class AfterPipelineLoggingWithExceptionModule : Module<IDictionary<string, object>?>
+    private class AfterPipelineLoggingWithExceptionModule : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             context.LogOnPipelineEnd("Blah!");
             await Task.CompletedTask;

--- a/test/ModularPipelines.UnitTests/AlwaysRunTests.cs
+++ b/test/ModularPipelines.UnitTests/AlwaysRunTests.cs
@@ -13,9 +13,9 @@ namespace ModularPipelines.UnitTests;
 
 public class AlwaysRunTests : TestBase
 {
-    public class MyModule1 : Module<IDictionary<string, object>?>
+    public class MyModule1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             throw new Exception();
@@ -23,9 +23,9 @@ public class AlwaysRunTests : TestBase
     }
 
     [ModularPipelines.Attributes.DependsOn<MyModule1>]
-    public class MyModule2 : Module<IDictionary<string, object>?>, IAlwaysRun
+    public class MyModule2 : Module<bool>, IAlwaysRun
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             throw new Exception();
@@ -33,9 +33,9 @@ public class AlwaysRunTests : TestBase
     }
 
     [ModularPipelines.Attributes.DependsOn<MyModule2>]
-    public class MyModule3 : Module<IDictionary<string, object>?>, IAlwaysRun
+    public class MyModule3 : Module<bool>, IAlwaysRun
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             throw new Exception();
@@ -43,9 +43,9 @@ public class AlwaysRunTests : TestBase
     }
 
     [ModularPipelines.Attributes.DependsOn<MyModule3>]
-    public class MyModule4 : Module<IDictionary<string, object>?>, IAlwaysRun
+    public class MyModule4 : Module<bool>, IAlwaysRun
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             throw new Exception();

--- a/test/ModularPipelines.UnitTests/AsyncDisposableModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/AsyncDisposableModuleTests.cs
@@ -15,16 +15,16 @@ public class AsyncDisposableModuleTests
         await Assert.That(pipelineSummary.Modules.OfType<AsyncDisposableModule>().Single().IsDisposed).IsTrue();
     }
 
-    public class AsyncDisposableModule : Module<IDictionary<string, object>?>, IAsyncDisposable
+    public class AsyncDisposableModule : Module<bool>, IAsyncDisposable
     {
         public bool IsDisposed { get; private set; }
 
         /// <inheritdoc/>
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             // Reduced delay from 100ms to 1ms for faster test execution
             await Task.Delay(1, cancellationToken);
-            return null;
+            return true;
         }
 
         /// <inheritdoc/>

--- a/test/ModularPipelines.UnitTests/DependsOnAllInheritingFromTests.cs
+++ b/test/ModularPipelines.UnitTests/DependsOnAllInheritingFromTests.cs
@@ -13,9 +13,9 @@ public class DependsOnAllInheritingFromTests : TestBase
 {
     private static readonly TimeSpan ModuleDelay = TimeSpan.FromMilliseconds(50);
 
-    private abstract class BaseModule : Module<IDictionary<string, object>?>
+    private abstract class BaseModule : Module<bool>
     {
-        public abstract override Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken);
+        public abstract override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken);
     }
 
     // Generic base module for testing open generic type dependencies (Issue #1337)
@@ -52,40 +52,40 @@ public class DependsOnAllInheritingFromTests : TestBase
 
     private class Module1 : BaseModule
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Delay(ModuleDelay, cancellationToken);
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>]
     private class Module2 : BaseModule
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Delay(ModuleDelay, cancellationToken);
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>(IgnoreIfNotRegistered = true)]
     private class Module3 : BaseModule
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Delay(ModuleDelay, cancellationToken);
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOnAllModulesInheritingFrom<BaseModule>]
-    private class Module4 : Module<IDictionary<string, object>?>
+    private class Module4 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/DependsOnTests.cs
+++ b/test/ModularPipelines.UnitTests/DependsOnTests.cs
@@ -9,76 +9,76 @@ namespace ModularPipelines.UnitTests;
 
 public class DependsOnTests : TestBase
 {
-    private class Module1 : Module<IDictionary<string, object>?>
+    private class Module1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>]
-    private class Module2 : Module<IDictionary<string, object>?>
+    private class Module2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>(IgnoreIfNotRegistered = true)]
-    private class Module3 : Module<IDictionary<string, object>?>
+    private class Module3 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>(IgnoreIfNotRegistered = true)]
-    private class Module3WithGetIfRegistered : Module<IDictionary<string, object>?>
+    private class Module3WithGetIfRegistered : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            _ = context.GetModuleIfRegistered<Module1, IDictionary<string, object>?>();
+            _ = context.GetModuleIfRegistered<Module1, bool>();
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>(IgnoreIfNotRegistered = true)]
-    private class Module3WithGet : Module<IDictionary<string, object>?>
+    private class Module3WithGet : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            _ = context.GetModule<Module1, IDictionary<string, object>?>();
+            _ = context.GetModule<Module1, bool>();
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<DependsOnSelfModule>]
-    private class DependsOnSelfModule : Module<IDictionary<string, object>?>
+    private class DependsOnSelfModule : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            _ = context.GetModule<Module1, IDictionary<string, object>?>();
+            _ = context.GetModule<Module1, bool>();
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn(typeof(ModuleFailedException))]
-    private class DependsOnNonModule : Module<IDictionary<string, object>?>
+    private class DependsOnNonModule : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            _ = context.GetModule<Module1, IDictionary<string, object>?>();
+            _ = context.GetModule<Module1, bool>();
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/DirectCollisionTests.cs
+++ b/test/ModularPipelines.UnitTests/DirectCollisionTests.cs
@@ -20,23 +20,23 @@ public class DirectCollisionTests
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyConflictModule2>]
-    private class DependencyConflictModule1 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            _ = context.GetModule<DependencyConflictModule2, IDictionary<string, object>?>();
+            _ = context.GetModule<DependencyConflictModule2, bool>();
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyConflictModule1>]
-    private class DependencyConflictModule2 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/DisposableModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/DisposableModuleTests.cs
@@ -15,16 +15,16 @@ public class DisposableModuleTests
         await Assert.That(pipelineSummary.Modules.OfType<DisposableModule>().Single().IsDisposed).IsTrue();
     }
 
-    public class DisposableModule : Module<IDictionary<string, object>?>, IDisposable
+    public class DisposableModule : Module<bool>, IDisposable
     {
         public bool IsDisposed { get; private set; }
 
         /// <inheritdoc/>
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             // Reduced delay from 100ms to 1ms for faster test execution
             await Task.Delay(1, cancellationToken);
-            return null;
+            return true;
         }
 
         /// <inheritdoc/>

--- a/test/ModularPipelines.UnitTests/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/EngineCancellationTokenTests.cs
@@ -14,9 +14,9 @@ public class EngineCancellationTokenTests : TestBase
 {
     private static readonly TimeSpan WaitForCancellationDelay = TimeSpan.FromMilliseconds(100);
 
-    private class BadModule : Module<IDictionary<string, object>?>
+    private class BadModule : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             throw new Exception();
@@ -24,35 +24,35 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [ModularPipelines.Attributes.DependsOn<BadModule>]
-    private class Module1 : Module<IDictionary<string, object>?>
+    private class Module1 : Module<bool>
     {
-        public override Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IDictionary<string, object>?>(null);
+            return Task.FromResult(true);
         }
     }
 
-    private class LongRunningModule : Module<IDictionary<string, object>?>
+    private class LongRunningModule : Module<bool>
     {
         private readonly TaskCompletionSource<bool> _taskCompletionSource = new();
 
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await _taskCompletionSource.Task.WaitAsync(cancellationToken);
-            return null;
+            return true;
         }
     }
 
-    private class LongRunningModuleWithoutCancellation : Module<IDictionary<string, object>?>, ITimeoutable
+    private class LongRunningModuleWithoutCancellation : Module<bool>, ITimeoutable
     {
         private readonly TaskCompletionSource<bool> _taskCompletionSource = new();
 
         public TimeSpan Timeout => TimeSpan.FromSeconds(1);
 
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await _taskCompletionSource.Task;
-            return null;
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/FailedPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/FailedPipelineTests.cs
@@ -9,31 +9,31 @@ namespace ModularPipelines.UnitTests;
 
 public class FailedPipelineTests : TestBase
 {
-    private class Module1 : Module<IDictionary<string, object>?>
+    private class Module1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
-    private class Module2 : Module<IDictionary<string, object>?>
+    private class Module2 : Module<bool>
     {
-        public override Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             throw new Exception();
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module2>(IgnoreIfNotRegistered = true)]
-    private class Module3 : Module<IDictionary<string, object>?>
+    private class Module3 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            _ = context.GetModuleIfRegistered<Module2, IDictionary<string, object>?>();
+            _ = context.GetModuleIfRegistered<Module2, bool>();
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
@@ -6,6 +6,12 @@ namespace ModularPipelines.UnitTests.Helpers;
 
 public class DownloaderTests : TestBase
 {
+    // NOTE: This test depends on an external URL (GitHub release artifact).
+    // The URL points to a specific versioned release which should remain stable,
+    // but if the test fails, verify the URL is still accessible and the checksum
+    // matches. The Retry(3) attribute helps handle transient network issues.
+    // Using a well-known, versioned release URL provides reasonable stability
+    // while testing real download functionality.
     [Test, Retry(3)]
     public async Task Can_Download()
     {

--- a/test/ModularPipelines.UnitTests/JsonSerializationTests.cs
+++ b/test/ModularPipelines.UnitTests/JsonSerializationTests.cs
@@ -11,9 +11,9 @@ namespace ModularPipelines.UnitTests;
 
 public class JsonSerializationTests : TestBase
 {
-    public class Module1 : Module<IDictionary<string, object>?>
+    public class Module1 : Module<IDictionary<string, object>>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<IDictionary<string, object>> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
 
@@ -25,9 +25,9 @@ public class JsonSerializationTests : TestBase
         }
     }
 
-    public class Module2 : Module<IDictionary<string, object>?>
+    public class Module2 : Module<IDictionary<string, object>>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<IDictionary<string, object>> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
 
@@ -39,9 +39,9 @@ public class JsonSerializationTests : TestBase
         }
     }
 
-    public class Module3 : Module<IDictionary<string, object>?>
+    public class Module3 : Module<IDictionary<string, object>>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<IDictionary<string, object>> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
 
@@ -63,7 +63,7 @@ public class JsonSerializationTests : TestBase
         var pipelineSummary = await host.ExecutePipelineAsync();
 
         var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
-        var module1Result = resultRegistry.GetResult<IDictionary<string, object>?>(typeof(Module1))!;
+        var module1Result = resultRegistry.GetResult<IDictionary<string, object>>(typeof(Module1))!;
 
         // Serialize and deserialize the pipeline summary
         var pipelineJson = JsonSerializer.Serialize(pipelineSummary);

--- a/test/ModularPipelines.UnitTests/LoggingSecretTests.cs
+++ b/test/ModularPipelines.UnitTests/LoggingSecretTests.cs
@@ -17,7 +17,7 @@ public class LoggingSecretTests
         [SecretValue] public string Secret1 { get; set; } = "";
     }
 
-    private class SecretValueLoggingModule1 : Module<IDictionary<string, object>?>
+    private class SecretValueLoggingModule1 : Module<bool>
     {
         private readonly IOptions<MySecretSettings> _options;
 
@@ -26,11 +26,11 @@ public class LoggingSecretTests
             _options = options;
         }
 
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             context.Logger.LogInformation("My Secret Value is: {SecretValue}", _options.Value.Secret1);
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/ModuleHistoryTests.cs
+++ b/test/ModularPipelines.UnitTests/ModuleHistoryTests.cs
@@ -14,11 +14,11 @@ namespace ModularPipelines.UnitTests;
 public class ModuleHistoryTests
 {
     [ModuleCategory("1")]
-    private class SkipFromCategory : Module<IDictionary<string, object>?>
+    private class SkipFromCategory : Module<bool>
     {
-        public override Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IDictionary<string, object>?>(null);
+            return Task.FromResult(true);
         }
     }
 
@@ -31,24 +31,24 @@ public class ModuleHistoryTests
     }
 
     [SkipRunCondition]
-    private class SkipFromRunCondition : Module<IDictionary<string, object>?>
+    private class SkipFromRunCondition : Module<bool>
     {
-        public override Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IDictionary<string, object>?>(null);
+            return Task.FromResult(true);
         }
     }
 
-    private class SkipFromMethod : Module<IDictionary<string, object>?>, ISkippable
+    private class SkipFromMethod : Module<bool>, ISkippable
     {
         public Task<SkipDecision> ShouldSkip(IPipelineContext context)
         {
             return SkipDecision.Skip("Testing").AsTask();
         }
 
-        public override Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IDictionary<string, object>?>(null);
+            return Task.FromResult(true);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/ModuleLoggerTests.cs
@@ -15,38 +15,38 @@ namespace ModularPipelines.UnitTests;
 public class ModuleLoggerTests
 {
     private static readonly string RandomString = Guid.NewGuid().ToString();
-    private class Module1 : Module<IDictionary<string, object>?>
+    private class Module1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             ((IConsoleWriter) context.Logger).LogToConsole(RandomString);
 
             ((IConsoleWriter) context.Logger).LogToConsole(new MySecrets().Value1!);
 
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
-    public class Module2 : Module<IDictionary<string, object>?>
+    public class Module2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             context.Logger.LogInformation(new MySecrets().Value1!);
 
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
-    public class Module3 : Module<IDictionary<string, object>?>
+    public class Module3 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             context.Logger.LogInformation("{Value}", new MySecrets().Value1!);
 
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/ModuleNotRegisteredExceptionTests.cs
+++ b/test/ModularPipelines.UnitTests/ModuleNotRegisteredExceptionTests.cs
@@ -8,23 +8,23 @@ namespace ModularPipelines.UnitTests;
 
 public class ModuleNotRegisteredExceptionTests : TestBase
 {
-    private class Module1 : Module<IDictionary<string, object>?>
+    private class Module1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>]
-    private class Module2 : Module<IDictionary<string, object>?>
+    private class Module2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            _ = context.GetModule<Module1, IDictionary<string, object>?>();
+            _ = context.GetModule<Module1, bool>();
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/NestedCollisionTests.cs
+++ b/test/ModularPipelines.UnitTests/NestedCollisionTests.cs
@@ -23,52 +23,52 @@ public class NestedCollisionTests
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyConflictModule2>]
-    private class DependencyConflictModule1 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyConflictModule3>]
-    private class DependencyConflictModule2 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyConflictModule4>]
-    private class DependencyConflictModule3 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule3 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyConflictModule5>]
-    private class DependencyConflictModule4 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule4 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyConflictModule2>]
-    private class DependencyConflictModule5 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule5 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/OneWayDependenciesNonCollisionTests.cs
+++ b/test/ModularPipelines.UnitTests/OneWayDependenciesNonCollisionTests.cs
@@ -20,51 +20,51 @@ public class OneWayDependenciesNonCollisionTests
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyConflictModule2>]
-    private class DependencyConflictModule1 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyConflictModule3>]
-    private class DependencyConflictModule2 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyConflictModule4>]
-    private class DependencyConflictModule3 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule3 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<DependencyConflictModule5>]
-    private class DependencyConflictModule4 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule4 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 
-    private class DependencyConflictModule5 : Module<IDictionary<string, object>?>
+    private class DependencyConflictModule5 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.CompletedTask;
-            return null;
+            return true;
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/PipelineProgressTests.cs
+++ b/test/ModularPipelines.UnitTests/PipelineProgressTests.cs
@@ -30,31 +30,31 @@ public class PipelineProgressTests
         AnsiConsole.Profile.Capabilities.Interactive = _originalInteractive;
     }
 
-    private class Module1 : Module<IDictionary<string, object>?>
+    private class Module1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             // Reduced delay from 1 second to 50ms for faster test execution
             await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken);
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>]
-    private class Module2 : Module<IDictionary<string, object>?>
+    private class Module2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             // Reduced delay from 1 second to 50ms for faster test execution
             await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken);
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>]
-    private class Module3 : Module<IDictionary<string, object>?>
+    private class Module3 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             throw new Exception();
@@ -62,38 +62,38 @@ public class PipelineProgressTests
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>]
-    private class Module4 : Module<IDictionary<string, object>?>, ISkippable
+    private class Module4 : Module<bool>, ISkippable
     {
         public Task<SkipDecision> ShouldSkip(IPipelineContext context)
         {
             return SkipDecision.Skip("Testing").AsTask();
         }
 
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>]
-    private class Module5 : Module<IDictionary<string, object>?>, IIgnoreFailures
+    private class Module5 : Module<bool>, IIgnoreFailures
     {
         public Task<bool> ShouldIgnoreFailures(IPipelineContext context, Exception exception)
         {
             return true.AsTask();
         }
 
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             throw new Exception();
         }
     }
 
-    private class Module6 : Module<IDictionary<string, object>?>
+    private class Module6 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             // SubModule functionality now needs to be handled differently in the new architecture
             // For now, just execute some work
@@ -101,13 +101,13 @@ public class PipelineProgressTests
             {
                 await Task.Yield();
             }
-            return null;
+            return true;
         }
     }
 
-    private class Module7 : Module<IDictionary<string, object>?>
+    private class Module7 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             // SubModule functionality now needs to be handled differently in the new architecture
             // For now, just execute some work
@@ -115,7 +115,7 @@ public class PipelineProgressTests
             {
                 await Task.Yield();
             }
-            return null;
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/PipelineRequirementTests.cs
+++ b/test/ModularPipelines.UnitTests/PipelineRequirementTests.cs
@@ -53,12 +53,12 @@ public class PipelineRequirementTests
             .And.HasMessageEqualTo("Requirements failed:\r\n" + TestConstants.RequirementErrorMessage);
     }
 
-    private class DummyModule : Module<IDictionary<string, object>?>
+    private class DummyModule : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return new Dictionary<string, object>();
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/ResultsRepositoryTests.cs
+++ b/test/ModularPipelines.UnitTests/ResultsRepositoryTests.cs
@@ -33,22 +33,22 @@ public class ResultsRepositoryTests : TestBase
         }
     }
 
-    private class Module1 : Module<IDictionary<string, object>?>
+    private class Module1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<Module1>]
-    private class Module2 : Module<IDictionary<string, object>?>
+    private class Module2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/RetryTests.cs
+++ b/test/ModularPipelines.UnitTests/RetryTests.cs
@@ -40,23 +40,23 @@ public class RetryTests : TestBase
     /// </summary>
     private const int ModuleDelayMs = 30;
 
-    private class SuccessModule : Module<IDictionary<string, object>?>
+    private class SuccessModule : Module<bool>
     {
         internal int ExecutionCount;
 
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             ExecutionCount++;
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
-    private class FailedModule : Module<IDictionary<string, object>?>
+    private class FailedModule : Module<bool>
     {
         internal int ExecutionCount;
 
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             ExecutionCount++;
 
@@ -66,22 +66,22 @@ public class RetryTests : TestBase
             }
 
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
-    private class FailedModuleWithCustomRetryPolicy : Module<IDictionary<string, object>?>, IRetryable<IDictionary<string, object>?>
+    private class FailedModuleWithCustomRetryPolicy : Module<string>, IRetryable<string>
     {
         internal int ExecutionCount;
 
-        public AsyncRetryPolicy<IDictionary<string, object>?> GetRetryPolicy(IPipelineContext context)
+        public AsyncRetryPolicy<string?> GetRetryPolicy(IPipelineContext context)
         {
-            return Policy<IDictionary<string, object>?>
+            return Policy<string?>
                 .Handle<Exception>()
                 .WaitAndRetryAsync(DefaultRetryCount, _ => TimeSpan.Zero);
         }
 
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             ExecutionCount++;
 
@@ -91,15 +91,15 @@ public class RetryTests : TestBase
             }
 
             await Task.Yield();
-            return null;
+            return "success";
         }
     }
 
-    private class FailedModuleWithTimeout : Module<IDictionary<string, object>?>, ITimeoutable
+    private class FailedModuleWithTimeout : Module<bool>, ITimeoutable
     {
         public TimeSpan Timeout => TimeSpan.FromMilliseconds(ModuleTimeoutMs);
 
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Delay(TimeSpan.FromMilliseconds(ModuleDelayMs), cancellationToken);
 

--- a/test/ModularPipelines.UnitTests/RunnableCategoryTests.cs
+++ b/test/ModularPipelines.UnitTests/RunnableCategoryTests.cs
@@ -12,61 +12,61 @@ namespace ModularPipelines.UnitTests;
 public class RunnableCategoryTests : TestBase
 {
     [ModuleCategory("Run1")]
-    private class RunnableModule1 : Module<IDictionary<string, object>?>
+    private class RunnableModule1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModuleCategory("Run2")]
-    private class RunnableModule2 : Module<IDictionary<string, object>?>
+    private class RunnableModule2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModuleCategory("Run1")]
-    private class RunnableModule3 : Module<IDictionary<string, object>?>
+    private class RunnableModule3 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModuleCategory("NoRun1")]
-    private class NonRunnableModule1 : Module<IDictionary<string, object>?>
+    private class NonRunnableModule1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [ModuleCategory("NoRun2")]
-    private class NonRunnableModule2 : Module<IDictionary<string, object>?>
+    private class NonRunnableModule2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
-    private class OtherModule3 : Module<IDictionary<string, object>?>
+    private class OtherModule3 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/SafeEstimatedTimeProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/SafeEstimatedTimeProviderTests.cs
@@ -56,11 +56,11 @@ public class SafeEstimatedTimeProviderTests
         await Assert.That(result.ModuleStatus).IsEqualTo(Status.Successful);
     }
 
-    private class DummyModule : Module<IDictionary<string, object>?>
+    private class DummyModule : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            return await new Dictionary<string, object>().AsTask();
+            return await true.AsTask();
         }
     }
 

--- a/test/ModularPipelines.UnitTests/SkipDependabotAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/SkipDependabotAttributeTests.cs
@@ -31,46 +31,46 @@ public class SkipDependabotAttributeTests : TestBase
     }
 
     [SkipIfDependabot]
-    private class Module1 : Module<IDictionary<string, object>?>
+    private class Module1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [SkipIfDependabot]
     [CanRun]
-    private class Module2 : Module<IDictionary<string, object>?>
+    private class Module2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [SkipIfDependabot]
     [CannotRun]
-    private class Module3 : Module<IDictionary<string, object>?>
+    private class Module3 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
     [SkipIfDependabot]
     [CanRun]
     [CannotRun]
-    private class Module4 : Module<IDictionary<string, object>?>
+    private class Module4 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/TimedDependencyTests.cs
+++ b/test/ModularPipelines.UnitTests/TimedDependencyTests.cs
@@ -40,22 +40,22 @@ public class TimedDependencyTests
         }
     }
 
-    private class FiveSecondModule : Module<IDictionary<string, object>?>
+    private class FiveSecondModule : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Delay(LongModuleDelay, cancellationToken);
-            return new Dictionary<string, object>();
+            return true;
         }
     }
 
     [ModularPipelines.Attributes.DependsOn<FiveSecondModule>]
-    private class OneSecondModuleDependentOnFiveSecondModule : Module<IDictionary<string, object>?>
+    private class OneSecondModuleDependentOnFiveSecondModule : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Delay(ShortModuleDelay, cancellationToken);
-            return new Dictionary<string, object>();
+            return true;
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/UnusedModuleDetectorTests.cs
+++ b/test/ModularPipelines.UnitTests/UnusedModuleDetectorTests.cs
@@ -61,48 +61,48 @@ public class UnusedModuleDetectorTests
         await Assert.That(actual).IsEqualTo(expected);
     }
 
-    private class Module1 : Module<IDictionary<string, object>?>
+    private class Module1 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
-    private class Module2 : Module<IDictionary<string, object>?>
+    private class Module2 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
-    private class Module3 : Module<IDictionary<string, object>?>
+    private class Module3 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
-    private class Module4 : Module<IDictionary<string, object>?>
+    private class Module4 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 
-    private class Module5 : Module<IDictionary<string, object>?>
+    private class Module5 : Module<bool>
     {
-        public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        public override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
-            return null;
+            return true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Changes test modules from `IDictionary<string, object>?` to `bool` when no meaningful return value is needed
- Adds documentation comment to DownloaderTests explaining external URL dependency

## Issues Fixed
- Closes #1597 - Test modules using IDictionary<string, object>? return type when null is always returned
- Closes #1619 - DownloaderTests uses external URL that could break or become unavailable

## Changes
- 26 test files updated to use `bool` return type instead of nullable dictionary
- JsonSerializationTests kept as `IDictionary<string, object>` (non-nullable) since actual values are tested
- FailedModuleWithCustomRetryPolicy uses `string` for IRetryable<T> interface compatibility
- DownloaderTests now has documentation explaining the external URL usage

## Test plan
- Build passes
- All existing tests continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)