### PR TITLE
Improve heuristic CLI option type detection

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
@@ -54,14 +54,15 @@ public class DescriptionEnumValueParserTests
     }
 
     [Test]
-    [Arguments("Output format. One of: (json, yaml, xml)")]
-    [Arguments("Accepted values: [json, yaml, xml].")]
-    public async Task TryParse_Accepts_Wrapped_Explicit_Values(string description)
+    [Arguments("Output format. One of: (json, yaml, xml)", "json,yaml,xml")]
+    [Arguments("Accepted values: [json, yaml, xml].", "json,yaml,xml")]
+    [Arguments("Compression (possible values: gzip, none)", "gzip,none")]
+    public async Task TryParse_Accepts_Wrapped_Explicit_Values(string description, string expectedValues)
     {
         var result = DescriptionEnumValueParser.TryParse(description);
 
         await Assert.That(result).IsNotNull();
-        await Assert.That(result!.Values).IsEquivalentTo(new[] { "json", "yaml", "xml" });
+        await Assert.That(result!.Values).IsEquivalentTo(expectedValues.Split(','));
         await Assert.That(result.MatchKind).IsEqualTo(DescriptionEnumMatchKind.Explicit);
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
@@ -52,4 +52,16 @@ public class DescriptionEnumValueParserTests
         await Assert.That(result!.Values).IsEquivalentTo(new[] { "table", "json", "yaml" });
         await Assert.That(result.MatchKind).IsEqualTo(DescriptionEnumMatchKind.Explicit);
     }
+
+    [Test]
+    [Arguments("Output format. One of: (json, yaml, xml)")]
+    [Arguments("Accepted values: [json, yaml, xml].")]
+    public async Task TryParse_Accepts_Wrapped_Explicit_Values(string description)
+    {
+        var result = DescriptionEnumValueParser.TryParse(description);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Values).IsEquivalentTo(new[] { "json", "yaml", "xml" });
+        await Assert.That(result.MatchKind).IsEqualTo(DescriptionEnumMatchKind.Explicit);
+    }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
@@ -1,0 +1,55 @@
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.TypeDetection;
+
+public class DescriptionEnumValueParserTests
+{
+    [Test]
+    public async Task TryParse_Rejects_Explanatory_Parenthesized_Lists()
+    {
+        var result = DescriptionEnumValueParser.TryParse("Size (bytes, kilobytes, or megabytes)");
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    [Arguments("Output format (table, json, yaml)", "table,json,yaml")]
+    [Arguments("Log types to enable (all, none, api, audit)", "all,none,api,audit")]
+    public async Task TryParse_Accepts_Contextual_Parenthesized_Values(string description, string expectedValues)
+    {
+        var result = DescriptionEnumValueParser.TryParse(description);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Values).IsEquivalentTo(expectedValues.Split(','));
+        await Assert.That(result.MatchKind).IsEqualTo(DescriptionEnumMatchKind.ContextualParenthesized);
+    }
+
+    [Test]
+    public async Task TryParse_Preserves_Trailing_Value_Before_Sentence_Punctuation()
+    {
+        var result = DescriptionEnumValueParser.TryParse("Valid values: json, yaml, xml.");
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Values).IsEquivalentTo(new[] { "json", "yaml", "xml" });
+    }
+
+    [Test]
+    [Arguments("Valid values: json, linux/amd64, yaml")]
+    [Arguments("Valid values: json, invalid@value, yaml")]
+    public async Task TryParse_Rejects_Entire_List_When_Any_Value_Is_Unsafe(string description)
+    {
+        var result = DescriptionEnumValueParser.TryParse(description);
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task TryParse_Accepts_Explicit_OneOf_Values()
+    {
+        var result = DescriptionEnumValueParser.TryParse("Must be one of: table|json|yaml");
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Values).IsEquivalentTo(new[] { "table", "json", "yaml" });
+        await Assert.That(result.MatchKind).IsEqualTo(DescriptionEnumMatchKind.Explicit);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
@@ -54,6 +54,20 @@ public class DescriptionEnumValueParserTests
     }
 
     [Test]
+    [Arguments("One of: json or yaml", "json,yaml")]
+    [Arguments("Valid values are low and high", "low,high")]
+    public async Task TryParse_Accepts_Prose_Separated_Explicit_Values(
+        string description,
+        string expectedValues)
+    {
+        var result = DescriptionEnumValueParser.TryParse(description);
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Values).IsEquivalentTo(expectedValues.Split(','));
+        await Assert.That(result.MatchKind).IsEqualTo(DescriptionEnumMatchKind.Explicit);
+    }
+
+    [Test]
     [Arguments("Output format. One of: (json, yaml, xml)", "json,yaml,xml")]
     [Arguments("Accepted values: [json, yaml, xml].", "json,yaml,xml")]
     [Arguments("Compression (possible values: gzip, none)", "gzip,none")]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/HeuristicTypeDetectorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/HeuristicTypeDetectorTests.cs
@@ -454,6 +454,20 @@ public class HeuristicTypeDetectorTests
     }
 
     [Test]
