### PR TITLE
fix: Use IHttpClientFactory with pre-registered named clients instead of creating ServiceProvider per HttpLoggingType

### DIFF
--- a/src/ModularPipelines.GitHub/GitHub.cs
+++ b/src/ModularPipelines.GitHub/GitHub.cs
@@ -71,13 +71,11 @@ internal class GitHub : IGitHub
         var connection = new Connection(new ProductHeaderValue("ModularPipelines"),
           new HttpClientAdapter(() =>
           {
-              var moduleLogger = _moduleLoggerProvider.GetLogger();
-
-              return new RequestLoggingHttpHandler(moduleLogger, _httpLogger)
+              return new RequestLoggingHttpHandler(_moduleLoggerProvider, _httpLogger)
               {
-                  InnerHandler = new ResponseLoggingHttpHandler(moduleLogger, _httpLogger)
+                  InnerHandler = new ResponseLoggingHttpHandler(_moduleLoggerProvider, _httpLogger)
                   {
-                      InnerHandler = new StatusCodeLoggingHttpHandler(moduleLogger, _httpLogger)
+                      InnerHandler = new StatusCodeLoggingHttpHandler(_moduleLoggerProvider, _httpLogger)
                       {
                           InnerHandler = new HttpClientHandler(),
                       },

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -51,6 +51,7 @@ internal static class DependencyInjectionSetup
                 });
             })
             .AddHttpClient()
+            .AddLoggingHttpClients()
             .AddInitializers()
             .AddServiceCollection()
             .AddMediator(); // Add Mediator for event handling

--- a/src/ModularPipelines/Http/DurationLoggingHttpHandler.cs
+++ b/src/ModularPipelines/Http/DurationLoggingHttpHandler.cs
@@ -5,12 +5,12 @@ namespace ModularPipelines.Http;
 
 internal class DurationLoggingHttpHandler : DelegatingHandler
 {
-    private readonly IModuleLogger _logger;
+    private readonly IModuleLoggerProvider _loggerProvider;
     private readonly IHttpLogger _httpLogger;
 
-    public DurationLoggingHttpHandler(IModuleLogger logger, IHttpLogger httpLogger)
+    public DurationLoggingHttpHandler(IModuleLoggerProvider loggerProvider, IHttpLogger httpLogger)
     {
-        _logger = logger;
+        _loggerProvider = loggerProvider;
         _httpLogger = httpLogger;
     }
 
@@ -24,7 +24,8 @@ internal class DurationLoggingHttpHandler : DelegatingHandler
         }
         finally
         {
-            _httpLogger.PrintDuration(stopwatch.Elapsed, _logger);
+            var logger = _loggerProvider.GetLogger();
+            _httpLogger.PrintDuration(stopwatch.Elapsed, logger);
         }
     }
 }

--- a/src/ModularPipelines/Http/HttpClientNames.cs
+++ b/src/ModularPipelines/Http/HttpClientNames.cs
@@ -1,0 +1,19 @@
+namespace ModularPipelines.Http;
+
+/// <summary>
+/// Helper class to generate consistent named HttpClient identifiers based on logging configuration.
+/// </summary>
+internal static class HttpClientNames
+{
+    private const string ClientNamePrefix = "ModularPipelines_LoggingClient_";
+
+    /// <summary>
+    /// Gets the named HttpClient identifier for the specified logging type.
+    /// </summary>
+    /// <param name="loggingType">The HTTP logging type flags.</param>
+    /// <returns>A consistent client name for the logging configuration.</returns>
+    public static string GetClientName(HttpLoggingType loggingType)
+    {
+        return $"{ClientNamePrefix}{(int)loggingType}";
+    }
+}

--- a/src/ModularPipelines/Http/HttpClientServiceCollectionExtensions.cs
+++ b/src/ModularPipelines/Http/HttpClientServiceCollectionExtensions.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ModularPipelines.Http;
+
+/// <summary>
+/// Extension methods for registering logging HttpClients with the DI container.
+/// </summary>
+internal static class HttpClientServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers all 16 combinations of logging HttpClients (2^4 from the 4 HttpLoggingType flags).
+    /// This allows sharing HttpClient instances through IHttpClientFactory instead of creating
+    /// new ServiceProviders per logging type configuration.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddLoggingHttpClients(this IServiceCollection services)
+    {
+        // Register the handlers as transient so they can be resolved per-request
+        services.AddTransient<RequestLoggingHttpHandler>();
+        services.AddTransient<ResponseLoggingHttpHandler>();
+        services.AddTransient<DurationLoggingHttpHandler>();
+        services.AddTransient<StatusCodeLoggingHttpHandler>();
+
+        // Register all 16 combinations of logging types (0-15)
+        // HttpLoggingType is a flags enum with: Request=1, Response=2, StatusCode=4, Duration=8
+        for (var i = 0; i <= 15; i++)
+        {
+            var loggingType = (HttpLoggingType)i;
+            var clientName = HttpClientNames.GetClientName(loggingType);
+
+            var builder = services.AddHttpClient(clientName);
+
+            // Add handlers based on the flags
+            if (loggingType.HasFlag(HttpLoggingType.Request))
+            {
+                builder.AddHttpMessageHandler<RequestLoggingHttpHandler>();
+            }
+
+            if (loggingType.HasFlag(HttpLoggingType.Response))
+            {
+                builder.AddHttpMessageHandler<ResponseLoggingHttpHandler>();
+            }
+
+            if (loggingType.HasFlag(HttpLoggingType.Duration))
+            {
+                builder.AddHttpMessageHandler<DurationLoggingHttpHandler>();
+            }
+
+            if (loggingType.HasFlag(HttpLoggingType.StatusCode))
+            {
+                builder.AddHttpMessageHandler<StatusCodeLoggingHttpHandler>();
+            }
+        }
+
+        return services;
+    }
+}

