### PR TITLE
refactor: Extract status reporting from ModuleScheduler (SRP)

### DIFF
--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -214,7 +214,8 @@ internal static class DependencyInjectionSetup
             .AddSingleton<Engine.Execution.IAlwaysRunHandler, Engine.Execution.AlwaysRunHandler>()
 
             // Module scheduling components (SRP extraction from ModuleScheduler)
-            .AddSingleton<Engine.Scheduling.IModuleConstraintEvaluator, Engine.Scheduling.ModuleConstraintEvaluator>();
+            .AddSingleton<Engine.Scheduling.IModuleConstraintEvaluator, Engine.Scheduling.ModuleConstraintEvaluator>()
+            .AddSingleton<Engine.Scheduling.ISchedulerStatusReporter, Engine.Scheduling.SchedulerStatusReporter>();
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/ModuleSchedulerFactory.cs
+++ b/src/ModularPipelines/Engine/ModuleSchedulerFactory.cs
@@ -17,6 +17,7 @@ internal class ModuleSchedulerFactory : IModuleSchedulerFactory
     private readonly IModuleDependencyRegistry _dependencyRegistry;
     private readonly IMetricsCollector _metricsCollector;
     private readonly IModuleConstraintEvaluator _constraintEvaluator;
+    private readonly ISchedulerStatusReporter _statusReporter;
 
     public ModuleSchedulerFactory(
         ILogger<ModuleScheduler> logger,
@@ -24,7 +25,8 @@ internal class ModuleSchedulerFactory : IModuleSchedulerFactory
         IOptions<SchedulerOptions> schedulerOptions,
         IModuleDependencyRegistry dependencyRegistry,
         IMetricsCollector metricsCollector,
-        IModuleConstraintEvaluator constraintEvaluator)
+        IModuleConstraintEvaluator constraintEvaluator,
+        ISchedulerStatusReporter statusReporter)
     {
         _logger = logger;
         _timeProvider = timeProvider;
@@ -32,10 +34,11 @@ internal class ModuleSchedulerFactory : IModuleSchedulerFactory
         _dependencyRegistry = dependencyRegistry;
         _metricsCollector = metricsCollector;
         _constraintEvaluator = constraintEvaluator;
+        _statusReporter = statusReporter;
     }
 
     public IModuleScheduler Create()
     {
-        return new ModuleScheduler(_logger, _timeProvider, _schedulerOptions, _dependencyRegistry, _metricsCollector, _constraintEvaluator);
+        return new ModuleScheduler(_logger, _timeProvider, _schedulerOptions, _dependencyRegistry, _metricsCollector, _constraintEvaluator, _statusReporter);
     }
 }

--- a/src/ModularPipelines/Engine/Scheduling/ISchedulerStatusReporter.cs
+++ b/src/ModularPipelines/Engine/Scheduling/ISchedulerStatusReporter.cs
@@ -1,0 +1,24 @@
+namespace ModularPipelines.Engine.Scheduling;
+
+/// <summary>
+/// Reports scheduler status at regular intervals for diagnostic purposes.
+/// </summary>
+/// <remarks>
+/// This interface encapsulates the periodic status logging responsibility
+/// previously embedded in ModuleScheduler, following the Single Responsibility Principle.
+/// The 15-second interval status reporting is a cross-cutting concern that helps
+/// diagnose pipeline progress and identify blocked modules.
+/// </remarks>
+internal interface ISchedulerStatusReporter
+{
+    /// <summary>
+    /// Logs the current scheduler status if the reporting interval has elapsed.
+    /// </summary>
+    /// <remarks>
+    /// This method is designed to be called frequently (e.g., each scheduler iteration)
+    /// but only produces output when the configured interval has passed since the last report.
+    /// </remarks>
+    /// <param name="stateQueries">Query helper for accessing module states.</param>
+    /// <param name="stateLock">Lock protecting state access.</param>
+    void LogStatusIfIntervalElapsed(ModuleStateQueries stateQueries, ReaderWriterLockSlim stateLock);
+}

