### PR TITLE
fix: Remove unnecessary finalizer from ModuleOutputWriter

### DIFF
--- a/src/ModularPipelines/Logging/ModuleOutputWriter.cs
+++ b/src/ModularPipelines/Logging/ModuleOutputWriter.cs
@@ -119,6 +119,10 @@ internal class ModuleOutputWriter : IModuleOutputWriter, IDisposable
     /// <summary>
     /// Flushes all buffered output with section header/footer.
     /// </summary>
+    /// <remarks>
+    /// No finalizer is needed since this class only manages managed resources.
+    /// If Dispose is not called, the IServiceScope will be cleaned up by GC.
+    /// </remarks>
     public void Dispose()
     {
         lock (_writeLock)
@@ -133,6 +137,7 @@ internal class ModuleOutputWriter : IModuleOutputWriter, IDisposable
 
         if (!_buffer.HasEvents)
         {
+            _scope.Dispose();
             return;
         }
 
@@ -173,12 +178,6 @@ internal class ModuleOutputWriter : IModuleOutputWriter, IDisposable
         }
 
         _scope.Dispose();
-        GC.SuppressFinalize(this);
-    }
-
-    ~ModuleOutputWriter()
-    {
-        Dispose();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Removes the finalizer since the class only manages managed resources (IServiceScope)
- Fixes a bug where `_scope` was not disposed when the buffer had no events
- Removes `GC.SuppressFinalize` call since no finalizer exists

## Why the finalizer was problematic
1. **Unsafe**: The finalizer called `Dispose()` which accessed managed objects that may already be finalized
2. **Locking in finalizer**: Taking locks in finalizers is risky and can cause hangs
3. **Unnecessary**: The class only manages managed resources, so a finalizer adds no value

Fixes #1533

## Test plan
- [ ] Existing unit tests pass
- [ ] Module output displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)