### PR TITLE
refactor: Fix inconsistent visibility boundaries in core types

### DIFF
--- a/src/ModularPipelines/Engine/SubModuleTracker.cs
+++ b/src/ModularPipelines/Engine/SubModuleTracker.cs
@@ -10,13 +10,15 @@ namespace ModularPipelines.Engine;
 /// <remarks>
 /// SubModuleTracker provides progress tracking for nested operations without the
 /// full complexity of a module. It tracks status, timing, and completion.
+/// This class is internal because it is only used within the engine infrastructure
+/// and is not intended for direct use by external consumers.
 /// </remarks>
-public class SubModuleTracker
+internal class SubModuleTracker
 {
     private readonly Stopwatch _stopwatch = new();
     private readonly TaskCompletionSource _completionSource = new();
 
-    internal SubModuleTracker(string name, Type parentModuleType)
+    public SubModuleTracker(string name, Type parentModuleType)
     {
         Name = name;
         ParentModuleType = parentModuleType;
@@ -60,7 +62,7 @@ public class SubModuleTracker
     /// <summary>
     /// Executes an action and tracks its progress.
     /// </summary>
-    internal async Task<T> ExecuteAsync<T>(Func<Task<T>> action)
+    public async Task<T> ExecuteAsync<T>(Func<Task<T>> action)
     {
         StartTime = DateTimeOffset.UtcNow;
         Status = Status.Processing;
@@ -86,7 +88,7 @@ public class SubModuleTracker
     /// <summary>
     /// Executes an action and tracks its progress.
     /// </summary>
-    internal async Task ExecuteAsync(Func<Task> action)
+    public async Task ExecuteAsync(Func<Task> action)
     {
         await ExecuteAsync(async () =>
         {


### PR DESCRIPTION
## Summary
- Fixed `SubModuleTracker` which was a public class with internal constructors and methods, creating an inconsistent API contract
- Made the class `internal` since it cannot be instantiated or used externally
- Changed internal members to public since the class itself is now internal

## Analysis
The `SubModuleTracker` class had a confusing visibility pattern:
- **Public class** - suggesting external use is intended
- **Internal constructor** - preventing external instantiation  
- **Internal execute methods** - preventing external execution

This meant external consumers could see the type but couldn't do anything with it. The class is only used within:
- `ModuleContext` (internal class) - creates and executes trackers
- `ModuleExecutionContext` (internal class) - stores trackers in a list
- `IModuleExecutionContext` (internal interface) - exposes SubModules property

Since there's no way for external code to create or use `SubModuleTracker`, making the class internal clarifies the API contract and removes the confusing mixed visibility.

## Test plan
- [x] Build solution: `dotnet build ModularPipelines.sln -c Release` - passes with 0 errors
- [x] Verify no external references to `SubModuleTracker` exist in test projects

Fixes #1908

---
Generated with [Claude Code](https://claude.ai/code)