### PR TITLE
fix: Remove duplicate RunOnLinuxOnly attribute (#1488)

### DIFF
--- a/src/ModularPipelines.Build/Modules/UploadPackagesToNugetModule.cs
+++ b/src/ModularPipelines.Build/Modules/UploadPackagesToNugetModule.cs
@@ -17,7 +17,6 @@ namespace ModularPipelines.Build.Modules;
 [RunOnLinuxOnly]
 [SkipIfNoGitHubToken]
 [RunOnlyOnBranch("main")]
-[RunOnLinuxOnly]
 public class UploadPackagesToNugetModule : Module<CommandResult[]>, ISkippable
 {
     private readonly IOptions<NuGetSettings> _nugetSettings;


### PR DESCRIPTION
## Summary
- Remove duplicate `[RunOnLinuxOnly]` attribute from `UploadPackagesToNugetModule`
- The attribute was applied twice (lines 17 and 20)

## Test plan
- [x] CI will verify build succeeds

Fixes #1488

🤖 Generated with [Claude Code](https://claude.com/claude-code)