### PR TITLE
perf: Convert logging string interpolation to structured logging

### DIFF
--- a/docs/architecture/interface-hierarchy.md
+++ b/docs/architecture/interface-hierarchy.md
@@ -117,7 +117,7 @@ public class MyHooks : IPipelineGlobalHooks
 
     public Task OnEndAsync(IPipelineHookContext context, PipelineSummary summary)
     {
-        context.Logger.LogInformation($"Pipeline finished: {summary.TotalModules} modules");
+        context.Logger.LogInformation("Pipeline finished: {TotalModules} modules", summary.TotalModules);
         return Task.CompletedTask;
     }
 }
@@ -132,13 +132,13 @@ public class MyModuleHooks : IPipelineModuleHooks
 {
     public Task OnBeforeModuleStartAsync(IPipelineHookContext context, IModule module)
     {
-        context.Logger.LogInformation($"Module {module.GetType().Name} starting...");
+        context.Logger.LogInformation("Module {ModuleName} starting...", module.GetType().Name);
         return Task.CompletedTask;
     }
 
     public Task OnAfterModuleEndAsync(IPipelineHookContext context, IModule module)
     {
-        context.Logger.LogInformation($"Module {module.GetType().Name} finished");
+        context.Logger.LogInformation("Module {ModuleName} finished", module.GetType().Name);
         return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- Update documentation examples in `docs/architecture/interface-hierarchy.md` to use structured logging format
- Replace string interpolation (`$"Message {value}"`) with message template format (`"Message {Value}", value`)
- This demonstrates the correct pattern that avoids unnecessary string allocations when log levels are disabled

## Investigation
Searched the entire codebase for logging calls using string interpolation (`_logger.LogDebug($"...")` patterns). Found that:
- All production C# code already uses structured logging correctly
- Only the documentation examples in the interface hierarchy guide were using the anti-pattern

## Test plan
- [x] Build passes with `dotnet build ModularPipelines.sln -c Release`

Fixes #1922

---
Generated with [Claude Code](https://claude.ai/code)