### PR TITLE
perf: Add cancellation support and short-circuit to ModuleConditionHandler

### DIFF
--- a/src/ModularPipelines/Engine/IModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/IModuleConditionHandler.cs
@@ -5,5 +5,5 @@ namespace ModularPipelines.Engine;
 
 internal interface IModuleConditionHandler
 {
-    Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnore(IModule module);
+    Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnore(IModule module, CancellationToken cancellationToken = default);
 }


### PR DESCRIPTION
## Summary

Fixes #1571

- Added `CancellationToken` parameter to `IModuleConditionHandler.ShouldIgnore` for proper cancellation support
- Changed from parallel condition evaluation to sequential with short-circuit optimization:
  - Mandatory conditions short-circuit on first failure
  - Non-mandatory conditions short-circuit on first success
- Removed dependency on `EnumerableAsyncProcessor` for simpler, more efficient code
- Added `ConfigureAwait(false)` to async calls

## Rationale

The previous implementation evaluated all conditions in parallel, which was wasteful when:
1. A mandatory condition fails early - no need to check remaining conditions
2. A non-mandatory condition succeeds - no need to check remaining conditions

Sequential evaluation with short-circuiting is both simpler and more efficient for this use case.

## Test plan
- [x] Build succeeds
- [x] Existing tests pass
- [ ] Verify cancellation behavior in module condition evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)