### PR TITLE
Fix dotnet builder after CLI option drift

### DIFF
--- a/src/ModularPipelines.DotNet/Builders/DotNetBuildBuilder.cs
+++ b/src/ModularPipelines.DotNet/Builders/DotNetBuildBuilder.cs
@@ -111,7 +111,7 @@ public class DotNetBuildBuilder : IDotNetBuildBuilder
     /// <inheritdoc />
     public IDotNetBuildBuilder WithNoLogo(bool noLogo = true)
     {
-        _toolOptions = _toolOptions with { Nologo = noLogo };
+        _toolOptions = _toolOptions with { NoLogo = noLogo };
         return this;
     }
 
@@ -151,9 +151,9 @@ public class DotNetBuildBuilder : IDotNetBuildBuilder
     }
 
     /// <inheritdoc />
+    [Obsolete("The dotnet --debug switch is no longer supported and this method has no effect.")]
     public IDotNetBuildBuilder WithDebug(bool debug = true)
     {
-        _toolOptions = _toolOptions with { Debug = debug };
         return this;
     }
 

--- a/src/ModularPipelines.DotNet/Builders/IDotNetBuildBuilder.cs
+++ b/src/ModularPipelines.DotNet/Builders/IDotNetBuildBuilder.cs
@@ -125,10 +125,11 @@ public interface IDotNetBuildBuilder
     IDotNetBuildBuilder WithDisableBuildServers(bool disableBuildServers = true);
 
     /// <summary>
-    /// Enables debug mode.
+    /// Retained for compatibility. The dotnet CLI no longer supports the debug switch.
     /// </summary>
-    /// <param name="debug">Whether to enable debug mode. Defaults to true.</param>
+    /// <param name="debug">Ignored.</param>
     /// <returns>The builder instance for chaining.</returns>
+    [Obsolete("The dotnet --debug switch is no longer supported and this method has no effect.")]
     IDotNetBuildBuilder WithDebug(bool debug = true);
 
     /// <summary>

--- a/src/ModularPipelines.DotNet/Options/DotNetBuildOptions.Generated.cs
+++ b/src/ModularPipelines.DotNet/Options/DotNetBuildOptions.Generated.cs
@@ -56,12 +56,6 @@ public record DotNetBuildOptions : DotNetOptions
     public bool? Interactive { get; set; }
 
     /// <summary>
-    /// [default: False]
-    /// </summary>
-    [CliFlag("--debug")]
-    public bool? Debug { get; set; }
-
-    /// <summary>
     /// The output directory to place built artifacts in.
     /// </summary>
     [CliOption("--output", ShortForm = "-o")]
@@ -86,10 +80,10 @@ public record DotNetBuildOptions : DotNetOptions
     public bool? NoDependencies { get; set; }
 
     /// <summary>
-    /// Do not display the startup banner or the copyright message. [default: False]
+    /// Do not display the startup banner or the copyright message. [default: True]
     /// </summary>
-    [CliFlag("--nologo")]
-    public bool? Nologo { get; set; }
+    [CliFlag("--no-logo", ShortForm = "-nologo")]
+    public bool? NoLogo { get; set; }
 
     /// <summary>
     /// Publish your application as a framework dependent application. A compatible .NET runtime must be installed on the target machine to run your application. [default: False]

--- a/src/ModularPipelines.DotNet/Options/DotNetBuildOptions.Generated.cs
+++ b/src/ModularPipelines.DotNet/Options/DotNetBuildOptions.Generated.cs
@@ -82,7 +82,7 @@ public record DotNetBuildOptions : DotNetOptions
     /// <summary>
     /// Do not display the startup banner or the copyright message. [default: True]
     /// </summary>
-    [CliFlag("--no-logo", ShortForm = "-nologo")]
+    [CliFlag("--nologo")]
     public bool? NoLogo { get; set; }
 
     /// <summary>
@@ -120,5 +120,15 @@ public record DotNetBuildOptions : DotNetOptions
     /// </summary>
     [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]
     public string? ProjectSolution { get; set; }
+
+    [Obsolete("Use NoLogo instead.")]
+    public bool? Nologo
+    {
+        get => NoLogo;
+        set => NoLogo = value;
+    }
+
+    [Obsolete("The dotnet --debug switch is no longer supported and this property has no effect.")]
+    public bool? Debug { get; set; }
 
 }

