### PR TITLE
fix: Preserve exception context in SubModuleTracker

### DIFF
--- a/src/ModularPipelines/Engine/SubModuleTracker.cs
+++ b/src/ModularPipelines/Engine/SubModuleTracker.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using ModularPipelines.Enums;
+using ModularPipelines.Exceptions;
 
 namespace ModularPipelines.Engine;
 
@@ -74,10 +75,10 @@ public class SubModuleTracker
 
             return result;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
             RecordCompletion(Status.Failed);
-            _completionSource.TrySetException(new Exception($"SubModule '{Name}' failed"));
+            _completionSource.TrySetException(new SubModuleFailedException(Name, ParentModuleType, ex));
             throw;
         }
     }

--- a/src/ModularPipelines/Exceptions/SubModuleFailedException.cs
+++ b/src/ModularPipelines/Exceptions/SubModuleFailedException.cs
@@ -2,18 +2,58 @@ using ModularPipelines.Modules;
 
 namespace ModularPipelines.Exceptions;
 
+/// <summary>
+/// Exception thrown when a sub-module fails execution.
+/// </summary>
 public class SubModuleFailedException : PipelineException
 {
+    /// <summary>
+    /// Gets the name of the sub-module that failed.
+    /// </summary>
+    public string? SubModuleName { get; }
+
+    /// <summary>
+    /// Gets the type of the parent module.
+    /// </summary>
+    public Type? ParentModuleType { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubModuleFailedException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
     public SubModuleFailedException(string message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubModuleFailedException"/> class.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The inner exception that caused this failure.</param>
     public SubModuleFailedException(string message, Exception innerException) : base(message, innerException)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubModuleFailedException"/> class.
+    /// </summary>
+    /// <param name="submodule">The sub-module that failed.</param>
+    /// <param name="exception">The inner exception that caused this failure.</param>
     public SubModuleFailedException(SubModuleBase submodule, Exception exception) :
         base($"The Sub-Module {submodule.Name} has failed.", exception)
     {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SubModuleFailedException"/> class.
+    /// </summary>
+    /// <param name="subModuleName">The name of the sub-module that failed.</param>
+    /// <param name="parentModuleType">The type of the parent module.</param>
+    /// <param name="innerException">The inner exception that caused this failure.</param>
+    public SubModuleFailedException(string subModuleName, Type parentModuleType, Exception innerException)
+        : base($"SubModule '{subModuleName}' in module '{parentModuleType.Name}' failed.", innerException)
+    {
+        SubModuleName = subModuleName;
+        ParentModuleType = parentModuleType;
     }
 }


### PR DESCRIPTION
## Summary
- Fixed `SubModuleTracker` catch block that was wrapping all exceptions with a generic message, losing the original exception details
- Now uses `SubModuleFailedException` with the original exception preserved as `InnerException`
- Added `SubModuleName` and `ParentModuleType` properties to `SubModuleFailedException` for better debugging context

## Changes
- **SubModuleTracker.cs**: Updated catch block to use `SubModuleFailedException` with inner exception instead of generic `Exception`
- **SubModuleFailedException.cs**: Added new constructor accepting `subModuleName`, `parentModuleType`, and `innerException`, plus new properties `SubModuleName` and `ParentModuleType`

## Test plan
- [x] Solution builds successfully (`dotnet build ModularPipelines.sln -c Release`)
- [ ] Verify exception stack traces now show full context when sub-module fails
- [ ] Confirm `SubModuleName` and `ParentModuleType` properties are populated correctly

Fixes #1907

🤖 Generated with [Claude Code](https://claude.com/claude-code)