### PR TITLE
Fix ArgoCD generator naming collisions

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -78,6 +78,20 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task NormalizeCommandClassNames_Does_Not_Overwrite_Real_Execute_Command()
+    {
+        var commands = GeneratorUtils.NormalizeCommandClassNames(
+        [
+            Command("ToolApplicationSetOptions", "ToolOptions", ["appset"]),
+            Command("ToolApplicationSetExecuteOptions", "ToolOptions", ["appset", "execute"], "ApplicationSet"),
+            Command("ToolApplicationSetGetOptions", "ToolOptions", ["appset", "get"], "ApplicationSet"),
+        ]);
+
+        await Assert.That(commands[0].ClassName).IsEqualTo("ToolApplicationSetExecuteExecuteOptions");
+        await Assert.That(commands[1].ClassName).IsEqualTo("ToolApplicationSetExecuteOptions");
+    }
+
+    [Test]
     public async Task SubDomain_Generators_Preserve_Compound_PascalCase()
     {
         var tool = Tool(Command(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -16,6 +16,7 @@ public class GeneratorHardeningTests
         string parentClassName,
         string[]? commandParts = null,
         string? subDomainGroup = null,
+        string? commandGroupIdentifierOverride = null,
         IReadOnlyList<CliEnumDefinition>? enums = null) =>
         new()
         {
@@ -26,6 +27,7 @@ public class GeneratorHardeningTests
             ToolNamespacePrefix = "Tool",
             Options = [],
             SubDomainGroup = subDomainGroup,
+            CommandGroupIdentifierOverride = commandGroupIdentifierOverride,
             Enums = enums ?? [],
         };
 
@@ -61,7 +63,7 @@ public class GeneratorHardeningTests
     }
 
     [Test]
-    public async Task NormalizeCommandClassNames_Renames_Root_Command_Colliding_With_SubDomain_Service()
+    public async Task NormalizeCommandClassNames_Leaves_Executable_Parent_Options_Stable()
     {
         var commands = GeneratorUtils.NormalizeCommandClassNames(
         [
@@ -73,7 +75,7 @@ public class GeneratorHardeningTests
                 subDomainGroup: "ApplicationSet"),
         ]);
 
-        await Assert.That(commands[0].ClassName).IsEqualTo("ToolApplicationSetExecuteOptions");
+        await Assert.That(commands[0].ClassName).IsEqualTo("ToolApplicationSetOptions");
         await Assert.That(commands[1].ClassName).IsEqualTo("ToolApplicationSetGetOptions");
     }
 
@@ -82,23 +84,29 @@ public class GeneratorHardeningTests
     {
         var commands = GeneratorUtils.NormalizeCommandClassNames(
         [
-            Command("ToolApplicationSetOptions", "ToolOptions", ["appset"]),
-            Command("ToolApplicationSetExecuteOptions", "ToolOptions", ["appset", "execute"], "ApplicationSet"),
-            Command("ToolApplicationSetGetOptions", "ToolOptions", ["appset", "get"], "ApplicationSet"),
+            Command("ToolOptions", "ToolOptions", ["tool"]),
+            Command("ToolExecuteOptions", "ToolOptions", ["execute"]),
         ]);
 
-        await Assert.That(commands[0].ClassName).IsEqualTo("ToolApplicationSetExecuteExecuteOptions");
-        await Assert.That(commands[1].ClassName).IsEqualTo("ToolApplicationSetExecuteOptions");
+        await Assert.That(commands[0].ClassName).IsEqualTo("ToolExecuteExecuteOptions");
+        await Assert.That(commands[1].ClassName).IsEqualTo("ToolExecuteOptions");
     }
 
     [Test]
     public async Task SubDomain_Generators_Preserve_Compound_PascalCase()
     {
-        var tool = Tool(Command(
-            "ToolApplicationSetGetOptions",
-            "ToolOptions",
-            ["appset", "get"],
-            subDomainGroup: "ApplicationSet"));
+        var tool = Tool(
+            Command(
+                "ToolApplicationSetOptions",
+                "ToolOptions",
+                ["appset"],
+                commandGroupIdentifierOverride: "ApplicationSet"),
+            Command(
+                "ToolApplicationSetGetOptions",
+                "ToolOptions",
+                ["appset", "get"],
+                subDomainGroup: "ApplicationSet",
+                commandGroupIdentifierOverride: "ApplicationSet"));
 
         var subDomainFiles = await new SubDomainClassGenerator().GenerateAsync(tool);
         var interfaceFiles = await new ServiceInterfaceGenerator().GenerateAsync(tool);
@@ -106,9 +114,28 @@ public class GeneratorHardeningTests
         var registrationFiles = await new DependencyRegistrationGenerator().GenerateAsync(tool);
 
         await Assert.That(subDomainFiles.Single().RelativePath).EndsWith("ToolApplicationSet.Generated.cs");
+        await Assert.That(subDomainFiles.Single().Content).Contains("ToolApplicationSetOptions? options = null");
         await Assert.That(interfaceFiles.Single().Content).Contains("ToolApplicationSet ApplicationSet { get; }");
+        await Assert.That(interfaceFiles.Single().Content).DoesNotContain("Appset(");
         await Assert.That(implementationFiles.Single().Content).Contains("ToolApplicationSet ApplicationSet { get; }");
         await Assert.That(registrationFiles.Single().Content).Contains("TryAddScoped<ToolApplicationSet>()");
+        await Assert.That(GeneratorUtils.GetNonCollidingRootCommands(tool)).IsEmpty();
+    }
+
+    [Test]
+    public async Task SubDomain_Generators_Preserve_Legacy_Casing_Without_Override()
+    {
+        var tool = Tool(Command(
+            "ToolWorkspaceAddOnsGetOptions",
+            "ToolOptions",
+            ["workspace-add-ons", "get"],
+            subDomainGroup: "WorkspaceAddOns"));
+
+        var subDomainFiles = await new SubDomainClassGenerator().GenerateAsync(tool);
+        var interfaceFiles = await new ServiceInterfaceGenerator().GenerateAsync(tool);
+
+        await Assert.That(subDomainFiles.Single().RelativePath).EndsWith("ToolWorkspaceaddons.Generated.cs");
+        await Assert.That(interfaceFiles.Single().Content).Contains("ToolWorkspaceaddons Workspaceaddons { get; }");
     }
 
     #endregion

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -77,6 +77,26 @@ public class GeneratorHardeningTests
         await Assert.That(commands[1].ClassName).IsEqualTo("ToolApplicationSetGetOptions");
     }
 