+    public async Task DetectType_Preserves_Repeatability_For_Allowed_Values()
+    {
+        var context = CreateContext(
+            "--sort",
+            description: "May be repeated or comma-separated. Possible values: ascending, descending.");
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.Enum);
+        await Assert.That(result.AcceptsMultipleValues).IsTrue();
+        await Assert.That(result.EnumValues).IsEquivalentTo(["ascending", "descending"]);
+    }
+
+    [Test]
     public async Task DetectType_Returns_Enum_For_Structured_Accepted_Values()
     {
         var context = CreateContext("--format", acceptedValues: "table|json|yaml");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/HeuristicTypeDetectorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/HeuristicTypeDetectorTests.cs
@@ -229,17 +229,49 @@ public class HeuristicTypeDetectorTests
     [Arguments("--limit")]
     [Arguments("--max-retries")]
     [Arguments("--min-value")]
-    [Arguments("--size")]
     [Arguments("--length")]
     [Arguments("--depth")]
     [Arguments("--retries")]
-    [Arguments("--timeout")]
-    [Arguments("--interval")]
     [Arguments("--port")]
     [Arguments("--number")]
     public async Task DetectType_Returns_Int_For_Numeric_Names(string optionName)
     {
         var context = CreateContext(optionName);
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.Int);
+    }
+
+    [Test]
+    [Arguments("--timeout")]
+    [Arguments("--request-duration")]
+    [Arguments("--poll-interval")]
+    [Arguments("--size")]
+    [Arguments("--max-image-size")]
+    public async Task DetectType_Returns_String_For_Potentially_UnitBearing_Names(string optionName)
+    {
+        var context = CreateContext(optionName);
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.String);
+    }
+
+    [Test]
+    public async Task DetectType_Returns_Int_For_UnitBearing_Name_With_Numeric_Default()
+    {
+        var context = CreateContext("--timeout", defaultValue: "30");
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.Int);
+    }
+
+    [Test]
+    public async Task DetectType_Returns_Int_When_Description_Confirms_Bare_Number()
+    {
+        var context = CreateContext("--timeout", description: "Timeout as an integer number of seconds");
 
         var result = await _detector.DetectTypeAsync(context);
 
@@ -369,11 +401,6 @@ public class HeuristicTypeDetectorTests
     [Arguments("Set to \"json\" for JSON output")]
     [Arguments("Defaults to 'yaml' format")]
     [Arguments("Defaults to \"text\" output")]
-    [Arguments("One of: debug, info, warn, error")]
-    [Arguments("Valid values: json, yaml, xml")]
-    [Arguments("Allowed values: true, false, auto")]
-    [Arguments("Possible values: always, never, auto")]
-    [Arguments("Accepted values: low, medium, high")]
     public async Task DetectType_Returns_String_For_HighConfidence_Value_Description_Patterns(string description)
     {
         var context = CreateContext("--config-type", description: description);
@@ -382,6 +409,57 @@ public class HeuristicTypeDetectorTests
 
         await Assert.That(result.Type).IsEqualTo(CliOptionType.String);
         await Assert.That(result.Confidence).IsEqualTo(85);
+    }
+
+    [Test]
+    [Arguments("One of: debug, info, warn, error")]
+    [Arguments("Valid values: json, yaml, xml")]
+    [Arguments("Allowed values: true, false, auto")]
+    [Arguments("Possible values: always, never, auto")]
+    [Arguments("Accepted values: low, medium, high")]
+    [Arguments("Output format (table, json, yaml)")]
+    public async Task DetectType_Returns_Enum_For_Allowed_Values_In_Description(string description)
+    {
+        var context = CreateContext("--format", description: description);
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.Enum);
+        await Assert.That(result.EnumValues).IsNotNull();
+        await Assert.That(result.EnumValues!.Length).IsGreaterThanOrEqualTo(3);
+    }
+
+    [Test]
+    public async Task DetectType_Returns_Enum_For_Structured_Accepted_Values()
+    {
+        var context = CreateContext("--format", acceptedValues: "table|json|yaml");
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.Enum);
+        await Assert.That(result.EnumValues).IsEquivalentTo(new[] { "table", "json", "yaml" });
+    }
+
+    [Test]
+    public async Task DetectType_Does_Not_Match_Boolean_Substrings_In_Accepted_Values()
+    {
+        var context = CreateContext("--mode", acceptedValues: "none, falsehood");
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.Enum);
+        await Assert.That(result.EnumValues).IsEquivalentTo(new[] { "none", "falsehood" });
+    }
+
+    [Test]
+    public async Task DetectType_Does_Not_Create_Numeric_Enums()
+    {
+        var context = CreateContext("--level", description: "Allowed values: 1, 2, 3");
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.String);
+        await Assert.That(result.EnumValues).IsNull();
     }
 
     #endregion

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/HeuristicTypeDetectorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/HeuristicTypeDetectorTests.cs
@@ -122,6 +122,17 @@ public class HeuristicTypeDetectorTests
         await Assert.That(result.Type).IsEqualTo(CliOptionType.Bool);
     }
 
+    [Test]
+    public async Task DetectType_Returns_Enum_WhenAcceptedValuesContainNonBooleanValue()
+    {
+        var context = CreateContext("--option", acceptedValues: "on|off|auto");
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.Enum);
+        await Assert.That(result.EnumValues).IsEquivalentTo(["on", "off", "auto"]);
+    }
+
     #endregion
 
     #region Boolean Detection Tests - Option Name Prefixes

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/HeuristicTypeDetectorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/HeuristicTypeDetectorTests.cs
@@ -109,6 +109,19 @@ public class HeuristicTypeDetectorTests
         await Assert.That(result.Type).IsEqualTo(CliOptionType.Bool);
     }
 
+    [Test]
+    [Arguments("true/false")]
+    [Arguments("yes/no")]
+    [Arguments("on/off")]
+    public async Task DetectType_Returns_Bool_For_Slash_Separated_AcceptedValues(string acceptedValues)
+    {
+        var context = CreateContext("--option", acceptedValues: acceptedValues);
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.Bool);
+    }
+
     #endregion
 
     #region Boolean Detection Tests - Option Name Prefixes
