### PR TITLE
refactor: Fix IModuleLogger internal method leakage

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -429,7 +429,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         IModuleLogger logger)
     {
         logger.LogDebug("Module failed. Cancelling the pipeline");
-        logger.SetException(exception);
+        ((IInternalModuleLogger)logger).SetException(exception);
 
         var moduleFailedException = new ModuleFailedException(executionContext.ModuleType, exception);
 

--- a/src/ModularPipelines/Logging/IInternalModuleLogger.cs
+++ b/src/ModularPipelines/Logging/IInternalModuleLogger.cs
@@ -1,0 +1,12 @@
+namespace ModularPipelines.Logging;
+
+/// <summary>
+/// Internal interface for module logger operations not exposed to consumers.
+/// </summary>
+internal interface IInternalModuleLogger : IModuleLogger
+{
+    /// <summary>
+    /// Sets the exception that occurred during module execution.
+    /// </summary>
+    void SetException(Exception exception);
+}

--- a/src/ModularPipelines/Logging/IModuleLogger.cs
+++ b/src/ModularPipelines/Logging/IModuleLogger.cs
@@ -13,5 +13,4 @@ namespace ModularPipelines.Logging;
 /// </remarks>
 public interface IModuleLogger : ILogger, IDisposable
 {
-    internal void SetException(Exception exception);
 }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -13,7 +13,7 @@ namespace ModularPipelines.Logging;
 /// This allows File/Folder helpers and other utilities to access the logger without explicit parameter passing.
 /// AsyncLocal is thread-safe and flows with async/await contexts, making it ideal for async module execution.
 /// </remarks>
-internal abstract class ModuleLogger : IModuleLogger, IConsoleWriter
+internal abstract class ModuleLogger : IInternalModuleLogger, IConsoleWriter
 {
     /// <summary>
     /// Ambient context storage for the current module's logger.
@@ -59,7 +59,7 @@ internal abstract class ModuleLogger : IModuleLogger, IConsoleWriter
     }
 }
 
-internal class ModuleLogger<T> : ModuleLogger, IModuleLogger, IConsoleWriter, ILogger<T>
+internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWriter, ILogger<T>
 {
     private static readonly string CategoryName = typeof(T).FullName ?? typeof(T).Name;
 

--- a/test/ModularPipelines.UnitTests/ModuleLoggerScopeTests.cs
+++ b/test/ModularPipelines.UnitTests/ModuleLoggerScopeTests.cs
@@ -26,10 +26,6 @@ public class ModuleLoggerScopeTests
         public void Dispose()
         {
         }
-
-        void IModuleLogger.SetException(Exception exception)
-        {
-        }
     }
 
     // Dummy types to use as module type identifiers for testing


### PR DESCRIPTION
## Summary
- Created new internal `IInternalModuleLogger` interface that extends `IModuleLogger`
- Moved the `SetException` method from public `IModuleLogger` to internal interface
- Updated `ModuleLogger` to implement `IInternalModuleLogger`
- Updated `ModuleExecutionPipeline` to cast to `IInternalModuleLogger` when calling `SetException`

This is a **breaking change** that removes internal implementation details from the public API.

Closes #1991

## Test plan
- [x] Build succeeds
- [x] Existing tests pass
- [x] Internal method no longer exposed to consumers

Generated with [Claude Code](https://claude.ai/code)