### PR TITLE
chore: add release notes config with Breaking Changes section

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  categories:
+    - title: ⚠️ Breaking Changes
+      labels:
+        - breaking
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/release.yml` so GitHub's auto-generated release notes (triggered by `CreateReleaseModule` via Octokit `GenerateReleaseNotes=true`) put PRs labelled `breaking` under a dedicated **Breaking Changes** section.
- Everything else falls through to **Other Changes** via the `"*"` catch-all.

## Test plan
- [ ] Merge a PR with the `breaking` label and verify the next release's auto-generated notes show a **Breaking Changes** section.