### PR TITLE
refactor: Fix mutable state and thread safety issues in DTOs/Models (#1818)

### DIFF
--- a/src/ModularPipelines.Git/Models/GitAuthor.cs
+++ b/src/ModularPipelines.Git/Models/GitAuthor.cs
@@ -2,9 +2,9 @@ namespace ModularPipelines.Git.Models;
 
 public record GitAuthor
 {
-    public string? Name { get; set; }
+    public string? Name { get; init; }
 
-    public string? Email { get; set; }
+    public string? Email { get; init; }
 
-    public DateTime Date { get; set; }
+    public DateTime Date { get; init; }
 }

--- a/src/ModularPipelines.Git/Models/GitCommit.cs
+++ b/src/ModularPipelines.Git/Models/GitCommit.cs
@@ -2,11 +2,11 @@ namespace ModularPipelines.Git.Models;
 
 public record GitCommit
 {
-    public GitHash? Hash { get; set; }
+    public GitHash? Hash { get; init; }
 
-    public GitAuthor? Author { get; set; }
+    public GitAuthor? Author { get; init; }
 
-    public GitAuthor? Committer { get; set; }
+    public GitAuthor? Committer { get; init; }
 
-    public GitMessage? Message { get; set; }
+    public GitMessage? Message { get; init; }
 }

--- a/src/ModularPipelines.Git/Models/GitHash.cs
+++ b/src/ModularPipelines.Git/Models/GitHash.cs
@@ -2,7 +2,7 @@ namespace ModularPipelines.Git.Models;
 
 public record GitHash
 {
-    public string? Long { get; set; }
+    public string? Long { get; init; }
 
-    public string? Short { get; set; }
+    public string? Short { get; init; }
 }

--- a/src/ModularPipelines.Git/Models/GitMessage.cs
+++ b/src/ModularPipelines.Git/Models/GitMessage.cs
@@ -2,7 +2,7 @@ namespace ModularPipelines.Git.Models;
 
 public record GitMessage
 {
-    public string? Subject { get; set; }
+    public string? Subject { get; init; }
 
-    public string? Body { get; set; }
+    public string? Body { get; init; }
 }

--- a/src/ModularPipelines/Engine/EngineCancellationToken.cs
+++ b/src/ModularPipelines/Engine/EngineCancellationToken.cs
@@ -12,7 +12,7 @@ internal class EngineCancellationToken : CancellationTokenSource
 {
     private readonly IPrimaryExceptionContainer _primaryExceptionContainer;
 
-    public string? Reason { get; set; }
+    public string? Reason { get; private set; }
 
     /// <summary>
     /// Gets the original exception that caused the pipeline to fail.

--- a/src/ModularPipelines/Models/PipelineSummary.cs
+++ b/src/ModularPipelines/Models/PipelineSummary.cs
@@ -10,10 +10,8 @@ namespace ModularPipelines.Models;
 public record PipelineSummary
 {
     private readonly IModuleResultRegistry? _resultRegistry;
-    private readonly IMetricsCollector? _metricsCollector;
-    private readonly int _maxParallelism;
-    private PipelineMetrics? _cachedMetrics;
-    private IReadOnlyList<ModuleTimeline>? _cachedTimelines;
+    private readonly Lazy<PipelineMetrics?>? _lazyMetrics;
+    private readonly Lazy<IReadOnlyList<ModuleTimeline>?>? _lazyTimelines;
 
     /// <summary>
     /// Gets the modules that are part of the pipeline.
@@ -47,14 +45,14 @@ public record PipelineSummary
     /// Contains parallelism factor, peak concurrency, and efficiency metrics.
     /// </summary>
     [JsonInclude]
-    public PipelineMetrics? Metrics => _cachedMetrics ??= _metricsCollector?.ComputeMetrics(Start, End, _maxParallelism);
+    public PipelineMetrics? Metrics => _lazyMetrics?.Value;
 
     /// <summary>
     /// Gets the timeline information for each module.
     /// Contains detailed timing data for when each module was ready, queued, started, and completed.
     /// </summary>
     [JsonInclude]
-    public IReadOnlyList<ModuleTimeline>? ModuleTimelines => _cachedTimelines ??= _metricsCollector?.GetTimelines();
+    public IReadOnlyList<ModuleTimeline>? ModuleTimelines => _lazyTimelines?.Value;
 
     [JsonConstructor]
     internal PipelineSummary(
@@ -98,8 +96,8 @@ public record PipelineSummary
         int maxParallelism)
         : this(modules, totalDuration, start, end, resultRegistry)
     {
-        _metricsCollector = metricsCollector;
-        _maxParallelism = maxParallelism;
+        _lazyMetrics = new Lazy<PipelineMetrics?>(() => metricsCollector.ComputeMetrics(start, end, maxParallelism));
+        _lazyTimelines = new Lazy<IReadOnlyList<ModuleTimeline>?>(() => metricsCollector.GetTimelines());
     }
 
     /// <summary>

--- a/src/ModularPipelines/Options/HttpOptions.cs
+++ b/src/ModularPipelines/Options/HttpOptions.cs
@@ -9,14 +9,14 @@ namespace ModularPipelines.Options;
 public record HttpOptions(HttpRequestMessage HttpRequestMessage)
 {
     /// <summary>
-    /// Gets or sets an optional HttpClient for handling the request.
+    /// Gets an optional HttpClient for handling the request.
     /// </summary>
-    public HttpClient? HttpClient { get; set; }
+    public HttpClient? HttpClient { get; init; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether to throw an exception if the request returns a bad HTTP status code.
+    /// Gets a value indicating whether to throw an exception if the request returns a bad HTTP status code.
     /// </summary>
-    public bool ThrowOnNonSuccessStatusCode { get; set; }
+    public bool ThrowOnNonSuccessStatusCode { get; init; }
 
     /// <summary>
     /// Gets or sets the logging for the HTTP request.


### PR DESCRIPTION
## Summary

Fixes #1818 - Addresses high and medium priority mutable state and thread safety issues.

### Changes

**Git Models** - Changed to immutable properties:
- `GitCommit.cs`, `GitAuthor.cs`, `GitHash.cs`, `GitMessage.cs`
- All properties changed from `{ get; set; }` to `{ get; init; }`

**PipelineSummary.cs** - Thread-safe lazy initialization:
- Replaced non-thread-safe `??=` pattern with `Lazy<T>` wrappers
- Ensures proper synchronization in multi-threaded scenarios

**HttpOptions.cs** - Standardized to init-only properties:
- `HttpClient` and `ThrowOnNonSuccessStatusCode` now use `{ get; init; }`

**EngineCancellationToken.cs** - Private setter:
- `Reason` property changed to `{ get; private set; }`
- Prevents external mutation while allowing internal updates

### Impact

- Git records are now truly immutable as expected
- Thread-safe lazy initialization prevents race conditions in PipelineSummary
- HttpOptions is now immutable after construction
- EngineCancellationToken.Reason is protected from external modification

## Test plan

- [ ] Verify build passes
- [ ] Verify existing tests pass
- [ ] Verify Git model deserialization still works
- [ ] Verify PipelineSummary metrics work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)