### PR TITLE
fix: Use explicit solution file in DotNetTests to prevent flaky failures

### DIFF
--- a/test/ModularPipelines.UnitTests/Helpers/DotNetTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DotNetTests.cs
@@ -15,9 +15,11 @@ public class DotNetTests : TestBase
     {
         public override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
+            // Use main solution explicitly - FindFile returns first match alphabetically
+            // which could be ModularPipelines.Analyzers.sln causing flaky failures
             return await context.DotNet().List.Package(new DotNetListPackageOptions
             {
-                ProjectSolution = context.Git().RootDirectory.FindFile(x => x.Extension == ".sln").AssertExists(),
+                ProjectSolution = context.Git().RootDirectory.FindFile(x => x.Name == "ModularPipelines.sln").AssertExists(),
             }, token: cancellationToken);
         }
     }


### PR DESCRIPTION
## Summary
- Fix flaky `DotNetTests.Has_Not_Errored` test on Windows CI
- Changed from picking first `.sln` file alphabetically to explicitly using `ModularPipelines.sln`

## Problem
The test was using:
```csharp
FindFile(x => x.Extension == ".sln")
```

This returns the first `.sln` file alphabetically, which on Windows CI picks `ModularPipelines.Analyzers.sln`. Running `dotnet list package` on this solution intermittently fails with exit code -1.

## Solution
Explicitly target the main solution file:
```csharp
FindFile(x => x.Name == "ModularPipelines.sln")
```

## Test plan
- [x] Build succeeds
- [ ] Windows CI passes consistently

🤖 Generated with [Claude Code](https://claude.ai/code)