### PR TITLE
refactor: Extract Command building logic into separate components

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -1,13 +1,8 @@
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Linq.Expressions;
-using System.Reflection;
 using System.Text;
 using CliWrap;
 using CliWrap.Exceptions;
-using ModularPipelines.Attributes;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers.Internal;
 using ModularPipelines.Logging;
@@ -16,22 +11,30 @@ using CommandResult = ModularPipelines.Models.CommandResult;
 
 namespace ModularPipelines.Context;
 
+/// <summary>
+/// Orchestrates command-line tool execution by coordinating argument building,
+/// placeholder replacement, and command execution.
+/// </summary>
 public sealed class Command : ICommand
 {
-    private static readonly ConcurrentDictionary<Type, IReadOnlyList<PlaceholderPropertyInfo>> PlaceholderPropertyCache = new();
-
     private readonly ICommandLogger _commandLogger;
     private readonly ICommandModelProvider _commandModelProvider;
     private readonly ICommandArgumentBuilder _commandArgumentBuilder;
+    private readonly IPlaceholderHandler _placeholderHandler;
+    private readonly ICommandPartsProvider _commandPartsProvider;
 
     public Command(
         ICommandLogger commandLogger,
         ICommandModelProvider commandModelProvider,
-        ICommandArgumentBuilder commandArgumentBuilder)
+        ICommandArgumentBuilder commandArgumentBuilder,
+        IPlaceholderHandler placeholderHandler,
+        ICommandPartsProvider commandPartsProvider)
     {
         _commandLogger = commandLogger;
         _commandModelProvider = commandModelProvider;
         _commandArgumentBuilder = commandArgumentBuilder;
+        _placeholderHandler = placeholderHandler;
+        _commandPartsProvider = commandPartsProvider;
     }
 
     public async Task<CommandResult> ExecuteCommandLineTool(
@@ -44,7 +47,8 @@ public sealed class Command : ICommand
         var optionsObject = GetOptionsObject(options);
 
         // Get subcommand parts and handle placeholder replacement
-        var precedingArgs = GetPrecedingArguments(optionsObject);
+        var rawCommandParts = _commandPartsProvider.GetRawCommandParts(optionsObject);
+        var precedingArgs = _placeholderHandler.ReplacePlaceholders(rawCommandParts, optionsObject);
 
         // Build arguments from the command model using the new services
         var commandModel = _commandModelProvider.GetCommandModel(optionsObject.GetType());
@@ -104,190 +108,6 @@ public sealed class Command : ICommand
         }
 
         return await Of(command, options, execOpts, cancellationToken).ConfigureAwait(false);
