### PR TITLE
fix: Handle ObjectDisposedException when disposing linked CancellationTokenSource

### DIFF
--- a/src/ModularPipelines/Engine/Executors/PrintProgressExecutor.cs
+++ b/src/ModularPipelines/Engine/Executors/PrintProgressExecutor.cs
@@ -46,7 +46,14 @@ internal class PrintProgressExecutor : IPrintProgressExecutor
 
     public async ValueTask DisposeAsync()
     {
-        _printProgressCancellationTokenSource?.CancelAfter(ProgressPrinterGracePeriodMs);
+        try
+        {
+            _printProgressCancellationTokenSource?.CancelAfter(ProgressPrinterGracePeriodMs);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Linked CancellationTokenSource may already be disposed if the engine token was cancelled
+        }
 
         await SafelyAwaitProgressPrinter().ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary
- Fixes race condition where `CancelAfter` is called on an already-disposed linked `CancellationTokenSource`
- The linked CTS can be disposed when the parent engine token is cancelled before `DisposeAsync` is called
- Wraps the `CancelAfter` call in a try-catch to gracefully handle this case

## Context
This bug was exposed by the logging improvements in PR #1711. The error manifests as:
```
System.ObjectDisposedException: The CancellationTokenSource has been disposed.
   at System.Threading.CancellationTokenSource.ThrowObjectDisposedException()
   at System.Threading.CancellationTokenSource.CancelAfter(Int32 millisecondsDelay)
   at ModularPipelines.Engine.Executors.PrintProgressExecutor.DisposeAsync() in PrintProgressExecutor.cs:line 49
```

## Test plan
- [x] Build succeeds
- [ ] CI pipeline passes
- [ ] No ObjectDisposedException in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)