### PR TITLE
fix: Improve null handling in extension methods

### DIFF
--- a/src/ModularPipelines/Extensions/CommandExtensions.cs
+++ b/src/ModularPipelines/Extensions/CommandExtensions.cs
@@ -80,7 +80,7 @@ public static class CommandExtensions
     {
         return options with
         {
-            Arguments = (options.Arguments ?? Array.Empty<string>()).Concat(arguments),
+            Arguments = (options.Arguments ?? Array.Empty<string>()).Concat(arguments).ToArray(),
         };
     }
 }

--- a/src/ModularPipelines/Extensions/ContextExtensions.cs
+++ b/src/ModularPipelines/Extensions/ContextExtensions.cs
@@ -19,7 +19,9 @@ public static class ContextExtensions
     /// </remarks>
     public static void LogOnPipelineEnd(this IPipelineHookContext pipelineContext, string value)
     {
-        var afterPipelineLogger = pipelineContext.Get<IAfterPipelineLogger>()!;
+        var afterPipelineLogger = pipelineContext.Get<IAfterPipelineLogger>()
+            ?? throw new InvalidOperationException(
+                $"Service {nameof(IAfterPipelineLogger)} is not registered. Ensure the pipeline is properly configured.");
         afterPipelineLogger.LogOnPipelineEnd(value);
     }
 }

--- a/src/ModularPipelines/Extensions/FileExtensions.cs
+++ b/src/ModularPipelines/Extensions/FileExtensions.cs
@@ -30,9 +30,14 @@ public static class FileExtensions
     /// <returns>The input object if not null.</returns>
     public static File AssertExists(this File? file, string? message = null)
     {
-        if (file is null || !file.Exists)
+        if (file is null)
         {
-            throw new FileNotFoundException($"The file does not exist{GetMessage(file, message)}", file?.Path);
+            throw new ArgumentNullException(nameof(file), $"File reference is null{GetMessage(null, message)}");
+        }
+
+        if (!file.Exists)
+        {
+            throw new FileNotFoundException($"The file does not exist{GetMessage(file, message)}", file.Path);
         }
 
         return file;

--- a/test/ModularPipelines.UnitTests/Extensions/FileExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Extensions/FileExtensionsTests.cs
@@ -49,9 +49,9 @@ public class FileExtensionsTests
     {
         var file = new Folder(Environment.CurrentDirectory).FindFile(_ => false);
 
-        var exception = Assert.Throws<FileNotFoundException>(() => file.AssertExists("My message"));
+        var exception = Assert.Throws<ArgumentNullException>(() => file.AssertExists("My message"));
 
-        await Assert.That(exception.Message).IsEqualTo("The file does not exist - My message");
+        await Assert.That(exception.Message).IsEqualTo("File reference is null - My message (Parameter 'file')");
     }
 
     [Test]
@@ -59,8 +59,8 @@ public class FileExtensionsTests
     {
         var file = new Folder(Environment.CurrentDirectory).FindFile(_ => false);
 
-        var exception = Assert.Throws<FileNotFoundException>(() => file.AssertExists());
+        var exception = Assert.Throws<ArgumentNullException>(() => file.AssertExists());
 
-        await Assert.That(exception.Message).IsEqualTo("The file does not exist");
+        await Assert.That(exception.Message).IsEqualTo("File reference is null (Parameter 'file')");
     }
 }

--- a/test/ModularPipelines.UnitTests/FileTests.cs
+++ b/test/ModularPipelines.UnitTests/FileTests.cs
@@ -328,7 +328,7 @@ public class FileTests : TestBase
     public async Task AssertExists_ThrowsWhenNull()
     {
         var file = null as File;
-        await Assert.That(() => file.AssertExists()).Throws<FileNotFoundException>();
+        await Assert.That(() => file.AssertExists()).Throws<ArgumentNullException>();
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Fix lazy evaluation issues and improve null safety in extension methods
- Add proper exception types for different failure modes
- Update tests to reflect new exception types

## Changes
- **CommandExtensions.cs**: Materialize `Concat()` result with `.ToArray()` to prevent lazy evaluation issues
- **FileExtensions.cs**: Separate null file check (throws `ArgumentNullException`) from exists check (throws `FileNotFoundException`)
- **ContextExtensions.cs**: Add null check with helpful error message for `IAfterPipelineLogger`

Fixes #1916

🤖 Generated with [Claude Code](https://claude.com/claude-code)