-    }
-
-    // Note: Placeholder sanitization is no longer needed since ReplacePlaceholders
-    // now handles placeholder replacement inline using CliArgumentAttribute.Name matching.
-    private static List<string> GetPrecedingArguments(object optionsObject)
-    {
-        var rawCommandParts = GetRawCommandParts(optionsObject);
-        return ReplacePlaceholders(rawCommandParts, optionsObject);
-    }
-
-    private static List<string> GetRawCommandParts(object optionsObject)
-    {
-        if (optionsObject is CommandLineToolOptions { CommandParts: not null } commandLineToolOptions)
-        {
-            return commandLineToolOptions.CommandParts.ToList();
-        }
-
-        var type = optionsObject.GetType();
-
-        // Try new CliCommand attribute first
-        // Check for preferred alias first
-        var preferredAlias = type.GetCustomAttributes<CliCommandAliasAttribute>()
-            .FirstOrDefault(a => a.IsPreferred);
-
-        if (preferredAlias is not null)
-        {
-            return preferredAlias.CommandParts.ToList();
-        }
-
-        // Prefer the explicit CliSubCommand attribute if it exists (for classes that inherit tool from base)
-        var cliSubCommandAttribute = type.GetCustomAttribute<CliSubCommandAttribute>();
-        if (cliSubCommandAttribute is not null)
-        {
-            return cliSubCommandAttribute.SubCommands.ToList();
-        }
-
-        // Fall back to full CliCommand attribute (defines both tool and subcommands)
-        var cliCommandAttribute = type.GetCustomAttribute<CliCommandAttribute>();
-        if (cliCommandAttribute is not null)
-        {
-            // Only return SubCommands, not the tool name (which is already used by Cli.Wrap)
-            return cliCommandAttribute.SubCommands.ToList();
-        }
-
-        return new List<string>();
-    }
-
-    /// <summary>
-    /// Replaces placeholder strings in command parts with actual argument values.
-    /// Placeholders are matched to properties via CliArgumentAttribute.Name.
-    /// </summary>
-    private static List<string> ReplacePlaceholders(List<string> commandParts, object optionsObject)
-    {
-        if (commandParts.Count == 0)
-        {
-            return commandParts;
-        }
-
-        // Build a lookup of placeholder name -> property value
-        var placeholderValues = BuildPlaceholderValueLookup(optionsObject);
-
-        var result = new List<string>();
-        foreach (var part in commandParts)
-        {
-            // Check if this is a placeholder (starts with < or [<)
-            if (IsPlaceholder(part))
-            {
-                // Try to find a matching argument value
-                if (placeholderValues.TryGetValue(part, out var values) && values.Count > 0)
-                {
-                    result.AddRange(values);
-                }
-
-                // If no value found, skip the placeholder (it's optional)
-            }
-            else
-            {
-                // Literal command part, add as-is
-                result.Add(part);
-            }
-        }
-
-        return result;
-    }
-
-    private static bool IsPlaceholder(string part)
-    {
-        return part.StartsWith('<') || part.StartsWith("[<");
-    }
-
-    private static Dictionary<string, List<string>> BuildPlaceholderValueLookup(object optionsObject)
-    {
-        var lookup = new Dictionary<string, List<string>>(StringComparer.Ordinal);
-        var type = optionsObject.GetType();
-
-        // Get cached placeholder properties for this type
-        var placeholderProperties = PlaceholderPropertyCache.GetOrAdd(type, BuildPlaceholderPropertyCache);
-
-        foreach (var placeholderProperty in placeholderProperties)
-        {
-            var rawValue = placeholderProperty.Getter(optionsObject);
-            if (rawValue is null)
-            {
-                continue;
-            }
-
-            var values = GetArgumentValues(rawValue);
-            if (values.Count > 0)
-            {
-                lookup[placeholderProperty.Name] = values;
-            }
-        }
-
-        return lookup;
-    }
-
-    private static IReadOnlyList<PlaceholderPropertyInfo> BuildPlaceholderPropertyCache(Type type)
-    {
-        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        var placeholderProperties = new List<PlaceholderPropertyInfo>();
-
-        foreach (var property in properties)
-        {
-            var cliArgument = property.GetCustomAttribute<CliArgumentAttribute>();
-            if (cliArgument?.Name is null)
-            {
-                continue;
-            }
-
-            var getter = CreatePropertyGetter(type, property);
-            placeholderProperties.Add(new PlaceholderPropertyInfo(cliArgument.Name, getter));
-        }
-
-        return placeholderProperties;
-    }
-
-    private static Func<object, object?> CreatePropertyGetter(Type type, PropertyInfo property)
-    {
-        // Create a compiled expression tree for fast property access
-        // Expression: (object obj) => (object?)((TType)obj).Property
-        var parameter = Expression.Parameter(typeof(object), "obj");
-        var castToType = Expression.Convert(parameter, type);
-        var propertyAccess = Expression.Property(castToType, property);
-        var castToObject = Expression.Convert(propertyAccess, typeof(object));
-
-        var lambda = Expression.Lambda<Func<object, object?>>(castToObject, parameter);
-        return lambda.Compile();
-    }
-
-    private static List<string> GetArgumentValues(object rawValue)
-    {
-        var result = new List<string>();
-
-        if (rawValue is string stringValue)
-        {
-            if (!string.IsNullOrEmpty(stringValue))
-            {
-                result.Add(stringValue);
-            }
-        }
-        else if (rawValue is IEnumerable enumerable and not IEnumerable<char>)
-        {
-            foreach (var item in enumerable)
-            {
-                if (item is not null)
-                {
-                    var itemStr = item.ToString();
-                    if (!string.IsNullOrEmpty(itemStr))
-                    {
-                        result.Add(itemStr);
-                    }
-                }
-            }
-        }
-        else
-        {
-            var str = rawValue.ToString();
-            if (!string.IsNullOrEmpty(str))
-            {
-                result.Add(str);
-            }
-        }
-
-        return result;
     }
 
     private static object GetOptionsObject(CommandLineToolOptions options)
@@ -406,11 +226,4 @@ public sealed class Command : ICommand
             }
         }
     }
-
-    /// <summary>
-    /// Cached information about a property that provides placeholder values.
-    /// </summary>
-    /// <param name="Name">The placeholder name (from CliArgumentAttribute.Name).</param>
-    /// <param name="Getter">A compiled delegate to get the property value.</param>
-    private sealed record PlaceholderPropertyInfo(string Name, Func<object, object?> Getter);
 }

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -200,6 +200,8 @@ internal static class DependencyInjectionSetup
             .AddSingleton<IParallelLimitProvider, ParallelLimitProvider>()
             .AddSingleton<ICommandModelProvider, CommandModelProvider>()
             .AddSingleton<ICommandArgumentBuilder, CommandArgumentBuilder>()
