### PR TITLE
refactor: Replace hardcoded type name strings with constants in analyzers

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AnalyzerConstants.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AnalyzerConstants.cs
@@ -1,0 +1,126 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ModularPipelines.Analyzers;
+
+/// <summary>
+/// Constants for type and member names used in analyzers.
+/// Using constants avoids magic strings that could break if types are renamed.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class AnalyzerConstants
+{
+    /// <summary>
+    /// Type name constants for ModularPipelines types.
+    /// </summary>
+    internal static class TypeNames
+    {
+        /// <summary>
+        /// The Module base type name (generic Module&lt;T&gt;).
+        /// </summary>
+        internal const string Module = "Module";
+
+        /// <summary>
+        /// The ModuleBase type name.
+        /// </summary>
+        internal const string ModuleBase = "ModuleBase";
+
+        /// <summary>
+        /// The DependsOn attribute type name.
+        /// </summary>
+        internal const string DependsOn = "DependsOn";
+
+        /// <summary>
+        /// The Task type name from System.Threading.Tasks.
+        /// </summary>
+        internal const string Task = "Task";
+
+        /// <summary>
+        /// The TaskExtensions type name from ModularPipelines.Extensions.
+        /// </summary>
+        internal const string TaskExtensions = "TaskExtensions";
+
+        /// <summary>
+        /// The IEnumerable interface name.
+        /// </summary>
+        internal const string IEnumerable = "IEnumerable";
+    }
+
+    /// <summary>
+    /// Method name constants used in analyzers.
+    /// </summary>
+    internal static class MethodNames
+    {
+        /// <summary>
+        /// The ExecuteAsync method name from Module.
+        /// </summary>
+        internal const string ExecuteAsync = "ExecuteAsync";
+
+        /// <summary>
+        /// The GetModule method name for retrieving module dependencies.
+        /// </summary>
+        internal const string GetModule = "GetModule";
+
+        /// <summary>
+        /// The AsTask extension method name.
+        /// </summary>
+        internal const string AsTask = "AsTask";
+
+        /// <summary>
+        /// The FromResult method name from Task.
+        /// </summary>
+        internal const string FromResult = "FromResult";
+
+        /// <summary>
+        /// The OnAfterExecute method name from Module.
+        /// </summary>
+        internal const string OnAfterExecute = "OnAfterExecute";
+    }
+
+    /// <summary>
+    /// Modifier keyword constants.
+    /// </summary>
+    internal static class Modifiers
+    {
+        /// <summary>
+        /// The async modifier keyword.
+        /// </summary>
+        internal const string Async = "async";
+
+        /// <summary>
+        /// The override modifier keyword.
+        /// </summary>
+        internal const string Override = "override";
+    }
+
+    /// <summary>
+    /// Namespace constants used in analyzers.
+    /// </summary>
+    internal static class Namespaces
+    {
+        /// <summary>
+        /// The System.Threading.Tasks namespace.
+        /// </summary>
+        internal const string SystemThreadingTasks = "System.Threading.Tasks";
+
+        /// <summary>
+        /// The ModularPipelines.Extensions namespace.
+        /// </summary>
+        internal const string ModularPipelinesExtensions = "ModularPipelines.Extensions";
+    }
+
+    /// <summary>
+    /// Fully qualified type name constants used in analyzers.
+    /// </summary>
+    internal static class FullyQualifiedTypeNames
+    {
+        /// <summary>
+        /// The fully qualified System.Console type in global:: format.
+        /// </summary>
+        internal const string SystemConsole = "global::System.Console";
+
+        /// <summary>
+        /// The prefix for IEnumerable&lt;T&gt; in global:: fully qualified format.
+        /// </summary>
+        internal const string IEnumerablePrefix = "global::System.Collections.Generic.IEnumerable<";
+    }
+}

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
@@ -134,9 +134,9 @@ public class AsyncModuleCodeFixProvider : CodeFixProvider
         }
 
         return