--- a/test/ModularPipelines.UnitTests/Attributes/DotNetBuildOptionsCompatibilityTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/DotNetBuildOptionsCompatibilityTests.cs
@@ -1,0 +1,41 @@
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Helpers.Internal;
+
+namespace ModularPipelines.UnitTests.Attributes;
+
+public class DotNetBuildOptionsCompatibilityTests
+{
+    private readonly CommandModelProvider _modelProvider = new();
+    private readonly CommandArgumentBuilder _argumentBuilder = new();
+
+    [Test]
+    public async Task Nologo_Forwards_To_NoLogo_And_Renders_Stable_Switch()
+    {
+#pragma warning disable CS0618
+        var options = new DotNetBuildOptions { Nologo = true };
+#pragma warning restore CS0618
+
+        var arguments = BuildArguments(options);
+
+        await Assert.That(options.NoLogo).IsTrue();
+        await Assert.That(arguments).IsEquivalentTo(["--nologo"]);
+    }
+
+    [Test]
+    public async Task Debug_Is_Retained_But_Not_Rendered()
+    {
+#pragma warning disable CS0618
+        var options = new DotNetBuildOptions { Debug = true };
+#pragma warning restore CS0618
+
+        var arguments = BuildArguments(options);
+
+        await Assert.That(arguments).Count().IsEqualTo(0);
+    }
+
+    private List<string> BuildArguments(DotNetBuildOptions options)
+    {
+        var model = _modelProvider.GetCommandModel(typeof(DotNetBuildOptions));
+        return _argumentBuilder.BuildArguments(model, options);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Builders/DotNetBuildBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Builders/DotNetBuildBuilderTests.cs
@@ -126,7 +126,7 @@ public class DotNetBuildBuilderTests : TestBase
         builder.WithNoLogo();
 
         var (toolOptions, _) = builder.ToOptions();
-        await Assert.That(toolOptions.Nologo).IsTrue();
+        await Assert.That(toolOptions.NoLogo).IsTrue();
     }
 
     [Test]
@@ -239,7 +239,7 @@ public class DotNetBuildBuilderTests : TestBase
         await Assert.That(toolOptions.Configuration).IsEqualTo("Release");
         await Assert.That(toolOptions.Framework).IsEqualTo("net8.0");
         await Assert.That(toolOptions.NoRestore).IsTrue();
-        await Assert.That(toolOptions.Nologo).IsTrue();
+        await Assert.That(toolOptions.NoLogo).IsTrue();
         await Assert.That(toolOptions.Properties!.First().Key).IsEqualTo("Version");
         await Assert.That(execOptions.WorkingDirectory).IsEqualTo("/project");
         await Assert.That(execOptions.ExecutionTimeout).IsEqualTo(TimeSpan.FromMinutes(15));

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -175,6 +175,40 @@ public class GeneratorHardeningTests
         await Assert.That(generated).DoesNotContain("CliFlag(\"--removed-flag\")");
     }
 
+    [Test]
+    public async Task OptionsClassGenerator_Emits_Case_Variant_Compatibility_Alias()
+    {
+        var command = Command("ToolBuildOptions", "ToolOptions") with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--nologo",
+                    PropertyName = "NoLogo",
+                    CSharpType = "bool?",
+                    IsFlag = true,
+                },
+            ],
+            CompatibilityProperties =
+            [
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "Nologo",
+                    CSharpType = "bool?",
+                    ForwardToPropertyName = "NoLogo",
+                    ObsoleteMessage = "Use NoLogo instead.",
+                },
+            ],
+        };
+
+        var generated = (await new OptionsClassGenerator().GenerateAsync(Tool(command))).Single().Content;
+
+        await Assert.That(generated).Contains("public bool? NoLogo { get; set; }");
+        await Assert.That(generated).Contains("public bool? Nologo");
+        await Assert.That(generated).Contains("get => NoLogo;");
+    }
+
     #endregion
 
     #region EnsureNoDuplicateFilePaths

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -140,6 +140,43 @@ public class GeneratorHardeningTests
 
     #endregion
 
