### PR TITLE
fix: Return deleted file count from PackageFilesRemovalModule (#1507)

### DIFF
--- a/src/ModularPipelines.Build/Modules/PackageFilesRemovalModule.cs
+++ b/src/ModularPipelines.Build/Modules/PackageFilesRemovalModule.cs
@@ -4,20 +4,22 @@ using ModularPipelines.Modules;
 
 namespace ModularPipelines.Build.Modules;
 
-public class PackageFilesRemovalModule : Module<IDictionary<string, object>>
+public class PackageFilesRemovalModule : Module<int>
 {
-    public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    public override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
         var packageFiles = context.Git()
             .RootDirectory
             .GetFiles(path => path.Extension is ".nupkg");
 
+        var count = 0;
         foreach (var packageFile in packageFiles)
         {
             packageFile.Delete();
+            count++;
         }
 
         await Task.CompletedTask;
-        return null;
+        return count;
     }
 }


### PR DESCRIPTION
## Summary
- Changed `PackageFilesRemovalModule` to return `int` (count of deleted files) instead of `IDictionary<string, object>?` which always returned `null`
- The module now returns meaningful data representing the number of package files removed

Fixes #1507

## Test plan
- [ ] Verify the build pipeline compiles without errors
- [ ] Run the build pipeline and verify the module returns the correct count

🤖 Generated with [Claude Code](https://claude.com/claude-code)