### PR TITLE
Honor WaitForAllModules after failures

### DIFF
--- a/src/ModularPipelines/Engine/EngineCancellationToken.cs
+++ b/src/ModularPipelines/Engine/EngineCancellationToken.cs
@@ -68,11 +68,16 @@ internal class EngineCancellationToken : IDisposable
 
     public void CancelWithException(Exception exception, string? reason = null)
     {
-        _primaryExceptionContainer.SetException(exception);
+        RecordException(exception);
 
         Reason = reason ?? exception.Message;
         _isCancelled = true;
         Cancel();
+    }
+
+    public void RecordException(Exception exception)
+    {
+        _primaryExceptionContainer.SetException(exception);
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/Executors/PipelineExecutor.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineExecutor.cs
@@ -1,8 +1,11 @@
 using System.Diagnostics;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModularPipelines.Enums;
 using ModularPipelines.Helpers;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 
 namespace ModularPipelines.Engine.Executors;
 
@@ -16,6 +19,7 @@ internal class PipelineExecutor : IPipelineExecutor
     private readonly IModuleResultRegistry _resultRegistry;
     private readonly IMetricsCollector _metricsCollector;
     private readonly IParallelLimitProvider _parallelLimitProvider;
+    private readonly IOptions<PipelineOptions> _options;
 
     public PipelineExecutor(
         IPipelineSetupExecutor pipelineSetupExecutor,
@@ -25,7 +29,8 @@ internal class PipelineExecutor : IPipelineExecutor
         ISecondaryExceptionContainer secondaryExceptionContainer,
         IModuleResultRegistry resultRegistry,
         IMetricsCollector metricsCollector,
-        IParallelLimitProvider parallelLimitProvider)
+        IParallelLimitProvider parallelLimitProvider,
+        IOptions<PipelineOptions> options)
     {
         _pipelineSetupExecutor = pipelineSetupExecutor;
         _moduleExecutor = moduleExecutor;
@@ -35,6 +40,7 @@ internal class PipelineExecutor : IPipelineExecutor
         _resultRegistry = resultRegistry;
         _metricsCollector = metricsCollector;
         _parallelLimitProvider = parallelLimitProvider;
+        _options = options;
     }
 
     public async Task<PipelineSummary> ExecuteAsync(List<IModule> runnableModules,
@@ -58,8 +64,13 @@ internal class PipelineExecutor : IPipelineExecutor
             await _pipelineSetupExecutor.OnPipelineEndAsync(pipelineSummary).ConfigureAwait(false);
         }
 
-        // Check for original exception first with preserved stack trace
-        _exceptionRethrowService.ThrowOriginalExceptionIfPresent();
+        // Wait-for-all may return a failed summary when configured not to throw.
+        // Fail-fast retains its existing behavior and always surfaces the original.
+        if (_options.Value.ExecutionMode == ExecutionMode.StopOnFirstException
+            || _options.Value.ThrowOnPipelineFailure)
+        {
+            _exceptionRethrowService.ThrowOriginalExceptionIfPresent();
+        }
 
         _secondaryExceptionContainer.ThrowExceptions();
 

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -441,12 +441,19 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         Exception exception,
         IModuleLogger logger)
     {
-        logger.LogDebug("Module failed. Cancelling the pipeline");
         ((IInternalModuleLogger)logger).SetException(exception);
 
         var moduleFailedException = new ModuleFailedException(executionContext.ModuleType, exception);
 
-        _engineCancellationToken.CancelWithException(moduleFailedException);
+        if (moduleContext.Services.Options.ExecutionMode == ExecutionMode.StopOnFirstException)
+        {
+            logger.LogDebug("Module failed. Cancelling the pipeline");
+            _engineCancellationToken.CancelWithException(moduleFailedException);
+        }
+        else
+        {
+            logger.LogDebug("Module failed. Waiting for all modules to complete");
+        }
 
         executionContext.SetException(moduleFailedException);
         throw moduleFailedException;

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -75,7 +75,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         var beforeHooksExecuted = false;
 
         // Get configuration once at the start
-        var config = ((IModule)module).Configuration;
+        var config = ((IModule) module).Configuration;
 
         try
         {
@@ -441,7 +441,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         Exception exception,
         IModuleLogger logger)
     {
-        ((IInternalModuleLogger)logger).SetException(exception);
+        ((IInternalModuleLogger) logger).SetException(exception);
 
         var moduleFailedException = new ModuleFailedException(executionContext.ModuleType, exception);
 
@@ -453,6 +453,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         else
         {
             logger.LogDebug("Module failed. Waiting for all modules to complete");
+            _engineCancellationToken.RecordException(moduleFailedException);
         }
 
         executionContext.SetException(moduleFailedException);

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -5,6 +5,7 @@ using ModularPipelines.Context;
 using ModularPipelines.Engine;
 using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 using Status = ModularPipelines.Enums.Status;
 
@@ -14,6 +15,7 @@ namespace ModularPipelines.UnitTests.Execution;
 public class EngineCancellationTokenTests : TestBase
 {
     private static readonly TimeSpan WaitForCancellationDelay = TimeSpan.FromMilliseconds(100);
+    private static TaskCompletionSource PeerModuleStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private class BadModule : ThrowingTestModule<bool>
     {
@@ -48,6 +50,34 @@ public class EngineCancellationTokenTests : TestBase
         {
             await _taskCompletionSource.Task;
             return true;
+        }
+    }
+
+    private class WaitForAllFailingModule : Module<bool>
+    {
+        protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            await PeerModuleStarted.Task.WaitAsync(cancellationToken);
+            throw new InvalidOperationException("Expected test failure");
+        }
+    }
+
+    private class WaitForAllCompletingModule : Module<bool>
+    {
+        protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            PeerModuleStarted.TrySetResult();
+            await Task.Delay(WaitForCancellationDelay, cancellationToken);
+            return true;
+        }
+    }
+
+    [ModularPipelines.Attributes.DependsOn<WaitForAllCompletingModule>]
+    private class WaitForAllPendingModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
         }
     }
 
