### PR TITLE
refactor: Standardize async patterns by removing unnecessary await statements

### DIFF
--- a/src/ModularPipelines.Build/Modules/CreateReleaseModule.cs
+++ b/src/ModularPipelines.Build/Modules/CreateReleaseModule.cs
@@ -31,22 +31,19 @@ public class CreateReleaseModule : Module<Release>, ISkippable, IIgnoreFailures
         _publishSettings = publishSettings;
     }
 
-    public async Task<bool> ShouldIgnoreFailures(IPipelineContext context, Exception exception)
+    public Task<bool> ShouldIgnoreFailures(IPipelineContext context, Exception exception)
     {
-        await Task.Yield();
-        return exception is ApiValidationException;
+        return Task.FromResult(exception is ApiValidationException);
     }
 
-    public async Task<SkipDecision> ShouldSkip(IPipelineContext context)
+    public Task<SkipDecision> ShouldSkip(IPipelineContext context)
     {
-        await Task.CompletedTask;
-
         if (!_publishSettings.Value.ShouldPublish)
         {
-            return "The 'ShouldPublish' flag is false";
+            return Task.FromResult<SkipDecision>("The 'ShouldPublish' flag is false");
         }
 
-        return string.IsNullOrEmpty(_githubSettings.Value.AdminToken);
+        return Task.FromResult<SkipDecision>(string.IsNullOrEmpty(_githubSettings.Value.AdminToken));
     }
 
     public override async Task<Release?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)

--- a/src/ModularPipelines.Build/Modules/FindProjectsModule.cs
+++ b/src/ModularPipelines.Build/Modules/FindProjectsModule.cs
@@ -9,11 +9,9 @@ namespace ModularPipelines.Build.Modules;
 
 public class FindProjectsModule : Module<IReadOnlyList<File>>, IAlwaysRun
 {
-    public override async Task<IReadOnlyList<File>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    public override Task<IReadOnlyList<File>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        await Task.Yield();
-
-        return
+        return Task.FromResult<IReadOnlyList<File>?>(
         [
             Sourcy.DotNet.Projects.ModularPipelines,
             Sourcy.DotNet.Projects.ModularPipelines_AmazonWebServices,
@@ -37,6 +35,6 @@ public class FindProjectsModule : Module<IReadOnlyList<File>>, IAlwaysRun
             Sourcy.DotNet.Projects.ModularPipelines_TeamCity,
             Sourcy.DotNet.Projects.ModularPipelines_Terraform,
             Sourcy.DotNet.Projects.ModularPipelines_WinGet
-        ];
+        ]);
     }
 }

--- a/src/ModularPipelines.Build/Modules/LocalMachine/CreateLocalNugetFolderModule.cs
+++ b/src/ModularPipelines.Build/Modules/LocalMachine/CreateLocalNugetFolderModule.cs
@@ -7,17 +7,15 @@ namespace ModularPipelines.Build.Modules.LocalMachine;
 
 public class CreateLocalNugetFolderModule : Module<Folder>
 {
-    public override async Task<Folder?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    public override Task<Folder?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
         var localNugetRepositoryFolder = context.FileSystem.GetFolder(Environment.SpecialFolder.ApplicationData)
             .GetFolder("ModularPipelines")
             .GetFolder("LocalNuget")
             .Create();
 
-        await Task.Yield();
-
         context.Logger.LogInformation("Local NuGet Repository Path: {Path}", localNugetRepositoryFolder.Path);
 
-        return localNugetRepositoryFolder;
+        return Task.FromResult<Folder?>(localNugetRepositoryFolder);
     }
 }

--- a/src/ModularPipelines.Build/Modules/PackageFilesRemovalModule.cs
+++ b/src/ModularPipelines.Build/Modules/PackageFilesRemovalModule.cs
@@ -6,7 +6,7 @@ namespace ModularPipelines.Build.Modules;
 
 public class PackageFilesRemovalModule : Module<int>
 {
-    public override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    public override Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
         var packageFiles = context.Git()
             .RootDirectory
@@ -19,7 +19,6 @@ public class PackageFilesRemovalModule : Module<int>
             count++;
         }
 
