### PR TITLE
Reject dynamic module dependency cycles

### DIFF
--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -7,6 +7,7 @@ using ModularPipelines.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Scheduling;
 using ModularPipelines.Enums;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Logging;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
@@ -27,6 +28,7 @@ internal class ModuleScheduler : IModuleScheduler
     private readonly IModuleConstraintEvaluator _constraintEvaluator;
     private readonly ISchedulerStatusReporter _statusReporter;
     private readonly ConcurrentDictionary<Type, ModuleState> _moduleStates;
+    private readonly Dictionary<Type, HashSet<Type>> _dependencyGraph;
     private readonly HashSet<ModuleState> _queuedModules;
     private readonly HashSet<ModuleState> _executingModules;
     private readonly ModuleStateQueries _stateQueries;
@@ -59,6 +61,7 @@ internal class ModuleScheduler : IModuleScheduler
         _constraintEvaluator = constraintEvaluator;
         _statusReporter = statusReporter;
         _moduleStates = new ConcurrentDictionary<Type, ModuleState>();
+        _dependencyGraph = new Dictionary<Type, HashSet<Type>>();
         _queuedModules = new HashSet<ModuleState>();
         _executingModules = new HashSet<ModuleState>();
         _stateQueries = new ModuleStateQueries(_moduleStates);
@@ -170,7 +173,8 @@ internal class ModuleScheduler : IModuleScheduler
             // - Predicate-based dependencies (DependsOnModulesWithTag, DependsOnModulesInCategory, DependsOnModulesWithAttribute)
             // - Programmatic dependencies from DeclareDependencies method
             // - Dynamic dependencies from registration events
