### PR TITLE
refactor: Separate exception storage from cancellation token (#1591)

### DIFF
--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -89,6 +89,7 @@ internal static class DependencyInjectionSetup
             .AddSingleton<IConsolePrinter, ConsolePrinter>()
             .AddSingleton<IAfterPipelineLogger, AfterPipelineLogger>()
             .AddSingleton<IExceptionBuffer, ExceptionBuffer>()
+            .AddSingleton<IPrimaryExceptionContainer, PrimaryExceptionContainer>()
             .AddSingleton<ISecondaryExceptionContainer, SecondaryExceptionContainer>()
             .AddSingleton<IPipelineContextProvider, ModuleContextProvider>()
             .AddSingleton<IDependencyChainProvider, DependencyChainProvider>()

--- a/src/ModularPipelines/Engine/IPrimaryExceptionContainer.cs
+++ b/src/ModularPipelines/Engine/IPrimaryExceptionContainer.cs
@@ -1,0 +1,32 @@
+using System.Runtime.ExceptionServices;
+
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Stores the primary/first exception that caused the pipeline to fail.
+/// This is the exception that should be rethrown when the pipeline execution completes.
+/// Secondary exceptions (from AlwaysRun modules, etc.) are stored in <see cref="ISecondaryExceptionContainer"/>.
+/// </summary>
+internal interface IPrimaryExceptionContainer
+{
+    /// <summary>
+    /// Gets the original exception that caused the pipeline to fail.
+    /// </summary>
+    Exception? OriginalException { get; }
+
+    /// <summary>
+    /// Gets the ExceptionDispatchInfo that preserves the original stack trace.
+    /// </summary>
+    ExceptionDispatchInfo? OriginalExceptionDispatchInfo { get; }
+
+    /// <summary>
+    /// Sets the primary exception. Only the first exception is stored; subsequent calls are ignored.
+    /// </summary>
+    /// <param name="exception">The exception to store.</param>
+    void SetException(Exception exception);
+
+    /// <summary>
+    /// Throws the stored exception if one exists, preserving the original stack trace.
+    /// </summary>
+    void ThrowIfHasException();
+}

--- a/src/ModularPipelines/Engine/ISecondaryExceptionContainer.cs
+++ b/src/ModularPipelines/Engine/ISecondaryExceptionContainer.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Collects secondary exceptions that occur during pipeline execution,
 /// such as failures in AlwaysRun modules or dependency resolution.
-/// The primary/first exception that fails the pipeline is stored in EngineCancellationToken.
+/// The primary/first exception that fails the pipeline is stored in <see cref="IPrimaryExceptionContainer"/>.
 /// </summary>
 internal interface ISecondaryExceptionContainer
 {

--- a/src/ModularPipelines/Engine/PrimaryExceptionContainer.cs
+++ b/src/ModularPipelines/Engine/PrimaryExceptionContainer.cs
@@ -1,0 +1,39 @@
+using System.Runtime.ExceptionServices;
+
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Stores the primary/first exception that caused the pipeline to fail.
+/// This is the exception that should be rethrown when the pipeline execution completes.
+/// Secondary exceptions (from AlwaysRun modules, etc.) are stored in <see cref="ISecondaryExceptionContainer"/>.
+/// </summary>
+internal class PrimaryExceptionContainer : IPrimaryExceptionContainer
+{
+    private readonly object _exceptionLock = new();
+
+    /// <inheritdoc />
+    public Exception? OriginalException { get; private set; }
+
+    /// <inheritdoc />
+    public ExceptionDispatchInfo? OriginalExceptionDispatchInfo { get; private set; }
+
+    /// <inheritdoc />
+    public void SetException(Exception exception)
+    {
+        lock (_exceptionLock)
+        {
+            // Only store the first exception
+            if (OriginalException == null)
+            {
+                OriginalException = exception;
+                OriginalExceptionDispatchInfo = ExceptionDispatchInfo.Capture(exception);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void ThrowIfHasException()
+    {
+        OriginalExceptionDispatchInfo?.Throw();
+    }
+}

--- a/src/ModularPipelines/Engine/SecondaryExceptionContainer.cs
+++ b/src/ModularPipelines/Engine/SecondaryExceptionContainer.cs
@@ -5,7 +5,7 @@ namespace ModularPipelines.Engine;
 /// <summary>
 /// Collects secondary exceptions that occur during pipeline execution,
 /// such as failures in AlwaysRun modules or dependency resolution.
-/// The primary/first exception that fails the pipeline is stored in EngineCancellationToken.
+/// The primary/first exception that fails the pipeline is stored in <see cref="IPrimaryExceptionContainer"/>.
 /// </summary>
 internal class SecondaryExceptionContainer : ISecondaryExceptionContainer
 {


### PR DESCRIPTION
## Summary
- Extract exception storage responsibility from `EngineCancellationToken` to a dedicated `IPrimaryExceptionContainer` interface and implementation
- This improves Single Responsibility Principle (SRP) compliance
- `EngineCancellationToken` now focuses solely on cancellation token management while delegating exception storage to `IPrimaryExceptionContainer`

## Changes
- Add `IPrimaryExceptionContainer` interface for storing primary exceptions
- Add `PrimaryExceptionContainer` implementing thread-safe exception storage
- Update `EngineCancellationToken` to inject and delegate to `IPrimaryExceptionContainer`
- Update XML doc comments in `ISecondaryExceptionContainer` and `SecondaryExceptionContainer` to reference new container interface
- Register `IPrimaryExceptionContainer` in DI container

## Test plan
- [x] Build succeeds with 0 errors
- [ ] Existing tests pass (coverage maintained)
- [ ] Exception handling behavior unchanged (primary exception preserved through delegation)

Fixes #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)