### PR TITLE
refactor: Use interface abstraction for IModuleResultRepository enabled check

### DIFF
--- a/src/ModularPipelines/Engine/IModuleResultRepository.cs
+++ b/src/ModularPipelines/Engine/IModuleResultRepository.cs
@@ -6,6 +6,15 @@ namespace ModularPipelines.Engine;
 
 public interface IModuleResultRepository
 {
+    /// <summary>
+    /// Gets a value indicating whether this repository is enabled and should be used for storing/retrieving results.
+    /// </summary>
+    /// <remarks>
+    /// When <c>false</c>, the pipeline will skip history-related operations.
+    /// Implementations that provide actual storage should return <c>true</c>.
+    /// </remarks>
+    bool IsEnabled { get; }
+
     Task SaveResultAsync<T>(Module<T> module, ModuleResult<T> moduleResult, IPipelineHookContext pipelineContext);
 
     Task<ModuleResult<T>?> GetResultAsync<T>(Module<T> module, IPipelineHookContext pipelineContext);

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -182,7 +182,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         // Check if we should use historical data
         // For skipped modules with a history repository configured, check for cached results
-        if (_resultRepository.GetType() != typeof(NoOpModuleResultRepository))
+        if (_resultRepository.IsEnabled)
         {
             var historicalResult = await _resultRepository.GetResultAsync<T>(module, moduleContext).ConfigureAwait(false);
             if (historicalResult != null)
@@ -270,7 +270,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         ModuleResult<T> result,
         IModuleContext moduleContext)
     {
-        if (_resultRepository.GetType() == typeof(NoOpModuleResultRepository))
+        if (!_resultRepository.IsEnabled)
         {
             return;
         }

--- a/src/ModularPipelines/Engine/NoOpModuleResultRepository.cs
+++ b/src/ModularPipelines/Engine/NoOpModuleResultRepository.cs
@@ -8,6 +8,9 @@ namespace ModularPipelines.Engine;
 [ExcludeFromCodeCoverage]
 internal class NoOpModuleResultRepository : IModuleResultRepository
 {
+    /// <inheritdoc />
+    public bool IsEnabled => false;
+
     public Task SaveResultAsync<T>(Module<T> module, ModuleResult<T> moduleResult, IPipelineHookContext pipelineContext)
     {
         return Task.CompletedTask;

--- a/test/ModularPipelines.UnitTests/ModuleHistoryTests.cs
+++ b/test/ModularPipelines.UnitTests/ModuleHistoryTests.cs
@@ -54,6 +54,8 @@ public class ModuleHistoryTests
 
     private class NotFoundModuleRepository : IModuleResultRepository
     {
+        public bool IsEnabled => true;
+
         public Task SaveResultAsync<T>(Module<T> module, ModuleResult<T> moduleResult, IPipelineHookContext pipelineContext)
         {
             return Task.CompletedTask;
@@ -67,6 +69,8 @@ public class ModuleHistoryTests
 
     private class GoodModuleRepository : IModuleResultRepository
     {
+        public bool IsEnabled => true;
+
         public Task SaveResultAsync<T>(Module<T> module, ModuleResult<T> moduleResult, IPipelineHookContext pipelineContext)
         {
             return Task.CompletedTask;

--- a/test/ModularPipelines.UnitTests/ResultsRepositoryTests.cs
+++ b/test/ModularPipelines.UnitTests/ResultsRepositoryTests.cs
@@ -18,6 +18,8 @@ public class ResultsRepositoryTests : TestBase
 
     private class JsonResultRepository : IModuleResultRepository
     {
+        public bool IsEnabled => true;
+
         public async Task SaveResultAsync<T>(Module<T> module, ModuleResult<T> moduleResult, IPipelineHookContext pipelineContext)
         {
             var file = Folder.CreateFile(module.GetType().FullName!);


### PR DESCRIPTION
## Summary

Fixes #1526

- Add `IsEnabled` property to `IModuleResultRepository` interface to indicate whether the repository is configured for actual storage
- Set `IsEnabled => false` in `NoOpModuleResultRepository` (the default no-op implementation)
- Set `IsEnabled => true` in test implementations
- Update `ModuleExecutionPipeline.cs` to use `_resultRepository.IsEnabled` instead of concrete type checks against `NoOpModuleResultRepository`

This change improves testability and follows the Dependency Inversion Principle by removing direct dependencies on concrete types.

## Test plan

- [x] Verify build compiles successfully
- [ ] Verify existing tests pass (ResultsRepositoryTests, ModuleHistoryTests)
- [ ] Verify no regressions in module history/skip functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)