-            methodSymbol.Name == "FromResult"
-            && methodSymbol.ContainingType.Name == "Task"
-            && methodSymbol.ContainingNamespace.ToDisplayString() == "System.Threading.Tasks";
+            methodSymbol.Name == AnalyzerConstants.MethodNames.FromResult
+            && methodSymbol.ContainingType.Name == AnalyzerConstants.TypeNames.Task
+            && methodSymbol.ContainingNamespace.ToDisplayString() == AnalyzerConstants.Namespaces.SystemThreadingTasks;
     }
 
     private static bool IsAsTaskExtension(ExpressionSyntax expressionSyntax, SemanticModel? semanticModel)
@@ -159,8 +159,8 @@ public class AsyncModuleCodeFixProvider : CodeFixProvider
         }
 
         return
-            methodSymbol.Name == "AsTask"
-            && methodSymbol.ContainingType.Name == "TaskExtensions"
-            && methodSymbol.ContainingNamespace.ToDisplayString() == "ModularPipelines.Extensions";
+            methodSymbol.Name == AnalyzerConstants.MethodNames.AsTask
+            && methodSymbol.ContainingType.Name == AnalyzerConstants.TypeNames.TaskExtensions
+            && methodSymbol.ContainingNamespace.ToDisplayString() == AnalyzerConstants.Namespaces.ModularPipelinesExtensions;
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerConstants.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerConstants.cs
@@ -1,0 +1,126 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ModularPipelines.Analyzers;
+
+/// <summary>
+/// Constants for type and member names used in analyzers.
+/// Using constants avoids magic strings that could break if types are renamed.
+/// </summary>
+[ExcludeFromCodeCoverage]
+internal static class AnalyzerConstants
+{
+    /// <summary>
+    /// Type name constants for ModularPipelines types.
+    /// </summary>
+    internal static class TypeNames
+    {
+        /// <summary>
+        /// The Module base type name (generic Module&lt;T&gt;).
+        /// </summary>
+        internal const string Module = "Module";
+
+        /// <summary>
+        /// The ModuleBase type name.
+        /// </summary>
+        internal const string ModuleBase = "ModuleBase";
+
+        /// <summary>
+        /// The DependsOn attribute type name.
+        /// </summary>
+        internal const string DependsOn = "DependsOn";
+
+        /// <summary>
+        /// The Task type name from System.Threading.Tasks.
+        /// </summary>
+        internal const string Task = "Task";
+
+        /// <summary>
+        /// The TaskExtensions type name from ModularPipelines.Extensions.
+        /// </summary>
+        internal const string TaskExtensions = "TaskExtensions";
+
+        /// <summary>
+        /// The IEnumerable interface name.
+        /// </summary>
+        internal const string IEnumerable = "IEnumerable";
+    }
+
+    /// <summary>
+    /// Method name constants used in analyzers.
+    /// </summary>
+    internal static class MethodNames
+    {
+        /// <summary>
+        /// The ExecuteAsync method name from Module.
+        /// </summary>
+        internal const string ExecuteAsync = "ExecuteAsync";
+
+        /// <summary>
+        /// The GetModule method name for retrieving module dependencies.
+        /// </summary>
+        internal const string GetModule = "GetModule";
+
+        /// <summary>
+        /// The AsTask extension method name.
+        /// </summary>
+        internal const string AsTask = "AsTask";
+
+        /// <summary>
+        /// The FromResult method name from Task.
+        /// </summary>
+        internal const string FromResult = "FromResult";
+
+        /// <summary>
+        /// The OnAfterExecute method name from Module.
+        /// </summary>
+        internal const string OnAfterExecute = "OnAfterExecute";
+    }
+
+    /// <summary>
+    /// Modifier keyword constants.
+    /// </summary>
+    internal static class Modifiers
+    {
+        /// <summary>
+        /// The async modifier keyword.
+        /// </summary>
+        internal const string Async = "async";
+
+        /// <summary>
+        /// The override modifier keyword.
+        /// </summary>
+        internal const string Override = "override";
+    }
+
+    /// <summary>
+    /// Namespace constants used in analyzers.
+    /// </summary>
+    internal static class Namespaces
+    {
+        /// <summary>
+        /// The System.Threading.Tasks namespace.
+        /// </summary>
+        internal const string SystemThreadingTasks = "System.Threading.Tasks";
+
+        /// <summary>
+        /// The ModularPipelines.Extensions namespace.
+        /// </summary>
+        internal const string ModularPipelinesExtensions = "ModularPipelines.Extensions";
+    }
+
+    /// <summary>
+    /// Fully qualified type name constants used in analyzers.
+    /// </summary>
+    internal static class FullyQualifiedTypeNames
+    {
+        /// <summary>
+        /// The fully qualified System.Console type in global:: format.
+        /// </summary>
+        internal const string SystemConsole = "global::System.Console";
+
+        /// <summary>
+        /// The prefix for IEnumerable&lt;T&gt; in global:: fully qualified format.
+        /// </summary>
+        internal const string IEnumerablePrefix = "global::System.Collections.Generic.IEnumerable<";
+    }
+}

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AsyncModuleAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AsyncModuleAnalyzer.cs
@@ -39,22 +39,22 @@ public class AsyncModuleAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (methodDeclarationSyntax.Identifier.Text != "ExecuteAsync")
+        if (methodDeclarationSyntax.Identifier.Text != AnalyzerConstants.MethodNames.ExecuteAsync)
         {
             return;
         }
 
