### PR TITLE
perf: Remove sync-over-async blocking in Disposer.DisposeObject

### DIFF
--- a/src/ModularPipelines/Helpers/Disposer.cs
+++ b/src/ModularPipelines/Helpers/Disposer.cs
@@ -8,12 +8,6 @@ namespace ModularPipelines.Helpers;
 public static class Disposer
 {
     /// <summary>
-    /// The default timeout for synchronous disposal operations.
-    /// Set to 1 second to accommodate the limited time available during process exit (typically 2 seconds).
-    /// </summary>
-    public static readonly TimeSpan DefaultDisposeTimeout = TimeSpan.FromSeconds(1);
-
-    /// <summary>
     /// Asynchronously disposes an object if it implements <see cref="IAsyncDisposable"/> or <see cref="IDisposable"/>.
     /// </summary>
     /// <param name="obj">The object to dispose. Can be null.</param>
@@ -31,68 +25,36 @@ public static class Disposer
     }
 
     /// <summary>
-    /// Synchronously disposes an object with the default timeout.
-    /// </summary>
-    /// <remarks>
-    /// This method uses a timeout to prevent indefinite blocking during process shutdown.
-    /// The default timeout is 1 second, which allows disposal to complete while leaving
-    /// buffer time within the typical 2-second process exit window.
-    /// If the disposal does not complete within the timeout, the method returns without
-    /// waiting further. The disposal operation may continue in the background but is not
-    /// guaranteed to complete.
-    /// </remarks>
-    /// <param name="obj">The object to dispose. Can be null.</param>
-    public static void DisposeObject(object? obj) => DisposeObject(obj, DefaultDisposeTimeout);
-
-    /// <summary>
-    /// Synchronously disposes an object with a custom timeout.
-    /// </summary>
-    /// <remarks>
-    /// This method uses a timeout to prevent indefinite blocking during process shutdown.
-    /// If the disposal does not complete within the specified timeout, the method returns
-    /// without waiting further. The disposal operation may continue in the background but
-    /// is not guaranteed to complete.
-    /// </remarks>
-    /// <param name="obj">The object to dispose. Can be null.</param>
-    /// <param name="timeout">The maximum time to wait for disposal to complete.</param>
-    public static void DisposeObject(object? obj, TimeSpan timeout)
-    {
-        if (obj is null)
-        {
-            return;
-        }
-
-        var disposeTask = DisposeObjectAsync(obj);
-
-        // Use Task.Wait with timeout to prevent indefinite blocking
-        // This is particularly important during ProcessExit which has limited time
-        try
-        {
-            disposeTask.Wait(timeout);
-        }
-        catch (AggregateException ex)
-        {
-            // Unwrap and rethrow the inner exception to preserve the original exception type
-            if (ex.InnerExceptions.Count == 1)
-            {
-                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex.InnerException!).Throw();
-            }
-
-            throw;
-        }
-    }
-
-    /// <summary>
     /// Registers an object to be disposed when the process exits.
     /// </summary>
     /// <remarks>
-    /// The disposal will use <see cref="DefaultDisposeTimeout"/> to prevent blocking
-    /// during the limited process exit window.
+    /// The disposal is performed asynchronously using a fire-and-forget pattern.
+    /// Since ProcessExit handlers have limited time (typically 2 seconds),
+    /// the disposal is started but may not complete if it takes too long.
+    /// Exceptions during disposal are suppressed since the process is exiting.
     /// </remarks>
     /// <param name="obj">The object to dispose on process exit. Can be null.</param>
     [ExcludeFromCodeCoverage]
     public static void RegisterOnShutdown(object? obj)
     {
-        AppDomain.CurrentDomain.ProcessExit += (_, _) => DisposeObject(obj);
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => _ = DisposeOnShutdownAsync(obj);
+    }
+
+    /// <summary>
+    /// Internal async disposal for shutdown scenarios.
+    /// </summary>
+    /// <param name="obj">The object to dispose.</param>
+    /// <returns>A task representing the disposal operation.</returns>
+    [ExcludeFromCodeCoverage]
+    private static async Task DisposeOnShutdownAsync(object? obj)
+    {
+        try
+        {
+            await DisposeObjectAsync(obj).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Suppress exceptions during shutdown - process is exiting anyway
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Removes the synchronous `DisposeObject` methods that used `.Wait()` to block on async disposal operations
- Eliminates the sync-over-async anti-pattern that could cause thread pool starvation under load
- Updates `RegisterOnShutdown` to use a fire-and-forget async pattern with proper exception handling

## Changes
The `DisposeObject` and `DisposeObject(timeout)` methods have been removed. The `RegisterOnShutdown` method now directly uses an async fire-and-forget pattern which is more appropriate for process exit scenarios where:
- The process has limited time (typically 2 seconds)
- Exceptions should be suppressed since the process is exiting anyway

The async `DisposeObjectAsync` method remains unchanged and should be used for all disposal operations.

## Test plan
- [x] Build succeeds: `dotnet build src/ModularPipelines/ModularPipelines.csproj -c Release`
- [x] Unit tests compile: `dotnet build test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj -c Release`

Fixes #1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)