### PR TITLE
perf(engine): Cache module attribute lookups to reduce reflection overhead (#1483)

### DIFF
--- a/src/ModularPipelines/Engine/ModuleMetadataCache.cs
+++ b/src/ModularPipelines/Engine/ModuleMetadataCache.cs
@@ -1,0 +1,28 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Caches module scheduling metadata to avoid repeated reflection lookups.
+/// </summary>
+internal static class ModuleMetadataCache
+{
+    private static readonly ConcurrentDictionary<Type, ModuleSchedulingMetadata> Cache = new();
+
+    /// <summary>
+    /// Gets the cached scheduling metadata for a module type.
+    /// </summary>
+    /// <param name="moduleType">The module type to get metadata for.</param>
+    /// <returns>The cached metadata containing scheduling attributes.</returns>
+    public static ModuleSchedulingMetadata GetMetadata(Type moduleType)
+    {
+        return Cache.GetOrAdd(moduleType, static t => new ModuleSchedulingMetadata
+        {
+            NotInParallelAttribute = t.GetCustomAttribute<NotInParallelAttribute>(),
+            PriorityAttribute = t.GetCustomAttribute<PriorityAttribute>(),
+            ExecutionHintAttribute = t.GetCustomAttribute<ExecutionHintAttribute>(),
+        });
+    }
+}

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -97,10 +97,12 @@ internal class ModuleScheduler : IModuleScheduler
         {
             var moduleType = state.ModuleType;
 
-            var notInParallelAttr = moduleType.GetCustomAttribute<NotInParallelAttribute>();
-            if (notInParallelAttr != null)
+            // Use cached metadata to avoid repeated reflection lookups
+            var metadata = ModuleMetadataCache.GetMetadata(moduleType);
+
+            if (metadata.NotInParallelAttribute != null)
             {
-                if (notInParallelAttr.ConstraintKeys.Length == 0)
+                if (metadata.NotInParallelAttribute.ConstraintKeys.Length == 0)
                 {
                     state.RequiresSequentialExecution = true;
                     _logger.LogDebug(
@@ -109,7 +111,7 @@ internal class ModuleScheduler : IModuleScheduler
                 }
                 else
                 {
-                    state.RequiredLockKeys = notInParallelAttr.ConstraintKeys;
+                    state.RequiredLockKeys = metadata.NotInParallelAttribute.ConstraintKeys;
                     _logger.LogDebug(
                         "Module {ModuleName} requires locks: {Keys}",
                         MarkupFormatter.FormatModuleName(moduleType.Name),
@@ -118,10 +120,9 @@ internal class ModuleScheduler : IModuleScheduler
             }
 
             // Read priority attribute
-            var priorityAttr = moduleType.GetCustomAttribute<PriorityAttribute>();
-            if (priorityAttr != null)
+            if (metadata.PriorityAttribute != null)
             {
-                state.Priority = priorityAttr.Priority;
+                state.Priority = metadata.PriorityAttribute.Priority;
                 _logger.LogDebug(
                     "Module {ModuleName} has priority: {Priority}",
                     MarkupFormatter.FormatModuleName(moduleType.Name),
@@ -129,10 +130,9 @@ internal class ModuleScheduler : IModuleScheduler
             }
 
             // Read execution hint attribute
-            var executionHintAttr = moduleType.GetCustomAttribute<ExecutionHintAttribute>();
-            if (executionHintAttr != null)
+            if (metadata.ExecutionHintAttribute != null)
             {
-                state.ExecutionType = executionHintAttr.ExecutionType;
+                state.ExecutionType = metadata.ExecutionHintAttribute.ExecutionType;
                 _logger.LogDebug(
                     "Module {ModuleName} has execution type: {ExecutionType}",
                     MarkupFormatter.FormatModuleName(moduleType.Name),

--- a/src/ModularPipelines/Engine/ModuleSchedulingMetadata.cs
+++ b/src/ModularPipelines/Engine/ModuleSchedulingMetadata.cs
@@ -1,0 +1,24 @@
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Cached metadata for module scheduling attributes.
+/// </summary>
+internal sealed record ModuleSchedulingMetadata
+{
+    /// <summary>
+    /// Gets the NotInParallel attribute if present on the module type.
+    /// </summary>
+    public NotInParallelAttribute? NotInParallelAttribute { get; init; }
+
+    /// <summary>
+    /// Gets the Priority attribute if present on the module type.
+    /// </summary>
+    public PriorityAttribute? PriorityAttribute { get; init; }
+
+    /// <summary>
+    /// Gets the ExecutionHint attribute if present on the module type.
+    /// </summary>
+    public ExecutionHintAttribute? ExecutionHintAttribute { get; init; }
+}


### PR DESCRIPTION
## Summary
- Create `ModuleMetadataCache` with static `ConcurrentDictionary` for caching
- Create `ModuleSchedulingMetadata` record to hold cached attributes
- Update `ModuleScheduler` to use cached metadata instead of repeated reflection

Fixes #1483

## Test Plan
- [x] Build succeeds
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)