### PR TITLE
docs: Add XML documentation to IYaml interface (#1511)

### DIFF
--- a/src/ModularPipelines/Context/IYaml.cs
+++ b/src/ModularPipelines/Context/IYaml.cs
@@ -3,13 +3,42 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace ModularPipelines.Context;
 
+/// <summary>
+/// Provides YAML serialization and deserialization functionality.
+/// </summary>
 public interface IYaml
 {
+    /// <summary>
+    /// Serializes an object to YAML string using the default camel case naming convention.
+    /// </summary>
+    /// <typeparam name="T">The type of object to serialize.</typeparam>
+    /// <param name="input">The object to serialize.</param>
+    /// <returns>The YAML string representation of the object.</returns>
     string ToYaml<T>(T input) => ToYaml(input, CamelCaseNamingConvention.Instance);
 
+    /// <summary>
+    /// Serializes an object to YAML string using the specified naming convention.
+    /// </summary>
+    /// <typeparam name="T">The type of object to serialize.</typeparam>
+    /// <param name="input">The object to serialize.</param>
+    /// <param name="namingConvention">The naming convention to use for property names.</param>
+    /// <returns>The YAML string representation of the object.</returns>
     string ToYaml<T>(T input, INamingConvention namingConvention);
 
+    /// <summary>
+    /// Deserializes a YAML string to an object using the default camel case naming convention.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize to.</typeparam>
+    /// <param name="input">The YAML string to deserialize.</param>
+    /// <returns>The deserialized object.</returns>
     T FromYaml<T>(string input) => FromYaml<T>(input, CamelCaseNamingConvention.Instance);
 
+    /// <summary>
+    /// Deserializes a YAML string to an object using the specified naming convention.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize to.</typeparam>
+    /// <param name="input">The YAML string to deserialize.</param>
+    /// <param name="namingConvention">The naming convention to use for property names.</param>
+    /// <returns>The deserialized object.</returns>
     T FromYaml<T>(string input, INamingConvention namingConvention);
 }


### PR DESCRIPTION
## Summary
- Added comprehensive XML documentation to the `IYaml` interface following the same pattern as `IJson`
- Documented the interface summary describing its purpose
- Added documentation for all four methods: `ToYaml<T>` (2 overloads) and `FromYaml<T>` (2 overloads)
- Each method now has proper `<summary>`, `<typeparam>`, `<param>`, and `<returns>` documentation

Fixes #1511

## Test plan
- [x] Build verified with `dotnet build src/ModularPipelines/ModularPipelines.csproj -c Release`
- [x] No breaking changes, documentation-only addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)