### PR TITLE
docs: Add XML documentation to ICertificates interface

### DIFF
--- a/src/ModularPipelines/Context/ICertificates.cs
+++ b/src/ModularPipelines/Context/ICertificates.cs
@@ -2,13 +2,41 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace ModularPipelines.Context;
 
+/// <summary>
+/// Provides functionality for retrieving X.509 certificates from the certificate store.
+/// </summary>
 public interface ICertificates
 {
-    public X509Certificate2? GetCertificateBySubject(StoreLocation storeLocation, string subject);
+    /// <summary>
+    /// Gets a certificate by its subject name.
+    /// </summary>
+    /// <param name="storeLocation">The store location to search.</param>
+    /// <param name="subject">The subject name to search for.</param>
+    /// <returns>The matching certificate, or null if not found.</returns>
+    X509Certificate2? GetCertificateBySubject(StoreLocation storeLocation, string subject);
 
-    public X509Certificate2? GetCertificateByThumbprint(StoreLocation storeLocation, string thumbprint);
+    /// <summary>
+    /// Gets a certificate by its thumbprint.
+    /// </summary>
+    /// <param name="storeLocation">The store location to search.</param>
+    /// <param name="thumbprint">The thumbprint to search for.</param>
+    /// <returns>The matching certificate, or null if not found.</returns>
+    X509Certificate2? GetCertificateByThumbprint(StoreLocation storeLocation, string thumbprint);
 
-    public X509Certificate2? GetCertificateBySerialNumber(StoreLocation storeLocation, string serialNumber);
+    /// <summary>
+    /// Gets a certificate by its serial number.
+    /// </summary>
+    /// <param name="storeLocation">The store location to search.</param>
+    /// <param name="serialNumber">The serial number to search for.</param>
+    /// <returns>The matching certificate, or null if not found.</returns>
+    X509Certificate2? GetCertificateBySerialNumber(StoreLocation storeLocation, string serialNumber);
 
+    /// <summary>
+    /// Gets a certificate using a custom find type and value.
+    /// </summary>
+    /// <param name="storeLocation">The store location to search.</param>
+    /// <param name="findType">The type of search to perform.</param>
+    /// <param name="findValue">The value to search for.</param>
+    /// <returns>The matching certificate, or null if not found.</returns>
     X509Certificate2? GetCertificateBy(StoreLocation storeLocation, X509FindType findType, string findValue);
 }


### PR DESCRIPTION
## Summary
- Added comprehensive XML documentation to the `ICertificates` interface
- Documented interface purpose (retrieving X.509 certificates from the certificate store)
- Added XML docs for all four methods with parameter and return value descriptions

Fixes #1530

## Test plan
- [x] Verify XML documentation renders correctly in IDE IntelliSense
- [x] Build passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)