+    #region Compatibility properties
+
+    [Test]
+    public async Task OptionsClassGenerator_Emits_NonCli_Compatibility_Properties()
+    {
+        var command = Command("ToolBuildOptions", "ToolOptions") with
+        {
+            CompatibilityProperties =
+            [
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "OldName",
+                    CSharpType = "bool?",
+                    ForwardToPropertyName = "NewName",
+                    ObsoleteMessage = "Use NewName instead.",
+                },
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "RemovedFlag",
+                    CSharpType = "bool?",
+                    ObsoleteMessage = "This flag has no effect.",
+                },
+            ],
+        };
+
+        var files = await new OptionsClassGenerator().GenerateAsync(Tool(command));
+        var generated = files.Single().Content;
+
+        await Assert.That(generated).Contains("[Obsolete(\"Use NewName instead.\")]");
+        await Assert.That(generated).Contains("get => NewName;");
+        await Assert.That(generated).Contains("set => NewName = value;");
+        await Assert.That(generated).Contains("public bool? RemovedFlag { get; set; }");
+        await Assert.That(generated).DoesNotContain("CliFlag(\"--removed-flag\")");
+    }
+
+    #endregion
+
     #region EnsureNoDuplicateFilePaths
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DotNetCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DotNetCliScraperTests.cs
@@ -1,5 +1,7 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.OptionsGenerator.Models;
-using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.Scrapers;
 
 namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
 
@@ -18,7 +20,7 @@ public class DotNetCliScraperTests
             Flag("--debug", "Debug"),
         };
 
-        DotNetCliScraper.ApplyBuildOptionCompatibility(["build"], options);
+        DotNetCliCompatibility.NormalizeOptions(["build"], options);
 
         await Assert.That(options).Count().IsEqualTo(1);
         await Assert.That(options[0].SwitchName).IsEqualTo("--nologo");
@@ -29,7 +31,7 @@ public class DotNetCliScraperTests
     [Test]
     public async Task Build_Compatibility_Preserves_Removed_Public_Properties()
     {
-        var properties = DotNetCliScraper.GetCompatibilityProperties(["build"]);
+        var properties = DotNetCliCompatibility.GetProperties(["build"]);
 
         await Assert.That(properties.Select(property => property.PropertyName))
             .IsEquivalentTo(["Nologo", "Debug"]);
@@ -37,6 +39,32 @@ public class DotNetCliScraperTests
             .IsEqualTo("NoLogo");
         await Assert.That(properties.Single(property => property.PropertyName == "Debug").ForwardToPropertyName)
             .IsNull();
+    }
+
+    [Test]
+    public async Task Documentation_Fallback_Applies_Build_Compatibility()
+    {
+        const string html = """
+                            <html><body><article>
+                            <dl>
+                              <dt>--no-logo</dt><dd>Do not display the startup banner.</dd>
+                              <dt>--debug</dt><dd>Enable debug output.</dd>
+                            </dl>
+                            </article></body></html>
+                            """;
+        using var httpClient = new HttpClient(new StaticHtmlHandler(html));
+        var scraper = new DotNetCliDocumentationScraper(
+            httpClient,
+            NullLogger<DotNetCliDocumentationScraper>.Instance);
+
+        var tool = await scraper.ScrapeAsync();
+        var build = tool.Commands.Single(command => command.CommandParts.SequenceEqual(["build"]));
+
+        await Assert.That(build.Options).Count().IsEqualTo(1);
+        await Assert.That(build.Options[0].SwitchName).IsEqualTo("--nologo");
+        await Assert.That(build.Options[0].PropertyName).IsEqualTo("NoLogo");
+        await Assert.That(build.CompatibilityProperties.Select(property => property.PropertyName))
+            .IsEquivalentTo(["Nologo", "Debug"]);
     }
 
     private static CliOptionDefinition Flag(string switchName, string propertyName) => new()
@@ -47,4 +75,16 @@ public class DotNetCliScraperTests
         CSharpType = "bool?",
         IsFlag = true,
     };
