### PR TITLE
fix: Dispose CancellationTokenSource in PrintProgressExecutor (#1502)

### DIFF
--- a/src/ModularPipelines/Engine/Executors/PrintProgressExecutor.cs
+++ b/src/ModularPipelines/Engine/Executors/PrintProgressExecutor.cs
@@ -49,6 +49,8 @@ internal class PrintProgressExecutor : IPrintProgressExecutor
         _printProgressCancellationTokenSource?.CancelAfter(ProgressPrinterGracePeriodMs);
 
         await SafelyAwaitProgressPrinter().ConfigureAwait(false);
+
+        _printProgressCancellationTokenSource?.Dispose();
     }
 
     private async Task SafelyAwaitProgressPrinter()


### PR DESCRIPTION
## Summary
- Add missing `Dispose()` call for `_printProgressCancellationTokenSource` in `DisposeAsync()`
- Prevents resource leak from undisposed linked token source

`CancellationTokenSource` implements `IDisposable` and linked token sources hold
references to the parent token that may prevent garbage collection.

## Test plan
- [x] Build succeeds with no errors

Fixes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)