### PR TITLE
refactor: Extract GetOrCreateLogger to IModuleLoggerContainer (#1495)

### DIFF
--- a/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
@@ -41,7 +41,7 @@ internal class DependencyWaiter : IDependencyWaiter
                 }
                 catch (Exception e) when (moduleState.Module.ModuleRunType == ModuleRunType.AlwaysRun)
                 {
-                    var depLogger = GetOrCreateLogger(moduleState.ModuleType, scopedServiceProvider);
+                    var depLogger = _loggerContainer.GetOrCreateLogger(moduleState.ModuleType, scopedServiceProvider);
                     _secondaryExceptionContainer.RegisterException(new AlwaysRunPostponedException(
                         $"{dependencyType.Name} threw an exception when {moduleState.ModuleType.Name} was waiting for it as a dependency",
                         e));
@@ -60,12 +60,5 @@ internal class DependencyWaiter : IDependencyWaiter
                 throw new ModuleNotRegisteredException(message, null);
             }
         }
-    }
-
-    private IModuleLogger GetOrCreateLogger(Type moduleType, IServiceProvider scopedServiceProvider)
-    {
-        var loggerType = typeof(ModuleLogger<>).MakeGenericType(moduleType);
-        return _loggerContainer.GetLogger(loggerType)
-            ?? (IModuleLogger)scopedServiceProvider.GetRequiredService(loggerType);
     }
 }

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -146,7 +146,7 @@ internal class ModuleRunner : IModuleRunner
 
         // Create module-specific context
         var executionContext = CreateExecutionContext(module, moduleType);
-        var logger = GetOrCreateLogger(moduleType, scopedServiceProvider);
+        var logger = _loggerContainer.GetOrCreateLogger(moduleType, scopedServiceProvider);
         var moduleContext = new ModuleContext(pipelineContext, module, executionContext, logger);
 
         // Start Activity for distributed tracing (Phase 1: alongside AsyncLocal for compatibility)
@@ -296,12 +296,5 @@ internal class ModuleRunner : IModuleRunner
         var executor = ModuleExecutionDelegateFactory.GetExecutor(module.ResultType);
         return await executor(_executionPipeline, module, executionContext, moduleContext, cancellationToken)
             .ConfigureAwait(false);
-    }
-
-    private IModuleLogger GetOrCreateLogger(Type moduleType, IServiceProvider scopedServiceProvider)
-    {
-        var loggerType = typeof(ModuleLogger<>).MakeGenericType(moduleType);
-        return _loggerContainer.GetLogger(loggerType)
-            ?? (IModuleLogger)scopedServiceProvider.GetRequiredService(loggerType);
     }
 }

--- a/src/ModularPipelines/Logging/IModuleLoggerContainer.cs
+++ b/src/ModularPipelines/Logging/IModuleLoggerContainer.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+
 namespace ModularPipelines.Logging;
 
 /// <summary>
@@ -5,6 +7,19 @@ namespace ModularPipelines.Logging;
 /// </summary>
 internal interface IModuleLoggerContainer
 {
+    /// <summary>
+    /// Gets an existing logger or creates one from the scoped service provider.
+    /// </summary>
+    /// <param name="moduleType">The module type to get/create a logger for.</param>
+    /// <param name="scopedServiceProvider">The scoped service provider to resolve from if not cached.</param>
+    /// <returns>The module logger instance.</returns>
+    IModuleLogger GetOrCreateLogger(Type moduleType, IServiceProvider scopedServiceProvider)
+    {
+        var loggerType = typeof(ModuleLogger<>).MakeGenericType(moduleType);
+        return GetLogger(loggerType)
+            ?? (IModuleLogger)scopedServiceProvider.GetRequiredService(loggerType);
+    }
+
     /// <summary>
     /// Flushes all buffered log events and disposes all registered loggers.
     /// Loggers are processed in order of last log written time.


### PR DESCRIPTION
## Summary
- Adds default interface method `GetOrCreateLogger` to `IModuleLoggerContainer`
- Removes duplicate implementations from `ModuleRunner` and `DependencyWaiter`
- Ensures consistent logger creation across the codebase

Fixes #1495

## Test plan
- [x] Code compiles successfully
- [ ] Existing tests pass (CI will verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)