### PR TITLE
fix: Use case-insensitive GetHashCode on Windows for File and Folder (#1510)

### DIFF
--- a/src/ModularPipelines/FileSystem/File.cs
+++ b/src/ModularPipelines/FileSystem/File.cs
@@ -423,6 +423,11 @@ public class File : IEquatable<File>
     /// <inheritdoc/>
     public override int GetHashCode()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(Path);
+        }
+
         return Path.GetHashCode();
     }
 

--- a/src/ModularPipelines/FileSystem/Folder.cs
+++ b/src/ModularPipelines/FileSystem/Folder.cs
@@ -583,6 +583,11 @@ public class Folder : IEquatable<Folder>
     /// <inheritdoc/>
     public override int GetHashCode()
     {
+        if (OperatingSystem.IsWindows())
+        {
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(Path);
+        }
+
         return Path.GetHashCode();
     }
 


### PR DESCRIPTION
## Summary
- Fixes issue where `File` and `Folder` classes have inconsistent `GetHashCode` behavior on Windows
- `Equals` method correctly uses case-insensitive comparison on Windows (`StringComparison.OrdinalIgnoreCase`)
- But `GetHashCode` was using `Path.GetHashCode()` which is case-sensitive
- This violates the .NET contract that equal objects must return equal hash codes
- Now uses `StringComparer.OrdinalIgnoreCase.GetHashCode(Path)` on Windows for both classes

## Test plan
- [x] Build the solution to verify no compilation errors
- [ ] Verify that `File` and `Folder` objects with different casing but same path work correctly in hash-based collections on Windows
- [ ] Verify behavior on Linux/macOS remains case-sensitive

Closes #1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)