### PR TITLE
Make default module timeout configurable

### DIFF
--- a/docs/docs/how-to/timeouts.md
+++ b/docs/docs/how-to/timeouts.md
@@ -4,7 +4,17 @@ title: Timeouts
 
 # Timeouts
 
-When creating modules, you can set a timeout per module using the `Configure()` method. You can set this to any timespan you like. Just bear in mind some build runners, like GitHub Actions, have their own timeouts, so extending past these won't help.
+Modules have a 30-minute timeout by default. Configure the pipeline default when your workloads need a different limit, or use `TimeSpan.Zero` to disable it:
+
+```csharp
+var builder = Pipeline.CreateBuilder();
+builder.Options.DefaultModuleTimeout = TimeSpan.FromHours(2);
+
+// Disable the default. Per-module timeouts still apply.
+builder.Options.DefaultModuleTimeout = TimeSpan.Zero;
+```
+
+You can override the pipeline default for one module using `Configure()`. Bear in mind some build runners, like GitHub Actions, have their own timeouts, so extending past these won't help.
 
 ## Using ModuleConfiguration
 
@@ -45,7 +55,8 @@ public class ResilientModule : Module<CommandResult>
 ## Timeout Behavior
 
 When a timeout occurs:
+
 - The `CancellationToken` passed to `ExecuteAsync` will be cancelled
-- The module will fail with a `TimeoutException`
+- The module will fail with a `ModuleTimeoutException`
 - If retry policies are configured, the module may be retried
 - If `WithIgnoreFailures()` is configured, the pipeline will continue despite the timeout

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -46,20 +46,21 @@ internal interface IModuleExecutionPipeline
 /// </remarks>
 internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 {
-    private const int DefaultTimeoutMinutes = 30;
-
     private readonly IModuleResultRepository _resultRepository;
     private readonly EngineCancellationToken _engineCancellationToken;
     private readonly IDirectHookInvoker _directHookInvoker;
+    private readonly IOptions<PipelineOptions> _pipelineOptions;
 
     public ModuleExecutionPipeline(
         IModuleResultRepository resultRepository,
         EngineCancellationToken engineCancellationToken,
-        IDirectHookInvoker directHookInvoker)
+        IDirectHookInvoker directHookInvoker,
+        IOptions<PipelineOptions> pipelineOptions)
     {
         _resultRepository = resultRepository;
         _engineCancellationToken = engineCancellationToken;
         _directHookInvoker = directHookInvoker;
+        _pipelineOptions = pipelineOptions;
     }
 
     public async Task<ModuleResult<T>> ExecuteAsync<T>(
@@ -256,6 +257,18 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         IModuleContext moduleContext)
     {
         var timeout = GetTimeout(config);
+        if (config.Timeout is null)
+        {
+            if (timeout == TimeSpan.Zero)
+            {
+                moduleContext.Logger.LogDebug("No module timeout configured. The pipeline default timeout is disabled");
+            }
+            else
+            {
+                moduleContext.Logger.LogDebug("No module timeout configured. Using pipeline default timeout {Timeout}", timeout);
+            }
+        }
+
         var cancellationToken = executionContext.ModuleCancellationTokenSource.Token;
 
         // Get retry policy if applicable
@@ -286,9 +299,9 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         return timeoutResult.Value;
     }
 
-    private static TimeSpan GetTimeout(ModuleConfiguration config)
+    private TimeSpan GetTimeout(ModuleConfiguration config)
     {
-        return config.Timeout ?? TimeSpan.FromMinutes(DefaultTimeoutMinutes);
+        return config.Timeout ?? _pipelineOptions.Value.DefaultModuleTimeout;
     }
 
     private static IAsyncPolicy? GetRetryPolicy<T>(
@@ -404,7 +417,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         throw exception;
     }
 
