### PR TITLE
refactor: Replace mutable collections with immutable alternatives in record types

### DIFF
--- a/src/ModularPipelines/Models/OrganizedModules.cs
+++ b/src/ModularPipelines/Models/OrganizedModules.cs
@@ -6,5 +6,5 @@ internal record IgnoredModule(IModule Module, SkipDecision SkipDecision);
 
 internal record OrganizedModules(IReadOnlyList<RunnableModule> RunnableModules, IReadOnlyList<IgnoredModule> IgnoredModules)
 {
-    public IReadOnlyList<IModule> AllModules { get; } = RunnableModules.Select(x => x.Module).Concat(IgnoredModules.Select(x => x.Module)).ToList();
+    public IReadOnlyList<IModule> AllModules { get; } = RunnableModules.Select(x => x.Module).Concat(IgnoredModules.Select(x => x.Module)).ToArray();
 }


### PR DESCRIPTION
## Summary
- Changed `ToList()` to `ToArray()` in `OrganizedModules` record to ensure true immutability
- Arrays are effectively immutable after creation, while `List<T>` exposed as `IReadOnlyList<T>` can still be cast back and mutated, breaking record semantics
- `ModuleDependencyModel` remains unchanged as it is an internal class with controlled mutation during initialization in `DependencyChainProvider`

## Test plan
- [x] Solution builds successfully with `dotnet build ModularPipelines.sln -c Release`
- [ ] Existing unit tests should continue to pass (no behavior change)

Fixes #1919

Generated with [Claude Code](https://claude.ai/code)