### PR TITLE
refactor(context): Separate internal members and consolidate Checksum (#1815)

### DIFF
--- a/src/ModularPipelines/Context/EncodingContext.cs
+++ b/src/ModularPipelines/Context/EncodingContext.cs
@@ -16,14 +16,10 @@ internal class EncodingContext : IEncodingContext
     /// <inheritdoc />
     public IHasher Hasher { get; }
 
-    /// <inheritdoc />
-    public IChecksum Checksum { get; }
-
-    public EncodingContext(IBase64 base64, IHex hex, IHasher hasher, IChecksum checksum)
+    public EncodingContext(IBase64 base64, IHex hex, IHasher hasher)
     {
         Base64 = base64;
         Hex = hex;
         Hasher = hasher;
-        Checksum = checksum;
     }
 }

--- a/src/ModularPipelines/Context/IEncodingContext.cs
+++ b/src/ModularPipelines/Context/IEncodingContext.cs
@@ -6,8 +6,9 @@ namespace ModularPipelines.Context;
 /// Provides access to encoding and hashing helpers.
 /// </summary>
 /// <remarks>
-/// This context groups related encoding services (Base64, Hex, Hasher, Checksum)
+/// This context groups related encoding services (Base64, Hex, Hasher)
 /// to reduce constructor parameter count in PipelineContext while maintaining the same public API.
+/// Note: Checksum is in IPipelineFileSystem as it operates on files.
 /// </remarks>
 public interface IEncodingContext
 {
@@ -28,9 +29,4 @@ public interface IEncodingContext
     /// Supports MD5, SHA1, SHA256, SHA512 hashing algorithms.
     /// </remarks>
     IHasher Hasher { get; }
-
-    /// <summary>
-    /// Gets helpers for checking the Checksum of a file.
-    /// </summary>
-    IChecksum Checksum { get; }
 }

--- a/src/ModularPipelines/Context/IInternalPipelineContext.cs
+++ b/src/ModularPipelines/Context/IInternalPipelineContext.cs
@@ -1,0 +1,36 @@
+using ModularPipelines.Engine;
+using ModularPipelines.Helpers;
+
+namespace ModularPipelines.Context;
+
+/// <summary>
+/// Internal interface for pipeline context members that are used by the framework internally.
+/// </summary>
+/// <remarks>
+/// This interface separates internal implementation details from the public API surface.
+/// These members are used by the pipeline engine for dependency detection, result storage,
+/// logger initialization, and cancellation handling.
+/// </remarks>
+internal interface IInternalPipelineContext
+{
+    /// <summary>
+    /// Gets the detector used to detect modules which depend on each other.
+    /// </summary>
+    IDependencyCollisionDetector DependencyCollisionDetector { get; }
+
+    /// <summary>
+    /// Gets the results repository used for storing module results.
+    /// </summary>
+    IModuleResultRepository ModuleResultRepository { get; }
+
+    /// <summary>
+    /// Used to initialise the logger for this context.
+    /// </summary>
+    /// <param name="getType">The module type.</param>
+    void InitializeLogger(Type getType);
+
+    /// <summary>
+    /// Gets the cancellation token used for cancelling the pipeline on failures.
+    /// </summary>
+    EngineCancellationToken EngineCancellationToken { get; }
+}

--- a/src/ModularPipelines/Context/IPipelineHookContext.cs
+++ b/src/ModularPipelines/Context/IPipelineHookContext.cs
@@ -1,11 +1,3 @@
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
-using ModularPipelines.Engine;
-using ModularPipelines.Helpers;
-using ModularPipelines.Http;
-using ModularPipelines.Logging;
-using ModularPipelines.Options;
-
 namespace ModularPipelines.Context;
 
 /// <summary>
@@ -36,28 +28,4 @@ public interface IPipelineHookContext :
     IPipelineFileSystem,
     IPipelineEnvironment
 {
-    #region Internal
-
-    /// <summary>
-    /// Gets the detector used to detect modules which depend on each other.
-    /// </summary>
-    internal IDependencyCollisionDetector DependencyCollisionDetector { get; }
-
-    /// <summary>
-    /// Gets the results repository used for storing module results.
-    /// </summary>
-    internal IModuleResultRepository ModuleResultRepository { get; }
-
-    /// <summary>
-    /// Used to initialise the logger for this context.
-    /// </summary>
-    /// <param name="getType">The module type.</param>
-    internal void InitializeLogger(Type getType);
-
-    /// <summary>
-    /// Gets the cancellation token used for cancelling the pipeline on failures.
-    /// </summary>
-    internal EngineCancellationToken EngineCancellationToken { get; }
-
-    #endregion
 }

