### PR TITLE
Allow Claude reviews for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'dependabot[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |


### PR DESCRIPTION
## Summary

- allow only the trusted `dependabot[bot]` actor to trigger Claude review
- keep the action default-deny behavior for every other bot

## Why

Dependabot PRs #3034-#3036 failed `claude-review` before review because `allowed_bots` was unset. Anthropic documents an explicit bot allowlist for this automation case.

## Validation

- compared input name/value with `anthropics/claude-code-action@v1` usage and security documentation
- `git diff --check`