### PR TITLE
fix: Add file existence validation in Checksum.Md5() (#1492)

### DIFF
--- a/src/ModularPipelines/Context/Checksum.cs
+++ b/src/ModularPipelines/Context/Checksum.cs
@@ -6,6 +6,11 @@ internal class Checksum : IChecksum
 {
     public string Md5(string filePath)
     {
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException($"Cannot calculate MD5 checksum: file not found at '{filePath}'", filePath);
+        }
+
         using var md5 = MD5.Create();
         using var stream = File.OpenRead(filePath);
         var hash = md5.ComputeHash(stream);


### PR DESCRIPTION
## Summary
- Adds `File.Exists()` check before opening file for MD5 hash calculation
- Throws `FileNotFoundException` with descriptive message when file doesn't exist
- Improves error handling to fail fast with clear messaging

Fixes #1492

## Test plan
- [x] Code compiles successfully
- [ ] Existing tests pass (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)