### PR TITLE
feat: Add new run condition API with clearer naming (#2012)

### DIFF
--- a/src/ModularPipelines/Attributes/IConditionAttribute.cs
+++ b/src/ModularPipelines/Attributes/IConditionAttribute.cs
@@ -1,0 +1,27 @@
+using ModularPipelines.Conditions;
+using ModularPipelines.Context;
+
+namespace ModularPipelines.Attributes;
+
+/// <summary>
+/// Interface for condition attributes that can be evaluated at runtime.
+/// </summary>
+public interface IConditionAttribute
+{
+    /// <summary>
+    /// Gets the logic used by this condition attribute.
+    /// </summary>
+    ConditionLogic Logic { get; }
+
+    /// <summary>
+    /// Evaluates the condition(s) in this attribute.
+    /// </summary>
+    /// <param name="context">The pipeline context.</param>
+    /// <returns><c>true</c> if the condition is satisfied; otherwise, <c>false</c>.</returns>
+    Task<bool> EvaluateAsync(IPipelineHookContext context);
+
+    /// <summary>
+    /// Gets a human-readable string of the condition names for error messages.
+    /// </summary>
+    string ConditionNames { get; }
+}

--- a/src/ModularPipelines/Attributes/RunIfAllAttribute.cs
+++ b/src/ModularPipelines/Attributes/RunIfAllAttribute.cs
@@ -1,0 +1,150 @@
+using ModularPipelines.Conditions;
+using ModularPipelines.Context;
+
+namespace ModularPipelines.Attributes;
+
+/// <summary>
+/// Specifies that all conditions must be satisfied for the module to run (AND logic).
+/// </summary>
+/// <remarks>
+/// <para>
+/// When multiple conditions are specified, ALL must return true for the module to run.
+/// If any condition returns false, the module is skipped.
+/// </para>
+/// <para>
+/// Multiple <c>[RunIfAll]</c> attributes on a module are combined with AND logic between them.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">The condition type that must be satisfied.</typeparam>
+/// <example>
+/// <code>
+/// [RunIfAll&lt;HasGitHubToken&gt;]
+/// [RunIfAll&lt;IsCI&gt;]
+/// public class PublishModule : Module&lt;None&gt;
+/// {
+///     // Only runs if BOTH HasGitHubToken AND IsCI return true
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class RunIfAllAttribute<T> : Attribute, IConditionAttribute
+    where T : IRunCondition, new()
+{
+    /// <inheritdoc />
+    public ConditionLogic Logic => ConditionLogic.All;
+
+    /// <inheritdoc />
+    public async Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        var condition = new T();
+        return await condition.EvaluateAsync(context);
+    }
+
+    /// <inheritdoc />
+    public string ConditionNames => typeof(T).Name;
+}
+
+/// <summary>
+/// Specifies that all conditions must be satisfied for the module to run (AND logic).
+/// </summary>
+/// <typeparam name="T1">The first condition type.</typeparam>
+/// <typeparam name="T2">The second condition type.</typeparam>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class RunIfAllAttribute<T1, T2> : Attribute, IConditionAttribute
+    where T1 : IRunCondition, new()
+    where T2 : IRunCondition, new()
+{
+    /// <inheritdoc />
+    public ConditionLogic Logic => ConditionLogic.All;
+
+    /// <inheritdoc />
+    public async Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        if (!await new T1().EvaluateAsync(context))
+        {
+            return false;
+        }
+
+        return await new T2().EvaluateAsync(context);
+    }
+
+    /// <inheritdoc />
+    public string ConditionNames => $"{typeof(T1).Name}, {typeof(T2).Name}";
+}
+
+/// <summary>
+/// Specifies that all conditions must be satisfied for the module to run (AND logic).
+/// </summary>
+/// <typeparam name="T1">The first condition type.</typeparam>
+/// <typeparam name="T2">The second condition type.</typeparam>
+/// <typeparam name="T3">The third condition type.</typeparam>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class RunIfAllAttribute<T1, T2, T3> : Attribute, IConditionAttribute
+    where T1 : IRunCondition, new()
+    where T2 : IRunCondition, new()
+    where T3 : IRunCondition, new()
+{
+    /// <inheritdoc />
+    public ConditionLogic Logic => ConditionLogic.All;
+
+    /// <inheritdoc />
+    public async Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        if (!await new T1().EvaluateAsync(context))
+        {
+            return false;
+        }
+
+        if (!await new T2().EvaluateAsync(context))
+        {
+            return false;
+        }
+
+        return await new T3().EvaluateAsync(context);
+    }
+
+    /// <inheritdoc />
+    public string ConditionNames => $"{typeof(T1).Name}, {typeof(T2).Name}, {typeof(T3).Name}";
+}
+
+/// <summary>
+/// Specifies that all conditions must be satisfied for the module to run (AND logic).
+/// </summary>
+/// <typeparam name="T1">The first condition type.</typeparam>
+/// <typeparam name="T2">The second condition type.</typeparam>
+/// <typeparam name="T3">The third condition type.</typeparam>
+/// <typeparam name="T4">The fourth condition type.</typeparam>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class RunIfAllAttribute<T1, T2, T3, T4> : Attribute, IConditionAttribute
+    where T1 : IRunCondition, new()
+    where T2 : IRunCondition, new()
+    where T3 : IRunCondition, new()
+    where T4 : IRunCondition, new()
+{
+    /// <inheritdoc />
+    public ConditionLogic Logic => ConditionLogic.All;
+
+    /// <inheritdoc />
+    public async Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        if (!await new T1().EvaluateAsync(context))
+        {
+            return false;
+        }
+
+        if (!await new T2().EvaluateAsync(context))
+        {
+            return false;
+        }
+
+        if (!await new T3().EvaluateAsync(context))
+        {
+            return false;
+        }
+
+        return await new T4().EvaluateAsync(context);
+    }
+
+    /// <inheritdoc />
+    public string ConditionNames => $"{typeof(T1).Name}, {typeof(T2).Name}, {typeof(T3).Name}, {typeof(T4).Name}";
+}

