### PR TITLE
Protect primary checkout during merge cleanup

### DIFF
--- a/scripts/Merge-Pr.ps1
+++ b/scripts/Merge-Pr.ps1
@@ -49,14 +49,9 @@ $headRef = $headRef.Trim()
 $mainRepo = ((git worktree list --porcelain) | Where-Object { $_ -like 'worktree *' } |
     Select-Object -First 1) -replace '^worktree ', ''
 
-# --- 2. Merge. -----------------------------------------------------------------
-gh pr merge $Pr @repoArgs --squash
-if ($LASTEXITCODE -ne 0) { Fail "gh pr merge failed (exit $LASTEXITCODE). Worktree untouched." }
-Write-Host "Merged #${Pr} ($headRef)."
-
-# --- 3. Remove the PR's worktree. ----------------------------------------------
+# Resolve cleanup before merging. If another process checked the PR branch out in the
+# primary checkout, abort while the PR is still open instead of risking that checkout.
 if (-not $Worktree) {
-    # Find the worktree whose checked-out branch matches the PR head branch.
     $wt = $null; $cur = $null
     foreach ($line in (git -C $mainRepo worktree list --porcelain)) {
         if ($line -like 'worktree *') { $cur = $line.Substring(9) }
@@ -64,6 +59,18 @@ if (-not $Worktree) {
     }
     $Worktree = $wt
 }
+if ($Worktree) {
+    if (Test-SameWorktreePath -Left $mainRepo -Right $Worktree) {
+        Fail "PR branch '$headRef' is checked out in the primary checkout '$mainRepo'. Move it to an isolated worktree first."
+    }
+}
+
+# --- 2. Merge. -----------------------------------------------------------------
+gh pr merge $Pr @repoArgs --squash
+if ($LASTEXITCODE -ne 0) { Fail "gh pr merge failed (exit $LASTEXITCODE). Worktree untouched." }
+Write-Host "Merged #${Pr} ($headRef)."
+
+# --- 3. Remove the PR's worktree. ----------------------------------------------
 if (-not $Worktree) {
     Write-Host "No isolated worktree found for branch '$headRef' (nothing to remove)."
     git -C $mainRepo worktree prune

--- a/scripts/Merge-Pr.ps1
+++ b/scripts/Merge-Pr.ps1
@@ -60,34 +60,72 @@ $mainRepo = ((git worktree list --porcelain) | Where-Object { $_ -like 'worktree
 
 # Resolve cleanup before merging. If another process checked the PR branch out in the
 # primary checkout, abort while the PR is still open instead of risking that checkout.
-if (-not $Worktree) {
+$worktreeWasExplicit = -not [string]::IsNullOrWhiteSpace($Worktree)
+if (-not $worktreeWasExplicit) {
     $Worktree = Find-WorktreeForBranch -RepoPath $mainRepo -Branch $headRef
+    if ($Worktree -and -not (Test-Path -LiteralPath $Worktree)) {
+        git -C $mainRepo worktree prune
+        $Worktree = Find-WorktreeForBranch -RepoPath $mainRepo -Branch $headRef
+    }
 }
+$worktreeIdentityToken = $null
+$worktreeIdentityFile = $null
 if ($Worktree) {
     if (-not (Test-IsLinkedWorktree -Path $Worktree)) {
         Fail "PR branch '$headRef' is not in an isolated linked worktree. Move it out of the primary checkout first."
     }
+
+    $worktreeGitDirectory = git -C $Worktree rev-parse --absolute-git-dir 2>$null
+    if ($LASTEXITCODE -ne 0 -or -not $worktreeGitDirectory) {
+        Fail "could not resolve linked-worktree identity for '$Worktree'"
+    }
+    $worktreeIdentityToken = [guid]::NewGuid().ToString('N')
+    $worktreeIdentityFile = Join-Path $worktreeGitDirectory.Trim() ".modularpipelines-merge-$worktreeIdentityToken"
+    Set-Content -LiteralPath $worktreeIdentityFile -Value $worktreeIdentityToken -NoNewline
 }
 
 # --- 2. Merge. -----------------------------------------------------------------
 gh pr merge $Pr @repoArgs --squash
-if ($LASTEXITCODE -ne 0) { Fail "gh pr merge failed (exit $LASTEXITCODE). Worktree untouched." }
+$mergeExitCode = $LASTEXITCODE
+if ($mergeExitCode -ne 0) {
+    if ($worktreeIdentityFile) { Remove-Item -LiteralPath $worktreeIdentityFile -Force -ErrorAction SilentlyContinue }
+    Fail "gh pr merge failed (exit $mergeExitCode). Worktree untouched."
+}
 Write-Host "Merged #${Pr} ($headRef)."
 
 # --- 3. Remove the PR's worktree. ----------------------------------------------
-# Re-resolve after the merge so a worktree reused while GitHub was processing the
-# merge cannot be deleted based on stale pre-merge state.
-$Worktree = Find-WorktreeForBranch -RepoPath $mainRepo -Branch $headRef
-if (-not $Worktree) {
+# Re-resolve after the merge for auto-discovered paths, but only remove the exact linked
+# worktree validated above. The private identity token disappears if that worktree is
+# removed/recreated, preventing a replacement worktree from becoming the target.
+$currentBranchWorktree = Find-WorktreeForBranch -RepoPath $mainRepo -Branch $headRef
+$currentIdentityToken = if ($worktreeIdentityFile -and (Test-Path -LiteralPath $worktreeIdentityFile -PathType Leaf)) {
+    Get-Content -LiteralPath $worktreeIdentityFile -Raw -ErrorAction SilentlyContinue
+}
+$identityValid = [bool]$worktreeIdentityToken -and $currentIdentityToken -eq $worktreeIdentityToken
+$cleanupWorktree = Select-MergeCleanupWorktree `
+    -ValidatedWorktree $Worktree `
+    -CurrentBranchWorktree $currentBranchWorktree `
+    -WasExplicit:$worktreeWasExplicit `
+    -IdentityValid:$identityValid
+
+if ($worktreeIdentityFile) {
+    Remove-Item -LiteralPath $worktreeIdentityFile -Force -ErrorAction SilentlyContinue
+}
+
+if (-not $Worktree -and -not $currentBranchWorktree) {
     Write-Host "No isolated worktree found for branch '$headRef' (nothing to remove)."
     git -C $mainRepo worktree prune
+} elseif (-not $cleanupWorktree) {
+    Write-Host "WARNING: merged #${Pr}, but the validated worktree identity changed. Preserving worktree and branches."
+    git -C $mainRepo worktree prune
+    exit 0
 } else {
-    Remove-MergedWorktree -Repo $mainRepo -Worktree $Worktree -Label "#${Pr}"
+    Remove-MergedWorktree -Repo $mainRepo -Worktree $cleanupWorktree -Label "#${Pr}"
 
     # A dirty worktree is intentionally preserved. Its local and remote branches are
     # also preserved so uncommitted work retains an upstream recovery point.
-    if (Test-Path -LiteralPath $Worktree) {
-        Write-Host "Preserving branches for worktree #${Pr}: $Worktree"
+    if (Test-Path -LiteralPath $cleanupWorktree) {
+        Write-Host "Preserving branches for worktree #${Pr}: $cleanupWorktree"
         exit 0
     }
 }

--- a/scripts/Merge-Pr.ps1
+++ b/scripts/Merge-Pr.ps1
@@ -35,6 +35,15 @@ $repoArgs = @(); if ($Repo) { $repoArgs = @('--repo', $Repo) }
 
 function Fail([string]$msg) { [Console]::Error.WriteLine("MERGE ABORTED #${Pr} -- $msg"); exit 1 }
 
+function Find-WorktreeForBranch([string]$RepoPath, [string]$Branch) {
+    $current = $null
+    foreach ($line in (git -C $RepoPath worktree list --porcelain)) {
+        if ($line -like 'worktree *') { $current = $line.Substring(9) }
+        elseif ($line -eq "branch refs/heads/$Branch") { return $current }
+    }
+    return $null
+}
+
 # --- 1. Gate: the pure predicate decides. No merge unless it exits 0. -----------
 & pwsh (Join-Path $PSScriptRoot 'Assert-PrGreen.ps1') -Pr $Pr @repoArgs
 if ($LASTEXITCODE -ne 0) { Fail "Assert-PrGreen denied (exit $LASTEXITCODE). Not merging." }
@@ -52,16 +61,11 @@ $mainRepo = ((git worktree list --porcelain) | Where-Object { $_ -like 'worktree
 # Resolve cleanup before merging. If another process checked the PR branch out in the
 # primary checkout, abort while the PR is still open instead of risking that checkout.
 if (-not $Worktree) {
-    $wt = $null; $cur = $null
-    foreach ($line in (git -C $mainRepo worktree list --porcelain)) {
-        if ($line -like 'worktree *') { $cur = $line.Substring(9) }
-        elseif ($line -eq "branch refs/heads/$headRef") { $wt = $cur; break }
-    }
-    $Worktree = $wt
+    $Worktree = Find-WorktreeForBranch -RepoPath $mainRepo -Branch $headRef
 }
 if ($Worktree) {
-    if (Test-SameWorktreePath -Left $mainRepo -Right $Worktree) {
-        Fail "PR branch '$headRef' is checked out in the primary checkout '$mainRepo'. Move it to an isolated worktree first."
+    if (-not (Test-IsLinkedWorktree -Path $Worktree)) {
+        Fail "PR branch '$headRef' is not in an isolated linked worktree. Move it out of the primary checkout first."
     }
 }
 
@@ -71,6 +75,9 @@ if ($LASTEXITCODE -ne 0) { Fail "gh pr merge failed (exit $LASTEXITCODE). Worktr
 Write-Host "Merged #${Pr} ($headRef)."
 
 # --- 3. Remove the PR's worktree. ----------------------------------------------
+# Re-resolve after the merge so a worktree reused while GitHub was processing the
+# merge cannot be deleted based on stale pre-merge state.
+$Worktree = Find-WorktreeForBranch -RepoPath $mainRepo -Branch $headRef
 if (-not $Worktree) {
     Write-Host "No isolated worktree found for branch '$headRef' (nothing to remove)."
     git -C $mainRepo worktree prune

--- a/scripts/Test-MergePr.ps1
+++ b/scripts/Test-MergePr.ps1
@@ -48,4 +48,18 @@ if ($postMergeScript -match '(?m)^\s*Fail\s+') {
     throw 'Post-merge cleanup must warn rather than report that the merge was aborted.'
 }
 
+if ($script -notmatch '\$worktreeWasExplicit') {
+    throw 'Merge-Pr must preserve whether -Worktree was explicitly supplied.'
+}
+
+if ($script -notmatch '\$worktreeIdentityToken') {
+    throw 'Merge-Pr must retain an identity token for the validated worktree.'
+}
+
+$stalePruneIndex = $script.IndexOf('worktree prune')
+$linkedGuardCallIndex = $script.IndexOf('Test-IsLinkedWorktree -Path $Worktree')
+if ($stalePruneIndex -lt 0 -or $stalePruneIndex -gt $linkedGuardCallIndex) {
+    throw 'Stale worktree registrations must be pruned before linked-worktree validation.'
+}
+
 Write-Output 'OK Merge-Pr command ordering and post-merge failure semantics passed.'

--- a/scripts/Test-MergePr.ps1
+++ b/scripts/Test-MergePr.ps1
@@ -12,7 +12,7 @@ if ($mergeMatch.Value -match '--delete-branch') {
     throw 'gh pr merge must not delete a branch before its worktree is removed.'
 }
 
-$primaryGuardIndex = $script.IndexOf("is checked out in the primary checkout")
+$primaryGuardIndex = $script.IndexOf("is not in an isolated linked worktree")
 if ($primaryGuardIndex -lt 0 -or $primaryGuardIndex -gt $mergeMatch.Index) {
     throw 'Primary-checkout cleanup guard must run before gh pr merge.'
 }
@@ -36,6 +36,11 @@ if ($cleanupIndex -gt $remoteDeleteIndex -or $cleanupIndex -gt $localDeleteIndex
 $mergedConfirmationIndex = $script.IndexOf('Write-Host "Merged', $mergeMatch.Index)
 if ($mergedConfirmationIndex -lt 0) {
     throw 'Successful merge confirmation is missing.'
+}
+
+$postMergeResolutionIndex = $script.IndexOf('# Re-resolve after the merge', $mergedConfirmationIndex)
+if ($postMergeResolutionIndex -lt 0 -or $postMergeResolutionIndex -gt $cleanupIndex) {
+    throw 'PR worktree must be re-resolved after the merge and before cleanup.'
 }
 
 $postMergeScript = $script.Substring($mergedConfirmationIndex)

--- a/scripts/Test-MergePr.ps1
+++ b/scripts/Test-MergePr.ps1
@@ -12,6 +12,11 @@ if ($mergeMatch.Value -match '--delete-branch') {
     throw 'gh pr merge must not delete a branch before its worktree is removed.'
 }
 
+$primaryGuardIndex = $script.IndexOf("is checked out in the primary checkout")
+if ($primaryGuardIndex -lt 0 -or $primaryGuardIndex -gt $mergeMatch.Index) {
+    throw 'Primary-checkout cleanup guard must run before gh pr merge.'
+}
+
 $cleanupIndex = $script.IndexOf('Remove-MergedWorktree', $mergeMatch.Index)
 $remoteDeleteIndex = $script.IndexOf('push origin --delete', $mergeMatch.Index)
 $localDeleteIndex = $script.IndexOf('branch -D', $mergeMatch.Index)

--- a/scripts/Test-WorktreeCleanup.ps1
+++ b/scripts/Test-WorktreeCleanup.ps1
@@ -41,6 +41,31 @@ function global:git {
 try {
     . $cleanupScript
 
+    $explicitSelection = Select-MergeCleanupWorktree `
+        -ValidatedWorktree $isolatedRoot `
+        -CurrentBranchWorktree $null `
+        -WasExplicit `
+        -IdentityValid
+    if ($explicitSelection -ne $isolatedRoot) {
+        throw 'Explicit worktree override was not preserved for cleanup.'
+    }
+
+    $replacementRoot = Join-Path $testRoot 'replacement'
+    $replacementSelection = Select-MergeCleanupWorktree `
+        -ValidatedWorktree $isolatedRoot `
+        -CurrentBranchWorktree $replacementRoot `
+        -IdentityValid
+    if ($null -ne $replacementSelection) {
+        throw 'A replacement worktree was selected for cleanup.'
+    }
+
+    $invalidIdentitySelection = Select-MergeCleanupWorktree `
+        -ValidatedWorktree $isolatedRoot `
+        -CurrentBranchWorktree $isolatedRoot
+    if ($null -ne $invalidIdentitySelection) {
+        throw 'A worktree with a changed identity was selected for cleanup.'
+    }
+
     $primarySpelling = if ($IsWindows) { ($primaryRoot + '\').ToUpperInvariant() } else { $primaryRoot + '/' }
     $output = Remove-MergedWorktree -Repo $primaryRoot -Worktree $primarySpelling -Label '#test' 6>&1
 

--- a/scripts/Test-WorktreeCleanup.ps1
+++ b/scripts/Test-WorktreeCleanup.ps1
@@ -4,22 +4,45 @@ $cleanupScript = Join-Path $PSScriptRoot 'WorktreeCleanup.ps1'
 $testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("worktree-cleanup-{0}" -f [guid]::NewGuid())
 $primaryRoot = Join-Path $testRoot 'primary'
 $isolatedRoot = Join-Path $testRoot 'isolated'
+$aliasRoot = Join-Path $testRoot 'primary-alias'
+$casePrimaryRoot = Join-Path $testRoot 'Repo'
+$caseIsolatedRoot = Join-Path $testRoot 'repo'
 $script:gitCalled = $false
 
 New-Item -ItemType Directory -Path $primaryRoot | Out-Null
 New-Item -ItemType Directory -Path $isolatedRoot | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $primaryRoot '.git') | Out-Null
+Set-Content -LiteralPath (Join-Path $isolatedRoot '.git') -Value 'gitdir: /tmp/fake-worktree'
+if (-not $IsWindows) {
+    New-Item -ItemType Directory -Path (Join-Path $casePrimaryRoot '.git') | Out-Null
+    New-Item -ItemType Directory -Path $caseIsolatedRoot | Out-Null
+    Set-Content -LiteralPath (Join-Path $caseIsolatedRoot '.git') -Value 'gitdir: /tmp/fake-case-worktree'
+}
+if ($IsWindows) {
+    New-Item -ItemType Junction -Path $aliasRoot -Target $primaryRoot | Out-Null
+}
+else {
+    New-Item -ItemType SymbolicLink -Path $aliasRoot -Target $primaryRoot | Out-Null
+}
 
 function global:git {
     $script:gitCalled = $true
     if ($args -contains 'remove') {
-        Remove-Item -LiteralPath $isolatedRoot -Recurse -Force
+        $target = $args[-1]
+        if ($target -eq $aliasRoot) {
+            Remove-Item -LiteralPath $aliasRoot -Force
+        }
+        else {
+            Remove-Item -LiteralPath $target -Recurse -Force
+        }
     }
 }
 
 try {
     . $cleanupScript
 
-    $output = Remove-MergedWorktree -Repo "$primaryRoot\" -Worktree $primaryRoot.ToUpperInvariant() -Label '#test' 6>&1
+    $primarySpelling = if ($IsWindows) { ($primaryRoot + '\').ToUpperInvariant() } else { $primaryRoot + '/' }
+    $output = Remove-MergedWorktree -Repo $primaryRoot -Worktree $primarySpelling -Label '#test' 6>&1
 
     if ($script:gitCalled) {
         throw 'Primary-checkout protection ran after a git operation.'
@@ -33,6 +56,17 @@ try {
         throw 'Cleanup must explain why the primary checkout was preserved.'
     }
 
+    $script:gitCalled = $false
+    Remove-MergedWorktree -Repo $primaryRoot -Worktree $aliasRoot -Label '#alias'
+
+    if ($script:gitCalled) {
+        throw 'A primary-checkout alias reached a git operation.'
+    }
+
+    if (-not (Test-Path -LiteralPath $primaryRoot)) {
+        throw 'Primary checkout was removed through an alias.'
+    }
+
     Remove-MergedWorktree -Repo $primaryRoot -Worktree $isolatedRoot -Label '#test'
 
     if (-not $script:gitCalled) {
@@ -42,9 +76,23 @@ try {
     if (Test-Path -LiteralPath $isolatedRoot) {
         throw 'Normal isolated worktree was not removed.'
     }
+
+    if (-not $IsWindows) {
+        $script:gitCalled = $false
+        Remove-MergedWorktree -Repo $casePrimaryRoot -Worktree $caseIsolatedRoot -Label '#case'
+
+        if (-not $script:gitCalled -or (Test-Path -LiteralPath $caseIsolatedRoot)) {
+            throw 'Case-distinct isolated worktree was incorrectly preserved.'
+        }
+
+        if (-not (Test-Path -LiteralPath $casePrimaryRoot)) {
+            throw 'Case-distinct primary checkout was removed.'
+        }
+    }
 }
 finally {
     Remove-Item -LiteralPath Function:\git -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $aliasRoot -Force -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
 

--- a/scripts/Test-WorktreeCleanup.ps1
+++ b/scripts/Test-WorktreeCleanup.ps1
@@ -1,0 +1,51 @@
+$ErrorActionPreference = 'Stop'
+
+$cleanupScript = Join-Path $PSScriptRoot 'WorktreeCleanup.ps1'
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("worktree-cleanup-{0}" -f [guid]::NewGuid())
+$primaryRoot = Join-Path $testRoot 'primary'
+$isolatedRoot = Join-Path $testRoot 'isolated'
+$script:gitCalled = $false
+
+New-Item -ItemType Directory -Path $primaryRoot | Out-Null
+New-Item -ItemType Directory -Path $isolatedRoot | Out-Null
+
+function global:git {
+    $script:gitCalled = $true
+    if ($args -contains 'remove') {
+        Remove-Item -LiteralPath $isolatedRoot -Recurse -Force
+    }
+}
+
+try {
+    . $cleanupScript
+
+    $output = Remove-MergedWorktree -Repo "$primaryRoot\" -Worktree $primaryRoot.ToUpperInvariant() -Label '#test' 6>&1
+
+    if ($script:gitCalled) {
+        throw 'Primary-checkout protection ran after a git operation.'
+    }
+
+    if (-not (Test-Path -LiteralPath $primaryRoot)) {
+        throw 'Primary checkout was removed.'
+    }
+
+    if (($output -join "`n") -notmatch 'primary checkout') {
+        throw 'Cleanup must explain why the primary checkout was preserved.'
+    }
+
+    Remove-MergedWorktree -Repo $primaryRoot -Worktree $isolatedRoot -Label '#test'
+
+    if (-not $script:gitCalled) {
+        throw 'Normal isolated-worktree cleanup did not run git.'
+    }
+
+    if (Test-Path -LiteralPath $isolatedRoot) {
+        throw 'Normal isolated worktree was not removed.'
+    }
+}
+finally {
+    Remove-Item -LiteralPath Function:\git -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Output 'OK primary checkout cleanup guard passed.'

--- a/scripts/WorktreeCleanup.ps1
+++ b/scripts/WorktreeCleanup.ps1
@@ -10,6 +10,18 @@
 #     system-wide; the `\\?\` extended-length Remove-Item is kept as a fallback for
 #     environments where that config is missing.
 
+function Test-SameWorktreePath {
+    param(
+        [Parameter(Mandatory)][string]$Left,
+        [Parameter(Mandatory)][string]$Right
+    )
+
+    $trimChars = [char[]]@([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
+    $leftPath = [IO.Path]::GetFullPath($Left).TrimEnd($trimChars)
+    $rightPath = [IO.Path]::GetFullPath($Right).TrimEnd($trimChars)
+    return $leftPath.Equals($rightPath, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
 function Remove-MergedWorktree {
     [CmdletBinding()]
     param(
@@ -20,6 +32,14 @@ function Remove-MergedWorktree {
 
     if (-not (Test-Path -LiteralPath $Worktree)) {
         git -C $Repo worktree prune
+        return
+    }
+
+    # Never remove the checkout used to administer worktrees. Besides being invalid
+    # for `git worktree remove`, allowing this to reach the recursive fallback would
+    # delete the primary checkout and any untracked user files in it.
+    if (Test-SameWorktreePath -Left $Repo -Right $Worktree) {
+        Write-Host "WARNING: refusing to remove primary checkout $Label : $Worktree"
         return
     }
 

--- a/scripts/WorktreeCleanup.ps1
+++ b/scripts/WorktreeCleanup.ps1
@@ -23,6 +23,40 @@ function Test-IsLinkedWorktree {
     return $firstLine -match '^gitdir:\s*\S+'
 }
 
+function Test-SameNativePath {
+    param(
+        [Parameter(Mandatory)][string]$Left,
+        [Parameter(Mandatory)][string]$Right
+    )
+
+    try {
+        $leftPath = [IO.Path]::GetFullPath($Left).TrimEnd([char[]]@('/', '\'))
+        $rightPath = [IO.Path]::GetFullPath($Right).TrimEnd([char[]]@('/', '\'))
+        $comparison = if ($IsWindows) { [StringComparison]::OrdinalIgnoreCase } else { [StringComparison]::Ordinal }
+        return [string]::Equals($leftPath, $rightPath, $comparison)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Select-MergeCleanupWorktree {
+    param(
+        [string]$ValidatedWorktree,
+        [string]$CurrentBranchWorktree,
+        [switch]$WasExplicit,
+        [switch]$IdentityValid
+    )
+
+    if (-not $ValidatedWorktree -or -not $IdentityValid) { return $null }
+    if ($WasExplicit) { return $ValidatedWorktree }
+    if (-not $CurrentBranchWorktree) { return $null }
+    if (Test-SameNativePath -Left $ValidatedWorktree -Right $CurrentBranchWorktree) {
+        return $ValidatedWorktree
+    }
+    return $null
+}
+
 function Remove-MergedWorktree {
     [CmdletBinding()]
     param(

--- a/scripts/WorktreeCleanup.ps1
+++ b/scripts/WorktreeCleanup.ps1
@@ -10,16 +10,17 @@
 #     system-wide; the `\\?\` extended-length Remove-Item is kept as a fallback for
 #     environments where that config is missing.
 
-function Test-SameWorktreePath {
-    param(
-        [Parameter(Mandatory)][string]$Left,
-        [Parameter(Mandatory)][string]$Right
-    )
+function Test-IsLinkedWorktree {
+    param([Parameter(Mandatory)][string]$Path)
 
-    $trimChars = [char[]]@([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar)
-    $leftPath = [IO.Path]::GetFullPath($Left).TrimEnd($trimChars)
-    $rightPath = [IO.Path]::GetFullPath($Right).TrimEnd($trimChars)
-    return $leftPath.Equals($rightPath, [System.StringComparison]::OrdinalIgnoreCase)
+    # A primary checkout has a .git directory. A linked worktree has a .git file,
+    # including when reached through a symlink or junction. Requiring that marker
+    # avoids path-text comparisons and refuses arbitrary directories fail-closed.
+    $marker = Join-Path $Path '.git'
+    if (-not (Test-Path -LiteralPath $marker -PathType Leaf)) { return $false }
+
+    $firstLine = Get-Content -LiteralPath $marker -TotalCount 1 -ErrorAction SilentlyContinue
+    return $firstLine -match '^gitdir:\s*\S+'
 }
 
 function Remove-MergedWorktree {
@@ -35,11 +36,10 @@ function Remove-MergedWorktree {
         return
     }
 
-    # Never remove the checkout used to administer worktrees. Besides being invalid
-    # for `git worktree remove`, allowing this to reach the recursive fallback would
-    # delete the primary checkout and any untracked user files in it.
-    if (Test-SameWorktreePath -Left $Repo -Right $Worktree) {
-        Write-Host "WARNING: refusing to remove primary checkout $Label : $Worktree"
+    # Only linked worktrees are valid deletion targets. This rejects the primary
+    # checkout even through a filesystem alias before any git or recursive delete.
+    if (-not (Test-IsLinkedWorktree -Path $Worktree)) {
+        Write-Host "WARNING: refusing to remove primary checkout or non-linked worktree $Label : $Worktree"
         return
     }
 


### PR DESCRIPTION
## Summary
- resolve PR worktree before merging and abort if it is the primary checkout
- add the same invariant to shared worktree cleanup as defense in depth
- cover path casing/trailing separators and normal isolated cleanup

## Tests
- `pwsh scripts/Test-WorktreeCleanup.ps1`
- `pwsh scripts/Test-MergePr.ps1`
- `git diff --check`

Closes #3029