### PR TITLE
Fix zero-output CLI scraper failures

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -525,6 +525,16 @@ jobs:
       # .NET CLI is installed via setup-dotnet
       # pip is pre-installed with Python on ubuntu-latest
 
+      - name: Verify affected tool installation
+        if: steps.should-run.outputs.run == 'true' && contains(fromJSON('["aws","gh","snyk","yarn","cosign","eksctl","trivy","liquibase"]'), matrix.tool)
+        run: |
+          command -v "${{ matrix.tool }}"
+          case "${{ matrix.tool }}" in
+            cosign) cosign version ;;
+            eksctl) eksctl version ;;
+            *) "${{ matrix.tool }}" --version ;;
+          esac
+
       - name: Build Generator
         if: steps.should-run.outputs.run == 'true'
         run: dotnet build -c Release

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
@@ -47,6 +47,45 @@ public class ZeroOutputScraperTests
     }
 
     [Test]
+    public async Task Gh_Parses_Inline_Usage_And_Indented_Flags_Sections()
+    {
+        const string helpText = """
+            Create an issue.
+
+            Usage: gh issue create [flags]
+
+              Flags:
+                -t, --title string   Supply a title
+            """;
+
+        var command = await new TestGhCliScraper().Parse(["gh", "issue", "create"], helpText);
+
+        await Assert.That(command).IsNotNull();
+        await Assert.That(command!.Options.Select(option => option.SwitchName))
+            .IsEquivalentTo(["--title"]);
+    }
+
+    [Test]
+    public async Task Gh_Parses_Indented_Usage_Heading()
+    {
+        const string helpText = """
+            Create an issue.
+
+              Usage:
+                gh issue create [flags]
+
+            Flags:
+              -t, --title string   Supply a title
+            """;
+
+        var command = await new TestGhCliScraper().Parse(["gh", "issue", "create"], helpText);
+
+        await Assert.That(command).IsNotNull();
+        await Assert.That(command!.Options.Select(option => option.SwitchName))
+            .IsEquivalentTo(["--title"]);
+    }
+
+    [Test]
     public async Task Yarn_Extracts_Classic_Bulleted_Command_List()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
