### PR TITLE
perf(engine): Replace ToList() with ToArray() to reduce allocations (#1525)

### DIFF
--- a/src/ModularPipelines/Engine/Attributes/RegistrationEventExecutor.cs
+++ b/src/ModularPipelines/Engine/Attributes/RegistrationEventExecutor.cs
@@ -36,10 +36,10 @@ internal class RegistrationEventExecutor : IRegistrationEventExecutor
 
     public async Task InvokeRegistrationEventsAsync(IEnumerable<IModule> modules)
     {
-        var moduleList = modules.ToList();
-        var registeredModuleTypes = moduleList.Select(m => m.GetType()).ToList();
+        var moduleArray = modules.ToArray();
+        var registeredModuleTypes = moduleArray.Select(m => m.GetType()).ToArray();
 
-        foreach (var module in moduleList)
+        foreach (var module in moduleArray)
         {
             var moduleType = module.GetType();
             var receivers = _attributeEventService.GetRegistrationReceivers(moduleType);
@@ -51,7 +51,7 @@ internal class RegistrationEventExecutor : IRegistrationEventExecutor
 
             var context = new ModuleRegistrationContext(
                 moduleType,
-                moduleType.GetCustomAttributes(inherit: true).OfType<Attribute>().ToList(),
+                moduleType.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray(),
                 _configuration,
                 _environment,
                 registeredModuleTypes,

--- a/src/ModularPipelines/Engine/DependencyChainProvider.cs
+++ b/src/ModularPipelines/Engine/DependencyChainProvider.cs
@@ -19,14 +19,14 @@ internal class DependencyChainProvider : IDependencyChainProvider, IInitializer
     public async Task InitializeAsync()
     {
         var modules = await _moduleRetriever.GetOrganizedModules().ConfigureAwait(false);
-        ModuleDependencyModels = Detect(modules.AllModules.Select(x => new ModuleDependencyModel(x)).ToList());
+        ModuleDependencyModels = Detect(modules.AllModules.Select(x => new ModuleDependencyModel(x)).ToArray());
     }
 
-    private List<ModuleDependencyModel> Detect(List<ModuleDependencyModel> allModules)
+    private ModuleDependencyModel[] Detect(ModuleDependencyModel[] allModules)
     {
         foreach (var moduleDependencyModel in allModules)
         {
-            var dependencies = GetModuleDependencies(moduleDependencyModel, allModules).ToList();
+            var dependencies = GetModuleDependencies(moduleDependencyModel, allModules).ToArray();
 
             moduleDependencyModel.IsDependentOn.AddRange(dependencies);
 
@@ -39,10 +39,10 @@ internal class DependencyChainProvider : IDependencyChainProvider, IInitializer
         return allModules;
     }
 
-    private IEnumerable<ModuleDependencyModel> GetModuleDependencies(ModuleDependencyModel moduleDependencyModel, IReadOnlyCollection<ModuleDependencyModel> allModules)
+    private IEnumerable<ModuleDependencyModel> GetModuleDependencies(ModuleDependencyModel moduleDependencyModel, ModuleDependencyModel[] allModules)
     {
         // Get all available module types for DependsOnAllModulesInheritingFrom resolution
-        var availableModuleTypes = allModules.Select(m => m.Module.GetType()).ToList();
+        var availableModuleTypes = allModules.Select(m => m.Module.GetType()).ToArray();
         var dependencies = ModuleDependencyResolver.GetDependencies(moduleDependencyModel.Module.GetType(), availableModuleTypes);
 
         foreach (var (dependencyType, _) in dependencies)

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -207,7 +207,7 @@ internal class ModuleRunner : IModuleRunner
 
         // Track start time for lifecycle events
         var startTime = DateTimeOffset.UtcNow;
-        var moduleAttributes = moduleType.GetCustomAttributes(inherit: true).OfType<Attribute>().ToList();
+        var moduleAttributes = moduleType.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray();
 
         var lifecycleContext = new ModuleLifecycleContext(
             module,

--- a/src/ModularPipelines/Engine/ModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/ModuleConditionHandler.cs
@@ -72,8 +72,8 @@ internal class ModuleConditionHandler : IModuleConditionHandler
 
     private async Task<(bool IsRunnable, SkipDecision? SkipDecision)> IsRunnableCondition(Type moduleType, CancellationToken cancellationToken)
     {
-        var mandatoryRunConditionAttributes = moduleType.GetCustomAttributes<MandatoryRunConditionAttribute>(true).ToList();
-        var runConditionAttributes = moduleType.GetCustomAttributes<RunConditionAttribute>(true).Except(mandatoryRunConditionAttributes).ToList();
+        var mandatoryRunConditionAttributes = moduleType.GetCustomAttributes<MandatoryRunConditionAttribute>(true).ToArray();
+        var runConditionAttributes = moduleType.GetCustomAttributes<RunConditionAttribute>(true).Except(mandatoryRunConditionAttributes).ToArray();
 
         // Get a context for condition evaluation
         var pipelineContext = _pipelineContextProvider.GetModuleContext();
@@ -90,7 +90,7 @@ internal class ModuleConditionHandler : IModuleConditionHandler
             }
         }
 
-        if (!runConditionAttributes.Any())
+        if (runConditionAttributes.Length == 0)
         {
             return (true, null);
         }

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -96,9 +96,9 @@ internal class ModuleScheduler : IModuleScheduler
     {
         ArgumentNullException.ThrowIfNull(modules);
 
-        var moduleList = modules.ToList();
+        var moduleArray = modules.ToArray();
 
-        foreach (var module in moduleList)
+        foreach (var module in moduleArray)
         {
             var moduleType = module.GetType();
             var state = new ModuleState(module, moduleType);
@@ -106,7 +106,7 @@ internal class ModuleScheduler : IModuleScheduler
         }
 
         // Get all available module types for DependsOnAllModulesInheritingFrom resolution
-        var availableModuleTypes = _moduleStates.Keys.ToList();
+        var availableModuleTypes = _moduleStates.Keys.ToArray();
 
         foreach (var state in _moduleStates.Values)
         {
@@ -343,15 +343,15 @@ internal class ModuleScheduler : IModuleScheduler
         // Previously this called LogPendingModules() and LogExecutingModules() separately,
         // each acquiring its own read lock
         ModuleStateStatistics stats;
-        List<ModuleState> pending;
-        List<ModuleState> executing;
+        ModuleState[] pending;
+        ModuleState[] executing;
 
         _stateLock.EnterReadLock();
         try
         {
             stats = _stateQueries.GetStatistics();
-            pending = _stateQueries.GetPendingModules().ToList();
-            executing = _stateQueries.GetExecutingModules().ToList();
+            pending = _stateQueries.GetPendingModules().ToArray();
+            executing = _stateQueries.GetExecutingModules().ToArray();
         }
         finally
         {
@@ -363,13 +363,13 @@ internal class ModuleScheduler : IModuleScheduler
             "Scheduler waiting: Total={Total}, Queued={Queued}, Executing={Executing}, Completed={Completed}, Pending={Pending}",
             stats.Total, stats.Queued, stats.Executing, stats.Completed, stats.Pending);
 
-        if (pending.Count > 0)
+        if (pending.Length > 0)
         {
             _logger.LogDebug("Pending modules: {Modules}",
                 string.Join(", ", pending.Select(FormatModuleWithDependencyCount)));
         }
 
-        if (executing.Count > 0)
+        if (executing.Length > 0)
         {
             _logger.LogDebug("Executing modules: {Modules}",
                 string.Join(", ", executing.Select(m => MarkupFormatter.FormatModuleName(m.ModuleType.Name))));
@@ -521,7 +521,7 @@ internal class ModuleScheduler : IModuleScheduler
             var potentiallyReadyModules = _moduleStates.Values
                 .Where(m => m.IsReadyToExecute)
                 .OrderByDescending(m => (int)m.Priority)
-                .ToList();
+                .ToArray();
 
             var modulesToQueue = new List<ModuleState>();
 

--- a/src/ModularPipelines/Extensions/TaskExtensions.cs
+++ b/src/ModularPipelines/Extensions/TaskExtensions.cs
@@ -31,18 +31,18 @@ public static class TaskExtensions
 
     internal static async Task<TResult[]> WhenAllFailFast<TResult>(this ICollection<Task<TResult>> tasks)
     {
-        var originalTasks = tasks.ToList();
+        var originalTasks = tasks.ToArray();
 
-        tasks = tasks.ToList();
+        var remainingTasks = new List<Task<TResult>>(originalTasks);
 
-        while (tasks.Any())
+        while (remainingTasks.Count > 0)
         {
-            var finished = await Task.WhenAny(tasks).ConfigureAwait(false);
+            var finished = await Task.WhenAny(remainingTasks).ConfigureAwait(false);
 
             // await to throw Exception if this Task errored
             await finished.ConfigureAwait(false);
 
-            tasks.Remove(finished);
+            remainingTasks.Remove(finished);
         }
 
         return await Task.WhenAll(originalTasks).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
Replace unnecessary `ToList()` calls with `ToArray()` throughout the engine for better memory efficiency:

- `TaskExtensions`: Return arrays directly
- `DependencyChainProvider`: Use `ToArray()` for dependency resolution
- `RegistrationEventExecutor`: Use `moduleArray` instead of `moduleList`
- `ModuleConditionHandler`: Use `ToArray()` for module filtering
- `ModuleRunner`: Use arrays for attribute lookup
- `ModuleScheduler`: Use `ToArray()` for pending modules

Fixes #1525

## Test Plan
- [x] Build succeeds
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)