--- a/src/ModularPipelines/Http/RequestLoggingHttpHandler.cs
+++ b/src/ModularPipelines/Http/RequestLoggingHttpHandler.cs
@@ -4,19 +4,20 @@ namespace ModularPipelines.Http;
 
 internal class RequestLoggingHttpHandler : DelegatingHandler
 {
-    private readonly IModuleLogger _logger;
+    private readonly IModuleLoggerProvider _loggerProvider;
     private readonly IHttpLogger _httpLogger;
 
-    public RequestLoggingHttpHandler(IModuleLogger logger, IHttpLogger httpLogger)
+    public RequestLoggingHttpHandler(IModuleLoggerProvider loggerProvider, IHttpLogger httpLogger)
     {
-        _logger = logger;
+        _loggerProvider = loggerProvider;
         _httpLogger = httpLogger;
     }
 
     /// <inheritdoc/>
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        await _httpLogger.PrintRequest(request, _logger).ConfigureAwait(false);
+        var logger = _loggerProvider.GetLogger();
+        await _httpLogger.PrintRequest(request, logger).ConfigureAwait(false);
 
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 

--- a/src/ModularPipelines/Http/ResponseLoggingHttpHandler.cs
+++ b/src/ModularPipelines/Http/ResponseLoggingHttpHandler.cs
@@ -4,12 +4,12 @@ namespace ModularPipelines.Http;
 
 internal class ResponseLoggingHttpHandler : DelegatingHandler
 {
-    private readonly IModuleLogger _logger;
+    private readonly IModuleLoggerProvider _loggerProvider;
     private readonly IHttpLogger _httpLogger;
 
-    public ResponseLoggingHttpHandler(IModuleLogger logger, IHttpLogger httpLogger)
+    public ResponseLoggingHttpHandler(IModuleLoggerProvider loggerProvider, IHttpLogger httpLogger)
     {
-        _logger = logger;
+        _loggerProvider = loggerProvider;
         _httpLogger = httpLogger;
     }
 
@@ -23,7 +23,8 @@ internal class ResponseLoggingHttpHandler : DelegatingHandler
         // making it unreadable by subsequent code. See issue #1610.
         await response.Content.LoadIntoBufferAsync().ConfigureAwait(false);
 
-        await _httpLogger.PrintResponse(response, _logger).ConfigureAwait(false);
+        var logger = _loggerProvider.GetLogger();
+        await _httpLogger.PrintResponse(response, logger).ConfigureAwait(false);
 
         return response;
     }

--- a/src/ModularPipelines/Http/StatusCodeLoggingHttpHandler.cs
+++ b/src/ModularPipelines/Http/StatusCodeLoggingHttpHandler.cs
@@ -4,12 +4,12 @@ namespace ModularPipelines.Http;
 
 internal class StatusCodeLoggingHttpHandler : DelegatingHandler
 {
-    private readonly IModuleLogger _logger;
+    private readonly IModuleLoggerProvider _loggerProvider;
     private readonly IHttpLogger _httpLogger;
 
-    public StatusCodeLoggingHttpHandler(IModuleLogger logger, IHttpLogger httpLogger)
+    public StatusCodeLoggingHttpHandler(IModuleLoggerProvider loggerProvider, IHttpLogger httpLogger)
     {
-        _logger = logger;
+        _loggerProvider = loggerProvider;
         _httpLogger = httpLogger;
     }
 
@@ -19,13 +19,15 @@ internal class StatusCodeLoggingHttpHandler : DelegatingHandler
         {
             var httpResponseMessage = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-            _httpLogger.PrintStatusCode(httpResponseMessage.StatusCode, _logger);
+            var logger = _loggerProvider.GetLogger();
+            _httpLogger.PrintStatusCode(httpResponseMessage.StatusCode, logger);
 
             return httpResponseMessage;
         }
         catch (HttpRequestException e)
         {
-            _httpLogger.PrintStatusCode(e.StatusCode, _logger);
+            var logger = _loggerProvider.GetLogger();
+            _httpLogger.PrintStatusCode(e.StatusCode, logger);
             throw;
         }
     }


### PR DESCRIPTION
## Summary

Fixes #1561 - The `Http` class was creating a new `ServiceCollection` and `ServiceProvider` for each unique `HttpLoggingType` combination, causing memory leaks and performance issues.

- Add `HttpClientNames` helper class for consistent named client identifiers
- Add `HttpClientServiceCollectionExtensions` with `AddLoggingHttpClients()` to register all 16 `HttpLoggingType` combinations at startup  
- Refactor `Http` class to use `IHttpClientFactory.CreateClient()` instead of building new ServiceProviders
- Update logging handlers to use `IModuleLoggerProvider` instead of `IModuleLogger`, allowing logger resolution at request time
- Update `ModularPipelines.GitHub` to pass `IModuleLoggerProvider` to handlers

This eliminates per-request ServiceProvider creation and properly leverages `IHttpClientFactory` for pooled HttpClient instances.

## Test plan

- [x] Build solution successfully
- [x] Run existing HTTP logging tests (`Assert_LoggingHttpClient_Logs_As_Expected`) - all pass
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)