### PR TITLE
feat: Spectre.Console dependency tree visualization

### DIFF
--- a/src/ModularPipelines/ConsoleWriter.cs
+++ b/src/ModularPipelines/ConsoleWriter.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace ModularPipelines;
 
@@ -18,5 +19,10 @@ internal class ConsoleWriter : IConsoleWriter
             // (e.g., unbalanced or invalid markup characters)
             System.Console.WriteLine(value);
         }
+    }
+
+    public void Write(IRenderable renderable)
+    {
+        AnsiConsole.Write(renderable);
     }
 }

--- a/src/ModularPipelines/Engine/DependencyPrinter.cs
+++ b/src/ModularPipelines/Engine/DependencyPrinter.cs
@@ -1,28 +1,25 @@
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Interfaces;
 using ModularPipelines.Options;
+using Spectre.Console;
 
 namespace ModularPipelines.Engine;
 
 internal class DependencyPrinter : IDependencyPrinter
 {
     private readonly IDependencyChainProvider _dependencyChainProvider;
-    private readonly ILogger<DependencyPrinter> _logger;
     private readonly IConsoleWriter _consoleWriter;
     private readonly IBuildSystemFormatter _formatter;
     private readonly IOptions<PipelineOptions> _options;
     private readonly IDependencyTreeFormatter _treeFormatter;
 
     public DependencyPrinter(IDependencyChainProvider dependencyChainProvider,
-        ILogger<DependencyPrinter> logger,
         IConsoleWriter consoleWriter,
         IBuildSystemFormatterProvider formatterProvider,
         IOptions<PipelineOptions> options,
         IDependencyTreeFormatter treeFormatter)
     {
         _dependencyChainProvider = dependencyChainProvider;
-        _logger = logger;
         _consoleWriter = consoleWriter;
         _formatter = formatterProvider.GetFormatter();
         _options = options;
@@ -36,34 +33,31 @@ internal class DependencyPrinter : IDependencyPrinter
             return;
         }
 
-        var formattedTree = _treeFormatter.FormatTree(_dependencyChainProvider.ModuleDependencyModels);
-
-        Print(formattedTree);
-    }
-
-    private void Print(string value)
-    {
-        if (string.IsNullOrWhiteSpace(value))
+        var models = _dependencyChainProvider.ModuleDependencyModels;
+        if (!models.Any())
         {
             return;
         }
 
-        _logger.LogDebug("\n");
+        var tree = _treeFormatter.FormatTree(models);
 
-        var startCommand = _formatter.GetStartBlockCommand("Dependency Chains");
+        Print(tree);
+    }
+
+    private void Print(Tree tree)
+    {
+        var startCommand = _formatter.GetStartBlockCommand("Module Dependencies");
         if (startCommand != null)
         {
             _consoleWriter.LogToConsole(startCommand);
         }
 
-        _logger.LogDebug("The following dependency chains have been detected:\r\n{Chain}", value);
+        _consoleWriter.Write(tree);
 
-        var endCommand = _formatter.GetEndBlockCommand("Dependency Chains");
+        var endCommand = _formatter.GetEndBlockCommand("Module Dependencies");
         if (endCommand != null)
         {
             _consoleWriter.LogToConsole(endCommand);
         }
-
-        _logger.LogDebug("\n");
     }
 }

--- a/src/ModularPipelines/IConsoleWriter.cs
+++ b/src/ModularPipelines/IConsoleWriter.cs
@@ -1,4 +1,5 @@
 using ModularPipelines.Logging;
+using Spectre.Console.Rendering;
 
 namespace ModularPipelines;
 
@@ -30,4 +31,10 @@ public interface IConsoleWriter
     /// </summary>
     /// <param name="value">The value to write.</param>
     void LogToConsole(string value);
+
+    /// <summary>
+    /// Writes a Spectre.Console renderable to the console.
+    /// </summary>
+    /// <param name="renderable">The renderable object to write (Tree, Table, Panel, etc.).</param>
+    void Write(IRenderable renderable);
 }