--- a/src/ModularPipelines/Engine/Scheduling/SchedulerStatusReporter.cs
+++ b/src/ModularPipelines/Engine/Scheduling/SchedulerStatusReporter.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Helpers;
+
+namespace ModularPipelines.Engine.Scheduling;
+
+/// <summary>
+/// Reports scheduler status at regular intervals for diagnostic purposes.
+/// </summary>
+/// <remarks>
+/// This class encapsulates the periodic status logging responsibility
+/// previously embedded in ModuleScheduler, following the Single Responsibility Principle.
+/// The status reporting helps diagnose pipeline progress by logging:
+/// - Overall statistics (total, queued, executing, completed, pending modules)
+/// - Pending modules with their unresolved dependency counts
+/// - Currently executing modules
+/// </remarks>
+internal class SchedulerStatusReporter : ISchedulerStatusReporter
+{
+    private static readonly TimeSpan StatusLogInterval = TimeSpan.FromSeconds(15);
+
+    private readonly ILogger<SchedulerStatusReporter> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    private DateTimeOffset _lastStatusLogTime;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SchedulerStatusReporter"/> class.
+    /// </summary>
+    /// <param name="logger">Logger for status output.</param>
+    /// <param name="timeProvider">Provider for current time.</param>
+    public SchedulerStatusReporter(ILogger<SchedulerStatusReporter> logger, TimeProvider timeProvider)
+    {
+        _logger = logger;
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public void LogStatusIfIntervalElapsed(ModuleStateQueries stateQueries, ReaderWriterLockSlim stateLock)
+    {
+        var now = _timeProvider.GetUtcNow();
+        if (now - _lastStatusLogTime < StatusLogInterval)
+        {
+            return;
+        }
+
+        _lastStatusLogTime = now;
+
+        // Consolidate all state queries under a single read lock to reduce contention
+        ModuleStateStatistics stats;
+        ModuleState[] pending;
+        ModuleState[] executing;
+
+        stateLock.EnterReadLock();
+        try
+        {
+            stats = stateQueries.GetStatistics();
+            pending = stateQueries.GetPendingModules().ToArray();
+            executing = stateQueries.GetExecutingModules().ToArray();
+        }
+        finally
+        {
+            stateLock.ExitReadLock();
+        }
+
+        // All logging outside lock to avoid holding lock during I/O
+        _logger.LogDebug(
+            "Scheduler waiting: Total={Total}, Queued={Queued}, Executing={Executing}, Completed={Completed}, Pending={Pending}",
+            stats.Total, stats.Queued, stats.Executing, stats.Completed, stats.Pending);
+
+        if (pending.Length > 0)
+        {
+            _logger.LogDebug("Pending modules: {Modules}",
+                string.Join(", ", pending.Select(FormatModuleWithDependencyCount)));
+        }
+
+        if (executing.Length > 0)
+        {
+            _logger.LogDebug("Executing modules: {Modules}",
+                string.Join(", ", executing.Select(m => MarkupFormatter.FormatModuleName(m.ModuleType.Name))));
+        }
+    }
+
+    private static string FormatModuleWithDependencyCount(ModuleState m)
+    {
+        return $"{MarkupFormatter.FormatModuleName(m.ModuleType.Name)} (deps: {m.UnresolvedDependencies.Count})";
+    }
+}


### PR DESCRIPTION
## Summary
- Extracts the periodic status logging functionality from `ModuleScheduler` into a dedicated `SchedulerStatusReporter` class
- Creates `ISchedulerStatusReporter` interface defining the contract for status reporting
- Follows Single Responsibility Principle by separating the cross-cutting concern of 15-second interval status logging from core scheduling logic
- Makes `ModuleScheduler` more focused and testable

## Changes
- **New files:**
  - `ISchedulerStatusReporter.cs` - Interface for scheduler status reporting
  - `SchedulerStatusReporter.cs` - Implementation with 15-second interval logging
- **Modified files:**
  - `ModuleScheduler.cs` - Removed `LogSchedulerWaitingState()`, `FormatModuleWithDependencyCount()`, `StatusLogInterval` constant, and `_lastStatusLogTime` field
  - `ModuleSchedulerFactory.cs` - Added injection of `ISchedulerStatusReporter`
  - `DependencyInjectionSetup.cs` - Registered new service

## Test plan
- [x] Build solution successfully
- [x] Run unit tests (580 passed, 1 expected failure in worktree context, 6 skipped)

Fixes #1905

---
Generated with [Claude Code](https://claude.ai/code)