@@ -1,0 +1,102 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class ZeroOutputScraperTests
+{
+    [Test]
+    public async Task Aws_Extracts_Current_Rendered_Service_List()
+    {
+        const string helpText = """
+            Available Services
+            ******************
+
+            * accessanalyzer
+
+            * cloudformation
+
+            * ec2
+            """;
+
+        await Assert.That(new TestAwsCliScraper().Extract(helpText))
+            .IsEquivalentTo(["accessanalyzer", "cloudformation", "ec2"]);
+    }
+
+    [Test]
+    public async Task Gh_Parses_Uppercase_Usage_And_Flags_Sections()
+    {
+        const string helpText = """
+            Create an issue.
+
+            USAGE
+              gh issue create [flags]
+
+            FLAGS
+              -t, --title string   Supply a title
+                  --web            Open the browser
+            """;
+
+        var command = await new TestGhCliScraper().Parse(["gh", "issue", "create"], helpText);
+
+        await Assert.That(command).IsNotNull();
+        await Assert.That(command!.Options.Select(option => option.SwitchName))
+            .IsEquivalentTo(["--title", "--web"]);
+    }
+
+    [Test]
+    public async Task Yarn_Extracts_Classic_Bulleted_Command_List()
+    {
+        const string helpText = """
+              Commands:
+                - add
+                - install
+                - workspace
+            """;
+
+        await Assert.That(new TestYarnCliScraper().Extract(helpText))
+            .IsEquivalentTo(["add", "install", "workspace"]);
+    }
+
+    private sealed class TestAwsCliScraper : AwsCliScraper
+    {
+        public TestAwsCliScraper()
+            : base(
+                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<AwsCliScraper>.Instance)
+        {
+        }
+
+        public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
+    }
+
+    private sealed class TestGhCliScraper : GhCliScraper
+    {
+        public TestGhCliScraper()
+            : base(
+                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<GhCliScraper>.Instance)
+        {
+        }
+
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+    }
+
+    private sealed class TestYarnCliScraper : YarnCliScraper
+    {
+        public TestYarnCliScraper()
+            : base(
+                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<YarnCliScraper>.Instance)
+        {
+        }
+
+        public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
@@ -487,9 +487,9 @@ public partial class AwsCliScraper : CliScraperBase
 
     /// <summary>
     /// Matches AWS command lines in AVAILABLE SERVICES/COMMANDS sections.
-    /// Format: "       o command-name"
+    /// Formats: "       o command-name" or "* command-name".
     /// </summary>
-    [GeneratedRegex(@"^\s+o\s+(?<name>[\w-]+)", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^\s*(?:o|\*)\s+(?<name>[\w-]+)", RegexOptions.Multiline)]
     private static partial Regex AwsCommandPattern();
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -886,7 +886,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// <summary>
     /// Matches "Flags:" or "Global Flags:" section headers.
     /// </summary>
-    [GeneratedRegex(@"(?:Global\s+)?Flags:\s*\n", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"^(?:Global\s+)?Flags:?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex FlagsSectionPattern();
 
     /// <summary>
@@ -919,7 +919,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// <summary>
     /// Matches usage line.
     /// </summary>
-    [GeneratedRegex(@"Usage:\s*\n?\s*(?<usage>[^\n]+)", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"^Usage:?\s*\n?\s*(?<usage>[^\n]+)", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex UsageLinePattern();
 
     /// <summary>
@@ -963,7 +963,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
         }
 
         // Valid Cobra command help always has "Usage:" section
-        if (!helpText.Contains("Usage:"))
+        if (!Regex.IsMatch(helpText, @"^Usage:?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline))
         {
             return false;
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -886,7 +886,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// <summary>
     /// Matches "Flags:" or "Global Flags:" section headers.
     /// </summary>
-    [GeneratedRegex(@"^(?:Global\s+)?Flags:?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
+    [GeneratedRegex(@"^[ \t]*(?:Global[ \t]+)?Flags:?[ \t]*\r?$", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex FlagsSectionPattern();
 
     /// <summary>
@@ -919,7 +919,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// <summary>
     /// Matches usage line.
     /// </summary>
-    [GeneratedRegex(@"^Usage:?\s*\n?\s*(?<usage>[^\n]+)", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
+    [GeneratedRegex(@"^[ \t]*Usage:?[ \t]*(?:\r?\n[ \t]*)?(?<usage>[^\r\n]+)", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex UsageLinePattern();
 
     /// <summary>
@@ -963,7 +963,8 @@ public abstract partial class CobraCliScraper : CliScraperBase
         }
 
         // Valid Cobra command help always has "Usage:" section
-        if (!Regex.IsMatch(helpText, @"^Usage:?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline))
+        var usageLineMatch = UsageLinePattern().Match(helpText);
+        if (!usageLineMatch.Success)
         {
             return false;
         }
@@ -982,15 +983,11 @@ public abstract partial class CobraCliScraper : CliScraperBase
         if (expectedCommandParts.Length > 0)
         {
             var lastPart = expectedCommandParts[^1];
-            var usageLineMatch = UsageLinePattern().Match(helpText);
-            if (usageLineMatch.Success)
+            var usageLine = usageLineMatch.Groups["usage"].Value;
+            // The last command part should appear in the usage line
+            if (!usageLine.Contains(lastPart, StringComparison.OrdinalIgnoreCase))
             {
-                var usageLine = usageLineMatch.Groups["usage"].Value;
-                // The last command part should appear in the usage line
-                if (!usageLine.Contains(lastPart, StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
+                return false;
             }
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -101,8 +101,16 @@ public partial class YarnCliScraper : CliScraperBase
         _yarnProjectDir = Path.Combine(Path.GetTempPath(), $"yarn-scraper-{Guid.NewGuid():N}");
         Directory.CreateDirectory(_yarnProjectDir);
 
+        var versionResult = await Executor.ExecuteAsync(ExecutablePath, "--version", cancellationToken);
+        var version = versionResult.StandardOutput.Trim();
+        var packageManager = YarnVersionPattern().IsMatch(version)
+            ? $",\"packageManager\":\"yarn@{version}\""
+            : string.Empty;
         var packageJson = Path.Combine(_yarnProjectDir, "package.json");
-        await File.WriteAllTextAsync(packageJson, "{\"name\":\"yarn-scraper-temp\",\"packageManager\":\"yarn@4.0.0\"}", cancellationToken);
+        await File.WriteAllTextAsync(
+            packageJson,
+            $"{{\"name\":\"yarn-scraper-temp\"{packageManager}}}",
+            cancellationToken);
 
         Logger.LogDebug("[yarn] Created temporary project context at {Dir}", _yarnProjectDir);
     }
@@ -115,6 +123,9 @@ public partial class YarnCliScraper : CliScraperBase
 
     public override string OutputDirectory => "src/ModularPipelines.Yarn";
 
+    protected override string ExecutablePath => OperatingSystem.IsWindows()
+        ? ResolveWindowsExecutablePath()
+        : ToolName;
 
     /// <summary>
     /// Skip utility commands.
@@ -667,6 +678,17 @@ public partial class YarnCliScraper : CliScraperBase
                helpText.Contains("--");
     }
 
+    private static string ResolveWindowsExecutablePath()
+    {
+        var pathDirectories = Environment.GetEnvironmentVariable("PATH")?
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries) ?? [];
+
+        return pathDirectories
+                   .Select(directory => Path.Combine(directory.Trim('"'), "yarn.cmd"))
+                   .FirstOrDefault(File.Exists)
+               ?? "yarn.cmd";
+    }
+
     #region Regex Patterns
 
     // ===== Clipanion-style patterns (Yarn Berry v2+/v4+) =====
@@ -753,7 +775,7 @@ public partial class YarnCliScraper : CliScraperBase
     /// <summary>
     /// Matches subcommand lines: "  command    description"
     /// </summary>
-    [GeneratedRegex(@"^\s{2,}(?<name>[\w-]+)\s{2,}", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^\s{2,}(?:-\s*)?(?<name>[\w-]+)(?:\s{2,}|\s*$)", RegexOptions.Multiline)]
     private static partial Regex SubcommandLinePattern();
 
     /// <summary>
@@ -763,6 +785,9 @@ public partial class YarnCliScraper : CliScraperBase
     /// </summary>
     [GeneratedRegex(@"^\s*(?:(?<short>-\w),)?(?<long>--[\w-]+)\s{2,}(?<desc>.*)$", RegexOptions.Multiline)]
     private static partial Regex YarnOptionPattern();
+
+    [GeneratedRegex(@"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")]
+    private static partial Regex YarnVersionPattern();
 
     #endregion
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
@@ -33,9 +33,7 @@ public class ProcessCliCommandExecutor : ICliCommandExecutor
         // Disable pagers for CLI tools - many CLIs use pagers by default which hang in non-interactive mode
         startInfo.Environment["AWS_PAGER"] = "";    // AWS CLI
         startInfo.Environment["GIT_PAGER"] = "";    // Git
-        startInfo.Environment["PAGER"] = "";        // Generic pager (used by many tools)
         startInfo.Environment["NO_COLOR"] = "1";    // Disable color output which can cause parsing issues
-        startInfo.Environment["TERM"] = "dumb";     // Simple terminal mode
 
         try
         {
@@ -63,6 +61,15 @@ public class ProcessCliCommandExecutor : ICliCommandExecutor
             var stderr = await stderrTask;
 
             _logger.LogDebug("Command completed with exit code {ExitCode}", process.ExitCode);
+            if (process.ExitCode != 0)
+            {
+                _logger.LogWarning(
+                    "Command failed: {Command} {Arguments} (exit code {ExitCode}). stderr: {StandardError}",
+                    command,
+                    arguments,
+                    process.ExitCode,
+                    stderr);
+            }
 
             return new CliCommandResult
             {


### PR DESCRIPTION
## Summary
- stop blanking generic PAGER/TERM variables that suppress AWS CLI help
- accept GitHub CLI's uppercase USAGE and colonless FLAGS headings
- match Yarn's installed version for temporary project context and support Classic command lists
- log failed CLI command, exit code, and stderr
- print explicit versions for all eight affected workflow tools

## Verification
- OptionsGenerator tests: 378 passed
- gh 2.95.0: 143 commands generated
- Yarn 1.22.22: 37 commands generated
- AWS CLI 2.32.28: 1,937 commands emitted during bounded full traversal (no zero-output failure)

Tool-specific fixes: #3037 (Cosign), #3038 (Eksctl), #3045 (Liquibase), #3048 (Snyk), #3058 (Trivy).

Closes #3010