--- a/test/ModularPipelines.UnitTests/Engine/DependencyTreeFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyTreeFormatterTests.cs
@@ -1,0 +1,219 @@
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using Spectre.Console;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+/// <summary>
+/// Tests for DependencyTreeFormatter Spectre.Console tree generation.
+/// </summary>
+public class DependencyTreeFormatterTests
+{
+    #region Test Modules
+
+    private class ModuleA : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult(true);
+    }
+
+    private class ModuleB : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult(true);
+    }
+
+    private class ModuleC : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult(true);
+    }
+
+    private class ModuleD : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult(true);
+    }
+
+    private class SharedModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult(true);
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static string RenderToString(Tree tree)
+    {
+        using var writer = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(writer),
+            Ansi = AnsiSupport.No, // Disable ANSI for easier text assertions
+        });
+        console.Write(tree);
+        return writer.ToString();
+    }
+
+    private static ModuleDependencyModel CreateModel<T>() where T : IModule, new()
+    {
+        return new ModuleDependencyModel(new T());
+    }
+
+    #endregion
+
+    [Test]
+    public async Task FormatTree_SingleModule_NoDependencies_ReturnsTreeWithSingleNode()
+    {
+        // Arrange
+        var formatter = new DependencyTreeFormatter();
+        var moduleA = CreateModel<ModuleA>();
+        var roots = new[] { moduleA };
+
+        // Act
+        var tree = formatter.FormatTree(roots);
+        var output = RenderToString(tree);
+
+        // Assert
+        await Assert.That(output).Contains("Module Dependencies");
+        await Assert.That(output).Contains("ModuleA");
+    }
+
+    [Test]
+    public async Task FormatTree_LinearChain_ReturnsTreeWithCorrectHierarchy()
+    {
+        // Arrange: A -> B -> C (A is root, B depends on A, C depends on B)
+        var formatter = new DependencyTreeFormatter();
+        var moduleA = CreateModel<ModuleA>();
+        var moduleB = CreateModel<ModuleB>();
+        var moduleC = CreateModel<ModuleC>();
+
+        // Set up dependency chain: A is dependency for B, B is dependency for C
+        moduleA.IsDependencyFor.Add(moduleB);
+        moduleB.IsDependencyFor.Add(moduleC);
+
+        var roots = new[] { moduleA };
+
+        // Act
+        var tree = formatter.FormatTree(roots);
+        var output = RenderToString(tree);
+
+        // Assert
+        await Assert.That(output).Contains("ModuleA");
+        await Assert.That(output).Contains("ModuleB");
+        await Assert.That(output).Contains("ModuleC");
+    }
+
+    [Test]
+    public async Task FormatTree_MultipleRoots_ReturnsTreeWithAllRoots()
+    {
+        // Arrange: Two independent modules
+        var formatter = new DependencyTreeFormatter();
+        var moduleA = CreateModel<ModuleA>();
+        var moduleB = CreateModel<ModuleB>();
+
+        var roots = new[] { moduleA, moduleB };
+
+        // Act
+        var tree = formatter.FormatTree(roots);
+        var output = RenderToString(tree);
+
+        // Assert
+        await Assert.That(output).Contains("ModuleA");
+        await Assert.That(output).Contains("ModuleB");
+    }
+
+    [Test]
+    public async Task FormatTree_SharedModule_MarkedAsReference_OnSecondOccurrence()
+    {
+        // Arrange: A -> Shared, B -> Shared (diamond pattern)
+        var formatter = new DependencyTreeFormatter();
+        var moduleA = CreateModel<ModuleA>();
+        var moduleB = CreateModel<ModuleB>();
+        var shared = CreateModel<SharedModule>();
+
+        moduleA.IsDependencyFor.Add(shared);
+        moduleB.IsDependencyFor.Add(shared);
+
+        var roots = new[] { moduleA, moduleB };
+
+        // Act
+        var tree = formatter.FormatTree(roots);
+        var output = RenderToString(tree);
+
+        // Assert
+        await Assert.That(output).Contains("SharedModule");
+        // Should have reference marker on second occurrence
+        await Assert.That(output).Contains("(↑)");
+    }
+
+    [Test]
+    public async Task FormatTree_DiamondDependency_ShowsReferenceMarkerForSharedLeaf()
+    {
+        // Arrange: A -> B -> D, A -> C -> D (diamond)
+        var formatter = new DependencyTreeFormatter();
+        var moduleA = CreateModel<ModuleA>();
+        var moduleB = CreateModel<ModuleB>();
+        var moduleC = CreateModel<ModuleC>();
+        var moduleD = CreateModel<ModuleD>();
+
+        moduleA.IsDependencyFor.Add(moduleB);
+        moduleA.IsDependencyFor.Add(moduleC);
+        moduleB.IsDependencyFor.Add(moduleD);
+        moduleC.IsDependencyFor.Add(moduleD);
+
+        var roots = new[] { moduleA };
+
+        // Act
+        var tree = formatter.FormatTree(roots);
+        var output = RenderToString(tree);
+
+        // Assert
+        await Assert.That(output).Contains("ModuleA");
+        await Assert.That(output).Contains("ModuleB");
+        await Assert.That(output).Contains("ModuleC");
+        await Assert.That(output).Contains("ModuleD");
+        // D appears twice, second should have reference marker
+        await Assert.That(output).Contains("(↑)");
+    }
+
+    [Test]
+    public async Task FormatTree_EmptyCollection_OnlyContainsHeader()
+    {
+        // Arrange
+        var formatter = new DependencyTreeFormatter();
+        var roots = Array.Empty<ModuleDependencyModel>();
+
+        // Act
+        var tree = formatter.FormatTree(roots);
+        var output = RenderToString(tree);
+
+        // Assert - should have header but no child nodes (no tree connectors)
+        await Assert.That(output).Contains("Module Dependencies");
+        await Assert.That(output).DoesNotContain("├");
+        await Assert.That(output).DoesNotContain("└");
+    }
+
+    [Test]
+    public async Task FormatTree_AlreadyPrintedRoot_SkipsIt()
+    {
+        // Arrange: Same module appearing as root twice shouldn't duplicate
+        var formatter = new DependencyTreeFormatter();
+        var moduleA = CreateModel<ModuleA>();
+
+        // Add same root twice
+        var roots = new[] { moduleA, moduleA };
+
+        // Act
+        var tree = formatter.FormatTree(roots);
+        var output = RenderToString(tree);
+
+        // Assert - should only appear once
+        var count = output.Split("ModuleA").Length - 1;
+        await Assert.That(count).IsEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces plain-text dependency chain output with Spectre.Console `Tree` widget
- Adds proper tree connectors (`├──`, `│`, `└──`) for better visual hierarchy
- Color-codes module names (blue for first occurrence, dimmed for references)
- Marks shared dependencies with `(↑)` reference marker for DAG support
- Output now visible by default (direct console write instead of DEBUG log level)
- Adds `Write(IRenderable)` method to `IConsoleWriter` interface

## Example Output

```
Module Dependencies
├── BuildModule
│   ├── CompileModule
│   │   └── TestModule
│   └── PackageModule
│       └── TestModule (↑)
└── DeployModule
    └── PackageModule (↑)
```

## Test plan

- [x] Added 7 unit tests covering:
  - Single module with no dependencies
  - Linear dependency chains
  - Multiple independent roots
  - Shared modules (diamond pattern)
  - Reference marker verification
  - Empty collection handling
  - Duplicate root handling
- [x] All existing tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)