### PR TITLE
refactor: Update FileHelper docs to reference constants (#1475)

### DIFF
--- a/src/ModularPipelines/Helpers/FileHelper.cs
+++ b/src/ModularPipelines/Helpers/FileHelper.cs
@@ -22,10 +22,10 @@ public static class FileHelper
     /// </summary>
     /// <param name="path">The path to the file to wait for.</param>
     /// <param name="timeout">
-    /// The maximum time to wait. If null, defaults to 30 seconds.
+    /// The maximum time to wait. If null, defaults to <see cref="DefaultTimeout"/>.
     /// </param>
     /// <param name="pollingInterval">
-    /// The interval between checks. If null, defaults to 500 milliseconds.
+    /// The interval between checks. If null, defaults to <see cref="DefaultPollingInterval"/>.
     /// </param>
     /// <param name="cancellationToken">A token to cancel the wait operation.</param>
     /// <returns>


### PR DESCRIPTION
## Summary
- Updates XML documentation in `WaitForFileAsync` to use `see cref` for `DefaultTimeout` and `DefaultPollingInterval`
- Replaces hardcoded numeric values in docs with references to the actual constants
- Ensures documentation stays in sync with implementation

Fixes #1475

## Test plan
- [x] Code compiles successfully
- [ ] Existing tests pass (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)