### PR TITLE
perf: Cache SemanticModel and improve null handling in generators

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -14,7 +14,7 @@ public static partial class GeneratorUtils
     /// <summary>
     /// Escapes text for use in XML documentation comments.
     /// </summary>
-    public static string EscapeXmlComment(string text)
+    public static string EscapeXmlComment(string? text)
     {
         if (string.IsNullOrEmpty(text))
         {
@@ -156,11 +156,11 @@ public static partial class GeneratorUtils
     /// <summary>
     /// Escapes a C# identifier if it's a reserved keyword by prefixing with @.
     /// </summary>
-    public static string EscapeIdentifier(string identifier)
+    public static string EscapeIdentifier(string? identifier)
     {
         if (string.IsNullOrEmpty(identifier))
         {
-            return identifier;
+            return string.Empty;
         }
 
         return CSharpKeywords.Contains(identifier) ? $"@{identifier}" : identifier;


### PR DESCRIPTION
## Summary
- Caches SemanticModel in AsyncModuleCodeFixProvider instead of calling GetSemanticModelAsync multiple times
- Improves null handling consistency in OptionsClassGenerator GeneratorUtils

## Issues Fixed
- Closes #1572 - Duplicate GetSemanticModelAsync calls in AsyncModuleCodeFixProvider
- Closes #1639 - OptionsClassGenerator has inconsistent null handling for options

## Changes
- AsyncModuleCodeFixProvider.cs: Caches SemanticModel, makes helper methods static
- GeneratorUtils.cs: Uses nullable parameters with consistent empty string return

## Test plan
- Build passes for both Analyzers and OptionsGenerator solutions

🤖 Generated with [Claude Code](https://claude.com/claude-code)