### PR TITLE
perf(async): Add ConfigureAwait(false) to await using statements

### DIFF
--- a/src/ModularPipelines/FileSystem/File.cs
+++ b/src/ModularPipelines/FileSystem/File.cs
@@ -326,9 +326,15 @@ public class File : IEquatable<File>
     {
         LogFileOperationWithDestination("Copying File: {Source} > {Destination} [Module: {ModuleName}, Activity: {ActivityId}]", this, path);
 
-        await using var sourceStream = System.IO.File.OpenRead(Path);
-        await using var destStream = System.IO.File.Create(path);
-        await sourceStream.CopyToAsync(destStream, cancellationToken).ConfigureAwait(false);
+        var sourceStream = System.IO.File.OpenRead(Path);
+        await using (sourceStream.ConfigureAwait(false))
+        {
+            var destStream = System.IO.File.Create(path);
+            await using (destStream.ConfigureAwait(false))
+            {
+                await sourceStream.CopyToAsync(destStream, cancellationToken).ConfigureAwait(false);
+            }
+        }
 
         return new File(path);
     }

--- a/src/ModularPipelines/FileSystem/Folder.cs
+++ b/src/ModularPipelines/FileSystem/Folder.cs
@@ -359,9 +359,15 @@ public class Folder : IEquatable<Folder>
             var relativePath = System.IO.Path.GetRelativePath(this, filePath);
             var newPath = System.IO.Path.Combine(targetPath, relativePath);
 
-            await using var sourceStream = System.IO.File.OpenRead(filePath);
-            await using var destStream = System.IO.File.Create(newPath);
-            await sourceStream.CopyToAsync(destStream, cancellationToken).ConfigureAwait(false);
+            var sourceStream = System.IO.File.OpenRead(filePath);
+            await using (sourceStream.ConfigureAwait(false))
+            {
+                var destStream = System.IO.File.Create(newPath);
+                await using (destStream.ConfigureAwait(false))
+                {
+                    await sourceStream.CopyToAsync(destStream, cancellationToken).ConfigureAwait(false);
+                }
+            }
 
             var targetFile = new FileInfo(newPath);
             targetFile.Attributes = sourceFile.Attributes;


### PR DESCRIPTION
## Summary
- Adds `ConfigureAwait(false)` to `await using` statements in library code
- Converts inline await using to block pattern where needed for proper disposal
- Prevents unnecessary synchronization context captures in async library code

Closes #1555

## Test plan
- [ ] Verify file operations work correctly with changes
- [ ] Verify folder operations work correctly with changes
- [ ] Run existing tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)