### PR TITLE
refactor: Replace magic numbers with named constants (#1521)

### DIFF
--- a/src/ModularPipelines/Context/IYaml.cs
+++ b/src/ModularPipelines/Context/IYaml.cs
@@ -3,13 +3,42 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace ModularPipelines.Context;
 
+/// <summary>
+/// Provides YAML serialization and deserialization functionality.
+/// </summary>
 public interface IYaml
 {
+    /// <summary>
+    /// Serializes an object to YAML string using the default camel case naming convention.
+    /// </summary>
+    /// <typeparam name="T">The type of object to serialize.</typeparam>
+    /// <param name="input">The object to serialize.</param>
+    /// <returns>The YAML string representation of the object.</returns>
     string ToYaml<T>(T input) => ToYaml(input, CamelCaseNamingConvention.Instance);
 
+    /// <summary>
+    /// Serializes an object to YAML string using the specified naming convention.
+    /// </summary>
+    /// <typeparam name="T">The type of object to serialize.</typeparam>
+    /// <param name="input">The object to serialize.</param>
+    /// <param name="namingConvention">The naming convention to use for property names.</param>
+    /// <returns>The YAML string representation of the object.</returns>
     string ToYaml<T>(T input, INamingConvention namingConvention);
 
+    /// <summary>
+    /// Deserializes a YAML string to an object using the default camel case naming convention.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize to.</typeparam>
+    /// <param name="input">The YAML string to deserialize.</param>
+    /// <returns>The deserialized object.</returns>
     T FromYaml<T>(string input) => FromYaml<T>(input, CamelCaseNamingConvention.Instance);
 
+    /// <summary>
+    /// Deserializes a YAML string to an object using the specified naming convention.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize to.</typeparam>
+    /// <param name="input">The YAML string to deserialize.</param>
+    /// <param name="namingConvention">The naming convention to use for property names.</param>
+    /// <returns>The deserialized object.</returns>
     T FromYaml<T>(string input, INamingConvention namingConvention);
 }


### PR DESCRIPTION
## Summary
- Replace magic number `300` with `LowestPriority` constant in `HeuristicTypeDetector.cs`
- Replace magic number `50` with `HeuristicConfidence` constant in `HeuristicTypeDetector.cs`
- Replace magic number `2` with `MinBooleanValueCount` constant in `HeuristicTypeDetector.cs`
- Replace magic number `(LanguageVersion)1100` with `CSharp11LanguageVersion` constant in `MissingDependsOnAttributeCodeFixProvider.cs`
- Add XML documentation to all new constants explaining their purpose

Fixes #1521

## Test plan
- [x] Build both modified projects with `dotnet build -c Release`
- [x] Verify no new warnings or errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)