### PR TITLE
docs(config): Clarify configuration precedence and document option priority

### DIFF
--- a/src/ModularPipelines/Attributes/ModuleCategoryAttribute.cs
+++ b/src/ModularPipelines/Attributes/ModuleCategoryAttribute.cs
@@ -1,5 +1,28 @@
 namespace ModularPipelines.Attributes;
 
+/// <summary>
+/// Assigns a category to a module for grouping and filtering purposes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Categories are used to organize modules and can be filtered at runtime using
+/// <see cref="Options.PipelineOptions.RunOnlyCategories"/> or <see cref="Options.PipelineOptions.IgnoreCategories"/>.
+/// </para>
+/// <para>
+/// <strong>Note:</strong> Categories are currently used for module filtering only.
+/// There is no category-level configuration API; configuration follows the standard precedence:
+/// Global (PipelineOptions) -> Module (behavior interfaces) -> Per-Call.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// [ModuleCategory("Build")]
+/// public class BuildModule : Module&lt;string&gt;
+/// {
+///     // This module belongs to the "Build" category
+/// }
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Class)]
 public class ModuleCategoryAttribute : Attribute
 {

--- a/src/ModularPipelines/Host/PipelineHostBuilder.cs
+++ b/src/ModularPipelines/Host/PipelineHostBuilder.cs
@@ -62,10 +62,43 @@ public class PipelineHostBuilder
     }
 
     /// <summary>
-    /// Used to configure the pipeline options.
+    /// Used to configure the pipeline options for the entire pipeline.
     /// </summary>
     /// <param name="configureDelegate">A delegate to amend the options.</param>
     /// <returns>The same pipeline host builder.</returns>
