### PR TITLE
feat: Add InvalidModuleTypeException for better error handling

### DIFF
--- a/src/ModularPipelines/Attributes/DependsOnAllModulesInheritingFromAttribute.cs
+++ b/src/ModularPipelines/Attributes/DependsOnAllModulesInheritingFromAttribute.cs
@@ -1,3 +1,4 @@
+using ModularPipelines.Exceptions;
 using ModularPipelines.Modules;
 
 namespace ModularPipelines.Attributes;
@@ -9,7 +10,7 @@ public class DependsOnAllModulesInheritingFromAttribute : Attribute
     {
         if (!type.IsAssignableTo(typeof(IModule)))
         {
-            throw new Exception($"{type.FullName} is not a Module class");
+            throw new InvalidModuleTypeException(type);
         }
 
         Type = type;

--- a/src/ModularPipelines/Attributes/DependsOnAttribute.cs
+++ b/src/ModularPipelines/Attributes/DependsOnAttribute.cs
@@ -1,3 +1,4 @@
+using ModularPipelines.Exceptions;
 using ModularPipelines.Modules;
 
 namespace ModularPipelines.Attributes;
@@ -9,7 +10,7 @@ public class DependsOnAttribute : Attribute
     {
         if (!type.IsAssignableTo(typeof(IModule)))
         {
-            throw new Exception($"{type.FullName} is not a Module (does not implement IModule)");
+            throw new InvalidModuleTypeException(type);
         }
 
         Type = type;

--- a/src/ModularPipelines/Exceptions/InvalidModuleTypeException.cs
+++ b/src/ModularPipelines/Exceptions/InvalidModuleTypeException.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ModularPipelines.Exceptions;
+
+/// <summary>
+/// Exception thrown when a type is expected to be a module but does not implement IModule.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class InvalidModuleTypeException : PipelineException
+{
+    /// <summary>
+    /// Gets the type that was expected to be a module but is not.
+    /// </summary>
+    public Type InvalidType { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InvalidModuleTypeException"/> class.
+    /// </summary>
+    /// <param name="invalidType">The type that does not implement IModule.</param>
+    public InvalidModuleTypeException(Type invalidType)
+        : base($"{invalidType.FullName} is not a Module (does not implement IModule)")
+    {
+        InvalidType = invalidType;
+    }
+}

--- a/src/ModularPipelines/Modules/DependencyDeclaration.cs
+++ b/src/ModularPipelines/Modules/DependencyDeclaration.cs
@@ -1,4 +1,5 @@
 using ModularPipelines.Enums;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Models;
 
 namespace ModularPipelines.Modules;
@@ -103,9 +104,7 @@ internal sealed class DependencyDeclaration : IDependencyDeclaration
 
         if (!moduleType.IsAssignableTo(typeof(IModule)))
         {
-            throw new ArgumentException(
-                $"{moduleType.FullName} is not a Module (does not implement IModule)",
-                nameof(moduleType));
+            throw new InvalidModuleTypeException(moduleType);
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/DependsOnTests.cs
+++ b/test/ModularPipelines.UnitTests/DependsOnTests.cs
@@ -141,7 +141,7 @@ public class DependsOnTests : TestBase
         await Assert.That(async () => await TestPipelineHostBuilder.Create()
                 .AddModule<DependsOnNonModule>()
                 .ExecutePipelineAsync()).
-            ThrowsException()
+            Throws<InvalidModuleTypeException>()
             .And.HasMessageEqualTo("ModularPipelines.Exceptions.ModuleFailedException is not a Module (does not implement IModule)");
     }
 }

--- a/test/ModularPipelines.UnitTests/DynamicDependencyDeclarationTests.cs
+++ b/test/ModularPipelines.UnitTests/DynamicDependencyDeclarationTests.cs
@@ -470,7 +470,7 @@ public class DynamicDependencyDeclarationTests : TestBase
         var declaration = new DependencyDeclaration();
 
         await Assert.That(() => declaration.DependsOn(typeof(string)))
-            .ThrowsException()
+            .Throws<InvalidModuleTypeException>()
             .And.HasMessageContaining("is not a Module");
     }
 


### PR DESCRIPTION
## Summary
- Created `InvalidModuleTypeException` class inheriting from `PipelineException` with an `InvalidType` property
- Replaced generic `Exception` throws in `DependsOnAttribute` and `DependsOnAllModulesInheritingFromAttribute`
- Replaced `ArgumentException` in `DependencyDeclaration` for consistent exception handling
- Updated tests to expect `InvalidModuleTypeException`

Closes #1987

## Test plan
- [x] Build succeeds
- [x] Existing tests updated and passing
- [x] New exception type provides clear error message with type information

Generated with [Claude Code](https://claude.ai/code)