### PR TITLE
Replace abandoned Spectre logger with MEL.Spectre

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,7 @@
     <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
     <PackageVersion Include="Slack.Webhooks" Version="1.1.6" />
     <PackageVersion Include="Sourcy.DotNet" Version="1.1.1" />
-    <PackageVersion Include="Spectre.Console" Version="0.54.0" />
+    <PackageVersion Include="Spectre.Console" Version="0.57.2" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
     <PackageVersion Include="StackExchange.Redis" Version="2.11.3" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
@@ -86,7 +86,7 @@
     <PackageVersion Include="TUnit" Version="1.61.23" />
     <PackageVersion Include="TUnit.Assertions" Version="1.61.23" />
     <PackageVersion Include="TUnit.Core" Version="1.61.23" />
-    <PackageVersion Include="vertical-spectreconsolelogger" Version="0.10.1-dev.20241201.35" />
+    <PackageVersion Include="MEL.Spectre" Version="0.5.0" />
     <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="AngleSharp" Version="1.5.2" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />

--- a/src/ModularPipelines/Console/DelegatingAnsiConsole.cs
+++ b/src/ModularPipelines/Console/DelegatingAnsiConsole.cs
@@ -30,5 +30,7 @@ internal sealed class DelegatingAnsiConsole : IAnsiConsole
 
     public void Clear(bool home) => Console.Clear(home);
 
+    public void WriteAnsi(Action<AnsiWriter> action) => Console.WriteAnsi(action);
+
     public void Write(IRenderable renderable) => Console.Write(renderable);
 }

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -1,4 +1,5 @@
 using Initialization.Microsoft.Extensions.DependencyInjection.Extensions;
+using MEL.Spectre;
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -36,8 +37,7 @@ using ModularPipelines.Distributed.Artifacts;
 using ModularPipelines.Distributed.Configuration;
 using ModularPipelines.Distributed.Coordination;
 using ModularPipelines.Distributed.Serialization;
-using Vertical.SpectreLogger;
-using Vertical.SpectreLogger.Options;
+using Spectre.Console;
 
 namespace ModularPipelines.DependencyInjection;
 
@@ -82,59 +82,27 @@ internal static class DependencyInjectionSetup
                 builder.AddFilter("Microsoft", LogLevel.Warning)
                     .AddFilter("System", LogLevel.Warning);
 
-                builder.AddSpectreConsole(config =>
-                {
-                    // Use delegating console that forwards to current AnsiConsole.Console
-                    // This allows ConsoleCoordinator to replace the console instance later
-                    // while SpectreLogger continues to use the correct one
-                    // Note: Console width is configured by ConsoleCoordinator.ConfigureConsoleWidth()
-                    config.UseConsole(DelegatingAnsiConsole.Instance);
-
-                    // Configure output templates without timestamps
-                    // Command logging already includes precise timestamps ([HH:mm:ss.fff])
-                    // so we don't need them from the logger as well
-                    config.ConfigureProfile(LogLevel.Trace, profile =>
-                    {
-                        profile.OutputTemplate = "[grey][[Trace]][/] {Message}{NewLine}{Exception}";
-                    });
-                    config.ConfigureProfile(LogLevel.Debug, profile =>
-                    {
-                        profile.OutputTemplate = "[grey][[Debug]][/] {Message}{NewLine}{Exception}";
-                    });
-                    config.ConfigureProfile(LogLevel.Information, profile =>
-                    {
-                        profile.OutputTemplate = "[deepskyblue1][[Info]][/] {Message}{NewLine}{Exception}";
-                    });
-                    config.ConfigureProfile(LogLevel.Warning, profile =>
-                    {
-                        profile.OutputTemplate = "[yellow][[Warn]][/] {Message}{NewLine}{Exception}";
-                    });
-                    config.ConfigureProfile(LogLevel.Error, profile =>
-                    {
-                        profile.OutputTemplate = "[red][[Error]][/] {Message}{NewLine}{Exception}";
-                    });
-                    config.ConfigureProfile(LogLevel.Critical, profile =>
-                    {
-                        profile.OutputTemplate = "[white on red][[Critical]][/] {Message}{NewLine}{Exception}";
-                    });
-
-                    config.ConfigureProfiles(profile =>
-                    {
-                        // Enable Spectre.Console markup rendering in log messages
-                        profile.PreserveMarkupInFormatStrings = true;
-
-                        profile.ConfigureOptions<Vertical.SpectreLogger.Rendering.ExceptionRenderer.Options>(options =>
-                        {
-                            options.MaxStackFrames = int.MaxValue;
-                        });
-                    });
-                });
+                builder.AddSpectreConsole(ConfigureSpectreConsoleLogger);
             })
             .AddHttpClient()
             .AddLoggingHttpClients()
             .AddInitializers()
             .AddServiceCollection()
             .AddMediator();
+    }
+
+    internal static void ConfigureSpectreConsoleLogger(SpectreConsoleLoggerOptions config) =>
+        ConfigureSpectreConsoleLogger(config, DelegatingAnsiConsole.Instance);
+
+    internal static void ConfigureSpectreConsoleLogger(
+        SpectreConsoleLoggerOptions config,
+        IAnsiConsole console)
+    {
+        // Console width and CI capabilities are configured by ConsoleCoordinator.
+        config.Console = console;
+        config.Template = "[{Level:u4}] {Message}{NewLine}{Exception}";
+        config.ExceptionFormats = ExceptionFormats.Default;
+        config.AllowMarkupInMessageTemplate = true;
     }
 
     /// <summary>

