### PR TITLE
Remove CI runner paths from generated docs

### DIFF
--- a/src/ModularPipelines.Azure/Options/AzAksGetCredentialsOptions.Generated.cs
+++ b/src/ModularPipelines.Azure/Options/AzAksGetCredentialsOptions.Generated.cs
@@ -33,7 +33,7 @@ public record AzAksGetCredentialsOptions : AzOptions
     public bool? Context { get; set; }
 
     /// <summary>
-    /// Kubernetes configuration file to update. Use "-" to print YAML to stdout instead.  Default: /home/runner/.kube/config.
+    /// Kubernetes configuration file to update. Use "-" to print YAML to stdout instead.  Default: ~/.kube/config.
     /// </summary>
     [CliFlag("--file", ShortForm = "-f")]
     public bool? File { get; set; }

--- a/src/ModularPipelines.Azure/Options/AzAksNamespaceGetCredentialsOptions.Generated.cs
+++ b/src/ModularPipelines.Azure/Options/AzAksNamespaceGetCredentialsOptions.Generated.cs
@@ -27,7 +27,7 @@ public record AzAksNamespaceGetCredentialsOptions : AzOptions
     public bool? Context { get; set; }
 
     /// <summary>
-    /// Kubernetes configuration file to update. Use "-" to print YAML to stdout instead.  Default: /home/runner/.kube/config.
+    /// Kubernetes configuration file to update. Use "-" to print YAML to stdout instead.  Default: ~/.kube/config.
     /// </summary>
     [CliFlag("--file", ShortForm = "-f")]
     public bool? File { get; set; }

--- a/src/ModularPipelines.DotNet/Options/DotNetFormatOptions.Generated.cs
+++ b/src/ModularPipelines.DotNet/Options/DotNetFormatOptions.Generated.cs
@@ -79,7 +79,7 @@ public record DotNetFormatOptions : DotNetOptions
     public string? Report { get; set; }
 
     /// <summary>
