### PR TITLE
refactor: Replace static FlushLock with DI-injectable IOutputFlushLock

### DIFF
--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -126,6 +126,7 @@ internal static class DependencyInjectionSetup
             .AddSingleton<IPipelineFileWriter, PipelineFileWriter>()
             .AddSingleton<EngineCancellationToken>()
             .AddSingleton<IModuleLoggerContainer, ModuleLoggerContainer>()
+            .AddSingleton<IOutputFlushLock, OutputFlushLock>()
             .AddSingleton<IModuleOutputWriterFactory, ModuleOutputWriterFactory>()
             .AddSingleton<IOptionsProvider, OptionsProvider>()
             .AddSingleton<ISecretProvider, SecretProvider>()

--- a/src/ModularPipelines/Logging/IOutputFlushLock.cs
+++ b/src/ModularPipelines/Logging/IOutputFlushLock.cs
@@ -1,0 +1,19 @@
+namespace ModularPipelines.Logging;
+
+/// <summary>
+/// Provides a shared lock for coordinating console output flushing across modules.
+/// This ensures that module outputs do not interleave when flushing to the console.
+/// </summary>
+/// <remarks>
+/// Registered as a singleton to share the lock across all <see cref="ModuleOutputWriter"/> instances.
+/// This replaces the static lock that was previously in <see cref="ModuleOutputWriter"/>,
+/// following proper DI patterns and enabling testability.
+/// </remarks>
+internal interface IOutputFlushLock
+{
+    /// <summary>
+    /// Gets the lock object used to synchronize console output flushing.
+    /// Use this with <c>lock</c> statement to ensure atomic output blocks.
+    /// </summary>
+    object Lock { get; }
+}

--- a/src/ModularPipelines/Logging/ModuleOutputWriterFactory.cs
+++ b/src/ModularPipelines/Logging/ModuleOutputWriterFactory.cs
@@ -10,6 +10,7 @@ namespace ModularPipelines.Logging;
 internal class ModuleOutputWriterFactory : IModuleOutputWriterFactory
 {
     private readonly IServiceProvider _serviceProvider;
+    private readonly IOutputFlushLock _flushLock;
     private readonly IBuildSystemFormatterProvider _formatterProvider;
     private readonly IConsoleWriter _consoleWriter;
     private readonly ISecretObfuscator _secretObfuscator;
@@ -17,12 +18,14 @@ internal class ModuleOutputWriterFactory : IModuleOutputWriterFactory
 
     public ModuleOutputWriterFactory(
         IServiceProvider serviceProvider,
+        IOutputFlushLock flushLock,
         IBuildSystemFormatterProvider formatterProvider,
         IConsoleWriter consoleWriter,
         ISecretObfuscator secretObfuscator,
         ILoggerFactory loggerFactory)
     {
         _serviceProvider = serviceProvider;
+        _flushLock = flushLock;
         _formatterProvider = formatterProvider;
         _consoleWriter = consoleWriter;
         _secretObfuscator = secretObfuscator;
@@ -40,6 +43,7 @@ internal class ModuleOutputWriterFactory : IModuleOutputWriterFactory
 
         return new ModuleOutputWriter(
             scope,
+            _flushLock,
             _formatterProvider,
             _consoleWriter,
             _secretObfuscator,

--- a/src/ModularPipelines/Logging/OutputFlushLock.cs
+++ b/src/ModularPipelines/Logging/OutputFlushLock.cs
@@ -1,0 +1,11 @@
+namespace ModularPipelines.Logging;
+
+/// <summary>
+/// Singleton implementation of <see cref="IOutputFlushLock"/> that provides
+/// a shared lock for coordinating console output flushing across modules.
+/// </summary>
+internal sealed class OutputFlushLock : IOutputFlushLock
+{
+    /// <inheritdoc />
+    public object Lock { get; } = new();
+}


### PR DESCRIPTION
## Summary
- Replaced static `FlushLock` in `ModuleOutputWriter` with a DI-injectable `IOutputFlushLock` singleton
- Added new `IOutputFlushLock` interface and `OutputFlushLock` implementation
- Updated `ModuleOutputWriterFactory` to inject the flush lock
- Registered `OutputFlushLock` as singleton in DI container

## Problem
The static `FlushLock` in `ModuleOutputWriter` caused potential cross-module blocking issues and violated DI patterns, making the code harder to test and reason about.

## Solution
By replacing the static lock with a DI-injectable singleton:
- **Same behavior**: Lock is still shared across all `ModuleOutputWriter` instances (registered as singleton)
- **Proper DI**: Follows dependency injection patterns used throughout the codebase
- **Testable**: Lock behavior can now be mocked/replaced in unit tests
- **No breaking changes**: Internal implementation detail, no public API changes

## Test plan
- [x] Build the core `ModularPipelines` project (0 errors, only pre-existing warnings)
- [ ] Run existing tests to verify no regressions
- [ ] Verify parallel module execution still produces non-interleaved output

Fixes #1624

🤖 Generated with [Claude Code](https://claude.com/claude-code)