### PR TITLE
feat: Add configurability and cancellation support to FileHelper.WaitForFileAsync (#1570)

### DIFF
--- a/src/ModularPipelines/Helpers/FileHelper.cs
+++ b/src/ModularPipelines/Helpers/FileHelper.cs
@@ -2,15 +2,50 @@ using System.Diagnostics;
 
 namespace ModularPipelines.Helpers;
 
+/// <summary>
+/// Helper methods for file system operations.
+/// </summary>
 public static class FileHelper
 {
-    public static async Task WaitForFileAsync(string path)
+    /// <summary>
+    /// Default timeout for waiting for a file.
+    /// </summary>
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Default polling interval when checking for file availability.
+    /// </summary>
+    public static readonly TimeSpan DefaultPollingInterval = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
+    /// Waits for a file to exist, have content, and be unlocked.
+    /// </summary>
+    /// <param name="path">The path to the file to wait for.</param>
+    /// <param name="timeout">
+    /// The maximum time to wait. If null, defaults to 30 seconds.
+    /// </param>
+    /// <param name="pollingInterval">
+    /// The interval between checks. If null, defaults to 500 milliseconds.
+    /// </param>
+    /// <param name="cancellationToken">A token to cancel the wait operation.</param>
+    /// <returns>
+    /// True if the file became available within the timeout; false if timed out.
+    /// </returns>
+    public static async Task<bool> WaitForFileAsync(
+        string path,
+        TimeSpan? timeout = null,
+        TimeSpan? pollingInterval = null,
+        CancellationToken cancellationToken = default)
     {
+        var actualTimeout = timeout ?? DefaultTimeout;
+        var actualPollingInterval = pollingInterval ?? DefaultPollingInterval;
         var stopWatch = Stopwatch.StartNew();
 
-        while (stopWatch.Elapsed < TimeSpan.FromSeconds(30))
+        while (stopWatch.Elapsed < actualTimeout)
         {
-            await Task.Delay(500).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await Task.Delay(actualPollingInterval, cancellationToken).ConfigureAwait(false);
 
             if (!File.Exists(path))
             {
@@ -29,10 +64,17 @@ public static class FileHelper
                 continue;
             }
 
-            break;
+            return true;
         }
+
+        return false;
     }
 
+    /// <summary>
+    /// Checks if a file is currently locked by another process.
+    /// </summary>
+    /// <param name="file">The file to check.</param>
+    /// <returns>True if the file is locked; otherwise, false.</returns>
     public static async Task<bool> IsFileLocked(FileInfo file)
     {
         try


### PR DESCRIPTION
## Summary
Makes `FileHelper.WaitForFileAsync` configurable with optional timeout, polling interval, and cancellation support.

## Changes
- Add optional `timeout` parameter (default: 30 seconds)
- Add optional `pollingInterval` parameter (default: 500ms)
- Add `CancellationToken` support
- Return `bool` to indicate success (true) or timeout (false)
- Add XML documentation for all public members
- Expose default values as public readonly fields

## API
```csharp
// Before
public static async Task WaitForFileAsync(string path)

// After
public static async Task<bool> WaitForFileAsync(
    string path,
    TimeSpan? timeout = null,
    TimeSpan? pollingInterval = null,
    CancellationToken cancellationToken = default)
```

## Compatibility
- Existing callers that `await` without using the return value will continue to work
- The return type change allows callers to handle timeout scenarios explicitly

Fixes #1570

🤖 Generated with [Claude Code](https://claude.com/claude-code)