+
+    private sealed class StaticHtmlHandler(string html) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(html),
+                RequestMessage = request,
+            });
+    }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DotNetCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DotNetCliScraperTests.cs
@@ -1,0 +1,50 @@
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class DotNetCliScraperTests
+{
+    [Test]
+    [Arguments("--nologo", "Nologo")]
+    [Arguments("--no-logo", "NoLogo")]
+    public async Task Build_Options_Are_Stable_Across_Sdk_Help_Formats(
+        string scrapedSwitch,
+        string scrapedPropertyName)
+    {
+        var options = new List<CliOptionDefinition>
+        {
+            Flag(scrapedSwitch, scrapedPropertyName),
+            Flag("--debug", "Debug"),
+        };
+
+        DotNetCliScraper.ApplyBuildOptionCompatibility(["build"], options);
+
+        await Assert.That(options).Count().IsEqualTo(1);
+        await Assert.That(options[0].SwitchName).IsEqualTo("--nologo");
+        await Assert.That(options[0].ShortForm).IsNull();
+        await Assert.That(options[0].PropertyName).IsEqualTo("NoLogo");
+    }
+
+    [Test]
+    public async Task Build_Compatibility_Preserves_Removed_Public_Properties()
+    {
+        var properties = DotNetCliScraper.GetCompatibilityProperties(["build"]);
+
+        await Assert.That(properties.Select(property => property.PropertyName))
+            .IsEquivalentTo(["Nologo", "Debug"]);
+        await Assert.That(properties.Single(property => property.PropertyName == "Nologo").ForwardToPropertyName)
+            .IsEqualTo("NoLogo");
+        await Assert.That(properties.Single(property => property.PropertyName == "Debug").ForwardToPropertyName)
+            .IsNull();
+    }
+
+    private static CliOptionDefinition Flag(string switchName, string propertyName) => new()
+    {
+        SwitchName = switchName,
+        ShortForm = "-nologo",
+        PropertyName = propertyName,
+        CSharpType = "bool?",
+        IsFlag = true,
+    };
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -127,9 +127,12 @@ public class OptionsClassGenerator : ICodeGenerator
             sb.AppendLine();
         }
 
+        // Compatibility aliases may intentionally differ from current members only by casing.
+        // CLR and C# member names are case-sensitive, unlike scraper duplicate detection.
+        var emittedCompatibilityNames = existingPropertyNames.ToHashSet(StringComparer.Ordinal);
         foreach (var compatibilityProperty in command.CompatibilityProperties)
         {
-            if (!existingPropertyNames.Add(compatibilityProperty.PropertyName))
+            if (!emittedCompatibilityNames.Add(compatibilityProperty.PropertyName))
             {
                 continue;
             }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -35,7 +35,31 @@ public class OptionsClassGenerator : ICodeGenerator
         // File header
         GenerateFileHeader(sb, command.DocumentationUrl);
 
-        // Usings
+        GenerateUsings(sb, command, tool);
+
+        // Namespace
+        sb.AppendLine($"namespace {tool.TargetNamespace}.Options;");
+        sb.AppendLine();
+
+        // XML documentation
+        GeneratorUtils.GenerateXmlDocumentation(sb, command.Description, "");
+
+        GenerateClassAttributes(sb, command);
+
+        // Class declaration. The returned set contains the names emitted as
+        // primary-constructor parameters, so a name scraped as both required and
+        // optional can't produce two members (CS0102).
+        var existingPropertyNames = GenerateClassDeclaration(sb, command);
+
+        sb.AppendLine("{");
+        GenerateProperties(sb, command, existingPropertyNames);
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    private static void GenerateUsings(StringBuilder sb, CliCommandDefinition command, CliToolDefinition tool)
+    {
         sb.AppendLine("using System.CodeDom.Compiler;");
         sb.AppendLine("using System.Diagnostics.CodeAnalysis;");
         sb.AppendLine("using ModularPipelines.Attributes;");
@@ -60,15 +84,10 @@ public class OptionsClassGenerator : ICodeGenerator
         }
 
         sb.AppendLine();
+    }
 
-        // Namespace
-        sb.AppendLine($"namespace {tool.TargetNamespace}.Options;");
-        sb.AppendLine();
-
-        // XML documentation
-        GeneratorUtils.GenerateXmlDocumentation(sb, command.Description, "");
-
-        // Class attributes
+    private static void GenerateClassAttributes(StringBuilder sb, CliCommandDefinition command)
+    {
         sb.AppendLine(GeneratorUtils.GeneratedCodeAttribute);
         sb.AppendLine("[ExcludeFromCodeCoverage]");
 
@@ -78,14 +97,13 @@ public class OptionsClassGenerator : ICodeGenerator
             var args = string.Join(", ", command.CommandParts.Select(p => $"\"{p}\""));
             sb.AppendLine($"[CliSubCommand({args})]");
         }
