### PR TITLE
fix: Replace hardcoded Windows paths with platform-agnostic alternatives in PredefinedInstallers.Nvm

### DIFF
--- a/src/ModularPipelines/Context/PredefinedInstallers.cs
+++ b/src/ModularPipelines/Context/PredefinedInstallers.cs
@@ -135,9 +135,12 @@ public partial class PredefinedInstallers : IPredefinedInstallers
 
             var newFolder = _zip.UnZipToFolder(zipFile, Folder.CreateTemporaryFolder());
 
+            var nvmRoot = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "nvm");
+            var nodejsPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "nodejs");
+
             await newFolder.GetFile("settings.txt").WriteAsync($"""
-                                                               root: {Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "nvm")}
-                                                               path: C:\Program Files\nodejs
+                                                               root: {nvmRoot}
+                                                               path: {nodejsPath}
                                                                arch: 64
                                                                proxy: none
                                                                """).ConfigureAwait(false);
@@ -163,7 +166,8 @@ public partial class PredefinedInstallers : IPredefinedInstallers
         await _bash.Command(new BashCommandOptions("[ -s \"$NVM_DIR/bash_completion\" ] && \\. \"$NVM_DIR/bash_completion\"")).ConfigureAwait(false);
         await _bash.Command(new BashCommandOptions("source ~/.bashrc")).ConfigureAwait(false);
 
-        return new File("/home/runner/.nvm");
+        var nvmDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nvm");
+        return new File(nvmDir);
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
## Summary

- Replaced hardcoded `C:\Program Files\nodejs` path with `Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)` combined with `"nodejs"`
- Replaced hardcoded `/home/runner/.nvm` path with `Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)` combined with `".nvm"`
- Extracted path construction into local variables for better readability

Fixes #1482

## Test plan

- [x] Build passes with `dotnet build`
- [ ] Manual verification on Windows to ensure `Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)` resolves correctly
- [ ] Manual verification on Linux/macOS to ensure `Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)