-            var dependencies = GetAllDependenciesIncludingPredicate(state.Module, availableModuleTypes);
+            var dependencies = GetAllDependenciesIncludingPredicate(state.Module, availableModuleTypes).ToArray();
+            _dependencyGraph[moduleType] = dependencies.Select(x => x.DependencyType).ToHashSet();
 
             foreach (var (dependencyType, ignoreIfNotRegistered) in dependencies)
             {
@@ -228,14 +232,10 @@ internal class ModuleScheduler : IModuleScheduler
     /// </summary>
     public void AddModule(IModule module)
     {
-        var moduleType = module.GetType();
-        var state = new ModuleState(module, moduleType);
+        ArgumentNullException.ThrowIfNull(module);
 
-        if (!_moduleStates.TryAdd(moduleType, state))
-        {
-            // Module already exists
-            return;
-        }
+        var moduleType = module.GetType();
+        ModuleState state;
 
         // Track unregistered dependencies for logging outside lock
         List<Type>? unregisteredDependencies = null;
@@ -243,10 +243,30 @@ internal class ModuleScheduler : IModuleScheduler
         _stateLock.EnterWriteLock();
         try
         {
-            // Resolve dependencies inside write lock to prevent race conditions
-            // where _moduleStates could change between resolution and processing
-            var dependencies = ModuleDependencyResolver.GetDependencies(moduleType)
-                .Concat(ModuleDependencyResolver.GetProgrammaticDependencies(module));
+            if (_moduleStates.ContainsKey(moduleType))
+            {
+                return;
+            }
+
+            state = new ModuleState(module, moduleType);
+            _metadataRegistry.FinalizeMetadata(moduleType, module);
+
+            var availableModuleTypes = _moduleStates.Keys.Append(moduleType).ToArray();
+            var dependencies = GetAllDependenciesIncludingPredicate(module, availableModuleTypes).ToArray();
+
+            _dependencyGraph[moduleType] = dependencies.Select(x => x.DependencyType).ToHashSet();
+
+            try
+            {
+                ModuleDependencyValidator.ValidateCircularDependencies(_dependencyGraph);
+            }
+            catch
+            {
+                _dependencyGraph.Remove(moduleType);
+                throw;
+            }
+
+            _moduleStates[moduleType] = state;
 
             foreach (var (dependencyType, ignoreIfNotRegistered) in dependencies)
             {
@@ -345,6 +365,7 @@ internal class ModuleScheduler : IModuleScheduler
         ModuleStateSnapshot snapshot;
         bool shouldExit;
         bool isDeadlocked;
+        string[] pendingModules;
 
         _stateLock.EnterWriteLock();
         try
@@ -352,6 +373,13 @@ internal class ModuleScheduler : IModuleScheduler
             snapshot = ModuleStateSnapshot.Create(_moduleStates.Values);
             shouldExit = _exitConditions.ShouldExit(snapshot, queuedCount);
             isDeadlocked = shouldExit && _exitConditions.IsDeadlocked(snapshot, queuedCount);
+            pendingModules = isDeadlocked
+                ? _moduleStates.Values
+                    .Where(x => x.State == ModuleExecutionState.Pending)
+                    .Select(x => x.ModuleType.Name)
+                    .OrderBy(x => x, StringComparer.Ordinal)
+                    .ToArray()
+                : [];
 
             if (shouldExit)
             {
@@ -363,13 +391,12 @@ internal class ModuleScheduler : IModuleScheduler
             _stateLock.ExitWriteLock();
         }
 
-        // Log outside lock to avoid holding lock during I/O
-        if (shouldExit && isDeadlocked)
+        // Fail outside lock to avoid holding lock while constructing the exception.
+        if (isDeadlocked)
         {
-            _logger.LogWarning(
-                "Scheduler detected deadlock: {Pending} modules pending but cannot make progress. " +
-                "Check for circular dependencies or missing module registrations.",
-                snapshot.Pending);
+            throw new DependencyCollisionException(
+                $"Scheduler deadlock detected with {snapshot.Pending} pending module(s): {string.Join(", ", pendingModules)}. " +
+                "Check for circular dependencies or missing module registrations.");
         }
 
         return shouldExit;

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -252,21 +252,31 @@ internal class ModuleScheduler : IModuleScheduler
             _metadataRegistry.FinalizeMetadata(moduleType, module);
 
             var availableModuleTypes = _moduleStates.Keys.Append(moduleType).ToArray();
-            var modulesByType = _moduleStates.Values
-                .ToDictionary(existingState => existingState.ModuleType, existingState => existingState.Module);
-            modulesByType.Add(moduleType, module);
-
-            var dependenciesByType = modulesByType.ToDictionary(
+            var newModuleDependencies = GetAllDependenciesIncludingPredicate(module, availableModuleTypes).ToArray();
+            var declaredDependenciesByType = _dependencyGraph.ToDictionary(
                 pair => pair.Key,
-                pair => GetAllDependenciesIncludingPredicate(pair.Value, availableModuleTypes).ToArray());
-            var candidateGraph = dependenciesByType.ToDictionary(
+                pair => new HashSet<Type>(pair.Value));
+            Type[] newlyAvailableModuleTypes = [moduleType];
+
+            foreach (var existingModuleType in _moduleStates.Keys)
+            {
+                var newlyResolvedDependencies = ModuleDependencyResolver
+                    .GetDependencies(existingModuleType, newlyAvailableModuleTypes, _metadataRegistry)
+                    .Where(dependency => dependency.DependencyType == moduleType)
+                    .Select(dependency => dependency.DependencyType);
+                declaredDependenciesByType[existingModuleType].UnionWith(newlyResolvedDependencies);
+            }
+
+            declaredDependenciesByType[moduleType] = newModuleDependencies
+                .Select(dependency => dependency.DependencyType)
+                .ToHashSet();
+
+            var candidateGraph = declaredDependenciesByType.ToDictionary(
                 pair => pair.Key,
                 pair => pair.Key == moduleType || _moduleStates[pair.Key].State == ModuleExecutionState.Pending
-                    ? pair.Value
-                        .Where(dependency =>
-                            !_moduleStates.TryGetValue(dependency.DependencyType, out var dependencyState)
+                    ? pair.Value.Where(dependencyType =>
+                            !_moduleStates.TryGetValue(dependencyType, out var dependencyState)
                             || dependencyState.State != ModuleExecutionState.Completed)
-                        .Select(dependency => dependency.DependencyType)
                         .ToHashSet()
                     : new HashSet<Type>());
 
@@ -274,14 +284,14 @@ internal class ModuleScheduler : IModuleScheduler
 
             _moduleStates[moduleType] = state;
             _dependencyGraph.Clear();
-            foreach (var (registeredType, registeredDependencies) in candidateGraph)
+            foreach (var (registeredType, registeredDependencies) in declaredDependenciesByType)
             {
                 _dependencyGraph[registeredType] = registeredDependencies;
             }
 
-            RebuildPendingDependencyState(dependenciesByType);
+            RebuildPendingDependencyState(declaredDependenciesByType);
 
-            foreach (var (dependencyType, ignoreIfNotRegistered) in dependenciesByType[moduleType])
+            foreach (var (dependencyType, ignoreIfNotRegistered) in newModuleDependencies)
             {
                 if (!_moduleStates.ContainsKey(dependencyType) && !ignoreIfNotRegistered)
                 {
@@ -316,7 +326,7 @@ internal class ModuleScheduler : IModuleScheduler
     }
 
     private void RebuildPendingDependencyState(
-        IReadOnlyDictionary<Type, (Type DependencyType, bool Optional)[]> dependenciesByType)
+        IReadOnlyDictionary<Type, HashSet<Type>> dependenciesByType)
     {
         foreach (var registeredState in _moduleStates.Values)
         {
@@ -332,7 +342,7 @@ internal class ModuleScheduler : IModuleScheduler
                 continue;
             }
 
-            foreach (var (dependencyType, _) in dependencies)
+            foreach (var dependencyType in dependencies)
             {
                 if (!_moduleStates.TryGetValue(dependencyType, out var dependencyState)
                     || dependencyState.State == ModuleExecutionState.Completed)

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -252,30 +252,31 @@ internal class ModuleScheduler : IModuleScheduler
             _metadataRegistry.FinalizeMetadata(moduleType, module);
 
             var availableModuleTypes = _moduleStates.Keys.Append(moduleType).ToArray();
-            var dependencies = GetAllDependenciesIncludingPredicate(module, availableModuleTypes).ToArray();
+            var modulesByType = _moduleStates.Values
+                .ToDictionary(existingState => existingState.ModuleType, existingState => existingState.Module);
+            modulesByType.Add(moduleType, module);
 
-            _dependencyGraph[moduleType] = dependencies.Select(x => x.DependencyType).ToHashSet();
+            var dependenciesByType = modulesByType.ToDictionary(
+                pair => pair.Key,
+                pair => GetAllDependenciesIncludingPredicate(pair.Value, availableModuleTypes).ToArray());
+            var candidateGraph = dependenciesByType.ToDictionary(
+                pair => pair.Key,
+                pair => pair.Value.Select(dependency => dependency.DependencyType).ToHashSet());
 
-            try
-            {
-                ModuleDependencyValidator.ValidateCircularDependencies(_dependencyGraph);
-            }
-            catch
-            {
-                _dependencyGraph.Remove(moduleType);
-                throw;
-            }
+            ModuleDependencyValidator.ValidateCircularDependencies(candidateGraph);
 
             _moduleStates[moduleType] = state;
-
-            foreach (var (dependencyType, ignoreIfNotRegistered) in dependencies)
+            _dependencyGraph.Clear();
+            foreach (var (registeredType, registeredDependencies) in candidateGraph)
             {
-                if (_moduleStates.TryGetValue(dependencyType, out var dependencyState))
-                {
-                    state.UnresolvedDependencies.Add(dependencyType);
-                    dependencyState.DependentModules.Add(state);
-                }
-                else if (!ignoreIfNotRegistered)
+                _dependencyGraph[registeredType] = registeredDependencies;
+            }
+
+            RebuildPendingDependencyState(dependenciesByType);
+
+            foreach (var (dependencyType, ignoreIfNotRegistered) in dependenciesByType[moduleType])
+            {
+                if (!_moduleStates.ContainsKey(dependencyType) && !ignoreIfNotRegistered)
                 {
                     unregisteredDependencies ??= new List<Type>();
                     unregisteredDependencies.Add(dependencyType);
@@ -305,6 +306,37 @@ internal class ModuleScheduler : IModuleScheduler
             state.UnresolvedDependencies.Count);
 
         _schedulerNotification.Release();
+    }
+
+    private void RebuildPendingDependencyState(
+        IReadOnlyDictionary<Type, (Type DependencyType, bool Optional)[]> dependenciesByType)
+    {
+        foreach (var registeredState in _moduleStates.Values)
+        {
+            registeredState.UnresolvedDependencies.Clear();
+            registeredState.DependentModules.Clear();
+        }
+
+        foreach (var (dependentType, dependencies) in dependenciesByType)
+        {
+            var dependentState = _moduleStates[dependentType];
+            if (dependentState.State != ModuleExecutionState.Pending)
+            {
+                continue;
+            }
+
+            foreach (var (dependencyType, _) in dependencies)
+            {
+                if (!_moduleStates.TryGetValue(dependencyType, out var dependencyState)
+                    || dependencyState.State == ModuleExecutionState.Completed)
+                {
+                    continue;
+                }
+
+                dependentState.UnresolvedDependencies.Add(dependencyType);
+                dependencyState.DependentModules.Add(dependentState);
+            }
+        }
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -586,7 +586,7 @@ internal class ModuleScheduler : IModuleScheduler
             // Sort by priority descending so higher priority modules are queued first
             var potentiallyReadyModules = _moduleStates.Values
                 .Where(m => m.IsReadyToExecute)
-                .OrderByDescending(m => (int)m.Priority)
+                .OrderByDescending(m => (int) m.Priority)
                 .ToArray();
 
             // Take immutable snapshot of already-active modules (queued or executing)
@@ -665,5 +665,4 @@ internal class ModuleScheduler : IModuleScheduler
             modulesToQueue.Count,
             string.Join(", ", modulesToQueue.Select(m => m.ModuleType.Name)));
     }
-
 }

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -261,7 +261,14 @@ internal class ModuleScheduler : IModuleScheduler
                 pair => GetAllDependenciesIncludingPredicate(pair.Value, availableModuleTypes).ToArray());
             var candidateGraph = dependenciesByType.ToDictionary(
                 pair => pair.Key,
-                pair => pair.Value.Select(dependency => dependency.DependencyType).ToHashSet());
+                pair => pair.Key == moduleType || _moduleStates[pair.Key].State == ModuleExecutionState.Pending
+                    ? pair.Value
+                        .Where(dependency =>
+                            !_moduleStates.TryGetValue(dependency.DependencyType, out var dependencyState)
+                            || dependencyState.State != ModuleExecutionState.Completed)
+                        .Select(dependency => dependency.DependencyType)
+                        .ToHashSet()
+                    : new HashSet<Type>());
 
             ModuleDependencyValidator.ValidateCircularDependencies(candidateGraph);
 

--- a/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
+++ b/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
@@ -93,30 +93,40 @@ public static class ModuleDependencyValidator
     private static void ValidateCircularDependencies(HashSet<Type> moduleTypes)
     {
         // Build dependency graph
-        var dependencyGraph = new Dictionary<Type, List<Type>>();
+        var dependencyGraph = new Dictionary<Type, HashSet<Type>>();
 
         foreach (var moduleType in moduleTypes)
         {
             var dependencies = ModuleDependencyResolver.GetDependencies(moduleType, moduleTypes)
                 .Where(d => moduleTypes.Contains(d.DependencyType))
                 .Select(d => d.DependencyType)
-                .ToList();
+                .ToHashSet();
 
             dependencyGraph[moduleType] = dependencies;
         }
 
+        ValidateCircularDependencies(dependencyGraph);
+    }
+
+    /// <summary>
+    /// Validates a dependency graph that may have been extended at runtime.
+    /// </summary>
+    /// <param name="dependencyGraph">The declared dependencies keyed by registered module type.</param>
+    /// <exception cref="DependencyCollisionException">Thrown when circular dependencies are detected.</exception>
+    internal static void ValidateCircularDependencies(IReadOnlyDictionary<Type, HashSet<Type>> dependencyGraph)
+    {
         // Detect cycles using DFS with coloring
         // White (0) = not visited, Gray (1) = in current path, Black (2) = fully processed
         var colors = new Dictionary<Type, int>();
         var parent = new Dictionary<Type, Type?>();
 
-        foreach (var moduleType in moduleTypes)
+        foreach (var moduleType in dependencyGraph.Keys)
         {
             colors[moduleType] = 0;
             parent[moduleType] = null;
         }
 
-        foreach (var moduleType in moduleTypes)
+        foreach (var moduleType in dependencyGraph.Keys)
         {
             if (colors[moduleType] == 0)
             {
@@ -144,7 +154,7 @@ public static class ModuleDependencyValidator
     /// </summary>
     private static Type? DetectCycleDfs(
         Type current,
-        Dictionary<Type, List<Type>> graph,
+        IReadOnlyDictionary<Type, HashSet<Type>> graph,
         Dictionary<Type, int> colors,
         Dictionary<Type, Type?> parent)
     {
@@ -154,6 +164,12 @@ public static class ModuleDependencyValidator
         {
             foreach (var dependency in dependencies)
             {
+                // Dependencies not yet registered cannot participate in a cycle.
+                if (!colors.ContainsKey(dependency))
+                {
+                    continue;
+                }
+
                 if (colors[dependency] == 1)
                 {
                     // Found a cycle - dependency is currently being processed

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -62,6 +62,20 @@ public class ModuleSchedulerDynamicCycleTests
             CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(CompletedDependencyModule));
     }
 
+    private class ConditionalExistingModule : Module<string>
+    {
+        public bool IncludeDependency { get; set; } = true;
+
+        protected override void DeclareDependencies(IDependencyDeclaration deps)
+        {
+            deps.DependsOnIf<CompletedDependencyModule>(IncludeDependency);
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(ConditionalExistingModule));
+    }
+
     [ModularPipelines.Attributes.DependsOn<CompletedDependencyModule>]
     private class LateDynamicModule : Module<string>
     {
@@ -145,6 +159,21 @@ public class ModuleSchedulerDynamicCycleTests
         var existingState = scheduler.GetModuleState(typeof(ExistingPredicateModule));
         await Assert.That(existingState).IsNotNull();
         await Assert.That(existingState!.UnresolvedDependencies).Contains(typeof(IndependentDynamicModule));
+    }
+
+    [Test]
+    public async Task AddModule_PreservesInitiallyDeclaredConditionalDependency()
+    {
+        var conditionalModule = new ConditionalExistingModule();
+        using var scheduler = CreateScheduler();
+        scheduler.InitializeModules([new CompletedDependencyModule(), conditionalModule]);
+        conditionalModule.IncludeDependency = false;
+
+        scheduler.AddModule(new IndependentDynamicModule());
+
+        var state = scheduler.GetModuleState(typeof(ConditionalExistingModule));
+        await Assert.That(state).IsNotNull();
+        await Assert.That(state!.UnresolvedDependencies).Contains(typeof(CompletedDependencyModule));
     }
 
     private static ModuleScheduler CreateScheduler()

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -12,6 +12,10 @@ namespace ModularPipelines.UnitTests.Engine;
 
 public class ModuleSchedulerDynamicCycleTests
 {
+    private abstract class DynamicBaseModule : Module<string>
+    {
+    }
+
     [ModularPipelines.Attributes.DependsOn<DynamicModule>(Optional = true)]
     private class ExistingModule : Module<string>
     {
@@ -26,6 +30,44 @@ public class ModuleSchedulerDynamicCycleTests
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
             CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DynamicModule));
+    }
+
+    [ModularPipelines.Attributes.DependsOnAllModulesInheritingFrom<DynamicBaseModule>]
+    private class ExistingPredicateModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(ExistingPredicateModule));
+    }
+
+    [ModularPipelines.Attributes.DependsOn<ExistingPredicateModule>]
+    private class DynamicPredicateModule : DynamicBaseModule
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DynamicPredicateModule));
+    }
+
+    private class IndependentDynamicModule : DynamicBaseModule
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(IndependentDynamicModule));
+    }
+
+    private class CompletedDependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(CompletedDependencyModule));
+    }
+
+    [ModularPipelines.Attributes.DependsOn<CompletedDependencyModule>]
+    private class LateDynamicModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(LateDynamicModule));
     }
 
     [Test]
