### PR TITLE
feat: Add platform-specific package manager contexts (Brew, Chocolatey, Winget)

### DIFF
--- a/src/ModularPipelines/Context/MacOS/Brew.cs
+++ b/src/ModularPipelines/Context/MacOS/Brew.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Models;
+using ModularPipelines.Options.MacOS.Brew;
+
+namespace ModularPipelines.Context.MacOS;
+
+/// <summary>
+/// Implementation of Homebrew package manager operations for macOS.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class Brew : IBrew
+{
+    private readonly ICommand _command;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Brew"/> class.
+    /// </summary>
+    /// <param name="command">The command execution service.</param>
+    public Brew(ICommand command)
+    {
+        _command = command;
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Install(BrewInstallOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Uninstall(BrewUninstallOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Update(BrewUpdateOptions? options = default, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options ?? new BrewUpdateOptions(), null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Upgrade(BrewUpgradeOptions? options = default, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options ?? new BrewUpgradeOptions(), null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> List(BrewListOptions? options = default, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options ?? new BrewListOptions(), null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Search(BrewSearchOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Info(BrewInfoOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Tap(BrewTapOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Untap(BrewUntapOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Cleanup(BrewCleanupOptions? options = default, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options ?? new BrewCleanupOptions(), null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Custom(BrewOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+}

--- a/src/ModularPipelines/Context/MacOS/IBrew.cs
+++ b/src/ModularPipelines/Context/MacOS/IBrew.cs
@@ -1,0 +1,102 @@
+using ModularPipelines.Models;
+using ModularPipelines.Options.MacOS.Brew;
+
+namespace ModularPipelines.Context.MacOS;
+
+/// <summary>
+/// Provides functionality for interacting with the Homebrew package manager on macOS.
+/// </summary>
+/// <remarks>
+/// Homebrew is a popular package manager for macOS that allows installing,
+/// upgrading, and managing software packages (formulae) and GUI applications (casks).
+/// </remarks>
+public interface IBrew
+{
+    /// <summary>
+    /// Installs a formula or cask using Homebrew.
+    /// </summary>
+    /// <param name="options">The install options specifying the package to install.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Install(BrewInstallOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Uninstalls a formula or cask using Homebrew.
+    /// </summary>
+    /// <param name="options">The uninstall options specifying the package to remove.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Uninstall(BrewUninstallOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Updates Homebrew and all formulae definitions.
+    /// </summary>
+    /// <param name="options">Optional update configuration.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Update(BrewUpdateOptions? options = default, CancellationToken token = default);
+
+    /// <summary>
+    /// Upgrades outdated formulae and casks.
+    /// </summary>
+    /// <param name="options">Optional upgrade configuration.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Upgrade(BrewUpgradeOptions? options = default, CancellationToken token = default);
+
+    /// <summary>
+    /// Lists installed formulae and casks.
+    /// </summary>
+    /// <param name="options">Optional list configuration.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> List(BrewListOptions? options = default, CancellationToken token = default);
+
+    /// <summary>
+    /// Searches for formulae and casks matching the query.
+    /// </summary>
+    /// <param name="options">The search options specifying the query.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Search(BrewSearchOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Displays information about a formula or cask.
+    /// </summary>
+    /// <param name="options">The info options specifying the package.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Info(BrewInfoOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Adds a third-party repository (tap) to Homebrew.
+    /// </summary>
+    /// <param name="options">The tap options specifying the repository.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Tap(BrewTapOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Removes a third-party repository (tap) from Homebrew.
+    /// </summary>
+    /// <param name="options">The untap options specifying the repository.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Untap(BrewUntapOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Removes old versions of installed formulae.
+    /// </summary>
+    /// <param name="options">Optional cleanup configuration.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Cleanup(BrewCleanupOptions? options = default, CancellationToken token = default);
+
+    /// <summary>
+    /// Executes a custom Homebrew command with the specified options.
+    /// </summary>
+    /// <param name="options">The custom command options.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Custom(BrewOptions options, CancellationToken token = default);
+}

--- a/src/ModularPipelines/Context/Windows/Chocolatey.cs
+++ b/src/ModularPipelines/Context/Windows/Chocolatey.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Models;
+using ModularPipelines.Options.Windows.Chocolatey;
+
+namespace ModularPipelines.Context.Windows;
+
+/// <summary>
+/// Implementation of Chocolatey package manager operations for Windows.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class Chocolatey : IChocolatey
+{
+    private readonly ICommand _command;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Chocolatey"/> class.
+    /// </summary>
+    /// <param name="command">The command execution service.</param>
+    public Chocolatey(ICommand command)
+    {
+        _command = command;
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Install(ChocolateyInstallOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Uninstall(ChocolateyUninstallOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Upgrade(ChocolateyUpgradeOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> List(ChocolateyListOptions? options = default, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options ?? new ChocolateyListOptions(), null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Search(ChocolateySearchOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Info(ChocolateyInfoOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Outdated(ChocolateyOutdatedOptions? options = default, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options ?? new ChocolateyOutdatedOptions(), null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Pin(ChocolateyPinOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Custom(ChocolateyOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+}

--- a/src/ModularPipelines/Context/Windows/IChocolatey.cs
+++ b/src/ModularPipelines/Context/Windows/IChocolatey.cs
@@ -1,0 +1,86 @@
+using ModularPipelines.Models;
+using ModularPipelines.Options.Windows.Chocolatey;
+
+namespace ModularPipelines.Context.Windows;
+
+/// <summary>
+/// Provides functionality for interacting with the Chocolatey package manager on Windows.
+/// </summary>
+/// <remarks>
+/// Chocolatey is a popular package manager for Windows that automates the process of
+/// installing, upgrading, configuring, and removing software.
+/// </remarks>
+public interface IChocolatey
+{
+    /// <summary>
+    /// Installs a package using Chocolatey.
+    /// </summary>
+    /// <param name="options">The install options specifying the package to install.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Install(ChocolateyInstallOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Uninstalls a package using Chocolatey.
+    /// </summary>
+    /// <param name="options">The uninstall options specifying the package to remove.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Uninstall(ChocolateyUninstallOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Upgrades a package or all packages using Chocolatey.
+    /// </summary>
+    /// <param name="options">The upgrade options.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Upgrade(ChocolateyUpgradeOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Lists installed packages.
+    /// </summary>
+    /// <param name="options">Optional list configuration.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> List(ChocolateyListOptions? options = default, CancellationToken token = default);
+
+    /// <summary>
+    /// Searches for packages in the Chocolatey repository.
+    /// </summary>
+    /// <param name="options">The search options specifying the query.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Search(ChocolateySearchOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Displays information about a package.
+    /// </summary>
+    /// <param name="options">The info options specifying the package.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Info(ChocolateyInfoOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Lists outdated packages.
+    /// </summary>
+    /// <param name="options">Optional configuration.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Outdated(ChocolateyOutdatedOptions? options = default, CancellationToken token = default);
+
+    /// <summary>
+    /// Pins a package to prevent it from being upgraded.
+    /// </summary>
+    /// <param name="options">The pin options.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Pin(ChocolateyPinOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Executes a custom Chocolatey command with the specified options.
+    /// </summary>
+    /// <param name="options">The custom command options.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Custom(ChocolateyOptions options, CancellationToken token = default);
+}

--- a/src/ModularPipelines/Context/Windows/IWinget.cs
+++ b/src/ModularPipelines/Context/Windows/IWinget.cs
@@ -1,0 +1,95 @@
+using ModularPipelines.Models;
+using ModularPipelines.Options.Windows.Winget;
+
+namespace ModularPipelines.Context.Windows;
+
+/// <summary>
+/// Provides functionality for interacting with the Windows Package Manager (winget).
+/// </summary>
+/// <remarks>
+/// Windows Package Manager (winget) is the official command-line package manager
+/// for Windows 10 (1709+) and Windows 11, allowing installation and management
+/// of applications from the Microsoft Store and other sources.
+/// </remarks>
+public interface IWinget
+{
+    /// <summary>
+    /// Installs a package using winget.
+    /// </summary>
+    /// <param name="options">The install options specifying the package to install.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Install(WingetInstallOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Uninstalls a package using winget.
+    /// </summary>
+    /// <param name="options">The uninstall options specifying the package to remove.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Uninstall(WingetUninstallOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Upgrades a package or all packages using winget.
+    /// </summary>
+    /// <param name="options">The upgrade options.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Upgrade(WingetUpgradeOptions? options = default, CancellationToken token = default);
+
+    /// <summary>
+    /// Lists installed packages.
+    /// </summary>
+    /// <param name="options">Optional list configuration.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> List(WingetListOptions? options = default, CancellationToken token = default);
+
+    /// <summary>
+    /// Searches for packages in the winget repository.
+    /// </summary>
+    /// <param name="options">The search options specifying the query.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Search(WingetSearchOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Shows detailed information about a package.
+    /// </summary>
+    /// <param name="options">The show options specifying the package.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Show(WingetShowOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Exports a list of installed packages.
+    /// </summary>
+    /// <param name="options">The export options.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Export(WingetExportOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Imports packages from a file.
+    /// </summary>
+    /// <param name="options">The import options.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Import(WingetImportOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Manages winget sources.
+    /// </summary>
+    /// <param name="options">The source options.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Source(WingetSourceOptions options, CancellationToken token = default);
+
+    /// <summary>
+    /// Executes a custom winget command with the specified options.
+    /// </summary>
+    /// <param name="options">The custom command options.</param>
+    /// <param name="token">Cancellation token.</param>
+    /// <returns>The command result containing output and exit code.</returns>
+    Task<CommandResult> Custom(WingetOptions options, CancellationToken token = default);
+}

--- a/src/ModularPipelines/Context/Windows/Winget.cs
+++ b/src/ModularPipelines/Context/Windows/Winget.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Models;
+using ModularPipelines.Options.Windows.Winget;
+
+namespace ModularPipelines.Context.Windows;
+
+/// <summary>
+/// Implementation of Windows Package Manager (winget) operations.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class Winget : IWinget
+{
+    private readonly ICommand _command;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Winget"/> class.
+    /// </summary>
+    /// <param name="command">The command execution service.</param>
+    public Winget(ICommand command)
+    {
+        _command = command;
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Install(WingetInstallOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Uninstall(WingetUninstallOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Upgrade(WingetUpgradeOptions? options = default, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options ?? new WingetUpgradeOptions(), null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> List(WingetListOptions? options = default, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options ?? new WingetListOptions(), null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Search(WingetSearchOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Show(WingetShowOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Export(WingetExportOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Import(WingetImportOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Source(WingetSourceOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public virtual async Task<CommandResult> Custom(WingetOptions options, CancellationToken token = default)
+    {
+        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+    }
+}

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Linux;
+using ModularPipelines.Context.MacOS;
+using ModularPipelines.Context.Windows;
 using ModularPipelines.Engine;
 using ModularPipelines.FileSystem;
 using ModularPipelines.Engine.Attributes;
@@ -122,6 +124,9 @@ internal static class DependencyInjectionSetup
             .AddScoped<IMacInstaller, MacInstaller>()
             .AddScoped<ILinuxInstaller, LinuxInstaller>()
             .AddScoped<IAptGet, AptGet>()
+            .AddScoped<IBrew, Brew>()
+            .AddScoped<IChocolatey, Chocolatey>()
+            .AddScoped<IWinget, Winget>()
             .AddScoped<IZip, Zip>()
             .AddScoped<IPowershell, Powershell>()
             .AddScoped<IBash, Bash>()

--- a/src/ModularPipelines/Options/MacOS/Brew/BrewCleanupOptions.cs
+++ b/src/ModularPipelines/Options/MacOS/Brew/BrewCleanupOptions.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.MacOS.Brew;
+
+/// <summary>
+/// Options for the 'brew cleanup' command.
+/// Removes old versions of installed formulae.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record BrewCleanupOptions : BrewOptions
+{
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "cleanup";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to perform a dry run.
+    /// </summary>
+    [CliFlag("--dry-run")]
+    public virtual bool? DryRun { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to remove downloads for casks.
+    /// </summary>
+    [CliFlag("--prune")]
+    public virtual int? PruneDays { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to scrub the cache.
+    /// </summary>
+    [CliFlag("-s")]
+    public virtual bool? Scrub { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to remove all cache files.
+    /// </summary>
+    [CliFlag("--prune-prefix")]
+    public virtual bool? PrunePrefix { get; set; }
+}

--- a/src/ModularPipelines/Options/MacOS/Brew/BrewInfoOptions.cs
+++ b/src/ModularPipelines/Options/MacOS/Brew/BrewInfoOptions.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.MacOS.Brew;
+
+/// <summary>
+/// Options for the 'brew info' command.
+/// Displays information about a formula or cask.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record BrewInfoOptions : BrewOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BrewInfoOptions"/> class
+    /// with the specified formula or cask.
+    /// </summary>
+    /// <param name="formulaOrCask">The name of the formula or cask to get information about.</param>
+    public BrewInfoOptions(string formulaOrCask)
+    {
+        FormulaOrCask = formulaOrCask;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "info";
+
+    /// <summary>
+    /// Gets the formula or cask to get information about.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string FormulaOrCask { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show cask information.
+    /// </summary>
+    [CliFlag("--cask")]
+    public virtual bool? Cask { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show formula information.
+    /// </summary>
+    [CliFlag("--formula")]
+    public virtual bool? Formula { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to output as JSON.
+    /// </summary>
+    [CliFlag("--json")]
+    public virtual bool? Json { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include analytics data.
+    /// </summary>
+    [CliFlag("--analytics")]
+    public virtual bool? Analytics { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show GitHub info.
+    /// </summary>
+    [CliFlag("--github")]
+    public virtual bool? GitHub { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show all versions.
+    /// </summary>
+    [CliFlag("--all")]
+    public virtual bool? All { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show installed files.
+    /// </summary>
+    [CliFlag("--installed")]
+    public virtual bool? Installed { get; set; }
+}

--- a/src/ModularPipelines/Options/MacOS/Brew/BrewInstallOptions.cs
+++ b/src/ModularPipelines/Options/MacOS/Brew/BrewInstallOptions.cs
@@ -1,0 +1,112 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.MacOS.Brew;
+
+/// <summary>
+/// Options for the 'brew install' command.
+/// Installs a formula or cask.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record BrewInstallOptions : BrewOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BrewInstallOptions"/> class
+    /// with the specified formula or cask to install.
+    /// </summary>
+    /// <param name="formulaOrCask">The name of the formula or cask to install.</param>
+    public BrewInstallOptions(string formulaOrCask)
+    {
+        FormulaOrCask = formulaOrCask;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "install";
+
+    /// <summary>
+    /// Gets the formula or cask to install.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string FormulaOrCask { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to install as a cask (GUI application).
+    /// </summary>
+    [CliFlag("--cask")]
+    public virtual bool? Cask { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to install as a formula (command-line tool).
+    /// </summary>
+    [CliFlag("--formula")]
+    public virtual bool? Formula { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip installing any cask dependencies.
+    /// </summary>
+    [CliFlag("--skip-cask-deps")]
+    public virtual bool? SkipCaskDeps { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to install without quarantine attribute.
+    /// </summary>
+    [CliFlag("--no-quarantine")]
+    public virtual bool? NoQuarantine { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to download and install from HEAD commit.
+    /// </summary>
+    [CliFlag("--HEAD")]
+    public virtual bool? Head { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force install even if already installed.
+    /// </summary>
+    [CliFlag("--force")]
+    public virtual bool? Force { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip build dependencies.
+    /// </summary>
+    [CliFlag("--ignore-dependencies")]
+    public virtual bool? IgnoreDependencies { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to only download and cache the file.
+    /// </summary>
+    [CliFlag("--fetch-HEAD")]
+    public virtual bool? FetchHead { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to build from source rather than bottle.
+    /// </summary>
+    [CliFlag("--build-from-source")]
+    public virtual bool? BuildFromSource { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to prefer bottle over building from source.
+    /// </summary>
+    [CliFlag("--force-bottle")]
+    public virtual bool? ForceBottle { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include test dependencies.
+    /// </summary>
+    [CliFlag("--include-test")]
+    public virtual bool? IncludeTest { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to produce a dry run with no actions.
+    /// </summary>
+    [CliFlag("--dry-run")]
+    public virtual bool? DryRun { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to create a symlink to the application.
+    /// </summary>
+    [CliFlag("--appdir")]
+    public virtual string? AppDir { get; set; }
+}

--- a/src/ModularPipelines/Options/MacOS/Brew/BrewListOptions.cs
+++ b/src/ModularPipelines/Options/MacOS/Brew/BrewListOptions.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.MacOS.Brew;
+
+/// <summary>
+/// Options for the 'brew list' command.
+/// Lists installed formulae and casks.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record BrewListOptions : BrewOptions
+{
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "list";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to list casks.
+    /// </summary>
+    [CliFlag("--cask")]
+    public virtual bool? Cask { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to list formulae.
+    /// </summary>
+    [CliFlag("--formula")]
+    public virtual bool? Formula { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show full paths.
+    /// </summary>
+    [CliFlag("--full-name")]
+    public virtual bool? FullName { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show versions.
+    /// </summary>
+    [CliFlag("--versions")]
+    public virtual bool? Versions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to list multiple versions.
+    /// </summary>
+    [CliFlag("--multiple")]
+    public virtual bool? Multiple { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to only show pinned formulae.
+    /// </summary>
+    [CliFlag("--pinned")]
+    public virtual bool? Pinned { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to output as one entry per line.
+    /// </summary>
+    [CliFlag("-1")]
+    public virtual bool? OnePerLine { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to output as long format.
+    /// </summary>
+    [CliFlag("-l")]
+    public virtual bool? Long { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to reverse the order.
+    /// </summary>
+    [CliFlag("-r")]
+    public virtual bool? Reverse { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to sort by time modified.
+    /// </summary>
+    [CliFlag("-t")]
+    public virtual bool? SortByTime { get; set; }
+}

--- a/src/ModularPipelines/Options/MacOS/Brew/BrewOptions.cs
+++ b/src/ModularPipelines/Options/MacOS/Brew/BrewOptions.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.MacOS.Brew;
+
+/// <summary>
+/// Base options class for Homebrew commands.
+/// Contains common flags available across most brew commands.
+/// </summary>
+[ExcludeFromCodeCoverage]
+[CliTool("brew")]
+public record BrewOptions : CommandLineToolOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether to print debugging information.
+    /// </summary>
+    [CliFlag("--debug")]
+    public virtual bool? Debug { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to make some output more quiet.
+    /// </summary>
+    [CliFlag("--quiet")]
+    public virtual bool? Quiet { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to make some output more verbose.
+    /// </summary>
+    [CliFlag("--verbose")]
+    public virtual bool? Verbose { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show version information.
+    /// </summary>
+    [CliFlag("--version")]
+    public virtual bool? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show help information.
+    /// </summary>
+    [CliFlag("--help")]
+    public virtual bool? Help { get; set; }
+}

--- a/src/ModularPipelines/Options/MacOS/Brew/BrewSearchOptions.cs
+++ b/src/ModularPipelines/Options/MacOS/Brew/BrewSearchOptions.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.MacOS.Brew;
+
+/// <summary>
+/// Options for the 'brew search' command.
+/// Searches for formulae and casks.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record BrewSearchOptions : BrewOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BrewSearchOptions"/> class
+    /// with the specified search text.
+    /// </summary>
+    /// <param name="text">The text to search for.</param>
+    public BrewSearchOptions(string text)
+    {
+        Text = text;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "search";
+
+    /// <summary>
+    /// Gets the text to search for.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string Text { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to search for casks.
+    /// </summary>
+    [CliFlag("--cask")]
+    public virtual bool? Cask { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to search for formulae.
+    /// </summary>
+    [CliFlag("--formula")]
+    public virtual bool? Formula { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include descriptions in search.
+    /// </summary>
+    [CliFlag("--desc")]
+    public virtual bool? Desc { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to search using extended regex.
+    /// </summary>
+    [CliFlag("--eval-all")]
+    public virtual bool? EvalAll { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to limit output to open results.
+    /// </summary>
+    [CliFlag("--open")]
+    public virtual bool? Open { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to limit output to closed results.
+    /// </summary>
+    [CliFlag("--closed")]
+    public virtual bool? Closed { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to search pull requests.
+    /// </summary>
+    [CliFlag("--pull-request")]
+    public virtual bool? PullRequest { get; set; }
+}

--- a/src/ModularPipelines/Options/MacOS/Brew/BrewTapOptions.cs
+++ b/src/ModularPipelines/Options/MacOS/Brew/BrewTapOptions.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.MacOS.Brew;
+
+/// <summary>
+/// Options for the 'brew tap' command.
+/// Taps a formula repository.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record BrewTapOptions : BrewOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BrewTapOptions"/> class
+    /// with the specified repository to tap.
+    /// </summary>
+    /// <param name="repository">The repository to tap (e.g., 'user/repo').</param>
+    public BrewTapOptions(string repository)
+    {
+        Repository = repository;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "tap";
+
+    /// <summary>
+    /// Gets the repository to tap.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string Repository { get; }
+
+    /// <summary>
+    /// Gets or sets a custom URL to clone the repository from.
+    /// </summary>
+    [CliArgument(2, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string? Url { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to perform a full clone.
+    /// </summary>
+    [CliFlag("--full")]
+    public virtual bool? Full { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to perform a shallow clone.
+    /// </summary>
+    [CliFlag("--shallow")]
+    public virtual bool? Shallow { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force tapping even if tap already exists.
+    /// </summary>
+    [CliFlag("--force")]
+    public virtual bool? Force { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force auto-update.
+    /// </summary>
+    [CliFlag("--force-auto-update")]
+    public virtual bool? ForceAutoUpdate { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to repair existing tap.
+    /// </summary>
+    [CliFlag("--repair")]
+    public virtual bool? Repair { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to list all taps.
+    /// </summary>
+    [CliFlag("--list-pinned")]
+    public virtual bool? ListPinned { get; set; }
+}

--- a/src/ModularPipelines/Options/MacOS/Brew/BrewUninstallOptions.cs
+++ b/src/ModularPipelines/Options/MacOS/Brew/BrewUninstallOptions.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.MacOS.Brew;
+
+/// <summary>
+/// Options for the 'brew uninstall' command.
+/// Uninstalls a formula or cask.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record BrewUninstallOptions : BrewOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BrewUninstallOptions"/> class
+    /// with the specified formula or cask to uninstall.
+    /// </summary>
+    /// <param name="formulaOrCask">The name of the formula or cask to uninstall.</param>
+    public BrewUninstallOptions(string formulaOrCask)
+    {
+        FormulaOrCask = formulaOrCask;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "uninstall";
+
+    /// <summary>
+    /// Gets the formula or cask to uninstall.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string FormulaOrCask { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to uninstall as a cask.
+    /// </summary>
+    [CliFlag("--cask")]
+    public virtual bool? Cask { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to uninstall as a formula.
+    /// </summary>
+    [CliFlag("--formula")]
+    public virtual bool? Formula { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force uninstall even if there are dependents.
+    /// </summary>
+    [CliFlag("--force")]
+    public virtual bool? Force { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore dependencies.
+    /// </summary>
+    [CliFlag("--ignore-dependencies")]
+    public virtual bool? IgnoreDependencies { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to delete cask app (not just config).
+    /// </summary>
+    [CliFlag("--zap")]
+    public virtual bool? Zap { get; set; }
+}

--- a/src/ModularPipelines/Options/MacOS/Brew/BrewUntapOptions.cs
+++ b/src/ModularPipelines/Options/MacOS/Brew/BrewUntapOptions.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.MacOS.Brew;
+
+/// <summary>
+/// Options for the 'brew untap' command.
+/// Removes a tapped formula repository.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record BrewUntapOptions : BrewOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BrewUntapOptions"/> class
+    /// with the specified repository to untap.
+    /// </summary>
+    /// <param name="repository">The repository to untap (e.g., 'user/repo').</param>
+    public BrewUntapOptions(string repository)
+    {
+        Repository = repository;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "untap";
+
+    /// <summary>
+    /// Gets the repository to untap.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string Repository { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force untapping even if formulae are installed from the tap.
+    /// </summary>
+    [CliFlag("--force")]
+    public virtual bool? Force { get; set; }
+}

--- a/src/ModularPipelines/Options/MacOS/Brew/BrewUpdateOptions.cs
+++ b/src/ModularPipelines/Options/MacOS/Brew/BrewUpdateOptions.cs
@@ -1,0 +1,36 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.MacOS.Brew;
+
+/// <summary>
+/// Options for the 'brew update' command.
+/// Fetches the newest version of Homebrew and all formulae.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record BrewUpdateOptions : BrewOptions
+{
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "update";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force update, even if unnecessary.
+    /// </summary>
+    [CliFlag("--force")]
+    public virtual bool? Force { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to merge changes instead of rebasing.
+    /// </summary>
+    [CliFlag("--merge")]
+    public virtual bool? Merge { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to perform a shallow clone for faster update.
+    /// </summary>
+    [CliFlag("--auto-update")]
+    public virtual bool? AutoUpdate { get; set; }
+}

--- a/src/ModularPipelines/Options/MacOS/Brew/BrewUpgradeOptions.cs
+++ b/src/ModularPipelines/Options/MacOS/Brew/BrewUpgradeOptions.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.MacOS.Brew;
+
+/// <summary>
+/// Options for the 'brew upgrade' command.
+/// Upgrades outdated formulae and casks.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record BrewUpgradeOptions : BrewOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BrewUpgradeOptions"/> class.
+    /// </summary>
+    public BrewUpgradeOptions()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BrewUpgradeOptions"/> class
+    /// with a specific formula or cask to upgrade.
+    /// </summary>
+    /// <param name="formulaOrCask">The name of the formula or cask to upgrade.</param>
+    public BrewUpgradeOptions(string formulaOrCask)
+    {
+        FormulaOrCask = formulaOrCask;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "upgrade";
+
+    /// <summary>
+    /// Gets or sets the formula or cask to upgrade. If not specified, all outdated packages are upgraded.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string? FormulaOrCask { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to upgrade casks.
+    /// </summary>
+    [CliFlag("--cask")]
+    public virtual bool? Cask { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to upgrade formulae.
+    /// </summary>
+    [CliFlag("--formula")]
+    public virtual bool? Formula { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force upgrade even if already latest.
+    /// </summary>
+    [CliFlag("--force")]
+    public virtual bool? Force { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to perform a dry run.
+    /// </summary>
+    [CliFlag("--dry-run")]
+    public virtual bool? DryRun { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to upgrade casks with auto-updates.
+    /// </summary>
+    [CliFlag("--greedy")]
+    public virtual bool? Greedy { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to fetch the latest version.
+    /// </summary>
+    [CliFlag("--fetch-HEAD")]
+    public virtual bool? FetchHead { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore pinned formulae.
+    /// </summary>
+    [CliFlag("--ignore-pinned")]
+    public virtual bool? IgnorePinned { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to build from source.
+    /// </summary>
+    [CliFlag("--build-from-source")]
+    public virtual bool? BuildFromSource { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyInfoOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyInfoOptions.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Chocolatey;
+
+/// <summary>
+/// Options for the 'choco info' command.
+/// Gets package information.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record ChocolateyInfoOptions : ChocolateyOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChocolateyInfoOptions"/> class
+    /// with the specified package name.
+    /// </summary>
+    /// <param name="package">The name of the package to get information about.</param>
+    public ChocolateyInfoOptions(string package)
+    {
+        Package = package;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "info";
+
+    /// <summary>
+    /// Gets the package to get information about.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string Package { get; }
+
+    /// <summary>
+    /// Gets or sets the source to find the package.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include pre-release versions.
+    /// </summary>
+    [CliFlag("--pre")]
+    public virtual bool? PreRelease { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to get local package information.
+    /// </summary>
+    [CliFlag("--local-only")]
+    public virtual bool? LocalOnly { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyInstallOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyInstallOptions.cs
@@ -1,0 +1,148 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Chocolatey;
+
+/// <summary>
+/// Options for the 'choco install' command.
+/// Installs a package.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record ChocolateyInstallOptions : ChocolateyOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChocolateyInstallOptions"/> class
+    /// with the specified package to install.
+    /// </summary>
+    /// <param name="package">The name of the package to install.</param>
+    public ChocolateyInstallOptions(string package)
+    {
+        Package = package;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "install";
+
+    /// <summary>
+    /// Gets the package to install.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string Package { get; }
+
+    /// <summary>
+    /// Gets or sets the source to find the package.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version of the package to install.
+    /// </summary>
+    [CliFlag("--version")]
+    public new virtual string? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to allow pre-release versions.
+    /// </summary>
+    [CliFlag("--pre")]
+    public virtual bool? PreRelease { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to reinstall if already installed.
+    /// </summary>
+    [CliFlag("--force")]
+    public new virtual bool? Force { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore dependencies.
+    /// </summary>
+    [CliFlag("--ignore-dependencies")]
+    public virtual bool? IgnoreDependencies { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force dependencies.
+    /// </summary>
+    [CliFlag("--force-dependencies")]
+    public virtual bool? ForceDependencies { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip PowerShell scripts.
+    /// </summary>
+    [CliFlag("--skip-automation-scripts")]
+    public virtual bool? SkipAutomationScripts { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to allow multiple versions.
+    /// </summary>
+    [CliFlag("--allow-multiple-versions")]
+    public virtual bool? AllowMultipleVersions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to allow downgrade.
+    /// </summary>
+    [CliFlag("--allow-downgrade")]
+    public virtual bool? AllowDowngrade { get; set; }
+
+    /// <summary>
+    /// Gets or sets the install arguments to pass to the native installer.
+    /// </summary>
+    [CliFlag("--install-arguments")]
+    public virtual string? InstallArguments { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to override arguments.
+    /// </summary>
+    [CliFlag("--override-arguments")]
+    public virtual bool? OverrideArguments { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to not install dependencies.
+    /// </summary>
+    [CliFlag("--ignore-checksums")]
+    public virtual bool? IgnoreChecksums { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to allow empty checksums.
+    /// </summary>
+    [CliFlag("--allow-empty-checksums")]
+    public virtual bool? AllowEmptyChecksums { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package parameters to pass to the package.
+    /// </summary>
+    [CliFlag("--package-parameters")]
+    public virtual string? PackageParameters { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to apply install arguments to dependencies.
+    /// </summary>
+    [CliFlag("--apply-install-arguments-to-dependencies")]
+    public virtual bool? ApplyInstallArgumentsToDependencies { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to apply package parameters to dependencies.
+    /// </summary>
+    [CliFlag("--apply-package-parameters-to-dependencies")]
+    public virtual bool? ApplyPackageParametersToDependencies { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip virus check.
+    /// </summary>
+    [CliFlag("--skip-virus-check")]
+    public virtual bool? SkipVirusCheck { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use 32bit (x86) package.
+    /// </summary>
+    [CliFlag("--x86")]
+    public virtual bool? X86 { get; set; }
+
+    /// <summary>
+    /// Gets or sets the install directory.
+    /// </summary>
+    [CliFlag("--install-directory")]
+    public virtual string? InstallDirectory { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyListOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyListOptions.cs
@@ -1,0 +1,78 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Chocolatey;
+
+/// <summary>
+/// Options for the 'choco list' command.
+/// Lists locally installed packages.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record ChocolateyListOptions : ChocolateyOptions
+{
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "list";
+
+    /// <summary>
+    /// Gets or sets the source to search (defaults to local).
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include pre-release versions.
+    /// </summary>
+    [CliFlag("--pre")]
+    public virtual bool? PreRelease { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include programs (Programs and Features).
+    /// </summary>
+    [CliFlag("--include-programs")]
+    public virtual bool? IncludePrograms { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show all versions.
+    /// </summary>
+    [CliFlag("--all-versions")]
+    public virtual bool? AllVersions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to only show exact matches.
+    /// </summary>
+    [CliFlag("--exact")]
+    public virtual bool? Exact { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show by ID-only.
+    /// </summary>
+    [CliFlag("--id-only")]
+    public virtual bool? IdOnly { get; set; }
+
+    /// <summary>
+    /// Gets or sets the page number for results.
+    /// </summary>
+    [CliFlag("--page")]
+    public virtual int? Page { get; set; }
+
+    /// <summary>
+    /// Gets or sets the page size for results.
+    /// </summary>
+    [CliFlag("--page-size")]
+    public virtual int? PageSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to order by popularity.
+    /// </summary>
+    [CliFlag("--order-by-popularity")]
+    public virtual bool? OrderByPopularity { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include configured sources in operation.
+    /// </summary>
+    [CliFlag("--use-windows-services")]
+    public virtual bool? UseWindowsServices { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyOptions.cs
@@ -1,0 +1,97 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Chocolatey;
+
+/// <summary>
+/// Base options class for Chocolatey commands.
+/// Contains common flags available across most choco commands.
+/// </summary>
+[ExcludeFromCodeCoverage]
+[CliTool("choco")]
+public record ChocolateyOptions : CommandLineToolOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether to show debug messages.
+    /// </summary>
+    [CliFlag("--debug")]
+    public virtual bool? Debug { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show verbose messages.
+    /// </summary>
+    [CliFlag("--verbose")]
+    public virtual bool? Verbose { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show trace messages.
+    /// </summary>
+    [CliFlag("--trace")]
+    public virtual bool? Trace { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to not show progress.
+    /// </summary>
+    [CliFlag("--no-progress")]
+    public virtual bool? NoProgress { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to confirm all prompts automatically.
+    /// </summary>
+    [CliFlag("--yes")]
+    public virtual bool? Yes { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force the operation.
+    /// </summary>
+    [CliFlag("--force")]
+    public virtual bool? Force { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to perform a dry run (noop).
+    /// </summary>
+    [CliFlag("--noop")]
+    public virtual bool? Noop { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to limit output.
+    /// </summary>
+    [CliFlag("--limit-output")]
+    public virtual bool? LimitOutput { get; set; }
+
+    /// <summary>
+    /// Gets or sets the execution timeout in seconds.
+    /// </summary>
+    [CliFlag("--execution-timeout")]
+    public virtual int? ExecutionTimeout { get; set; }
+
+    /// <summary>
+    /// Gets or sets the cache location path.
+    /// </summary>
+    [CliFlag("--cache-location")]
+    public virtual string? CacheLocation { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept license automatically.
+    /// </summary>
+    [CliFlag("--accept-license")]
+    public virtual bool? AcceptLicense { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to confirm all prompts for scripts.
+    /// </summary>
+    [CliFlag("--confirm")]
+    public virtual bool? Confirm { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show help information.
+    /// </summary>
+    [CliFlag("--help")]
+    public virtual bool? Help { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show version information.
+    /// </summary>
+    [CliFlag("--version")]
+    public virtual bool? Version { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyOutdatedOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyOutdatedOptions.cs
@@ -1,0 +1,42 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Chocolatey;
+
+/// <summary>
+/// Options for the 'choco outdated' command.
+/// Lists outdated packages.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record ChocolateyOutdatedOptions : ChocolateyOptions
+{
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "outdated";
+
+    /// <summary>
+    /// Gets or sets the source to check for updates.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include pre-release versions.
+    /// </summary>
+    [CliFlag("--pre")]
+    public virtual bool? PreRelease { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore pinned packages.
+    /// </summary>
+    [CliFlag("--ignore-pinned")]
+    public virtual bool? IgnorePinned { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore unfound packages.
+    /// </summary>
+    [CliFlag("--ignore-unfound")]
+    public virtual bool? IgnoreUnfound { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyPinOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyPinOptions.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Chocolatey;
+
+/// <summary>
+/// Options for the 'choco pin' command.
+/// Pins or unpins a package to prevent upgrades.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record ChocolateyPinOptions : ChocolateyOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChocolateyPinOptions"/> class
+    /// with the specified action and package name.
+    /// </summary>
+    /// <param name="action">The pin action: "add", "remove", or "list".</param>
+    /// <param name="package">The name of the package to pin or unpin (optional for "list").</param>
+    public ChocolateyPinOptions(string action, string? package = null)
+    {
+        Action = action;
+        Package = package;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "pin";
+
+    /// <summary>
+    /// Gets the pin action: "add", "remove", or "list".
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string Action { get; }
+
+    /// <summary>
+    /// Gets or sets the package name to pin or unpin.
+    /// </summary>
+    [CliFlag("--name")]
+    public virtual string? Package { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version to pin.
+    /// </summary>
+    [CliFlag("--version")]
+    public new virtual string? Version { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateySearchOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateySearchOptions.cs
@@ -1,0 +1,118 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Chocolatey;
+
+/// <summary>
+/// Options for the 'choco search' command.
+/// Searches remote packages.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record ChocolateySearchOptions : ChocolateyOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChocolateySearchOptions"/> class
+    /// with the specified search filter.
+    /// </summary>
+    /// <param name="filter">The search filter text.</param>
+    public ChocolateySearchOptions(string filter)
+    {
+        Filter = filter;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "search";
+
+    /// <summary>
+    /// Gets the search filter.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string Filter { get; }
+
+    /// <summary>
+    /// Gets or sets the source to search.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include pre-release versions.
+    /// </summary>
+    [CliFlag("--pre")]
+    public virtual bool? PreRelease { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show all versions.
+    /// </summary>
+    [CliFlag("--all-versions")]
+    public virtual bool? AllVersions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to only show exact matches.
+    /// </summary>
+    [CliFlag("--exact")]
+    public virtual bool? Exact { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show by ID-only.
+    /// </summary>
+    [CliFlag("--id-only")]
+    public virtual bool? IdOnly { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include approved packages only.
+    /// </summary>
+    [CliFlag("--approved-only")]
+    public virtual bool? ApprovedOnly { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include packages that have been downloaded a certain number of times.
+    /// </summary>
+    [CliFlag("--download-cache-only")]
+    public virtual bool? DownloadCacheOnly { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to not include packages that have been marked as not broken.
+    /// </summary>
+    [CliFlag("--not-broken")]
+    public virtual bool? NotBroken { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include detailed information.
+    /// </summary>
+    [CliFlag("--detailed")]
+    public virtual bool? Detailed { get; set; }
+
+    /// <summary>
+    /// Gets or sets the page number for results.
+    /// </summary>
+    [CliFlag("--page")]
+    public virtual int? Page { get; set; }
+
+    /// <summary>
+    /// Gets or sets the page size for results.
+    /// </summary>
+    [CliFlag("--page-size")]
+    public virtual int? PageSize { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to order by popularity.
+    /// </summary>
+    [CliFlag("--order-by-popularity")]
+    public virtual bool? OrderByPopularity { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to search by tags only.
+    /// </summary>
+    [CliFlag("--by-tag-only")]
+    public virtual bool? ByTagOnly { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to search by ID starts with.
+    /// </summary>
+    [CliFlag("--by-id-only")]
+    public virtual bool? ByIdOnly { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyUninstallOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyUninstallOptions.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Chocolatey;
+
+/// <summary>
+/// Options for the 'choco uninstall' command.
+/// Uninstalls a package.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record ChocolateyUninstallOptions : ChocolateyOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChocolateyUninstallOptions"/> class
+    /// with the specified package to uninstall.
+    /// </summary>
+    /// <param name="package">The name of the package to uninstall.</param>
+    public ChocolateyUninstallOptions(string package)
+    {
+        Package = package;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "uninstall";
+
+    /// <summary>
+    /// Gets the package to uninstall.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string Package { get; }
+
+    /// <summary>
+    /// Gets or sets the version of the package to uninstall.
+    /// </summary>
+    [CliFlag("--version")]
+    public new virtual string? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to uninstall all versions.
+    /// </summary>
+    [CliFlag("--all-versions")]
+    public virtual bool? AllVersions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to uninstall dependencies.
+    /// </summary>
+    [CliFlag("--remove-dependencies")]
+    public virtual bool? RemoveDependencies { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip PowerShell scripts.
+    /// </summary>
+    [CliFlag("--skip-automation-scripts")]
+    public virtual bool? SkipAutomationScripts { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force removal even if it affects other packages.
+    /// </summary>
+    [CliFlag("--force-dependencies")]
+    public virtual bool? ForceDependencies { get; set; }
+
+    /// <summary>
+    /// Gets or sets the uninstall arguments to pass to the native uninstaller.
+    /// </summary>
+    [CliFlag("--uninstall-arguments")]
+    public virtual string? UninstallArguments { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to override uninstall arguments.
+    /// </summary>
+    [CliFlag("--override-arguments")]
+    public virtual bool? OverrideArguments { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use autouninstaller.
+    /// </summary>
+    [CliFlag("--use-autouninstaller")]
+    public virtual bool? UseAutoUninstaller { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip autouninstaller.
+    /// </summary>
+    [CliFlag("--skip-autouninstaller")]
+    public virtual bool? SkipAutoUninstaller { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to fail on autouninstaller failure.
+    /// </summary>
+    [CliFlag("--fail-on-autouninstaller")]
+    public virtual bool? FailOnAutoUninstaller { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore autouninstaller failure.
+    /// </summary>
+    [CliFlag("--ignore-autouninstaller-failure")]
+    public virtual bool? IgnoreAutoUninstallerFailure { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyUpgradeOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Chocolatey/ChocolateyUpgradeOptions.cs
@@ -1,0 +1,136 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Chocolatey;
+
+/// <summary>
+/// Options for the 'choco upgrade' command.
+/// Upgrades a package to the latest version.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record ChocolateyUpgradeOptions : ChocolateyOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChocolateyUpgradeOptions"/> class
+    /// with the specified package to upgrade. Use "all" to upgrade all packages.
+    /// </summary>
+    /// <param name="package">The name of the package to upgrade, or "all" for all packages.</param>
+    public ChocolateyUpgradeOptions(string package)
+    {
+        Package = package;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "upgrade";
+
+    /// <summary>
+    /// Gets the package to upgrade (or "all" for all packages).
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string Package { get; }
+
+    /// <summary>
+    /// Gets or sets the source to find the package.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version to upgrade to.
+    /// </summary>
+    [CliFlag("--version")]
+    public new virtual string? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to allow pre-release versions.
+    /// </summary>
+    [CliFlag("--pre")]
+    public virtual bool? PreRelease { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore dependencies.
+    /// </summary>
+    [CliFlag("--ignore-dependencies")]
+    public virtual bool? IgnoreDependencies { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip PowerShell scripts.
+    /// </summary>
+    [CliFlag("--skip-automation-scripts")]
+    public virtual bool? SkipAutomationScripts { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to fail on unfound.
+    /// </summary>
+    [CliFlag("--fail-on-unfound")]
+    public virtual bool? FailOnUnfound { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to fail on not installed.
+    /// </summary>
+    [CliFlag("--fail-on-not-installed")]
+    public virtual bool? FailOnNotInstalled { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore checksums.
+    /// </summary>
+    [CliFlag("--ignore-checksums")]
+    public virtual bool? IgnoreChecksums { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to allow empty checksums.
+    /// </summary>
+    [CliFlag("--allow-empty-checksums")]
+    public virtual bool? AllowEmptyChecksums { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore pinned packages.
+    /// </summary>
+    [CliFlag("--ignore-pinned")]
+    public virtual bool? IgnorePinned { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to exclude pre-release.
+    /// </summary>
+    [CliFlag("--except")]
+    public virtual string? Except { get; set; }
+
+    /// <summary>
+    /// Gets or sets the install arguments to pass to the native installer.
+    /// </summary>
+    [CliFlag("--install-arguments")]
+    public virtual string? InstallArguments { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to override arguments.
+    /// </summary>
+    [CliFlag("--override-arguments")]
+    public virtual bool? OverrideArguments { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package parameters to pass to the package.
+    /// </summary>
+    [CliFlag("--package-parameters")]
+    public virtual string? PackageParameters { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip virus check.
+    /// </summary>
+    [CliFlag("--skip-virus-check")]
+    public virtual bool? SkipVirusCheck { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use 32bit (x86) package.
+    /// </summary>
+    [CliFlag("--x86")]
+    public virtual bool? X86 { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to exclude self from upgrade.
+    /// </summary>
+    [CliFlag("--exclude-chocolatey-packages-during-upgrade-all")]
+    public virtual bool? ExcludeChocolateyPackagesDuringUpgradeAll { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Winget/WingetExportOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Winget/WingetExportOptions.cs
@@ -1,0 +1,58 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Winget;
+
+/// <summary>
+/// Options for the 'winget export' command.
+/// Exports a list of installed packages.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record WingetExportOptions : WingetOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetExportOptions"/> class
+    /// with the specified output file.
+    /// </summary>
+    /// <param name="output">The output file path.</param>
+    public WingetExportOptions(string output)
+    {
+        Output = output;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "export";
+
+    /// <summary>
+    /// Gets the output file path.
+    /// </summary>
+    [CliFlag("--output")]
+    public virtual string Output { get; }
+
+    /// <summary>
+    /// Gets or sets the source to filter by.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include version numbers.
+    /// </summary>
+    [CliFlag("--include-versions")]
+    public virtual bool? IncludeVersions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the header to use for REST source operations.
+    /// </summary>
+    [CliFlag("--header")]
+    public virtual string? Header { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept source agreements.
+    /// </summary>
+    [CliFlag("--accept-source-agreements")]
+    public virtual bool? AcceptSourceAgreements { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Winget/WingetImportOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Winget/WingetImportOptions.cs
@@ -1,0 +1,64 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Winget;
+
+/// <summary>
+/// Options for the 'winget import' command.
+/// Imports packages from a file.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record WingetImportOptions : WingetOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetImportOptions"/> class
+    /// with the specified import file.
+    /// </summary>
+    /// <param name="importFile">The import file path.</param>
+    public WingetImportOptions(string importFile)
+    {
+        ImportFile = importFile;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "import";
+
+    /// <summary>
+    /// Gets the import file path.
+    /// </summary>
+    [CliFlag("--import-file")]
+    public virtual string ImportFile { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore package versions.
+    /// </summary>
+    [CliFlag("--ignore-versions")]
+    public virtual bool? IgnoreVersions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to ignore unavailable packages.
+    /// </summary>
+    [CliFlag("--ignore-unavailable")]
+    public virtual bool? IgnoreUnavailable { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept package agreements.
+    /// </summary>
+    [CliFlag("--accept-package-agreements")]
+    public virtual bool? AcceptPackageAgreements { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept source agreements.
+    /// </summary>
+    [CliFlag("--accept-source-agreements")]
+    public virtual bool? AcceptSourceAgreements { get; set; }
+
+    /// <summary>
+    /// Gets or sets the header to use for REST source operations.
+    /// </summary>
+    [CliFlag("--header")]
+    public virtual string? Header { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Winget/WingetInstallOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Winget/WingetInstallOptions.cs
@@ -1,0 +1,174 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Winget;
+
+/// <summary>
+/// Options for the 'winget install' command.
+/// Installs a package.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record WingetInstallOptions : WingetOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetInstallOptions"/> class.
+    /// At least one of Id, Name, or Moniker must be specified.
+    /// </summary>
+    public WingetInstallOptions()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetInstallOptions"/> class
+    /// with the specified package ID.
+    /// </summary>
+    /// <param name="id">The package ID to install.</param>
+    public WingetInstallOptions(string id)
+    {
+        Id = id;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "install";
+
+    /// <summary>
+    /// Gets or sets the package ID to install.
+    /// </summary>
+    [CliFlag("--id")]
+    public virtual string? Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package name to install.
+    /// </summary>
+    [CliFlag("--name")]
+    public virtual string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package moniker to install.
+    /// </summary>
+    [CliFlag("--moniker")]
+    public virtual string? Moniker { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version to install.
+    /// </summary>
+    [CliFlag("--version")]
+    public new virtual string? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source to use.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use exact match.
+    /// </summary>
+    [CliFlag("--exact")]
+    public virtual bool? Exact { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to request interactive mode.
+    /// </summary>
+    [CliFlag("--interactive")]
+    public virtual bool? Interactive { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to request silent mode.
+    /// </summary>
+    [CliFlag("--silent")]
+    public virtual bool? Silent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the locale to install.
+    /// </summary>
+    [CliFlag("--locale")]
+    public virtual string? Locale { get; set; }
+
+    /// <summary>
+    /// Gets or sets the log file location.
+    /// </summary>
+    [CliFlag("--log")]
+    public virtual string? Log { get; set; }
+
+    /// <summary>
+    /// Gets or sets custom switches to pass to the installer.
+    /// </summary>
+    [CliFlag("--custom")]
+    public virtual string? Custom { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to override installer arguments.
+    /// </summary>
+    [CliFlag("--override")]
+    public virtual string? Override { get; set; }
+
+    /// <summary>
+    /// Gets or sets the installation location.
+    /// </summary>
+    [CliFlag("--location")]
+    public virtual string? Location { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force install even if already installed.
+    /// </summary>
+    [CliFlag("--force")]
+    public virtual bool? Force { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept package agreements.
+    /// </summary>
+    [CliFlag("--accept-package-agreements")]
+    public virtual bool? AcceptPackageAgreements { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept source agreements.
+    /// </summary>
+    [CliFlag("--accept-source-agreements")]
+    public virtual bool? AcceptSourceAgreements { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip dependencies.
+    /// </summary>
+    [CliFlag("--ignore-security-hash")]
+    public virtual bool? IgnoreSecurityHash { get; set; }
+
+    /// <summary>
+    /// Gets or sets the scope for installation (user or machine).
+    /// </summary>
+    [CliFlag("--scope")]
+    public virtual string? Scope { get; set; }
+
+    /// <summary>
+    /// Gets or sets the architecture to install.
+    /// </summary>
+    [CliFlag("--architecture")]
+    public virtual string? Architecture { get; set; }
+
+    /// <summary>
+    /// Gets or sets the installer type to use.
+    /// </summary>
+    [CliFlag("--installer-type")]
+    public virtual string? InstallerType { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to skip hash validation.
+    /// </summary>
+    [CliFlag("--allow-reboot")]
+    public virtual bool? AllowReboot { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to download only.
+    /// </summary>
+    [CliFlag("--download-only")]
+    public virtual bool? DownloadOnly { get; set; }
+
+    /// <summary>
+    /// Gets or sets the header to use for REST source operations.
+    /// </summary>
+    [CliFlag("--header")]
+    public virtual string? Header { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Winget/WingetListOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Winget/WingetListOptions.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Winget;
+
+/// <summary>
+/// Options for the 'winget list' command.
+/// Lists installed packages.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record WingetListOptions : WingetOptions
+{
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "list";
+
+    /// <summary>
+    /// Gets or sets the package ID to filter.
+    /// </summary>
+    [CliFlag("--id")]
+    public virtual string? Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package name to filter.
+    /// </summary>
+    [CliFlag("--name")]
+    public virtual string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package moniker to filter.
+    /// </summary>
+    [CliFlag("--moniker")]
+    public virtual string? Moniker { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source to use.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use exact match.
+    /// </summary>
+    [CliFlag("--exact")]
+    public virtual bool? Exact { get; set; }
+
+    /// <summary>
+    /// Gets or sets the query to filter packages.
+    /// </summary>
+    [CliFlag("--query")]
+    public virtual string? Query { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tag to filter packages.
+    /// </summary>
+    [CliFlag("--tag")]
+    public virtual string? Tag { get; set; }
+
+    /// <summary>
+    /// Gets or sets the command to filter packages.
+    /// </summary>
+    [CliFlag("--command")]
+    public virtual string? Command { get; set; }
+
+    /// <summary>
+    /// Gets or sets the count of results to show.
+    /// </summary>
+    [CliFlag("--count")]
+    public virtual int? Count { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to check for available upgrades.
+    /// </summary>
+    [CliFlag("--upgrade-available")]
+    public virtual bool? UpgradeAvailable { get; set; }
+
+    /// <summary>
+    /// Gets or sets the header to use for REST source operations.
+    /// </summary>
+    [CliFlag("--header")]
+    public virtual string? Header { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept source agreements.
+    /// </summary>
+    [CliFlag("--accept-source-agreements")]
+    public virtual bool? AcceptSourceAgreements { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Winget/WingetOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Winget/WingetOptions.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Winget;
+
+/// <summary>
+/// Base options class for Windows Package Manager (winget) commands.
+/// Contains common flags available across most winget commands.
+/// </summary>
+[ExcludeFromCodeCoverage]
+[CliTool("winget")]
+public record WingetOptions : CommandLineToolOptions
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether to disable interactive prompts.
+    /// </summary>
+    [CliFlag("--disable-interactivity")]
+    public virtual bool? DisableInteractivity { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show version information.
+    /// </summary>
+    [CliFlag("--version")]
+    public virtual bool? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show help information.
+    /// </summary>
+    [CliFlag("--help")]
+    public virtual bool? Help { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show additional logs.
+    /// </summary>
+    [CliFlag("--verbose")]
+    public virtual bool? Verbose { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show verbose logs.
+    /// </summary>
+    [CliFlag("--verbose-logs")]
+    public virtual bool? VerboseLogs { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to wait for user input on exit.
+    /// </summary>
+    [CliFlag("--wait")]
+    public virtual bool? Wait { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to open settings.
+    /// </summary>
+    [CliFlag("--info")]
+    public virtual bool? Info { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Winget/WingetSearchOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Winget/WingetSearchOptions.cs
@@ -1,0 +1,101 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Winget;
+
+/// <summary>
+/// Options for the 'winget search' command.
+/// Searches for packages.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record WingetSearchOptions : WingetOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetSearchOptions"/> class.
+    /// </summary>
+    public WingetSearchOptions()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetSearchOptions"/> class
+    /// with the specified query.
+    /// </summary>
+    /// <param name="query">The search query.</param>
+    public WingetSearchOptions(string query)
+    {
+        Query = query;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "search";
+
+    /// <summary>
+    /// Gets or sets the search query.
+    /// </summary>
+    [CliFlag("--query")]
+    public virtual string? Query { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package ID to search.
+    /// </summary>
+    [CliFlag("--id")]
+    public virtual string? Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package name to search.
+    /// </summary>
+    [CliFlag("--name")]
+    public virtual string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package moniker to search.
+    /// </summary>
+    [CliFlag("--moniker")]
+    public virtual string? Moniker { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source to use.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use exact match.
+    /// </summary>
+    [CliFlag("--exact")]
+    public virtual bool? Exact { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tag to filter packages.
+    /// </summary>
+    [CliFlag("--tag")]
+    public virtual string? Tag { get; set; }
+
+    /// <summary>
+    /// Gets or sets the command to filter packages.
+    /// </summary>
+    [CliFlag("--command")]
+    public virtual string? Command { get; set; }
+
+    /// <summary>
+    /// Gets or sets the count of results to show.
+    /// </summary>
+    [CliFlag("--count")]
+    public virtual int? Count { get; set; }
+
+    /// <summary>
+    /// Gets or sets the header to use for REST source operations.
+    /// </summary>
+    [CliFlag("--header")]
+    public virtual string? Header { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept source agreements.
+    /// </summary>
+    [CliFlag("--accept-source-agreements")]
+    public virtual bool? AcceptSourceAgreements { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Winget/WingetShowOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Winget/WingetShowOptions.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Winget;
+
+/// <summary>
+/// Options for the 'winget show' command.
+/// Shows information about a package.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record WingetShowOptions : WingetOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetShowOptions"/> class.
+    /// At least one of Id, Name, or Moniker must be specified.
+    /// </summary>
+    public WingetShowOptions()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetShowOptions"/> class
+    /// with the specified package ID.
+    /// </summary>
+    /// <param name="id">The package ID to show.</param>
+    public WingetShowOptions(string id)
+    {
+        Id = id;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "show";
+
+    /// <summary>
+    /// Gets or sets the package ID to show.
+    /// </summary>
+    [CliFlag("--id")]
+    public virtual string? Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package name to show.
+    /// </summary>
+    [CliFlag("--name")]
+    public virtual string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package moniker to show.
+    /// </summary>
+    [CliFlag("--moniker")]
+    public virtual string? Moniker { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version to show.
+    /// </summary>
+    [CliFlag("--version")]
+    public new virtual string? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source to use.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use exact match.
+    /// </summary>
+    [CliFlag("--exact")]
+    public virtual bool? Exact { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show all versions.
+    /// </summary>
+    [CliFlag("--versions")]
+    public virtual bool? Versions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the header to use for REST source operations.
+    /// </summary>
+    [CliFlag("--header")]
+    public virtual string? Header { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept source agreements.
+    /// </summary>
+    [CliFlag("--accept-source-agreements")]
+    public virtual bool? AcceptSourceAgreements { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Winget/WingetSourceOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Winget/WingetSourceOptions.cs
@@ -1,0 +1,70 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Winget;
+
+/// <summary>
+/// Options for the 'winget source' command.
+/// Manages package sources.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record WingetSourceOptions : WingetOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetSourceOptions"/> class
+    /// with the specified subcommand.
+    /// </summary>
+    /// <param name="subCommand">The source subcommand: "list", "add", "remove", "update", "reset", or "export".</param>
+    public WingetSourceOptions(string subCommand)
+    {
+        SubCommand = subCommand;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "source";
+
+    /// <summary>
+    /// Gets the source subcommand.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string SubCommand { get; }
+
+    /// <summary>
+    /// Gets or sets the source name.
+    /// </summary>
+    [CliFlag("--name")]
+    public virtual string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source argument (URL for add).
+    /// </summary>
+    [CliFlag("--arg")]
+    public virtual string? Arg { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source type.
+    /// </summary>
+    [CliFlag("--type")]
+    public virtual string? Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept source agreements.
+    /// </summary>
+    [CliFlag("--accept-source-agreements")]
+    public virtual bool? AcceptSourceAgreements { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force the operation.
+    /// </summary>
+    [CliFlag("--force")]
+    public virtual bool? Force { get; set; }
+
+    /// <summary>
+    /// Gets or sets the header to use for REST source operations.
+    /// </summary>
+    [CliFlag("--header")]
+    public virtual string? Header { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Winget/WingetUninstallOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Winget/WingetUninstallOptions.cs
@@ -1,0 +1,126 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Winget;
+
+/// <summary>
+/// Options for the 'winget uninstall' command.
+/// Uninstalls a package.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record WingetUninstallOptions : WingetOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetUninstallOptions"/> class.
+    /// At least one of Id, Name, or Moniker must be specified.
+    /// </summary>
+    public WingetUninstallOptions()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetUninstallOptions"/> class
+    /// with the specified package ID.
+    /// </summary>
+    /// <param name="id">The package ID to uninstall.</param>
+    public WingetUninstallOptions(string id)
+    {
+        Id = id;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "uninstall";
+
+    /// <summary>
+    /// Gets or sets the package ID to uninstall.
+    /// </summary>
+    [CliFlag("--id")]
+    public virtual string? Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package name to uninstall.
+    /// </summary>
+    [CliFlag("--name")]
+    public virtual string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package moniker to uninstall.
+    /// </summary>
+    [CliFlag("--moniker")]
+    public virtual string? Moniker { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version to uninstall.
+    /// </summary>
+    [CliFlag("--version")]
+    public new virtual string? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source to use.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use exact match.
+    /// </summary>
+    [CliFlag("--exact")]
+    public virtual bool? Exact { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to request interactive mode.
+    /// </summary>
+    [CliFlag("--interactive")]
+    public virtual bool? Interactive { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to request silent mode.
+    /// </summary>
+    [CliFlag("--silent")]
+    public virtual bool? Silent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the log file location.
+    /// </summary>
+    [CliFlag("--log")]
+    public virtual string? Log { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force uninstall.
+    /// </summary>
+    [CliFlag("--force")]
+    public virtual bool? Force { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to purge all files and data.
+    /// </summary>
+    [CliFlag("--purge")]
+    public virtual bool? Purge { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to preserve data files.
+    /// </summary>
+    [CliFlag("--preserve")]
+    public virtual bool? Preserve { get; set; }
+
+    /// <summary>
+    /// Gets or sets the product code to uninstall.
+    /// </summary>
+    [CliFlag("--product-code")]
+    public virtual string? ProductCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the header to use for REST source operations.
+    /// </summary>
+    [CliFlag("--header")]
+    public virtual string? Header { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept source agreements.
+    /// </summary>
+    [CliFlag("--accept-source-agreements")]
+    public virtual bool? AcceptSourceAgreements { get; set; }
+}

--- a/src/ModularPipelines/Options/Windows/Winget/WingetUpgradeOptions.cs
+++ b/src/ModularPipelines/Options/Windows/Winget/WingetUpgradeOptions.cs
@@ -1,0 +1,173 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Attributes;
+
+namespace ModularPipelines.Options.Windows.Winget;
+
+/// <summary>
+/// Options for the 'winget upgrade' command.
+/// Upgrades installed packages.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public record WingetUpgradeOptions : WingetOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetUpgradeOptions"/> class.
+    /// </summary>
+    public WingetUpgradeOptions()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WingetUpgradeOptions"/> class
+    /// with the specified package ID.
+    /// </summary>
+    /// <param name="id">The package ID to upgrade.</param>
+    public WingetUpgradeOptions(string id)
+    {
+        Id = id;
+    }
+
+    /// <summary>
+    /// Gets the command name.
+    /// </summary>
+    [CliArgument(Placement = ArgumentPlacement.AfterOptions)]
+    public virtual string CommandName { get; } = "upgrade";
+
+    /// <summary>
+    /// Gets or sets the package ID to upgrade.
+    /// </summary>
+    [CliFlag("--id")]
+    public virtual string? Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package name to upgrade.
+    /// </summary>
+    [CliFlag("--name")]
+    public virtual string? Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the package moniker to upgrade.
+    /// </summary>
+    [CliFlag("--moniker")]
+    public virtual string? Moniker { get; set; }
+
+    /// <summary>
+    /// Gets or sets the version to upgrade to.
+    /// </summary>
+    [CliFlag("--version")]
+    public new virtual string? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source to use.
+    /// </summary>
+    [CliFlag("--source")]
+    public virtual string? Source { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use exact match.
+    /// </summary>
+    [CliFlag("--exact")]
+    public virtual bool? Exact { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to request interactive mode.
+    /// </summary>
+    [CliFlag("--interactive")]
+    public virtual bool? Interactive { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to request silent mode.
+    /// </summary>
+    [CliFlag("--silent")]
+    public virtual bool? Silent { get; set; }
+
+    /// <summary>
+    /// Gets or sets the log file location.
+    /// </summary>
+    [CliFlag("--log")]
+    public virtual string? Log { get; set; }
+
+    /// <summary>
+    /// Gets or sets custom switches to pass to the installer.
+    /// </summary>
+    [CliFlag("--custom")]
+    public virtual string? Custom { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to override installer arguments.
+    /// </summary>
+    [CliFlag("--override")]
+    public virtual string? Override { get; set; }
+
+    /// <summary>
+    /// Gets or sets the installation location.
+    /// </summary>
+    [CliFlag("--location")]
+    public virtual string? Location { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to force upgrade.
+    /// </summary>
+    [CliFlag("--force")]
+    public virtual bool? Force { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to upgrade all packages.
+    /// </summary>
+    [CliFlag("--all")]
+    public virtual bool? All { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept package agreements.
+    /// </summary>
+    [CliFlag("--accept-package-agreements")]
+    public virtual bool? AcceptPackageAgreements { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to accept source agreements.
+    /// </summary>
+    [CliFlag("--accept-source-agreements")]
+    public virtual bool? AcceptSourceAgreements { get; set; }
+
+    /// <summary>
+    /// Gets or sets the scope for upgrade (user or machine).
+    /// </summary>
+    [CliFlag("--scope")]
+    public virtual string? Scope { get; set; }
+
+    /// <summary>
+    /// Gets or sets the architecture to upgrade.
+    /// </summary>
+    [CliFlag("--architecture")]
+    public virtual string? Architecture { get; set; }
+
+    /// <summary>
+    /// Gets or sets the installer type to use.
+    /// </summary>
+    [CliFlag("--installer-type")]
+    public virtual string? InstallerType { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include unknown packages.
+    /// </summary>
+    [CliFlag("--include-unknown")]
+    public virtual bool? IncludeUnknown { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to include pinned packages.
+    /// </summary>
+    [CliFlag("--include-pinned")]
+    public virtual bool? IncludePinned { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to uninstall previous version.
+    /// </summary>
+    [CliFlag("--uninstall-previous")]
+    public virtual bool? UninstallPrevious { get; set; }
+
+    /// <summary>
+    /// Gets or sets the header to use for REST source operations.
+    /// </summary>
+    [CliFlag("--header")]
+    public virtual string? Header { get; set; }
+}


### PR DESCRIPTION
## Summary

Adds package manager abstractions to the core ModularPipelines package for macOS and Windows, following the existing `IAptGet` pattern for Linux:

- **IBrew**: Homebrew operations for macOS (install, uninstall, update, upgrade, list, search, info, tap, untap, cleanup)
- **IChocolatey**: Chocolatey operations for Windows (install, uninstall, upgrade, list, search, info, outdated, pin)
- **IWinget**: Windows Package Manager operations (install, uninstall, upgrade, list, search, show, export, import, source)

Each interface includes strongly-typed options classes with common CLI flags and command-specific parameters, registered in DI as scoped services.

**Files Changed**: 37 files (3,089 insertions)

Closes #1995

## Test plan

- [x] Build succeeds with 0 errors
- [x] Follows existing `IAptGet` pattern
- [x] All options classes have proper CLI attributes
- [x] Services registered in DI

🤖 Generated with [Claude Code](https://claude.ai/code)