--- a/src/ModularPipelines/Context/ModuleContext.cs
+++ b/src/ModularPipelines/Context/ModuleContext.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Context;
 /// <summary>
 /// Module-specific context that wraps the pipeline context and adds module-specific capabilities.
 /// </summary>
-internal class ModuleContext : IModuleContext
+internal class ModuleContext : IModuleContext, IInternalPipelineContext
 {
     private readonly IPipelineContext _pipelineContext;
     private readonly IModule _currentModule;
@@ -164,19 +164,19 @@ internal class ModuleContext : IModuleContext
 
     public IInstaller Installer => _pipelineContext.Installer;
 
-    IDependencyCollisionDetector IPipelineHookContext.DependencyCollisionDetector =>
-        _pipelineContext.DependencyCollisionDetector;
+    IDependencyCollisionDetector IInternalPipelineContext.DependencyCollisionDetector =>
+        ((IInternalPipelineContext)_pipelineContext).DependencyCollisionDetector;
 
-    IModuleResultRepository IPipelineHookContext.ModuleResultRepository =>
-        _pipelineContext.ModuleResultRepository;
+    IModuleResultRepository IInternalPipelineContext.ModuleResultRepository =>
+        ((IInternalPipelineContext)_pipelineContext).ModuleResultRepository;
 
-    void IPipelineHookContext.InitializeLogger(Type getType)
+    void IInternalPipelineContext.InitializeLogger(Type getType)
     {
         // Logger is already initialized in constructor
     }
 
-    EngineCancellationToken IPipelineHookContext.EngineCancellationToken =>
-        _pipelineContext.EngineCancellationToken;
+    EngineCancellationToken IInternalPipelineContext.EngineCancellationToken =>
+        ((IInternalPipelineContext)_pipelineContext).EngineCancellationToken;
 
     #endregion
 }

--- a/src/ModularPipelines/Context/PipelineContext.cs
+++ b/src/ModularPipelines/Context/PipelineContext.cs
@@ -17,7 +17,7 @@ namespace ModularPipelines.Context;
 /// This class is registered as Scoped in the DI container, meaning each module execution
 /// gets its own instance. This ensures proper isolation between concurrent module executions.
 /// </remarks>
-internal class PipelineContext : IPipelineContext
+internal class PipelineContext : IPipelineContext, IInternalPipelineContext
 {
     private readonly IModuleLoggerProvider _moduleLoggerProvider;
 
@@ -115,7 +115,8 @@ internal class PipelineContext : IPipelineContext
         IBuildSystemDetector buildSystemDetector,
         ISerializationContext serializationContext,
         IEncodingContext encodingContext,
-        IShellContext shellContext)
+        IShellContext shellContext,
+        IChecksum checksum)
     {
         _moduleLoggerProvider = moduleLoggerProvider;
         Http = http;
@@ -141,7 +142,9 @@ internal class PipelineContext : IPipelineContext
         Hex = encodingContext.Hex;
         Base64 = encodingContext.Base64;
         Hasher = encodingContext.Hasher;
-        Checksum = encodingContext.Checksum;
+
+        // Checksum is part of file system operations (IPipelineFileSystem)
+        Checksum = checksum;
 
         // Unpack shell context
         Powershell = shellContext.Powershell;


### PR DESCRIPTION
## Summary
- Extract internal members from `IPipelineHookContext` to new `IInternalPipelineContext` interface
- Remove duplicate `Checksum` from `IEncodingContext` (consolidate to `IPipelineFileSystem` only)
- Update `PipelineContext` and `ModuleContext` to implement `IInternalPipelineContext`

## Changes
- **New:** `IInternalPipelineContext.cs` - internal interface for framework-only members
- **Modified:** `IPipelineHookContext.cs` - removed internal members (cleaner public API)
- **Modified:** `PipelineContext.cs` - implements both interfaces, receives `IChecksum` directly
- **Modified:** `ModuleContext.cs` - implements `IInternalPipelineContext`
- **Modified:** `IEncodingContext.cs` and `EncodingContext.cs` - removed `Checksum`

## Test plan
- [x] Build passes
- [ ] Verify no breaking changes for consumers

Fixes part of #1815

🤖 Generated with [Claude Code](https://claude.com/claude-code)