### PR TITLE
fix(http): Obfuscate sensitive HTTP headers in logging

### DIFF
--- a/src/ModularPipelines/Http/HttpResponseFormatter.cs
+++ b/src/ModularPipelines/Http/HttpResponseFormatter.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text;
+using ModularPipelines.Constants;
 using ModularPipelines.Engine;
 using ModularPipelines.Options;
 
@@ -63,7 +64,7 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
 
         if (options.LogResponseHeaders)
         {
-            AppendHeaders(sb, response.Headers, response.Content.Headers);
+            AppendHeaders(sb, response.Headers, response.Content.Headers, options.SensitiveHeaderNames);
             sb.AppendLine();
         }
 
@@ -75,7 +76,7 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
         return sb.ToString();
     }
 
-    private static void AppendHeaders(StringBuilder sb, HttpHeaders baseHeaders, HttpHeaders? contentHeaders)
+    private static void AppendHeaders(StringBuilder sb, HttpHeaders baseHeaders, HttpHeaders? contentHeaders, IReadOnlyList<string> sensitiveHeaderNames)
     {
         sb.AppendLine("Headers");
 
@@ -83,7 +84,8 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
         {
             foreach (var value in values)
             {
-                sb.AppendLine($"\t{key}: {value}");
+                var displayValue = IsSensitiveHeader(key, sensitiveHeaderNames) ? LoggingConstants.SecretMask : value;
+                sb.AppendLine($"\t{key}: {displayValue}");
             }
         }
 
@@ -94,7 +96,8 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
         {
             foreach (var value in values)
             {
-                sb.AppendLine($"\t{key}: {value}");
+                var displayValue = IsSensitiveHeader(key, sensitiveHeaderNames) ? LoggingConstants.SecretMask : value;
+                sb.AppendLine($"\t{key}: {displayValue}");
             }
         }
 
@@ -102,6 +105,26 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
         {
             sb.AppendLine("\t(null)");
         }
+    }
+
+    private static bool IsSensitiveHeader(string headerName, IReadOnlyList<string> sensitiveHeaderNames)
+    {
+        // Use HashSet for O(1) lookup when using default headers
+        if (ReferenceEquals(sensitiveHeaderNames, HttpLoggingOptions.DefaultSensitiveHeaders))
+        {
+            return HttpLoggingOptions.DefaultSensitiveHeadersSet.Contains(headerName);
+        }
+
+        // For custom lists, fall back to case-insensitive comparison
+        foreach (var sensitiveHeader in sensitiveHeaderNames)
+        {
+            if (string.Equals(headerName, sensitiveHeader, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private async Task AppendBodyAsync(StringBuilder sb, HttpContent? content, int maxBodySize, CancellationToken cancellationToken)

--- a/src/ModularPipelines/Options/HttpLoggingOptions.cs
+++ b/src/ModularPipelines/Options/HttpLoggingOptions.cs
@@ -72,6 +72,45 @@ public record HttpLoggingOptions
     public int MaxBodySizeToLog { get; init; } = LoggingConstants.DefaultMaxBodySizeToLog;
 
     /// <summary>
+    /// Gets or sets the list of header names that should have their values obfuscated in logs.
+    /// Values are compared case-insensitively. Default includes common sensitive headers like
+    /// Authorization, X-API-Key, Cookie, Set-Cookie, and various token/key headers.
+    /// </summary>
+    public IReadOnlyList<string> SensitiveHeaderNames { get; init; } = DefaultSensitiveHeaders;
+
+    /// <summary>
+    /// Default list of sensitive header names that should be obfuscated.
+    /// </summary>
+    public static IReadOnlyList<string> DefaultSensitiveHeaders { get; } = new[]
+    {
+        "Authorization",
+        "X-API-Key",
+        "X-Api-Key",
+        "Api-Key",
+        "ApiKey",
+        "X-Auth-Token",
+        "X-Access-Token",
+        "X-Secret",
+        "X-Secret-Key",
+        "Cookie",
+        "Set-Cookie",
+        "WWW-Authenticate",
+        "Proxy-Authorization",
+        "Proxy-Authenticate",
+        "X-CSRF-Token",
+        "X-XSRF-Token",
+        "X-Amz-Security-Token",
+        "X-Amz-Credential",
+    };
+
+    /// <summary>
+    /// HashSet of default sensitive headers for O(1) lookup.
+    /// Used internally by formatters for performance.
+    /// </summary>
+    internal static HashSet<string> DefaultSensitiveHeadersSet { get; } =
+        new(DefaultSensitiveHeaders, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Default logging options (all logging enabled, 4KB body limit).
     /// </summary>
     public static HttpLoggingOptions Default { get; } = new();


### PR DESCRIPTION
## Summary
- Adds `SensitiveHeaderNames` property to `HttpLoggingOptions`
- Default list includes Authorization, API keys, cookies, tokens, and other sensitive headers
- Updates `HttpRequestFormatter` and `HttpResponseFormatter` to obfuscate sensitive header values
- Prevents accidental secret leakage through HTTP header logging

Closes #1508

## Test plan
- [ ] Verify Authorization header values are obfuscated in logs
- [ ] Verify API key headers are obfuscated
- [ ] Verify non-sensitive headers log normally
- [ ] Run existing tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)