+    }
 
-        // Class declaration. The returned set contains the names emitted as
-        // primary-constructor parameters, so a name scraped as both required and
-        // optional can't produce two members (CS0102).
-        var existingPropertyNames = GenerateClassDeclaration(sb, command);
-
-        sb.AppendLine("{");
-
+    private static void GenerateProperties(
+        StringBuilder sb,
+        CliCommandDefinition command,
+        HashSet<string> existingPropertyNames)
+    {
         // Properties for non-required options
         foreach (var option in command.Options.Where(o => !o.IsRequired))
         {
@@ -109,9 +127,16 @@ public class OptionsClassGenerator : ICodeGenerator
             sb.AppendLine();
         }
 
-        sb.AppendLine("}");
+        foreach (var compatibilityProperty in command.CompatibilityProperties)
+        {
+            if (!existingPropertyNames.Add(compatibilityProperty.PropertyName))
+            {
+                continue;
+            }
 
-        return sb.ToString();
+            GenerateCompatibilityProperty(sb, compatibilityProperty);
+            sb.AppendLine();
+        }
     }
 
     private static void GenerateFileHeader(StringBuilder sb, string? documentationUrl)
@@ -197,6 +222,26 @@ public class OptionsClassGenerator : ICodeGenerator
         var attrString = GetPositionalAttributeString(positional);
         sb.AppendLine($"    [{attrString}]");
         sb.AppendLine($"    public {positional.CSharpType} {positional.PropertyName} {{ get; set; }}");
+    }
+
+    private static void GenerateCompatibilityProperty(StringBuilder sb, CliCompatibilityProperty property)
+    {
+        var obsoleteMessage = property.ObsoleteMessage
+            .Replace("\\", "\\\\")
+            .Replace("\"", "\\\"");
+        sb.AppendLine($"    [Obsolete(\"{obsoleteMessage}\")]");
+
+        if (property.ForwardToPropertyName is null)
+        {
+            sb.AppendLine($"    public {property.CSharpType} {property.PropertyName} {{ get; set; }}");
+            return;
+        }
+
+        sb.AppendLine($"    public {property.CSharpType} {property.PropertyName}");
+        sb.AppendLine("    {");
+        sb.AppendLine($"        get => {property.ForwardToPropertyName};");
+        sb.AppendLine($"        set => {property.ForwardToPropertyName} = value;");
+        sb.AppendLine("    }");
     }
 
     private static string GetPositionalAttributeString(CliPositionalArgument positional)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -71,4 +71,35 @@ public record CliCommandDefinition
     /// Enums that need to be generated for this command's options.
     /// </summary>
     public IReadOnlyList<CliEnumDefinition> Enums { get; init; } = [];
+
+    /// <summary>
+    /// Public properties retained for source and binary compatibility but excluded from CLI rendering.
+    /// </summary>
+    public IReadOnlyList<CliCompatibilityProperty> CompatibilityProperties { get; init; } = [];
+}
+
+/// <summary>
+/// Describes an obsolete generated property retained for API compatibility.
+/// </summary>
+public record CliCompatibilityProperty
+{
+    /// <summary>
+    /// CLR property name.
+    /// </summary>
+    public required string PropertyName { get; init; }
+
+    /// <summary>
+    /// C# property type.
+    /// </summary>
+    public required string CSharpType { get; init; }
+
+    /// <summary>
+    /// Optional replacement property that this compatibility alias forwards to.
+    /// </summary>
+    public string? ForwardToPropertyName { get; init; }
+
+    /// <summary>
+    /// Obsolete diagnostic shown to consumers.
+    /// </summary>
+    public required string ObsoleteMessage { get; init; }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.csproj
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.csproj
@@ -24,4 +24,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ModularPipelines.OptionsGenerator.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
@@ -140,6 +140,7 @@ public partial class DotNetCliScraper : CliScraperBase
 
         // Parse options from the help text
         var options = ParseOptions(helpText, commandParts);
+        ApplyBuildOptionCompatibility(commandParts, options);
 
         // Parse positional arguments
         var positionalArgs = ParsePositionalArguments(helpText);
@@ -167,11 +168,65 @@ public partial class DotNetCliScraper : CliScraperBase
             Options = options,
             PositionalArguments = positionalArgs,
             SubDomainGroup = subDomain,
-            Enums = enums
+            Enums = enums,
+            CompatibilityProperties = GetCompatibilityProperties(commandParts),
         };
 
         return Task.FromResult<CliCommandDefinition?>(command);
     }
