### PR TITLE
Standardize CancellationToken parameter names

### DIFF
--- a/src/ModularPipelines.Build/GitHelpers.cs
+++ b/src/ModularPipelines.Build/GitHelpers.cs
@@ -27,7 +27,7 @@ public static class GitHelpers
             {
                 "user.name", settings.GitUserName,
             },
-        }, token: cancellationToken);
+        }, cancellationToken: cancellationToken);
     }
 
     public static async Task SetEmail(IModuleContext context, CancellationToken cancellationToken)
@@ -41,7 +41,7 @@ public static class GitHelpers
             {
                 "user.email", settings.GitUserEmail,
             },
-        }, token: cancellationToken);
+        }, cancellationToken: cancellationToken);
     }
 
     public static async Task CheckoutBranch(IModuleContext context, string branchName, CancellationToken cancellationToken)
@@ -58,10 +58,10 @@ public static class GitHelpers
             ],
         }, null, cancellationToken);
 
-        await context.Git().Commands.Fetch(new GitFetchOptions(), token: cancellationToken);
+        await context.Git().Commands.Fetch(new GitFetchOptions(), cancellationToken: cancellationToken);
 
         await context.Git().Commands
-            .Checkout(new GitCheckoutOptions(branchName), token: cancellationToken);
+            .Checkout(new GitCheckoutOptions(branchName), cancellationToken: cancellationToken);
     }
 
     public static async Task CommitAndPush(IModuleContext context, string? branchToPushTo, string message, string token,
@@ -69,17 +69,17 @@ public static class GitHelpers
     {
         var settings = GetGitHubSettings(context);
 
-        await context.Git().Commands.Pull(token: cancellationToken);
+        await context.Git().Commands.Pull(cancellationToken: cancellationToken);
 
         await context.Git().Commands.Add(new GitAddOptions
         {
             All = true,
-        }, token: cancellationToken);
+        }, cancellationToken: cancellationToken);
 
         await context.Git().Commands.Commit(new GitCommitOptions
         {
             Message = message,
-        }, token: cancellationToken);
+        }, cancellationToken: cancellationToken);
 
         var author = context.GitHub().EnvironmentVariables.Actor ?? settings.RepositoryOwner;
 
@@ -93,7 +93,7 @@ public static class GitHelpers
         await context.Git().Commands.Push(new GitPushOptions
         {
             Arguments = arguments,
-        }, token: cancellationToken);
+        }, cancellationToken: cancellationToken);
     }
 
     public static async Task<bool> HasUncommittedChanges(IModuleContext context)

--- a/src/ModularPipelines.Build/Modules/PushVersionTagModule.cs
+++ b/src/ModularPipelines.Build/Modules/PushVersionTagModule.cs
@@ -59,7 +59,7 @@ public class PushVersionTagModule : Module<CommandResult>
         await context.Git().Commands.Tag(new GitTagOptions
         {
             TagName = $"v{versionInformation.ValueOrDefault!}",
-        }, token: cancellationToken);
+        }, cancellationToken: cancellationToken);
 
         return await context.Git().Commands.Push
         (
@@ -71,7 +71,7 @@ public class PushVersionTagModule : Module<CommandResult>
             {
                 ThrowOnNonZeroExitCode = false,
             },
-            token: cancellationToken
+            cancellationToken: cancellationToken
         );
     }
 }