-    private static bool IsTimeout(ModuleConfiguration config, ModuleExecutionContext executionContext, Exception exception)
+    private bool IsTimeout(ModuleConfiguration config, ModuleExecutionContext executionContext, Exception exception)
     {
         var timeout = GetTimeout(config);
         if (timeout == TimeSpan.Zero)

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -54,6 +54,12 @@ public record PipelineOptions
     public ExecutionMode ExecutionMode { get; set; } = ExecutionMode.StopOnFirstException;
 
     /// <summary>
+    /// Gets or sets the default timeout for modules that do not configure their own timeout.
+    /// Set to <see cref="TimeSpan.Zero"/> to disable the default module timeout.
+    /// </summary>
+    public TimeSpan DefaultModuleTimeout { get; set; } = TimeSpan.FromMinutes(30);
+
+    /// <summary>
     /// Gets or sets the collection of module categories to run exclusively. If specified, only modules in these categories will run.
     /// </summary>
     public ICollection<string>? RunOnlyCategories { get; set; }

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -265,6 +265,7 @@ public sealed class PipelineBuilder
             services.Configure<PipelineOptions>(opts =>
             {
                 opts.ExecutionMode = _options.ExecutionMode;
+                opts.DefaultModuleTimeout = _options.DefaultModuleTimeout;
                 opts.RunOnlyCategories = _options.RunOnlyCategories;
                 opts.IgnoreCategories = _options.IgnoreCategories;
                 opts.ShowProgressInConsole = _options.ShowProgressInConsole;

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -37,6 +37,13 @@ internal class OptionsValidator : IOptionsValidator
                 $"DefaultRetryCount cannot be negative. Current value: {options.DefaultRetryCount}"));
         }
 
+        if (options.DefaultModuleTimeout < TimeSpan.Zero)
+        {
+            result.AddError(new ValidationError(
+                ValidationErrorCategory.Options,
+                $"DefaultModuleTimeout cannot be negative. Current value: {options.DefaultModuleTimeout}"));
+        }
+
         // Validate concurrency options
         if (options.Concurrency.MaxParallelism < 1)
         {

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -2,6 +2,7 @@ using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 
 namespace ModularPipelines.UnitTests.Execution;
@@ -52,6 +53,45 @@ public class ModuleTimeoutTests : TestBase
             await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken);
             return TestConstants.TestString;
         }
+    }
+
+    private class PipelineDefaultTimeoutModule : Module<string>
+    {
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+            return TestConstants.TestString;
+        }
+    }
+
+    [Test]
+    public async Task Default_Module_Timeout_Is_Thirty_Minutes()
+    {
+        var options = new PipelineOptions();
+
+        await Assert.That(options.DefaultModuleTimeout).IsEqualTo(TimeSpan.FromMinutes(30));
+    }
+
+    [Test]
+    public async Task Pipeline_Default_Module_Timeout_Is_Applied()
+    {
+        var exception = await Assert.ThrowsAsync<ModuleFailedException>(async () => await TestPipelineHostBuilder.Create()
+            .ConfigurePipelineOptions((_, options) => options.DefaultModuleTimeout = TimeSpan.FromMilliseconds(10))
+            .AddModule<PipelineDefaultTimeoutModule>()
+            .ExecutePipelineAsync());
+
+        var timeoutException = exception.InnerException as ModuleTimeoutException;
+        await Assert.That(timeoutException).IsNotNull();
+        await Assert.That(timeoutException!.ConfiguredTimeout).IsEqualTo(TimeSpan.FromMilliseconds(10));
+    }
+
+    [Test]
+    public async Task Zero_Pipeline_Default_Module_Timeout_Disables_Timeout()
+    {
+        await Assert.That(async () => await TestPipelineHostBuilder.Create()
+            .ConfigurePipelineOptions((_, options) => options.DefaultModuleTimeout = TimeSpan.Zero)
+            .AddModule<PipelineDefaultTimeoutModule>()
+            .ExecutePipelineAsync()).ThrowsNothing();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -280,6 +280,21 @@ public class ValidationTests
     }
 
     [Test]
+    public async Task ValidateAsync_WithNegativeDefaultModuleTimeout_ReturnsError()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.Services.AddModule<SimpleModule>();
+        builder.Options.DefaultModuleTimeout = TimeSpan.FromSeconds(-1);
+
+        var result = await builder.ValidateAsync();
+
+        await Assert.That(result.HasErrors).IsTrue();
+        await Assert.That(result.Errors.Any(e =>
+            e.Category == ValidationErrorCategory.Options &&
+            e.Message.Contains("DefaultModuleTimeout"))).IsTrue();
+    }
+
+    [Test]
     public async Task ValidateAsync_WithConflictingCategories_ReturnsError()
     {
         // Arrange


### PR DESCRIPTION
## Summary

- add `PipelineOptions.DefaultModuleTimeout` with the existing 30-minute default
- allow `TimeSpan.Zero` to disable the pipeline default
- validate negative values and propagate the option through `PipelineBuilder`
- log when an unconfigured module uses or disables the pipeline default
- document default, override, and disable behavior

## Validation

- Release build of `ModularPipelines.UnitTests` passed
- focused tests passed for default value, custom timeout application, zero disable behavior, and negative-value validation

Closes #2988