### PR TITLE
refactor: Logging infrastructure thread-safety and modernization (#1812)

### DIFF
--- a/src/ModularPipelines/Logging/AfterPipelineLogger.cs
+++ b/src/ModularPipelines/Logging/AfterPipelineLogger.cs
@@ -13,6 +13,7 @@ internal class AfterPipelineLogger : IAfterPipelineLogger
     private readonly StringBuilder _stringBuilder = new();
     private readonly List<string> _values = [];
     private readonly object _lock = new();
+    private bool _isCacheValid;
 
     public AfterPipelineLogger(ILogger<AfterPipelineLogger> logger)
     {
@@ -27,8 +28,7 @@ internal class AfterPipelineLogger : IAfterPipelineLogger
         lock (_lock)
         {
             _values.Add(value);
-            // Clear cached output so GetOutput() rebuilds it with the new value
-            _stringBuilder.Clear();
+            _isCacheValid = false;
         }
     }
 
@@ -39,17 +39,18 @@ internal class AfterPipelineLogger : IAfterPipelineLogger
     {
         lock (_lock)
         {
-            if (_stringBuilder.Length > 0)
+            if (_isCacheValid)
             {
                 return _stringBuilder.ToString();
             }
 
-            // Build once and cache
+            _stringBuilder.Clear();
             foreach (var value in _values)
             {
                 _stringBuilder.AppendLine(value);
             }
 
+            _isCacheValid = true;
             return _stringBuilder.ToString();
         }
     }


### PR DESCRIPTION
## Summary

This PR addresses several items from issue #1812:

- **Add thread-safety to AfterPipelineLogger** - Multiple modules can call `LogOnPipelineEnd()` concurrently
- **Replace legacy MethodImplOptions.Synchronized** with modern lock pattern in ModuleLoggerProvider

## Changes

### 1. Thread-Safety Gap - AfterPipelineLogger (Fixed)

Added thread-safety using explicit `lock` synchronization:
- `LogOnPipelineEnd()`: Protected `_values.Add()` with lock
- `GetOutput()`: Protected entire method body with lock
- `WriteLogs()`: Created a copy of `_values` under lock before iterating

### 2. Legacy Synchronization Pattern (Fixed)

Replaced `[MethodImpl(MethodImplOptions.Synchronized)]` in ModuleLoggerProvider with explicit `lock` statement:
- Removed legacy `System.Runtime.CompilerServices` usage
- Added private `_lock` object for better encapsulation
- The legacy pattern locks on `this` which can cause deadlocks if external code acquires the same lock

### 3. DRY Investigation (No changes needed)

Investigated duration formatting - the codebase already consistently uses `TimeSpanFormatter.ToDisplayString()`.

## Test plan
- [x] Build passes
- [ ] Existing tests pass
- [ ] Verify thread-safety under concurrent access

🤖 Generated with [Claude Code](https://claude.com/claude-code)