@@ -123,5 +153,30 @@ public class EngineCancellationTokenTests : TestBase
         var longRunningModuleResult = resultRegistry.GetResult(typeof(LongRunningModuleWithoutCancellation));
         await Assert.That(longRunningModuleResult).IsNotNull();
         await Assert.That(longRunningModuleResult!.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+    }
+
+    [Test]
+    public async Task WaitForAllModules_Allows_InFlight_And_Pending_Modules_To_Complete()
+    {
+        PeerModuleStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var builder = TestPipelineHostBuilder.Create()
+            .ConfigurePipelineOptions((_, options) => options.ExecutionMode = ExecutionMode.WaitForAllModules)
+            .AddModule<WaitForAllFailingModule>()
+            .AddModule<WaitForAllCompletingModule>()
+            .AddModule<WaitForAllPendingModule>();
+
+        var host = await builder.BuildHostAsync();
+        var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
+
+        var pipelineSummary = await host.ExecutePipelineAsync();
+
+        var completingModuleResult = resultRegistry.GetResult(typeof(WaitForAllCompletingModule));
+        var pendingModuleResult = resultRegistry.GetResult(typeof(WaitForAllPendingModule));
+        await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Failed);
+        await Assert.That(completingModuleResult).IsNotNull();
+        await Assert.That(completingModuleResult!.ModuleStatus).IsEqualTo(Status.Successful);
+        await Assert.That(pendingModuleResult).IsNotNull();
+        await Assert.That(pendingModuleResult!.ModuleStatus).IsEqualTo(Status.Successful);
     }
 }

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -3,6 +3,7 @@ using ModularPipelines.Attributes;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
@@ -178,5 +179,26 @@ public class EngineCancellationTokenTests : TestBase
         await Assert.That(completingModuleResult!.ModuleStatus).IsEqualTo(Status.Successful);
         await Assert.That(pendingModuleResult).IsNotNull();
         await Assert.That(pendingModuleResult!.ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task WaitForAllModules_Preserves_Original_Failure()
+    {
+        PeerModuleStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var builder = TestPipelineHostBuilder.Create()
+            .ConfigurePipelineOptions((_, options) =>
+            {
+                options.ExecutionMode = ExecutionMode.WaitForAllModules;
+                options.ThrowOnPipelineFailure = true;
+            })
+            .AddModule<WaitForAllFailingModule>()
+            .AddModule<WaitForAllCompletingModule>();
+
+        var exception = await Assert.ThrowsAsync<ModuleFailedException>(
+            async () => await builder.ExecutePipelineAsync());
+
+        await Assert.That(exception.InnerException).IsTypeOf<InvalidOperationException>();
+        await Assert.That(exception.InnerException!).HasMessageEqualTo("Expected test failure");
     }
 }

--- a/test/ModularPipelines.UnitTests/Execution/FailedPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/FailedPipelineTests.cs
@@ -43,8 +43,11 @@ public class FailedPipelineTests : TestBase
     public async Task Given_Failing_Module_With_Dependent_Module_When_Fail_Fast_Then_Failures_Propagate(ExecutionMode executionMode)
     {
         await Assert.That(async () => await TestPipelineHostBuilder.Create()
-                .ConfigurePipelineOptions((_, options)
-                    => options.ExecutionMode = executionMode)
+                .ConfigurePipelineOptions((_, options) =>
+                {
+                    options.ExecutionMode = executionMode;
+                    options.ThrowOnPipelineFailure = true;
+                })
                 .AddModule<Module1>()
                 .AddModule<Module2>()
                 .AddModule<Module3>()
@@ -58,8 +61,11 @@ public class FailedPipelineTests : TestBase
     public async Task Given_Failing_Module_When_Fail_Fast_Then_Failures_Propagate(ExecutionMode executionMode)
     {
         await Assert.That(async () => await TestPipelineHostBuilder.Create()
-                .ConfigurePipelineOptions((_, options)
-                    => options.ExecutionMode = executionMode)
+                .ConfigurePipelineOptions((_, options) =>
+                {
+                    options.ExecutionMode = executionMode;
+                    options.ThrowOnPipelineFailure = true;
+                })
                 .AddModule<Module1>()
                 .AddModule<Module2>()
                 .ExecutePipelineAsync()).


### PR DESCRIPTION
## Summary

- cancel the engine after a module failure only in `StopOnFirstException` mode
- keep in-flight and pending modules running in `WaitForAllModules` mode
- add a regression test covering both module states

## Root cause

`ModuleExecutionPipeline` cancelled the shared engine token for every hard module failure. That contradicted the worker pool execution-mode gate and terminated other modules even when configured to wait for all work.

## Validation

- Release build of `ModularPipelines.UnitTests` passed
- focused `WaitForAllModules_Allows_InFlight_And_Pending_Modules_To_Complete` test passed

Closes #2985