### PR TITLE
feat(analyzers): Add missing code fix providers for analyzers

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -76,5 +76,32 @@ namespace ModularPipelines.Analyzers {
                 return ResourceManager.GetString("MissingDependsOnAttributeCodeFixTitle", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Replace IEnumerable with List.
+        /// </summary>
+        internal static string EnumerableModuleResultToListCodeFixTitle {
+            get {
+                return ResourceManager.GetString("EnumerableModuleResultToListCodeFixTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Replace IEnumerable with Array.
+        /// </summary>
+        internal static string EnumerableModuleResultToArrayCodeFixTitle {
+            get {
+                return ResourceManager.GetString("EnumerableModuleResultToArrayCodeFixTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Remove DependsOn Attribute.
+        /// </summary>
+        internal static string ConflictingDependsOnAttributeCodeFixTitle {
+            get {
+                return ResourceManager.GetString("ConflictingDependsOnAttributeCodeFixTitle", resourceCulture);
+            }
+        }
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/CodeFixResources.resx
@@ -124,4 +124,16 @@
   <data name="AsyncModuleCodeFixTitle" xml:space="preserve">
     <value>Add Async Modifier</value>
   </data>
+  <data name="EnumerableModuleResultToListCodeFixTitle" xml:space="preserve">
+    <value>Replace IEnumerable with List</value>
+    <comment>The title of the code fix to replace IEnumerable with List.</comment>
+  </data>
+  <data name="EnumerableModuleResultToArrayCodeFixTitle" xml:space="preserve">
+    <value>Replace IEnumerable with Array</value>
+    <comment>The title of the code fix to replace IEnumerable with Array.</comment>
+  </data>
+  <data name="ConflictingDependsOnAttributeCodeFixTitle" xml:space="preserve">
+    <value>Remove DependsOn Attribute</value>
+    <comment>The title of the code fix to remove a conflicting DependsOn attribute.</comment>
+  </data>
 </root>

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
@@ -1,0 +1,84 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ModularPipelines.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ConflictingDependsOnAttributeCodeFixProvider))]
+[Shared]
+[ExcludeFromCodeCoverage]
+public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ConflictingDependsOnAttributeAnalyzer.DiagnosticId);
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc/>
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        if (root is null)
+        {
+            return;
+        }
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        // Find the attribute syntax identified by the diagnostic.
+        var attributeSyntax = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<AttributeSyntax>().FirstOrDefault();
+
+        if (attributeSyntax is null)
+        {
+            return;
+        }
+
+        // Register a code action that will remove the conflicting attribute.
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: CodeFixResources.ConflictingDependsOnAttributeCodeFixTitle,
+                createChangedDocument: c => RemoveAttribute(context, attributeSyntax, c),
+                equivalenceKey: nameof(CodeFixResources.ConflictingDependsOnAttributeCodeFixTitle)),
+            diagnostic);
+    }
+
+    private static async Task<Document> RemoveAttribute(CodeFixContext context, AttributeSyntax attributeSyntax, CancellationToken cancellationToken)
+    {
+        var document = context.Document;
+        var documentRoot = (await document.GetSyntaxRootAsync(cancellationToken))!;
+
+        // Get the attribute list that contains this attribute
+        var attributeList = attributeSyntax.Parent as AttributeListSyntax;
+        if (attributeList is null)
+        {
+            return document;
+        }
+
+        SyntaxNode newRoot;
+
+        // If this is the only attribute in the list, remove the entire attribute list
+        if (attributeList.Attributes.Count == 1)
+        {
+            newRoot = documentRoot.RemoveNode(attributeList, SyntaxRemoveOptions.KeepNoTrivia)!;
+        }
+        else
+        {
+            // Otherwise, just remove this attribute from the list
+            var newAttributes = attributeList.Attributes.Remove(attributeSyntax);
+            var newAttributeList = attributeList.WithAttributes(newAttributes);
+            newRoot = documentRoot.ReplaceNode(attributeList, newAttributeList);
+        }
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/EnumerableModuleResultCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/EnumerableModuleResultCodeFixProvider.cs
@@ -1,0 +1,164 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ModularPipelines.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(EnumerableModuleResultCodeFixProvider))]
+[Shared]
+[ExcludeFromCodeCoverage]
+public class EnumerableModuleResultCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc/>
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(EnumerableModuleResultAnalyzer.DiagnosticId);
+
+    /// <inheritdoc/>
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc/>
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        if (root is null)
+        {
+            return;
+        }
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        // Find the base type syntax identified by the diagnostic.
+        var baseTypeSyntax = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<SimpleBaseTypeSyntax>().FirstOrDefault();
+
+        if (baseTypeSyntax is null)
+        {
+            return;
+        }
+
+        // Register a code action to convert IEnumerable<T> to List<T>
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: CodeFixResources.EnumerableModuleResultToListCodeFixTitle,
+                createChangedDocument: c => ReplaceEnumerableWithList(context, baseTypeSyntax, c),
+                equivalenceKey: nameof(CodeFixResources.EnumerableModuleResultToListCodeFixTitle)),
+            diagnostic);
+
+        // Register a code action to convert IEnumerable<T> to T[]
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: CodeFixResources.EnumerableModuleResultToArrayCodeFixTitle,
+                createChangedDocument: c => ReplaceEnumerableWithArray(context, baseTypeSyntax, c),
+                equivalenceKey: nameof(CodeFixResources.EnumerableModuleResultToArrayCodeFixTitle)),
+            diagnostic);
+    }
+
+    private static async Task<Document> ReplaceEnumerableWithList(CodeFixContext context, SimpleBaseTypeSyntax baseTypeSyntax, CancellationToken cancellationToken)
+    {
+        var document = context.Document;
+        var documentRoot = (await document.GetSyntaxRootAsync(cancellationToken))!;
+
+        if (baseTypeSyntax.Type is not GenericNameSyntax moduleGenericSyntax)
+        {
+            return document;
+        }
+
+        if (moduleGenericSyntax.TypeArgumentList.Arguments.FirstOrDefault() is not GenericNameSyntax enumerableGenericSyntax)
+        {
+            return document;
+        }
+
+        // Get the inner type argument (the T in IEnumerable<T>)
+        var innerTypeArgument = enumerableGenericSyntax.TypeArgumentList.Arguments.FirstOrDefault();
+        if (innerTypeArgument is null)
+        {
+            return document;
+        }
+
+        // Create List<T>
+        var listType = SyntaxFactory.GenericName(
+            SyntaxFactory.Identifier("List"),
+            SyntaxFactory.TypeArgumentList(
+                SyntaxFactory.SingletonSeparatedList(innerTypeArgument)));
+
+        // Create new Module<List<T>>
+        var newModuleType = SyntaxFactory.GenericName(
+            SyntaxFactory.Identifier("Module"),
+            SyntaxFactory.TypeArgumentList(
+                SyntaxFactory.SingletonSeparatedList<TypeSyntax>(listType)));
+
+        var newBaseTypeSyntax = SyntaxFactory.SimpleBaseType(newModuleType);
+
+        var newRoot = documentRoot.ReplaceNode(baseTypeSyntax, newBaseTypeSyntax);
+
+        // Add using for System.Collections.Generic if not present
+        newRoot = AddUsingIfNeeded(newRoot, "System.Collections.Generic");
+
+        return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static async Task<Document> ReplaceEnumerableWithArray(CodeFixContext context, SimpleBaseTypeSyntax baseTypeSyntax, CancellationToken cancellationToken)
+    {
+        var document = context.Document;
+        var documentRoot = (await document.GetSyntaxRootAsync(cancellationToken))!;
+
+        if (baseTypeSyntax.Type is not GenericNameSyntax moduleGenericSyntax)
+        {
+            return document;
+        }
+
+        if (moduleGenericSyntax.TypeArgumentList.Arguments.FirstOrDefault() is not GenericNameSyntax enumerableGenericSyntax)
+        {
+            return document;
+        }
+
+        // Get the inner type argument (the T in IEnumerable<T>)
+        var innerTypeArgument = enumerableGenericSyntax.TypeArgumentList.Arguments.FirstOrDefault();
+        if (innerTypeArgument is null)
+        {
+            return document;
+        }
+
+        // Create T[]
+        var arrayType = SyntaxFactory.ArrayType(
+            innerTypeArgument,
+            SyntaxFactory.SingletonList(
+                SyntaxFactory.ArrayRankSpecifier(
+                    SyntaxFactory.SingletonSeparatedList<ExpressionSyntax>(
+                        SyntaxFactory.OmittedArraySizeExpression()))));
+
+        // Create new Module<T[]>
+        var newModuleType = SyntaxFactory.GenericName(
+            SyntaxFactory.Identifier("Module"),
+            SyntaxFactory.TypeArgumentList(
+                SyntaxFactory.SingletonSeparatedList<TypeSyntax>(arrayType)));
+
+        var newBaseTypeSyntax = SyntaxFactory.SimpleBaseType(newModuleType);
+
+        return document.WithSyntaxRoot(documentRoot.ReplaceNode(baseTypeSyntax, newBaseTypeSyntax));
+    }
+
+    private static SyntaxNode AddUsingIfNeeded(SyntaxNode documentRoot, string namespaceName)
+    {
+        if (documentRoot is not CompilationUnitSyntax compilationUnitSyntax)
+        {
+            return documentRoot;
+        }
+
+        if (compilationUnitSyntax.Usings.Any(u => u.Name?.ToFullString() == namespaceName))
+        {
+            return documentRoot;
+        }
+
+        return compilationUnitSyntax.AddUsings(
+            SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName)));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `EnumerableModuleResultCodeFixProvider` to fix IEnumerable module return types
- Adds `ConflictingDependsOnAttributeCodeFixProvider` to remove conflicting dependencies
- Updates `CodeFixResources.resx` with new fix descriptions

Closes #1499

## Test plan
- [ ] Verify code fix suggestions appear in IDE for IEnumerable module results
- [ ] Verify code fix suggestions appear for conflicting DependsOn attributes
- [ ] Verify applying fixes produces correct code
- [ ] Run existing analyzer tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)