+    /// <remarks>
+    /// <para>
+    /// <strong>Configuration Precedence:</strong>
+    /// Settings configured here represent the "Global Configuration" level in the precedence hierarchy.
+    /// These settings apply as defaults across the pipeline but can be overridden at more specific levels.
+    /// </para>
+    /// <para>
+    /// <strong>Precedence order (highest to lowest):</strong>
+    /// </para>
+    /// <list type="number">
+    /// <item>Per-Call Configuration - Options passed to individual method calls (e.g., <see cref="CommandExecutionOptions.LogSettings"/>)</item>
+    /// <item>Module Configuration - Behavior interfaces on modules (e.g., <see cref="Modules.Behaviors.IRetryable{T}"/>, <see cref="Modules.Behaviors.ITimeoutable"/>)</item>
+    /// <item>Global Configuration - Settings in <see cref="PipelineOptions"/> configured here</item>
+    /// <item>System Defaults - Built-in framework defaults (e.g., 30-minute module timeout)</item>
+    /// </list>
+    /// <para>
+    /// Example: If <see cref="PipelineOptions.DefaultRetryCount"/> is set to 3, all modules will retry
+    /// up to 3 times on failure. However, a module implementing <see cref="Modules.Behaviors.IRetryable{T}"/>
+    /// will use its custom retry policy instead.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// PipelineHostBuilder.Create()
+    ///     .ConfigurePipelineOptions((context, options) =>
+    ///     {
+    ///         options.DefaultRetryCount = 3;
+    ///         options.DefaultLoggingOptions = CommandLoggingOptions.Diagnostic;
+    ///     })
+    ///     .AddModule&lt;MyModule&gt;()
+    ///     .ExecutePipelineAsync();
+    /// </code>
+    /// </example>
     public PipelineHostBuilder ConfigurePipelineOptions(Action<HostBuilderContext, PipelineOptions> configureDelegate)
     {
         _internalHost.ConfigureServices((context, collection) =>

--- a/src/ModularPipelines/Modules/Behaviors/IRetryable.cs
+++ b/src/ModularPipelines/Modules/Behaviors/IRetryable.cs
@@ -8,8 +8,18 @@ namespace ModularPipelines.Modules.Behaviors;
 /// </summary>
 /// <typeparam name="T">The result type of the module.</typeparam>
 /// <remarks>
-/// If not implemented, modules do not retry on failure.
+/// <para>
+/// <strong>Configuration Precedence:</strong>
+/// Implementing this interface on a module takes precedence over the global
+/// <see cref="Options.PipelineOptions.DefaultRetryCount"/> setting.
+/// </para>
+/// <para>
+/// If not implemented, modules will use <see cref="Options.PipelineOptions.DefaultRetryCount"/>
+/// if set to a value greater than 0. Otherwise, no retries are attempted.
+/// </para>
+/// <para>
 /// The retry policy is applied to the <see cref="Module{T}.ExecuteAsync"/> call.
+/// </para>
 /// </remarks>
 public interface IRetryable<T>
 {

--- a/src/ModularPipelines/Modules/Behaviors/ITimeoutable.cs
+++ b/src/ModularPipelines/Modules/Behaviors/ITimeoutable.cs
@@ -4,8 +4,20 @@ namespace ModularPipelines.Modules.Behaviors;
 /// Implement this interface to specify a custom timeout for module execution.
 /// </summary>
 /// <remarks>
-/// If not implemented, modules use a default timeout of 30 minutes.
+/// <para>
+/// <strong>Configuration Precedence:</strong>
+/// Implementing this interface on a module takes precedence over the system default timeout.
+/// </para>
+/// <para>
+/// <strong>Precedence order (highest to lowest):</strong>
+/// </para>
+/// <list type="number">
+/// <item>Module-level: This interface implementation (highest priority)</item>
+/// <item>System default: 30 minutes (lowest priority)</item>
+/// </list>
+/// <para>
 /// When a module times out, it will throw a <see cref="Exceptions.ModuleTimeoutException"/>.
+/// </para>
 /// </remarks>
 public interface ITimeoutable
 {

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -7,6 +7,45 @@ namespace ModularPipelines.Options;
 /// <summary>
 /// Configuration options for pipeline execution behavior.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <strong>Configuration Precedence:</strong>
+/// ModularPipelines uses a layered configuration system where more specific settings override more general ones.
+/// The precedence order from lowest to highest priority is:
+/// </para>
+/// <list type="number">
+/// <item>
+/// <term>System Defaults (lowest priority)</term>
+/// <description>Built-in defaults in the framework code (e.g., 30-minute module timeout, no retries)</description>
+/// </item>
+/// <item>
+/// <term>Global Configuration</term>
+/// <description>Settings in this <see cref="PipelineOptions"/> class, configured via <see cref="Host.PipelineHostBuilder.ConfigurePipelineOptions"/></description>
+/// </item>
+/// <item>
+/// <term>Module Configuration</term>
+/// <description>Settings defined on individual modules via behavior interfaces
+/// (<see cref="Modules.Behaviors.IRetryable{T}"/>, <see cref="Modules.Behaviors.ITimeoutable"/>, etc.)</description>
+/// </item>
+/// <item>
+/// <term>Per-Call Configuration (highest priority)</term>
+/// <description>Options passed to individual method calls (e.g., <see cref="CommandExecutionOptions.LogSettings"/>,
+/// <see cref="HttpOptions.LogSettings"/>)</description>
+/// </item>
+/// </list>
+/// <para>
+/// <strong>Example:</strong>
+/// If <see cref="DefaultLoggingOptions"/> is set globally, it applies to all command executions.
+/// However, if a specific command call passes <see cref="CommandExecutionOptions.LogSettings"/>,
+/// that per-call setting takes precedence for that execution only.
+/// </para>
+/// <para>
+/// <strong>Module Behaviors:</strong>
+/// Module-level configuration uses the behavior interface pattern. A module implementing
+/// <see cref="Modules.Behaviors.IRetryable{T}"/> will use its custom retry policy instead of
+/// <see cref="DefaultRetryCount"/>. Modules without behavior interfaces fall back to global settings.
+/// </para>
+/// </remarks>
 [ExcludeFromCodeCoverage]
 public record PipelineOptions
 {
@@ -54,12 +93,32 @@ public record PipelineOptions
     /// <summary>
     /// Gets or sets the default number of retry attempts for failed operations.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Configuration Precedence:</strong>
+    /// This is a global default that applies when a module does not implement <see cref="Modules.Behaviors.IRetryable{T}"/>.
+    /// </para>
+    /// <list type="bullet">
+    /// <item>If a module implements <see cref="Modules.Behaviors.IRetryable{T}"/>, its custom retry policy takes precedence</item>
+    /// <item>Otherwise, this global <see cref="DefaultRetryCount"/> is used</item>
+    /// <item>If this value is 0 (default), no retries are attempted</item>
+    /// </list>
+    /// </remarks>
     public int DefaultRetryCount { get; set; }
 
     /// <summary>
     /// Gets or sets the default logging options for all commands.
-    /// When set, this takes precedence over DefaultCommandLogging.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Configuration Precedence (highest to lowest):</strong>
+    /// </para>
+    /// <list type="number">
+    /// <item><see cref="CommandExecutionOptions.LogSettings"/> - Per-call override (highest priority)</item>
+    /// <item>This <see cref="DefaultLoggingOptions"/> - Global default</item>
+    /// <item><see cref="DefaultCommandLogging"/> - Legacy enum-based fallback (lowest priority)</item>
+    /// </list>
+    /// </remarks>
     public CommandLoggingOptions? DefaultLoggingOptions { get; set; }
 
     /// <summary>
@@ -76,6 +135,16 @@ public record PipelineOptions
     /// <see cref="HttpLoggingOptions.Headers"/> for headers without body,
     /// or <see cref="HttpLoggingOptions.Full"/> for complete logging.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Configuration Precedence (highest to lowest):</strong>
+    /// </para>
+    /// <list type="number">
+    /// <item><see cref="HttpOptions.LogSettings"/> - Per-request override (highest priority)</item>
+    /// <item>This <see cref="DefaultHttpLoggingOptions"/> - Global default</item>
+    /// <item><see cref="HttpLoggingOptions.Default"/> - System default (lowest priority)</item>
+    /// </list>
+    /// </remarks>
     public HttpLoggingOptions? DefaultHttpLoggingOptions { get; set; }
 
     /// <summary>
@@ -84,6 +153,16 @@ public record PipelineOptions
     /// unless overridden by <see cref="HttpOptions.Timeout"/> on individual requests.
     /// If not set (null), HTTP requests will use the default HttpClient timeout.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Configuration Precedence (highest to lowest):</strong>
+    /// </para>
+    /// <list type="number">
+    /// <item><see cref="HttpOptions.Timeout"/> - Per-request override (highest priority)</item>
+    /// <item>This <see cref="DefaultHttpTimeout"/> - Global default</item>
+    /// <item>HttpClient default timeout - System default (lowest priority)</item>
+    /// </list>
+    /// </remarks>
     public TimeSpan? DefaultHttpTimeout { get; set; }
 
     /// <summary>
@@ -106,5 +185,12 @@ public record PipelineOptions
     /// Gets or sets the default execution options for all commands.
     /// When set, these options apply to all command executions unless overridden per-call.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Configuration Precedence:</strong>
+    /// Per-call options always take precedence over these global defaults.
+    /// Properties set on per-call <see cref="CommandExecutionOptions"/> override matching properties here.
+    /// </para>
+    /// </remarks>
     public CommandExecutionOptions? DefaultExecutionOptions { get; set; }
 }


### PR DESCRIPTION
## Summary

- Added comprehensive XML documentation clarifying the 4-tier configuration precedence hierarchy
- Documented precedence order for all major configurable options
- Clarified that category-level configuration API does not exist (categories are for filtering only)

## Configuration Precedence (documented)

From lowest to highest priority:
1. **System Defaults** - Built-in framework defaults
2. **Global Configuration** - Settings via `ConfigurePipelineOptions`
3. **Module Configuration** - Behavior interfaces (`IRetryable<T>`, `ITimeoutable`, etc.)
4. **Per-Call Configuration** - Options passed to individual method calls

## Files Changed

- `PipelineOptions.cs` - Class and property-level precedence documentation
- `PipelineHostBuilder.cs` - Enhanced `ConfigurePipelineOptions` documentation with examples
- `IRetryable.cs` - Documented precedence over global retry settings
- `ITimeoutable.cs` - Documented timeout precedence order
- `ModuleCategoryAttribute.cs` - Clarified categories are for filtering, not configuration

## Test plan

- [ ] Verify documentation renders correctly in IDE tooltips
- [ ] Review precedence order matches actual behavior
- [ ] Ensure all cross-references are valid

Closes #1874

🤖 Generated with [Claude Code](https://claude.com/claude-code)