### PR TITLE
fix: Extract hardcoded skip reason in CodeFormattedNicelyModule (#1523)

### DIFF
--- a/src/ModularPipelines.Build/Modules/CodeFormattedNicelyModule.cs
+++ b/src/ModularPipelines.Build/Modules/CodeFormattedNicelyModule.cs
@@ -22,6 +22,7 @@ namespace ModularPipelines.Build.Modules;
 public class CodeFormattedNicelyModule : Module<CommandResult>, ISkippable, IAlwaysRun
 {
     private const string DotnetFormatGitMessage = "DotNet Format";
+    private const string TemporarilyDisabledSkipReason = "Temporarily disabled";
 
     private readonly IOptions<GitHubSettings> _githubSettings;
 
@@ -32,7 +33,7 @@ public class CodeFormattedNicelyModule : Module<CommandResult>, ISkippable, IAlw
 
     public Task<SkipDecision> ShouldSkip(IPipelineContext context)
     {
-        return SkipDecision.Skip("Temporarily disabled").AsTask();
+        return SkipDecision.Skip(TemporarilyDisabledSkipReason).AsTask();
     }
 
     public override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- Extracted the hardcoded "Temporarily disabled" skip reason string to a private constant `TemporarilyDisabledSkipReason`
- Follows the same pattern already used for `DotnetFormatGitMessage` in the same file

Fixes #1523

## Test plan
- [x] The change is a simple code smell fix with no behavioral changes
- [x] Build verified (no errors related to the changed file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)