+            .AddSingleton<IPlaceholderHandler, PlaceholderHandler>()
+            .AddSingleton<ICommandPartsProvider, CommandPartsProvider>()
             .AddSingleton<IMetricsCollector, MetricsCollector>()
 
             // Module execution components (SRP extraction from ModuleExecutor)

--- a/src/ModularPipelines/Helpers/Internal/CommandPartsProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandPartsProvider.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+using ModularPipelines.Attributes;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Helpers.Internal;
+
+/// <inheritdoc/>
+internal sealed class CommandPartsProvider : ICommandPartsProvider
+{
+    /// <inheritdoc/>
+    public List<string> GetRawCommandParts(object optionsObject)
+    {
+        if (optionsObject is CommandLineToolOptions { CommandParts: not null } commandLineToolOptions)
+        {
+            return commandLineToolOptions.CommandParts.ToList();
+        }
+
+        var type = optionsObject.GetType();
+
+        // Try new CliCommand attribute first
+        // Check for preferred alias first
+        var preferredAlias = type.GetCustomAttributes<CliCommandAliasAttribute>()
+            .FirstOrDefault(a => a.IsPreferred);
+
+        if (preferredAlias is not null)
+        {
+            return preferredAlias.CommandParts.ToList();
+        }
+
+        // Prefer the explicit CliSubCommand attribute if it exists (for classes that inherit tool from base)
+        var cliSubCommandAttribute = type.GetCustomAttribute<CliSubCommandAttribute>();
+        if (cliSubCommandAttribute is not null)
+        {
+            return cliSubCommandAttribute.SubCommands.ToList();
+        }
+
+        // Fall back to full CliCommand attribute (defines both tool and subcommands)
+        var cliCommandAttribute = type.GetCustomAttribute<CliCommandAttribute>();
+        if (cliCommandAttribute is not null)
+        {
+            // Only return SubCommands, not the tool name (which is already used by Cli.Wrap)
+            return cliCommandAttribute.SubCommands.ToList();
+        }
+
+        return new List<string>();
+    }
+}

--- a/src/ModularPipelines/Helpers/Internal/ICommandPartsProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/ICommandPartsProvider.cs
@@ -1,0 +1,17 @@
+namespace ModularPipelines.Helpers.Internal;
+
+/// <summary>
+/// Service that extracts the raw command parts (subcommands) from an options object.
+/// Command parts are determined from CliCommand, CliSubCommand, or CliCommandAlias attributes,
+/// or from the CommandParts property on CommandLineToolOptions.
+/// </summary>
+public interface ICommandPartsProvider
+{
+    /// <summary>
+    /// Gets the raw command parts (subcommands) from an options object.
+    /// These parts may include placeholders that need to be replaced.
+    /// </summary>
+    /// <param name="optionsObject">The options object to extract command parts from.</param>
+    /// <returns>A list of command parts, potentially including placeholders.</returns>
+    List<string> GetRawCommandParts(object optionsObject);
+}

--- a/src/ModularPipelines/Helpers/Internal/IPlaceholderHandler.cs
+++ b/src/ModularPipelines/Helpers/Internal/IPlaceholderHandler.cs
@@ -1,0 +1,18 @@
+namespace ModularPipelines.Helpers.Internal;
+
+/// <summary>
+/// Service that handles placeholder replacement in command parts.
+/// Placeholders (e.g., &lt;argument&gt; or [&lt;optional&gt;]) in command templates
+/// are replaced with actual values from the options object.
+/// </summary>
+public interface IPlaceholderHandler
+{
+    /// <summary>
+    /// Replaces placeholder strings in command parts with actual argument values.
+    /// Placeholders are matched to properties via CliArgumentAttribute.Name.
+    /// </summary>
+    /// <param name="commandParts">The raw command parts that may contain placeholders.</param>
+    /// <param name="optionsObject">The options object containing values for the placeholders.</param>
+    /// <returns>A list of command parts with placeholders replaced by their values.</returns>
+    List<string> ReplacePlaceholders(List<string> commandParts, object optionsObject);
+}

