### PR TITLE
fix: Prevent concurrent modification in SecretProvider.GetSecrets

### DIFF
--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -70,13 +70,16 @@ internal class SecretProvider : ISecretProvider, IInitializer
 
     private IEnumerable<string> GetSecrets(IEnumerable<object?> options)
     {
+        var secrets = new List<string>();
+
         foreach (var option in options)
         {
             foreach (var secret in GetSecretsInObject(option))
             {
-                _secrets.Add(secret);
-                yield return secret;
+                secrets.Add(secret);
             }
         }
+
+        return secrets;
     }
 }


### PR DESCRIPTION
## Summary
- Fixes issue #1480 where `GetSecrets()` was modifying `_secrets` collection while also yielding from it
- Changed implementation to collect secrets into a local list first, then return the list instead of yielding while modifying

## Test plan
- [x] Build succeeds with `dotnet build`
- [ ] Verify existing tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)