--- a/src/ModularPipelines/Attributes/RunIfAnyAttribute.cs
+++ b/src/ModularPipelines/Attributes/RunIfAnyAttribute.cs
@@ -1,0 +1,149 @@
+using ModularPipelines.Conditions;
+using ModularPipelines.Context;
+
+namespace ModularPipelines.Attributes;
+
+/// <summary>
+/// Specifies that at least one condition must be satisfied for the module to run (OR logic).
+/// </summary>
+/// <remarks>
+/// <para>
+/// When multiple conditions are specified, at least one must return true for the module to run.
+/// If all conditions return false, the module is skipped.
+/// </para>
+/// <para>
+/// Multiple <c>[RunIfAny]</c> attributes on a module are combined with AND logic between them.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">The condition type.</typeparam>
+/// <example>
+/// <code>
+/// [RunIfAny&lt;OnLinux, OnMacOS&gt;]
+/// public class UnixModule : Module&lt;None&gt;
+/// {
+///     // Runs on Linux OR macOS, skipped on Windows
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class RunIfAnyAttribute<T> : Attribute, IConditionAttribute
+    where T : IRunCondition, new()
+{
+    /// <inheritdoc />
+    public ConditionLogic Logic => ConditionLogic.Any;
+
+    /// <inheritdoc />
+    public async Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        var condition = new T();
+        return await condition.EvaluateAsync(context);
+    }
+
+    /// <inheritdoc />
+    public string ConditionNames => typeof(T).Name;
+}
+
+/// <summary>
+/// Specifies that at least one condition must be satisfied for the module to run (OR logic).
+/// </summary>
+/// <typeparam name="T1">The first condition type.</typeparam>
+/// <typeparam name="T2">The second condition type.</typeparam>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class RunIfAnyAttribute<T1, T2> : Attribute, IConditionAttribute
+    where T1 : IRunCondition, new()
+    where T2 : IRunCondition, new()
+{
+    /// <inheritdoc />
+    public ConditionLogic Logic => ConditionLogic.Any;
+
+    /// <inheritdoc />
+    public async Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        if (await new T1().EvaluateAsync(context))
+        {
+            return true;
+        }
+
+        return await new T2().EvaluateAsync(context);
+    }
+
+    /// <inheritdoc />
+    public string ConditionNames => $"{typeof(T1).Name}, {typeof(T2).Name}";
+}
+
+/// <summary>
+/// Specifies that at least one condition must be satisfied for the module to run (OR logic).
+/// </summary>
+/// <typeparam name="T1">The first condition type.</typeparam>
+/// <typeparam name="T2">The second condition type.</typeparam>
+/// <typeparam name="T3">The third condition type.</typeparam>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class RunIfAnyAttribute<T1, T2, T3> : Attribute, IConditionAttribute
+    where T1 : IRunCondition, new()
+    where T2 : IRunCondition, new()
+    where T3 : IRunCondition, new()
+{
+    /// <inheritdoc />
+    public ConditionLogic Logic => ConditionLogic.Any;
+
+    /// <inheritdoc />
+    public async Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        if (await new T1().EvaluateAsync(context))
+        {
+            return true;
+        }
+
+        if (await new T2().EvaluateAsync(context))
+        {
+            return true;
+        }
+
+        return await new T3().EvaluateAsync(context);
+    }
+
+    /// <inheritdoc />
+    public string ConditionNames => $"{typeof(T1).Name}, {typeof(T2).Name}, {typeof(T3).Name}";
+}
+
+/// <summary>
+/// Specifies that at least one condition must be satisfied for the module to run (OR logic).
+/// </summary>
+/// <typeparam name="T1">The first condition type.</typeparam>
+/// <typeparam name="T2">The second condition type.</typeparam>
+/// <typeparam name="T3">The third condition type.</typeparam>
+/// <typeparam name="T4">The fourth condition type.</typeparam>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class RunIfAnyAttribute<T1, T2, T3, T4> : Attribute, IConditionAttribute
+    where T1 : IRunCondition, new()
+    where T2 : IRunCondition, new()
+    where T3 : IRunCondition, new()
+    where T4 : IRunCondition, new()
+{
+    /// <inheritdoc />
+    public ConditionLogic Logic => ConditionLogic.Any;
+
+    /// <inheritdoc />
+    public async Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        if (await new T1().EvaluateAsync(context))
+        {
+            return true;
+        }
+
+        if (await new T2().EvaluateAsync(context))
+        {
+            return true;
+        }
+
+        if (await new T3().EvaluateAsync(context))
+        {
+            return true;
+        }
+
+        return await new T4().EvaluateAsync(context);
+    }
+
+    /// <inheritdoc />
+    public string ConditionNames => $"{typeof(T1).Name}, {typeof(T2).Name}, {typeof(T3).Name}, {typeof(T4).Name}";
+}

