### PR TITLE
fix: Remove unused static singleton from BuildSystemDetector (#1607)

### DIFF
--- a/src/ModularPipelines/BuildSystemDetector.cs
+++ b/src/ModularPipelines/BuildSystemDetector.cs
@@ -32,7 +32,6 @@ namespace ModularPipelines;
 /// </example>
 internal class BuildSystemDetector : IBuildSystemDetector
 {
-    public static readonly BuildSystemDetector Instance = new(new EnvironmentVariables());
     private readonly IEnvironmentVariables _environmentVariables;
 
     private readonly Dictionary<string, BuildSystem> _variablesToBuildSystem = new()


### PR DESCRIPTION
## Summary
- Removes unused static `Instance` field from `BuildSystemDetector`
- All code properly uses the DI-injected `IBuildSystemDetector` interface
- Eliminates the mixed singleton/DI pattern anti-pattern

## Changes
The static field was defined but never accessed:
```csharp
// Removed:
public static readonly BuildSystemDetector Instance = new(new EnvironmentVariables());
```

Fixes #1607

🤖 Generated with [Claude Code](https://claude.com/claude-code)