### PR TITLE
docs: Clarify IConsoleWriter vs IModuleLogger APIs

### DIFF
--- a/src/ModularPipelines/IConsoleWriter.cs
+++ b/src/ModularPipelines/IConsoleWriter.cs
@@ -1,8 +1,28 @@
+using ModularPipelines.Logging;
+
 namespace ModularPipelines;
 
 /// <summary>
-/// Used for writing to the console.
+/// Provides direct console output with Spectre.Console markup support.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Use <see cref="IConsoleWriter"/> when you need rich console formatting such as
+/// colors, tables, progress bars, or other Spectre.Console features. Output from
+/// this interface goes directly to the console and is not captured by logging providers.
+/// </para>
+/// <para>
+/// For structured logging with log levels that flows to configured log sinks
+/// (file, Application Insights, etc.), use <see cref="IModuleLogger"/> instead.
+/// </para>
+/// <para><b>Example usage:</b></para>
+/// <code>
+/// // Rich console output with markup
+/// consoleWriter.LogToConsole("[green]Build succeeded![/]");
+/// consoleWriter.LogToConsole("[red]Error:[/] Something went wrong");
+/// </code>
+/// </remarks>
+/// <seealso cref="IModuleLogger"/>
 public interface IConsoleWriter
 {
     /// <summary>

--- a/src/ModularPipelines/Logging/IModuleLogger.cs
+++ b/src/ModularPipelines/Logging/IModuleLogger.cs
@@ -3,14 +3,26 @@ using Microsoft.Extensions.Logging;
 namespace ModularPipelines.Logging;
 
 /// <summary>
-/// Provides logging functionality specifically for modules.
-/// Combines standard logging with lifecycle management through disposal.
+/// Provides structured logging capabilities for modules, extending <see cref="ILogger"/>.
 /// </summary>
 /// <remarks>
-/// This interface follows the Interface Segregation Principle by focusing only on core logging concerns.
-/// For console writing capabilities, see <see cref="IConsoleWriter"/>.
-/// Module loggers typically implement both interfaces, but consumers should depend only on what they need.
+/// <para>
+/// Use <see cref="IModuleLogger"/> for structured logging that should flow to
+/// configured logging providers (console, files, Application Insights, etc.).
+/// Supports log levels (Debug, Information, Warning, Error) and structured data.
+/// </para>
+/// <para>
+/// For rich console output with Spectre.Console markup (colors, tables, etc.),
+/// use <see cref="IConsoleWriter"/> instead.
+/// </para>
+/// <para><b>Example usage:</b></para>
+/// <code>
+/// // Structured logging
+/// logger.LogInformation("Processing {ItemCount} items", items.Count);
+/// logger.LogError(ex, "Failed to process item {ItemId}", itemId);
+/// </code>
 /// </remarks>
+/// <seealso cref="IConsoleWriter"/>
 public interface IModuleLogger : ILogger, IDisposable
 {
 }


### PR DESCRIPTION
## Summary
Added comprehensive XML documentation to clarify the different purposes of the two logging interfaces:

**IConsoleWriter:**
- For user-facing console output with Spectre.Console markup support
- Methods: `LogToConsole`, `LogToConsolePlain`, `LogError`
- Supports rich formatting like `[red]Error:[/]`
- Best for progress updates and user-facing messages

**IModuleLogger:**
- For structured logging via `ILogger<T>`
- Standard log levels: Debug, Information, Warning, Error
- Best for diagnostic logging, debugging, and log aggregation
- Integrates with standard .NET logging infrastructure

Documentation includes usage examples and guidance on when to use each interface.

Closes #1996

## Test plan
- [x] Build passes
- [x] Documentation visible in IDE tooltips

🤖 Generated with [Claude Code](https://claude.ai/code)