--- a/src/ModularPipelines/ModularPipelines.csproj
+++ b/src/ModularPipelines/ModularPipelines.csproj
@@ -78,7 +78,7 @@
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="EnumerableAsyncProcessor" />
     <PackageReference Include="Initialization.Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="vertical-spectreconsolelogger" />
+    <PackageReference Include="MEL.Spectre" />
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -18,7 +18,6 @@ using ModularPipelines.Exceptions;
 using ModularPipelines.Options;
 using ModularPipelines.Plugins;
 using ModularPipelines.Validation;
-using Vertical.SpectreLogger.Options;
 
 namespace ModularPipelines;
 
@@ -97,7 +96,6 @@ public sealed class PipelineBuilder
     /// <returns>The same builder instance for chaining.</returns>
     public PipelineBuilder SetLogLevel(LogLevel logLevel)
     {
-        _services.Configure<SpectreLoggerOptions>(options => options.MinimumLogLevel = logLevel);
         _services.Configure<LoggerFilterOptions>(options => options.MinLevel = logLevel);
         return this;
     }

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -6,7 +6,6 @@ using ModularPipelines.Context;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 using NReco.Logging.File;
-using Vertical.SpectreLogger.Options;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace ModularPipelines.UnitTests.Commands;
@@ -20,7 +19,6 @@ public class CommandLoggerTests : TestBase
         var file = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".txt");
         var result = await GetService<ICommand>((_, collection) =>
         {
-            collection.Configure<SpectreLoggerOptions>(options => options.MinimumLogLevel = LogLevel.Information);
             collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
             collection.AddLogging(builder => builder.AddFile(file));
         });
@@ -105,7 +103,6 @@ public class CommandLoggerTests : TestBase
 
         var result = await GetService<ICommand>((_, collection) =>
         {
-            collection.Configure<SpectreLoggerOptions>(options => options.MinimumLogLevel = LogLevel.Information);
             collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
             collection.AddLogging(builder => { builder.AddFile(file); });
         });
@@ -231,7 +228,6 @@ public class CommandLoggerTests : TestBase
 
         var result = await GetService<ICommand>((_, collection) =>
         {
-            collection.Configure<SpectreLoggerOptions>(options => options.MinimumLogLevel = LogLevel.Information);
             collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
             collection.AddLogging(builder => { builder.AddFile(file); });
         });

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -4,7 +4,6 @@ using ModularPipelines.Http;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 using NReco.Logging.File;
-using Vertical.SpectreLogger.Options;
 using File = System.IO.File;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
@@ -31,7 +30,6 @@ public class HttpTests : TestBase
         {
             collection.AddLogging(builder =>
             {
-                collection.Configure<SpectreLoggerOptions>(options => options.MinimumLogLevel = LogLevel.Information);
                 collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
                 builder.AddFile(file);
             });
@@ -61,7 +59,6 @@ public class HttpTests : TestBase
         {
             collection.AddLogging(builder =>
             {
-                collection.Configure<SpectreLoggerOptions>(options => options.MinimumLogLevel = LogLevel.Information);
                 collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
                 builder.AddFile(file);
             });
@@ -93,7 +90,6 @@ public class HttpTests : TestBase
         {
             collection.AddLogging(builder =>
             {
-                collection.Configure<SpectreLoggerOptions>(options => options.MinimumLogLevel = LogLevel.Information);
                 collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
                 builder.AddFile(file);
             });

--- a/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
@@ -1,0 +1,63 @@
+using MEL.Spectre;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModularPipelines.DependencyInjection;
+using Spectre.Console;
+
+namespace ModularPipelines.UnitTests.Logging;
+
+public class SpectreConsoleLoggerTests
+{
+    [Test]
+    public async Task Renders_Markup_Level_And_Exception_Details()
+    {
+        var writer = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.Standard,
+            Interactive = InteractionSupport.No,
+            Out = new AnsiConsoleOutput(writer),
+        });
+
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(LogLevel.Trace);
+            builder.AddSpectreConsole(options =>
+            {
+                DependencyInjectionSetup.ConfigureSpectreConsoleLogger(options, console);
+                options.CiMode = CiMode.Off;
+                options.WriteMode = WriteMode.Synchronous;
+            });
+        });
+
+        await using var provider = services.BuildServiceProvider();
+        var logger = provider.GetRequiredService<ILogger<SpectreConsoleLoggerTests>>();
+        var exception = CaptureException();
+
+        logger.LogError(exception, "Failure in [bold]pipeline[/]");
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("FAIL");
+        await Assert.That(output).Contains("Failure in");
+        await Assert.That(output).Contains("pipeline");
+        await Assert.That(output).Contains(nameof(InvalidOperationException));
+        await Assert.That(output).Contains("logger failure");
+        await Assert.That(output).Contains(nameof(CaptureException));
+        await Assert.That(output).Contains("\u001b[");
+        await Assert.That(output).DoesNotContain("[bold]");
+    }
+
+    private static Exception CaptureException()
+    {
+        try
+        {
+            throw new InvalidOperationException("logger failure");
+        }
+        catch (Exception exception)
+        {
+            return exception;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- replace abandoned vertical-spectreconsolelogger with MEL.Spectre 0.5.0
- update Spectre.Console from 0.54.0 to 0.57.2
- preserve markup rendering, colored level styling, exception details, and full stack traces
- keep LoggerFilterOptions as the single minimum-level source

## Validation

- full solution Release build
- CommandLoggerTests: 38 passed
- HttpTests: 5 passed
- SpectreConsoleLoggerTests: 1 passed
- resolved graph contains MEL.Spectre 0.5.0 and Spectre.Console 0.57.2; no Vertical.SpectreLogger

Closes #2620