@@ -455,6 +468,28 @@ public class HeuristicTypeDetectorTests
     public async Task DetectType_Does_Not_Create_Numeric_Enums()
     {
         var context = CreateContext("--level", description: "Allowed values: 1, 2, 3");
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.String);
+        await Assert.That(result.EnumValues).IsNull();
+    }
+
+    [Test]
+    public async Task DetectType_Does_Not_Create_Enums_From_Explanatory_Lists()
+    {
+        var context = CreateContext("--size", description: "Size (bytes, kilobytes, or megabytes)");
+
+        var result = await _detector.DetectTypeAsync(context);
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.String);
+        await Assert.That(result.EnumValues).IsNull();
+    }
+
+    [Test]
+    public async Task DetectType_Does_Not_Create_Enums_With_Unsafe_Identifiers()
+    {
+        var context = CreateContext("--platform", description: "Allowed values: linux/amd64, windows/amd64");
 
         var result = await _detector.DetectTypeAsync(context);
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/OptionTypeEnhancerTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/OptionTypeEnhancerTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.TypeDetection;
+
+public class OptionTypeEnhancerTests
+{
+    [Test]
+    public async Task EnhanceAsync_Preserves_Repeatability_For_Detected_Enums()
+    {
+        var detector = new HeuristicTypeDetector(NullLogger<HeuristicTypeDetector>.Instance);
+        var pipeline = new OptionTypeDetectorPipeline(
+            [detector],
+            NullLogger<OptionTypeDetectorPipeline>.Instance);
+        var enhancer = new OptionTypeEnhancer(pipeline, NullLogger<OptionTypeEnhancer>.Instance);
+        var option = new CliOptionDefinition
+        {
+            SwitchName = "--sort",
+            PropertyName = "Sort",
+            CSharpType = "IEnumerable<string>?",
+            Description = "May be repeated or comma-separated. Possible values: ascending, descending.",
+            AcceptsMultipleValues = true,
+        };
+        var command = new CliCommandDefinition
+        {
+            FullCommand = "pulumi stack ls",
+            CommandParts = ["stack", "ls"],
+            ClassName = "PulumiStackLsOptions",
+            ParentClassName = "PulumiOptions",
+            ToolNamespacePrefix = "Pulumi",
+            Options = [option],
+        };
+        var tool = new CliToolDefinition
+        {
+            ToolName = "pulumi",
+            NamespacePrefix = "Pulumi",
+            TargetNamespace = "ModularPipelines.Pulumi",
+            OutputDirectory = "src/ModularPipelines.Pulumi",
+            Commands = [command],
+        };
+
+        var enhanced = await enhancer.EnhanceAsync(tool);
+        var enhancedOption = enhanced.Commands.Single().Options.Single();
+
+        await Assert.That(enhancedOption.AcceptsMultipleValues).IsTrue();
+        await Assert.That(enhancedOption.EnumDefinition).IsNotNull();
+        await Assert.That(enhancedOption.CSharpType)
+            .IsEqualTo($"IEnumerable<{enhancedOption.EnumDefinition!.EnumName}>?");
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -528,26 +528,10 @@ public abstract partial class CobraCliScraper : CliScraperBase
         string typeHint,
         string description)
     {
-        // Pattern 1: "One of: json|yaml|table"
-        var oneOfMatch = OneOfPattern().Match(description);
-        if (oneOfMatch.Success)
+        var descriptionMatch = DescriptionEnumValueParser.TryParse(description);
+        if (descriptionMatch is not null)
         {
-            var values = ParseEnumValues(oneOfMatch.Groups["values"].Value);
-            if (values.Length > 0)
-            {
-                return CreateEnumDefinition(propertyName, className, values);
-            }
-        }
-
-        // Pattern 2: "(json, yaml, table)" or "(json|yaml|table)"
-        var parenMatch = ParenthesizedValuesPattern().Match(description);
-        if (parenMatch.Success)
-        {
-            var values = ParseEnumValues(parenMatch.Groups["values"].Value);
-            if (values.Length >= 2 && values.Length <= 10 && values.All(IsValidEnumValue))
-            {
-                return CreateEnumDefinition(propertyName, className, values);
-            }
+            return CreateEnumDefinition(propertyName, className, descriptionMatch.Values);
         }
 
         // Pattern 3: Type hint contains pipe-separated values
@@ -903,18 +887,6 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// </summary>
     [GeneratedRegex(@"^\s*(?:(?<short>-\w),\s*)?(?<long>--[\w-]+)(?:(?<default>=)(?<type>[^:\s]*))?:\s*(?<desc>.*)?$", RegexOptions.Multiline)]
     private static partial Regex KubectlOptionPattern();
-
-    /// <summary>
-    /// Matches "One of: value1|value2" pattern.
-    /// </summary>
-    [GeneratedRegex(@"[Oo]ne of[:\s]+(?<values>[\w\-|,\s""'`]+?)(?:\s*\(|$|\.|;)", RegexOptions.IgnoreCase)]
-    private static partial Regex OneOfPattern();
-
-    /// <summary>
-    /// Matches "(value1, value2)" or "(value1|value2)" patterns.
-    /// </summary>
-    [GeneratedRegex(@"\((?<values>[\w\-]+(?:\s*[|,]\s*[\w\-]+)+)\)")]
-    private static partial Regex ParenthesizedValuesPattern();
 
     /// <summary>
     /// Matches usage line.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/CobraHelpTypeDetector.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/CobraHelpTypeDetector.cs
@@ -195,5 +195,4 @@ public partial class CobraHelpTypeDetector : HelpTextTypeDetectorBase
     /// </summary>
     [GeneratedRegex(@"^\s*(?:(?<short>-\w),\s*)?(?<long>--[\w-]+)(?:\s+(?<type>\S+))?\s{2,}", RegexOptions.Multiline)]
     private static partial Regex CobraOptionLinePattern();
-
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/CobraHelpTypeDetector.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/CobraHelpTypeDetector.cs
@@ -85,83 +85,22 @@ public partial class CobraHelpTypeDetector : HelpTextTypeDetectorBase
     /// </summary>
     private OptionTypeDetectionResult? TryDetectEnumValues(string optionLine, string optionName)
     {
-        // Pattern 1: "One of: json|yaml|table" or "one of json, yaml, table"
-        var oneOfMatch = OneOfPattern().Match(optionLine);
-        if (oneOfMatch.Success)
+        var match = DescriptionEnumValueParser.TryParse(optionLine);
+        if (match is null)
         {
-            var values = ParseEnumValues(oneOfMatch.Groups["values"].Value);
-            if (values.Length > 0)
-            {
-                Logger.LogDebug("Detected {Option} as Enum (One of: {Values})", optionName, string.Join(", ", values));
-                return new OptionTypeDetectionResult
-                {
-                    Type = CliOptionType.Enum,
-                    Confidence = 95,
-                    Source = Name,
-                    Notes = $"Detected via 'One of' pattern: {string.Join(", ", values)}",
-                    EnumValues = values
-                };
-            }
+            return null;
         }
 
-        // Pattern 2: "(json, yaml, table)" or "(json|yaml|table)" in parentheses
-        var parenMatch = ParenthesizedValuesPattern().Match(optionLine);
-        if (parenMatch.Success)
+        var confidence = match.MatchKind == DescriptionEnumMatchKind.Explicit ? 95 : 85;
+        Logger.LogDebug("Detected {Option} as Enum ({Values})", optionName, string.Join(", ", match.Values));
+        return new OptionTypeDetectionResult
         {
-            var values = ParseEnumValues(parenMatch.Groups["values"].Value);
-            // Only treat as enum if we have 2-10 values and they look like identifiers
-            if (values.Length >= 2 && values.Length <= 10 && values.All(v => IdentifierPattern().IsMatch(v)))
-            {
-                Logger.LogDebug("Detected {Option} as Enum (parenthesized: {Values})", optionName, string.Join(", ", values));
-                return new OptionTypeDetectionResult
-                {
-                    Type = CliOptionType.Enum,
-                    Confidence = 85,
-                    Source = Name,
-                    Notes = $"Detected via parenthesized values: {string.Join(", ", values)}",
-                    EnumValues = values
-                };
-            }
-        }
-
-        // Pattern 3: "Must be one of" or "Valid values:"
-        var validValuesMatch = ValidValuesPattern().Match(optionLine);
-        if (validValuesMatch.Success)
-        {
-            var values = ParseEnumValues(validValuesMatch.Groups["values"].Value);
-            if (values.Length > 0)
-            {
-                Logger.LogDebug("Detected {Option} as Enum (Valid values: {Values})", optionName, string.Join(", ", values));
-                return new OptionTypeDetectionResult
-                {
-                    Type = CliOptionType.Enum,
-                    Confidence = 95,
-                    Source = Name,
-                    Notes = $"Detected via 'Valid values' pattern: {string.Join(", ", values)}",
-                    EnumValues = values
-                };
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Parses enum values from a string like "json|yaml|table" or "json, yaml, table".
-    /// </summary>
-    private static string[] ParseEnumValues(string valuesText)
-    {
-        // Split on common separators: |, comma, "or", "and"
-        var values = valuesText
-            .Replace(" or ", "|")
-            .Replace(" and ", "|")
-            .Split(['|', ','], StringSplitOptions.RemoveEmptyEntries)
-            .Select(v => v.Trim().Trim('"', '\'', '`'))
-            .Where(v => !string.IsNullOrWhiteSpace(v) && v.Length < 30) // Reasonable length
-            .Distinct()
-            .ToArray();
-
-        return values;
+            Type = CliOptionType.Enum,
+            Confidence = confidence,
+            Source = Name,
+            Notes = $"Detected via description values: {string.Join(", ", match.Values)}",
+            EnumValues = match.Values
+        };
     }
 
     /// <summary>
@@ -257,27 +196,4 @@ public partial class CobraHelpTypeDetector : HelpTextTypeDetectorBase
     [GeneratedRegex(@"^\s*(?:(?<short>-\w),\s*)?(?<long>--[\w-]+)(?:\s+(?<type>\S+))?\s{2,}", RegexOptions.Multiline)]
     private static partial Regex CobraOptionLinePattern();
 
-    /// <summary>
-    /// Matches "One of: value1|value2" or "one of value1, value2" patterns.
-    /// </summary>
-    [GeneratedRegex(@"[Oo]ne of[:\s]+(?<values>[\w\-|,\s""'`]+?)(?:\s*\(|$|\.|;)", RegexOptions.IgnoreCase)]
-    private static partial Regex OneOfPattern();
-
-    /// <summary>
-    /// Matches "(value1, value2, value3)" or "(value1|value2|value3)" patterns.
-    /// </summary>
-    [GeneratedRegex(@"\((?<values>[\w\-]+(?:\s*[|,]\s*[\w\-]+)+)\)")]
-    private static partial Regex ParenthesizedValuesPattern();
-
-    /// <summary>
-    /// Matches "Valid values:" or "Must be one of:" patterns.
-    /// </summary>
-    [GeneratedRegex(@"(?:Valid values|Must be one of|Allowed values)[:\s]+(?<values>[\w\-|,\s""'`]+?)(?:\s*\(|$|\.|;)", RegexOptions.IgnoreCase)]
-    private static partial Regex ValidValuesPattern();
-
-    /// <summary>
-    /// Matches valid identifier-like strings for enum values.
-    /// </summary>
-    [GeneratedRegex(@"^[\w][\w\-]*$")]
-    private static partial Regex IdentifierPattern();
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
@@ -69,13 +69,13 @@ internal static partial class DescriptionEnumValueParser
         return values is null ? null : new DescriptionEnumMatch(values, matchKind);
     }
 
-    [GeneratedRegex("""\b(?:must be one of|one of|valid values|allowed values|possible values|accepted values)\b(?:\s+are)?\s*:?\s*[\[(]?(?<values>[^\s,|)\]]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|)\]]+)+)""", RegexOptions.IgnoreCase)]
+    [GeneratedRegex("""\b(?:must be one of|one of|valid values|allowed values|possible values|accepted values)\b(?:\s+are)?\s*:?\s*[\[(]?(?<values>[^\s,|)\]]+(?:(?:\s*(?:\||,)\s*(?:(?:or|and)\s+)?|\s+(?:or|and)\s+)[^\s,|)\]]+)+)""", RegexOptions.IgnoreCase)]
     private static partial Regex ExplicitValuesPattern();
 
     [GeneratedRegex("""\b(?:format|types?|mode)\b[^()\r\n]{0,40}\((?<values>[^\s,|)]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|)]+)+)\)""", RegexOptions.IgnoreCase)]
     private static partial Regex ContextualParenthesizedValuesPattern();
 
-    [GeneratedRegex(@"\s*(?:\||,)\s*")]
+    [GeneratedRegex(@"\s*(?:\||,|\b(?:or|and)\b)\s*", RegexOptions.IgnoreCase)]
     private static partial Regex EnumValueSeparatorPattern();
 
     [GeneratedRegex(@"^(?:or|and)\s+", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
@@ -69,7 +69,7 @@ internal static partial class DescriptionEnumValueParser
         return values is null ? null : new DescriptionEnumMatch(values, matchKind);
     }
 
-    [GeneratedRegex("""\b(?:must be one of|one of|valid values|allowed values|possible values|accepted values)\b(?:\s+are)?\s*:?\s*(?<values>[^\s,|]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|]+)+)""", RegexOptions.IgnoreCase)]
+    [GeneratedRegex("""\b(?:must be one of|one of|valid values|allowed values|possible values|accepted values)\b(?:\s+are)?\s*:?\s*[\[(]?(?<values>[^\s,|)\]]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|)\]]+)+)""", RegexOptions.IgnoreCase)]
     private static partial Regex ExplicitValuesPattern();
 
     [GeneratedRegex("""\b(?:format|types?|mode)\b[^()\r\n]{0,40}\((?<values>[^\s,|)]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|)]+)+)\)""", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
@@ -1,0 +1,78 @@
+using System.Text.RegularExpressions;
+
+namespace ModularPipelines.OptionsGenerator.TypeDetection;
+
+internal enum DescriptionEnumMatchKind
+{
+    Explicit,
+    ContextualParenthesized
+}
+
+internal sealed record DescriptionEnumMatch(string[] Values, DescriptionEnumMatchKind MatchKind);
+
+internal static partial class DescriptionEnumValueParser
+{
+    public static DescriptionEnumMatch? TryParse(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return null;
+        }
+
+        var explicitMatch = ExplicitValuesPattern().Match(description);
+        if (explicitMatch.Success)
+        {
+            return CreateMatch(explicitMatch, DescriptionEnumMatchKind.Explicit);
+        }
+
+        var parenthesizedMatch = ContextualParenthesizedValuesPattern().Match(description);
+        return parenthesizedMatch.Success
+            ? CreateMatch(parenthesizedMatch, DescriptionEnumMatchKind.ContextualParenthesized)
+            : null;
+    }
+
+    public static string[]? TryParseValues(string valuesText)
+    {
+        var candidates = EnumValueSeparatorPattern().Split(valuesText);
+        var values = new List<string>(candidates.Length);
+
+        foreach (var candidate in candidates)
+        {
+            var value = LeadingConjunctionPattern().Replace(candidate.Trim(), "")
+                .TrimEnd('.', ';', ':')
+                .Trim()
+                .Trim('"', '\'', '`');
+
+            if (!EnumValuePattern().IsMatch(value) || !value.Any(char.IsLetter))
+            {
+                return null;
+            }
+
+            values.Add(value);
+        }
+
+        var distinctValues = values.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+        return distinctValues.Length is >= 2 and <= 20 ? distinctValues : null;
+    }
+
+    private static DescriptionEnumMatch? CreateMatch(Match match, DescriptionEnumMatchKind matchKind)
+    {
+        var values = TryParseValues(match.Groups["values"].Value);
+        return values is null ? null : new DescriptionEnumMatch(values, matchKind);
+    }
+
+    [GeneratedRegex("""\b(?:must be one of|one of|valid values|allowed values|possible values|accepted values)\b(?:\s+are)?\s*:?\s*(?<values>[^\s,|]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|]+)+)""", RegexOptions.IgnoreCase)]
+    private static partial Regex ExplicitValuesPattern();
+
+    [GeneratedRegex("""\b(?:format|types?|mode)\b[^()\r\n]{0,40}\((?<values>[^\s,|)]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|)]+)+)\)""", RegexOptions.IgnoreCase)]
+    private static partial Regex ContextualParenthesizedValuesPattern();
+
+    [GeneratedRegex(@"\s*(?:\||,)\s*")]
+    private static partial Regex EnumValueSeparatorPattern();
+
+    [GeneratedRegex(@"^(?:or|and)\s+", RegexOptions.IgnoreCase)]
+    private static partial Regex LeadingConjunctionPattern();
+
+    [GeneratedRegex(@"^[A-Za-z0-9][A-Za-z0-9_-]{0,28}$")]
+    private static partial Regex EnumValuePattern();
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
@@ -33,6 +33,14 @@ internal static partial class DescriptionEnumValueParser
 
     public static string[]? TryParseValues(string valuesText)
     {
+        valuesText = valuesText.Trim().TrimEnd('.', ';', ':').Trim();
+        if (valuesText.Length >= 2
+            && ((valuesText[0] == '(' && valuesText[^1] == ')')
+                || (valuesText[0] == '[' && valuesText[^1] == ']')))
+        {
+            valuesText = valuesText[1..^1];
+        }
+
         var candidates = EnumValueSeparatorPattern().Split(valuesText);
         var values = new List<string>(candidates.Length);
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/HeuristicTypeDetector.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/HeuristicTypeDetector.cs
@@ -332,31 +332,23 @@ public partial class HeuristicTypeDetector : IOptionTypeDetector
 
     private OptionTypeDetectionResult? TryDetectEnumFromDescription(string? description)
     {
-        if (string.IsNullOrWhiteSpace(description))
+        var match = DescriptionEnumValueParser.TryParse(description);
+        return match?.MatchKind switch
         {
-            return null;
-        }
-
-        var explicitValuesMatch = ExplicitValuesPattern().Match(description);
-        if (explicitValuesMatch.Success)
-        {
-            return TryCreateEnumResult(explicitValuesMatch.Groups["values"].Value, "Explicit allowed values");
-        }
-
-        var parenthesizedValuesMatch = ParenthesizedValuesPattern().Match(description);
-        return parenthesizedValuesMatch.Success
-            ? TryCreateEnumResult(parenthesizedValuesMatch.Groups["values"].Value, "Parenthesized allowed values", 85)
-            : null;
+            DescriptionEnumMatchKind.Explicit => CreateEnumResult(match.Values, "Explicit allowed values", 95),
+            DescriptionEnumMatchKind.ContextualParenthesized => CreateEnumResult(match.Values, "Parenthesized allowed values", 85),
+            _ => null
+        };
     }
 
     private OptionTypeDetectionResult? TryCreateEnumResult(string valuesText, string reason, int confidence = 95)
     {
-        var values = ParseEnumValues(valuesText);
-        if (values.Length < 2 || values.Length > 20)
-        {
-            return null;
-        }
+        var values = DescriptionEnumValueParser.TryParseValues(valuesText);
+        return values is null ? null : CreateEnumResult(values, reason, confidence);
+    }
 
+    private OptionTypeDetectionResult CreateEnumResult(string[] values, string reason, int confidence)
+    {
         _logger.LogDebug(
             "Heuristic detection: Enum - {Reason}: {Values} (confidence: {Confidence})",
             reason,
@@ -373,32 +365,6 @@ public partial class HeuristicTypeDetector : IOptionTypeDetector
         };
     }
 
-    private static string[] ParseEnumValues(string valuesText)
-    {
-        return EnumValueSeparatorPattern()
-            .Split(valuesText)
-            .Select(value => LeadingConjunctionPattern().Replace(value.Trim(), ""))
-            .Select(value => value.Trim('"', '\'', '`'))
-            .Where(value => EnumValuePattern().IsMatch(value) && value.Any(char.IsLetter))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-    }
-
-    [GeneratedRegex("""(?:one of|valid values|allowed values|possible values|accepted values)(?:\s+are)?\s*:?\s*(?<values>[\w.+/\-'`"]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[\w.+/\-'`"]+)+)""", RegexOptions.IgnoreCase)]
-    private static partial Regex ExplicitValuesPattern();
-
-    [GeneratedRegex("""(?:format|type|mode)\s*\((?<values>[\w.+/\-'`"]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[\w.+/\-'`"]+)+)\)""", RegexOptions.IgnoreCase)]
-    private static partial Regex ParenthesizedValuesPattern();
-
-    [GeneratedRegex(@"\s*(?:\||,)\s*")]
-    private static partial Regex EnumValueSeparatorPattern();
-
     [GeneratedRegex(@"\s*(?:\||,|/)\s*")]
     private static partial Regex BooleanValueSeparatorPattern();
-
-    [GeneratedRegex(@"^(?:or|and)\s+", RegexOptions.IgnoreCase)]
-    private static partial Regex LeadingConjunctionPattern();
-
-    [GeneratedRegex(@"^[A-Za-z0-9][A-Za-z0-9_-]{0,28}$")]
-    private static partial Regex EnumValuePattern();
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/HeuristicTypeDetector.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/HeuristicTypeDetector.cs
@@ -326,8 +326,8 @@ public partial class HeuristicTypeDetector : IOptionTypeDetector
             .Split(acceptedValues)
             .Select(value => value.Trim(' ', '"', '\'', '`'))
             .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
-        var count = BooleanLiteralValues.Count(values.Contains);
-        return count >= 2; // At least 2 boolean-like values
+        return values.Count >= 2
+               && values.All(value => BooleanLiteralValues.Contains(value, StringComparer.OrdinalIgnoreCase));
     }
 
     private OptionTypeDetectionResult? TryDetectEnumFromDescription(string? description)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/HeuristicTypeDetector.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/HeuristicTypeDetector.cs
@@ -1,4 +1,5 @@
 using System.Collections.Frozen;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 
 namespace ModularPipelines.OptionsGenerator.TypeDetection;
@@ -7,7 +8,7 @@ namespace ModularPipelines.OptionsGenerator.TypeDetection;
 /// Fallback detector that uses heuristics based on option names and descriptions.
 /// This is the lowest priority detector, used when all others fail.
 /// </summary>
-public class HeuristicTypeDetector : IOptionTypeDetector
+public partial class HeuristicTypeDetector : IOptionTypeDetector
 {
     #region Pattern Constants
 
@@ -59,13 +60,31 @@ public class HeuristicTypeDetector : IOptionTypeDetector
 
     /// <summary>
     /// Option name patterns that indicate numeric/integer values.
-    /// These patterns suggest counts, limits, sizes, or other numerical quantities.
+    /// These patterns suggest counts, limits, or other numerical quantities.
     /// Note: "level" is intentionally excluded as it often refers to verbosity levels which are enums/strings.
     /// </summary>
     private static readonly string[] NumericNamePatterns =
     [
-        "count", "limit", "max", "min", "size", "length", "depth",
-        "retries", "timeout", "interval", "port", "number"
+        "count", "limit", "max", "min", "length", "depth",
+        "retries", "port", "number"
+    ];
+
+    /// <summary>
+    /// Option name patterns whose values commonly include units.
+    /// These remain strings unless stronger evidence, such as a numeric default, proves otherwise.
+    /// </summary>
+    private static readonly string[] UnitBearingNamePatterns =
+    [
+        "timeout", "duration", "interval", "size"
+    ];
+
+    /// <summary>
+    /// Description patterns that explicitly require a bare integer.
+    /// These provide stronger evidence than a potentially unit-bearing option name.
+    /// </summary>
+    private static readonly string[] NumericDescriptionPatterns =
+    [
+        "integer", "whole number", "number of seconds", "number of milliseconds", "number of bytes"
     ];
 
     /// <summary>
@@ -208,6 +227,23 @@ public class HeuristicTypeDetector : IOptionTypeDetector
             {
                 return CreateResult(CliOptionType.Bool, "Accepted values indicate boolean");
             }
+
+            var enumResult = TryCreateEnumResult(context.AcceptedValues!, "Accepted values");
+            if (enumResult is not null)
+            {
+                return enumResult;
+            }
+        }
+
+        var descriptionEnumResult = TryDetectEnumFromDescription(context.Description);
+        if (descriptionEnumResult is not null)
+        {
+            return descriptionEnumResult;
+        }
+
+        if (NumericDescriptionPatterns.Any(pattern => description.Contains(pattern)))
+        {
+            return CreateResult(CliOptionType.Int, "Description explicitly indicates an integer value", 85);
         }
 
         // Check for strong value-indicating patterns FIRST (before boolean checks)
@@ -239,6 +275,13 @@ public class HeuristicTypeDetector : IOptionTypeDetector
         if (BooleanDescriptionPatterns.Any(p => description.Contains(p)))
         {
             return CreateResult(CliOptionType.Bool, "Description suggests boolean flag");
+        }
+
+        // Durations and sizes frequently include units (for example, 5m0s or 10Gi).
+        // A numeric default was already handled above and remains stronger evidence.
+        if (UnitBearingNamePatterns.Any(p => optionName.Contains(p, StringComparison.OrdinalIgnoreCase)))
+        {
+            return CreateResult(CliOptionType.String, $"Option name may accept a unit-bearing value: {optionName}", 70);
         }
 
         // Check for numeric patterns
@@ -279,7 +322,80 @@ public class HeuristicTypeDetector : IOptionTypeDetector
 
     private static bool IsBooleanAcceptedValues(string acceptedValues)
     {
-        var count = BooleanLiteralValues.Count(v => acceptedValues.Contains(v));
+        var values = EnumValueSeparatorPattern()
+            .Split(acceptedValues)
+            .Select(value => value.Trim(' ', '"', '\'', '`'))
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+        var count = BooleanLiteralValues.Count(values.Contains);
         return count >= 2; // At least 2 boolean-like values
     }
+
+    private OptionTypeDetectionResult? TryDetectEnumFromDescription(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return null;
+        }
+
+        var explicitValuesMatch = ExplicitValuesPattern().Match(description);
+        if (explicitValuesMatch.Success)
+        {
+            return TryCreateEnumResult(explicitValuesMatch.Groups["values"].Value, "Explicit allowed values");
+        }
+
+        var parenthesizedValuesMatch = ParenthesizedValuesPattern().Match(description);
+        return parenthesizedValuesMatch.Success
+            ? TryCreateEnumResult(parenthesizedValuesMatch.Groups["values"].Value, "Parenthesized allowed values", 85)
+            : null;
+    }
+
+    private OptionTypeDetectionResult? TryCreateEnumResult(string valuesText, string reason, int confidence = 95)
+    {
+        var values = ParseEnumValues(valuesText);
+        if (values.Length < 2 || values.Length > 20)
+        {
+            return null;
+        }
+
+        _logger.LogDebug(
+            "Heuristic detection: Enum - {Reason}: {Values} (confidence: {Confidence})",
+            reason,
+            string.Join(", ", values),
+            confidence);
+
+        return new OptionTypeDetectionResult
+        {
+            Type = CliOptionType.Enum,
+            Confidence = confidence,
+            Source = Name,
+            Notes = $"{reason}: {string.Join(", ", values)}",
+            EnumValues = values
+        };
+    }
+
+    private static string[] ParseEnumValues(string valuesText)
+    {
+        return EnumValueSeparatorPattern()
+            .Split(valuesText)
+            .Select(value => LeadingConjunctionPattern().Replace(value.Trim(), ""))
+            .Select(value => value.Trim('"', '\'', '`'))
+            .Where(value => EnumValuePattern().IsMatch(value) && value.Any(char.IsLetter))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    [GeneratedRegex("""(?:one of|valid values|allowed values|possible values|accepted values)(?:\s+are)?\s*:?\s*(?<values>[\w.+/\-'`"]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[\w.+/\-'`"]+)+)""", RegexOptions.IgnoreCase)]
+    private static partial Regex ExplicitValuesPattern();
+
+    [GeneratedRegex("""\((?<values>[\w.+/\-'`"]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[\w.+/\-'`"]+)+)\)""")]
+    private static partial Regex ParenthesizedValuesPattern();
+
+    [GeneratedRegex(@"\s*(?:\||,)\s*")]
+    private static partial Regex EnumValueSeparatorPattern();
+
+    [GeneratedRegex(@"^(?:or|and)\s+", RegexOptions.IgnoreCase)]
+    private static partial Regex LeadingConjunctionPattern();
+
+    [GeneratedRegex(@"^[A-Za-z0-9][\w.+/\-]{0,28}$")]
+    private static partial Regex EnumValuePattern();
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/HeuristicTypeDetector.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/HeuristicTypeDetector.cs
@@ -122,7 +122,7 @@ public partial class HeuristicTypeDetector : IOptionTypeDetector
     /// </summary>
     private static readonly string[] BooleanLiteralValues =
     [
-        "true", "false", "yes", "no", "0", "1"
+        "true", "false", "yes", "no", "on", "off", "0", "1"
     ];
 
     /// <summary>
@@ -322,7 +322,7 @@ public partial class HeuristicTypeDetector : IOptionTypeDetector
 
     private static bool IsBooleanAcceptedValues(string acceptedValues)
     {
-        var values = EnumValueSeparatorPattern()
+        var values = BooleanValueSeparatorPattern()
             .Split(acceptedValues)
             .Select(value => value.Trim(' ', '"', '\'', '`'))
             .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
@@ -387,15 +387,18 @@ public partial class HeuristicTypeDetector : IOptionTypeDetector
     [GeneratedRegex("""(?:one of|valid values|allowed values|possible values|accepted values)(?:\s+are)?\s*:?\s*(?<values>[\w.+/\-'`"]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[\w.+/\-'`"]+)+)""", RegexOptions.IgnoreCase)]
     private static partial Regex ExplicitValuesPattern();
 
-    [GeneratedRegex("""\((?<values>[\w.+/\-'`"]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[\w.+/\-'`"]+)+)\)""")]
+    [GeneratedRegex("""(?:format|type|mode)\s*\((?<values>[\w.+/\-'`"]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[\w.+/\-'`"]+)+)\)""", RegexOptions.IgnoreCase)]
     private static partial Regex ParenthesizedValuesPattern();
 
     [GeneratedRegex(@"\s*(?:\||,)\s*")]
     private static partial Regex EnumValueSeparatorPattern();
 
+    [GeneratedRegex(@"\s*(?:\||,|/)\s*")]
+    private static partial Regex BooleanValueSeparatorPattern();
+
     [GeneratedRegex(@"^(?:or|and)\s+", RegexOptions.IgnoreCase)]
     private static partial Regex LeadingConjunctionPattern();
 
-    [GeneratedRegex(@"^[A-Za-z0-9][\w.+/\-]{0,28}$")]
+    [GeneratedRegex(@"^[A-Za-z0-9][A-Za-z0-9_-]{0,28}$")]
     private static partial Regex EnumValuePattern();
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/HeuristicTypeDetector.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/HeuristicTypeDetector.cs
@@ -205,6 +205,7 @@ public partial class HeuristicTypeDetector : IOptionTypeDetector
         var description = context.Description?.ToLowerInvariant() ?? "";
         var defaultValue = context.DefaultValue?.ToLowerInvariant() ?? "";
         var acceptedValues = context.AcceptedValues?.ToLowerInvariant() ?? "";
+        var acceptsMultipleValues = MultiValueDescriptionPatterns.Any(pattern => description.Contains(pattern));
 
         // Check default value first
         if (!string.IsNullOrEmpty(defaultValue))
@@ -228,14 +229,17 @@ public partial class HeuristicTypeDetector : IOptionTypeDetector
                 return CreateResult(CliOptionType.Bool, "Accepted values indicate boolean");
             }
 
-            var enumResult = TryCreateEnumResult(context.AcceptedValues!, "Accepted values");
+            var enumResult = TryCreateEnumResult(
+                context.AcceptedValues!,
+                "Accepted values",
+                acceptsMultipleValues);
             if (enumResult is not null)
             {
                 return enumResult;
             }
         }
 
-        var descriptionEnumResult = TryDetectEnumFromDescription(context.Description);
+        var descriptionEnumResult = TryDetectEnumFromDescription(context.Description, acceptsMultipleValues);
         if (descriptionEnumResult is not null)
         {
             return descriptionEnumResult;
@@ -248,7 +252,7 @@ public partial class HeuristicTypeDetector : IOptionTypeDetector
 
         // Check for strong value-indicating patterns FIRST (before boolean checks)
         // These patterns override any potential boolean detection based on name alone
-        if (MultiValueDescriptionPatterns.Any(p => description.Contains(p)))
+        if (acceptsMultipleValues)
         {
             return CreateResult(CliOptionType.StringList, "Description indicates multi-value option", 80);
         }
@@ -330,24 +334,32 @@ public partial class HeuristicTypeDetector : IOptionTypeDetector
                && values.All(value => BooleanLiteralValues.Contains(value, StringComparer.OrdinalIgnoreCase));
     }
 
-    private OptionTypeDetectionResult? TryDetectEnumFromDescription(string? description)
+    private OptionTypeDetectionResult? TryDetectEnumFromDescription(string? description, bool acceptsMultipleValues)
     {
         var match = DescriptionEnumValueParser.TryParse(description);
         return match?.MatchKind switch
         {
-            DescriptionEnumMatchKind.Explicit => CreateEnumResult(match.Values, "Explicit allowed values", 95),
-            DescriptionEnumMatchKind.ContextualParenthesized => CreateEnumResult(match.Values, "Parenthesized allowed values", 85),
+            DescriptionEnumMatchKind.Explicit => CreateEnumResult(match.Values, "Explicit allowed values", 95, acceptsMultipleValues),
+            DescriptionEnumMatchKind.ContextualParenthesized => CreateEnumResult(match.Values, "Parenthesized allowed values", 85, acceptsMultipleValues),
             _ => null
         };
     }
 
-    private OptionTypeDetectionResult? TryCreateEnumResult(string valuesText, string reason, int confidence = 95)
+    private OptionTypeDetectionResult? TryCreateEnumResult(
+        string valuesText,
+        string reason,
+        bool acceptsMultipleValues,
+        int confidence = 95)
     {
         var values = DescriptionEnumValueParser.TryParseValues(valuesText);
-        return values is null ? null : CreateEnumResult(values, reason, confidence);
+        return values is null ? null : CreateEnumResult(values, reason, confidence, acceptsMultipleValues);
     }
 
-    private OptionTypeDetectionResult CreateEnumResult(string[] values, string reason, int confidence)
+    private OptionTypeDetectionResult CreateEnumResult(
+        string[] values,
+        string reason,
+        int confidence,
+        bool acceptsMultipleValues)
     {
         _logger.LogDebug(
             "Heuristic detection: Enum - {Reason}: {Values} (confidence: {Confidence})",
@@ -361,7 +373,8 @@ public partial class HeuristicTypeDetector : IOptionTypeDetector
             Confidence = confidence,
             Source = Name,
             Notes = $"{reason}: {string.Join(", ", values)}",
-            EnumValues = values
+            EnumValues = values,
+            AcceptsMultipleValues = acceptsMultipleValues
         };
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/OptionTypeDetectionResult.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/OptionTypeDetectionResult.cs
@@ -32,6 +32,11 @@ public class OptionTypeDetectionResult
     public string[]? EnumValues { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether the detected value type is repeatable.
+    /// </summary>
+    public bool AcceptsMultipleValues { get; init; }
+
+    /// <summary>
     /// Creates a result indicating the detector could not determine the type.
     /// </summary>
     public static OptionTypeDetectionResult Unknown(string source) => new()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/OptionTypeEnhancer.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/OptionTypeEnhancer.cs
@@ -125,7 +125,13 @@ public class OptionTypeEnhancer
 
                 // Use existing enum def or newly created one
                 var effectiveEnumDef = enumDef ?? option.EnumDefinition;
-                var newCSharpType = CliTypeMapper.ToCSharpType(result.Type, effectiveEnumDef);
+                var acceptsMultipleValues = result.Type == CliOptionType.StringList
+                    || (result.Type == CliOptionType.Enum
+                        && (result.AcceptsMultipleValues || option.AcceptsMultipleValues));
+                var detectedCSharpType = CliTypeMapper.ToCSharpType(result.Type, effectiveEnumDef);
+                var newCSharpType = result.Type == CliOptionType.Enum && acceptsMultipleValues
+                    ? $"IEnumerable<{detectedCSharpType.TrimEnd('?')}>?"
+                    : detectedCSharpType;
                 var newIsFlag = result.Type == CliOptionType.Bool;
 
                 // Only update if the detection changed the type
@@ -146,7 +152,7 @@ public class OptionTypeEnhancer
                         CSharpType = newCSharpType,
                         IsFlag = newIsFlag,
                         IsNumeric = result.Type == CliOptionType.Int || result.Type == CliOptionType.Decimal,
-                        AcceptsMultipleValues = result.Type == CliOptionType.StringList,
+                        AcceptsMultipleValues = acceptsMultipleValues,
                         IsKeyValue = result.Type == CliOptionType.KeyValue,
                         ValueSeparator = newIsFlag ? " " : "=",
                         EnumDefinition = effectiveEnumDef


### PR DESCRIPTION
## Summary
- generate enums from structured accepted values and allowed-value help text
- keep timeout, duration, interval, and size options as strings when they may carry units
- preserve integer inference when defaults or descriptions explicitly prove a bare number
- avoid substring false positives when recognizing boolean accepted values

## Validation
- dotnet test tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ModularPipelines.OptionsGenerator.Tests.csproj --no-restore (383 passed)
- formatter verification scoped to changed files

Closes #2990