### PR TITLE
Hide CliWrap implementation types from consumers

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -99,12 +99,7 @@ internal sealed class Command : ICommand, ICommandContext
 
         if (execOpts.CommandLineCredentials != null)
         {
-            var credentials = execOpts.CommandLineCredentials;
-            command = command.WithCredentials(new Credentials(
-                credentials.Domain,
-                credentials.UserName,
-                credentials.Password,
-                credentials.LoadUserProfile));
+            command = command.WithCredentials(execOpts.CommandLineCredentials.ToCliWrapCredentials());
         }
 
         if (execOpts.InternalDryRun)

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -97,6 +97,16 @@ internal sealed class Command : ICommand, ICommandContext
             command = command.WithEnvironmentVariables(new ReadOnlyDictionary<string, string?>(execOpts.EnvironmentVariables));
         }
 
+        if (execOpts.CommandLineCredentials != null)
+        {
+            var credentials = execOpts.CommandLineCredentials;
+            command = command.WithCredentials(new Credentials(
+                credentials.Domain,
+                credentials.UserName,
+                credentials.Password,
+                credentials.LoadUserProfile));
+        }
+
         if (execOpts.InternalDryRun)
         {
             _commandLogger.Log(

--- a/src/ModularPipelines/Context/CommandLineCredentialsMapper.cs
+++ b/src/ModularPipelines/Context/CommandLineCredentialsMapper.cs
@@ -1,0 +1,16 @@
+using CliWrap;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Context;
+
+internal static class CommandLineCredentialsMapper
+{
+    internal static Credentials ToCliWrapCredentials(this CommandLineCredentials credentials)
+    {
+        return new Credentials(
+            credentials.Domain,
+            credentials.UserName,
+            credentials.Password,
+            credentials.LoadUserProfile);
+    }
+}

--- a/src/ModularPipelines/Context/CommandLineExecutor.cs
+++ b/src/ModularPipelines/Context/CommandLineExecutor.cs
@@ -37,6 +37,16 @@ internal sealed class CommandLineExecutor : ICommandLineExecutor
             environmentVariables = new ReadOnlyDictionary<string, string?>(options.EnvironmentVariables);
         }
 
+        if (options?.CommandLineCredentials is not null)
+        {
+            var credentials = options.CommandLineCredentials;
+            command = command.WithCredentials(new Credentials(
+                credentials.Domain,
+                credentials.UserName,
+                credentials.Password,
+                credentials.LoadUserProfile));
+        }
+
         var timeout = options?.ExecutionTimeout ?? TimeSpan.FromMinutes(30);
         using var timeoutCts = new CancellationTokenSource(timeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);

--- a/src/ModularPipelines/Context/CommandLineExecutor.cs
+++ b/src/ModularPipelines/Context/CommandLineExecutor.cs
@@ -39,12 +39,7 @@ internal sealed class CommandLineExecutor : ICommandLineExecutor
 
         if (options?.CommandLineCredentials is not null)
         {
-            var credentials = options.CommandLineCredentials;
-            command = command.WithCredentials(new Credentials(
-                credentials.Domain,
-                credentials.UserName,
-                credentials.Password,
-                credentials.LoadUserProfile));
+            command = command.WithCredentials(options.CommandLineCredentials.ToCliWrapCredentials());
         }
 
         var timeout = options?.ExecutionTimeout ?? TimeSpan.FromMinutes(30);

--- a/src/ModularPipelines/ModularPipelines.csproj
+++ b/src/ModularPipelines/ModularPipelines.csproj
@@ -67,7 +67,9 @@
     <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CliWrap" />
+    <PackageReference Include="CliWrap">
+      <PrivateAssets>compile;contentfiles;build;analyzers</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Polly" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="System.Text.Json" />

--- a/src/ModularPipelines/Options/CommandExecutionOptions.cs
+++ b/src/ModularPipelines/Options/CommandExecutionOptions.cs
@@ -1,5 +1,3 @@
-using CliWrap;
-
 namespace ModularPipelines.Options;
 
 /// <summary>
@@ -17,8 +15,10 @@ public record CommandExecutionOptions
     /// </summary>
     public string? WorkingDirectory { get; init; }
 
-    /// <inheritdoc cref="CommandLineCredentials"/>
-    public Credentials? CommandLineCredentials { get; init; }
+    /// <summary>
+    /// Gets the credentials used to start the command-line process.
+    /// </summary>
+    public CommandLineCredentials? CommandLineCredentials { get; init; }
 
     /// <summary>
     /// Gets or sets logging options for command execution.

--- a/src/ModularPipelines/Options/CommandLineCredentials.cs
+++ b/src/ModularPipelines/Options/CommandLineCredentials.cs
@@ -1,0 +1,27 @@
+namespace ModularPipelines.Options;
+
+/// <summary>
+/// Credentials used when starting a command-line process.
+/// </summary>
+public sealed record CommandLineCredentials
+{
+    /// <summary>
+    /// Gets the domain associated with the user account.
+    /// </summary>
+    public string? Domain { get; init; }
+
+    /// <summary>
+    /// Gets the user name used to start the process.
+    /// </summary>
+    public string? UserName { get; init; }
+
+    /// <summary>
+    /// Gets the password associated with the user account.
+    /// </summary>
+    public string? Password { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the user's profile should be loaded.
+    /// </summary>
+    public bool LoadUserProfile { get; init; }
+}

--- a/test/ModularPipelines.UnitTests/Api/CommandLineCredentialsApiTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/CommandLineCredentialsApiTests.cs
@@ -1,0 +1,16 @@
+using ModularPipelines.Options;
+
+namespace ModularPipelines.UnitTests.Api;
+
+public class CommandLineCredentialsApiTests
+{
+    [Test]
+    public async Task CommandExecutionOptions_ExposeFrameworkOwnedCredentials()
+    {
+        var property = typeof(CommandExecutionOptions).GetProperty(nameof(CommandExecutionOptions.CommandLineCredentials));
+
+        await Assert.That(property).IsNotNull();
+        await Assert.That(property!.PropertyType).IsEqualTo(typeof(CommandLineCredentials));
+        await Assert.That(property.PropertyType.Assembly).IsEqualTo(typeof(CommandExecutionOptions).Assembly);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Context/CommandLineCredentialsMapperTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineCredentialsMapperTests.cs
@@ -1,0 +1,26 @@
+using ModularPipelines.Context;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.UnitTests.Context;
+
+public class CommandLineCredentialsMapperTests
+{
+    [Test]
+    public async Task ToCliWrapCredentials_MapsEveryProperty()
+    {
+        var credentials = new CommandLineCredentials
+        {
+            Domain = "domain",
+            UserName = "user",
+            Password = "password",
+            LoadUserProfile = true
+        };
+
+        var result = credentials.ToCliWrapCredentials();
+
+        await Assert.That(result.Domain).IsEqualTo(credentials.Domain);
+        await Assert.That(result.UserName).IsEqualTo(credentials.UserName);
+        await Assert.That(result.Password).IsEqualTo(credentials.Password);
+        await Assert.That(result.LoadUserProfile).IsEqualTo(credentials.LoadUserProfile);
+    }
+}

--- a/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
+++ b/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
@@ -8,6 +8,7 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="CliWrap" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />


### PR DESCRIPTION
## What changed

- Added framework-owned `CommandLineCredentials` API.
- Mapped credentials to CliWrap inside both command execution paths.
- Marked CliWrap compile assets private while retaining its runtime dependency.
- Added API coverage proving `CommandExecutionOptions` exposes only the framework-owned credentials type.

## Why

CliWrap was exposed transitively to package consumers, causing `CliWrap.CommandResult` to appear alongside `ModularPipelines.Models.CommandResult` in IntelliSense. The core package still needs CliWrap at runtime, so removing the dependency or setting all assets private would break execution. Excluding only compile assets hides implementation types while preserving runtime behavior.

## Impact

`CommandExecutionOptions.CommandLineCredentials` now accepts `ModularPipelines.Options.CommandLineCredentials` instead of `CliWrap.Credentials`. Existing assignments must migrate to the framework-owned type.

## Validation

- Focused TUnit API test: 1 passed.
- Release build: succeeded with 0 errors (existing warnings remain).
- Packed `.nuspec`: CliWrap dependency has `exclude="Compile,Build,Analyzers"`.
- Full unit project run exceeded the 5-minute local timeout without producing a result.

Closes #2441