### PR TITLE
perf: Remove redundant Contains check in SecretObfuscator

### DIFF
--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -29,10 +29,7 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
 
         foreach (var secret in _secretProvider.Secrets.Concat(secretsFromExtraObject))
         {
-            if (input.Contains(secret))
-            {
-                stringBuilder.Replace(secret, LoggingConstants.SecretMask);
-            }
+            stringBuilder.Replace(secret, LoggingConstants.SecretMask);
         }
 
         return stringBuilder.ToString();


### PR DESCRIPTION
## Summary
- Removes redundant `Contains` check before calling `StringBuilder.Replace`
- `Replace` already handles the case where the search string doesn't exist
- Fixes inconsistency where `Contains` checked the original input but `Replace` operated on the modified StringBuilder

## Changes
Before:
```csharp
if (input.Contains(secret))
{
    stringBuilder.Replace(secret, LoggingConstants.SecretMask);
}
```

After:
```csharp
stringBuilder.Replace(secret, LoggingConstants.SecretMask);
```

## Test plan
- [x] Build succeeds
- [ ] CI pipeline passes
- [ ] Existing secret obfuscation tests pass

Fixes #1549

🤖 Generated with [Claude Code](https://claude.com/claude-code)