+
+    internal static void ApplyBuildOptionCompatibility(
+        string[] commandParts,
+        List<CliOptionDefinition> options)
+    {
+        if (!IsBuildCommand(commandParts))
+        {
+            return;
+        }
+
+        options.RemoveAll(option => option.SwitchName.Equals("--debug", StringComparison.OrdinalIgnoreCase));
+
+        var noLogoIndex = options.FindIndex(option =>
+            option.SwitchName.Equals("--nologo", StringComparison.OrdinalIgnoreCase) ||
+            option.SwitchName.Equals("--no-logo", StringComparison.OrdinalIgnoreCase));
+        if (noLogoIndex >= 0)
+        {
+            options[noLogoIndex] = options[noLogoIndex] with
+            {
+                SwitchName = "--nologo",
+                ShortForm = null,
+                PropertyName = "NoLogo",
+            };
+        }
+    }
+
+    internal static IReadOnlyList<CliCompatibilityProperty> GetCompatibilityProperties(string[] commandParts)
+    {
+        if (!IsBuildCommand(commandParts))
+        {
+            return [];
+        }
+
+        return
+        [
+            new CliCompatibilityProperty
+            {
+                PropertyName = "Nologo",
+                CSharpType = "bool?",
+                ForwardToPropertyName = "NoLogo",
+                ObsoleteMessage = "Use NoLogo instead.",
+            },
+            new CliCompatibilityProperty
+            {
+                PropertyName = "Debug",
+                CSharpType = "bool?",
+                ObsoleteMessage = "The dotnet --debug switch is no longer supported and this property has no effect.",
+            },
+        ];
+    }
+
+    private static bool IsBuildCommand(IReadOnlyList<string> commandParts) =>
+        commandParts.Count == 1 && commandParts[0].Equals("build", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Extracts description from help text.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
 namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
@@ -140,7 +141,7 @@ public partial class DotNetCliScraper : CliScraperBase
 
         // Parse options from the help text
         var options = ParseOptions(helpText, commandParts);
-        ApplyBuildOptionCompatibility(commandParts, options);
+        DotNetCliCompatibility.NormalizeOptions(commandParts, options);
 
         // Parse positional arguments
         var positionalArgs = ParsePositionalArguments(helpText);
@@ -169,64 +170,11 @@ public partial class DotNetCliScraper : CliScraperBase
             PositionalArguments = positionalArgs,
             SubDomainGroup = subDomain,
             Enums = enums,
-            CompatibilityProperties = GetCompatibilityProperties(commandParts),
+            CompatibilityProperties = DotNetCliCompatibility.GetProperties(commandParts),
         };
 
         return Task.FromResult<CliCommandDefinition?>(command);
     }
