### PR TITLE
fix(generator): Handle Chocolatey help format without underline

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
@@ -443,9 +443,12 @@ public partial class ChocolateyCliScraper : CliScraperBase
     #region Regex Patterns
 
     /// <summary>
-    /// Matches "Commands" section followed by ===== underline.
+    /// Matches "Commands" section header.
+    /// Handles two formats:
+    /// 1. With underline: "Commands\n========="
+    /// 2. Without underline: "Commands\n\n * list -"
     /// </summary>
-    [GeneratedRegex(@"Commands\s*\n\s*=+\s*\n", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"^Commands\s*\n(?:\s*=+\s*\n)?", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex CommandSectionPattern();
 
     /// <summary>
@@ -455,9 +458,12 @@ public partial class ChocolateyCliScraper : CliScraperBase
     private static partial Regex OptionsSectionPattern();
 
     /// <summary>
-    /// Matches next section headers (with ===== underline).
+    /// Matches next section headers.
+    /// Handles both:
+    /// 1. Headers with ===== underline
+    /// 2. Headers like "Please run" or "How To Pass"
     /// </summary>
-    [GeneratedRegex(@"\n[A-Z][\w\s]*\n\s*=+", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"(?:\n[A-Z][\w\s]*\n\s*=+|\nPlease run|\nHow To Pass)", RegexOptions.IgnoreCase)]
     private static partial Regex NextSectionPattern();
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Fixed ChocolateyCliScraper failing to find commands on newer Chocolatey versions
- Newer Chocolatey outputs "Commands" section without the "=======" underline
- Updated regex patterns to handle both formats

## Root Cause
ChocolateyCliScraper expected help output like:
```
Commands
=========
 * list - lists remote...
```

But newer Chocolatey outputs:
```
Commands

 * list - lists remote...
```

The `CommandSectionPattern` regex was requiring the underline, causing 0 commands to be scraped.

## Changes
- Made the underline optional in `CommandSectionPattern`: `(?:\s*=+\s*\n)?`
- Added "Please run" and "How To Pass" as end-of-section markers in `NextSectionPattern`

## Test Plan
- [x] Ran generator locally with `--tools choco` - now scrapes 23 commands (was 0)
- [x] Generator builds successfully

Fixes #1811

🤖 Generated with [Claude Code](https://claude.com/claude-code)