### PR TITLE
fix(core): Improve thread-safety in singleton services

### DIFF
--- a/src/ModularPipelines/Engine/Dependencies/ModuleDependencyRegistry.cs
+++ b/src/ModularPipelines/Engine/Dependencies/ModuleDependencyRegistry.cs
@@ -5,11 +5,30 @@ namespace ModularPipelines.Engine.Dependencies;
 /// <summary>
 /// Stores dynamic dependencies added via attribute event receivers.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Thread Safety:</b> This class is thread-safe. All public methods can be called
+/// concurrently from multiple threads without external synchronization.
+/// </para>
+/// <para>
+/// Dependencies are stored in a <see cref="ConcurrentDictionary{TKey,TValue}"/> with
+/// internal locking to protect <see cref="HashSet{T}"/> modifications.
+/// </para>
+/// </remarks>
+/// <threadsafety static="true" instance="true"/>
 internal class ModuleDependencyRegistry : IModuleDependencyRegistry
 {
     private readonly ConcurrentDictionary<Type, HashSet<Type>> _dynamicDependencies = new();
     private readonly object _lock = new();
 
+    /// <summary>
+    /// Adds a dynamic dependency between modules.
+    /// </summary>
+    /// <param name="module">The module that depends on the dependency.</param>
+    /// <param name="dependency">The dependency module type.</param>
+    /// <remarks>
+    /// This method is thread-safe and can be called concurrently.
+    /// </remarks>
     public void AddDynamicDependency(Type module, Type dependency)
     {
         lock (_lock)
@@ -19,6 +38,14 @@ internal class ModuleDependencyRegistry : IModuleDependencyRegistry
         }
     }
 
+    /// <summary>
+    /// Removes a dynamic dependency between modules.
+    /// </summary>
+    /// <param name="module">The module that depends on the dependency.</param>
+    /// <param name="dependency">The dependency module type to remove.</param>
+    /// <remarks>
+    /// This method is thread-safe and can be called concurrently.
+    /// </remarks>
     public void RemoveDependency(Type module, Type dependency)
     {
         lock (_lock)
@@ -30,21 +57,40 @@ internal class ModuleDependencyRegistry : IModuleDependencyRegistry
         }
     }
 
+    /// <summary>
+    /// Gets all dynamic dependencies for a module.
+    /// </summary>
+    /// <param name="module">The module to get dependencies for.</param>
+    /// <returns>An enumerable of dependency types.</returns>
+    /// <remarks>
+    /// This method is thread-safe. Returns a snapshot of dependencies at call time.
+    /// </remarks>
     public IEnumerable<Type> GetDynamicDependencies(Type module)
     {
-        if (_dynamicDependencies.TryGetValue(module, out var deps))
+        lock (_lock)
         {
-            lock (_lock)
+            if (_dynamicDependencies.TryGetValue(module, out var deps))
             {
                 return deps.ToList();
             }
-        }
 
-        return Enumerable.Empty<Type>();
+            return Enumerable.Empty<Type>();
+        }
     }
 
+    /// <summary>
+    /// Checks if a module has any dynamic dependencies.
+    /// </summary>
+    /// <param name="module">The module to check.</param>
+    /// <returns>True if the module has dynamic dependencies; otherwise, false.</returns>
+    /// <remarks>
+    /// This method is thread-safe. The result reflects the state at call time.
+    /// </remarks>
     public bool HasDynamicDependencies(Type module)
     {
-        return _dynamicDependencies.TryGetValue(module, out var deps) && deps.Count > 0;
+        lock (_lock)
+        {
+            return _dynamicDependencies.TryGetValue(module, out var deps) && deps.Count > 0;
+        }
     }
 }

--- a/src/ModularPipelines/Engine/IModuleResultRegistry.cs
+++ b/src/ModularPipelines/Engine/IModuleResultRegistry.cs
@@ -7,6 +7,12 @@ namespace ModularPipelines.Engine;
 /// Registry for storing and retrieving module execution results.
 /// Used for coordinating results between pure IModule&lt;T&gt; implementations.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Thread Safety:</b> Implementations of this interface must be thread-safe.
