### PR TITLE
refactor: Extract duplicated branch condition logic to shared helper

### DIFF
--- a/src/ModularPipelines.Git/Attributes/BranchConditionHelper.cs
+++ b/src/ModularPipelines.Git/Attributes/BranchConditionHelper.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Context;
+using ModularPipelines.Git.Extensions;
+
+namespace ModularPipelines.Git.Attributes;
+
+/// <summary>
+/// Helper class for branch condition checking logic used by branch-related attributes.
+/// </summary>
+internal static class BranchConditionHelper
+{
+    /// <summary>
+    /// Checks if the current branch matches the expected branch name.
+    /// </summary>
+    internal static bool CheckBranchMatches(
+        IPipelineHookContext pipelineContext,
+        string expectedBranchName,
+        string logMessageFormat)
+    {
+        var currentBranchName = pipelineContext.Git().Information.BranchName;
+        pipelineContext.Logger.LogDebug(logMessageFormat, currentBranchName, expectedBranchName);
+        return currentBranchName == expectedBranchName;
+    }
+
+    /// <summary>
+    /// Checks if the current branch starts with the expected prefix.
+    /// </summary>
+    internal static bool CheckBranchStartsWith(
+        IPipelineHookContext pipelineContext,
+        string expectedPrefix,
+        string logMessageFormat)
+    {
+        var currentBranchName = pipelineContext.Git().Information.BranchName;
+        pipelineContext.Logger.LogDebug(logMessageFormat, currentBranchName, expectedPrefix);
+        return currentBranchName?.StartsWith(expectedPrefix) ?? false;
+    }
+}

--- a/src/ModularPipelines.Git/Attributes/RunIfBranchAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunIfBranchAttribute.cs
@@ -1,8 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 
 namespace ModularPipelines.Git.Attributes;
 
@@ -18,10 +16,9 @@ public class RunIfBranchAttribute : RunConditionAttribute
 
     public override Task<bool> Condition(IPipelineHookContext pipelineContext)
     {
-        var currentBranchName = pipelineContext.Git().Information.BranchName;
-
-        pipelineContext.Logger.LogDebug("Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}", currentBranchName, BranchName);
-
-        return Task.FromResult(currentBranchName == BranchName);
+        return Task.FromResult(BranchConditionHelper.CheckBranchMatches(
+            pipelineContext,
+            BranchName,
+            "Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}"));
     }
 }

--- a/src/ModularPipelines.Git/Attributes/RunIfBranchStartsWithAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunIfBranchStartsWithAttribute.cs
@@ -1,8 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 
 namespace ModularPipelines.Git.Attributes;
 
@@ -18,10 +16,9 @@ public class RunIfBranchStartsWithAttribute : RunConditionAttribute
 
     public override Task<bool> Condition(IPipelineHookContext pipelineContext)
     {
-        var currentBranchName = pipelineContext.Git().Information.BranchName;
-
-        pipelineContext.Logger.LogDebug("Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}", currentBranchName, BranchNamePrefix);
-
-        return Task.FromResult(currentBranchName?.StartsWith(BranchNamePrefix) ?? false);
+        return Task.FromResult(BranchConditionHelper.CheckBranchStartsWith(
+            pipelineContext,
+            BranchNamePrefix,
+            "Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}"));
     }
 }

--- a/src/ModularPipelines.Git/Attributes/RunOnlyIfBranchStartsWithAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunOnlyIfBranchStartsWithAttribute.cs
@@ -1,8 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 
 namespace ModularPipelines.Git.Attributes;
 
@@ -18,10 +16,9 @@ public class RunOnlyIfBranchStartsWithAttribute : MandatoryRunConditionAttribute
 
     public override Task<bool> Condition(IPipelineHookContext pipelineContext)
     {
-        var currentBranchName = pipelineContext.Git().Information.BranchName;
-
-        pipelineContext.Logger.LogDebug("Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}", currentBranchName, BranchNamePrefix);
-
-        return Task.FromResult(currentBranchName?.StartsWith(BranchNamePrefix) ?? false);
+        return Task.FromResult(BranchConditionHelper.CheckBranchStartsWith(
+            pipelineContext,
+            BranchNamePrefix,
+            "Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}"));
     }
 }

--- a/src/ModularPipelines.Git/Attributes/RunOnlyOnBranchAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunOnlyOnBranchAttribute.cs
@@ -1,8 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 
 namespace ModularPipelines.Git.Attributes;
 
@@ -18,10 +16,9 @@ public class RunOnlyOnBranchAttribute : MandatoryRunConditionAttribute
 
     public override Task<bool> Condition(IPipelineHookContext pipelineContext)
     {
-        var currentBranchName = pipelineContext.Git().Information.BranchName;
-
-        pipelineContext.Logger.LogDebug("Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}", currentBranchName, BranchName);
-
-        return Task.FromResult(currentBranchName == BranchName);
+        return Task.FromResult(BranchConditionHelper.CheckBranchMatches(
+            pipelineContext,
+            BranchName,
+            "Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}"));
     }
 }

--- a/src/ModularPipelines.Git/Attributes/SkipIfBranchAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/SkipIfBranchAttribute.cs
@@ -1,8 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
-using ModularPipelines.Git.Extensions;
 
 namespace ModularPipelines.Git.Attributes;
 
@@ -18,10 +16,9 @@ public class SkipIfBranchAttribute : MandatoryRunConditionAttribute
 
     public override Task<bool> Condition(IPipelineHookContext pipelineContext)
     {
-        var currentBranchName = pipelineContext.Git().Information.BranchName;
-
-        pipelineContext.Logger.LogDebug("Current Branch: {CurrentBranch} | Will skip on: {SkipBranch}", currentBranchName, BranchName);
-
-        return Task.FromResult(currentBranchName != BranchName);
+        return Task.FromResult(!BranchConditionHelper.CheckBranchMatches(
+            pipelineContext,
+            BranchName,
+            "Current Branch: {CurrentBranch} | Will skip on: {SkipBranch}"));
     }
 }


### PR DESCRIPTION
## Summary
- Created `BranchConditionHelper` static class with `CheckBranchMatches` and `CheckBranchStartsWith` methods
- Updated `RunIfBranchAttribute`, `RunOnlyOnBranchAttribute`, `RunIfBranchStartsWithAttribute`, `RunOnlyIfBranchStartsWithAttribute`, and `SkipIfBranchAttribute` to use the shared helper
- Eliminates code duplication across Git branch-related attributes while preserving exact same behavior and logging

## Test plan
- [ ] Build the solution to verify compilation
- [ ] Run existing tests to ensure behavior is unchanged
- [ ] Verify debug logging still works correctly for branch conditions

Fixes #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)