### PR TITLE
fix: Properly dispose CancellationToken registration and HttpClient lifecycle

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -270,7 +270,7 @@ public sealed class Command : ICommand
 
         using var forcefulCancellationToken = new CancellationTokenSource();
 
-        cancellationToken.Register(() =>
+        await using var registration = cancellationToken.Register(() =>
         {
             try
             {


### PR DESCRIPTION
## Summary
- Fixes memory leak in Command class by properly disposing CancellationTokenRegistration
- Fixes incorrect HttpClient disposal in Http class when obtained from IHttpClientFactory
- Tracks ServiceProvider instances to properly dispose logging HttpClient infrastructure

## Issues Fixed
- Closes #1632 - Command class CancellationToken registration may cause memory leaks
- Closes #1567 - Http class disposes HttpClients obtained from IHttpClientFactory

## Changes
- Command.cs: Uses `await using` for CancellationTokenRegistration
- Http.cs: Removes disposal of injected HttpClient, tracks ServiceProviders for proper cleanup

## Test plan
- Build passes
- Memory leak scenarios resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)