-        if (methodDeclarationSyntax.Modifiers.Any(x => x.ValueText == "async"))
+        if (methodDeclarationSyntax.Modifiers.Any(x => x.ValueText == AnalyzerConstants.Modifiers.Async))
         {
             return;
         }
 
-        if (methodDeclarationSyntax.Modifiers.All(x => x.ValueText != "override"))
+        if (methodDeclarationSyntax.Modifiers.All(x => x.ValueText != AnalyzerConstants.Modifiers.Override))
         {
             return;
         }
 
-        if (context.GetClassThatNodeIsIn().GetSelfAndAllBaseTypes().All(x => x.Name != "ModuleBase"))
+        if (context.GetClassThatNodeIsIn().GetSelfAndAllBaseTypes().All(x => x.Name != AnalyzerConstants.TypeNames.ModuleBase))
         {
             return;
         }
@@ -85,18 +85,18 @@ public class AsyncModuleAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        if (methodSymbol.Name != "AsTask" && methodSymbol.Name != "FromResult")
+        if (methodSymbol.Name != AnalyzerConstants.MethodNames.AsTask && methodSymbol.Name != AnalyzerConstants.MethodNames.FromResult)
         {
             return false;
         }
 
-        if (methodSymbol.ContainingType.Name != "Task" && methodSymbol.ContainingType.Name != "TaskExtensions")
+        if (methodSymbol.ContainingType.Name != AnalyzerConstants.TypeNames.Task && methodSymbol.ContainingType.Name != AnalyzerConstants.TypeNames.TaskExtensions)
         {
             return false;
         }
 
