### PR TITLE
docs: Add XML documentation to installer interfaces (#1551)

### DIFF
--- a/src/ModularPipelines/Context/IFileInstaller.cs
+++ b/src/ModularPipelines/Context/IFileInstaller.cs
@@ -3,11 +3,26 @@ using ModularPipelines.Options;
 
 namespace ModularPipelines.Context;
 
+/// <summary>
+/// Provides methods for installing software from local files or web URLs.
+/// </summary>
 public interface IFileInstaller
 {
+    /// <summary>
+    /// Installs software from a local installer file.
+    /// </summary>
+    /// <param name="options">The options specifying the installer file path and installation parameters.</param>
+    /// <param name="cancellationToken">A token to cancel the installation operation.</param>
+    /// <returns>A <see cref="CommandResult"/> containing the result of the installation command.</returns>
     Task<CommandResult> InstallFromFileAsync(InstallerOptions options,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Downloads and installs software from a web URL.
+    /// </summary>
+    /// <param name="options">The options specifying the download URL and installation parameters.</param>
+    /// <param name="cancellationToken">A token to cancel the download and installation operation.</param>
+    /// <returns>A <see cref="CommandResult"/> containing the result of the installation command.</returns>
     Task<CommandResult> InstallFromWebAsync(WebInstallerOptions options,
         CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Context/ILinuxInstaller.cs
+++ b/src/ModularPipelines/Context/ILinuxInstaller.cs
@@ -3,7 +3,15 @@ using ModularPipelines.Options.Linux;
 
 namespace ModularPipelines.Context;
 
+/// <summary>
+/// Provides methods for installing software on Linux systems.
+/// </summary>
 public interface ILinuxInstaller
 {
+    /// <summary>
+    /// Installs a Debian package using dpkg.
+    /// </summary>
+    /// <param name="options">The options specifying the package file and installation parameters.</param>
+    /// <returns>A <see cref="CommandResult"/> containing the result of the dpkg installation command.</returns>
     Task<CommandResult> InstallFromDpkg(DpkgInstallOptions options);
 }

--- a/src/ModularPipelines/Context/IMacInstaller.cs
+++ b/src/ModularPipelines/Context/IMacInstaller.cs
@@ -3,7 +3,15 @@ using ModularPipelines.Options.Mac;
 
 namespace ModularPipelines.Context;
 
+/// <summary>
+/// Provides methods for installing software on macOS systems.
+/// </summary>
 public interface IMacInstaller
 {
+    /// <summary>
+    /// Installs software using Homebrew package manager.
+    /// </summary>
+    /// <param name="macBrewOptions">The options specifying the package name and installation parameters.</param>
+    /// <returns>A <see cref="CommandResult"/> containing the result of the Homebrew installation command.</returns>
     Task<CommandResult> InstallFromBrew(MacBrewOptions macBrewOptions);
 }

--- a/src/ModularPipelines/Context/IWindowsInstaller.cs
+++ b/src/ModularPipelines/Context/IWindowsInstaller.cs
@@ -3,9 +3,22 @@ using ModularPipelines.Options.Windows;
 
 namespace ModularPipelines.Context;
 
+/// <summary>
+/// Provides methods for installing software on Windows systems.
+/// </summary>
 public interface IWindowsInstaller
 {
+    /// <summary>
+    /// Installs software from an MSI (Windows Installer) package.
+    /// </summary>
+    /// <param name="msiInstallerOptions">The options specifying the MSI file path and installation parameters.</param>
+    /// <returns>A <see cref="CommandResult"/> containing the result of the MSI installation command.</returns>
     Task<CommandResult> InstallMsi(MsiInstallerOptions msiInstallerOptions);
 
+    /// <summary>
+    /// Installs software from an executable installer.
+    /// </summary>
+    /// <param name="exeInstallerOptions">The options specifying the executable file path and installation parameters.</param>
+    /// <returns>A <see cref="CommandResult"/> containing the result of the executable installation command.</returns>
     Task<CommandResult> InstallExe(ExeInstallerOptions exeInstallerOptions);
 }


### PR DESCRIPTION
## Summary
- Add comprehensive XML documentation to all installer interfaces
- Document interface purpose, method parameters, and return values

## Changes
Added documentation to:
- `IFileInstaller`: Methods for installing from local files or web URLs
- `ILinuxInstaller`: Methods for installing on Linux systems (dpkg)
- `IWindowsInstaller`: Methods for installing on Windows (MSI, EXE)
- `IMacInstaller`: Methods for installing on macOS (Homebrew)

## Why This Change
These are public APIs that users interact with for installing software. Clear documentation helps users understand how to use these interfaces correctly.

Fixes #1551

## Test plan
- [x] Build succeeds locally
- [ ] CI builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)