--- a/src/ModularPipelines/Attributes/SkipIfAttribute.cs
+++ b/src/ModularPipelines/Attributes/SkipIfAttribute.cs
@@ -1,0 +1,72 @@
+using ModularPipelines.Conditions;
+using ModularPipelines.Context;
+
+namespace ModularPipelines.Attributes;
+
+/// <summary>
+/// Specifies that the module should be skipped if the condition is satisfied.
+/// </summary>
+/// <remarks>
+/// <para>
+/// If the condition returns true, the module is skipped.
+/// This is useful for excluding certain scenarios (e.g., skip on Dependabot PRs).
+/// </para>
+/// <para>
+/// <c>[SkipIf]</c> attributes are evaluated first, before <c>[RunIfAll]</c> and <c>[RunIfAny]</c>.
+/// </para>
+/// </remarks>
+/// <typeparam name="T">The condition type. If it returns true, the module is skipped.</typeparam>
+/// <example>
+/// <code>
+/// [SkipIf&lt;IsDependabot&gt;]
+/// public class ReleaseModule : Module&lt;None&gt;
+/// {
+///     // Skipped when running on Dependabot PRs
+/// }
+/// </code>
+/// </example>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class SkipIfAttribute<T> : Attribute, IConditionAttribute
+    where T : IRunCondition, new()
+{
+    /// <inheritdoc />
+    public ConditionLogic Logic => ConditionLogic.Skip;
+
+    /// <inheritdoc />
+    public async Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        var condition = new T();
+        return await condition.EvaluateAsync(context);
+    }
+
+    /// <inheritdoc />
+    public string ConditionNames => typeof(T).Name;
+}
+
+/// <summary>
+/// Specifies that the module should be skipped if any condition is satisfied.
+/// </summary>
+/// <typeparam name="T1">The first condition type.</typeparam>
+/// <typeparam name="T2">The second condition type.</typeparam>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+public sealed class SkipIfAttribute<T1, T2> : Attribute, IConditionAttribute
+    where T1 : IRunCondition, new()
+    where T2 : IRunCondition, new()
+{
+    /// <inheritdoc />
+    public ConditionLogic Logic => ConditionLogic.Skip;
+
+    /// <inheritdoc />
+    public async Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        if (await new T1().EvaluateAsync(context))
+        {
+            return true;
+        }
+
+        return await new T2().EvaluateAsync(context);
+    }
+
+    /// <inheritdoc />
+    public string ConditionNames => $"{typeof(T1).Name}, {typeof(T2).Name}";
+}