@@ -50,6 +92,45 @@ public class ModuleSchedulerDynamicCycleTests
         await Assert.That(() => scheduler.RunSchedulerAsync(CancellationToken.None))
             .Throws<DependencyCollisionException>()
             .And.HasMessageContaining("Scheduler deadlock detected with 2 pending module(s)");
+    }
+
+    [Test]
+    public async Task AddModule_WhenExistingPredicateCreatesCycle_ThrowsAndRollsBack()
+    {
+        using var scheduler = CreateScheduler();
+        scheduler.InitializeModules([new ExistingPredicateModule()]);
+
+        await Assert.That(() => scheduler.AddModule(new DynamicPredicateModule()))
+            .Throws<DependencyCollisionException>();
+        await Assert.That(scheduler.GetModuleState(typeof(DynamicPredicateModule))).IsNull();
+    }
+
+    [Test]
+    public async Task AddModule_WhenDependencyAlreadyCompleted_IsReady()
+    {
+        using var scheduler = CreateScheduler();
+        scheduler.InitializeModules([new CompletedDependencyModule()]);
+        scheduler.MarkModuleCompleted(typeof(CompletedDependencyModule), success: true);
+
+        scheduler.AddModule(new LateDynamicModule());
+
+        var state = scheduler.GetModuleState(typeof(LateDynamicModule));
+        await Assert.That(state).IsNotNull();
+        await Assert.That(state!.UnresolvedDependencies).IsEmpty();
+        await Assert.That(state.IsReadyToExecute).IsTrue();
+    }
+
+    [Test]
+    public async Task AddModule_ReconcilesExistingPredicateDependencies()
+    {
+        using var scheduler = CreateScheduler();
+        scheduler.InitializeModules([new ExistingPredicateModule()]);
+
+        scheduler.AddModule(new IndependentDynamicModule());
+
+        var existingState = scheduler.GetModuleState(typeof(ExistingPredicateModule));
+        await Assert.That(existingState).IsNotNull();
+        await Assert.That(existingState!.UnresolvedDependencies).Contains(typeof(IndependentDynamicModule));
     }
 
     private static ModuleScheduler CreateScheduler()

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -121,6 +121,20 @@ public class ModuleSchedulerDynamicCycleTests
     }
 
     [Test]
