### PR TITLE
fix: emit #nullable enable in generated service files

### DIFF
--- a/test/ModularPipelines.UnitTests/Hooks/DirectModuleHooksIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Hooks/DirectModuleHooksIntegrationTests.cs
@@ -12,6 +12,7 @@ namespace ModularPipelines.UnitTests.Hooks;
 /// <summary>
 /// Integration tests for Direct Module-Level Hooks that test full pipeline execution scenarios.
 /// </summary>
+[NotInParallel(nameof(DirectModuleHooksIntegrationTests))]
 public class DirectModuleHooksIntegrationTests : TestBase
 {
     #region Test Modules for Integration Tests

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
@@ -381,13 +381,13 @@ public class GeneratorUtilsTests
     }
 
     [Test]
-    public async Task GenerateFileHeaderWithNullable_DoesNot_Include_Nullable_Enable()
+    public async Task GenerateFileHeaderWithNullable_Includes_Nullable_Enable()
     {
         var sb = new StringBuilder();
 
         GeneratorUtils.GenerateFileHeaderWithNullable(sb);
 
-        await Assert.That(sb.ToString()).DoesNotContain("#nullable enable");
+        await Assert.That(sb.ToString()).Contains("#nullable enable");
     }
 
     #endregion

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -87,11 +87,13 @@ public static partial class GeneratorUtils
     }
 
     /// <summary>
-    /// Generates a standard auto-generated file header.
+    /// Generates a standard auto-generated file header and enables nullable reference types.
     /// </summary>
     public static void GenerateFileHeaderWithNullable(StringBuilder sb, string? sourceUrl = null)
     {
         GenerateFileHeader(sb, sourceUrl);
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
@@ -31,8 +31,7 @@ public class ServiceImplementationGenerator : ICodeGenerator
     {
         var sb = new StringBuilder();
 
-        // File header
-        GeneratorUtils.GenerateFileHeader(sb);
+        GeneratorUtils.GenerateFileHeaderWithNullable(sb);
 
         sb.AppendLine("using System.CodeDom.Compiler;");
         sb.AppendLine("using ModularPipelines.Context;");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceInterfaceGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceInterfaceGenerator.cs
@@ -30,8 +30,7 @@ public class ServiceInterfaceGenerator : ICodeGenerator
     {
         var sb = new StringBuilder();
 
-        // File header
-        GeneratorUtils.GenerateFileHeader(sb);
+        GeneratorUtils.GenerateFileHeaderWithNullable(sb);
 
         sb.AppendLine("using System.CodeDom.Compiler;");
         sb.AppendLine("using ModularPipelines.Models;");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
@@ -120,8 +120,7 @@ public class SubDomainClassGenerator : ICodeGenerator
     {
         var sb = new StringBuilder();
 
-        // File header
-        GeneratorUtils.GenerateFileHeader(sb);
+        GeneratorUtils.GenerateFileHeaderWithNullable(sb);
 
         sb.AppendLine("using System.CodeDom.Compiler;");
         sb.AppendLine("using ModularPipelines.Context;");


### PR DESCRIPTION
## Summary
- `GeneratorUtils.GenerateFileHeaderWithNullable` was a no-op wrapper — never emitted the `#nullable enable` directive, causing CS8669 warnings in consuming projects for any generated file that used `?` annotations.
- Actually append `#nullable enable` after the header.
- Switch `ServiceImplementationGenerator`, `ServiceInterfaceGenerator`, and `SubDomainClassGenerator` from `GenerateFileHeader` to the nullable-aware variant (their output contains nullable annotations).
- Flip the corresponding unit test from `DoesNotContain` to `Contains`.

Regenerating CLI options for each tool (separate PRs) will propagate the directive into the actual `.Generated.cs` files.

## Test plan
- [x] Generator unit tests: 309/309 pass locally
- [ ] CI build passes
- [ ] Spot-check a regenerated tool to confirm CS8669 no longer appears in downstream builds