-        await Task.CompletedTask;
-        return count;
+        return Task.FromResult(count);
     }
 }

--- a/src/ModularPipelines.Build/Modules/PrintEnvironmentVariablesModule.cs
+++ b/src/ModularPipelines.Build/Modules/PrintEnvironmentVariablesModule.cs
@@ -8,12 +8,10 @@ namespace ModularPipelines.Build.Modules;
 
 public class PrintEnvironmentVariablesModule : Module<IDictionary<string, object>>
 {
-    public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    public override Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        await Task.CompletedTask;
-
         context.Logger.LogInformation("Environment Variables: {EnvVars}", JsonSerializer.Serialize(context.Environment.EnvironmentVariables.GetEnvironmentVariables(), DiagnosticSerializerOptions.Instance));
 
-        return null;
+        return Task.FromResult<IDictionary<string, object>?>(null);
     }
 }

--- a/src/ModularPipelines.Build/Modules/PrintGitInformationModule.cs
+++ b/src/ModularPipelines.Build/Modules/PrintGitInformationModule.cs
@@ -9,12 +9,10 @@ namespace ModularPipelines.Build.Modules;
 
 public class PrintGitInformationModule : Module<IDictionary<string, object>>
 {
-    public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    public override Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        await Task.CompletedTask;
-
         context.Logger.LogInformation("Git Info: {GitInfo}", JsonSerializer.Serialize(context.Git().Information, DiagnosticSerializerOptions.Instance));
 
-        return null;
+        return Task.FromResult<IDictionary<string, object>?>(null);
     }
 }

--- a/src/ModularPipelines.Examples/LogSecretModule.cs
+++ b/src/ModularPipelines.Examples/LogSecretModule.cs
@@ -15,10 +15,9 @@ public class LogSecretModule : Module<IDictionary<string, object>?>
     }
 
     /// <inheritdoc/>
-    public override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    public override Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
         context.Logger.LogInformation("Value is {Value}", _options.Value.MySecret);
-        await Task.Yield();
-        return null;
+        return Task.FromResult<IDictionary<string, object>?>(null);
     }
 }

--- a/src/ModularPipelines.Examples/Modules/GitLastCommitModule.cs
+++ b/src/ModularPipelines.Examples/Modules/GitLastCommitModule.cs
@@ -9,14 +9,12 @@ namespace ModularPipelines.Examples.Modules;
 public class GitLastCommitModule : Module<GitCommit?>
 {
     /// <inheritdoc/>
-    public override async Task<GitCommit?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    public override Task<GitCommit?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        await Task.Yield();
-
         context.Logger.LogInformation("Getting Last Git Commit");
 
         var lastCommit = context.Git().Information.PreviousCommit;
 
-        return lastCommit;
+        return Task.FromResult(lastCommit);
     }
 }

--- a/src/ModularPipelines.Examples/WindowsRequirement.cs
+++ b/src/ModularPipelines.Examples/WindowsRequirement.cs
@@ -7,9 +7,8 @@ namespace ModularPipelines.Examples;
 public class WindowsRequirement : IPipelineRequirement
 {
     /// <inheritdoc/>
-    public async Task<RequirementDecision> MustAsync(IPipelineHookContext context)
+    public Task<RequirementDecision> MustAsync(IPipelineHookContext context)
     {
-        await Task.Yield();
-        return context.Environment.OperatingSystem == OperatingSystemIdentifier.Windows;
+        return Task.FromResult<RequirementDecision>(context.Environment.OperatingSystem == OperatingSystemIdentifier.Windows);
     }
 }


### PR DESCRIPTION
## Summary
- Removes unnecessary `await Task.CompletedTask` and `await Task.Yield()` patterns
- Converts async methods that don't need async to return `Task.FromResult` or `ValueTask.FromResult`
- Standardizes async patterns across the codebase

Closes #1500

## Test plan
- [ ] Verify module execution still works correctly
- [ ] Run build pipeline tests to confirm no regressions
- [ ] Run existing tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)