+    public async Task AddModule_DoesNotCreateCycleThroughCompletedDependent()
+    {
+        using var scheduler = CreateScheduler();
+        scheduler.InitializeModules([new ExistingModule()]);
+        scheduler.MarkModuleCompleted(typeof(ExistingModule), success: true);
+
+        scheduler.AddModule(new DynamicModule());
+
+        var state = scheduler.GetModuleState(typeof(DynamicModule));
+        await Assert.That(state).IsNotNull();
+        await Assert.That(state!.IsReadyToExecute).IsTrue();
+    }
+
+    [Test]
     public async Task AddModule_ReconcilesExistingPredicateDependencies()
     {
         using var scheduler = CreateScheduler();

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Engine.Scheduling;
+using ModularPipelines.Exceptions;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class ModuleSchedulerDynamicCycleTests
+{
+    [ModularPipelines.Attributes.DependsOn<DynamicModule>(Optional = true)]
+    private class ExistingModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(ExistingModule));
+    }
+
+    [ModularPipelines.Attributes.DependsOn<ExistingModule>]
+    private class DynamicModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DynamicModule));
+    }
+
+    [Test]
+    public async Task AddModule_WhenModuleIntroducesCycle_ThrowsAndRollsBack()
+    {
+        using var scheduler = CreateScheduler();
+        scheduler.InitializeModules([new ExistingModule()]);
+
+        await Assert.That(() => scheduler.AddModule(new DynamicModule()))
+            .Throws<DependencyCollisionException>()
+            .And.HasMessageEqualTo(
+                "Dependency collision detected: **ExistingModule** -> DynamicModule -> **ExistingModule**");
+        await Assert.That(scheduler.GetModuleState(typeof(DynamicModule))).IsNull();
+    }
+
+    [Test]
+    public async Task RunSchedulerAsync_WhenDeadlocked_ThrowsHardError()
+    {
+        using var scheduler = CreateScheduler();
+        scheduler.InitializeModules([new ExistingModule(), new DynamicModule()]);
+
+        await Assert.That(() => scheduler.RunSchedulerAsync(CancellationToken.None))
+            .Throws<DependencyCollisionException>()
+            .And.HasMessageContaining("Scheduler deadlock detected with 2 pending module(s)");
+    }
+
+    private static ModuleScheduler CreateScheduler()
+    {
+        return new ModuleScheduler(
+            NullLogger.Instance,
+            TimeProvider.System,
+            Microsoft.Extensions.Options.Options.Create(new SchedulerOptions()),
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            Mock.Of<IMetricsCollector>(),
+            Mock.Of<IModuleConstraintEvaluator>(),
+            Mock.Of<ISchedulerStatusReporter>());
+    }
+}


### PR DESCRIPTION
## Summary

- retain the declared dependency graph as modules are scheduled
- validate dynamic additions before exposing their scheduler state
- roll back rejected additions and report the same formatted cycle path as static validation
- convert residual scheduler deadlocks from warnings into hard `DependencyCollisionException` failures

## Validation

- unit-test project build
- `ModuleSchedulerDynamicCycleTests`: 2/2
- static direct/nested collision regressions: 2/2
- scoped `dotnet format`

Closes #2989