+    [Test]
+    public async Task SubDomain_Generators_Preserve_Compound_PascalCase()
+    {
+        var tool = Tool(Command(
+            "ToolApplicationSetGetOptions",
+            "ToolOptions",
+            ["appset", "get"],
+            subDomainGroup: "ApplicationSet"));
+
+        var subDomainFiles = await new SubDomainClassGenerator().GenerateAsync(tool);
+        var interfaceFiles = await new ServiceInterfaceGenerator().GenerateAsync(tool);
+        var implementationFiles = await new ServiceImplementationGenerator().GenerateAsync(tool);
+        var registrationFiles = await new DependencyRegistrationGenerator().GenerateAsync(tool);
+
+        await Assert.That(subDomainFiles.Single().RelativePath).EndsWith("ToolApplicationSet.Generated.cs");
+        await Assert.That(interfaceFiles.Single().Content).Contains("ToolApplicationSet ApplicationSet { get; }");
+        await Assert.That(implementationFiles.Single().Content).Contains("ToolApplicationSet ApplicationSet { get; }");
+        await Assert.That(registrationFiles.Single().Content).Contains("TryAddScoped<ToolApplicationSet>()");
+    }
+
     #endregion
 
     #region EnsureNoDuplicateFilePaths

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -60,6 +60,23 @@ public class GeneratorHardeningTests
         await Assert.That(commands[0].ClassName).IsEqualTo("HelmInstallOptions");
     }
 
