### PR TITLE
fix(dotnet): emit --exclude-diagnostics per diagnostic ID

### DIFF
--- a/src/ModularPipelines.DotNet/Generated/Options/DotNetFormatOptions.cs
+++ b/src/ModularPipelines.DotNet/Generated/Options/DotNetFormatOptions.cs
@@ -30,7 +30,7 @@ public record DotNetFormatOptions : DotNetOptions
     public string? Exclude { get; set; }
 
     [CliOption("--exclude-diagnostics")]
-    public string? ExcludeDiagnostics { get; set; }
+    public string[]? ExcludeDiagnostics { get; set; }
 
     [CliOption("--include")]
     public string? Include { get; set; }

--- a/src/ModularPipelines.DotNet/Options/DotNetFormatOptions.Generated.cs
+++ b/src/ModularPipelines.DotNet/Options/DotNetFormatOptions.Generated.cs
@@ -19,10 +19,10 @@ namespace ModularPipelines.DotNet.Options;
 public record DotNetFormatOptions : DotNetOptions
 {
     /// <summary>
-    /// A space separated list of diagnostic ids to ignore when fixing code style or 3rd party issues.
+    /// A list of diagnostic ids to ignore when fixing code style or 3rd party issues.
     /// </summary>
     [CliOption("--exclude-diagnostics")]
-    public string? ExcludeDiagnostics { get; set; }
+    public string[]? ExcludeDiagnostics { get; set; }
 
     /// <summary>
     /// The severity of diagnostics to fix. Allowed values are info, warn, and error.

--- a/test/ModularPipelines.UnitTests/Attributes/DotNetFormatOptionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/DotNetFormatOptionsTests.cs
@@ -1,0 +1,33 @@
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Helpers.Internal;
+
+namespace ModularPipelines.UnitTests.Attributes;
+
+public class DotNetFormatOptionsTests
+{
+    private readonly CommandModelProvider _modelProvider = new();
+    private readonly CommandArgumentBuilder _argumentBuilder = new();
+
+    private List<string> BuildArguments(object optionsObject)
+    {
+        var model = _modelProvider.GetCommandModel(optionsObject.GetType());
+        return _argumentBuilder.BuildArguments(model, optionsObject);
+    }
+
+    [Test]
+    public async Task ExcludeDiagnostics_Passes_Each_Id_Separately()
+    {
+        var options = new DotNetFormatOptions
+        {
+            ExcludeDiagnostics = ["CS0246", "CS1503"],
+        };
+
+        var args = BuildArguments(options);
+
+        await Assert.That(args).IsEquivalentTo(new[]
+        {
+            "--exclude-diagnostics", "CS0246",
+            "--exclude-diagnostics", "CS1503",
+        });
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeOverrides/dotnet.json
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeOverrides/dotnet.json
@@ -173,6 +173,12 @@
         "reason": "Don't display startup banner"
       }
     },
+    "format": {
+      "--exclude-diagnostics": {
+        "type": "stringlist",
+        "reason": "Repeatable option: emit --exclude-diagnostics once per diagnostic ID"
+      }
+    },
     "nuget.push": {
       "--skip-duplicate": {
         "type": "bool",


### PR DESCRIPTION
## Summary
- Typed `DotNetFormatOptions.ExcludeDiagnostics` as `string[]?` so each ID renders as a separate `--exclude-diagnostics <id>` flag. The old `string?` value was quoted as one CLI arg, so `dotnet format` treated the whole value as a single (invalid) diagnostic ID.
- Added a `stringlist` override in `TypeOverrides/dotnet.json` so regeneration preserves the fix.
- Added a regression test verifying the array value produces repeated flags.

Fixes #2472

**Breaking:** callers now pass `string[]` (e.g. `["CS0246", "CS1503"]`) instead of a space-separated string.

## Test plan
- [x] `dotnet build` clean
- [x] New `DotNetFormatOptionsTests.ExcludeDiagnostics_Passes_Each_Id_Separately` passes
- [x] Existing `CliAttributeTests` (26 tests) still pass