### PR TITLE
feat: Add Phase 2 Activity-based logging to FileSystem operations

### DIFF
--- a/src/ModularPipelines/Tracing/ModuleActivityTracing.cs
+++ b/src/ModularPipelines/Tracing/ModuleActivityTracing.cs
@@ -109,4 +109,22 @@ public static class ModuleActivityTracing
         activity.SetTag(ExceptionMessageTag, exception.Message);
         activity.SetStatus(ActivityStatusCode.Error, exception.Message);
     }
+
+    /// <summary>
+    /// Gets the current module name from the current Activity, if available.
+    /// </summary>
+    /// <returns>The module name, or null if no module activity is active.</returns>
+    public static string? GetCurrentModuleName()
+    {
+        return Activity.Current?.GetTagItem(ModuleTypeTag) as string;
+    }
+
+    /// <summary>
+    /// Gets the current Activity ID, if available.
+    /// </summary>
+    /// <returns>The activity ID, or null if no activity is active.</returns>
+    public static string? GetCurrentActivityId()
+    {
+        return Activity.Current?.Id;
+    }
 }


### PR DESCRIPTION
## Summary
- Added Activity context information to all FileSystem logging operations
- Enables better distributed tracing by including module name and activity ID in logs
- Phase 2 of the Activity-based tracing refactor (follows Phase 1 in #1466)

## Changes

### ModuleActivityTracing.cs
- Added `GetCurrentModuleName()` helper to retrieve current module from Activity.Current
- Added `GetCurrentActivityId()` helper to retrieve current Activity ID

### File.cs
- Added `LogFileOperation()` and `LogFileOperationWithDestination()` helper methods
- All file operations now log with format: `"{Operation}: {Path} [Module: {ModuleName}, Activity: {ActivityId}]"`

### Folder.cs
- Added logging helper methods for folder operations
- All folder operations now include Activity context in logs

## Dependencies
- Depends on #1693 (Folder.Clean/CopyTo enhancements)

## Test Plan
- [x] Build succeeds
- [ ] Verify logs include module name and activity ID
- [ ] Verify Activity.Current integration works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)