### PR TITLE
docs: Clarify RunOn vs RunOnOnly attribute semantics

### DIFF
--- a/src/ModularPipelines/Attributes/RunOnLinuxAttribute.cs
+++ b/src/ModularPipelines/Attributes/RunOnLinuxAttribute.cs
@@ -3,6 +3,36 @@ using ModularPipelines.Context;
 
 namespace ModularPipelines.Attributes;
 
+/// <summary>
+/// Specifies that this module can run on Linux.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This attribute uses OR logic with other <see cref="RunConditionAttribute"/> attributes.
+/// When combined with other <c>RunOn*</c> attributes (e.g., <see cref="RunOnWindowsAttribute"/>),
+/// the module will run if ANY of the conditions are met.
+/// </para>
+/// <para>
+/// Use this attribute when you want to specify multiple platforms on which the module can execute.
+/// For example, applying both <c>[RunOnLinux]</c> and <c>[RunOnMacOS]</c> means the module
+/// will run on either Linux OR macOS, but will be skipped on Windows.
+/// </para>
+/// <para>
+/// <b>Example - Run on multiple platforms:</b>
+/// <code>
+/// [RunOnLinux]
+/// [RunOnMacOS]
+/// public class UnixLikeModule : Module&lt;None&gt;
+/// {
+///     // This module runs on Linux OR macOS, skipped on Windows
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+/// <seealso cref="RunOnLinuxOnlyAttribute"/>
+/// <seealso cref="RunOnWindowsAttribute"/>
+/// <seealso cref="RunOnMacOSAttribute"/>
+/// <seealso cref="RunConditionAttribute"/>
 [ExcludeFromCodeCoverage]
 public class RunOnLinuxAttribute : RunConditionAttribute
 {

--- a/src/ModularPipelines/Attributes/RunOnLinuxOnlyAttribute.cs
+++ b/src/ModularPipelines/Attributes/RunOnLinuxOnlyAttribute.cs
@@ -3,6 +3,41 @@ using ModularPipelines.Context;
 
 namespace ModularPipelines.Attributes;
 
+/// <summary>
+/// Specifies that this module must run only on Linux.
+/// The module will be skipped on all other operating systems.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This attribute uses AND logic with other <see cref="MandatoryRunConditionAttribute"/> attributes.
+/// ALL mandatory conditions must be satisfied for the module to run.
+/// </para>
+/// <para>
+/// Use this attribute when your module contains Linux-specific logic that cannot
+/// and should not run on other platforms.
+/// </para>
+/// <para>
+/// <b>Difference from <see cref="RunOnLinuxAttribute"/>:</b>
+/// <list type="bullet">
+/// <item><description><c>[RunOnLinux]</c> - Uses OR logic; can be combined with other <c>RunOn*</c> attributes to run on multiple platforms.</description></item>
+/// <item><description><c>[RunOnLinuxOnly]</c> - Uses AND logic; the module will ONLY run on Linux regardless of other attributes.</description></item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>Example:</b>
+/// <code>
+/// [RunOnLinuxOnly]
+/// public class SystemdServiceModule : Module&lt;None&gt;
+/// {
+///     // This module will only execute on Linux
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+/// <seealso cref="RunOnLinuxAttribute"/>
+/// <seealso cref="RunOnWindowsOnlyAttribute"/>
+/// <seealso cref="RunOnMacOSOnlyAttribute"/>
+/// <seealso cref="MandatoryRunConditionAttribute"/>
 [ExcludeFromCodeCoverage]
 public class RunOnLinuxOnlyAttribute : MandatoryRunConditionAttribute
 {

--- a/src/ModularPipelines/Attributes/RunOnMacOSAttribute.cs
+++ b/src/ModularPipelines/Attributes/RunOnMacOSAttribute.cs
@@ -3,6 +3,36 @@ using ModularPipelines.Context;
 
 namespace ModularPipelines.Attributes;
 
+/// <summary>
+/// Specifies that this module can run on macOS.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This attribute uses OR logic with other <see cref="RunConditionAttribute"/> attributes.
+/// When combined with other <c>RunOn*</c> attributes (e.g., <see cref="RunOnLinuxAttribute"/>),
+/// the module will run if ANY of the conditions are met.
+/// </para>
+/// <para>
+/// Use this attribute when you want to specify multiple platforms on which the module can execute.
+/// For example, applying both <c>[RunOnMacOS]</c> and <c>[RunOnLinux]</c> means the module
+/// will run on either macOS OR Linux, but will be skipped on Windows.
+/// </para>
+/// <para>
+/// <b>Example - Run on multiple platforms:</b>
+/// <code>
+/// [RunOnMacOS]
+/// [RunOnLinux]
+/// public class UnixLikeModule : Module&lt;None&gt;
+/// {
+///     // This module runs on macOS OR Linux, skipped on Windows
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+/// <seealso cref="RunOnMacOSOnlyAttribute"/>
+/// <seealso cref="RunOnWindowsAttribute"/>
+/// <seealso cref="RunOnLinuxAttribute"/>
+/// <seealso cref="RunConditionAttribute"/>
 [ExcludeFromCodeCoverage]
 public class RunOnMacOSAttribute : RunConditionAttribute
 {

--- a/src/ModularPipelines/Attributes/RunOnMacOSOnlyAttribute.cs
+++ b/src/ModularPipelines/Attributes/RunOnMacOSOnlyAttribute.cs
@@ -3,6 +3,41 @@ using ModularPipelines.Context;
 
 namespace ModularPipelines.Attributes;
 
+/// <summary>
+/// Specifies that this module must run only on macOS.
+/// The module will be skipped on all other operating systems.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This attribute uses AND logic with other <see cref="MandatoryRunConditionAttribute"/> attributes.
+/// ALL mandatory conditions must be satisfied for the module to run.
+/// </para>
+/// <para>
+/// Use this attribute when your module contains macOS-specific logic that cannot
+/// and should not run on other platforms.
+/// </para>
+/// <para>
+/// <b>Difference from <see cref="RunOnMacOSAttribute"/>:</b>
+/// <list type="bullet">
+/// <item><description><c>[RunOnMacOS]</c> - Uses OR logic; can be combined with other <c>RunOn*</c> attributes to run on multiple platforms.</description></item>
+/// <item><description><c>[RunOnMacOSOnly]</c> - Uses AND logic; the module will ONLY run on macOS regardless of other attributes.</description></item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>Example:</b>
+/// <code>
+/// [RunOnMacOSOnly]
+/// public class XcodeToolsModule : Module&lt;None&gt;
+/// {
+///     // This module will only execute on macOS
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+/// <seealso cref="RunOnMacOSAttribute"/>
+/// <seealso cref="RunOnWindowsOnlyAttribute"/>
+/// <seealso cref="RunOnLinuxOnlyAttribute"/>
+/// <seealso cref="MandatoryRunConditionAttribute"/>
 [ExcludeFromCodeCoverage]
 public class RunOnMacOSOnlyAttribute : MandatoryRunConditionAttribute
 {

--- a/src/ModularPipelines/Attributes/RunOnWindowsAttribute.cs
+++ b/src/ModularPipelines/Attributes/RunOnWindowsAttribute.cs
@@ -3,6 +3,36 @@ using ModularPipelines.Context;
 
 namespace ModularPipelines.Attributes;
 
+/// <summary>
+/// Specifies that this module can run on Windows.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This attribute uses OR logic with other <see cref="RunConditionAttribute"/> attributes.
+/// When combined with other <c>RunOn*</c> attributes (e.g., <see cref="RunOnLinuxAttribute"/>),
+/// the module will run if ANY of the conditions are met.
+/// </para>
+/// <para>
+/// Use this attribute when you want to specify multiple platforms on which the module can execute.
+/// For example, applying both <c>[RunOnWindows]</c> and <c>[RunOnLinux]</c> means the module
+/// will run on either Windows OR Linux, but will be skipped on macOS.
+/// </para>
+/// <para>
+/// <b>Example - Run on multiple platforms:</b>
+/// <code>
+/// [RunOnWindows]
+/// [RunOnLinux]
+/// public class CrossPlatformModule : Module&lt;None&gt;
+/// {
+///     // This module runs on Windows OR Linux, skipped on macOS
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+/// <seealso cref="RunOnWindowsOnlyAttribute"/>
+/// <seealso cref="RunOnLinuxAttribute"/>
+/// <seealso cref="RunOnMacOSAttribute"/>
+/// <seealso cref="RunConditionAttribute"/>
 [ExcludeFromCodeCoverage]
 public class RunOnWindowsAttribute : RunConditionAttribute
 {

--- a/src/ModularPipelines/Attributes/RunOnWindowsOnlyAttribute.cs
+++ b/src/ModularPipelines/Attributes/RunOnWindowsOnlyAttribute.cs
@@ -3,6 +3,41 @@ using ModularPipelines.Context;
 
 namespace ModularPipelines.Attributes;
 
+/// <summary>
+/// Specifies that this module must run only on Windows.
+/// The module will be skipped on all other operating systems.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This attribute uses AND logic with other <see cref="MandatoryRunConditionAttribute"/> attributes.
+/// ALL mandatory conditions must be satisfied for the module to run.
+/// </para>
+/// <para>
+/// Use this attribute when your module contains Windows-specific logic that cannot
+/// and should not run on other platforms.
+/// </para>
+/// <para>
+/// <b>Difference from <see cref="RunOnWindowsAttribute"/>:</b>
+/// <list type="bullet">
+/// <item><description><c>[RunOnWindows]</c> - Uses OR logic; can be combined with other <c>RunOn*</c> attributes to run on multiple platforms.</description></item>
+/// <item><description><c>[RunOnWindowsOnly]</c> - Uses AND logic; the module will ONLY run on Windows regardless of other attributes.</description></item>
+/// </list>
+/// </para>
+/// <para>
+/// <b>Example:</b>
+/// <code>
+/// [RunOnWindowsOnly]
+/// public class WindowsRegistryModule : Module&lt;None&gt;
+/// {
+///     // This module will only execute on Windows
+/// }
+/// </code>
+/// </para>
+/// </remarks>
+/// <seealso cref="RunOnWindowsAttribute"/>
+/// <seealso cref="RunOnLinuxOnlyAttribute"/>
+/// <seealso cref="RunOnMacOSOnlyAttribute"/>
+/// <seealso cref="MandatoryRunConditionAttribute"/>
 [ExcludeFromCodeCoverage]
 public class RunOnWindowsOnlyAttribute : MandatoryRunConditionAttribute
 {


### PR DESCRIPTION
## Summary
- Added comprehensive XML documentation to all platform-specific attributes
- Clarified that `RunOn*` attributes use OR logic (any condition can allow execution)
- Clarified that `RunOn*Only` attributes use AND logic (all conditions must match)
- Documented the difference between `RunConditionAttribute` and `MandatoryRunConditionAttribute` base classes

Closes #1989

## Test plan
- [x] Build succeeds
- [x] Documentation is clear and accurate

Generated with [Claude Code](https://claude.ai/code)