-    /// The project or solution file to operate on. If a file is not specified, the command will search the current directory for one. [default: /home/runner/work/ModularPipelines/ModularPipelines/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/]
+    /// The project or solution file to operate on. If a file is not specified, the command will search the current directory for one. [default: ~/work/ModularPipelines/ModularPipelines/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/]
     /// </summary>
     [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]
     public string? ProjectSolution { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxBootstrapGitOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapGitOptions.Generated.cs
@@ -125,7 +125,7 @@ public record FluxBootstrapGitOptions : FluxOptions
     public string? CaFile { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxBootstrapGiteaOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapGiteaOptions.Generated.cs
@@ -136,7 +136,7 @@ public record FluxBootstrapGiteaOptions : FluxOptions
     public string? CaFile { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxBootstrapGithubOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapGithubOptions.Generated.cs
@@ -136,7 +136,7 @@ public record FluxBootstrapGithubOptions : FluxOptions
     public string? CaFile { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxBootstrapGitlabOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapGitlabOptions.Generated.cs
@@ -142,7 +142,7 @@ public record FluxBootstrapGitlabOptions : FluxOptions
     public string? CaFile { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxBootstrapOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapOptions.Generated.cs
@@ -254,7 +254,7 @@ public record FluxBootstrapOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxBuildArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBuildArtifactOptions.Generated.cs
@@ -75,7 +75,7 @@ public record FluxBuildArtifactOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBuildOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxBuildOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCheckOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCheckOptions.Generated.cs
@@ -75,7 +75,7 @@ public record FluxCheckOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateAlertOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateAlertOptions.Generated.cs
@@ -69,7 +69,7 @@ public record FluxCreateAlertOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateHelmreleaseOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateHelmreleaseOptions.Generated.cs
@@ -149,7 +149,7 @@ public record FluxCreateHelmreleaseOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateImageOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxCreateImageOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateImagePolicyOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateImagePolicyOptions.Generated.cs
@@ -99,7 +99,7 @@ public record FluxCreateImagePolicyOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateImageRepositoryOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateImageRepositoryOptions.Generated.cs
@@ -76,7 +76,7 @@ public record FluxCreateImageRepositoryOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateImageUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateImageUpdateOptions.Generated.cs
@@ -112,7 +112,7 @@ public record FluxCreateImageUpdateOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateKustomizationOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateKustomizationOptions.Generated.cs
@@ -132,7 +132,7 @@ public record FluxCreateKustomizationOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateOptions.Generated.cs
@@ -69,7 +69,7 @@ public record FluxCreateOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateReceiverOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateReceiverOptions.Generated.cs
@@ -74,7 +74,7 @@ public record FluxCreateReceiverOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSecretGitOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSecretGitOptions.Generated.cs
@@ -109,7 +109,7 @@ public record FluxCreateSecretGitOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSecretGithubappOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSecretGithubappOptions.Generated.cs
@@ -82,7 +82,7 @@ public record FluxCreateSecretGithubappOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSecretHelmOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSecretHelmOptions.Generated.cs
@@ -82,7 +82,7 @@ public record FluxCreateSecretHelmOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSecretNotationOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSecretNotationOptions.Generated.cs
@@ -63,7 +63,7 @@ public record FluxCreateSecretNotationOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSecretOciOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSecretOciOptions.Generated.cs
@@ -70,7 +70,7 @@ public record FluxCreateSecretOciOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSecretOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSecretOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxCreateSecretOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSecretProxyOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSecretProxyOptions.Generated.cs
@@ -70,7 +70,7 @@ public record FluxCreateSecretProxyOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSecretReceiverOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSecretReceiverOptions.Generated.cs
@@ -83,7 +83,7 @@ public record FluxCreateSecretReceiverOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSecretTlsOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSecretTlsOptions.Generated.cs
@@ -69,7 +69,7 @@ public record FluxCreateSecretTlsOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSourceBucketOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSourceBucketOptions.Generated.cs
@@ -116,7 +116,7 @@ public record FluxCreateSourceBucketOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSourceChartOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSourceChartOptions.Generated.cs
@@ -101,7 +101,7 @@ public record FluxCreateSourceChartOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSourceGitOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSourceGitOptions.Generated.cs
@@ -176,7 +176,7 @@ public record FluxCreateSourceGitOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSourceHelmOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSourceHelmOptions.Generated.cs
@@ -107,7 +107,7 @@ public record FluxCreateSourceHelmOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSourceOciOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSourceOciOptions.Generated.cs
@@ -151,7 +151,7 @@ public record FluxCreateSourceOciOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateSourceOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxCreateSourceOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxCreateTenantOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxCreateTenantOptions.Generated.cs
@@ -75,7 +75,7 @@ public record FluxCreateTenantOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDebugHelmreleaseOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDebugHelmreleaseOptions.Generated.cs
@@ -69,7 +69,7 @@ public record FluxDebugHelmreleaseOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDebugOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDebugOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDebugOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteAlertOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteAlertOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteAlertOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteHelmreleaseOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteHelmreleaseOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteHelmreleaseOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteImageOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteImageOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteImagePolicyOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteImagePolicyOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteImagePolicyOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteImageRepositoryOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteImageRepositoryOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteImageRepositoryOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteImageUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteImageUpdateOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteImageUpdateOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteKustomizationOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteKustomizationOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteKustomizationOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxDeleteOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteReceiverOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteReceiverOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteReceiverOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteSourceBucketOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteSourceBucketOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteSourceBucketOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteSourceChartOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteSourceChartOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteSourceChartOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteSourceGitOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteSourceGitOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteSourceGitOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteSourceHelmOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteSourceHelmOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteSourceHelmOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteSourceOciOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteSourceOciOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteSourceOciOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDeleteSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDeleteSourceOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDeleteSourceOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDiffArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDiffArtifactOptions.Generated.cs
@@ -82,7 +82,7 @@ public record FluxDiffArtifactOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxDiffOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDiffOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxDiffOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxEnvsubstOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxEnvsubstOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxEnvsubstOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxEventsOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxEventsOptions.Generated.cs
@@ -75,7 +75,7 @@ public record FluxEventsOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportAlertOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportAlertOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportAlertOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportArtifactGeneratorOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportArtifactGeneratorOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportArtifactGeneratorOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportArtifactOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportArtifactOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportHelmreleaseOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportHelmreleaseOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportHelmreleaseOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportImageOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportImageOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportImagePolicyOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportImagePolicyOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportImagePolicyOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportImageRepositoryOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportImageRepositoryOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportImageRepositoryOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportImageUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportImageUpdateOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportImageUpdateOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportKustomizationOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportKustomizationOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportKustomizationOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportReceiverOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportReceiverOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportReceiverOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportSourceBucketOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportSourceBucketOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportSourceBucketOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportSourceChartOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportSourceChartOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportSourceChartOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportSourceExternalOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportSourceExternalOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportSourceExternalOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportSourceGitOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportSourceGitOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportSourceGitOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportSourceHelmOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportSourceHelmOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportSourceHelmOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportSourceOciOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportSourceOciOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxExportSourceOciOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxExportSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxExportSourceOptions.Generated.cs
@@ -63,7 +63,7 @@ public record FluxExportSourceOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetAlertsOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetAlertsOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetAlertsOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetAllOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetAllOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetAllOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetArtifactsGeneratorsOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetArtifactsGeneratorsOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetArtifactsGeneratorsOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetArtifactsOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetArtifactsOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetArtifactsOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetHelmreleasesOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetHelmreleasesOptions.Generated.cs
@@ -63,7 +63,7 @@ public record FluxGetHelmreleasesOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetImagesAllOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetImagesAllOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetImagesAllOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetImagesOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetImagesOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetImagesOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetImagesPolicyOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetImagesPolicyOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetImagesPolicyOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetImagesRepositoryOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetImagesRepositoryOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetImagesRepositoryOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetImagesUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetImagesUpdateOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetImagesUpdateOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetKustomizationsOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetKustomizationsOptions.Generated.cs
@@ -63,7 +63,7 @@ public record FluxGetKustomizationsOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetOptions.Generated.cs
@@ -81,7 +81,7 @@ public record FluxGetOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetReceiversOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetReceiversOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetReceiversOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetSourcesAllOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetSourcesAllOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetSourcesAllOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetSourcesBucketOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetSourcesBucketOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetSourcesBucketOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetSourcesChartOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetSourcesChartOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetSourcesChartOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetSourcesExternalOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetSourcesExternalOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetSourcesExternalOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetSourcesGitOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetSourcesGitOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetSourcesGitOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetSourcesHelmOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetSourcesHelmOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetSourcesHelmOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetSourcesOciOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetSourcesOciOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetSourcesOciOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxGetSourcesOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxGetSourcesOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxGetSourcesOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxInstallOptions.Generated.cs
@@ -131,7 +131,7 @@ public record FluxInstallOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxListArtifactsOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxListArtifactsOptions.Generated.cs
@@ -82,7 +82,7 @@ public record FluxListArtifactsOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxListOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxListOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxListOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxLogsOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxLogsOptions.Generated.cs
@@ -106,7 +106,7 @@ public record FluxLogsOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxMigrateOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxMigrateOptions.Generated.cs
@@ -81,7 +81,7 @@ public record FluxMigrateOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxPluginInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPluginInstallOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxPluginInstallOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxPluginListOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPluginListOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxPluginListOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxPluginOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPluginOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxPluginOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxPluginSearchOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPluginSearchOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxPluginSearchOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxPluginUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPluginUninstallOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxPluginUninstallOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxPluginUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPluginUpdateOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxPluginUpdateOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxPullArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPullArtifactOptions.Generated.cs
@@ -76,7 +76,7 @@ public record FluxPullArtifactOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxPullOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPullOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxPullOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxPushArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPushArtifactOptions.Generated.cs
@@ -124,7 +124,7 @@ public record FluxPushArtifactOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxPushOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPushOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxPushOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileHelmreleaseOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileHelmreleaseOptions.Generated.cs
@@ -69,7 +69,7 @@ public record FluxReconcileHelmreleaseOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileImageOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxReconcileImageOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileImagePolicyOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileImagePolicyOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxReconcileImagePolicyOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileImageRepositoryOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileImageRepositoryOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxReconcileImageRepositoryOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileImageUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileImageUpdateOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxReconcileImageUpdateOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxReconcileOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileReceiverOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileReceiverOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxReconcileReceiverOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileSourceBucketOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileSourceBucketOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxReconcileSourceBucketOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileSourceChartOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileSourceChartOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxReconcileSourceChartOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileSourceGitOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileSourceGitOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxReconcileSourceGitOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileSourceHelmOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileSourceHelmOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxReconcileSourceHelmOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileSourceOciOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileSourceOciOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxReconcileSourceOciOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxReconcileSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxReconcileSourceOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxReconcileSourceOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeAlertOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeAlertOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeAlertOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeHelmreleaseOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeHelmreleaseOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeHelmreleaseOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeImageOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeImageOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeImagePolicyOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeImagePolicyOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeImagePolicyOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeImageRepositoryOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeImageRepositoryOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeImageRepositoryOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeImageUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeImageUpdateOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeImageUpdateOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeKustomizationOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeKustomizationOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeKustomizationOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeOptions.Generated.cs
@@ -63,7 +63,7 @@ public record FluxResumeOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeReceiverOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeReceiverOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeReceiverOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeSourceBucketOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeSourceBucketOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeSourceBucketOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeSourceChartOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeSourceChartOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeSourceChartOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeSourceGitOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeSourceGitOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeSourceGitOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeSourceHelmOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeSourceHelmOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeSourceHelmOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeSourceOciOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeSourceOciOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeSourceOciOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxResumeSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxResumeSourceOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxResumeSourceOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxStatsOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxStatsOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxStatsOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendAlertOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendAlertOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendAlertOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendHelmreleaseOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendHelmreleaseOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendHelmreleaseOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendImageOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendImageOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendImageOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendImagePolicyOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendImagePolicyOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendImagePolicyOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendImageRepositoryOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendImageRepositoryOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendImageRepositoryOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendImageUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendImageUpdateOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendImageUpdateOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendKustomizationOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendKustomizationOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendKustomizationOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendReceiverOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendReceiverOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendReceiverOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendSourceBucketOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendSourceBucketOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendSourceBucketOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendSourceChartOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendSourceChartOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendSourceChartOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendSourceGitOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendSourceGitOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendSourceGitOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendSourceHelmOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendSourceHelmOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendSourceHelmOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendSourceOciOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendSourceOciOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendSourceOciOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxSuspendSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxSuspendSourceOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxSuspendSourceOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxTagArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTagArtifactOptions.Generated.cs
@@ -70,7 +70,7 @@ public record FluxTagArtifactOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxTagOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTagOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxTagOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxTraceOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTraceOptions.Generated.cs
@@ -63,7 +63,7 @@ public record FluxTraceOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxTreeArtifactGeneratorOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTreeArtifactGeneratorOptions.Generated.cs
@@ -57,7 +57,7 @@ public record FluxTreeArtifactGeneratorOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxTreeArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTreeArtifactOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxTreeArtifactOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxTreeOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTreeOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxTreeOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxTriggerOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTriggerOptions.Generated.cs
@@ -51,7 +51,7 @@ public record FluxTriggerOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxTriggerReceiverOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTriggerReceiverOptions.Generated.cs
@@ -108,7 +108,7 @@ public record FluxTriggerReceiverOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Flux/Options/FluxUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxUninstallOptions.Generated.cs
@@ -69,7 +69,7 @@ public record FluxUninstallOptions : FluxOptions
     public IEnumerable<string>? AsUserExtra { get; set; }
 
     /// <summary>
-    /// Default cache directory (default "/home/runner/.kube/cache")
+    /// Default cache directory (default "~/.kube/cache")
     /// </summary>
     [CliOption("--cache-dir", Format = OptionFormat.EqualsSeparated)]
     public string? CacheDir { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmCreateOptions.Generated.cs
@@ -112,19 +112,19 @@ public record HelmCreateOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmDependencyBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmDependencyBuildOptions.Generated.cs
@@ -51,7 +51,7 @@ public record HelmDependencyBuildOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// keyring containing public keys (default "/home/runner/.gnupg/pubring.gpg")
+    /// keyring containing public keys (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -167,19 +167,19 @@ public record HelmDependencyBuildOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmDependencyListOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmDependencyListOptions.Generated.cs
@@ -112,19 +112,19 @@ public record HelmDependencyListOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmDependencyOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmDependencyOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmDependencyOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmDependencyUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmDependencyUpdateOptions.Generated.cs
@@ -51,7 +51,7 @@ public record HelmDependencyUpdateOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// keyring containing public keys (default "/home/runner/.gnupg/pubring.gpg")
+    /// keyring containing public keys (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -167,19 +167,19 @@ public record HelmDependencyUpdateOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmEnvOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmEnvOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmEnvOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmGetAllOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmGetAllOptions.Generated.cs
@@ -118,19 +118,19 @@ public record HelmGetAllOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmGetHooksOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmGetHooksOptions.Generated.cs
@@ -112,19 +112,19 @@ public record HelmGetHooksOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmGetManifestOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmGetManifestOptions.Generated.cs
@@ -112,19 +112,19 @@ public record HelmGetManifestOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmGetMetadataOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmGetMetadataOptions.Generated.cs
@@ -118,19 +118,19 @@ public record HelmGetMetadataOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmGetNotesOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmGetNotesOptions.Generated.cs
@@ -112,19 +112,19 @@ public record HelmGetNotesOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmGetOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmGetOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmGetOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmGetValuesOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmGetValuesOptions.Generated.cs
@@ -124,19 +124,19 @@ public record HelmGetValuesOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmHistoryOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmHistoryOptions.Generated.cs
@@ -118,19 +118,19 @@ public record HelmHistoryOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmInstallOptions.Generated.cs
@@ -124,7 +124,7 @@ public record HelmInstallOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// location of public keys used for verification (default "/home/runner/.gnupg/pubring.gpg")
+    /// location of public keys used for verification (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -372,19 +372,19 @@ public record HelmInstallOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmLintOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmLintOptions.Generated.cs
@@ -172,19 +172,19 @@ public record HelmLintOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmListOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmListOptions.Generated.cs
@@ -214,19 +214,19 @@ public record HelmListOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmPackageOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmPackageOptions.Generated.cs
@@ -75,7 +75,7 @@ public record HelmPackageOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// location of a public keyring (default "/home/runner/.gnupg/pubring.gpg")
+    /// location of a public keyring (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -197,19 +197,19 @@ public record HelmPackageOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmPluginInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmPluginInstallOptions.Generated.cs
@@ -112,19 +112,19 @@ public record HelmPluginInstallOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmPluginListOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmPluginListOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmPluginListOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmPluginOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmPluginOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmPluginOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmPluginUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmPluginUninstallOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmPluginUninstallOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmPluginUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmPluginUpdateOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmPluginUpdateOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmPullOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmPullOptions.Generated.cs
@@ -63,7 +63,7 @@ public record HelmPullOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// location of public keys used for verification (default "/home/runner/.gnupg/pubring.gpg")
+    /// location of public keys used for verification (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -209,19 +209,19 @@ public record HelmPullOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmPushOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmPushOptions.Generated.cs
@@ -149,19 +149,19 @@ public record HelmPushOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmRegistryLoginOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmRegistryLoginOptions.Generated.cs
@@ -155,19 +155,19 @@ public record HelmRegistryLoginOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmRegistryLogoutOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmRegistryLogoutOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmRegistryLogoutOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmRegistryOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmRegistryOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmRegistryOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmRepoAddOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmRepoAddOptions.Generated.cs
@@ -179,19 +179,19 @@ public record HelmRepoAddOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmRepoIndexOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmRepoIndexOptions.Generated.cs
@@ -124,19 +124,19 @@ public record HelmRepoIndexOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmRepoListOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmRepoListOptions.Generated.cs
@@ -112,19 +112,19 @@ public record HelmRepoListOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmRepoOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmRepoOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmRepoOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmRepoRemoveOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmRepoRemoveOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmRepoRemoveOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmRepoUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmRepoUpdateOptions.Generated.cs
@@ -118,19 +118,19 @@ public record HelmRepoUpdateOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmRollbackOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmRollbackOptions.Generated.cs
@@ -162,19 +162,19 @@ public record HelmRollbackOptions(
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmSearchHubOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmSearchHubOptions.Generated.cs
@@ -136,19 +136,19 @@ public record HelmSearchHubOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmSearchOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmSearchOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmSearchOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmSearchRepoOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmSearchRepoOptions.Generated.cs
@@ -148,19 +148,19 @@ public record HelmSearchRepoOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmShowAllOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmShowAllOptions.Generated.cs
@@ -57,7 +57,7 @@ public record HelmShowAllOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// location of public keys used for verification (default "/home/runner/.gnupg/pubring.gpg")
+    /// location of public keys used for verification (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -185,19 +185,19 @@ public record HelmShowAllOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmShowChartOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmShowChartOptions.Generated.cs
@@ -57,7 +57,7 @@ public record HelmShowChartOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// location of public keys used for verification (default "/home/runner/.gnupg/pubring.gpg")
+    /// location of public keys used for verification (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -185,19 +185,19 @@ public record HelmShowChartOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmShowCrdsOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmShowCrdsOptions.Generated.cs
@@ -57,7 +57,7 @@ public record HelmShowCrdsOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// location of public keys used for verification (default "/home/runner/.gnupg/pubring.gpg")
+    /// location of public keys used for verification (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -185,19 +185,19 @@ public record HelmShowCrdsOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmShowOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmShowOptions.Generated.cs
@@ -106,19 +106,19 @@ public record HelmShowOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmShowReadmeOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmShowReadmeOptions.Generated.cs
@@ -57,7 +57,7 @@ public record HelmShowReadmeOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// location of public keys used for verification (default "/home/runner/.gnupg/pubring.gpg")
+    /// location of public keys used for verification (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -185,19 +185,19 @@ public record HelmShowReadmeOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmShowValuesOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmShowValuesOptions.Generated.cs
@@ -63,7 +63,7 @@ public record HelmShowValuesOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// location of public keys used for verification (default "/home/runner/.gnupg/pubring.gpg")
+    /// location of public keys used for verification (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -191,19 +191,19 @@ public record HelmShowValuesOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmStatusOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmStatusOptions.Generated.cs
@@ -130,19 +130,19 @@ public record HelmStatusOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmTemplateOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmTemplateOptions.Generated.cs
@@ -136,7 +136,7 @@ public record HelmTemplateOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// location of public keys used for verification (default "/home/runner/.gnupg/pubring.gpg")
+    /// location of public keys used for verification (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -414,19 +414,19 @@ public record HelmTemplateOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmTestOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmTestOptions.Generated.cs
@@ -130,19 +130,19 @@ public record HelmTestOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmUninstallOptions.Generated.cs
@@ -154,19 +154,19 @@ public record HelmUninstallOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmUpgradeOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmUpgradeOptions.Generated.cs
@@ -136,7 +136,7 @@ public record HelmUpgradeOptions : HelmOptions
     public string? KeyFile { get; set; }
 
     /// <summary>
-    /// location of public keys used for verification (default "/home/runner/.gnupg/pubring.gpg")
+    /// location of public keys used for verification (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -390,19 +390,19 @@ public record HelmUpgradeOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Helm/Options/HelmVerifyOptions.Generated.cs
+++ b/src/ModularPipelines.Helm/Options/HelmVerifyOptions.Generated.cs
@@ -27,7 +27,7 @@ public record HelmVerifyOptions : HelmOptions
     public bool? Help { get; set; }
 
     /// <summary>
-    /// keyring containing public keys (default "/home/runner/.gnupg/pubring.gpg")
+    /// keyring containing public keys (default "~/.gnupg/pubring.gpg")
     /// </summary>
     [CliOption("--keyring", Format = OptionFormat.EqualsSeparated)]
     public string? Keyring { get; set; }
@@ -112,19 +112,19 @@ public record HelmVerifyOptions : HelmOptions
     public double? Qps { get; set; }
 
     /// <summary>
-    /// path to the registry config file (default "/home/runner/.config/helm/registry/config.json")
+    /// path to the registry config file (default "~/.config/helm/registry/config.json")
     /// </summary>
     [CliOption("--registry-config", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryConfig { get; set; }
 
     /// <summary>
-    /// path to the directory containing cached repository indexes (default "/home/runner/.cache/helm/repository")
+    /// path to the directory containing cached repository indexes (default "~/.cache/helm/repository")
     /// </summary>
     [CliOption("--repository-cache", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryCache { get; set; }
 
     /// <summary>
-    /// path to the file containing repository names and URLs (default "/home/runner/.config/helm/repositories.yaml")
+    /// path to the file containing repository names and URLs (default "~/.config/helm/repositories.yaml")
     /// </summary>
     [CliOption("--repository-config", Format = OptionFormat.EqualsSeparated)]
     public string? RepositoryConfig { get; set; }

--- a/src/ModularPipelines.Node/Options/PnpmAddOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmAddOptions.Generated.cs
@@ -39,7 +39,7 @@ public record PnpmAddOptions : PnpmOptions
     public string? Config { get; set; }
 
     /// <summary>
-    /// Change to directory &lt;dir&gt; (default: /home/runner/work/ModularPipelines/ ModularPipelines/tools/ModularPipelines. OptionsGenerator/src/ModularPipelines. OptionsGenerator)
+    /// Change to directory &lt;dir&gt; (default: ~/work/ModularPipelines/ ModularPipelines/tools/ModularPipelines. OptionsGenerator/src/ModularPipelines. OptionsGenerator)
     /// </summary>
     [CliOption("--dir", ShortForm = "-C")]
     public string? Dir { get; set; }

--- a/src/ModularPipelines.Node/Options/PnpmRunOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmRunOptions.Generated.cs
@@ -27,7 +27,7 @@ public record PnpmRunOptions : PnpmOptions
     public string? AggregateOutput { get; set; }
 
     /// <summary>
-    /// Change to directory &lt;dir&gt; (default: /home/runner/work/ModularPipelines/ ModularPipelines/tools/ModularPipelines. OptionsGenerator/src/ModularPipelines. OptionsGenerator)
+    /// Change to directory &lt;dir&gt; (default: ~/work/ModularPipelines/ ModularPipelines/tools/ModularPipelines. OptionsGenerator/src/ModularPipelines. OptionsGenerator)
     /// </summary>
     [CliOption("--dir", ShortForm = "-C")]
     public string? Dir { get; set; }

--- a/src/ModularPipelines.Node/Options/PnpmUnlinkOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmUnlinkOptions.Generated.cs
@@ -27,7 +27,7 @@ public record PnpmUnlinkOptions : PnpmOptions
     public string? AggregateOutput { get; set; }
 
     /// <summary>
-    /// Change to directory &lt;dir&gt; (default: /home/runner/work/ModularPipelines/ModularPipelines/ tools/ModularPipelines.OptionsGenerator/src/ ModularPipelines.OptionsGenerator)
+    /// Change to directory &lt;dir&gt; (default: ~/work/ModularPipelines/ModularPipelines/ tools/ModularPipelines.OptionsGenerator/src/ ModularPipelines.OptionsGenerator)
     /// </summary>
     [CliOption("--dir", ShortForm = "-C")]
     public string? Dir { get; set; }

--- a/src/ModularPipelines.Node/Options/PnpmWhyOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmWhyOptions.Generated.cs
@@ -39,7 +39,7 @@ public record PnpmWhyOptions : PnpmOptions
     public string? Dev { get; set; }
 
     /// <summary>
-    /// Change to directory &lt;dir&gt; (default: /home/runner/work/ModularPipelines/ModularPipelines/ tools/ModularPipelines.OptionsGenerator/src/ ModularPipelines.OptionsGenerator)
+    /// Change to directory &lt;dir&gt; (default: ~/work/ModularPipelines/ModularPipelines/ tools/ModularPipelines.OptionsGenerator/src/ ModularPipelines.OptionsGenerator)
     /// </summary>
     [CliOption("--dir", ShortForm = "-C")]
     public string? Dir { get; set; }


### PR DESCRIPTION
## Summary

- replace CI-runner home paths with `~` in 218 generated options files
- cover Azure, DotNet, Flux, Helm, and Node outputs
- align checked-in output with the sanitizer already merged in #3016

## Root cause

Generated help text captured machine-specific defaults before the generator sanitizer existed. Although future generations are normalized, current shipped XML docs still exposed `/home/runner` paths.

## Validation

- no Linux, macOS, or Windows runner-home patterns remain in affected generated files
- full `ModularPipelines.sln` Release build passed

Closes #2991