### PR TITLE
fix: Add ExcludeFromCodeCoverage attribute to Development.Analyzers (#1531)

### DIFF
--- a/src/ModularPipelines.Development.Analyzers/VirtualCommandAnalyzer.cs
+++ b/src/ModularPipelines.Development.Analyzers/VirtualCommandAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -7,6 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace ModularPipelines.Development.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
+[ExcludeFromCodeCoverage]
 public class VirtualCommandAnalyzer : DiagnosticAnalyzer
 {
     private const string Category = "Usage";

--- a/src/ModularPipelines.Development.Analyzers/VirtualSwitchPropertyAnalyzer.cs
+++ b/src/ModularPipelines.Development.Analyzers/VirtualSwitchPropertyAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -7,6 +8,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace ModularPipelines.Development.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
+[ExcludeFromCodeCoverage]
 public class VirtualSwitchPropertyAnalyzer : DiagnosticAnalyzer
 {
     private const string Category = "Usage";


### PR DESCRIPTION
## Summary
- Add `[ExcludeFromCodeCoverage]` attribute to `VirtualCommandAnalyzer`
- Add `[ExcludeFromCodeCoverage]` attribute to `VirtualSwitchPropertyAnalyzer`
- Consistent with `ModularPipelines.Analyzers` project pattern

Analyzer code requires compilation context for testing and is typically integration-tested
rather than unit-tested, so including in coverage metrics can skew results.

## Test plan
- [x] Build succeeds with no errors

Fixes #1531

🤖 Generated with [Claude Code](https://claude.com/claude-code)