### PR TITLE
docs: Added FSharp Example to Docs

### DIFF
--- a/docs/docs/examples/fsharp-interactive.md
+++ b/docs/docs/examples/fsharp-interactive.md
@@ -10,17 +10,22 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
 2. **Add ModularPipelines to your script:** You can add ModularPipelines as a package reference in your F# script. At the top of your `example.fsx`, add the following line:
 
     ```fsharp
+
     #r "nuget: ModularPipelines, 3.*"
+
     ```
 
     Alternatively, you can specify a specific version:
 
     ```fsharp
+
     #r "nuget: ModularPipelines, 3.2.8"
+
     ```
 3. **Write your F# code:** Below the package reference, you can write your F# code using ModularPipelines. Here’s a simple example that uses ModularPipelines to check the dotnet version:
 
     ```fsharp
+
     #r "nuget: ModularPipelines.DotNet, 3.*"
     open ModularPipelines.DotNet
     open ModularPipelines.Attributes
@@ -55,11 +60,14 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
     builder.Build().RunAsync()
     |> Async.AwaitTask
     |> Async.RunSynchronously   
+
     ``` 
 4. **Run your F# script:** You can run your F# script using the F# Interactive environment. If you are using Visual Studio, you can simply open the `example.fsx` file and execute it. Alternatively, you can run it from the command line using:
 
     ```powershell
+
     dotnet fsi example.fsx
+    
     ```
 ## Additional Notes
 

--- a/docs/docs/examples/fsharp-interactive.md
+++ b/docs/docs/examples/fsharp-interactive.md
@@ -1,0 +1,63 @@
+---
+title: F# Interactive Example
+---
+
+F# Interactive (FSI) is a powerful tool for executing F# code snippets and scripts in an interactive environment. It allows you to quickly test and iterate on your F# code without needing to create a full project structure.
+
+## Using F# Interactive with ModularPipelines
+
+1. **Create a new F# script file:** Create a new file named `example.fsx` (or any name with `.fsx` extension).
+2. **Add ModularPipelines to your script:** You can add ModularPipelines as a package reference in your F# script. At the top of your `example.fsx`, add the following line:
+
+    ```fsharp
+    #r "nuget: ModularPipelines, 3.*"
+    ```
+
+    Alternatively, you can specify a specific version:
+
+    ```fsharp
+    #r "nuget: ModularPipelines, 3.2.8"
+    ```
+3. **Write your F# code:** Below the package reference, you can write your F# code using ModularPipelines. Here’s a simple example that uses ModularPipelines to check the dotnet version:
+
+    ```fsharp
+    #r "nuget: ModularPipelines.DotNet, 3.*"
+    open ModularPipelines.DotNet
+    open ModularPipelines.Attributes
+    open ModularPipelines.Context
+    open ModularPipelines.DotNet.Extensions
+    open ModularPipelines.Extensions
+    open ModularPipelines.Models
+    open ModularPipelines.Modules
+    open ModularPipelines
+    open System.Threading
+
+    type UpdateDotnetWorkloads() =
+        inherit Module<CommandResult>()
+        override this.ExecuteAsync (context: IModuleContext, cancellationToken: CancellationToken): Tasks.Task<CommandResult> = 
+                context.DotNet().Workload.Update(cancellationToken = cancellationToken)
+
+    /// Generic attributes are not supported in fsharp, so have to use the old way of declaring dependencies
+    [<DependsOn(typeof<UpdateDotnetWorkloads>)>]
+    type CheckDotnetSdkModule () =
+        inherit Module<CommandResult>()
+        override this.ExecuteAsync (context: IModuleContext, cancellationToken: CancellationToken): Tasks.Task<CommandResult> = 
+                context.DotNet().Sdk.Check(cancellationToken = cancellationToken);
+
+    let args = System.Environment.GetCommandLineArgs()
+    let builder = Pipeline.CreateBuilder(args)
+
+    builder.Services
+        .RegisterDotNetContext()
+        .AddModule<UpdateDotnetWorkloads>()
+        .AddModule<CheckDotnetSdkModule>()
+
+    builder.Build().RunAsync()
+    |> Async.AwaitTask
+    |> Async.RunSynchronously   
+    ``` 
+4. **Run your F# script:** You can run your F# script using the F# Interactive environment. If you are using Visual Studio, you can simply open the `example.fsx` file and execute it. Alternatively, you can run it from the command line using:
+
+    ```powershell
+    dotnet fsi example.fsx
+    ```       

--- a/docs/docs/examples/fsharp-interactive.md
+++ b/docs/docs/examples/fsharp-interactive.md
@@ -60,4 +60,9 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
 
     ```powershell
     dotnet fsi example.fsx
-    ```       
+    ```
+## Additional Notes
+
+- Fsharp Interactive does allow you to have modules and types across different files, for simplicity we have only 1 file in this example.
+- The fsharp compiler does not support generic attributes
+- The fsharp compiler requires code and files to be declared in order, due to the fsharp compiler being sequential. For example, if you have a module that depends on another module, the module it depends on must be declared first.

--- a/docs/docs/examples/fsharp-interactive.md
+++ b/docs/docs/examples/fsharp-interactive.md
@@ -10,22 +10,17 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
 2. **Add ModularPipelines to your script:** You can add ModularPipelines as a package reference in your F# script. At the top of your `example.fsx`, add the following line:
 
     ```fsharp
-
     #r "nuget: ModularPipelines, 3.*"
-
     ```
 
     Alternatively, you can specify a specific version:
 
     ```fsharp
-
     #r "nuget: ModularPipelines, 3.2.8"
-
     ```
 3. **Write your F# code:** Below the package reference, you can write your F# code using ModularPipelines. Here’s a simple example that uses ModularPipelines to check the dotnet version:
 
     ```fsharp
-
     #r "nuget: ModularPipelines.DotNet, 3.*"
     open ModularPipelines.DotNet
     open ModularPipelines.Attributes
@@ -60,14 +55,11 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
     builder.Build().RunAsync()
     |> Async.AwaitTask
     |> Async.RunSynchronously   
-
     ``` 
 4. **Run your F# script:** You can run your F# script using the F# Interactive environment. If you are using Visual Studio, you can simply open the `example.fsx` file and execute it. Alternatively, you can run it from the command line using:
 
     ```powershell
-
     dotnet fsi example.fsx
-    
     ```
 ## Additional Notes
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -112,7 +112,7 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} Tom Longhurst. Built with Docusaurus.`,
     },
     prism: {
-      additionalLanguages: ['csharp', 'powershell'],
+      additionalLanguages: ['csharp', 'powershell', 'fsharp'],
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
     },


### PR DESCRIPTION
This pull request adds comprehensive support for F# in the documentation. It introduces a new example guide for using F# Interactive with ModularPipelines and enhances syntax highlighting for F# code snippets.

**Documentation improvements:**

* Added a new file, `fsharp-interactive.md`, that provides a step-by-step example of using ModularPipelines with F# Interactive, including code samples and important notes about F# scripting.

**Syntax highlighting enhancements:**

* Updated the Docusaurus configuration in `docusaurus.config.ts` to enable syntax highlighting for F# code blocks by adding `'fsharp'` to the list of additional Prism languages.