### PR TITLE
Finish housekeeping sweep

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
   workflow_dispatch:
     inputs:
       pr_number:
@@ -26,11 +20,9 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: write        # Allows pushing fixes/commits
+      contents: read         # Allows reading repository files
       pull-requests: write   # Allows posting review comments
       issues: write          # Allows creating/updating issues
-      checks: write          # Allows creating check runs
-      statuses: write        # Allows updating commit statuses
       id-token: write        # Required for OIDC authentication
 
     steps:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -56,7 +56,7 @@ jobs:
           path: ${{ matrix.os == 'windows-latest' && format('{0}\{1}', env.DEV_DRIVE, 'nuget') || '~/.nuget/packages' }}
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
           restore-keys: |
-            ${{ runner.os }}-nuget- }}
+            ${{ runner.os }}-nuget-
       - name: Build ModularPipelines.Analyzers.sln
         run: dotnet build ModularPipelines.Analyzers.sln -c Release
       - name: Build

--- a/src/ModularPipelines/Modules/SyncModule.cs
+++ b/src/ModularPipelines/Modules/SyncModule.cs
@@ -50,7 +50,7 @@ namespace ModularPipelines.Modules;
 /// {
 ///     protected override string? Execute(IModuleContext context, CancellationToken cancellationToken)
 ///     {
-///         var buildResult = context.GetModule&lt;BuildModule, BuildOutput&gt;();
+///         var buildResult = context.GetModule&lt;BuildModule&gt;();
 ///
 ///         // Synchronously access the result (it's already complete due to DependsOn)
 ///         return Path.Combine(buildResult.Value!.OutputPath, "artifacts");

--- a/src/ModularPipelines/Modules/SyncModule.cs
+++ b/src/ModularPipelines/Modules/SyncModule.cs
@@ -50,10 +50,10 @@ namespace ModularPipelines.Modules;
 /// {
 ///     protected override string? Execute(IModuleContext context, CancellationToken cancellationToken)
 ///     {
-///         var buildResult = context.GetModule&lt;BuildModule&gt;();
+///         var buildResult = context.GetModule&lt;BuildModule&gt;().GetAwaiter().GetResult();
 ///
 ///         // Synchronously access the result (it's already complete due to DependsOn)
-///         return Path.Combine(buildResult.Value!.OutputPath, "artifacts");
+///         return Path.Combine(buildResult.ValueOrDefault!.OutputPath, "artifacts");
 ///     }
 /// }
 /// </code>


### PR DESCRIPTION
## Summary

- fix the malformed NuGet cache restore key
- update the stale two-type-parameter `GetModule` XML example
- remove irrelevant TypeScript path-filter comments
- reduce Claude review workflow permissions: `contents` becomes read-only; unused checks/status writes are removed

## Existing fix

The generated-code version template and its regression test landed on `main` in commit `8604c5a5a` after #2997 was opened. This PR verifies that test rather than duplicating generator work or rewriting 15,091 outputs before the generator workflows are repaired.

## Validation

- both edited workflows parsed successfully as YAML
- stale signature and malformed-key searches returned no matches
- `ModularPipelines` Release build passed
- OptionsGenerator tests Release build passed
- `GeneratedCodeAttribute_Contains_A_Version` passed

Closes #2997