### PR TITLE
feat(events): Add priority-based ordering for attribute event handlers

### DIFF
--- a/src/ModularPipelines/Attributes/Events/IEventHandlerPriority.cs
+++ b/src/ModularPipelines/Attributes/Events/IEventHandlerPriority.cs
@@ -1,0 +1,42 @@
+namespace ModularPipelines.Attributes.Events;
+
+/// <summary>
+/// Implement this interface on an event receiver attribute to specify its execution priority.
+/// Lower priority values run first (priority 0 runs before priority 100).
+/// </summary>
+/// <remarks>
+/// <para>
+/// When multiple event receivers of the same type are applied to a module,
+/// they are invoked in order of their priority. Receivers with lower priority
+/// values execute before those with higher values.
+/// </para>
+/// <para>
+/// Receivers that do not implement this interface default to priority 0.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [EventHandlerPriority(100)]
+/// public class LoggingEventHandler : Attribute, IModuleStartEventReceiver, IEventHandlerPriority
+/// {
+///     public int Priority => 100;
+///     public Task OnModuleStartAsync(IModuleEventContext context) => /* log */;
+/// }
+///
+/// [EventHandlerPriority(200)]
+/// public class MetricsEventHandler : Attribute, IModuleStartEventReceiver, IEventHandlerPriority
+/// {
+///     public int Priority => 200;
+///     public Task OnModuleStartAsync(IModuleEventContext context) => /* record metrics */;
+/// }
+/// // LoggingEventHandler (100) runs before MetricsEventHandler (200)
+/// </code>
+/// </example>
+public interface IEventHandlerPriority
+{
+    /// <summary>
+    /// Gets the execution priority of this event handler.
+    /// Lower values execute first. Default is 0.
+    /// </summary>
+    int Priority { get; }
+}

--- a/test/ModularPipelines.UnitTests/Attributes/ModuleAttributeEventServiceTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/ModuleAttributeEventServiceTests.cs
@@ -21,6 +21,42 @@ public class ModuleAttributeEventServiceTests
         public Task OnModuleFailureAsync(IModuleEventContext context, Exception exception) => Task.CompletedTask;
     }
 