--- a/src/ModularPipelines/Helpers/Internal/PlaceholderHandler.cs
+++ b/src/ModularPipelines/Helpers/Internal/PlaceholderHandler.cs
@@ -1,0 +1,156 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Linq.Expressions;
+using System.Reflection;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Helpers.Internal;
+
+/// <inheritdoc/>
+internal sealed class PlaceholderHandler : IPlaceholderHandler
+{
+    private static readonly ConcurrentDictionary<Type, IReadOnlyList<PlaceholderPropertyInfo>> PlaceholderPropertyCache = new();
+
+    /// <inheritdoc/>
+    public List<string> ReplacePlaceholders(List<string> commandParts, object optionsObject)
+    {
+        if (commandParts.Count == 0)
+        {
+            return commandParts;
+        }
+
+        // Build a lookup of placeholder name -> property value
+        var placeholderValues = BuildPlaceholderValueLookup(optionsObject);
+
+        var result = new List<string>();
+        foreach (var part in commandParts)
+        {
+            // Check if this is a placeholder (starts with < or [<)
+            if (IsPlaceholder(part))
+            {
+                // Try to find a matching argument value
+                if (placeholderValues.TryGetValue(part, out var values) && values.Count > 0)
+                {
+                    result.AddRange(values);
+                }
+
+                // If no value found, skip the placeholder (it's optional)
+            }
+            else
+            {
+                // Literal command part, add as-is
+                result.Add(part);
+            }
+        }
+
+        return result;
+    }
+
+    private static bool IsPlaceholder(string part)
+    {
+        return part.StartsWith('<') || part.StartsWith("[<");
+    }
+
+    private static Dictionary<string, List<string>> BuildPlaceholderValueLookup(object optionsObject)
+    {
+        var lookup = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var type = optionsObject.GetType();
+
+        // Get cached placeholder properties for this type
+        var placeholderProperties = PlaceholderPropertyCache.GetOrAdd(type, BuildPlaceholderPropertyCache);
+
+        foreach (var placeholderProperty in placeholderProperties)
+        {
+            var rawValue = placeholderProperty.Getter(optionsObject);
+            if (rawValue is null)
+            {
+                continue;
+            }
+
+            var values = GetArgumentValues(rawValue);
+            if (values.Count > 0)
+            {
+                lookup[placeholderProperty.Name] = values;
+            }
+        }
+
+        return lookup;
+    }
+
+    private static IReadOnlyList<PlaceholderPropertyInfo> BuildPlaceholderPropertyCache(Type type)
+    {
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var placeholderProperties = new List<PlaceholderPropertyInfo>();
+
+        foreach (var property in properties)
+        {
+            var cliArgument = property.GetCustomAttribute<CliArgumentAttribute>();
+            if (cliArgument?.Name is null)
+            {
+                continue;
+            }
+
+            var getter = CreatePropertyGetter(type, property);
+            placeholderProperties.Add(new PlaceholderPropertyInfo(cliArgument.Name, getter));
+        }
+
+        return placeholderProperties;
+    }
+
+    private static Func<object, object?> CreatePropertyGetter(Type type, PropertyInfo property)
+    {
+        // Create a compiled expression tree for fast property access
+        // Expression: (object obj) => (object?)((TType)obj).Property
+        var parameter = Expression.Parameter(typeof(object), "obj");
+        var castToType = Expression.Convert(parameter, type);
+        var propertyAccess = Expression.Property(castToType, property);
+        var castToObject = Expression.Convert(propertyAccess, typeof(object));
+
+        var lambda = Expression.Lambda<Func<object, object?>>(castToObject, parameter);
+        return lambda.Compile();
+    }
+
+    private static List<string> GetArgumentValues(object rawValue)
+    {
+        var result = new List<string>();
+
+        if (rawValue is string stringValue)
+        {
+            if (!string.IsNullOrEmpty(stringValue))
+            {
+                result.Add(stringValue);
+            }
+        }
+        else if (rawValue is IEnumerable enumerable and not IEnumerable<char>)
+        {
+            foreach (var item in enumerable)
+            {
+                if (item is not null)
+                {
+                    var itemStr = item.ToString();
+                    if (!string.IsNullOrEmpty(itemStr))
+                    {
+                        result.Add(itemStr);
+                    }
+                }
+            }
+        }
+        else
+        {
+            var str = rawValue.ToString();
+            if (!string.IsNullOrEmpty(str))
+            {
+                result.Add(str);
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Cached information about a property that provides placeholder values.
+    /// </summary>
+    /// <param name="Name">The placeholder name (from CliArgumentAttribute.Name).</param>
+    /// <param name="Getter">A compiled delegate to get the property value.</param>
+    private sealed record PlaceholderPropertyInfo(string Name, Func<object, object?> Getter);
+}


### PR DESCRIPTION
## Summary

- Extract placeholder handling from `Command.cs` into `IPlaceholderHandler`/`PlaceholderHandler` - handles `<argument>` and `[<optional>]` syntax replacement
- Extract command parts extraction into `ICommandPartsProvider`/`CommandPartsProvider` - gets raw command parts from `CliCommand`, `CliSubCommand`, and `CliCommandAlias` attributes
- Update `Command.cs` to act as orchestrator using the extracted services via dependency injection
- Register new services as singletons in `DependencyInjectionSetup.cs`

## Test plan

- [x] Build passes with `dotnet build ModularPipelines.sln -c Release`
- [ ] Existing unit tests continue to pass (verifies no behavioral changes)
- [ ] Manual verification with example pipeline

Fixes #1909

🤖 Generated with [Claude Code](https://claude.com/claude-code)