### PR TITLE
refactor: Convert CodeCovSettings from class to record

### DIFF
--- a/src/ModularPipelines.Build/Settings/CodeCovSettings.cs
+++ b/src/ModularPipelines.Build/Settings/CodeCovSettings.cs
@@ -1,6 +1,9 @@
+using ModularPipelines.Attributes;
+
 namespace ModularPipelines.Build.Settings;
 
-public class CodeCovSettings
+public record CodeCovSettings
 {
+    [SecretValue]
     public string? Token { get; init; }
 }


### PR DESCRIPTION
## Summary
- Converts `CodeCovSettings` from `class` to `record` for consistency with other settings
- Adds `[SecretValue]` attribute to `Token` property to match the pattern in other settings

## Context
All other settings classes in the build pipeline use `record`:
- `CodacySettings` - record with `[SecretValue]` on Token
- `GitHubSettings` - record
- `NuGetSettings` - record with `[SecretValue]` on ApiKey
- `PublishSettings` - record

`CodeCovSettings` was the only one using `class`, creating an inconsistency.

## Test plan
- [ ] CI pipeline passes

Fixes #1546

🤖 Generated with [Claude Code](https://claude.com/claude-code)