### PR TITLE
refactor: Remove duplicate ToPascalCase implementation (#1486)

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
@@ -522,21 +523,9 @@ public abstract partial class CliScraperBase : ICliScraper
 
     /// <summary>
     /// Converts a string to PascalCase.
+    /// Delegates to <see cref="GeneratorUtils.ToPascalCase"/> for consistent behavior.
     /// </summary>
-    protected static string ToPascalCase(string input)
-    {
-        if (string.IsNullOrEmpty(input))
-        {
-            return input;
-        }
-
-        if (input.Length == 1)
-        {
-            return char.ToUpperInvariant(input[0]).ToString();
-        }
-
-        return char.ToUpperInvariant(input[0]) + input[1..].ToLowerInvariant();
-    }
+    protected static string ToPascalCase(string input) => GeneratorUtils.ToPascalCase(input);
 
     /// <summary>
     /// Pattern to match option lines (e.g., "-f, --flag" or "--option").


### PR DESCRIPTION
## Summary
- Replaces duplicate ToPascalCase method in CliScraperBase with delegation to GeneratorUtils.ToPascalCase
- Eliminates DRY violation between two inconsistent implementations
- Ensures consistent PascalCase conversion with proper kebab-case handling

Fixes #1486

## Test plan
- [x] Code compiles successfully
- [ ] Existing tests pass (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)