### PR TITLE
refactor(analyzers): Create DiagnosticDescriptorFactory to reduce DRY violations (#1476)

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AsyncModuleAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AsyncModuleAnalyzer.cs
@@ -14,13 +14,11 @@ public class AsyncModuleAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "AsyncModule";
 
-    public static DiagnosticDescriptor Rule => PrivateRule;
-
-    private const string Category = "Usage";
-    private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.AsyncModuleAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AsyncModuleAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AsyncModuleAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
-    private static readonly DiagnosticDescriptor PrivateRule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    public static DiagnosticDescriptor Rule { get; } = DiagnosticDescriptorFactory.Create(
+        DiagnosticId,
+        nameof(Resources.AsyncModuleAnalyzerTitle),
+        nameof(Resources.AsyncModuleAnalyzerMessageFormat),
+        nameof(Resources.AsyncModuleAnalyzerDescription));
 
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
@@ -14,13 +14,11 @@ public class AwaitThisAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "AwaitThis";
 
-    public static DiagnosticDescriptor Rule => PrivateRule;
-
-    private const string Category = "Usage";
-    private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.AwaitThisAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.AwaitThisAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.AwaitThisAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
-    private static readonly DiagnosticDescriptor PrivateRule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    public static DiagnosticDescriptor Rule { get; } = DiagnosticDescriptorFactory.Create(
+        DiagnosticId,
+        nameof(Resources.AwaitThisAnalyzerTitle),
+        nameof(Resources.AwaitThisAnalyzerMessageFormat),
+        nameof(Resources.AwaitThisAnalyzerDescription));
 
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
@@ -14,14 +14,11 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "ConflictingDependsOnAttribute";
 
-    public static DiagnosticDescriptor Rule => PrivateRule;
-
-    private const string Category = "Usage";
-    private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.ConflictingDependsOnAttributeAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.ConflictingDependsOnAttributeAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.ConflictingDependsOnAttributeAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
-
-    private static readonly DiagnosticDescriptor PrivateRule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    public static DiagnosticDescriptor Rule { get; } = DiagnosticDescriptorFactory.Create(
+        DiagnosticId,
+        nameof(Resources.ConflictingDependsOnAttributeAnalyzerTitle),
+        nameof(Resources.ConflictingDependsOnAttributeAnalyzerMessageFormat),
+        nameof(Resources.ConflictingDependsOnAttributeAnalyzerDescription));
 
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConsoleUseAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConsoleUseAnalyzer.cs
@@ -13,13 +13,11 @@ public class ConsoleUseAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "ConsoleUse";
 
-    public static DiagnosticDescriptor Rule => PrivateRule;
-
-    private const string Category = "Usage";
-    private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.ConsoleUseAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.ConsoleUseAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.ConsoleUseAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
-    private static readonly DiagnosticDescriptor PrivateRule = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    public static DiagnosticDescriptor Rule { get; } = DiagnosticDescriptorFactory.Create(
+        DiagnosticId,
+        nameof(Resources.ConsoleUseAnalyzerTitle),
+        nameof(Resources.ConsoleUseAnalyzerMessageFormat),
+        nameof(Resources.ConsoleUseAnalyzerDescription));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/DiagnosticDescriptorFactory.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/DiagnosticDescriptorFactory.cs
@@ -1,0 +1,42 @@
+using Microsoft.CodeAnalysis;
+
+namespace ModularPipelines.Analyzers;
+
+/// <summary>
+/// Factory class for creating <see cref="DiagnosticDescriptor"/> instances with consistent configuration.
+/// Eliminates boilerplate code across analyzers by centralizing the creation of localizable diagnostic descriptors.
+/// </summary>
+internal static class DiagnosticDescriptorFactory
+{
+    /// <summary>
+    /// Creates a <see cref="DiagnosticDescriptor"/> with localizable strings from the Resources file.
+    /// </summary>
+    /// <param name="id">The unique identifier for the diagnostic.</param>
+    /// <param name="titleResourceName">The resource name for the title string.</param>
+    /// <param name="messageFormatResourceName">The resource name for the message format string.</param>
+    /// <param name="descriptionResourceName">The resource name for the description string.</param>
+    /// <param name="category">The category of the diagnostic. Defaults to "Usage".</param>
+    /// <param name="severity">The severity of the diagnostic. Defaults to <see cref="DiagnosticSeverity.Error"/>.</param>
+    /// <returns>A configured <see cref="DiagnosticDescriptor"/> instance.</returns>
+    public static DiagnosticDescriptor Create(
+        string id,
+        string titleResourceName,
+        string messageFormatResourceName,
+        string descriptionResourceName,
+        string category = "Usage",
+        DiagnosticSeverity severity = DiagnosticSeverity.Error)
+    {
+        var title = new LocalizableResourceString(titleResourceName, Resources.ResourceManager, typeof(Resources));
+        var messageFormat = new LocalizableResourceString(messageFormatResourceName, Resources.ResourceManager, typeof(Resources));
+        var description = new LocalizableResourceString(descriptionResourceName, Resources.ResourceManager, typeof(Resources));
+
+        return new DiagnosticDescriptor(
+            id,
+            title,
+            messageFormat,
+            category,
+            severity,
+            isEnabledByDefault: true,
+            description: description);
+    }
+}

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/EnumerableModuleResultAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/EnumerableModuleResultAnalyzer.cs
@@ -14,13 +14,11 @@ public class EnumerableModuleResultAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "EnumerableModuleResult";
 
-    public static DiagnosticDescriptor Rule => PrivateRule;
-
-    private const string Category = "Usage";
-    private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.IEnumerableModuleResultAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.IEnumerableModuleResultAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.IEnumerableModuleResultAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
-    private static readonly DiagnosticDescriptor PrivateRule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    public static DiagnosticDescriptor Rule { get; } = DiagnosticDescriptorFactory.Create(
+        DiagnosticId,
+        nameof(Resources.IEnumerableModuleResultAnalyzerTitle),
+        nameof(Resources.IEnumerableModuleResultAnalyzerMessageFormat),
+        nameof(Resources.IEnumerableModuleResultAnalyzerDescription));
 
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/LoggerInConstructorAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/LoggerInConstructorAnalyzer.cs
@@ -14,13 +14,11 @@ public class LoggerInConstructorAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "LoggerInConstructor";
 
-    public static DiagnosticDescriptor Rule => PrivateRule;
-
-    private const string Category = "Usage";
-    private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.LoggerInConstructorAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.LoggerInConstructorAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.LoggerInConstructorAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
-    private static readonly DiagnosticDescriptor PrivateRule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    public static DiagnosticDescriptor Rule { get; } = DiagnosticDescriptorFactory.Create(
+        DiagnosticId,
+        nameof(Resources.LoggerInConstructorAnalyzerTitle),
+        nameof(Resources.LoggerInConstructorAnalyzerMessageFormat),
+        nameof(Resources.LoggerInConstructorAnalyzerDescription));
 
     /// <summary>
     /// Logging types from Microsoft.Extensions.Logging that should not be injected directly.

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/MissingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/MissingDependsOnAttributeAnalyzer.cs
@@ -14,14 +14,11 @@ public class MissingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
 {
     public const string DiagnosticId = "MissingDependsOnAttribute";
 
-    public static DiagnosticDescriptor Rule => PrivateRule;
-
-    private const string Category = "Usage";
-    private static readonly LocalizableString Title = new LocalizableResourceString(nameof(Resources.MissingDependsOnAttributeAnalyzerTitle), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(Resources.MissingDependsOnAttributeAnalyzerMessageFormat), Resources.ResourceManager, typeof(Resources));
-    private static readonly LocalizableString Description = new LocalizableResourceString(nameof(Resources.MissingDependsOnAttributeAnalyzerDescription), Resources.ResourceManager, typeof(Resources));
-
-    private static readonly DiagnosticDescriptor PrivateRule = new(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Error, isEnabledByDefault: true, description: Description);
+    public static DiagnosticDescriptor Rule { get; } = DiagnosticDescriptorFactory.Create(
+        DiagnosticId,
+        nameof(Resources.MissingDependsOnAttributeAnalyzerTitle),
+        nameof(Resources.MissingDependsOnAttributeAnalyzerMessageFormat),
+        nameof(Resources.MissingDependsOnAttributeAnalyzerDescription));
 
     /// <inheritdoc/>
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);


### PR DESCRIPTION
## Summary
- Create `DiagnosticDescriptorFactory` static class to centralize diagnostic descriptor creation
- Update all 7 analyzer files to use the factory pattern
- Reduces code duplication for `LocalizableResourceString` creation

Fixes #1476

## Test Plan
- [x] Build succeeds
- [ ] Analyzer tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)