-
-    internal static void ApplyBuildOptionCompatibility(
-        string[] commandParts,
-        List<CliOptionDefinition> options)
-    {
-        if (!IsBuildCommand(commandParts))
-        {
-            return;
-        }
-
-        options.RemoveAll(option => option.SwitchName.Equals("--debug", StringComparison.OrdinalIgnoreCase));
-
-        var noLogoIndex = options.FindIndex(option =>
-            option.SwitchName.Equals("--nologo", StringComparison.OrdinalIgnoreCase) ||
-            option.SwitchName.Equals("--no-logo", StringComparison.OrdinalIgnoreCase));
-        if (noLogoIndex >= 0)
-        {
-            options[noLogoIndex] = options[noLogoIndex] with
-            {
-                SwitchName = "--nologo",
-                ShortForm = null,
-                PropertyName = "NoLogo",
-            };
-        }
-    }
-
-    internal static IReadOnlyList<CliCompatibilityProperty> GetCompatibilityProperties(string[] commandParts)
-    {
-        if (!IsBuildCommand(commandParts))
-        {
-            return [];
-        }
-
-        return
-        [
-            new CliCompatibilityProperty
-            {
-                PropertyName = "Nologo",
-                CSharpType = "bool?",
-                ForwardToPropertyName = "NoLogo",
-                ObsoleteMessage = "Use NoLogo instead.",
-            },
-            new CliCompatibilityProperty
-            {
-                PropertyName = "Debug",
-                CSharpType = "bool?",
-                ObsoleteMessage = "The dotnet --debug switch is no longer supported and this property has no effect.",
-            },
-        ];
-    }
-
-    private static bool IsBuildCommand(IReadOnlyList<string> commandParts) =>
-        commandParts.Count == 1 && commandParts[0].Equals("build", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Extracts description from help text.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/DotNetCliCompatibility.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/DotNetCliCompatibility.cs
@@ -1,0 +1,52 @@
+using ModularPipelines.OptionsGenerator.Models;
+
+namespace ModularPipelines.OptionsGenerator.Scrapers;
+
+internal static class DotNetCliCompatibility
+{
+    private static readonly IReadOnlyList<CliCompatibilityProperty> BuildProperties =
+    [
+        new CliCompatibilityProperty
+        {
+            PropertyName = "Nologo",
+            CSharpType = "bool?",
+            ForwardToPropertyName = "NoLogo",
+            ObsoleteMessage = "Use NoLogo instead.",
+        },
+        new CliCompatibilityProperty
+        {
+            PropertyName = "Debug",
+            CSharpType = "bool?",
+            ObsoleteMessage = "The dotnet --debug switch is no longer supported and this property has no effect.",
+        },
+    ];
+
+    public static void NormalizeOptions(IReadOnlyList<string> commandParts, List<CliOptionDefinition> options)
+    {
+        if (!IsBuildCommand(commandParts))
+        {
+            return;
+        }
+
+        options.RemoveAll(option => option.SwitchName.Equals("--debug", StringComparison.OrdinalIgnoreCase));
+
+        var noLogoIndex = options.FindIndex(option =>
+            option.SwitchName.Equals("--nologo", StringComparison.OrdinalIgnoreCase) ||
+            option.SwitchName.Equals("--no-logo", StringComparison.OrdinalIgnoreCase));
+        if (noLogoIndex >= 0)
+        {
+            options[noLogoIndex] = options[noLogoIndex] with
+            {
+                SwitchName = "--nologo",
+                ShortForm = null,
+                PropertyName = "NoLogo",
+            };
+        }
+    }
+
+    public static IReadOnlyList<CliCompatibilityProperty> GetProperties(IReadOnlyList<string> commandParts) =>
+        IsBuildCommand(commandParts) ? BuildProperties : [];
+
+    private static bool IsBuildCommand(IReadOnlyList<string> commandParts) =>
+        commandParts.Count == 1 && commandParts[0].Equals("build", StringComparison.OrdinalIgnoreCase);
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/DotNetCliDocumentationScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/DotNetCliDocumentationScraper.cs
@@ -146,6 +146,7 @@ public partial class DotNetCliDocumentationScraper : CliDocumentationScraperBase
 
         // Parse options
         var options = ExtractOptions(doc, commandParts);
+        DotNetCliCompatibility.NormalizeOptions(commandParts, options);
 
         // Parse positional arguments (like project path)
         var positionalArgs = ExtractPositionalArguments(doc);
@@ -168,7 +169,8 @@ public partial class DotNetCliDocumentationScraper : CliDocumentationScraperBase
             Options = options,
             PositionalArguments = positionalArgs,
             SubDomainGroup = subDomain,
-            Enums = options.Where(o => o.EnumDefinition is not null).Select(o => o.EnumDefinition!).ToList()
+            Enums = options.Where(o => o.EnumDefinition is not null).Select(o => o.EnumDefinition!).ToList(),
+            CompatibilityProperties = DotNetCliCompatibility.GetProperties(commandParts),
         };
     }
 


### PR DESCRIPTION
## Summary
- normalize changing .NET SDK help output while always emitting the supported `--nologo` build switch
- expose corrected `NoLogo` while preserving obsolete `Nologo` and `Debug` compatibility members
- apply the same compatibility rules to CLI-first and HTML fallback generation

## Validation
- generator tests: 343/343
- `DotNetBuildOptionsCompatibilityTests`: 2/2
- `DotNetBuildBuilderTests`: 20/20
- `dotnet build ModularPipelines.sln -c Release --no-restore`
- local SDK 10.0.302 help verification

Closes #3014