### PR TITLE
fix: Report all logger parameter violations in LoggerInConstructorAnalyzer

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/LoggerInConstructorAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/LoggerInConstructorAnalyzer.cs
@@ -53,7 +53,6 @@ public class LoggerInConstructorAnalyzer : DiagnosticAnalyzer
             if (TryGetProhibitedLoggerType(context, parameter, out var parameterSymbol))
             {
                 ReportDiagnostic(context, parameter.GetLocation(), parameterSymbol!);
-                return;
             }
         }
     }


### PR DESCRIPTION
## Summary
- Removed early `return` statement in `LoggerInConstructorAnalyzer.AnalyzeLoggersInConstructors` that was causing only the first logger parameter violation to be reported
- Now all prohibited logger type parameters in a constructor are properly reported

Fixes #1920

## Test plan
- [x] Build succeeds with `dotnet build ModularPipelines.Analyzers.sln -c Release`
- [ ] Verify analyzer reports multiple violations when constructor has multiple logger parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)