### PR TITLE
perf: Add caching to AttributeHelpers.GetCustomAttributesIncludingBaseInterfaces

### DIFF
--- a/src/ModularPipelines/Extensions/AttributeHelpers.cs
+++ b/src/ModularPipelines/Extensions/AttributeHelpers.cs
@@ -1,21 +1,43 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace ModularPipelines.Extensions;
 
 internal static class AttributeHelpers
 {
+    private static readonly ConcurrentDictionary<(Type Type, Type AttributeType), object[]> Cache = new();
+
     public static IEnumerable<T> GetCustomAttributesIncludingBaseInterfaces<T>(this Type type)
         where T : Attribute
     {
+        var key = (type, typeof(T));
+
+        if (Cache.TryGetValue(key, out var cachedResult))
+        {
+            return cachedResult.Cast<T>();
+        }
+
+        var attributes = GetAttributesInternal<T>(type);
+        Cache[key] = attributes;
+        return attributes.Cast<T>();
+    }
+
+    private static object[] GetAttributesInternal<T>(Type type)
+        where T : Attribute
+    {
+        var results = new List<object>();
+
         foreach (var result in type.GetInterfaces()
                      .SelectMany(i => i.GetCustomAttributes<T>(true)))
         {
-            yield return result;
+            results.Add(result);
         }
 
         foreach (var customAttribute in type.GetCustomAttributes<T>(true))
         {
-            yield return customAttribute;
+            results.Add(customAttribute);
         }
+
+        return results.ToArray();
     }
 }


### PR DESCRIPTION
## Summary
- Added a `ConcurrentDictionary<(Type, Type), object[]>` cache to store attribute lookup results
- Cache key is a tuple of `(Type, AttributeType)` for efficient lookups
- Eliminates redundant reflection calls for repeated attribute queries on the same type

Fixes #1532

## Test plan
- [x] Verify the project builds successfully
- [ ] Existing unit tests should pass unchanged (behavior is identical, only performance improves)
- [ ] Verify caching behavior in scenarios with repeated attribute lookups

🤖 Generated with [Claude Code](https://claude.com/claude-code)