### PR TITLE
fix: Simplify SubModule exception handling control flow (#1563)

### DIFF
--- a/src/ModularPipelines/Modules/SubModule.cs
+++ b/src/ModularPipelines/Modules/SubModule.cs
@@ -26,17 +26,21 @@ internal class SubModule<T> : SubModuleBase
             Duration = stopwatch.Elapsed;
             EndTime = DateTimeOffset.UtcNow;
             Status = Status.Successful;
-            SubModuleResultTaskCompletionSource.SetResult(result);
+            SubModuleResultTaskCompletionSource.TrySetResult(result);
+
+            return result;
         }
         catch (Exception ex)
         {
             Duration = stopwatch.Elapsed;
             EndTime = DateTimeOffset.UtcNow;
             Status = Status.Failed;
-            SubModuleResultTaskCompletionSource.SetException(new SubModuleFailedException(this, ex));
-        }
 
-        return await SubModuleResultTaskCompletionSource.Task.ConfigureAwait(false);
+            var wrappedException = new SubModuleFailedException(this, ex);
+            SubModuleResultTaskCompletionSource.TrySetException(wrappedException);
+
+            throw wrappedException;
+        }
     }
 
     public override Task CallbackTask => SubModuleResultTaskCompletionSource.Task;


### PR DESCRIPTION
## Summary
Simplifies the control flow in `SubModule.Execute()` by returning/throwing directly instead of going through the TaskCompletionSource and re-awaiting it.

## Before
```csharp
try {
    // ...
    SubModuleResultTaskCompletionSource.SetResult(result);
}
catch (Exception ex) {
    // ...
    SubModuleResultTaskCompletionSource.SetException(new SubModuleFailedException(this, ex));
}
// Re-awaits the TCS which will throw the wrapped exception
return await SubModuleResultTaskCompletionSource.Task.ConfigureAwait(false);
```

## After
```csharp
try {
    // ...
    SubModuleResultTaskCompletionSource.TrySetResult(result);
    return result;  // Direct return
}
catch (Exception ex) {
    // ...
    var wrappedException = new SubModuleFailedException(this, ex);
    SubModuleResultTaskCompletionSource.TrySetException(wrappedException);
    throw wrappedException;  // Direct throw
}
```

## Changes
- Return result directly instead of going through TaskCompletionSource then re-awaiting
- Throw exception directly instead of setting on TCS then re-awaiting
- Use `TrySetResult`/`TrySetException` for safety
- Clearer control flow and proper exception propagation

Fixes #1563

🤖 Generated with [Claude Code](https://claude.com/claude-code)