### PR TITLE
fix(generator): Parse Chocolatey options without underline

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
@@ -452,9 +452,10 @@ public partial class ChocolateyCliScraper : CliScraperBase
     private static partial Regex CommandSectionPattern();
 
     /// <summary>
-    /// Matches "Options and Switches" section followed by ===== underline.
+    /// Matches "Options and Switches" section header.
+    /// Handles formats with and without ===== underline.
     /// </summary>
-    [GeneratedRegex(@"Options and Switches\s*\n\s*=+\s*\n", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"Options and Switches\s*\n(?:\s*=+\s*\n)?", RegexOptions.IgnoreCase)]
     private static partial Regex OptionsSectionPattern();
 
     /// <summary>
@@ -480,10 +481,11 @@ public partial class ChocolateyCliScraper : CliScraperBase
 
     /// <summary>
     /// Matches Chocolatey-style option lines:
-    /// -?, --help, -h
-    /// --source=VALUE
+    ///  -?, --help, -h
+    ///      --source=VALUE
+    /// Note: Lines have leading whitespace in help output.
     /// </summary>
-    [GeneratedRegex(@"^(?<flags>(?:-[\w?],?\s*)*(?:--[\w-]+(?:=VALUE)?))$")]
+    [GeneratedRegex(@"^\s*(?<flags>(?:-[\w?],?\s*)*(?:--[\w-]+(?:=VALUE)?))$")]
     private static partial Regex ChocolateyOptionPattern();
 
     #endregion


### PR DESCRIPTION
## Summary
Follow-up to #1849 - the options/flags were still not being parsed because the "Options and Switches" section also lacks the "=======" underline in newer Chocolatey versions.

## Root Cause
After #1849 fixed command discovery, options were still empty because:
1. `OptionsSectionPattern` required `Options and Switches\n=====\n` but actual output has no underline
2. `ChocolateyOptionPattern` didn't handle leading whitespace on option lines

## Changes
- Made underline optional in `OptionsSectionPattern`: `(?:\s*=+\s*\n)?`
- Added `\s*` prefix to `ChocolateyOptionPattern` to handle indented option lines

## Before
```
ChocoInstallOptions : ChocoOptions
{
    // empty - no properties
}
```

## After  
```
ChocoInstallOptions : ChocoOptions
{
    public bool? Debug { get; set; }
    public bool? Verbose { get; set; }
    public string? Proxy { get; set; }
    public string? Source { get; set; }
    // ... 20+ more options
}
```

## Test Plan
- [x] Ran generator locally - `ChocoInstallOptions` now has 22 properties (was 0)
- [x] Generator builds successfully

Fixes #1811

🤖 Generated with [Claude Code](https://claude.com/claude-code)