--- a/src/ModularPipelines/Conditions/ConditionGroup.cs
+++ b/src/ModularPipelines/Conditions/ConditionGroup.cs
@@ -1,0 +1,90 @@
+using ModularPipelines.Context;
+
+namespace ModularPipelines.Conditions;
+
+/// <summary>
+/// Base class for creating reusable groups of conditions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Condition groups allow you to define a set of conditions once and reuse them
+/// across multiple modules. The group specifies how its conditions are combined
+/// (AND or OR logic).
+/// </para>
+/// <para>
+/// <b>Example - Unix platforms group:</b>
+/// <code>
+/// public sealed class OnUnixPlatforms : ConditionGroup
+/// {
+///     public override IRunCondition[] Conditions =&gt; [new OnLinux(), new OnMacOS()];
+///     public override ConditionLogic Logic =&gt; ConditionLogic.Any;
+/// }
+///
+/// // Usage:
+/// [RunIfAny&lt;OnUnixPlatforms&gt;]
+/// public class UnixModule : Module&lt;None&gt; { }
+/// </code>
+/// </para>
+/// </remarks>
+public abstract class ConditionGroup : IRunCondition
+{
+    /// <summary>
+    /// Gets the conditions in this group.
+    /// </summary>
+    public abstract IRunCondition[] Conditions { get; }
+
+    /// <summary>
+    /// Gets the logic used to combine conditions in this group.
+    /// </summary>
+    public abstract ConditionLogic Logic { get; }
+
+    /// <summary>
+    /// Evaluates all conditions in the group according to the specified logic.
+    /// </summary>
+    /// <param name="context">The pipeline context.</param>
+    /// <returns>
+    /// For <see cref="ConditionLogic.All"/>: <c>true</c> if all conditions pass.
+    /// For <see cref="ConditionLogic.Any"/>: <c>true</c> if any condition passes.
+    /// </returns>
+    public async Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        if (Conditions.Length == 0)
+        {
+            return true;
+        }
+
+        return Logic switch
+        {
+            ConditionLogic.All => await EvaluateAllAsync(context),
+            ConditionLogic.Any => await EvaluateAnyAsync(context),
+            ConditionLogic.Skip => await EvaluateAnyAsync(context),
+            _ => throw new ArgumentOutOfRangeException(nameof(Logic), Logic, "Unknown condition logic")
+        };
+    }
+
+    private async Task<bool> EvaluateAllAsync(IPipelineHookContext context)
+    {
+        foreach (var condition in Conditions)
+        {
+            if (!await condition.EvaluateAsync(context))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private async Task<bool> EvaluateAnyAsync(IPipelineHookContext context)
+    {
+        foreach (var condition in Conditions)
+        {
+            if (await condition.EvaluateAsync(context))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/ModularPipelines/Conditions/ConditionLogic.cs
+++ b/src/ModularPipelines/Conditions/ConditionLogic.cs
@@ -1,0 +1,22 @@
+namespace ModularPipelines.Conditions;
+
+/// <summary>
+/// Specifies how multiple conditions within a group are combined.
+/// </summary>
+public enum ConditionLogic
+{
+    /// <summary>
+    /// All conditions must return true (AND logic).
+    /// </summary>
+    All,
+
+    /// <summary>
+    /// At least one condition must return true (OR logic).
+    /// </summary>
+    Any,
+
+    /// <summary>
+    /// Used for skip conditions - if condition returns true, module is skipped.
+    /// </summary>
+    Skip
+}

--- a/src/ModularPipelines/Conditions/IRunCondition.cs
+++ b/src/ModularPipelines/Conditions/IRunCondition.cs
@@ -1,0 +1,33 @@
+using ModularPipelines.Context;
+
+namespace ModularPipelines.Conditions;
+
+/// <summary>
+/// Defines a condition that determines whether a module should run.
+/// </summary>
+/// <remarks>
+/// Implement this interface to create custom run conditions.
+/// Conditions are evaluated before module execution and can access
+/// the pipeline context for environment checks, HTTP calls, etc.
+/// </remarks>
+/// <example>
+/// <code>
+/// public sealed class HasGitHubToken : IRunCondition
+/// {
+///     public Task&lt;bool&gt; EvaluateAsync(IPipelineHookContext context)
+///         =&gt; Task.FromResult(!string.IsNullOrEmpty(
+///             context.Environment.GetEnvironmentVariable("GITHUB_TOKEN")));
+/// }
+/// </code>
+/// </example>
+public interface IRunCondition
+{
+    /// <summary>
+    /// Evaluates the condition asynchronously.
+    /// </summary>
+    /// <param name="context">The pipeline context for accessing environment, HTTP, etc.</param>
+    /// <returns>
+    /// A task that returns <c>true</c> if the condition is satisfied; otherwise, <c>false</c>.
+    /// </returns>
+    Task<bool> EvaluateAsync(IPipelineHookContext context);
+}

--- a/src/ModularPipelines/Conditions/IsCI.cs
+++ b/src/ModularPipelines/Conditions/IsCI.cs
@@ -1,0 +1,33 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Context;
+
+namespace ModularPipelines.Conditions;
+
+/// <summary>
+/// A condition that returns true when running in a CI environment.
+/// </summary>
+/// <remarks>
+/// Checks for the presence of the <c>CI</c> environment variable, which is
+/// set by most CI providers (GitHub Actions, Azure Pipelines, GitLab CI, etc.).
+/// </remarks>
+/// <example>
+/// <code>
+/// [RunIfAll&lt;IsCI&gt;]
+/// public class PublishModule : Module&lt;None&gt;
+/// {
+///     // Only runs in CI, skipped locally
+/// }
+/// </code>
+/// </example>
+[ExcludeFromCodeCoverage]
+public sealed class IsCI : IRunCondition
+{
+    /// <inheritdoc />
+    public Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        var ciEnvVar = context.Environment.EnvironmentVariables.GetEnvironmentVariable("CI");
+        var isCI = !string.IsNullOrEmpty(ciEnvVar) &&
+                   !string.Equals(ciEnvVar, "false", StringComparison.OrdinalIgnoreCase);
+        return Task.FromResult(isCI);
+    }
+}

--- a/src/ModularPipelines/Conditions/IsLocal.cs
+++ b/src/ModularPipelines/Conditions/IsLocal.cs
@@ -1,0 +1,32 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Context;
+
+namespace ModularPipelines.Conditions;
+
+/// <summary>
+/// A condition that returns true when running locally (not in CI).
+/// </summary>
+/// <remarks>
+/// Returns true when the <c>CI</c> environment variable is not set or is "false".
+/// </remarks>
+/// <example>
+/// <code>
+/// [RunIfAll&lt;IsLocal&gt;]
+/// public class LocalDevModule : Module&lt;None&gt;
+/// {
+///     // Only runs locally, skipped in CI
+/// }
+/// </code>
+/// </example>
+[ExcludeFromCodeCoverage]
+public sealed class IsLocal : IRunCondition
+{
+    /// <inheritdoc />
+    public Task<bool> EvaluateAsync(IPipelineHookContext context)
+    {
+        var ciEnvVar = context.Environment.EnvironmentVariables.GetEnvironmentVariable("CI");
+        var isLocal = string.IsNullOrEmpty(ciEnvVar) ||
+                      string.Equals(ciEnvVar, "false", StringComparison.OrdinalIgnoreCase);
+        return Task.FromResult(isLocal);
+    }
+}

--- a/src/ModularPipelines/Conditions/OnLinux.cs
+++ b/src/ModularPipelines/Conditions/OnLinux.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Context;
+
+namespace ModularPipelines.Conditions;
+
+/// <summary>
+/// A condition that returns true when running on Linux.
+/// </summary>
+/// <example>
+/// <code>
+/// [RunIfAny&lt;OnLinux, OnMacOS&gt;]
+/// public class UnixModule : Module&lt;None&gt; { }
+/// </code>
+/// </example>
+[ExcludeFromCodeCoverage]
+public sealed class OnLinux : IRunCondition
+{
+    /// <inheritdoc />
+    public Task<bool> EvaluateAsync(IPipelineHookContext context)
+        => Task.FromResult(OperatingSystem.IsLinux());
+}

--- a/src/ModularPipelines/Conditions/OnMacOS.cs
+++ b/src/ModularPipelines/Conditions/OnMacOS.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Context;
+
+namespace ModularPipelines.Conditions;
+
+/// <summary>
+/// A condition that returns true when running on macOS.
+/// </summary>
+/// <example>
+/// <code>
+/// [RunIfAny&lt;OnLinux, OnMacOS&gt;]
+/// public class UnixModule : Module&lt;None&gt; { }
+/// </code>
+/// </example>
+[ExcludeFromCodeCoverage]
+public sealed class OnMacOS : IRunCondition
+{
+    /// <inheritdoc />
+    public Task<bool> EvaluateAsync(IPipelineHookContext context)
+        => Task.FromResult(OperatingSystem.IsMacOS());
+}

--- a/src/ModularPipelines/Conditions/OnUnix.cs
+++ b/src/ModularPipelines/Conditions/OnUnix.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ModularPipelines.Conditions;
+
+/// <summary>
+/// A condition group that returns true when running on Linux or macOS.
+/// </summary>
+/// <remarks>
+/// This is a convenience group that combines <see cref="OnLinux"/> and <see cref="OnMacOS"/>
+/// with OR logic.
+/// </remarks>
+/// <example>
+/// <code>
+/// [RunIfAny&lt;OnUnix&gt;]
+/// public class UnixModule : Module&lt;None&gt; { }
+/// </code>
+/// </example>
+[ExcludeFromCodeCoverage]
+public sealed class OnUnix : ConditionGroup
+{
+    /// <inheritdoc />
+    public override IRunCondition[] Conditions => [new OnLinux(), new OnMacOS()];
+
+    /// <inheritdoc />
+    public override ConditionLogic Logic => ConditionLogic.Any;
+}

--- a/src/ModularPipelines/Conditions/OnWindows.cs
+++ b/src/ModularPipelines/Conditions/OnWindows.cs
@@ -1,0 +1,21 @@
+using System.Diagnostics.CodeAnalysis;
+using ModularPipelines.Context;
+
+namespace ModularPipelines.Conditions;
+
+/// <summary>
+/// A condition that returns true when running on Windows.
+/// </summary>
+/// <example>
+/// <code>
+/// [RunIfAll&lt;OnWindows&gt;]
+/// public class WindowsOnlyModule : Module&lt;None&gt; { }
+/// </code>
+/// </example>
+[ExcludeFromCodeCoverage]
+public sealed class OnWindows : IRunCondition
+{
+    /// <inheritdoc />
+    public Task<bool> EvaluateAsync(IPipelineHookContext context)
+        => Task.FromResult(OperatingSystem.IsWindows());
+}

--- a/src/ModularPipelines/Engine/ModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/ModuleConditionHandler.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
+using ModularPipelines.Conditions;
 using ModularPipelines.Context;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -72,11 +73,83 @@ internal class ModuleConditionHandler : IModuleConditionHandler
 
     private async Task<(bool IsRunnable, SkipDecision? SkipDecision)> IsRunnableCondition(Type moduleType, CancellationToken cancellationToken)
     {
-        var mandatoryRunConditionAttributes = moduleType.GetCustomAttributes<MandatoryRunConditionAttribute>(true).ToArray();
-        var runConditionAttributes = moduleType.GetCustomAttributes<RunConditionAttribute>(true).Except(mandatoryRunConditionAttributes).ToArray();
-
         // Get a context for condition evaluation
         var pipelineContext = _pipelineContextProvider.GetModuleContext();
+
+        // First, evaluate new-style IConditionAttribute attributes
+        var newStyleResult = await EvaluateNewStyleConditions(moduleType, pipelineContext, cancellationToken).ConfigureAwait(false);
+        if (!newStyleResult.IsRunnable)
+        {
+            return newStyleResult;
+        }
+
+        // Then, evaluate legacy RunConditionAttribute/MandatoryRunConditionAttribute for backwards compatibility
+        var legacyResult = await EvaluateLegacyConditions(moduleType, pipelineContext, cancellationToken).ConfigureAwait(false);
+        return legacyResult;
+    }
+
+    private static async Task<(bool IsRunnable, SkipDecision? SkipDecision)> EvaluateNewStyleConditions(
+        Type moduleType,
+        IPipelineHookContext pipelineContext,
+        CancellationToken cancellationToken)
+    {
+        // Get all IConditionAttribute implementations
+        var conditionAttributes = moduleType
+            .GetCustomAttributes(true)
+            .OfType<IConditionAttribute>()
+            .ToArray();
+
+        if (conditionAttributes.Length == 0)
+        {
+            return (true, null);
+        }
+
+        // 1. Evaluate SkipIf attributes first (fail-fast)
+        var skipConditions = conditionAttributes.Where(a => a.Logic == ConditionLogic.Skip).ToArray();
+        foreach (var attr in skipConditions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (await attr.EvaluateAsync(pipelineContext).ConfigureAwait(false))
+            {
+                return (false, SkipDecision.Skip($"SkipIf<{attr.ConditionNames}> returned true"));
+            }
+        }
+
+        // 2. Evaluate RunIfAll attributes (all conditions in each must pass)
+        var allConditions = conditionAttributes.Where(a => a.Logic == ConditionLogic.All).ToArray();
+        foreach (var attr in allConditions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!await attr.EvaluateAsync(pipelineContext).ConfigureAwait(false))
+            {
+                return (false, SkipDecision.Skip($"RunIfAll<{attr.ConditionNames}> not satisfied"));
+            }
+        }
+
+        // 3. Evaluate RunIfAny attributes (at least one condition must pass per attribute)
+        var anyConditions = conditionAttributes.Where(a => a.Logic == ConditionLogic.Any).ToArray();
+        foreach (var attr in anyConditions)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!await attr.EvaluateAsync(pipelineContext).ConfigureAwait(false))
+            {
+                return (false, SkipDecision.Skip($"RunIfAny<{attr.ConditionNames}> not satisfied"));
+            }
+        }
+
+        return (true, null);
+    }
+
+    private static async Task<(bool IsRunnable, SkipDecision? SkipDecision)> EvaluateLegacyConditions(
+        Type moduleType,
+        IPipelineHookContext pipelineContext,
+        CancellationToken cancellationToken)
+    {
+        var mandatoryRunConditionAttributes = moduleType.GetCustomAttributes<MandatoryRunConditionAttribute>(true).ToArray();
+        var runConditionAttributes = moduleType.GetCustomAttributes<RunConditionAttribute>(true).Except(mandatoryRunConditionAttributes).ToArray();
 
         // Evaluate mandatory conditions sequentially with short-circuit on first failure
         foreach (var attr in mandatoryRunConditionAttributes)

--- a/test/ModularPipelines.UnitTests/Execution/NewRunConditionAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/NewRunConditionAttributeTests.cs
@@ -1,0 +1,347 @@
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Attributes;
+using ModularPipelines.Conditions;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Extensions;
+using ModularPipelines.TestHelpers;
+using Status = ModularPipelines.Enums.Status;
+
+namespace ModularPipelines.UnitTests.Execution;
+
+/// <summary>
+/// Tests for the new run condition attributes: RunIfAll, RunIfAny, and SkipIf.
+/// </summary>
+public class NewRunConditionAttributeTests : TestBase
+{
+    #region Test Conditions
+
+    private class AlwaysTrue : IRunCondition
+    {
+        public Task<bool> EvaluateAsync(IPipelineHookContext context)
+            => Task.FromResult(true);
+    }
+
+    private class AlwaysFalse : IRunCondition
+    {
+        public Task<bool> EvaluateAsync(IPipelineHookContext context)
+            => Task.FromResult(false);
+    }
+
+    private class TrueConditionGroup : ConditionGroup
+    {
+        public override IRunCondition[] Conditions => [new AlwaysTrue()];
+        public override ConditionLogic Logic => ConditionLogic.Any;
+    }
+
+    private class FalseConditionGroup : ConditionGroup
+    {
+        public override IRunCondition[] Conditions => [new AlwaysFalse()];
+        public override ConditionLogic Logic => ConditionLogic.All;
+    }
+
+    #endregion
+
+    #region Test Modules
+
+    // No conditions - should run
+    private class NoConditionsModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // RunIfAll with single true condition - should run
+    [RunIfAll<AlwaysTrue>]
+    private class RunIfAllTrueModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // RunIfAll with single false condition - should skip
+    [RunIfAll<AlwaysFalse>]
+    private class RunIfAllFalseModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // RunIfAll with two conditions, one false - should skip
+    [RunIfAll<AlwaysTrue, AlwaysFalse>]
+    private class RunIfAllMixedModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // RunIfAny with single true condition - should run
+    [RunIfAny<AlwaysTrue>]
+    private class RunIfAnyTrueModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // RunIfAny with single false condition - should skip
+    [RunIfAny<AlwaysFalse>]
+    private class RunIfAnyFalseModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // RunIfAny with two conditions, one true - should run
+    [RunIfAny<AlwaysFalse, AlwaysTrue>]
+    private class RunIfAnyMixedModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // SkipIf with true condition - should skip
+    [SkipIf<AlwaysTrue>]
+    private class SkipIfTrueModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // SkipIf with false condition - should run
+    [SkipIf<AlwaysFalse>]
+    private class SkipIfFalseModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // Combined: RunIfAll + SkipIf - SkipIf should be evaluated first
+    [RunIfAll<AlwaysTrue>]
+    [SkipIf<AlwaysTrue>]
+    private class CombinedSkipAndRunModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // Multiple RunIfAll attributes - all must pass (AND between attributes)
+    [RunIfAll<AlwaysTrue>]
+    [RunIfAll<AlwaysTrue>]
+    private class MultipleRunIfAllTrueModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // Multiple RunIfAll attributes - one fails (AND between attributes)
+    [RunIfAll<AlwaysTrue>]
+    [RunIfAll<AlwaysFalse>]
+    private class MultipleRunIfAllMixedModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    // ConditionGroup test
+    [RunIfAny<TrueConditionGroup>]
+    private class ConditionGroupTrueModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    [RunIfAll<FalseConditionGroup>]
+    private class ConditionGroupFalseModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    #endregion
+
+    #region Tests
+
+    [Test]
+    public async Task NoConditions_ShouldRun()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<NoConditionsModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(NoConditionsModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task RunIfAll_SingleTrueCondition_ShouldRun()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<RunIfAllTrueModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(RunIfAllTrueModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task RunIfAll_SingleFalseCondition_ShouldSkip()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<RunIfAllFalseModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(RunIfAllFalseModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Skipped);
+    }
+
+    [Test]
+    public async Task RunIfAll_MixedConditions_ShouldSkip()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<RunIfAllMixedModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(RunIfAllMixedModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Skipped);
+    }
+
+    [Test]
+    public async Task RunIfAny_SingleTrueCondition_ShouldRun()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<RunIfAnyTrueModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(RunIfAnyTrueModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task RunIfAny_SingleFalseCondition_ShouldSkip()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<RunIfAnyFalseModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(RunIfAnyFalseModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Skipped);
+    }
+
+    [Test]
+    public async Task RunIfAny_MixedConditions_ShouldRun()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<RunIfAnyMixedModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(RunIfAnyMixedModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task SkipIf_TrueCondition_ShouldSkip()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<SkipIfTrueModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(SkipIfTrueModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Skipped);
+    }
+
+    [Test]
+    public async Task SkipIf_FalseCondition_ShouldRun()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<SkipIfFalseModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(SkipIfFalseModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task SkipIf_EvaluatedBeforeRunIfAll_ShouldSkip()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<CombinedSkipAndRunModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(CombinedSkipAndRunModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Skipped);
+    }
+
+    [Test]
+    public async Task MultipleRunIfAll_AllTrue_ShouldRun()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<MultipleRunIfAllTrueModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(MultipleRunIfAllTrueModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task MultipleRunIfAll_OneFails_ShouldSkip()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<MultipleRunIfAllMixedModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(MultipleRunIfAllMixedModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Skipped);
+    }
+
+    [Test]
+    public async Task ConditionGroup_TrueGroup_ShouldRun()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<ConditionGroupTrueModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(ConditionGroupTrueModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task ConditionGroup_FalseGroup_ShouldSkip()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<ConditionGroupFalseModule>()
+            .BuildHostAsync();
+
+        await host.ExecutePipelineAsync();
+
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+        var moduleResult = resultRegistry.GetResult(typeof(ConditionGroupFalseModule))!;
+        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Skipped);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

This PR redesigns the run condition system to address the confusing naming and limited flexibility in the current `RunConditionAttribute` and `MandatoryRunConditionAttribute` attributes.

### New API

**Attributes with explicit logic:**
- `[RunIfAll<T1, T2, ...>]` - Module runs if ALL conditions return true (AND logic)
- `[RunIfAny<T1, T2, ...>]` - Module runs if ANY condition returns true (OR logic)
- `[SkipIf<T>]` - Module is skipped if condition returns true (negation)

**Reusable condition building blocks:**
- `IRunCondition` - Core interface for condition classes
- `ConditionGroup` - Base class for grouping multiple conditions

**Built-in conditions:**
- Platform: `OnLinux`, `OnWindows`, `OnMacOS`, `OnUnix` (group)
- Environment: `IsCI`, `IsLocal`

### Example Usage

```csharp
// Run only on Linux and in CI
[RunIfAll<OnLinux, IsCI>]
public class LinuxCIModule : Module<None> { }

// Run on any Unix-like system
[RunIfAny<OnLinux, OnMacOS>]
public class UnixModule : Module<None> { }

// Skip when running locally
[SkipIf<IsLocal>]
public class CIOnlyModule : Module<None> { }

// Custom reusable condition group
public sealed class ProductionEnvironment : ConditionGroup
{
    public override IRunCondition[] Conditions => [new IsCI(), new IsMainBranch()];
    public override ConditionLogic Logic => ConditionLogic.All;
}

[RunIfAll<ProductionEnvironment>]
public class DeployModule : Module<None> { }
```

### Evaluation Order

1. `SkipIf` conditions are evaluated first (fail-fast skip)
2. `RunIfAll` conditions - all must pass
3. `RunIfAny` conditions - at least one must pass per attribute

### Backwards Compatibility

Legacy `RunConditionAttribute` and `MandatoryRunConditionAttribute` continue to work and are evaluated after the new attributes.

Closes #2012

## Test Plan

- [x] 14 unit tests added covering:
  - `RunIfAll` with single/multiple conditions
  - `RunIfAny` with single/multiple conditions  
  - `SkipIf` with true/false conditions
  - Combined attributes (SkipIf evaluated before RunIfAll)
  - Multiple attributes of same type (AND between attributes)
  - ConditionGroup evaluation

🤖 Generated with [Claude Code](https://claude.com/claude-code)