+    /// <summary>
+    /// A start receiver with priority 100 (runs last).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class LowPriorityStartAttribute : Attribute, IModuleStartEventReceiver, IEventHandlerPriority
+    {
+        public bool ContinueOnError => false;
+        public int Priority => 100;
+
+        public Task OnModuleStartAsync(IModuleEventContext context) => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// A start receiver with priority 10 (runs second).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class MediumPriorityStartAttribute : Attribute, IModuleStartEventReceiver, IEventHandlerPriority
+    {
+        public bool ContinueOnError => false;
+        public int Priority => 10;
+
+        public Task OnModuleStartAsync(IModuleEventContext context) => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// A start receiver with priority 1 (runs first with explicit priority).
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class HighPriorityStartAttribute : Attribute, IModuleStartEventReceiver, IEventHandlerPriority
+    {
+        public bool ContinueOnError => false;
+        public int Priority => 1;
+
+        public Task OnModuleStartAsync(IModuleEventContext context) => Task.CompletedTask;
+    }
+
     [TestStart]
     [TestFailure]
     private class ModuleWithAttributes : Module<string>
@@ -30,6 +66,26 @@ public class ModuleAttributeEventServiceTests
     }
 
     private class ModuleWithoutAttributes : Module<string>
+    {
+        public override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult<string?>("test");
+    }
+
+    // Attributes are applied in reverse order of priority to test that sorting works
+    [LowPriorityStart]   // Priority 100 - should be last
+    [MediumPriorityStart] // Priority 10 - should be second
+    [HighPriorityStart]  // Priority 1 - should be first
+    private class ModuleWithPrioritizedReceivers : Module<string>
+    {
+        public override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult<string?>("test");
+    }
+
+    // Mix of prioritized and non-prioritized receivers
+    [LowPriorityStart]   // Priority 100 - should be last
+    [TestStart]          // No priority (defaults to 0) - should be first
+    [HighPriorityStart]  // Priority 1 - should be second
+    private class ModuleWithMixedPriorityReceivers : Module<string>
     {
         public override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string?>("test");
@@ -76,5 +132,45 @@ public class ModuleAttributeEventServiceTests
         var receivers2 = service.GetStartReceivers(typeof(ModuleWithAttributes));
 
         await Assert.That(ReferenceEquals(receivers1, receivers2)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetStartReceivers_WithPriority_ReturnsSortedByPriority()
+    {
+        var service = new ModuleAttributeEventService();
+
+        var receivers = service.GetStartReceivers(typeof(ModuleWithPrioritizedReceivers));
+
+        await Assert.That(receivers.Count).IsEqualTo(3);
+        // Lower priority values run first
+        await Assert.That(receivers[0]).IsTypeOf<HighPriorityStartAttribute>();   // Priority 1
+        await Assert.That(receivers[1]).IsTypeOf<MediumPriorityStartAttribute>(); // Priority 10
+        await Assert.That(receivers[2]).IsTypeOf<LowPriorityStartAttribute>();    // Priority 100
+    }
+
+    [Test]
+    public async Task GetStartReceivers_WithMixedPriority_DefaultsToZero()
+    {
+        var service = new ModuleAttributeEventService();
+
+        var receivers = service.GetStartReceivers(typeof(ModuleWithMixedPriorityReceivers));
+
+        await Assert.That(receivers.Count).IsEqualTo(3);
+        // Non-prioritized receiver (defaults to 0) should be first
+        await Assert.That(receivers[0]).IsTypeOf<TestStartAttribute>();          // No priority (0)
+        await Assert.That(receivers[1]).IsTypeOf<HighPriorityStartAttribute>();  // Priority 1
+        await Assert.That(receivers[2]).IsTypeOf<LowPriorityStartAttribute>();   // Priority 100
+    }
+
+    [Test]
+    public async Task GetStartReceivers_SingleReceiver_ReturnsWithoutSorting()
+    {
+        var service = new ModuleAttributeEventService();
+
+        var receivers = service.GetStartReceivers(typeof(ModuleWithAttributes));
+
+        // Single receiver should be returned as-is
+        await Assert.That(receivers.Count).IsEqualTo(1);
+        await Assert.That(receivers[0]).IsTypeOf<TestStartAttribute>();
     }
 }


### PR DESCRIPTION
## Summary

Implements issue #1875 by adding explicit ordering for event handler attributes.

- Add `IEventHandlerPriority` interface for declaring handler priority
- Modify `ModuleAttributeEventService` to sort handlers by priority value
- Lower priority values execute first (0 runs before 100)
- Handlers without `IEventHandlerPriority` default to priority 0
- Add comprehensive unit tests for priority ordering scenarios

This ensures deterministic, documented execution order for multiple event handlers of the same type, replacing the previous fragile reflection-based ordering.

## Changes

| File | Description |
|------|-------------|
| `src/ModularPipelines/Attributes/Events/IEventHandlerPriority.cs` | New interface for declaring handler priority |
| `src/ModularPipelines/Engine/Attributes/ModuleAttributeEventService.cs` | Added priority-based sorting using stable sort |
| `test/ModularPipelines.UnitTests/Attributes/ModuleAttributeEventServiceTests.cs` | Added tests for priority ordering |

## Usage Example

```csharp
[AttributeUsage(AttributeTargets.Class)]
public class LoggingEventHandler : Attribute, IModuleStartEventReceiver, IEventHandlerPriority
{
    public int Priority => 100;  // Runs second
    public bool ContinueOnError => false;
    public Task OnModuleStartAsync(IModuleEventContext context) => /* log */;
}

[AttributeUsage(AttributeTargets.Class)]
public class AuthEventHandler : Attribute, IModuleStartEventReceiver  // No IEventHandlerPriority
{
    public bool ContinueOnError => false;
    public Task OnModuleStartAsync(IModuleEventContext context) => /* authenticate */;
}
// Execution order: AuthEventHandler (0), LoggingEventHandler (100)
```

## Test plan

- [x] Unit tests for priority sorting with explicit priorities
- [x] Unit tests for mixed priority (with and without interface)
- [x] Unit tests for single receiver (no sorting needed)
- [x] Verify stable sort preserves declaration order for equal priorities
- [x] Build succeeds

Closes #1875

🤖 Generated with [Claude Code](https://claude.com/claude-code)