### PR TITLE
fix: Properly escape file path in chmod command (#1527)

### DIFF
--- a/src/ModularPipelines/Context/FileInstaller.cs
+++ b/src/ModularPipelines/Context/FileInstaller.cs
@@ -28,7 +28,8 @@ public class FileInstaller : IFileInstaller
             }, cancellationToken).ConfigureAwait(false);
         }
 
-        await _bash.Command(new BashCommandOptions($"chmod u+x {options.Path}"), cancellationToken).ConfigureAwait(false);
+        var escapedPath = options.Path.Replace("'", "'\\''");
+        await _bash.Command(new BashCommandOptions($"chmod u+x '{escapedPath}'"), cancellationToken).ConfigureAwait(false);
 
         return await _bash.FromFile(new BashFileOptions(options.Path), cancellationToken).ConfigureAwait(false);
     }


### PR DESCRIPTION
## Summary

- Fixed security/reliability issue where file paths containing special characters (spaces, quotes, etc.) could cause the `chmod` command to fail or behave unexpectedly
- The path is now properly escaped by wrapping it in single quotes and escaping any embedded single quotes with `'\''`

## Changes

**Before:**
```csharp
await _bash.Command(new BashCommandOptions($"chmod u+x {options.Path}"), cancellationToken)
```

**After:**
```csharp
var escapedPath = options.Path.Replace("'", "'\''");
await _bash.Command(new BashCommandOptions($"chmod u+x '{escapedPath}'"), cancellationToken)
```

## Test plan

- [ ] Verify build passes in CI
- [ ] Test with file paths containing spaces (e.g., `/path/to/my script.sh`)
- [ ] Test with file paths containing single quotes (e.g., `/path/to/it's working.sh`)

Fixes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)