### PR TITLE
refactor: Replace Task.Result with GetAwaiter().GetResult() (#1504)

### DIFF
--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -258,7 +258,8 @@ internal class ModuleRunner : IModuleRunner
             // Even when an exception is thrown, we need to register the result if one was set
             if (executionContext.ExecutionTask.IsCompleted && !executionContext.ExecutionTask.IsFaulted && !executionContext.ExecutionTask.IsCanceled)
             {
-                var result = executionContext.ExecutionTask.Result;
+                // Use GetAwaiter().GetResult() instead of .Result to avoid wrapping in AggregateException
+                var result = executionContext.ExecutionTask.GetAwaiter().GetResult();
                 moduleState.Result = result;
                 _resultRegistry.RegisterResult(moduleType, result);
             }


### PR DESCRIPTION
## Summary
- Replaces `.Result` with `.GetAwaiter().GetResult()` in the catch block
- Avoids wrapping exceptions in AggregateException
- Follows better async patterns while maintaining sync access where required

The task is already verified to be completed and not faulted before access, so this is safe.

Fixes #1504

## Test plan
- [x] Code compiles successfully
- [ ] Existing tests pass (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)