### PR TITLE
fix: Standardize RunOnLinuxOnly attribute usage in build modules

### DIFF
--- a/docs/docs/how-to/run-conditions.md
+++ b/docs/docs/how-to/run-conditions.md
@@ -44,6 +44,18 @@ The above module will run on either Linux, or Mac. But not windows.
 
 Mandatory run conditions are similar to standard run conditions, but they MUST return true to run the module. If ANY return false, then the module will not run.
 
+For built-in OS conditions, use the `*Only` variants for mandatory behavior:
+- `[RunOnLinuxOnly]` - Module runs ONLY on Linux
+- `[RunOnWindowsOnly]` - Module runs ONLY on Windows
+- `[RunOnMacOSOnly]` - Module runs ONLY on macOS
+
+```csharp
+[RunOnLinuxOnly]
+public class MyLinuxOnlyModule : Module
+```
+
+The above module will ONLY run on Linux and will be skipped on Windows and macOS.
+
 You can create your own custom mandatory run conditions by inheriting from `MandatoryRunConditionAttribute` and plugging custom logic into the `Condition` method.
 
 ```csharp

--- a/src/ModularPipelines.Build/Modules/ChangedFilesInPullRequestModule.cs
+++ b/src/ModularPipelines.Build/Modules/ChangedFilesInPullRequestModule.cs
@@ -8,7 +8,7 @@ using File = ModularPipelines.FileSystem.File;
 
 namespace ModularPipelines.Build.Modules;
 
-[RunOnLinux]
+[RunOnLinuxOnly]
 [SkipOnMainBranch]
 public class ChangedFilesInPullRequestModule : Module<IReadOnlyList<File>>
 {


### PR DESCRIPTION
## Summary

Fixes #1528 - Inconsistent naming RunOnLinux vs RunOnLinuxOnly attributes

**Investigation findings:**
- `RunOnLinux` and `RunOnLinuxOnly` are **different attributes** with different semantics:
  - `RunOnLinux` inherits from `RunConditionAttribute` (OR logic - module runs if ANY condition is met)
  - `RunOnLinuxOnly` inherits from `MandatoryRunConditionAttribute` (AND logic - ALL conditions must be met)

**Issue:**
- `ChangedFilesInPullRequestModule` used `[RunOnLinux]` while all other build modules used `[RunOnLinuxOnly]`
- Since the module should only run on Linux (mandatory requirement), this was inconsistent with other modules

**Changes:**
- Updated `ChangedFilesInPullRequestModule` to use `[RunOnLinuxOnly]` for consistency
- Added documentation for the `*Only` variants in the run-conditions documentation

## Test plan

- [x] Verified the attribute change is syntactically correct (same namespace already imported)
- [x] Core ModularPipelines project builds successfully
- [ ] CI will validate full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)