--- a/src/ModularPipelines.Git/GitCommands.cs
+++ b/src/ModularPipelines.Git/GitCommands.cs
@@ -23,471 +23,471 @@ public class GitCommands : IGitCommands
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Add(GitAddOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Add(GitAddOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Am(GitAmOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Am(GitAmOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Apply(GitApplyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Apply(GitApplyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Archive(GitArchiveOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Archive(GitArchiveOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Base(GitBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Base(GitBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Bisect(GitBisectOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Bisect(GitBisectOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Blame(GitBlameOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Blame(GitBlameOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Branch(GitBranchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Branch(GitBranchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Bugreport(GitBugreportOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Bugreport(GitBugreportOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Bundle(GitBundleOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Bundle(GitBundleOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> CatFile(GitCatFileOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> CatFile(GitCatFileOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> CheckIgnore(GitCheckIgnoreOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> CheckIgnore(GitCheckIgnoreOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> CheckoutIndex(GitCheckoutIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> CheckoutIndex(GitCheckoutIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Checkout(GitCheckoutOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Checkout(GitCheckoutOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> CherryPick(GitCherryPickOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> CherryPick(GitCherryPickOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Clean(GitCleanOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Clean(GitCleanOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Clone(GitCloneOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Clone(GitCloneOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Commit(GitCommitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Commit(GitCommitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> CommitTree(GitCommitTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> CommitTree(GitCommitTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Config(GitConfigOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Config(GitConfigOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> CountObjects(GitCountObjectsOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> CountObjects(GitCountObjectsOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Daemon(GitDaemonOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Daemon(GitDaemonOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Describe(GitDescribeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Describe(GitDescribeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> DiffIndex(GitDiffIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> DiffIndex(GitDiffIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Diff(GitDiffOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Diff(GitDiffOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Difftool(GitDifftoolOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Difftool(GitDifftoolOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> FastImport(GitFastImportOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> FastImport(GitFastImportOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Fetch(GitFetchOptions? options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Fetch(GitFetchOptions? options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new GitFetchOptions(), executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new GitFetchOptions(), executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> FilterBranch(GitFilterBranchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> FilterBranch(GitFilterBranchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> ForEachRef(GitForEachRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> ForEachRef(GitForEachRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> FormatPatch(GitFormatPatchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> FormatPatch(GitFormatPatchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Fsck(GitFsckOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Fsck(GitFsckOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Gc(GitGcOptions? options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Gc(GitGcOptions? options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new GitGcOptions(), executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new GitGcOptions(), executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Grep(GitGrepOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Grep(GitGrepOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> HashObject(GitHashObjectOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> HashObject(GitHashObjectOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Help(GitHelpOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Help(GitHelpOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Init(GitInitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Init(GitInitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Instaweb(GitInstawebOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Instaweb(GitInstawebOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Log(GitLogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Log(GitLogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> LsFiles(GitLsFilesOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> LsFiles(GitLsFilesOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> LsTree(GitLsTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> LsTree(GitLsTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> MergeBase(GitMergeBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> MergeBase(GitMergeBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Merge(GitMergeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Merge(GitMergeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Mergetool(GitMergetoolOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Mergetool(GitMergetoolOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Mv(GitMvOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Mv(GitMvOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Notes(GitNotesOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Notes(GitNotesOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Git(GitBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Git(GitBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Pull(GitPullOptions? options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Pull(GitPullOptions? options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new GitPullOptions(), executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new GitPullOptions(), executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Push(GitPushOptions? options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Push(GitPushOptions? options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new GitPushOptions(), executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new GitPushOptions(), executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> RangeDiff(GitRangeDiffOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> RangeDiff(GitRangeDiffOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> ReadTree(GitReadTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> ReadTree(GitReadTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Rebase(GitRebaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Rebase(GitRebaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Reflog(GitReflogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Reflog(GitReflogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Remote(GitRemoteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Remote(GitRemoteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> RequestPull(GitRequestPullOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> RequestPull(GitRequestPullOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Reset(GitResetOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Reset(GitResetOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Restore(GitRestoreOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Restore(GitRestoreOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Revert(GitRevertOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Revert(GitRevertOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> RevList(GitRevListOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> RevList(GitRevListOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> RevParse(GitRevParseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> RevParse(GitRevParseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Rm(GitRmOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Rm(GitRmOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> SendEmail(GitSendEmailOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> SendEmail(GitSendEmailOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Shortlog(GitShortlogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Shortlog(GitShortlogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Show(GitShowOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Show(GitShowOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> ShowRef(GitShowRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> ShowRef(GitShowRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Stash(GitStashOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Stash(GitStashOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Status(GitStatusOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Status(GitStatusOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Submodule(GitSubmoduleOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Submodule(GitSubmoduleOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Svn(GitSvnOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Svn(GitSvnOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Switch(GitSwitchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Switch(GitSwitchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> SymbolicRef(GitSymbolicRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> SymbolicRef(GitSymbolicRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Tag(GitTagOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Tag(GitTagOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> UpdateIndex(GitUpdateIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> UpdateIndex(GitUpdateIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> UpdateRef(GitUpdateRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> UpdateRef(GitUpdateRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> UpdateServerInfo(GitUpdateServerInfoOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> UpdateServerInfo(GitUpdateServerInfoOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> VerifyPack(GitVerifyPackOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> VerifyPack(GitVerifyPackOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Worktree(GitWorktreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> Worktree(GitWorktreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> WriteTree(GitWriteTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default)
+    public virtual async Task<CommandResult> WriteTree(GitWriteTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, executionOptions, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>

--- a/src/ModularPipelines.Git/IGitCommands.cs
+++ b/src/ModularPipelines.Git/IGitCommands.cs
@@ -7,161 +7,161 @@ namespace ModularPipelines.Git;
 
 public interface IGitCommands
 {
-    Task<CommandResult> Add(GitAddOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Add(GitAddOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Am(GitAmOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Am(GitAmOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Apply(GitApplyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Apply(GitApplyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Archive(GitArchiveOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Archive(GitArchiveOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Base(GitBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Base(GitBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Bisect(GitBisectOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Bisect(GitBisectOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Blame(GitBlameOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Blame(GitBlameOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Branch(GitBranchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Branch(GitBranchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Bugreport(GitBugreportOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Bugreport(GitBugreportOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Bundle(GitBundleOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Bundle(GitBundleOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> CatFile(GitCatFileOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> CatFile(GitCatFileOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> CheckIgnore(GitCheckIgnoreOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> CheckIgnore(GitCheckIgnoreOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> CheckoutIndex(GitCheckoutIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> CheckoutIndex(GitCheckoutIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Checkout(GitCheckoutOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Checkout(GitCheckoutOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> CherryPick(GitCherryPickOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> CherryPick(GitCherryPickOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Clean(GitCleanOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Clean(GitCleanOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Clone(GitCloneOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Clone(GitCloneOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Commit(GitCommitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Commit(GitCommitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> CommitTree(GitCommitTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> CommitTree(GitCommitTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Config(GitConfigOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Config(GitConfigOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> CountObjects(GitCountObjectsOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> CountObjects(GitCountObjectsOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Daemon(GitDaemonOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Daemon(GitDaemonOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Describe(GitDescribeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Describe(GitDescribeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> DiffIndex(GitDiffIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> DiffIndex(GitDiffIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Diff(GitDiffOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Diff(GitDiffOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Difftool(GitDifftoolOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Difftool(GitDifftoolOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> FastImport(GitFastImportOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> FastImport(GitFastImportOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Fetch(GitFetchOptions? options = default, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Fetch(GitFetchOptions? options = default, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> FilterBranch(GitFilterBranchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> FilterBranch(GitFilterBranchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ForEachRef(GitForEachRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> ForEachRef(GitForEachRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> FormatPatch(GitFormatPatchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> FormatPatch(GitFormatPatchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Fsck(GitFsckOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Fsck(GitFsckOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Gc(GitGcOptions? options = default, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Gc(GitGcOptions? options = default, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Grep(GitGrepOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Grep(GitGrepOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> HashObject(GitHashObjectOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> HashObject(GitHashObjectOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Help(GitHelpOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Help(GitHelpOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Init(GitInitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Init(GitInitOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Instaweb(GitInstawebOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Instaweb(GitInstawebOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Log(GitLogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Log(GitLogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> LsFiles(GitLsFilesOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> LsFiles(GitLsFilesOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> LsTree(GitLsTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> LsTree(GitLsTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> MergeBase(GitMergeBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> MergeBase(GitMergeBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Merge(GitMergeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Merge(GitMergeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Mergetool(GitMergetoolOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Mergetool(GitMergetoolOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Mv(GitMvOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Mv(GitMvOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Notes(GitNotesOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Notes(GitNotesOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Git(GitBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Git(GitBaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Pull(GitPullOptions? options = default, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Pull(GitPullOptions? options = default, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Push(GitPushOptions? options = default, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Push(GitPushOptions? options = default, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> RangeDiff(GitRangeDiffOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> RangeDiff(GitRangeDiffOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ReadTree(GitReadTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> ReadTree(GitReadTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Rebase(GitRebaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Rebase(GitRebaseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Reflog(GitReflogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Reflog(GitReflogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Remote(GitRemoteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Remote(GitRemoteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> RequestPull(GitRequestPullOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> RequestPull(GitRequestPullOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Reset(GitResetOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Reset(GitResetOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Restore(GitRestoreOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Restore(GitRestoreOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Revert(GitRevertOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Revert(GitRevertOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> RevList(GitRevListOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> RevList(GitRevListOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> RevParse(GitRevParseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> RevParse(GitRevParseOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Rm(GitRmOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Rm(GitRmOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> SendEmail(GitSendEmailOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> SendEmail(GitSendEmailOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Shortlog(GitShortlogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Shortlog(GitShortlogOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Show(GitShowOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Show(GitShowOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ShowRef(GitShowRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> ShowRef(GitShowRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Stash(GitStashOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Stash(GitStashOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Status(GitStatusOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Status(GitStatusOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Submodule(GitSubmoduleOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Submodule(GitSubmoduleOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Svn(GitSvnOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Svn(GitSvnOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Switch(GitSwitchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Switch(GitSwitchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> SymbolicRef(GitSymbolicRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> SymbolicRef(GitSymbolicRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Tag(GitTagOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Tag(GitTagOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> UpdateIndex(GitUpdateIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> UpdateIndex(GitUpdateIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> UpdateRef(GitUpdateRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> UpdateRef(GitUpdateRefOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> UpdateServerInfo(GitUpdateServerInfoOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> UpdateServerInfo(GitUpdateServerInfoOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> VerifyPack(GitVerifyPackOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> VerifyPack(GitVerifyPackOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Worktree(GitWorktreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> Worktree(GitWorktreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> WriteTree(GitWriteTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken token = default);
+    Task<CommandResult> WriteTree(GitWriteTreeOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     IAsyncEnumerable<GitCommit> Commits(GitOptions? options = null, CancellationToken cancellationToken = default);
 

--- a/src/ModularPipelines.Node/INpm.cs
+++ b/src/ModularPipelines.Node/INpm.cs
@@ -6,197 +6,197 @@ namespace ModularPipelines.Node;
 public interface INpm
 {
     Task<CommandResult> AccessListPackages(NpmAccessListPackagesOptions? options = default,
-        CancellationToken token = default);
+        CancellationToken cancellationToken = default);
 
     Task<CommandResult> AccessListCollaborators(NpmAccessListCollaboratorsOptions? options = default,
-        CancellationToken token = default);
+        CancellationToken cancellationToken = default);
 
     Task<CommandResult> AccessGetStatus(NpmAccessGetStatusOptions? options = default,
-        CancellationToken token = default);
+        CancellationToken cancellationToken = default);
 
-    Task<CommandResult> AccessSet(NpmAccessSetOptions options, CancellationToken token = default);
+    Task<CommandResult> AccessSet(NpmAccessSetOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> AccessGrant(NpmAccessGrantOptions options, CancellationToken token = default);
+    Task<CommandResult> AccessGrant(NpmAccessGrantOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> AccessRevoke(NpmAccessRevokeOptions options, CancellationToken token = default);
+    Task<CommandResult> AccessRevoke(NpmAccessRevokeOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Adduser(NpmAdduserOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Adduser(NpmAdduserOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Audit(NpmAuditOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Audit(NpmAuditOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Bugs(NpmBugsOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Bugs(NpmBugsOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> CacheAdd(NpmCacheAddOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> CacheAdd(NpmCacheAddOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> CacheClean(NpmCacheCleanOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> CacheClean(NpmCacheCleanOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> CacheLs(NpmCacheLsOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> CacheLs(NpmCacheLsOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> CacheVerify(NpmCacheVerifyOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> CacheVerify(NpmCacheVerifyOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Ci(NpmCiOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Ci(NpmCiOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Completion(NpmCompletionOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Completion(NpmCompletionOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ConfigSet(NpmConfigSetOptions options, CancellationToken token = default);
+    Task<CommandResult> ConfigSet(NpmConfigSetOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ConfigSetRegistry(NpmConfigSetRegistryOptions options, CancellationToken token = default);
+    Task<CommandResult> ConfigSetRegistry(NpmConfigSetRegistryOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ConfigGet(NpmConfigGetOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> ConfigGet(NpmConfigGetOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ConfigDelete(NpmConfigDeleteOptions options, CancellationToken token = default);
+    Task<CommandResult> ConfigDelete(NpmConfigDeleteOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ConfigList(NpmConfigListOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> ConfigList(NpmConfigListOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ConfigEdit(NpmConfigEditOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> ConfigEdit(NpmConfigEditOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ConfigFix(NpmConfigFixOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> ConfigFix(NpmConfigFixOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Dedupe(NpmDedupeOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Dedupe(NpmDedupeOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Deprecate(NpmDeprecateOptions options, CancellationToken token = default);
+    Task<CommandResult> Deprecate(NpmDeprecateOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Diff(NpmDiffOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Diff(NpmDiffOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Docs(NpmDocsOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Docs(NpmDocsOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Doctor(NpmDoctorOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Doctor(NpmDoctorOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Edit(NpmEditOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Edit(NpmEditOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Exec(NpmExecOptions options, CancellationToken token = default);
+    Task<CommandResult> Exec(NpmExecOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ExecC(NpmExecCOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> ExecC(NpmExecCOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Explain(NpmExplainOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Explain(NpmExplainOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Explore(NpmExploreOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Explore(NpmExploreOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Fund(NpmFundOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Fund(NpmFundOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Help(NpmHelpOptions options, CancellationToken token = default);
+    Task<CommandResult> Help(NpmHelpOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> HookAdd(NpmHookAddOptions options, CancellationToken token = default);
+    Task<CommandResult> HookAdd(NpmHookAddOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> HookLs(NpmHookLsOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> HookLs(NpmHookLsOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> HookRm(NpmHookRmOptions options, CancellationToken token = default);
+    Task<CommandResult> HookRm(NpmHookRmOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> HookUpdate(NpmHookUpdateOptions options, CancellationToken token = default);
+    Task<CommandResult> HookUpdate(NpmHookUpdateOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Init(NpmInitOptions options, CancellationToken token = default);
+    Task<CommandResult> Init(NpmInitOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Install(NpmInstallOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Install(NpmInstallOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Link(NpmLinkOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Link(NpmLinkOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Login(NpmLoginOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Login(NpmLoginOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Logout(NpmLogoutOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Logout(NpmLogoutOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Ls(NpmLsOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Ls(NpmLsOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> OrgSet(NpmOrgSetOptions options, CancellationToken token = default);
+    Task<CommandResult> OrgSet(NpmOrgSetOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> OrgRm(NpmOrgRmOptions options, CancellationToken token = default);
+    Task<CommandResult> OrgRm(NpmOrgRmOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> OrgLs(NpmOrgLsOptions options, CancellationToken token = default);
+    Task<CommandResult> OrgLs(NpmOrgLsOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Outdated(NpmOutdatedOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Outdated(NpmOutdatedOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> OwnerAdd(NpmOwnerAddOptions options, CancellationToken token = default);
+    Task<CommandResult> OwnerAdd(NpmOwnerAddOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> OwnerRm(NpmOwnerRmOptions options, CancellationToken token = default);
+    Task<CommandResult> OwnerRm(NpmOwnerRmOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> OwnerLs(NpmOwnerLsOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> OwnerLs(NpmOwnerLsOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Pack(NpmPackOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Pack(NpmPackOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Ping(NpmPingOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Ping(NpmPingOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> PkgSet(NpmPkgSetOptions options, CancellationToken token = default);
+    Task<CommandResult> PkgSet(NpmPkgSetOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> PkgGet(NpmPkgGetOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> PkgGet(NpmPkgGetOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> PkgDelete(NpmPkgDeleteOptions options, CancellationToken token = default);
+    Task<CommandResult> PkgDelete(NpmPkgDeleteOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> PkgFix(NpmPkgFixOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> PkgFix(NpmPkgFixOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Prefix(NpmPrefixOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Prefix(NpmPrefixOptions? options = default, CancellationToken cancellationToken = default);
 
     Task<CommandResult> ProfileEnable2fa(NpmProfileEnable2faOptions? options = default,
-        CancellationToken token = default);
+        CancellationToken cancellationToken = default);
 
     Task<CommandResult> ProfileDisable2fa(NpmProfileDisable2faOptions? options = default,
-        CancellationToken token = default);
+        CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ProfileGet(NpmProfileGetOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> ProfileGet(NpmProfileGetOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> ProfileSet(NpmProfileSetOptions options, CancellationToken token = default);
+    Task<CommandResult> ProfileSet(NpmProfileSetOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Prune(NpmPruneOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Prune(NpmPruneOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Publish(NpmPublishOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Publish(NpmPublishOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Query(NpmQueryOptions options, CancellationToken token = default);
+    Task<CommandResult> Query(NpmQueryOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Rebuild(NpmRebuildOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Rebuild(NpmRebuildOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Repo(NpmRepoOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Repo(NpmRepoOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Restart(NpmRestartOptions options, CancellationToken token = default);
+    Task<CommandResult> Restart(NpmRestartOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Root(NpmRootOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Root(NpmRootOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Run(NpmRunOptions options, CancellationToken token = default);
+    Task<CommandResult> Run(NpmRunOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Sbom(NpmSbomOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Sbom(NpmSbomOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Search(NpmSearchOptions options, CancellationToken token = default);
+    Task<CommandResult> Search(NpmSearchOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Shrinkwrap(NpmShrinkwrapOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Shrinkwrap(NpmShrinkwrapOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Star(NpmStarOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Star(NpmStarOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Stars(NpmStarsOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Stars(NpmStarsOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Start(NpmStartOptions options, CancellationToken token = default);
+    Task<CommandResult> Start(NpmStartOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Stop(NpmStopOptions options, CancellationToken token = default);
+    Task<CommandResult> Stop(NpmStopOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> TeamCreate(NpmTeamCreateOptions options, CancellationToken token = default);
+    Task<CommandResult> TeamCreate(NpmTeamCreateOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> TeamDestroy(NpmTeamDestroyOptions options, CancellationToken token = default);
+    Task<CommandResult> TeamDestroy(NpmTeamDestroyOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> TeamAdd(NpmTeamAddOptions options, CancellationToken token = default);
+    Task<CommandResult> TeamAdd(NpmTeamAddOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> TeamRm(NpmTeamRmOptions options, CancellationToken token = default);
+    Task<CommandResult> TeamRm(NpmTeamRmOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> TeamLs(NpmTeamLsOptions options, CancellationToken token = default);
+    Task<CommandResult> TeamLs(NpmTeamLsOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Test(NpmTestOptions options, CancellationToken token = default);
+    Task<CommandResult> Test(NpmTestOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> TokenList(NpmTokenListOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> TokenList(NpmTokenListOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> TokenRevoke(NpmTokenRevokeOptions options, CancellationToken token = default);
+    Task<CommandResult> TokenRevoke(NpmTokenRevokeOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> TokenCreate(NpmTokenCreateOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> TokenCreate(NpmTokenCreateOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Uninstall(NpmUninstallOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Uninstall(NpmUninstallOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Unpublish(NpmUnpublishOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Unpublish(NpmUnpublishOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Unstar(NpmUnstarOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Unstar(NpmUnstarOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Update(NpmUpdateOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Update(NpmUpdateOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Version(NpmVersionOptions options, CancellationToken token = default);
+    Task<CommandResult> Version(NpmVersionOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> View(NpmViewOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> View(NpmViewOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Whoami(NpmWhoamiOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Whoami(NpmWhoamiOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Npx(NpxOptions options, CancellationToken token = default);
+    Task<CommandResult> Npx(NpxOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> NpxC(NpxCOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> NpxC(NpxCOptions? options = default, CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines.Node/Npm.cs
+++ b/src/ModularPipelines.Node/Npm.cs
@@ -16,500 +16,500 @@ internal class Npm : INpm
     }
 
     public virtual async Task<CommandResult> AccessListPackages(NpmAccessListPackagesOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmAccessListPackagesOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmAccessListPackagesOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> AccessListCollaborators(NpmAccessListCollaboratorsOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmAccessListCollaboratorsOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmAccessListCollaboratorsOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> AccessGetStatus(NpmAccessGetStatusOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmAccessGetStatusOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmAccessGetStatusOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> AccessSet(NpmAccessSetOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> AccessSet(NpmAccessSetOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> AccessGrant(NpmAccessGrantOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> AccessGrant(NpmAccessGrantOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> AccessRevoke(NpmAccessRevokeOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> AccessRevoke(NpmAccessRevokeOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Adduser(NpmAdduserOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Adduser(NpmAdduserOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmAdduserOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmAdduserOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Audit(NpmAuditOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Audit(NpmAuditOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmAuditOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmAuditOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Bugs(NpmBugsOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Bugs(NpmBugsOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmBugsOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmBugsOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> CacheAdd(NpmCacheAddOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmCacheAddOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmCacheAddOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> CacheClean(NpmCacheCleanOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmCacheCleanOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmCacheCleanOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> CacheLs(NpmCacheLsOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> CacheLs(NpmCacheLsOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmCacheLsOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmCacheLsOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> CacheVerify(NpmCacheVerifyOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmCacheVerifyOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmCacheVerifyOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Ci(NpmCiOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Ci(NpmCiOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmCiOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmCiOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> Completion(NpmCompletionOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmCompletionOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmCompletionOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> ConfigSet(NpmConfigSetOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> ConfigSet(NpmConfigSetOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> ConfigSetRegistry(NpmConfigSetRegistryOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> ConfigSetRegistry(NpmConfigSetRegistryOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> ConfigGet(NpmConfigGetOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmConfigGetOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmConfigGetOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> ConfigDelete(NpmConfigDeleteOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> ConfigDelete(NpmConfigDeleteOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> ConfigList(NpmConfigListOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmConfigListOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmConfigListOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> ConfigEdit(NpmConfigEditOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmConfigEditOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmConfigEditOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> ConfigFix(NpmConfigFixOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmConfigFixOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmConfigFixOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Dedupe(NpmDedupeOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Dedupe(NpmDedupeOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmDedupeOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmDedupeOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Deprecate(NpmDeprecateOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Deprecate(NpmDeprecateOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Diff(NpmDiffOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Diff(NpmDiffOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmDiffOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmDiffOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Docs(NpmDocsOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Docs(NpmDocsOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmDocsOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmDocsOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Doctor(NpmDoctorOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Doctor(NpmDoctorOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmDoctorOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmDoctorOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Edit(NpmEditOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Edit(NpmEditOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmEditOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmEditOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Exec(NpmExecOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Exec(NpmExecOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> ExecC(NpmExecCOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> ExecC(NpmExecCOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmExecCOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmExecCOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Explain(NpmExplainOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Explain(NpmExplainOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmExplainOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmExplainOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Explore(NpmExploreOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Explore(NpmExploreOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmExploreOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmExploreOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Fund(NpmFundOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Fund(NpmFundOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmFundOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmFundOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Help(NpmHelpOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Help(NpmHelpOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> HookAdd(NpmHookAddOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> HookAdd(NpmHookAddOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> HookLs(NpmHookLsOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> HookLs(NpmHookLsOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmHookLsOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmHookLsOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> HookRm(NpmHookRmOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> HookRm(NpmHookRmOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> HookUpdate(NpmHookUpdateOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> HookUpdate(NpmHookUpdateOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Init(NpmInitOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Init(NpmInitOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Install(NpmInstallOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Install(NpmInstallOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmInstallOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmInstallOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Link(NpmLinkOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Link(NpmLinkOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmLinkOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmLinkOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Login(NpmLoginOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Login(NpmLoginOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmLoginOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmLoginOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Logout(NpmLogoutOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Logout(NpmLogoutOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmLogoutOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmLogoutOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Ls(NpmLsOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Ls(NpmLsOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmLsOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmLsOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> OrgSet(NpmOrgSetOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> OrgSet(NpmOrgSetOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> OrgRm(NpmOrgRmOptions options,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> OrgLs(NpmOrgLsOptions options,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> Outdated(NpmOutdatedOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmOutdatedOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmOutdatedOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> OwnerAdd(NpmOwnerAddOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> OwnerAdd(NpmOwnerAddOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> OwnerRm(NpmOwnerRmOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> OwnerRm(NpmOwnerRmOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> OwnerLs(NpmOwnerLsOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> OwnerLs(NpmOwnerLsOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmOwnerLsOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmOwnerLsOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Pack(NpmPackOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Pack(NpmPackOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmPackOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmPackOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Ping(NpmPingOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Ping(NpmPingOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmPingOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmPingOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> PkgSet(NpmPkgSetOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> PkgSet(NpmPkgSetOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> PkgGet(NpmPkgGetOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> PkgGet(NpmPkgGetOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmPkgGetOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmPkgGetOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> PkgDelete(NpmPkgDeleteOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> PkgDelete(NpmPkgDeleteOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> PkgFix(NpmPkgFixOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> PkgFix(NpmPkgFixOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmPkgFixOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmPkgFixOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Prefix(NpmPrefixOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Prefix(NpmPrefixOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmPrefixOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmPrefixOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> ProfileEnable2fa(NpmProfileEnable2faOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmProfileEnable2faOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmProfileEnable2faOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> ProfileDisable2fa(NpmProfileDisable2faOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmProfileDisable2faOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmProfileDisable2faOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> ProfileGet(NpmProfileGetOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmProfileGetOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmProfileGetOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> ProfileSet(NpmProfileSetOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> ProfileSet(NpmProfileSetOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Prune(NpmPruneOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Prune(NpmPruneOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmPruneOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmPruneOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Publish(NpmPublishOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Publish(NpmPublishOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmPublishOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmPublishOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Query(NpmQueryOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Query(NpmQueryOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Rebuild(NpmRebuildOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Rebuild(NpmRebuildOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmRebuildOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmRebuildOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Repo(NpmRepoOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Repo(NpmRepoOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmRepoOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmRepoOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Restart(NpmRestartOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Restart(NpmRestartOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Root(NpmRootOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Root(NpmRootOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmRootOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmRootOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Run(NpmRunOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Run(NpmRunOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Sbom(NpmSbomOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Sbom(NpmSbomOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmSbomOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmSbomOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> Search(NpmSearchOptions options,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> Shrinkwrap(NpmShrinkwrapOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmShrinkwrapOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmShrinkwrapOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Star(NpmStarOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Star(NpmStarOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmStarOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmStarOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Stars(NpmStarsOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Stars(NpmStarsOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmStarsOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmStarsOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Start(NpmStartOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Start(NpmStartOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Stop(NpmStopOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Stop(NpmStopOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> TeamCreate(NpmTeamCreateOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> TeamCreate(NpmTeamCreateOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> TeamDestroy(NpmTeamDestroyOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> TeamDestroy(NpmTeamDestroyOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> TeamAdd(NpmTeamAddOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> TeamAdd(NpmTeamAddOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> TeamRm(NpmTeamRmOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> TeamRm(NpmTeamRmOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> TeamLs(NpmTeamLsOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> TeamLs(NpmTeamLsOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Test(NpmTestOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Test(NpmTestOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> TokenList(NpmTokenListOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmTokenListOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmTokenListOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> TokenRevoke(NpmTokenRevokeOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> TokenRevoke(NpmTokenRevokeOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> TokenCreate(NpmTokenCreateOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmTokenCreateOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmTokenCreateOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> Uninstall(NpmUninstallOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmUninstallOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmUninstallOptions(), null, cancellationToken);
     }
 
     public virtual async Task<CommandResult> Unpublish(NpmUnpublishOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmUnpublishOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmUnpublishOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Unstar(NpmUnstarOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Unstar(NpmUnstarOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmUnstarOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmUnstarOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Update(NpmUpdateOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Update(NpmUpdateOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmUpdateOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmUpdateOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Version(NpmVersionOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Version(NpmVersionOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> View(NpmViewOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> View(NpmViewOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmViewOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmViewOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Whoami(NpmWhoamiOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Whoami(NpmWhoamiOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpmWhoamiOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpmWhoamiOptions(), null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> Npx(NpxOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Npx(NpxOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken);
     }
 
-    public virtual async Task<CommandResult> NpxC(NpxCOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> NpxC(NpxCOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new NpxCOptions(), null, token);
+        return await _command.ExecuteCommandLineTool(options ?? new NpxCOptions(), null, cancellationToken);
     }
 }

--- a/src/ModularPipelines/Attributes/DependsOnAttribute.cs
+++ b/src/ModularPipelines/Attributes/DependsOnAttribute.cs
@@ -25,7 +25,7 @@ namespace ModularPipelines.Attributes;
 /// [DependsOn&lt;Module1&gt;(Optional = true)]
 /// public class Module3 : Module&lt;string&gt;
 /// {
-///     protected override async Task&lt;string?&gt; ExecuteAsync(IModuleContext context, CancellationToken ct)
+///     protected override async Task&lt;string?&gt; ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
 ///     {
 ///         // Use GetModuleIfRegistered for optional dependencies
 ///         var module1 = context.GetModuleIfRegistered&lt;Module1&gt;();

--- a/src/ModularPipelines/Context/IModuleContext.cs
+++ b/src/ModularPipelines/Context/IModuleContext.cs
@@ -37,7 +37,7 @@ namespace ModularPipelines.Context;
 /// <b>Example - Safe Concurrent Access:</b>
 /// </para>
 /// <code>
-/// protected override async Task&lt;MyResult&gt; ExecuteAsync(IModuleContext context, CancellationToken token)
+/// protected override async Task&lt;MyResult&gt; ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
 /// {
 ///     // Safe: Multiple parallel tasks accessing the same context
 ///     var tasks = files.Select(async file =&gt;

--- a/src/ModularPipelines/Context/Linux/AptGet.cs
+++ b/src/ModularPipelines/Context/Linux/AptGet.cs
@@ -16,76 +16,76 @@ public class AptGet : IAptGet
 
     /// <inheritdoc/>
     public virtual async Task<CommandResult> Autoclean(AptGetAutocleanOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new AptGetAutocleanOptions(), null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new AptGetAutocleanOptions(), null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public virtual async Task<CommandResult> BuildDep(AptGetBuildDepOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new AptGetBuildDepOptions(), null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new AptGetBuildDepOptions(), null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Check(AptGetCheckOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Check(AptGetCheckOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new AptGetCheckOptions(), null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new AptGetCheckOptions(), null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Clean(AptGetCleanOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Clean(AptGetCleanOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new AptGetCleanOptions(), null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new AptGetCleanOptions(), null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
     public virtual async Task<CommandResult> DistUpgrade(AptGetDistUpgradeOptions? options = default,
-        CancellationToken token = default)
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new AptGetDistUpgradeOptions(), null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new AptGetDistUpgradeOptions(), null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Install(AptGetInstallOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Install(AptGetInstallOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Package(AptGetPackageOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Package(AptGetPackageOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new AptGetPackageOptions(), null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new AptGetPackageOptions(), null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Remove(AptGetRemoveOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Remove(AptGetRemoveOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Source(AptGetSourceOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Source(AptGetSourceOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new AptGetSourceOptions(), null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new AptGetSourceOptions(), null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Update(AptGetUpdateOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Update(AptGetUpdateOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new AptGetUpdateOptions(), null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new AptGetUpdateOptions(), null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Upgrade(AptGetUpgradeOptions? options = default, CancellationToken token = default)
+    public virtual async Task<CommandResult> Upgrade(AptGetUpgradeOptions? options = default, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new AptGetUpgradeOptions(), null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options ?? new AptGetUpgradeOptions(), null, cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Custom(AptGetOptions options, CancellationToken token = default)
+    public virtual async Task<CommandResult> Custom(AptGetOptions options, CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options, null, token).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineTool(options, null, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/ModularPipelines/Context/Linux/IAptGet.cs
+++ b/src/ModularPipelines/Context/Linux/IAptGet.cs
@@ -5,27 +5,27 @@ namespace ModularPipelines.Context.Linux;
 
 public interface IAptGet
 {
-    Task<CommandResult> Autoclean(AptGetAutocleanOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Autoclean(AptGetAutocleanOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> BuildDep(AptGetBuildDepOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> BuildDep(AptGetBuildDepOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Check(AptGetCheckOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Check(AptGetCheckOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Clean(AptGetCleanOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Clean(AptGetCleanOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> DistUpgrade(AptGetDistUpgradeOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> DistUpgrade(AptGetDistUpgradeOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Install(AptGetInstallOptions options, CancellationToken token = default);
+    Task<CommandResult> Install(AptGetInstallOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Package(AptGetPackageOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Package(AptGetPackageOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Remove(AptGetRemoveOptions options, CancellationToken token = default);
+    Task<CommandResult> Remove(AptGetRemoveOptions options, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Source(AptGetSourceOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Source(AptGetSourceOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Update(AptGetUpdateOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Update(AptGetUpdateOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Upgrade(AptGetUpgradeOptions? options = default, CancellationToken token = default);
+    Task<CommandResult> Upgrade(AptGetUpgradeOptions? options = default, CancellationToken cancellationToken = default);
 
-    Task<CommandResult> Custom(AptGetOptions options, CancellationToken token = default);
+    Task<CommandResult> Custom(AptGetOptions options, CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Exceptions/InvalidModuleTypeException.cs
+++ b/src/ModularPipelines/Exceptions/InvalidModuleTypeException.cs
@@ -39,7 +39,7 @@ namespace ModularPipelines.Exceptions;
 /// <code>
 /// public class MyModule : Module&lt;string&gt;
 /// {
-///     protected override async Task&lt;string&gt; ExecuteAsync(IModuleContext context, CancellationToken token)
+///     protected override async Task&lt;string&gt; ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
 ///     {
 ///         return "result";
 ///     }

--- a/src/ModularPipelines/Exceptions/ModuleNotInitializedException.cs
+++ b/src/ModularPipelines/Exceptions/ModuleNotInitializedException.cs
@@ -31,7 +31,7 @@ namespace ModularPipelines.Exceptions;
 ///     }
 ///
 ///     // All work should happen here
-///     protected override async Task&lt;string&gt; ExecuteAsync(IModuleContext context, CancellationToken token)
+///     protected override async Task&lt;string&gt; ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
 ///     {
 ///         return await _service.DoWorkAsync();
 ///     }

--- a/test/ModularPipelines.UnitTests/Api/CancellationTokenApiTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/CancellationTokenApiTests.cs
@@ -1,0 +1,32 @@
+using ModularPipelines.Context;
+using ModularPipelines.Git;
+using ModularPipelines.Node;
+
+namespace ModularPipelines.UnitTests.Api;
+
+public class CancellationTokenApiTests
+{
+    [Test]
+    public async Task PublicMethods_UseStandardCancellationTokenParameterName()
+    {
+        var assemblies = new[]
+        {
+            typeof(IModuleContext).Assembly,
+            typeof(IGitCommands).Assembly,
+            typeof(INpm).Assembly,
+        };
+
+        var nonstandardParameters = assemblies
+            .SelectMany(assembly => assembly.GetExportedTypes())
+            .SelectMany(type => type.GetMethods())
+            .SelectMany(method => method.GetParameters())
+            .Where(parameter => parameter.ParameterType == typeof(CancellationToken))
+            .Where(parameter => parameter.Name != "cancellationToken")
+            .Select(parameter => $"{parameter.Member.DeclaringType?.FullName}.{parameter.Member.Name}({parameter.Name})")
+            .Distinct()
+            .Order()
+            .ToArray();
+
+        await Assert.That(nonstandardParameters).IsEmpty();
+    }
+}

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
@@ -8,7 +8,7 @@ public class ModuleConfigureTests
 {
     private class TestModule : Module<string>
     {
-        protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string?>("test");
     }
 
@@ -19,7 +19,7 @@ public class ModuleConfigureTests
             .WithAlwaysRun()
             .Build();
 
-        protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string?>("test");
     }
 

--- a/test/ModularPipelines.UnitTests/Dependencies/FlexibleDependencyIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/FlexibleDependencyIntegrationTests.cs
@@ -380,7 +380,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [ModuleTag("database")]
     private class DatabaseModuleA : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(DatabaseModuleA));
@@ -391,7 +391,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [ModuleTag("database")]
     private class DatabaseModuleB : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(DatabaseModuleB));
@@ -402,7 +402,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [ModuleTag("other")]
     private class NonDatabaseModule : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(NonDatabaseModule));
@@ -413,7 +413,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [DependsOnModulesWithTag("database")]
     private class AfterDatabaseModule : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(AfterDatabaseModule));
@@ -424,7 +424,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [DependsOnModulesWithTag("nonexistent")]
     private class ModuleDependingOnNonExistentTag : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(ModuleDependingOnNonExistentTag));
@@ -437,7 +437,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [ModuleTag("critical")]
     private class ModuleWithMultipleTags : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(ModuleWithMultipleTags));
@@ -448,7 +448,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [DependsOnModulesWithTag("slow")]
     private class AfterSlowModule : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(AfterSlowModule));
@@ -463,7 +463,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [ModuleCategory("infrastructure")]
     private class InfrastructureModuleA : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(InfrastructureModuleA));
@@ -474,7 +474,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [ModuleCategory("infrastructure")]
     private class InfrastructureModuleB : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(InfrastructureModuleB));
@@ -485,7 +485,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [ModuleCategory("build")]
     private class BuildModule : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(BuildModule));
@@ -496,7 +496,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [DependsOnModulesInCategory("infrastructure")]
     private class AfterInfrastructureModule : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(AfterInfrastructureModule));
@@ -507,7 +507,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [DependsOnModulesInCategory("nonexistent")]
     private class ModuleDependingOnNonExistentCategory : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(ModuleDependingOnNonExistentCategory));
@@ -522,7 +522,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [Critical]
     private class CriticalModuleA : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(CriticalModuleA));
@@ -533,7 +533,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [Critical]
     private class CriticalModuleB : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(CriticalModuleB));
@@ -543,7 +543,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
 
     private class NonCriticalModule : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(NonCriticalModule));
@@ -554,7 +554,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [Critical]
     private class BaseCriticalModule : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(BaseCriticalModule));
@@ -565,7 +565,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     // Inherits Critical attribute from base class
     private class DerivedCriticalModule : BaseCriticalModule
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(DerivedCriticalModule));
@@ -576,7 +576,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [DependsOnModulesWithAttribute<CriticalAttribute>]
     private class AfterCriticalModule : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(AfterCriticalModule));
@@ -592,7 +592,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     {
         public override IReadOnlySet<string> Tags => new HashSet<string> { "database", "override-tag" };
 
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(ModuleWithOverrideTags));
@@ -604,7 +604,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     {
         public override string? Category => "infrastructure";
 
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(ModuleWithOverrideCategory));
@@ -618,7 +618,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
 
     private class PlainModule : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(PlainModule));
@@ -635,7 +635,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [DependsOnModulesWithAttribute<CriticalAttribute>]
     private class ModuleWithMultipleFlexibleDependencies : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(ModuleWithMultipleFlexibleDependencies));
@@ -648,7 +648,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [ModuleTag("phase1")]
     private class AfterDatabaseModuleWithPhase1Tag : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(AfterDatabaseModuleWithPhase1Tag));
@@ -659,7 +659,7 @@ public class FlexibleDependencyIntegrationTests : TestBase
     [DependsOnModulesWithTag("phase1")]
     private class AfterPhase1Module : Module<string>
     {
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken token)
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             await Task.Yield();
             RecordExecution(nameof(AfterPhase1Module));

--- a/test/ModularPipelines.UnitTests/Helpers/GitTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/GitTests.cs
@@ -18,7 +18,7 @@ public class GitTests : TestBase
             return await context.Git().Commands.Git(new GitBaseOptions
             {
                 Version = true,
-            }, token: cancellationToken);
+            }, cancellationToken: cancellationToken);
         }
     }
 


### PR DESCRIPTION
## What changed

- Renamed `CancellationToken token` parameters to `cancellationToken` across Git, npm, and apt APIs and implementations.
- Updated named-argument call sites and code examples.
- Standardized module test overrides for the same convention.
- Added reflection coverage that checks public APIs in the affected assemblies.

## Why

Different parameter names made optional cancellation-token arguments inconsistent and broke reusable named-argument patterns between integrations. `cancellationToken` is the established .NET convention and already used by current generated services.

## Impact

This changes source-level named arguments. Calls using `token:` must migrate to `cancellationToken:`. Positional calls and runtime behavior are unchanged.

## Validation

- Focused TUnit API test: 1 passed.
- Build pipeline project Release build: succeeded with 0 errors after restore (existing warnings remain).
- Repository scan: no `CancellationToken token` or `CancellationToken ct` declarations remain.

Closes #2240