### PR TITLE
feat: surface errors/exceptions more cleanly

### DIFF
--- a/src/ModularPipelines/Models/PipelineSummary.cs
+++ b/src/ModularPipelines/Models/PipelineSummary.cs
@@ -133,6 +133,32 @@ public record PipelineSummary
         }).ProcessInParallel();
     }
 
+    /// <summary>
+    /// Gets the results of all failed modules.
+    /// Returns an empty list if no modules failed or if the result registry is not available.
+    /// </summary>
+    /// <returns>A list of failed module results with their exceptions.</returns>
+    public IReadOnlyList<IModuleResult> GetFailedModuleResults()
+    {
+        if (_resultRegistry == null)
+        {
+            return Array.Empty<IModuleResult>();
+        }
+
+        var failedResults = new List<IModuleResult>();
+
+        foreach (var module in Modules)
+        {
+            var result = _resultRegistry.GetResult(module.GetType());
+            if (result is { IsFailure: true })
+            {
+                failedResults.Add(result);
+            }
+        }
+
+        return failedResults;
+    }
+
     private Status GetStatus()
     {
         // Check if we have a result registry to get module statuses


### PR DESCRIPTION
## Summary

- Adds a **"Failed Modules"** section to the pipeline results output that displays exception details directly in the summary
- Shows exception type, message, and first 5 stack frames for each failed module
- Displays full exception chain including inner exceptions
- Only appears when pipeline status is `Failed`

**Before:** Users had to dig through module output to find exception details

**After:** Exception information is prominently displayed in the summary:
```
⚠ Failed Modules

  ✗ BuildModule
    HttpRequestException: Connection refused
      at BuildModule.ExecuteAsync() in BuildModule.cs:42
      at ModuleRunner.ExecuteCore() in ModuleRunner.cs:156
    
  ✗ TestModule  
    InvalidOperationException: Database not initialized
    ─── Inner Exception ───
    SqlException: Cannot open database "TestDb"
      at TestModule.ExecuteAsync() in TestModule.cs:28
```

## Changes
- `PipelineSummary.cs`: Added `GetFailedModuleResults()` method to retrieve failed module results
- `SpectreResultsPrinter.cs`: Added `PrintFailedModules()` method to render the new section

Closes #2059

## Test plan
- [ ] Build succeeds
- [ ] Existing unit tests pass
- [ ] Manual verification with a failing pipeline shows the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)