### PR TITLE
fix: Add consistent debug logging to all branch condition attributes (#1553)

### DIFF
--- a/src/ModularPipelines.Git/Attributes/RunIfBranchAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunIfBranchAttribute.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
 using ModularPipelines.Git.Extensions;
@@ -17,6 +18,10 @@ public class RunIfBranchAttribute : RunConditionAttribute
 
     public override Task<bool> Condition(IPipelineHookContext pipelineContext)
     {
-        return Task.FromResult(pipelineContext.Git().Information.BranchName == BranchName);
+        var currentBranchName = pipelineContext.Git().Information.BranchName;
+
+        pipelineContext.Logger.LogDebug("Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}", currentBranchName, BranchName);
+
+        return Task.FromResult(currentBranchName == BranchName);
     }
 }

--- a/src/ModularPipelines.Git/Attributes/RunIfBranchStartsWithAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunIfBranchStartsWithAttribute.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
 using ModularPipelines.Git.Extensions;
@@ -17,6 +18,10 @@ public class RunIfBranchStartsWithAttribute : RunConditionAttribute
 
     public override Task<bool> Condition(IPipelineHookContext pipelineContext)
     {
-        return Task.FromResult(pipelineContext.Git().Information.BranchName?.StartsWith(BranchNamePrefix) ?? false);
+        var currentBranchName = pipelineContext.Git().Information.BranchName;
+
+        pipelineContext.Logger.LogDebug("Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}", currentBranchName, BranchNamePrefix);
+
+        return Task.FromResult(currentBranchName?.StartsWith(BranchNamePrefix) ?? false);
     }
 }

--- a/src/ModularPipelines.Git/Attributes/RunOnlyIfBranchStartsWithAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunOnlyIfBranchStartsWithAttribute.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
 using ModularPipelines.Git.Extensions;
@@ -17,6 +18,10 @@ public class RunOnlyIfBranchStartsWithAttribute : MandatoryRunConditionAttribute
 
     public override Task<bool> Condition(IPipelineHookContext pipelineContext)
     {
-        return Task.FromResult(pipelineContext.Git().Information.BranchName?.StartsWith(BranchNamePrefix) ?? false);
+        var currentBranchName = pipelineContext.Git().Information.BranchName;
+
+        pipelineContext.Logger.LogDebug("Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}", currentBranchName, BranchNamePrefix);
+
+        return Task.FromResult(currentBranchName?.StartsWith(BranchNamePrefix) ?? false);
     }
 }

--- a/src/ModularPipelines.Git/Attributes/SkipIfBranchAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/SkipIfBranchAttribute.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
 using ModularPipelines.Git.Extensions;
@@ -17,6 +18,10 @@ public class SkipIfBranchAttribute : MandatoryRunConditionAttribute
 
     public override Task<bool> Condition(IPipelineHookContext pipelineContext)
     {
-        return Task.FromResult(pipelineContext.Git().Information.BranchName != BranchName);
+        var currentBranchName = pipelineContext.Git().Information.BranchName;
+
+        pipelineContext.Logger.LogDebug("Current Branch: {CurrentBranch} | Will skip on: {SkipBranch}", currentBranchName, BranchName);
+
+        return Task.FromResult(currentBranchName != BranchName);
     }
 }


### PR DESCRIPTION
## Summary
- Add debug logging to branch condition attributes that were missing it
- All branch condition attributes now log the current branch and the condition being evaluated

## Changes
Added debug logging to:
- `RunIfBranchAttribute`
- `SkipIfBranchAttribute`
- `RunIfBranchStartsWithAttribute`
- `RunOnlyIfBranchStartsWithAttribute`

This makes them consistent with `RunOnlyOnBranchAttribute` which already had logging.

## Why This Change
When modules are skipped due to branch conditions, having consistent debug logging across all branch condition attributes helps with troubleshooting and debugging pipeline execution.

Fixes #1553

## Test plan
- [x] Build succeeds locally
- [ ] CI builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)