+/// All methods can be called concurrently from multiple threads without external synchronization.
+/// </para>
+/// </remarks>
 internal interface IModuleResultRegistry
 {
     /// <summary>
@@ -62,18 +68,39 @@ internal interface IModuleResultRegistry
 
 /// <summary>
 /// Default implementation of the module result registry.
-/// Uses ConcurrentDictionary for lock-free reads and thread-safe writes.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Thread Safety:</b> This class is thread-safe. All public methods can be called
+/// concurrently from multiple threads without external synchronization.
+/// </para>
+/// <para>
+/// Uses <see cref="ConcurrentDictionary{TKey,TValue}"/> for lock-free reads and thread-safe writes.
+/// The <see cref="TaskCompletionSource{TResult}"/> provides memory barriers ensuring visibility
+/// of result writes to awaiting threads.
+/// </para>
+/// </remarks>
+/// <threadsafety static="true" instance="true"/>
 internal class ModuleResultRegistry : IModuleResultRegistry
 {
     private readonly ConcurrentDictionary<Type, object> _results = new();
     private readonly ConcurrentDictionary<Type, TaskCompletionSource<object?>> _completionSources = new();
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This method is thread-safe. Uses <see cref="ConcurrentDictionary{TKey,TValue}.GetOrAdd"/>
+    /// for atomic registration.
+    /// </remarks>
     public void RegisterModule(Type moduleType)
     {
         _completionSources.GetOrAdd(moduleType, _ => new TaskCompletionSource<object?>());
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This method is thread-safe. The result is stored before signaling completion,
+    /// and TrySetResult provides release semantics ensuring visibility to awaiters.
+    /// </remarks>
     public void RegisterResult<T>(Type moduleType, ModuleResult<T> result)
     {
         // Store result first, then signal completion
@@ -83,6 +110,10 @@ internal class ModuleResultRegistry : IModuleResultRegistry
         tcs.TrySetResult(result);
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This method is thread-safe. Uses lock-free reads from ConcurrentDictionary.
+    /// </remarks>
     public ModuleResult<T>? GetResult<T>(Type moduleType)
     {
         if (_results.TryGetValue(moduleType, out var result) && result is ModuleResult<T> typedResult)
@@ -93,6 +124,10 @@ internal class ModuleResultRegistry : IModuleResultRegistry
         return null;
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This method is thread-safe. Uses lock-free reads from ConcurrentDictionary.
+    /// </remarks>
     public IModuleResult? GetResult(Type moduleType)
     {
         if (_results.TryGetValue(moduleType, out var result))
@@ -103,11 +138,19 @@ internal class ModuleResultRegistry : IModuleResultRegistry
         return null;
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This method is thread-safe. Uses lock-free reads from ConcurrentDictionary.
+    /// </remarks>
     public Task? GetCompletionTask(Type moduleType)
     {
         return _completionSources.TryGetValue(moduleType, out var tcs) ? tcs.Task : null;
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This method is thread-safe. Uses TrySetException for atomic exception signaling.
+    /// </remarks>
     public void SetException(Type moduleType, Exception exception)
     {
         // Only set exception if module was previously registered (preserves original behavior)
@@ -117,6 +160,11 @@ internal class ModuleResultRegistry : IModuleResultRegistry
         }
     }
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// This method is thread-safe. The result is stored before signaling completion,
+    /// and TrySetResult provides release semantics ensuring visibility to awaiters.
+    /// </remarks>
     public void RegisterResult(Type moduleType, IModuleResult result)
     {
         // Store result first, then signal completion

--- a/src/ModularPipelines/Engine/ISecondaryExceptionContainer.cs
+++ b/src/ModularPipelines/Engine/ISecondaryExceptionContainer.cs
@@ -1,13 +1,33 @@
-﻿namespace ModularPipelines.Engine;
+namespace ModularPipelines.Engine;
 
 /// <summary>
 /// Collects secondary exceptions that occur during pipeline execution,
 /// such as failures in AlwaysRun modules or dependency resolution.
 /// The primary/first exception that fails the pipeline is stored in <see cref="IPrimaryExceptionContainer"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Thread Safety:</b> Implementations of this interface must be thread-safe.
+/// <see cref="RegisterException"/> can be called concurrently from multiple threads.
+/// </para>
+/// </remarks>
 internal interface ISecondaryExceptionContainer
 {
+    /// <summary>
+    /// Registers an exception that occurred during pipeline execution.
+    /// </summary>
+    /// <param name="exception">The exception to register.</param>
+    /// <remarks>
+    /// This method must be thread-safe and can be called concurrently from multiple modules.
+    /// </remarks>
     void RegisterException(Exception exception);
 
+    /// <summary>
+    /// Throws all registered exceptions.
+    /// </summary>
+    /// <remarks>
+    /// If exactly one exception was registered, it is rethrown with its original stack trace preserved.
+    /// If multiple exceptions were registered, an <see cref="AggregateException"/> is thrown.
+    /// </remarks>
     void ThrowExceptions();
 }

--- a/src/ModularPipelines/Engine/PrimaryExceptionContainer.cs
+++ b/src/ModularPipelines/Engine/PrimaryExceptionContainer.cs
@@ -7,17 +7,41 @@ namespace ModularPipelines.Engine;
 /// This is the exception that should be rethrown when the pipeline execution completes.
 /// Secondary exceptions (from AlwaysRun modules, etc.) are stored in <see cref="ISecondaryExceptionContainer"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Thread Safety:</b> This class is thread-safe. All public methods can be called
+/// concurrently from multiple threads without external synchronization.
+/// </para>
+/// <para>
+/// Uses lock-based synchronization to ensure only the first exception is stored,
+/// with proper memory barriers for reads after the lock is released.
+/// </para>
+/// </remarks>
+/// <threadsafety static="true" instance="true"/>
 internal class PrimaryExceptionContainer : IPrimaryExceptionContainer
 {
     private readonly object _exceptionLock = new();
 
     /// <inheritdoc />
+    /// <remarks>
+    /// This property is safe to read concurrently. The lock in <see cref="SetException"/>
+    /// provides the necessary memory barrier for visibility.
+    /// </remarks>
     public Exception? OriginalException { get; private set; }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// This property is safe to read concurrently. The lock in <see cref="SetException"/>
+    /// provides the necessary memory barrier for visibility.
+    /// </remarks>
     public ExceptionDispatchInfo? OriginalExceptionDispatchInfo { get; private set; }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// This method is thread-safe. Only the first exception set will be stored;
+    /// subsequent calls are ignored. Uses lock-based synchronization to ensure
+    /// atomicity of the check-then-set operation.
+    /// </remarks>
     public void SetException(Exception exception)
     {
         lock (_exceptionLock)
@@ -32,6 +56,10 @@ internal class PrimaryExceptionContainer : IPrimaryExceptionContainer
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// This method is thread-safe. Reads the exception dispatch info set by <see cref="SetException"/>.
+    /// If an exception was set, this method will rethrow it preserving the original stack trace.
+    /// </remarks>
     public void ThrowIfHasException()
     {
         OriginalExceptionDispatchInfo?.Throw();

--- a/src/ModularPipelines/Engine/SecondaryExceptionContainer.cs
+++ b/src/ModularPipelines/Engine/SecondaryExceptionContainer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Runtime.ExceptionServices;
 
 namespace ModularPipelines.Engine;
@@ -7,25 +8,59 @@ namespace ModularPipelines.Engine;
 /// such as failures in AlwaysRun modules or dependency resolution.
 /// The primary/first exception that fails the pipeline is stored in <see cref="IPrimaryExceptionContainer"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <b>Thread Safety:</b> This class is thread-safe. All public methods can be called
+/// concurrently from multiple threads without external synchronization.
+/// </para>
+/// <para>
+/// Exceptions are stored in a <see cref="ConcurrentBag{T}"/> which provides
+/// lock-free thread-safe operations for concurrent module execution scenarios.
+/// </para>
+/// </remarks>
+/// <threadsafety static="true" instance="true"/>
 internal class SecondaryExceptionContainer : ISecondaryExceptionContainer
 {
-    private readonly List<ExceptionDispatchInfo> _exceptions = [];
+    private readonly ConcurrentBag<ExceptionDispatchInfo> _exceptions = [];
 
+    /// <summary>
+    /// Registers an exception that occurred during pipeline execution.
+    /// </summary>
+    /// <param name="exception">The exception to register.</param>
+    /// <remarks>
+    /// This method is thread-safe and can be called concurrently from multiple modules.
+    /// </remarks>
     public void RegisterException(Exception exception)
     {
         _exceptions.Add(ExceptionDispatchInfo.Capture(exception));
     }
 
+    /// <summary>
+    /// Throws all registered exceptions.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If exactly one exception was registered, it is rethrown with its original stack trace preserved.
+    /// If multiple exceptions were registered, an <see cref="AggregateException"/> is thrown containing all of them.
+    /// </para>
+    /// <para>
+    /// This method should typically be called after all module execution has completed,
+    /// when no more concurrent registrations are expected.
+    /// </para>
+    /// </remarks>
     public void ThrowExceptions()
     {
-        if (_exceptions.Count == 1)
+        // Take a snapshot for consistent behavior
+        var exceptionsList = _exceptions.ToArray();
+
+        if (exceptionsList.Length == 1)
         {
-            _exceptions.First().Throw();
+            exceptionsList[0].Throw();
         }
 
-        if (_exceptions.Any())
+        if (exceptionsList.Length > 0)
         {
-            throw new AggregateException(_exceptions.Select(e => e.SourceException));
+            throw new AggregateException(exceptionsList.Select(e => e.SourceException));
         }
     }
 }


### PR DESCRIPTION
## Summary

- Improved thread-safety in singleton services used during concurrent module execution
- Replaced non-thread-safe collections with concurrent alternatives
- Fixed race conditions in `ModuleDependencyRegistry` and `OptionsProvider`
- Added `<threadsafety>` XML documentation tags to all affected classes

## Changes

**SecondaryExceptionContainer:**
- Replaced `List<ExceptionDispatchInfo>` with `ConcurrentBag<ExceptionDispatchInfo>`
- Added snapshot-based iteration in `ThrowExceptions()` for consistent behavior

**OptionsProvider:**
- Replaced nullable `List<Type>?` with `Lazy<IReadOnlyList<Type>>`
- Uses `LazyThreadSafetyMode.ExecutionAndPublication` for proper initialization

**ModuleDependencyRegistry:**
- Fixed race condition in `HasDynamicDependencies()` by moving count access inside lock
- Fixed `TryGetValue` to be inside lock in `GetDynamicDependencies()`

## Test plan

- [ ] Verify existing tests pass
- [ ] Run concurrent module execution scenarios
- [ ] Review thread-safety documentation added

Closes #1879

🤖 Generated with [Claude Code](https://claude.com/claude-code)