### PR TITLE
fix: Add CancellationToken to Slack and remove unused IHttpClientFactory

### DIFF
--- a/src/ModularPipelines.Slack/ISlack.cs
+++ b/src/ModularPipelines.Slack/ISlack.cs
@@ -4,5 +4,5 @@ namespace ModularPipelines.Slack;
 
 public interface ISlack
 {
-    Task PostWebHookMessage(SlackWebHookOptions options);
+    Task PostWebHookMessage(SlackWebHookOptions options, CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines.Slack/Slack.cs
+++ b/src/ModularPipelines.Slack/Slack.cs
@@ -13,8 +13,10 @@ internal class Slack : ISlack
         _http = http;
     }
 
-    public async Task PostWebHookMessage(SlackWebHookOptions options)
+    public async Task PostWebHookMessage(SlackWebHookOptions options, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var slackClient = new SlackClient(options.WebHookUri.AbsoluteUri, httpClient: _http.GetLoggingHttpClient());
 
         await slackClient.PostAsync(options.SlackMessage);

--- a/src/ModularPipelines/Http/Http.cs
+++ b/src/ModularPipelines/Http/Http.cs
@@ -20,7 +20,6 @@ internal class Http : IHttp, IDisposable
 
     public Http(HttpClient defaultHttpClient,
         IModuleLoggerProvider moduleLoggerProvider,
-        IHttpClientFactory httpClientFactory,
         IHttpLogger httpLogger,
         IOptions<PipelineOptions> pipelineOptions)
     {


### PR DESCRIPTION
## Summary
- Added `CancellationToken` parameter to `ISlack.PostWebHookMessage` for proper cancellation support
- Removed unused `IHttpClientFactory` parameter from `Http.cs` constructor

## Changes
- `ISlack.cs`: Added optional CancellationToken parameter to PostWebHookMessage
- `Slack.cs`: Implemented cancellation token check in PostWebHookMessage
- `Http.cs`: Removed unused IHttpClientFactory from constructor

Fixes #1547, Fixes #1583

## Test plan
- [x] Build succeeds
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)