### PR TITLE
fix: Install AWS CLI in /tmp to avoid committing installation files

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -149,9 +149,12 @@ jobs:
         if: steps.should-run.outputs.run == 'true' && matrix.tool == 'aws'
         run: |
           # AWS CLI may be pre-installed on ubuntu-latest, use --update flag
+          # Install in /tmp to avoid committing installation files
+          cd /tmp
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip -q awscliv2.zip
           sudo ./aws/install --update
+          cd -
 
       # Docker is pre-installed on ubuntu-latest
       # .NET CLI is installed via setup-dotnet


### PR DESCRIPTION
## Summary
Fixes the AWS job failure in the CLI options generator workflow.

**Root cause:** The AWS CLI installation was downloading files (`awscliv2.zip` and `aws/` directory) into the workspace. When `git add -A` ran later, these files got staged.

**Fix:** Change to `/tmp` before downloading AWS CLI, then return to the original directory.

## Test Plan
- [ ] Run the workflow with `tools: aws` to verify installation works
- [ ] Verify no installation files are staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)