### PR TITLE
refactor: Extract magic strings to constants in PackagePathsParserModule (#1519)

### DIFF
--- a/src/ModularPipelines.Build/Modules/PackagePathsParserModule.cs
+++ b/src/ModularPipelines.Build/Modules/PackagePathsParserModule.cs
@@ -10,14 +10,17 @@ namespace ModularPipelines.Build.Modules;
 [RunOnLinuxOnly]
 public class PackagePathsParserModule : Module<List<File>>
 {
+    private const string PackageCreationSuccessPrefix = "Successfully created package '";
+    private const string PackagePathSuffix = "'.";
+
     public override Task<List<File>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
         var packPackagesModuleResult = context.GetModule<PackProjectsModule, CommandResult[]>();
 
         return Task.FromResult<List<File>?>(packPackagesModuleResult.Value!
             .Select(x => x.StandardOutput)
-            .Select(x => x.Split("Successfully created package '")[1])
-            .Select(x => x.Split("'.")[0])
+            .Select(x => x.Split(PackageCreationSuccessPrefix)[1])
+            .Select(x => x.Split(PackagePathSuffix)[0])
             .Select(x => new File(x))
             .ToList());
     }


### PR DESCRIPTION
## Summary
- Extract inline magic strings to named constants in `PackagePathsParserModule`
- Introduces `PackageCreationSuccessPrefix` constant for `"Successfully created package '"`
- Introduces `PackagePathSuffix` constant for `"'."`

## Changes
This refactoring improves code readability and maintainability by replacing magic strings with descriptive constants. The functionality remains unchanged.

## Test plan
- [x] Build verification passed (solution builds successfully)
- [x] No new tests required - this is a pure refactoring with no behavioral changes

Fixes #1519

🤖 Generated with [Claude Code](https://claude.com/claude-code)