### PR TITLE
fix: Preserve original path in File and Folder classes (#1620)

### DIFF
--- a/src/ModularPipelines/FileSystem/File.cs
+++ b/src/ModularPipelines/FileSystem/File.cs
@@ -24,14 +24,18 @@ public class File : IEquatable<File>
         }
     }
 
-    public File(string path) : this(new FileInfo(path))
+    public File(string path) : this(new FileInfo(path), path)
     {
     }
 
-    internal File(FileInfo fileInfo)
+    internal File(FileInfo fileInfo) : this(fileInfo, fileInfo.FullName)
+    {
+    }
+
+    private File(FileInfo fileInfo, string originalPath)
     {
         _fileInfo = fileInfo;
-        OriginalPath = Path;
+        OriginalPath = originalPath;
     }
 
     /// <inheritdoc cref="System.IO.File.ReadAllTextAsync(string,System.Text.Encoding,System.Threading.CancellationToken)"/>>
@@ -141,6 +145,13 @@ public class File : IEquatable<File>
     /// <inheritdoc cref="FileSystemInfo.FullName"/>>
     public string Path => FileInfo.FullName;
 
+    /// <summary>
+    /// Gets the original path string that was used to construct this File instance.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="Path"/> which always returns the absolute path,
+    /// this property preserves the original input (which may be relative).
+    /// </remarks>
     public string OriginalPath { get; }
 
     public File Create()

--- a/src/ModularPipelines/FileSystem/Folder.cs
+++ b/src/ModularPipelines/FileSystem/Folder.cs
@@ -28,14 +28,18 @@ public class Folder : IEquatable<Folder>
         }
     }
 
-    public Folder(string path) : this(new DirectoryInfo(path))
+    public Folder(string path) : this(new DirectoryInfo(path), path)
     {
     }
 
-    internal Folder(DirectoryInfo directoryInfo)
+    internal Folder(DirectoryInfo directoryInfo) : this(directoryInfo, directoryInfo.FullName)
+    {
+    }
+
+    private Folder(DirectoryInfo directoryInfo, string originalPath)
     {
         _directoryInfo = directoryInfo;
-        OriginalPath = Path;
+        OriginalPath = originalPath;
     }
 
     public bool Exists => DirectoryInfo.Exists;
@@ -49,6 +53,13 @@ public class Folder : IEquatable<Folder>
 
     public string Path => DirectoryInfo.FullName;
 
+    /// <summary>
+    /// Gets the original path string that was used to construct this Folder instance.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="Path"/> which always returns the absolute path,
+    /// this property preserves the original input (which may be relative).
+    /// </remarks>
     public string OriginalPath { get; }
 
     public FileAttributes Attributes


### PR DESCRIPTION
## Summary
Fixes the `OriginalPath` property in `File` and `Folder` classes to actually store the original input path, not the resolved absolute path.

## Problem
Previously, both classes stored `Path` (the absolute path) in `OriginalPath`:
```csharp
// Before
public File(string path) : this(new FileInfo(path)) { }

internal File(FileInfo fileInfo)
{
    _fileInfo = fileInfo;
    OriginalPath = Path;  // Always absolute!
}
```

This meant:
```csharp
var file = new File("document.txt");
file.Path;          // "C:\Users\...\document.txt"
file.OriginalPath;  // "C:\Users\...\document.txt" (wrong!)
```

## Solution
Store the actual input string:
```csharp
// After
public File(string path) : this(new FileInfo(path), path) { }

private File(FileInfo fileInfo, string originalPath)
{
    _fileInfo = fileInfo;
    OriginalPath = originalPath;  // Preserves original input
}
```

Now:
```csharp
var file = new File("document.txt");
file.Path;          // "C:\Users\...\document.txt"
file.OriginalPath;  // "document.txt" (correct!)
```

## Changes
- `File.cs`: Updated constructor chain to preserve original path
- `Folder.cs`: Updated constructor chain to preserve original path
- Added XML documentation explaining the difference between `Path` and `OriginalPath`

## Test Plan
- [x] Build succeeds
- [ ] `new File("relative.txt").OriginalPath == "relative.txt"`
- [ ] `new File("/absolute/path.txt").OriginalPath == "/absolute/path.txt"`

Fixes #1620

🤖 Generated with [Claude Code](https://claude.com/claude-code)