+    [Test]
+    public async Task NormalizeCommandClassNames_Renames_Root_Command_Colliding_With_SubDomain_Service()
+    {
+        var commands = GeneratorUtils.NormalizeCommandClassNames(
+        [
+            Command("ToolApplicationSetOptions", "ToolOptions", ["appset"]),
+            Command(
+                "ToolApplicationSetGetOptions",
+                "ToolOptions",
+                ["appset", "get"],
+                subDomainGroup: "ApplicationSet"),
+        ]);
+
+        await Assert.That(commands[0].ClassName).IsEqualTo("ToolApplicationSetExecuteOptions");
+        await Assert.That(commands[1].ClassName).IsEqualTo("ToolApplicationSetGetOptions");
+    }
+
     #endregion
 
     #region EnsureNoDuplicateFilePaths

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ArgoCdCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ArgoCdCliScraperTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class ArgoCdCliScraperTests
+{
+    [Test]
+    public async Task Appset_Uses_ApplicationSet_Identifier()
+    {
+        var scraper = new TestArgoCdCliScraper();
+
+        await Assert.That(scraper.NormalizeIdentifier("appset")).IsEqualTo("ApplicationSet");
+        await Assert.That(scraper.NormalizeIdentifier("app")).IsEqualTo("App");
+    }
+
+    private sealed class TestArgoCdCliScraper : ArgoCdCliScraper
+    {
+        public TestArgoCdCliScraper()
+            : base(
+                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<ArgoCdCliScraper>.Instance)
+        {
+        }
+
+        public string NormalizeIdentifier(string commandPart) => NormalizeCommandIdentifier(commandPart);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
@@ -87,7 +87,8 @@ public class DependencyRegistrationGenerator : ICodeGenerator
         var subDomains = tool.SubDomainGroups.OrderBy(s => s).ToList();
         foreach (var subDomain in subDomains)
         {
-            var subDomainClassName = $"{tool.NamespacePrefix}{subDomain}";
+            var subDomainIdentifier = GeneratorUtils.GetSubDomainIdentifier(tool, subDomain);
+            var subDomainClassName = $"{tool.NamespacePrefix}{subDomainIdentifier}";
             sb.AppendLine($"        services.TryAddScoped<{subDomainClassName}>();");
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
@@ -87,7 +87,7 @@ public class DependencyRegistrationGenerator : ICodeGenerator
         var subDomains = tool.SubDomainGroups.OrderBy(s => s).ToList();
         foreach (var subDomain in subDomains)
         {
-            var pascalSubDomain = GeneratorUtils.ToPascalCase(subDomain);
+            var pascalSubDomain = subDomain;
             var subDomainClassName = $"{tool.NamespacePrefix}{pascalSubDomain}";
             sb.AppendLine($"        services.TryAddScoped<{subDomainClassName}>();");
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DependencyRegistrationGenerator.cs
@@ -87,8 +87,7 @@ public class DependencyRegistrationGenerator : ICodeGenerator
         var subDomains = tool.SubDomainGroups.OrderBy(s => s).ToList();
         foreach (var subDomain in subDomains)
         {
-            var pascalSubDomain = subDomain;
-            var subDomainClassName = $"{tool.NamespacePrefix}{pascalSubDomain}";
+            var subDomainClassName = $"{tool.NamespacePrefix}{subDomain}";
             sb.AppendLine($"        services.TryAddScoped<{subDomainClassName}>();");
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -519,31 +519,45 @@ public static partial class GeneratorUtils
     }
 
     /// <summary>
-    /// Renames command options classes that share their name with the parent (base) options
-    /// class. Single-command tools (ansible, jq, shellcheck, ...) scrape their root command
-    /// into a class named "{Prefix}Options" — the same name the abstract global-options base
-    /// class uses — so both generators wrote the same file and the abstract base won,
-    /// producing services that instantiate an abstract type (CS0144).
+    /// Renames command options classes that collide with another generated type. This covers
+    /// single-command tools whose command class matches their global-options base, and root
+    /// commands whose options class matches the service class generated for their subdomain.
     /// </summary>
     public static IReadOnlyList<CliCommandDefinition> NormalizeCommandClassNames(IReadOnlyList<CliCommandDefinition> commands)
     {
         ArgumentNullException.ThrowIfNull(commands);
 
-        if (!commands.Any(c => string.Equals(c.ClassName, c.ParentClassName, StringComparison.OrdinalIgnoreCase)))
+        var subDomainClassNames = commands
+            .Where(c => c.SubDomainGroup is not null)
+            .Select(c => $"{c.ToolNamespacePrefix}{c.SubDomainGroup}Options")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        static bool MatchesParentOptions(CliCommandDefinition command) =>
+            string.Equals(command.ClassName, command.ParentClassName, StringComparison.OrdinalIgnoreCase);
+
+        bool MatchesSubDomainService(CliCommandDefinition command) =>
+            command.SubDomainGroup is null &&
+            command.CommandParts.Length == 1 &&
+            subDomainClassNames.Contains(command.ClassName);
+
+        if (!commands.Any(command => MatchesParentOptions(command) || MatchesSubDomainService(command)))
         {
             return commands;
         }
 
         return commands.Select(command =>
         {
-            if (!string.Equals(command.ClassName, command.ParentClassName, StringComparison.OrdinalIgnoreCase))
+            if (!MatchesParentOptions(command) && !MatchesSubDomainService(command))
             {
                 return command;
             }
 
-            var baseName = command.ParentClassName.EndsWith("Options", StringComparison.Ordinal)
-                ? command.ParentClassName[..^"Options".Length]
-                : command.ParentClassName;
+            var collidingName = MatchesParentOptions(command)
+                ? command.ParentClassName
+                : command.ClassName;
+            var baseName = collidingName.EndsWith("Options", StringComparison.Ordinal)
+                ? collidingName[..^"Options".Length]
+                : collidingName;
 
             return command with { ClassName = $"{baseName}ExecuteOptions" };
         }).ToList();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -532,15 +532,7 @@ public static partial class GeneratorUtils
             .Select(c => $"{c.ToolNamespacePrefix}{c.SubDomainGroup}Options")
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        static bool MatchesParentOptions(CliCommandDefinition command) =>
-            string.Equals(command.ClassName, command.ParentClassName, StringComparison.OrdinalIgnoreCase);
-
-        bool MatchesSubDomainService(CliCommandDefinition command) =>
-            command.SubDomainGroup is null &&
-            command.CommandParts.Length == 1 &&
-            subDomainClassNames.Contains(command.ClassName);
-
-        if (!commands.Any(command => MatchesParentOptions(command) || MatchesSubDomainService(command)))
+        if (!commands.Any(command => NeedsClassNameNormalization(command, subDomainClassNames)))
         {
             return commands;
         }
@@ -552,31 +544,14 @@ public static partial class GeneratorUtils
 
         foreach (var command in commands)
         {
-            var matchesParentOptions = MatchesParentOptions(command);
-            var matchesSubDomainService = MatchesSubDomainService(command);
-            if (!matchesParentOptions && !matchesSubDomainService)
+            if (!NeedsClassNameNormalization(command, subDomainClassNames))
             {
                 normalizedCommands.Add(command);
                 continue;
             }
 
-            var collidingName = matchesParentOptions
-                ? command.ParentClassName
-                : command.ClassName;
-            var baseName = collidingName.EndsWith("Options", StringComparison.Ordinal)
-                ? collidingName[..^"Options".Length]
-                : collidingName;
-            var suffix = "Execute";
-            var candidate = $"{baseName}{suffix}Options";
-
-            while (occupiedClassNames.Contains(candidate))
-            {
-                suffix += "Execute";
-                candidate = $"{baseName}{suffix}Options";
-            }
-
-            occupiedClassNames.Add(candidate);
-            normalizedCommands.Add(command with { ClassName = candidate });
+            var className = AllocateExecuteClassName(command, occupiedClassNames);
+            normalizedCommands.Add(command with { ClassName = className });
         }
 
         return normalizedCommands;
@@ -619,5 +594,40 @@ public static partial class GeneratorUtils
         }
 
         return rootCommands;
+    }
+
+    private static bool NeedsClassNameNormalization(
+        CliCommandDefinition command,
+        IReadOnlySet<string> subDomainClassNames)
+    {
+        return string.Equals(command.ClassName, command.ParentClassName, StringComparison.OrdinalIgnoreCase)
+               || (command.SubDomainGroup is null
+                   && command.CommandParts.Length == 1
+                   && subDomainClassNames.Contains(command.ClassName));
+    }
+
+    private static string AllocateExecuteClassName(
+        CliCommandDefinition command,
+        ISet<string> occupiedClassNames)
+    {
+        var collidingName = string.Equals(
+            command.ClassName,
+            command.ParentClassName,
+            StringComparison.OrdinalIgnoreCase)
+            ? command.ParentClassName
+            : command.ClassName;
+        var baseName = collidingName.EndsWith("Options", StringComparison.Ordinal)
+            ? collidingName[..^"Options".Length]
+            : collidingName;
+        var suffix = "Execute";
+        var candidate = $"{baseName}{suffix}Options";
+
+        while (!occupiedClassNames.Add(candidate))
+        {
+            suffix += "Execute";
+            candidate = $"{baseName}{suffix}Options";
+        }
+
+        return candidate;
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -519,20 +519,14 @@ public static partial class GeneratorUtils
     }
 
     /// <summary>
-    /// Renames command options classes that collide with another generated type. This covers
-    /// single-command tools whose command class matches their global-options base, and root
-    /// commands whose options class matches the service class generated for their subdomain.
+    /// Renames command options classes that share their name with the parent global-options
+    /// class. The allocated fallback is guaranteed not to collide with another command class.
     /// </summary>
     public static IReadOnlyList<CliCommandDefinition> NormalizeCommandClassNames(IReadOnlyList<CliCommandDefinition> commands)
     {
         ArgumentNullException.ThrowIfNull(commands);
 
-        var subDomainClassNames = commands
-            .Where(c => c.SubDomainGroup is not null)
-            .Select(c => $"{c.ToolNamespacePrefix}{c.SubDomainGroup}Options")
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-        if (!commands.Any(command => NeedsClassNameNormalization(command, subDomainClassNames)))
+        if (!commands.Any(command => NeedsClassNameNormalization(command)))
         {
             return commands;
         }
@@ -544,7 +538,7 @@ public static partial class GeneratorUtils
 
         foreach (var command in commands)
         {
-            if (!NeedsClassNameNormalization(command, subDomainClassNames))
+            if (!NeedsClassNameNormalization(command))
             {
                 normalizedCommands.Add(command);
                 continue;
@@ -569,12 +563,12 @@ public static partial class GeneratorUtils
         ArgumentNullException.ThrowIfNull(tool);
 
         var subDomainNames = new HashSet<string>(
-            tool.SubDomainGroups,
+            tool.SubDomainGroups.Select(group => GetSubDomainIdentifier(tool, group)),
             StringComparer.OrdinalIgnoreCase);
 
         var rootCommands = tool.Commands
             .Where(c => c.SubDomainGroup is null)
-            .Where(c => !subDomainNames.Contains(GenerateMethodNameFromCommandParts(c.CommandParts)))
+            .Where(c => !subDomainNames.Contains(GetCommandGroupIdentifier(c)))
             .ToList();
 
         // Distinct commands can normalize to the same method name (e.g. "build-server"
@@ -596,29 +590,49 @@ public static partial class GeneratorUtils
         return rootCommands;
     }
 
-    private static bool NeedsClassNameNormalization(
-        CliCommandDefinition command,
-        IReadOnlySet<string> subDomainClassNames)
+    /// <summary>
+    /// Gets the generated identifier for a sub-domain while preserving legacy casing unless
+    /// the scraper supplied an explicit tool-specific override.
+    /// </summary>
+    public static string GetSubDomainIdentifier(CliToolDefinition tool, string subDomainGroup)
     {
-        return string.Equals(command.ClassName, command.ParentClassName, StringComparison.OrdinalIgnoreCase)
-               || (command.SubDomainGroup is null
-                   && command.CommandParts.Length == 1
-                   && subDomainClassNames.Contains(command.ClassName));
+        ArgumentNullException.ThrowIfNull(tool);
+        ArgumentException.ThrowIfNullOrWhiteSpace(subDomainGroup);
+
+        var overrides = tool.Commands
+            .Where(command => string.Equals(
+                command.SubDomainGroup,
+                subDomainGroup,
+                StringComparison.OrdinalIgnoreCase))
+            .Select(command => command.CommandGroupIdentifierOverride)
+            .Where(identifier => identifier is not null)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return overrides.Count switch
+        {
+            0 => ToPascalCase(subDomainGroup),
+            1 => overrides[0]!,
+            _ => throw new InvalidOperationException(
+                $"The {tool.ToolName} scraper produced conflicting identifiers for sub-domain " +
+                $"'{subDomainGroup}': {string.Join(", ", overrides)}.")
+        };
     }
+
+    private static string GetCommandGroupIdentifier(CliCommandDefinition command) =>
+        command.CommandGroupIdentifierOverride
+        ?? GenerateMethodNameFromCommandParts(command.CommandParts);
+
+    private static bool NeedsClassNameNormalization(CliCommandDefinition command) =>
+        string.Equals(command.ClassName, command.ParentClassName, StringComparison.OrdinalIgnoreCase);
 
     private static string AllocateExecuteClassName(
         CliCommandDefinition command,
         ISet<string> occupiedClassNames)
     {
-        var collidingName = string.Equals(
-            command.ClassName,
-            command.ParentClassName,
-            StringComparison.OrdinalIgnoreCase)
-            ? command.ParentClassName
-            : command.ClassName;
-        var baseName = collidingName.EndsWith("Options", StringComparison.Ordinal)
-            ? collidingName[..^"Options".Length]
-            : collidingName;
+        var baseName = command.ParentClassName.EndsWith("Options", StringComparison.Ordinal)
+            ? command.ParentClassName[..^"Options".Length]
+            : command.ParentClassName;
         var suffix = "Execute";
         var candidate = $"{baseName}{suffix}Options";
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -545,22 +545,41 @@ public static partial class GeneratorUtils
             return commands;
         }
 
-        return commands.Select(command =>
+        var occupiedClassNames = commands
+            .Select(command => command.ClassName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var normalizedCommands = new List<CliCommandDefinition>(commands.Count);
+
+        foreach (var command in commands)
         {
-            if (!MatchesParentOptions(command) && !MatchesSubDomainService(command))
+            var matchesParentOptions = MatchesParentOptions(command);
+            var matchesSubDomainService = MatchesSubDomainService(command);
+            if (!matchesParentOptions && !matchesSubDomainService)
             {
-                return command;
+                normalizedCommands.Add(command);
+                continue;
             }
 
-            var collidingName = MatchesParentOptions(command)
+            var collidingName = matchesParentOptions
                 ? command.ParentClassName
                 : command.ClassName;
             var baseName = collidingName.EndsWith("Options", StringComparison.Ordinal)
                 ? collidingName[..^"Options".Length]
                 : collidingName;
+            var suffix = "Execute";
+            var candidate = $"{baseName}{suffix}Options";
 
-            return command with { ClassName = $"{baseName}ExecuteOptions" };
-        }).ToList();
+            while (occupiedClassNames.Contains(candidate))
+            {
+                suffix += "Execute";
+                candidate = $"{baseName}{suffix}Options";
+            }
+
+            occupiedClassNames.Add(candidate);
+            normalizedCommands.Add(command with { ClassName = candidate });
+        }
+
+        return normalizedCommands;
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -575,7 +575,7 @@ public static partial class GeneratorUtils
         ArgumentNullException.ThrowIfNull(tool);
 
         var subDomainNames = new HashSet<string>(
-            tool.SubDomainGroups.Select(ToPascalCase),
+            tool.SubDomainGroups,
             StringComparer.OrdinalIgnoreCase);
 
         var rootCommands = tool.Commands

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
@@ -48,7 +48,9 @@ public class ServiceImplementationGenerator : ICodeGenerator
         var interfaceName = $"I{tool.NamespacePrefix}";
 
         // Check if we have sub-domains
-        var subDomains = tool.SubDomainGroups.ToList();
+        var subDomains = tool.SubDomainGroups
+            .Select(group => GeneratorUtils.GetSubDomainIdentifier(tool, group))
+            .ToList();
 
         // Class documentation
         sb.AppendLine("/// <summary>");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
@@ -74,7 +74,7 @@ public class ServiceImplementationGenerator : ICodeGenerator
             var constructorParams = new List<string>();
             foreach (var subDomain in subDomains.OrderBy(s => s))
             {
-                var pascalSubDomain = GeneratorUtils.ToPascalCase(subDomain);
+                var pascalSubDomain = subDomain;
                 var subDomainClassName = $"{tool.NamespacePrefix}{pascalSubDomain}";
                 var rawParamName = char.ToLowerInvariant(pascalSubDomain[0]) + pascalSubDomain[1..];
                 var paramName = GeneratorUtils.EscapeIdentifier(rawParamName);
@@ -89,7 +89,7 @@ public class ServiceImplementationGenerator : ICodeGenerator
             // Assign sub-domains
             foreach (var subDomain in subDomains.OrderBy(s => s))
             {
-                var pascalSubDomain = GeneratorUtils.ToPascalCase(subDomain);
+                var pascalSubDomain = subDomain;
                 var rawParamName = char.ToLowerInvariant(pascalSubDomain[0]) + pascalSubDomain[1..];
                 var paramName = GeneratorUtils.EscapeIdentifier(rawParamName);
                 sb.AppendLine($"        {pascalSubDomain} = {paramName};");
@@ -120,7 +120,7 @@ public class ServiceImplementationGenerator : ICodeGenerator
 
             foreach (var subDomain in subDomains.OrderBy(s => s))
             {
-                var pascalSubDomain = GeneratorUtils.ToPascalCase(subDomain);
+                var pascalSubDomain = subDomain;
                 var subDomainClassName = $"{tool.NamespacePrefix}{pascalSubDomain}";
                 sb.AppendLine($"    /// <inheritdoc />");
                 sb.AppendLine($"    public {subDomainClassName} {pascalSubDomain} {{ get; }}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceImplementationGenerator.cs
@@ -74,9 +74,8 @@ public class ServiceImplementationGenerator : ICodeGenerator
             var constructorParams = new List<string>();
             foreach (var subDomain in subDomains.OrderBy(s => s))
             {
-                var pascalSubDomain = subDomain;
-                var subDomainClassName = $"{tool.NamespacePrefix}{pascalSubDomain}";
-                var rawParamName = char.ToLowerInvariant(pascalSubDomain[0]) + pascalSubDomain[1..];
+                var subDomainClassName = $"{tool.NamespacePrefix}{subDomain}";
+                var rawParamName = char.ToLowerInvariant(subDomain[0]) + subDomain[1..];
                 var paramName = GeneratorUtils.EscapeIdentifier(rawParamName);
                 constructorParams.Add($"        {subDomainClassName} {paramName}");
             }
@@ -89,10 +88,9 @@ public class ServiceImplementationGenerator : ICodeGenerator
             // Assign sub-domains
             foreach (var subDomain in subDomains.OrderBy(s => s))
             {
-                var pascalSubDomain = subDomain;
-                var rawParamName = char.ToLowerInvariant(pascalSubDomain[0]) + pascalSubDomain[1..];
+                var rawParamName = char.ToLowerInvariant(subDomain[0]) + subDomain[1..];
                 var paramName = GeneratorUtils.EscapeIdentifier(rawParamName);
-                sb.AppendLine($"        {pascalSubDomain} = {paramName};");
+                sb.AppendLine($"        {subDomain} = {paramName};");
             }
 
             sb.AppendLine("        _command = command;");
@@ -120,10 +118,9 @@ public class ServiceImplementationGenerator : ICodeGenerator
 
             foreach (var subDomain in subDomains.OrderBy(s => s))
             {
-                var pascalSubDomain = subDomain;
-                var subDomainClassName = $"{tool.NamespacePrefix}{pascalSubDomain}";
+                var subDomainClassName = $"{tool.NamespacePrefix}{subDomain}";
                 sb.AppendLine($"    /// <inheritdoc />");
-                sb.AppendLine($"    public {subDomainClassName} {pascalSubDomain} {{ get; }}");
+                sb.AppendLine($"    public {subDomainClassName} {subDomain} {{ get; }}");
                 sb.AppendLine();
             }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceInterfaceGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceInterfaceGenerator.cs
@@ -59,12 +59,11 @@ public class ServiceInterfaceGenerator : ICodeGenerator
 
             foreach (var subDomain in subDomains)
             {
-                var pascalSubDomain = subDomain;
-                var subDomainClassName = $"{tool.NamespacePrefix}{pascalSubDomain}";
+                var subDomainClassName = $"{tool.NamespacePrefix}{subDomain}";
                 sb.AppendLine($"    /// <summary>");
                 sb.AppendLine($"    /// Gets the {subDomain.ToLowerInvariant()} sub-domain service.");
                 sb.AppendLine($"    /// </summary>");
-                sb.AppendLine($"    {subDomainClassName} {pascalSubDomain} {{ get; }}");
+                sb.AppendLine($"    {subDomainClassName} {subDomain} {{ get; }}");
                 sb.AppendLine();
             }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceInterfaceGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceInterfaceGenerator.cs
@@ -59,7 +59,7 @@ public class ServiceInterfaceGenerator : ICodeGenerator
 
             foreach (var subDomain in subDomains)
             {
-                var pascalSubDomain = GeneratorUtils.ToPascalCase(subDomain);
+                var pascalSubDomain = subDomain;
                 var subDomainClassName = $"{tool.NamespacePrefix}{pascalSubDomain}";
                 sb.AppendLine($"    /// <summary>");
                 sb.AppendLine($"    /// Gets the {subDomain.ToLowerInvariant()} sub-domain service.");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceInterfaceGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ServiceInterfaceGenerator.cs
@@ -59,11 +59,12 @@ public class ServiceInterfaceGenerator : ICodeGenerator
 
             foreach (var subDomain in subDomains)
             {
-                var subDomainClassName = $"{tool.NamespacePrefix}{subDomain}";
+                var subDomainIdentifier = GeneratorUtils.GetSubDomainIdentifier(tool, subDomain);
+                var subDomainClassName = $"{tool.NamespacePrefix}{subDomainIdentifier}";
                 sb.AppendLine($"    /// <summary>");
                 sb.AppendLine($"    /// Gets the {subDomain.ToLowerInvariant()} sub-domain service.");
                 sb.AppendLine($"    /// </summary>");
-                sb.AppendLine($"    {subDomainClassName} {subDomain} {{ get; }}");
+                sb.AppendLine($"    {subDomainClassName} {subDomainIdentifier} {{ get; }}");
                 sb.AppendLine();
             }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
@@ -47,7 +47,9 @@ public class SubDomainClassGenerator : ICodeGenerator
         // Duplicate definitions of the same command are a scraper bug; picking an
         // arbitrary survivor would silently generate Execute() from the wrong options.
         var duplicateParentNames = singlePartRootCommands
-            .GroupBy(c => c.CommandParts[0], StringComparer.OrdinalIgnoreCase)
+            .GroupBy(
+                c => c.CommandGroupIdentifierOverride ?? c.CommandParts[0],
+                StringComparer.OrdinalIgnoreCase)
             .Where(g => g.Count() > 1)
             .Select(g => g.Key)
             .ToList();
@@ -60,18 +62,23 @@ public class SubDomainClassGenerator : ICodeGenerator
         }
 
         var parentCommands = singlePartRootCommands
-            .ToDictionary(c => c.CommandParts[0], StringComparer.OrdinalIgnoreCase);
+            .ToDictionary(
+                c => c.CommandGroupIdentifierOverride ?? c.CommandParts[0],
+                StringComparer.OrdinalIgnoreCase);
 
-        foreach (var subDomain in tool.SubDomainGroups)
+        foreach (var subDomainGroup in tool.SubDomainGroups)
         {
-            var commands = tool.Commands.Where(c => c.SubDomainGroup == subDomain).ToList();
+            var commands = tool.Commands
+                .Where(c => string.Equals(c.SubDomainGroup, subDomainGroup, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var subDomainIdentifier = GeneratorUtils.GetSubDomainIdentifier(tool, subDomainGroup);
 
             // Build tree structure for this sub-domain
-            var tree = CommandTreeNode.BuildTree(tool.NamespacePrefix, subDomain, commands);
+            var tree = CommandTreeNode.BuildTree(tool.NamespacePrefix, subDomainIdentifier, commands);
 
             // Check if there's a parent command for this sub-domain
             CliCommandDefinition? parentCommand = null;
-            if (parentCommands.TryGetValue(subDomain, out var cmd))
+            if (parentCommands.TryGetValue(subDomainIdentifier, out var cmd))
             {
                 parentCommand = cmd;
             }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -62,6 +62,12 @@ public record CliCommandDefinition
     public string? SubDomainGroup { get; init; }
 
     /// <summary>
+    /// Optional generated identifier for the command's first segment when a tool-specific
+    /// compound name cannot be inferred from the CLI spelling.
+    /// </summary>
+    public string? CommandGroupIdentifierOverride { get; init; }
+
+    /// <summary>
     /// Enums that need to be generated for this command's options.
     /// </summary>
     public IReadOnlyList<CliEnumDefinition> Enums { get; init; } = [];

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
@@ -56,13 +56,12 @@ public class CommandTreeNode
     {
         // SubDomainGroup is already normalized by the scraper. Re-normalizing it would
         // collapse compound identifiers such as ApplicationSet to Applicationset.
-        var pascalSubDomain = subDomain;
-        var rootClassName = $"{toolPrefix}{pascalSubDomain}";
+        var rootClassName = $"{toolPrefix}{subDomain}";
 
         var root = new CommandTreeNode
         {
             Segment = subDomain,
-            PascalSegment = pascalSubDomain,
+            PascalSegment = subDomain,
             ClassName = rootClassName,
             Depth = 0
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
@@ -54,8 +54,7 @@ public class CommandTreeNode
         string subDomain,
         IReadOnlyList<CliCommandDefinition> commands)
     {
-        // SubDomainGroup is already normalized by the scraper. Re-normalizing it would
-        // collapse compound identifiers such as ApplicationSet to Applicationset.
+        // The caller resolves legacy casing or an explicit scraper override.
         var rootClassName = $"{toolPrefix}{subDomain}";
 
         var root = new CommandTreeNode

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
@@ -54,7 +54,9 @@ public class CommandTreeNode
         string subDomain,
         IReadOnlyList<CliCommandDefinition> commands)
     {
-        var pascalSubDomain = ToPascalCase(subDomain);
+        // SubDomainGroup is already normalized by the scraper. Re-normalizing it would
+        // collapse compound identifiers such as ApplicationSet to Applicationset.
+        var pascalSubDomain = subDomain;
         var rootClassName = $"{toolPrefix}{pascalSubDomain}";
 
         var root = new CommandTreeNode

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ArgoCdCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ArgoCdCliScraper.cs
@@ -36,6 +36,15 @@ public partial class ArgoCdCliScraper : CobraCliScraper
     public override string OutputDirectory => "src/ModularPipelines.ArgoCd";
 
     /// <summary>
+    /// Argo CD calls the ApplicationSet command "appset". Expanding the compound name
+    /// prevents it from colliding with the separate "app set" command in generated code.
+    /// </summary>
+    protected override string NormalizeCommandIdentifier(string commandPart) =>
+        commandPart.Equals("appset", StringComparison.OrdinalIgnoreCase)
+            ? "ApplicationSet"
+            : base.NormalizeCommandIdentifier(commandPart);
+
+    /// <summary>
     /// Skip utility commands.
     /// </summary>
     protected override IReadOnlySet<string> AdditionalSkipSubcommands => new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -63,6 +63,12 @@ public abstract partial class CliScraperBase : ICliScraper
     protected virtual string BaseOptionsClassName => $"{NamespacePrefix}Options";
 
     /// <summary>
+    /// Converts a CLI command segment into its generated C# identifier.
+    /// Override for tool-specific compound names that cannot be inferred from separators.
+    /// </summary>
+    protected virtual string NormalizeCommandIdentifier(string commandPart) => ToPascalCase(commandPart);
+
+    /// <summary>
     /// Whether to skip deprecated commands (identified by "DEPRECATED" in help text).
     /// Defaults to false (include deprecated commands).
     /// </summary>
@@ -519,7 +525,7 @@ public abstract partial class CliScraperBase : ICliScraper
         var parts = commandParts
             .Skip(1) // Skip tool name
             .SelectMany(part => part.Split('-', StringSplitOptions.RemoveEmptyEntries))
-            .Select(ToPascalCase);
+            .Select(NormalizeCommandIdentifier);
 
         return $"{NamespacePrefix}{string.Join("", parts)}Options";
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -134,8 +134,15 @@ public abstract partial class CobraCliScraper : CliScraperBase
             return Task.FromResult<CliCommandDefinition?>(null);
         }
 
-        // Get the first subcommand for grouping
-        var subDomain = commandParts.Length > 1 ? NormalizeCommandIdentifier(commandParts[0]) : null;
+        // Get the first subcommand for grouping. Record only tool-specific identifier
+        // overrides so shared generators preserve existing public names for other tools.
+        var commandGroupIdentifier = NormalizeCommandIdentifier(commandParts[0]);
+        var commandGroupIdentifierOverride = commandGroupIdentifier.Equals(
+            ToPascalCase(commandParts[0]),
+            StringComparison.Ordinal)
+            ? null
+            : commandGroupIdentifier;
+        var subDomain = commandParts.Length > 1 ? commandGroupIdentifier : null;
 
         // Parse description from synopsis or first line
         var description = ExtractDescription(helpText);
@@ -166,6 +173,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
             Options = options,
             PositionalArguments = positionalArgs,
             SubDomainGroup = subDomain,
+            CommandGroupIdentifierOverride = commandGroupIdentifierOverride,
             Enums = enums
         };
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -135,7 +135,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
         }
 
         // Get the first subcommand for grouping
-        var subDomain = commandParts.Length > 1 ? ToPascalCase(commandParts[0]) : null;
+        var subDomain = commandParts.Length > 1 ? NormalizeCommandIdentifier(commandParts[0]) : null;
 
         // Parse description from synopsis or first line
         var description = ExtractDescription(helpText);


### PR DESCRIPTION
## Summary
- expand ArgoCD's compound `appset` command to the collision-free `ApplicationSet` identifier
- carry the explicit identifier through root filtering, subdomain generation, services, and registration
- preserve existing public option types and legacy casing for other CLI integrations
- add regression coverage for naming collisions, `ApplicationSet.Execute`, and legacy casing

## Validation
- reproduced the collision with ArgoCD CLI v3.4.5
- regenerated 484 ArgoCD files with zero generator errors
- built `ModularPipelines.ArgoCd` successfully after regeneration
- all 337 OptionsGenerator tests pass
- scoped format and diff checks pass

Closes #3012