### PR TITLE
refactor: Remove Sourcy.DotNet source generator from Build project

### DIFF
--- a/src/ModularPipelines.Build/ModularPipelines.Build.csproj
+++ b/src/ModularPipelines.Build/ModularPipelines.Build.csproj
@@ -16,10 +16,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="Sourcy.DotNet">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ModularPipelines.Build/Modules/FindProjectsModule.cs
+++ b/src/ModularPipelines.Build/Modules/FindProjectsModule.cs
@@ -9,34 +9,44 @@ namespace ModularPipelines.Build.Modules;
 
 public class FindProjectsModule : Module<IReadOnlyList<File>>, IAlwaysRun
 {
-    public override async Task<IReadOnlyList<File>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-    {
-        await Task.Yield();
+    /// <summary>
+    /// List of project names to publish. These correspond to projects in the src directory.
+    /// </summary>
+    private static readonly string[] ProjectNames =
+    [
+        "ModularPipelines",
+        "ModularPipelines.AmazonWebServices",
+        "ModularPipelines.Azure",
+        "ModularPipelines.Azure.Pipelines",
+        "ModularPipelines.Chocolatey",
+        "ModularPipelines.Cmd",
+        "ModularPipelines.Docker",
+        "ModularPipelines.DotNet",
+        "ModularPipelines.Email",
+        "ModularPipelines.Ftp",
+        "ModularPipelines.Yarn",
+        "ModularPipelines.Node",
+        "ModularPipelines.Git",
+        "ModularPipelines.GitHub",
+        "ModularPipelines.Google",
+        "ModularPipelines.Helm",
+        "ModularPipelines.Kubernetes",
+        "ModularPipelines.MicrosoftTeams",
+        "ModularPipelines.Slack",
+        "ModularPipelines.TeamCity",
+        "ModularPipelines.Terraform",
+        "ModularPipelines.WinGet",
+    ];
 
-        return
-        [
-            Sourcy.DotNet.Projects.ModularPipelines,
-            Sourcy.DotNet.Projects.ModularPipelines_AmazonWebServices,
-            Sourcy.DotNet.Projects.ModularPipelines_Azure,
-            Sourcy.DotNet.Projects.ModularPipelines_Azure_Pipelines,
-            Sourcy.DotNet.Projects.ModularPipelines_Chocolatey,
-            Sourcy.DotNet.Projects.ModularPipelines_Cmd,
-            Sourcy.DotNet.Projects.ModularPipelines_Docker,
-            Sourcy.DotNet.Projects.ModularPipelines_DotNet,
-            Sourcy.DotNet.Projects.ModularPipelines_Email,
-            Sourcy.DotNet.Projects.ModularPipelines_Ftp,
-            Sourcy.DotNet.Projects.ModularPipelines_Yarn,
-            Sourcy.DotNet.Projects.ModularPipelines_Node,
-            Sourcy.DotNet.Projects.ModularPipelines_Git,
-            Sourcy.DotNet.Projects.ModularPipelines_GitHub,
-            Sourcy.DotNet.Projects.ModularPipelines_Google,
-            Sourcy.DotNet.Projects.ModularPipelines_Helm,
-            Sourcy.DotNet.Projects.ModularPipelines_Kubernetes,
-            Sourcy.DotNet.Projects.ModularPipelines_MicrosoftTeams,
-            Sourcy.DotNet.Projects.ModularPipelines_Slack,
-            Sourcy.DotNet.Projects.ModularPipelines_TeamCity,
-            Sourcy.DotNet.Projects.ModularPipelines_Terraform,
-            Sourcy.DotNet.Projects.ModularPipelines_WinGet
-        ];
+    public override Task<IReadOnlyList<File>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {
+        var gitRootDirectory = context.Git().RootDirectory;
+        var srcDirectory = gitRootDirectory.GetFolder("src");
+
+        var projects = ProjectNames
+            .Select(name => srcDirectory.GetFolder(name).GetFile($"{name}.csproj"))
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<File>?>(projects);
     }
 }


### PR DESCRIPTION
## Summary
- Remove Sourcy.DotNet source generator dependency from ModularPipelines.Build
- Replace with direct file system operations to find project files
- Eliminates build issues caused by source generator not producing output

## Changes
- Modified `FindProjectsModule.cs` to use a static array of project names and resolve paths dynamically
- Removed Sourcy.DotNet package reference from `ModularPipelines.Build.csproj`

## Why This Change
The Sourcy.DotNet source generator was causing build failures when it didn't produce the expected `Projects` class with project properties. This was happening intermittently on some development machines.

The new implementation:
- Uses a static array of project names
- Resolves project paths dynamically using Git root directory and file system APIs
- Is simpler and more maintainable
- Has no external source generator dependencies

## Test plan
- [x] Build succeeds locally
- [ ] CI builds pass
- [ ] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)