### PR TITLE
fix(plugins): eliminate PluginRegistry race causing flaky CI tests

### DIFF
--- a/src/ModularPipelines/Plugins/PluginRegistry.cs
+++ b/src/ModularPipelines/Plugins/PluginRegistry.cs
@@ -6,13 +6,22 @@ namespace ModularPipelines.Plugins;
 /// </summary>
 public static class PluginRegistry
 {
+    private static readonly object Lock = new();
     private static readonly List<IModularPipelinesPlugin> Registered = [];
 
     /// <summary>
     /// Gets all registered plugins, ordered by priority (ascending).
     /// </summary>
-    public static IReadOnlyList<IModularPipelinesPlugin> Plugins =>
-        Registered.OrderBy(p => p.Priority).ToList();
+    public static IReadOnlyList<IModularPipelinesPlugin> Plugins
+    {
+        get
+        {
+            lock (Lock)
+            {
+                return Registered.OrderBy(p => p.Priority).ToList();
+            }
+        }
+    }
 
     /// <summary>
     /// Registers a plugin. Call this from a [ModuleInitializer] method.
@@ -23,16 +32,25 @@ public static class PluginRegistry
     {
         ArgumentNullException.ThrowIfNull(plugin);
 
-        if (Registered.Any(p => p.Name == plugin.Name))
+        lock (Lock)
         {
-            throw new InvalidOperationException($"Plugin '{plugin.Name}' is already registered.");
-        }
+            if (Registered.Any(p => p.Name == plugin.Name))
+            {
+                throw new InvalidOperationException($"Plugin '{plugin.Name}' is already registered.");
+            }
 
-        Registered.Add(plugin);
+            Registered.Add(plugin);
+        }
     }
 
     /// <summary>
     /// Clears all registered plugins. For testing purposes only.
     /// </summary>
-    internal static void Clear() => Registered.Clear();
+    internal static void Clear()
+    {
+        lock (Lock)
+        {
+            Registered.Clear();
+        }
+    }
 }

--- a/test/ModularPipelines.UnitTests/Plugins/PluginIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Plugins/PluginIntegrationTests.cs
@@ -4,7 +4,7 @@ using ModularPipelines.Plugins;
 
 namespace ModularPipelines.UnitTests.Plugins;
 
-[TUnit.Core.NotInParallel(nameof(PluginIntegrationTests))]
+[TUnit.Core.NotInParallel("PluginRegistry")]
 public class PluginIntegrationTests
 {
     [Test]

--- a/test/ModularPipelines.UnitTests/Plugins/PluginRegistryTests.cs
+++ b/test/ModularPipelines.UnitTests/Plugins/PluginRegistryTests.cs
@@ -3,7 +3,7 @@ using ModularPipelines.Plugins;
 
 namespace ModularPipelines.UnitTests.Plugins;
 
-[TUnit.Core.NotInParallel(nameof(PluginRegistryTests))]
+[TUnit.Core.NotInParallel("PluginRegistry")]
 public class PluginRegistryTests
 {
     [Test]


### PR DESCRIPTION
## Summary

Fixes the intermittent `pipeline (ubuntu-latest)` failures seen across recent PRs (#2970, #2959, and one run on the #3016 branch), where these two tests randomly failed:

- `PluginRegistryTests.Register_DuplicateName_ThrowsInvalidOperationException` — "Expected to throw InvalidOperationException but no exception was thrown"
- `PluginIntegrationTests.Plugins_CanRegisterServices` — "Destination array was not long enough" from `List.CopyTo` inside `PluginRegistry.get_Plugins()`

## Root cause

`PluginRegistry` is static shared state with no synchronization. The two test classes used **different** `NotInParallel` keys (`nameof(PluginRegistryTests)` vs `nameof(PluginIntegrationTests)`), so TUnit ran them concurrently — both clearing/registering the same static list via `PluginTestHelper.IsolatedRegistry()`:

- A parallel `Clear()` between `Register(plugin1)` and `Register(plugin2)` removed the first plugin, so the duplicate check passed and no exception was thrown.
- The backing `List` was mutated while `Plugins` enumerated it (`OrderBy().ToList()`), producing the `CopyTo` destination-array error.

## Fix

- Both test classes now share the same `[NotInParallel("PluginRegistry")]` key, serializing all tests that mutate the static registry.
- All `PluginRegistry` members (`Plugins`, `Register`, `Clear`) are now guarded by a lock, so real-world concurrent registration (e.g. `[ModuleInitializer]` during parallel assembly load) is also safe.

## Testing

- All 24 tests in `ModularPipelines.UnitTests.Plugins` pass locally (net10.0, Release).