-        if (methodSymbol.ContainingNamespace.ToDisplayString() != "ModularPipelines.Extensions"
-            && methodSymbol.ContainingNamespace.ToDisplayString() != "System.Threading.Tasks")
+        if (methodSymbol.ContainingNamespace.ToDisplayString() != AnalyzerConstants.Namespaces.ModularPipelinesExtensions
+            && methodSymbol.ContainingNamespace.ToDisplayString() != AnalyzerConstants.Namespaces.SystemThreadingTasks)
         {
             return false;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
@@ -52,14 +52,14 @@ public class AwaitThisAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (containingClass.GetSelfAndAllBaseTypes().All(x => x.Name != "ModuleBase"))
+        if (containingClass.GetSelfAndAllBaseTypes().All(x => x.Name != AnalyzerConstants.TypeNames.ModuleBase))
         {
             return;
         }
 
         // Check if we're inside the OnAfterExecute method - if so, allow await this
         var containingMethod = awaitExpression.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-        if (containingMethod?.Identifier.Text == "OnAfterExecute")
+        if (containingMethod?.Identifier.Text == AnalyzerConstants.MethodNames.OnAfterExecute)
         {
             return;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
@@ -71,7 +71,7 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        if (genericNameSyntax.Identifier.ValueText is not "DependsOn")
+        if (genericNameSyntax.Identifier.ValueText is not AnalyzerConstants.TypeNames.DependsOn)
         {
             return false;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConsoleUseAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConsoleUseAnalyzer.cs
@@ -56,7 +56,7 @@ public class ConsoleUseAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (namedTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == "global::System.Console")
+        if (namedTypeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) == AnalyzerConstants.FullyQualifiedTypeNames.SystemConsole)
         {
             context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation(),
                 namedTypeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/EnumerableModuleResultAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/EnumerableModuleResultAnalyzer.cs
@@ -44,7 +44,7 @@ public class EnumerableModuleResultAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (genericNameSyntax.Identifier.ValueText is not "Module")
+        if (genericNameSyntax.Identifier.ValueText is not AnalyzerConstants.TypeNames.Module)
         {
             return;
         }
@@ -55,7 +55,7 @@ public class EnumerableModuleResultAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (innerGenericNameSyntax.Identifier.ValueText is not "IEnumerable")
+        if (innerGenericNameSyntax.Identifier.ValueText is not AnalyzerConstants.TypeNames.IEnumerable)
         {
             return;
         }
@@ -67,7 +67,7 @@ public class EnumerableModuleResultAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (genericArgumentSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).StartsWith("global::System.Collections.Generic.IEnumerable<"))
+        if (genericArgumentSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat).StartsWith(AnalyzerConstants.FullyQualifiedTypeNames.IEnumerablePrefix))
         {
             var properties = new Dictionary<string, string?>
             {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/MissingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/MissingDependsOnAttributeAnalyzer.cs
@@ -44,7 +44,7 @@ public class MissingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (genericNameSyntax.Identifier.ValueText is not "GetModule")
+        if (genericNameSyntax.Identifier.ValueText is not AnalyzerConstants.MethodNames.GetModule)
         {
             return;
         }


### PR DESCRIPTION
## Summary
- Creates a centralized `AnalyzerConstants` class with constants for type names, method names, modifiers, namespaces, and fully qualified type names
- Replaces all hardcoded string literals in the analyzers and code fix providers with these constants
- Eliminates magic strings that could break silently if types are renamed

## Changes
- **New files**: `AnalyzerConstants.cs` in both `ModularPipelines.Analyzers` and `ModularPipelines.Analyzers.CodeFixes` projects
- **Updated analyzers**:
  - `AsyncModuleAnalyzer.cs` - ExecuteAsync, async, override, ModuleBase, AsTask, FromResult, Task, TaskExtensions, namespaces
  - `AwaitThisAnalyzer.cs` - ModuleBase, OnAfterExecute
  - `ConflictingDependsOnAttributeAnalyzer.cs` - DependsOn
  - `ConsoleUseAnalyzer.cs` - System.Console
  - `EnumerableModuleResultAnalyzer.cs` - Module, IEnumerable
  - `MissingDependsOnAttributeAnalyzer.cs` - GetModule
  - `AsyncModuleCodeFixProvider.cs` - FromResult, Task, AsTask, TaskExtensions, namespaces

## Test plan
- [x] Build verification: `dotnet build ModularPipelines.Analyzers.sln -c Release` passes

Fixes #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)