### PR TITLE
refactor: Improve error handling - aggregate exceptions instead of swallowing (#1817)

### DIFF
--- a/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
+++ b/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
@@ -99,7 +99,7 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
         {
             if (_hasRun)
             {
-                throw new Exception("This pipeline has already been triggerred.");
+                throw new InvalidOperationException("This pipeline has already been triggered.");
             }
 
             _hasRun = true;

--- a/src/ModularPipelines/Engine/Executors/ModuleDisposeExecutor.cs
+++ b/src/ModularPipelines/Engine/Executors/ModuleDisposeExecutor.cs
@@ -37,6 +37,8 @@ internal class ModuleDisposeExecutor : IModuleDisposeExecutor
 
         var modules = await _moduleRetriever.GetOrganizedModules().ConfigureAwait(false);
 
+        var exceptions = new List<Exception>();
+
         foreach (var module in modules.AllModules)
         {
             try
@@ -46,7 +48,13 @@ internal class ModuleDisposeExecutor : IModuleDisposeExecutor
             catch (Exception e)
             {
                 _logger.LogError(e, "Error disposing module {ModuleType}", module.GetType().Name);
+                exceptions.Add(e);
             }
+        }
+
+        if (exceptions.Count > 0)
+        {
+            throw new AggregateException("One or more modules failed to dispose", exceptions);
         }
     }
 }

--- a/src/ModularPipelines/Exceptions/ModuleNotInitializedException.cs
+++ b/src/ModularPipelines/Exceptions/ModuleNotInitializedException.cs
@@ -1,6 +1,6 @@
 namespace ModularPipelines.Exceptions;
 
-internal class ModuleNotInitializedException : Exception
+internal class ModuleNotInitializedException : PipelineException
 {
     public ModuleNotInitializedException(Type moduleType) : base($"Module {moduleType.Name} has not been initialized. Avoid doing any work in the constructor other than assigning fields via Dependency Injection.")
     {


### PR DESCRIPTION
## Summary

Fixes #1817 - Addresses critical and medium priority error handling issues.

### Changes

- **AlwaysRunHandler.cs**: Collect exceptions from AlwaysRun modules and throw `AggregateException` if any failed, instead of swallowing exceptions
- **ModuleDisposeExecutor.cs**: Collect disposal exceptions and throw `AggregateException` after all modules are disposed
- **ModuleNotInitializedException.cs**: Inherit from `PipelineException` for consistent exception hierarchy
- **ExecutionOrchestrator.cs**: Fix typo "triggerred" → "triggered" and use `InvalidOperationException` instead of bare `Exception`

### Impact

- AlwaysRun module failures are now properly propagated to callers
- Disposal failures are aggregated and thrown after all modules attempt disposal
- Exception hierarchy is consistent across the codebase

## Test plan

- [ ] Verify build passes
- [ ] Verify existing tests pass
- [ ] Test AlwaysRun module failure propagation
- [ ] Test disposal exception aggregation

🤖 Generated with [Claude Code](https://claude.com/claude-code)