### PR TITLE
Mask transformed and short secrets safely

### DIFF
--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -297,8 +297,12 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     public IModuleOutputBuffer GetUnattributedBuffer() => _unattributedBuffer;
 
     /// <inheritdoc />
-    public async Task FlushPendingWritesAsync()
+    public async Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync()
     {
+        var populatedBeforeFlush = _moduleBuffers.Values
+            .Where(buffer => buffer.HasOutput)
+            .ToHashSet();
+
         CoordinatedTextWriter? output;
         CoordinatedTextWriter? error;
         lock (_phaseLock)
@@ -316,6 +320,11 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         {
             await error.FlushAsync().ConfigureAwait(false);
         }
+
+        return _moduleBuffers.Values
+            .Where(buffer => buffer.HasOutput && !populatedBeforeFlush.Contains(buffer))
+            .Cast<IModuleOutputBuffer>()
+            .ToArray();
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -297,6 +297,28 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     public IModuleOutputBuffer GetUnattributedBuffer() => _unattributedBuffer;
 
     /// <inheritdoc />
+    public async Task FlushPendingWritesAsync()
+    {
+        CoordinatedTextWriter? output;
+        CoordinatedTextWriter? error;
+        lock (_phaseLock)
+        {
+            output = _coordinatedOut;
+            error = _coordinatedError;
+        }
+
+        if (output is not null)
+        {
+            await output.FlushAsync().ConfigureAwait(false);
+        }
+
+        if (error is not null && !ReferenceEquals(error, output))
+        {
+            await error.FlushAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
     public void FlushModuleOutput()
     {
         // Output is now flushed immediately when modules complete.

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -37,6 +37,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     private readonly IBuildSystemFormatterProvider _formatterProvider;
     private readonly IResultsPrinter _resultsPrinter;
     private readonly ISecretObfuscator _secretObfuscator;
+    private readonly ISecretProvider _secretProvider;
     private readonly IOptions<PipelineOptions> _options;
     private readonly ILoggerFactory _loggerFactory;
     private readonly IBuildSystemDetector _buildSystemDetector;
@@ -70,6 +71,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         IBuildSystemFormatterProvider formatterProvider,
         IResultsPrinter resultsPrinter,
         ISecretObfuscator secretObfuscator,
+        ISecretProvider secretProvider,
         IOptions<PipelineOptions> options,
         ILoggerFactory loggerFactory,
         IBuildSystemDetector buildSystemDetector,
@@ -79,6 +81,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         _formatterProvider = formatterProvider;
         _resultsPrinter = resultsPrinter;
         _secretObfuscator = secretObfuscator;
+        _secretProvider = secretProvider;
         _options = options;
         _loggerFactory = loggerFactory;
         _buildSystemDetector = buildSystemDetector;
@@ -129,13 +132,15 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                     this,
                     _originalConsoleOut,
                     () => _isProgressActive && !_outputCoordinator.IsFlushing,
-                    _secretObfuscator);
+                    _secretObfuscator,
+                    _secretProvider);
 
                 _coordinatedError = new CoordinatedTextWriter(
                     this,
                     _originalConsoleError,
                     () => _isProgressActive && !_outputCoordinator.IsFlushing,
-                    _secretObfuscator);
+                    _secretObfuscator,
+                    _secretProvider);
 
                 System.Console.SetOut(_coordinatedOut);
                 System.Console.SetError(_coordinatedError);

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -125,7 +125,8 @@ internal class CoordinatedTextWriter : TextWriter
     private void WriteCore(string value, bool appendNewLine)
     {
         var requestedBufferMode = _shouldBuffer();
-        string[]? patterns = null;
+        var patterns = GetSecretPatterns();
+        value = ObfuscateCompleteMultilinePatterns(value, patterns);
         var segmentStart = 0;
         var newlineIndex = value.IndexOf('\n', segmentStart);
 
@@ -136,7 +137,7 @@ internal class CoordinatedTextWriter : TextWriter
 
             if (!shouldBuffer)
             {
-                FlushSafeDirectOutput(patterns ??= GetSecretPatterns());
+                FlushSafeDirectOutput(patterns);
             }
 
             WriteCompletedLine(shouldBuffer);
@@ -149,7 +150,7 @@ internal class CoordinatedTextWriter : TextWriter
 
         if (!finalBufferMode)
         {
-            FlushSafeDirectOutput(patterns ??= GetSecretPatterns());
+            FlushSafeDirectOutput(patterns);
         }
 
         if (appendNewLine)
@@ -172,7 +173,24 @@ internal class CoordinatedTextWriter : TextWriter
         _secretProvider.Secrets
             .Where(pattern => !string.IsNullOrEmpty(pattern))
             .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderByDescending(pattern => pattern.Length)
             .ToArray();
+
+    private string ObfuscateCompleteMultilinePatterns(string value, IReadOnlyList<string> patterns)
+    {
+        foreach (var pattern in patterns)
+        {
+            if (pattern.IndexOfAny(['\r', '\n']) < 0 || !value.Contains(pattern, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var obfuscatedPattern = _secretObfuscator.Obfuscate(pattern, null);
+            value = value.Replace(pattern, obfuscatedPattern, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return value;
+    }
 
     private void FlushSafeDirectOutput(IReadOnlyList<string> patterns)
     {

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -37,6 +37,7 @@ internal class CoordinatedTextWriter : TextWriter
     private bool? _lineBufferShouldBuffer;
 
     /// <summary>
+    /// Initialises a new instance of the <see cref="CoordinatedTextWriter"/> class.
     /// Initializes a new coordinated text writer.
     /// </summary>
     /// <param name="coordinator">The console coordinator.</param>
@@ -124,39 +125,17 @@ internal class CoordinatedTextWriter : TextWriter
 
     private void WriteCore(string value, bool appendNewLine)
     {
-        var requestedBufferMode = _shouldBuffer();
-        var patterns = GetSecretPatterns();
-        value = ObfuscateCompleteMultilinePatterns(value, patterns);
-        var segmentStart = 0;
-        var newlineIndex = value.IndexOf('\n', segmentStart);
-
-        while (newlineIndex >= 0)
-        {
-            var shouldBuffer = GetBufferMode(requestedBufferMode);
-            _lineBuffer.Append(value, segmentStart, newlineIndex - segmentStart);
-
-            if (!shouldBuffer)
-            {
-                FlushSafeDirectOutput(patterns);
-            }
-
-            WriteCompletedLine(shouldBuffer);
-            segmentStart = newlineIndex + 1;
-            newlineIndex = value.IndexOf('\n', segmentStart);
-        }
-
-        var finalBufferMode = GetBufferMode(requestedBufferMode);
-        _lineBuffer.Append(value, segmentStart, value.Length - segmentStart);
-
-        if (!finalBufferMode)
-        {
-            FlushSafeDirectOutput(patterns);
-        }
+        var shouldBuffer = GetBufferMode(_shouldBuffer());
+        _lineBuffer.Append(value);
 
         if (appendNewLine)
         {
-            WriteCompletedLine(finalBufferMode);
+            _lineBuffer.Append(Environment.NewLine);
         }
+
+        var patterns = GetSecretPatterns();
+        ObfuscateCompletePatterns(patterns);
+        FlushSafeOutput(patterns, shouldBuffer);
     }
 
     private bool GetBufferMode(bool requestedBufferMode)
@@ -176,59 +155,96 @@ internal class CoordinatedTextWriter : TextWriter
             .OrderByDescending(pattern => pattern.Length)
             .ToArray();
 
-    private string ObfuscateCompleteMultilinePatterns(string value, IReadOnlyList<string> patterns)
+    private void ObfuscateCompletePatterns(IReadOnlyList<string> patterns)
     {
-        foreach (var pattern in patterns)
+        if (_lineBuffer.Length == 0 || patterns.Count == 0)
         {
-            if (pattern.IndexOfAny(['\r', '\n']) < 0 || !value.Contains(pattern, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            var obfuscatedPattern = _secretObfuscator.Obfuscate(pattern, null);
-            value = value.Replace(pattern, obfuscatedPattern, StringComparison.OrdinalIgnoreCase);
-        }
-
-        return value;
-    }
-
-    private void FlushSafeDirectOutput(IReadOnlyList<string> patterns)
-    {
-        if (patterns.Count == 0)
-        {
-            FlushDirectPrefix(_lineBuffer.Length);
             return;
         }
 
-        while (_lineBuffer.Length > 0)
-        {
-            var pending = _lineBuffer.ToString();
-            var match = FindFirstPattern(pending, patterns);
-            if (match.Index >= 0)
-            {
-                if (match.Index == 0 && GetPotentialPatternPrefixLength(pending, patterns) == pending.Length)
-                {
-                    return;
-                }
+        var pending = _lineBuffer.ToString();
+        var output = new StringBuilder(pending.Length);
+        var searchIndex = 0;
+        var replaced = false;
 
-                FlushDirectPrefix(match.Index > 0 ? match.Index : match.Length);
-                continue;
+        while (searchIndex < pending.Length)
+        {
+            var match = FindFirstPattern(pending, patterns, searchIndex);
+            if (match.Index < 0)
+            {
+                output.Append(pending, searchIndex, pending.Length - searchIndex);
+                break;
             }
 
-            var retainedLength = GetPotentialPatternPrefixLength(pending, patterns);
-            FlushDirectPrefix(pending.Length - retainedLength);
-            return;
+            var matchReachesEnd = match.Index + match.Length == pending.Length;
+            if (matchReachesEnd
+                && GetPotentialPatternPrefixLength(pending, patterns) == pending.Length - match.Index)
+            {
+                output.Append(pending, searchIndex, pending.Length - searchIndex);
+                break;
+            }
+
+            output.Append(pending, searchIndex, match.Index - searchIndex);
+            var secret = pending.Substring(match.Index, match.Length);
+            output.Append(_secretObfuscator.Obfuscate(secret, null));
+            searchIndex = match.Index + match.Length;
+            replaced = true;
+        }
+
+        if (replaced)
+        {
+            _lineBuffer.Clear();
+            _lineBuffer.Append(output);
         }
     }
 
-    private static (int Index, int Length) FindFirstPattern(string input, IReadOnlyList<string> patterns)
+    private void FlushSafeOutput(IReadOnlyList<string> patterns, bool shouldBuffer)
+    {
+        var retainedLength = patterns.Count == 0
+            ? 0
+            : GetPotentialPatternPrefixLength(_lineBuffer.ToString(), patterns);
+
+        FlushSafePrefix(_lineBuffer.Length - retainedLength, shouldBuffer);
+
+        if (_lineBuffer.Length == 0)
+        {
+            _lineBufferShouldBuffer = null;
+        }
+    }
+
+    private void FlushSafePrefix(int safeLength, bool shouldBuffer)
+    {
+        while (safeLength > 0)
+        {
+            var newlineIndex = _lineBuffer.ToString(0, safeLength).IndexOf('\n');
+            if (newlineIndex < 0)
+            {
+                break;
+            }
+
+            var line = _lineBuffer.ToString(0, newlineIndex).TrimEnd('\r');
+            _lineBuffer.Remove(0, newlineIndex + 1);
+            safeLength -= newlineIndex + 1;
+            WriteCompletedLine(line, shouldBuffer);
+        }
+
+        if (!shouldBuffer)
+        {
+            FlushDirectPrefix(safeLength);
+        }
+    }
+
+    private static (int Index, int Length) FindFirstPattern(
+        string input,
+        IReadOnlyList<string> patterns,
+        int startIndex)
     {
         var firstIndex = -1;
         var longestMatch = 0;
 
         foreach (var pattern in patterns)
         {
-            var index = input.IndexOf(pattern, StringComparison.OrdinalIgnoreCase);
+            var index = input.IndexOf(pattern, startIndex, StringComparison.OrdinalIgnoreCase);
             if (index >= 0 && (firstIndex < 0 || index < firstIndex || (index == firstIndex && pattern.Length > longestMatch)))
             {
                 firstIndex = index;
@@ -269,11 +285,8 @@ internal class CoordinatedTextWriter : TextWriter
         _realConsole.Write(_secretObfuscator.Obfuscate(output, null));
     }
 
-    private void WriteCompletedLine(bool shouldBuffer)
+    private void WriteCompletedLine(string line, bool shouldBuffer)
     {
-        var line = _lineBuffer.ToString().TrimEnd('\r');
-        _lineBuffer.Clear();
-        _lineBufferShouldBuffer = null;
         var obfuscated = _secretObfuscator.Obfuscate(line, null);
 
         if (shouldBuffer)
@@ -315,7 +328,10 @@ internal class CoordinatedTextWriter : TextWriter
         {
             if (_lineBuffer.Length > 0)
             {
-                FlushPartialLine(_lineBufferShouldBuffer ?? _shouldBuffer());
+                var shouldBuffer = _lineBufferShouldBuffer ?? _shouldBuffer();
+                ObfuscateCompletePatterns(GetSecretPatterns());
+                FlushSafePrefix(_lineBuffer.Length, shouldBuffer);
+                FlushPartialLine(shouldBuffer);
                 _lineBufferShouldBuffer = null;
             }
         }

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -141,7 +141,7 @@ internal class CoordinatedTextWriter : TextWriter
     private LineBufferState GetLineBufferState()
     {
         var moduleType = ModuleLogger.CurrentModuleType.Value;
-        var key = (object?)moduleType ?? UnattributedContext;
+        var key = (object?) moduleType ?? UnattributedContext;
 
         if (!_lineBuffers.TryGetValue(key, out var state))
         {
@@ -180,6 +180,8 @@ internal class CoordinatedTextWriter : TextWriter
         var output = new StringBuilder(pending.Length);
         var searchIndex = 0;
         var replaced = false;
+        var retainedPrefixLength = GetPotentialPatternPrefixLength(pending, patterns);
+        var retainedPrefixStart = pending.Length - retainedPrefixLength;
 
         while (searchIndex < pending.Length)
         {
@@ -190,9 +192,8 @@ internal class CoordinatedTextWriter : TextWriter
                 break;
             }
 
-            var matchReachesEnd = match.Index + match.Length == pending.Length;
-            if (matchReachesEnd
-                && GetPotentialPatternPrefixLength(pending, patterns) == pending.Length - match.Index)
+            if (retainedPrefixLength > 0
+                && match.Index + match.Length > retainedPrefixStart)
             {
                 output.Append(pending, searchIndex, pending.Length - searchIndex);
                 break;

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -31,8 +31,10 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly TextWriter _realConsole;
     private readonly Func<bool> _shouldBuffer;
     private readonly ISecretObfuscator _secretObfuscator;
+    private readonly ISecretProvider _secretProvider;
     private readonly StringBuilder _lineBuffer = new();
     private readonly object _lineBufferLock = new();
+    private bool? _lineBufferShouldBuffer;
 
     /// <summary>
     /// Initializes a new coordinated text writer.
@@ -41,16 +43,19 @@ internal class CoordinatedTextWriter : TextWriter
     /// <param name="realConsole">The real console to write to when not buffering.</param>
     /// <param name="shouldBuffer">Function that returns whether output should be buffered.</param>
     /// <param name="secretObfuscator">Obfuscator for secrets in output.</param>
+    /// <param name="secretProvider">Provider for registered secret patterns.</param>
     public CoordinatedTextWriter(
         IConsoleCoordinator coordinator,
         TextWriter realConsole,
         Func<bool> shouldBuffer,
-        ISecretObfuscator secretObfuscator)
+        ISecretObfuscator secretObfuscator,
+        ISecretProvider secretProvider)
     {
         _coordinator = coordinator;
         _realConsole = realConsole;
         _shouldBuffer = shouldBuffer;
         _secretObfuscator = secretObfuscator;
+        _secretProvider = secretProvider;
     }
 
     /// <inheritdoc />
@@ -59,13 +64,9 @@ internal class CoordinatedTextWriter : TextWriter
     /// <inheritdoc />
     public override void WriteLine(string? value)
     {
-        var message = value ?? string.Empty;
-
         lock (_lineBufferLock)
         {
-            _lineBuffer.Append(message);
-            WriteCompletedLine(_lineBuffer.ToString());
-            _lineBuffer.Clear();
+            WriteCore(value ?? string.Empty, appendNewLine: true);
         }
     }
 
@@ -83,24 +84,9 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        // Accumulate raw text until newline so secrets split across multiple
-        // Write calls are masked as one value.
         lock (_lineBufferLock)
         {
-            foreach (var c in value)
-            {
-                if (c == '\n')
-                {
-                    // Flush the line
-                    var line = _lineBuffer.ToString().TrimEnd('\r');
-                    _lineBuffer.Clear();
-                    WriteCompletedLine(line);
-                }
-                else
-                {
-                    _lineBuffer.Append(c);
-                }
-            }
+            WriteCore(value, appendNewLine: false);
         }
     }
 
@@ -136,17 +122,165 @@ internal class CoordinatedTextWriter : TextWriter
         }
     }
 
-    private void WriteCompletedLine(string line)
+    private void WriteCore(string value, bool appendNewLine)
     {
+        var requestedBufferMode = _shouldBuffer();
+        string[]? patterns = null;
+        var segmentStart = 0;
+        var newlineIndex = value.IndexOf('\n', segmentStart);
+
+        while (newlineIndex >= 0)
+        {
+            var shouldBuffer = GetBufferMode(requestedBufferMode);
+            _lineBuffer.Append(value, segmentStart, newlineIndex - segmentStart);
+
+            if (!shouldBuffer)
+            {
+                FlushSafeDirectOutput(patterns ??= GetSecretPatterns());
+            }
+
+            WriteCompletedLine(shouldBuffer);
+            segmentStart = newlineIndex + 1;
+            newlineIndex = value.IndexOf('\n', segmentStart);
+        }
+
+        var finalBufferMode = GetBufferMode(requestedBufferMode);
+        _lineBuffer.Append(value, segmentStart, value.Length - segmentStart);
+
+        if (!finalBufferMode)
+        {
+            FlushSafeDirectOutput(patterns ??= GetSecretPatterns());
+        }
+
+        if (appendNewLine)
+        {
+            WriteCompletedLine(finalBufferMode);
+        }
+    }
+
+    private bool GetBufferMode(bool requestedBufferMode)
+    {
+        if (_lineBufferShouldBuffer is null || _lineBuffer.Length == 0)
+        {
+            _lineBufferShouldBuffer = requestedBufferMode;
+        }
+
+        return _lineBufferShouldBuffer.Value;
+    }
+
+    private string[] GetSecretPatterns() =>
+        _secretProvider.Secrets
+            .Where(pattern => !string.IsNullOrEmpty(pattern))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private void FlushSafeDirectOutput(IReadOnlyList<string> patterns)
+    {
+        if (patterns.Count == 0)
+        {
+            FlushDirectPrefix(_lineBuffer.Length);
+            return;
+        }
+
+        while (_lineBuffer.Length > 0)
+        {
+            var pending = _lineBuffer.ToString();
+            var match = FindFirstPattern(pending, patterns);
+            if (match.Index >= 0)
+            {
+                FlushDirectPrefix(match.Index > 0 ? match.Index : match.Length);
+                continue;
+            }
+
+            var retainedLength = GetPotentialPatternPrefixLength(pending, patterns);
+            FlushDirectPrefix(pending.Length - retainedLength);
+            return;
+        }
+    }
+
+    private static (int Index, int Length) FindFirstPattern(string input, IReadOnlyList<string> patterns)
+    {
+        var firstIndex = -1;
+        var longestMatch = 0;
+
+        foreach (var pattern in patterns)
+        {
+            var index = input.IndexOf(pattern, StringComparison.OrdinalIgnoreCase);
+            if (index >= 0 && (firstIndex < 0 || index < firstIndex || (index == firstIndex && pattern.Length > longestMatch)))
+            {
+                firstIndex = index;
+                longestMatch = pattern.Length;
+            }
+        }
+
+        return (firstIndex, longestMatch);
+    }
+
+    private static int GetPotentialPatternPrefixLength(string input, IReadOnlyList<string> patterns)
+    {
+        var maximumLength = patterns.Max(pattern => pattern.Length) - 1;
+        for (var length = Math.Min(input.Length, maximumLength); length > 0; length--)
+        {
+            var suffix = input.AsSpan(input.Length - length, length);
+            foreach (var pattern in patterns)
+            {
+                if (pattern.Length > length && pattern.AsSpan().StartsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                {
+                    return length;
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    private void FlushDirectPrefix(int length)
+    {
+        if (length <= 0)
+        {
+            return;
+        }
+
+        var output = _lineBuffer.ToString(0, length);
+        _lineBuffer.Remove(0, length);
+        _realConsole.Write(_secretObfuscator.Obfuscate(output, null));
+    }
+
+    private void WriteCompletedLine(bool shouldBuffer)
+    {
+        var line = _lineBuffer.ToString().TrimEnd('\r');
+        _lineBuffer.Clear();
+        _lineBufferShouldBuffer = null;
         var obfuscated = _secretObfuscator.Obfuscate(line, null);
 
-        if (_shouldBuffer())
+        if (shouldBuffer)
         {
             RouteToBuffer(obfuscated);
         }
         else
         {
             _realConsole.WriteLine(obfuscated);
+        }
+    }
+
+    private void FlushPartialLine(bool shouldBuffer)
+    {
+        if (_lineBuffer.Length == 0)
+        {
+            return;
+        }
+
+        var pending = _lineBuffer.ToString();
+        _lineBuffer.Clear();
+        var obfuscated = _secretObfuscator.Obfuscate(pending, null);
+
+        if (shouldBuffer)
+        {
+            RouteToBuffer(obfuscated);
+        }
+        else
+        {
+            _realConsole.Write(obfuscated);
         }
     }
 
@@ -158,18 +292,8 @@ internal class CoordinatedTextWriter : TextWriter
         {
             if (_lineBuffer.Length > 0)
             {
-                var line = _lineBuffer.ToString();
-                _lineBuffer.Clear();
-                var obfuscated = _secretObfuscator.Obfuscate(line, null);
-
-                if (_shouldBuffer())
-                {
-                    RouteToBuffer(obfuscated);
-                }
-                else
-                {
-                    _realConsole.Write(obfuscated);
-                }
+                FlushPartialLine(_lineBufferShouldBuffer ?? _shouldBuffer());
+                _lineBufferShouldBuffer = null;
             }
         }
 

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -60,17 +60,13 @@ internal class CoordinatedTextWriter : TextWriter
     public override void WriteLine(string? value)
     {
         var message = value ?? string.Empty;
-        var obfuscated = _secretObfuscator.Obfuscate(message, null);
 
-        if (!_shouldBuffer())
+        lock (_lineBufferLock)
         {
-            // Progress not running - write directly
-            _realConsole.WriteLine(obfuscated);
-            return;
+            _lineBuffer.Append(message);
+            WriteCompletedLine(_lineBuffer.ToString());
+            _lineBuffer.Clear();
         }
-
-        // Progress is active - buffer the output
-        RouteToBuffer(obfuscated);
     }
 
     /// <inheritdoc />
@@ -87,26 +83,18 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        var obfuscated = _secretObfuscator.Obfuscate(value, null);
-
-        if (!_shouldBuffer())
-        {
-            // Progress not running - write directly
-            _realConsole.Write(obfuscated);
-            return;
-        }
-
-        // Progress is active - accumulate until newline
+        // Accumulate raw text until newline so secrets split across multiple
+        // Write calls are masked as one value.
         lock (_lineBufferLock)
         {
-            foreach (var c in obfuscated)
+            foreach (var c in value)
             {
                 if (c == '\n')
                 {
                     // Flush the line
                     var line = _lineBuffer.ToString().TrimEnd('\r');
                     _lineBuffer.Clear();
-                    RouteToBuffer(line);
+                    WriteCompletedLine(line);
                 }
                 else
                 {
@@ -148,6 +136,20 @@ internal class CoordinatedTextWriter : TextWriter
         }
     }
 
+    private void WriteCompletedLine(string line)
+    {
+        var obfuscated = _secretObfuscator.Obfuscate(line, null);
+
+        if (_shouldBuffer())
+        {
+            RouteToBuffer(obfuscated);
+        }
+        else
+        {
+            _realConsole.WriteLine(obfuscated);
+        }
+    }
+
     /// <inheritdoc />
     public override void Flush()
     {
@@ -158,14 +160,15 @@ internal class CoordinatedTextWriter : TextWriter
             {
                 var line = _lineBuffer.ToString();
                 _lineBuffer.Clear();
+                var obfuscated = _secretObfuscator.Obfuscate(line, null);
 
                 if (_shouldBuffer())
                 {
-                    RouteToBuffer(line);
+                    RouteToBuffer(obfuscated);
                 }
                 else
                 {
-                    _realConsole.Write(line);
+                    _realConsole.Write(obfuscated);
                 }
             }
         }

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -188,6 +188,11 @@ internal class CoordinatedTextWriter : TextWriter
             var match = FindFirstPattern(pending, patterns);
             if (match.Index >= 0)
             {
+                if (match.Index == 0 && GetPotentialPatternPrefixLength(pending, patterns) == pending.Length)
+                {
+                    return;
+                }
+
                 FlushDirectPrefix(match.Index > 0 ? match.Index : match.Length);
                 continue;
             }

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -27,14 +27,15 @@ namespace ModularPipelines.Console;
 [ExcludeFromCodeCoverage]
 internal class CoordinatedTextWriter : TextWriter
 {
+    private static readonly object UnattributedContext = new();
+
     private readonly IConsoleCoordinator _coordinator;
     private readonly TextWriter _realConsole;
     private readonly Func<bool> _shouldBuffer;
     private readonly ISecretObfuscator _secretObfuscator;
     private readonly ISecretProvider _secretProvider;
-    private readonly StringBuilder _lineBuffer = new();
+    private readonly Dictionary<object, LineBufferState> _lineBuffers = [];
     private readonly object _lineBufferLock = new();
-    private bool? _lineBufferShouldBuffer;
 
     /// <summary>
     /// Initialises a new instance of the <see cref="CoordinatedTextWriter"/> class.
@@ -106,14 +107,12 @@ internal class CoordinatedTextWriter : TextWriter
     /// <summary>
     /// Routes a message to the appropriate buffer based on current module context.
     /// </summary>
-    private void RouteToBuffer(string message)
+    private void RouteToBuffer(string message, Type? moduleType)
     {
-        var currentModule = ModuleLogger.CurrentModuleType.Value;
-
-        if (currentModule != null)
+        if (moduleType != null)
         {
             // Inside a module - route to that module's buffer
-            var buffer = _coordinator.GetModuleBuffer(currentModule);
+            var buffer = _coordinator.GetModuleBuffer(moduleType);
             buffer.WriteLine(message);
         }
         else
@@ -125,27 +124,42 @@ internal class CoordinatedTextWriter : TextWriter
 
     private void WriteCore(string value, bool appendNewLine)
     {
-        var shouldBuffer = GetBufferMode(_shouldBuffer());
-        _lineBuffer.Append(value);
+        var state = GetLineBufferState();
+        var shouldBuffer = GetBufferMode(state, _shouldBuffer());
+        state.Buffer.Append(value);
 
         if (appendNewLine)
         {
-            _lineBuffer.Append(Environment.NewLine);
+            state.Buffer.Append(Environment.NewLine);
         }
 
         var patterns = GetSecretPatterns();
-        ObfuscateCompletePatterns(patterns);
-        FlushSafeOutput(patterns, shouldBuffer);
+        ObfuscateCompletePatterns(state, patterns);
+        FlushSafeOutput(state, patterns, shouldBuffer);
     }
 
-    private bool GetBufferMode(bool requestedBufferMode)
+    private LineBufferState GetLineBufferState()
     {
-        if (_lineBufferShouldBuffer is null || _lineBuffer.Length == 0)
+        var moduleType = ModuleLogger.CurrentModuleType.Value;
+        var key = (object?)moduleType ?? UnattributedContext;
+
+        if (!_lineBuffers.TryGetValue(key, out var state))
         {
-            _lineBufferShouldBuffer = requestedBufferMode;
+            state = new LineBufferState(moduleType);
+            _lineBuffers.Add(key, state);
         }
 
-        return _lineBufferShouldBuffer.Value;
+        return state;
+    }
+
+    private static bool GetBufferMode(LineBufferState state, bool requestedBufferMode)
+    {
+        if (state.ShouldBuffer is null || state.Buffer.Length == 0)
+        {
+            state.ShouldBuffer = requestedBufferMode;
+        }
+
+        return state.ShouldBuffer.Value;
     }
 
     private string[] GetSecretPatterns() =>
@@ -155,14 +169,14 @@ internal class CoordinatedTextWriter : TextWriter
             .OrderByDescending(pattern => pattern.Length)
             .ToArray();
 
-    private void ObfuscateCompletePatterns(IReadOnlyList<string> patterns)
+    private void ObfuscateCompletePatterns(LineBufferState state, IReadOnlyList<string> patterns)
     {
-        if (_lineBuffer.Length == 0 || patterns.Count == 0)
+        if (state.Buffer.Length == 0 || patterns.Count == 0)
         {
             return;
         }
 
-        var pending = _lineBuffer.ToString();
+        var pending = state.Buffer.ToString();
         var output = new StringBuilder(pending.Length);
         var searchIndex = 0;
         var replaced = false;
@@ -193,44 +207,44 @@ internal class CoordinatedTextWriter : TextWriter
 
         if (replaced)
         {
-            _lineBuffer.Clear();
-            _lineBuffer.Append(output);
+            state.Buffer.Clear();
+            state.Buffer.Append(output);
         }
     }
 
-    private void FlushSafeOutput(IReadOnlyList<string> patterns, bool shouldBuffer)
+    private void FlushSafeOutput(LineBufferState state, IReadOnlyList<string> patterns, bool shouldBuffer)
     {
         var retainedLength = patterns.Count == 0
             ? 0
-            : GetPotentialPatternPrefixLength(_lineBuffer.ToString(), patterns);
+            : GetPotentialPatternPrefixLength(state.Buffer.ToString(), patterns);
 
-        FlushSafePrefix(_lineBuffer.Length - retainedLength, shouldBuffer);
+        FlushSafePrefix(state, state.Buffer.Length - retainedLength, shouldBuffer);
 
-        if (_lineBuffer.Length == 0)
+        if (state.Buffer.Length == 0)
         {
-            _lineBufferShouldBuffer = null;
+            state.ShouldBuffer = null;
         }
     }
 
-    private void FlushSafePrefix(int safeLength, bool shouldBuffer)
+    private void FlushSafePrefix(LineBufferState state, int safeLength, bool shouldBuffer)
     {
         while (safeLength > 0)
         {
-            var newlineIndex = _lineBuffer.ToString(0, safeLength).IndexOf('\n');
+            var newlineIndex = state.Buffer.ToString(0, safeLength).IndexOf('\n');
             if (newlineIndex < 0)
             {
                 break;
             }
 
-            var line = _lineBuffer.ToString(0, newlineIndex).TrimEnd('\r');
-            _lineBuffer.Remove(0, newlineIndex + 1);
+            var line = state.Buffer.ToString(0, newlineIndex).TrimEnd('\r');
+            state.Buffer.Remove(0, newlineIndex + 1);
             safeLength -= newlineIndex + 1;
-            WriteCompletedLine(line, shouldBuffer);
+            WriteCompletedLine(line, shouldBuffer, state.ModuleType);
         }
 
         if (!shouldBuffer)
         {
-            FlushDirectPrefix(safeLength);
+            FlushDirectPrefix(state, safeLength);
         }
     }
 
@@ -273,25 +287,25 @@ internal class CoordinatedTextWriter : TextWriter
         return 0;
     }
 
-    private void FlushDirectPrefix(int length)
+    private void FlushDirectPrefix(LineBufferState state, int length)
     {
         if (length <= 0)
         {
             return;
         }
 
-        var output = _lineBuffer.ToString(0, length);
-        _lineBuffer.Remove(0, length);
+        var output = state.Buffer.ToString(0, length);
+        state.Buffer.Remove(0, length);
         _realConsole.Write(_secretObfuscator.Obfuscate(output, null));
     }
 
-    private void WriteCompletedLine(string line, bool shouldBuffer)
+    private void WriteCompletedLine(string line, bool shouldBuffer, Type? moduleType)
     {
         var obfuscated = _secretObfuscator.Obfuscate(line, null);
 
         if (shouldBuffer)
         {
-            RouteToBuffer(obfuscated);
+            RouteToBuffer(obfuscated, moduleType);
         }
         else
         {
@@ -299,20 +313,20 @@ internal class CoordinatedTextWriter : TextWriter
         }
     }
 
-    private void FlushPartialLine(bool shouldBuffer)
+    private void FlushPartialLine(LineBufferState state, bool shouldBuffer)
     {
-        if (_lineBuffer.Length == 0)
+        if (state.Buffer.Length == 0)
         {
             return;
         }
 
-        var pending = _lineBuffer.ToString();
-        _lineBuffer.Clear();
+        var pending = state.Buffer.ToString();
+        state.Buffer.Clear();
         var obfuscated = _secretObfuscator.Obfuscate(pending, null);
 
         if (shouldBuffer)
         {
-            RouteToBuffer(obfuscated);
+            RouteToBuffer(obfuscated, state.ModuleType);
         }
         else
         {
@@ -326,13 +340,13 @@ internal class CoordinatedTextWriter : TextWriter
         // Flush any partial line in the buffer
         lock (_lineBufferLock)
         {
-            if (_lineBuffer.Length > 0)
+            foreach (var state in _lineBuffers.Values.Where(state => state.Buffer.Length > 0))
             {
-                var shouldBuffer = _lineBufferShouldBuffer ?? _shouldBuffer();
-                ObfuscateCompletePatterns(GetSecretPatterns());
-                FlushSafePrefix(_lineBuffer.Length, shouldBuffer);
-                FlushPartialLine(shouldBuffer);
-                _lineBufferShouldBuffer = null;
+                var shouldBuffer = state.ShouldBuffer ?? _shouldBuffer();
+                ObfuscateCompletePatterns(state, GetSecretPatterns());
+                FlushSafePrefix(state, state.Buffer.Length, shouldBuffer);
+                FlushPartialLine(state, shouldBuffer);
+                state.ShouldBuffer = null;
             }
         }
 
@@ -356,5 +370,14 @@ internal class CoordinatedTextWriter : TextWriter
         }
 
         base.Dispose(disposing);
+    }
+
+    private sealed class LineBufferState(Type? moduleType)
+    {
+        public Type? ModuleType { get; } = moduleType;
+
+        public StringBuilder Buffer { get; } = new();
+
+        public bool? ShouldBuffer { get; set; }
     }
 }

--- a/src/ModularPipelines/Console/IConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/IConsoleCoordinator.cs
@@ -74,7 +74,8 @@ internal interface IConsoleCoordinator : IAsyncDisposable
     /// <summary>
     /// Flushes retained fragments from the intercepted output and error writers.
     /// </summary>
-    Task FlushPendingWritesAsync();
+    /// <returns>Module buffers populated for the first time by the flush.</returns>
+    Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync();
 
     /// <summary>
     /// Flushes any remaining unattributed output.

--- a/src/ModularPipelines/Console/IConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/IConsoleCoordinator.cs
@@ -72,6 +72,11 @@ internal interface IConsoleCoordinator : IAsyncDisposable
     IModuleOutputBuffer GetUnattributedBuffer();
 
     /// <summary>
+    /// Flushes retained fragments from the intercepted output and error writers.
+    /// </summary>
+    Task FlushPendingWritesAsync();
+
+    /// <summary>
     /// Flushes any remaining unattributed output.
     /// Module output is flushed immediately when modules complete.
     /// </summary>

--- a/src/ModularPipelines/Engine/BuildSystemFormatters/GitHubActionsFormatter.cs
+++ b/src/ModularPipelines/Engine/BuildSystemFormatters/GitHubActionsFormatter.cs
@@ -24,5 +24,13 @@ internal class GitHubActionsFormatter : IBuildSystemFormatter
 
     public string GetEndBlockCommand(string name) => "::endgroup::";
 
-    public string GetMaskSecretCommand(string secret) => $"::add-mask::{secret}";
+    public string GetMaskSecretCommand(string secret) => $"::add-mask::{EscapeCommandData(secret)}";
+
+    private static string EscapeCommandData(string value)
+    {
+        return value
+            .Replace("%", "%25", StringComparison.Ordinal)
+            .Replace("\r", "%0D", StringComparison.Ordinal)
+            .Replace("\n", "%0A", StringComparison.Ordinal);
+    }
 }

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -105,10 +105,14 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
             // 1. Stop progress display FIRST (ends buffering phase)
             await _printProgressExecutor.DisposeAsync().ConfigureAwait(false);
 
-            // 2. Flush deferred module output (in completion order)
+            // 2. Flush retained console fragments into their original module buffers
+            // before those buffers are drained.
+            await _consoleCoordinator.FlushPendingWritesAsync().ConfigureAwait(false);
+
+            // 3. Flush deferred module output (in completion order)
             await _outputCoordinator.FlushDeferredAsync().ConfigureAwait(false);
 
-            // 3. Flush any unattributed output from coordinator
+            // 4. Flush any unattributed output from coordinator
             _consoleCoordinator.FlushModuleOutput();
         }
     }

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -102,17 +102,26 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
         public async ValueTask DisposeAsync()
         {
             // CRITICAL: Order matters!
-            // 1. Stop progress display FIRST (ends buffering phase)
+            // 1. Flush retained console fragments while progress deferral is still active.
+            var newlyPopulatedBuffers = await _consoleCoordinator
+                .FlushPendingWritesAsync()
+                .ConfigureAwait(false);
+
+            // 2. Schedule buffers populated after their modules completed.
+            foreach (var buffer in newlyPopulatedBuffers)
+            {
+                await _outputCoordinator
+                    .OnModuleCompletedAsync(buffer, buffer.ModuleType)
+                    .ConfigureAwait(false);
+            }
+
+            // 3. Stop progress display (ends buffering phase).
             await _printProgressExecutor.DisposeAsync().ConfigureAwait(false);
 
-            // 2. Flush retained console fragments into their original module buffers
-            // before those buffers are drained.
-            await _consoleCoordinator.FlushPendingWritesAsync().ConfigureAwait(false);
-
-            // 3. Flush deferred module output (in completion order)
+            // 4. Flush deferred module output (in completion order).
             await _outputCoordinator.FlushDeferredAsync().ConfigureAwait(false);
 
-            // 4. Flush any unattributed output from coordinator
+            // 5. Flush any unattributed output from coordinator.
             _consoleCoordinator.FlushModuleOutput();
         }
     }

--- a/src/ModularPipelines/Engine/SecretMaskingPatternGenerator.cs
+++ b/src/ModularPipelines/Engine/SecretMaskingPatternGenerator.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Generates common textual representations of a secret that may appear in logs.
+/// </summary>
+internal static class SecretMaskingPatternGenerator
+{
+    public static IReadOnlyList<string> Generate(string secret)
+    {
+        var json = JsonSerializer.Serialize(secret);
+        var patterns = new HashSet<string>(StringComparer.Ordinal)
+        {
+            secret,
+            Convert.ToBase64String(Encoding.UTF8.GetBytes(secret)),
+            Uri.EscapeDataString(secret),
+            WebUtility.UrlEncode(secret),
+            json[1..^1],
+        };
+
+        return patterns.ToArray();
+    }
+}

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -27,18 +27,15 @@ namespace ModularPipelines.Engine;
 /// <threadsafety static="true" instance="true"/>
 internal class SecretObfuscator : ISecretObfuscator, IInitializer
 {
-    private readonly IBuildSystemSecretMasker _buildSystemSecretMasker;
     private readonly ISecretProvider _secretProvider;
     private readonly IOptions<SecretMaskingOptions> _maskingOptions;
 
     public int Order => int.MaxValue;
 
     public SecretObfuscator(
-        IBuildSystemSecretMasker buildSystemSecretMasker,
         ISecretProvider secretProvider,
         IOptions<SecretMaskingOptions> maskingOptions)
     {
-        _buildSystemSecretMasker = buildSystemSecretMasker;
         _secretProvider = secretProvider;
         _maskingOptions = maskingOptions;
     }
@@ -64,13 +61,16 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         var maskValue = string.IsNullOrWhiteSpace(options.MaskValue) ? "**********" : options.MaskValue;
         var caseInsensitive = options.CaseInsensitive;
 
-        var secretsFromExtraObject = _secretProvider.GetSecretsInObject(optionsObject);
+        var minimumLength = Math.Max(1, options.MinimumSecretLength);
+        var secretsFromExtraObject = _secretProvider.GetSecretsInObject(optionsObject)
+            .Where(secret => secret.Length >= minimumLength)
+            .SelectMany(SecretMaskingPatternGenerator.Generate);
 
         // Combine all secrets and sort by length (longest first) to ensure
         // longer secrets are replaced before shorter ones that might be substrings
         var allSecrets = _secretProvider.Secrets
             .Concat(secretsFromExtraObject)
-            .Where(s => !string.IsNullOrWhiteSpace(s) && s.Length >= options.MinimumSecretLength)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
             .Distinct(caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
             .OrderByDescending(s => s.Length)
             .ToList();

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Initialization.Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
 using ModularPipelines.Options;
@@ -32,7 +33,10 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
     private readonly IOptionsProvider _optionsProvider;
     private readonly IBuildSystemSecretMasker _buildSystemSecretMasker;
     private readonly IOptions<SecretMaskingOptions> _maskingOptions;
+    private readonly ILogger<SecretProvider> _logger;
     private readonly ConcurrentDictionary<string, byte> _secrets = new();
+    private readonly ConcurrentDictionary<string, byte> _nativeMaskPatterns = new();
+    private readonly ConcurrentDictionary<string, byte> _shortSecretWarnings = new();
     private readonly object _initLock = new();
 
     private volatile bool _initialized;
@@ -50,11 +54,13 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
     public SecretProvider(
         IOptionsProvider optionsProvider,
         IBuildSystemSecretMasker buildSystemSecretMasker,
-        IOptions<SecretMaskingOptions> maskingOptions)
+        IOptions<SecretMaskingOptions> maskingOptions,
+        ILogger<SecretProvider> logger)
     {
         _optionsProvider = optionsProvider;
         _buildSystemSecretMasker = buildSystemSecretMasker;
         _maskingOptions = maskingOptions;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -65,19 +71,27 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             return;
         }
 
-        var options = _maskingOptions.Value;
+        var patterns = SecretMaskingPatternGenerator.Generate(secret);
+        RegisterNativeMaskPatterns(patterns);
 
-        // Check minimum length requirement
-        if (secret.Length < options.MinimumSecretLength)
+        var minimumLength = Math.Max(1, _maskingOptions.Value.MinimumSecretLength);
+        if (secret.Length < minimumLength)
         {
+            if (_shortSecretWarnings.TryAdd(secret, 0))
+            {
+                _logger.LogWarning(
+                    "A secret with length {SecretLength} is shorter than MinimumSecretLength {MinimumSecretLength}. " +
+                    "Framework log masking is disabled for this value; native build-system masking was requested.",
+                    secret.Length,
+                    minimumLength);
+            }
+
             return;
         }
 
-        // TryAdd returns false if already exists, providing thread-safe deduplication
-        if (_secrets.TryAdd(secret, 0))
+        foreach (var pattern in patterns)
         {
-            // Register with build system for native masking (only for new secrets)
-            _buildSystemSecretMasker.MaskSecrets([secret]);
+            _secrets.TryAdd(pattern, 0);
         }
     }
 
@@ -93,7 +107,7 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
     /// <inheritdoc />
     public void AddSecrets(params string?[] secrets)
     {
-        AddSecrets((IEnumerable<string?>)secrets);
+        AddSecrets((IEnumerable<string?>) secrets);
     }
 
     public IEnumerable<string> GetSecretsInObject(object? value)
@@ -109,13 +123,11 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             secretProperties = ReflectionAccessorsCache.GetOrAdd(type, GetSecretProperties);
         }
 
-        var options = _maskingOptions.Value;
-
         foreach (var property in secretProperties)
         {
             var secret = property.Getter(value)?.ToString();
 
-            if (!string.IsNullOrWhiteSpace(secret) && secret.Length >= options.MinimumSecretLength)
+            if (!string.IsNullOrWhiteSpace(secret))
             {
                 yield return secret;
             }
@@ -140,18 +152,7 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
                 return Task.CompletedTask;
             }
 
-            var secretsFromOptions = GetSecrets(_optionsProvider.GetOptions()).ToList();
-
-            foreach (var secret in secretsFromOptions)
-            {
-                _secrets.TryAdd(secret, 0);
-            }
-
-            // Register all discovered secrets with build system in a single batch
-            if (secretsFromOptions.Count > 0)
-            {
-                _buildSystemSecretMasker.MaskSecrets(secretsFromOptions);
-            }
+            AddSecrets(GetSecrets(_optionsProvider.GetOptions()));
 
             _initialized = true;
         }
@@ -177,6 +178,15 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             {
                 yield return secret;
             }
+        }
+    }
+
+    private void RegisterNativeMaskPatterns(IEnumerable<string> patterns)
+    {
+        var newPatterns = patterns.Where(pattern => _nativeMaskPatterns.TryAdd(pattern, 0)).ToArray();
+        if (newPatterns.Length > 0)
+        {
+            _buildSystemSecretMasker.MaskSecrets(newPatterns);
         }
     }
 }

--- a/src/ModularPipelines/Options/SecretMaskingOptions.cs
+++ b/src/ModularPipelines/Options/SecretMaskingOptions.cs
@@ -54,8 +54,9 @@ public record SecretMaskingOptions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Secrets shorter than this length are ignored to prevent excessive false positives.
+    /// Secrets shorter than this length are excluded from framework substring masking to prevent excessive false positives.
     /// For example, a 1-character secret like "a" would mask all "a" characters in output.
+    /// A warning is logged, and native build-system masking is still requested when supported.
     /// </para>
     /// <para>
     /// The default value of 1 ensures all non-empty secrets are masked, maintaining backward

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -9,16 +9,25 @@ namespace ModularPipelines.UnitTests.Engine;
 public class PipelineOutputCoordinatorTests
 {
     [Test]
-    public async Task Dispose_FlushesRetainedModuleWritesBeforeDeferredBuffers()
+    public async Task Dispose_SchedulesBuffersCreatedByRetainedWriteFlush()
     {
         var events = new List<string>();
+        var retainedBuffer = new Mock<IModuleOutputBuffer>();
+        retainedBuffer.SetupGet(x => x.ModuleType).Returns(typeof(PipelineOutputCoordinatorTests));
         var consoleCoordinator = new Mock<IConsoleCoordinator>();
         consoleCoordinator.Setup(x => x.FlushPendingWritesAsync())
             .Callback(() => events.Add("retained"))
-            .Returns(Task.CompletedTask);
+            .ReturnsAsync([retainedBuffer.Object]);
         consoleCoordinator.Setup(x => x.FlushModuleOutput()).Callback(() => events.Add("unattributed"));
 
         var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(x => x.OnModuleCompletedAsync(
+                retainedBuffer.Object,
+                typeof(PipelineOutputCoordinatorTests),
+                It.IsAny<CancellationToken>()))
+            .Callback(() => events.Add("scheduled"))
+            .Returns(Task.CompletedTask);
         outputCoordinator.Setup(x => x.FlushDeferredAsync(It.IsAny<CancellationToken>()))
             .Callback(() => events.Add("deferred"))
             .Returns(Task.CompletedTask);
@@ -35,7 +44,8 @@ public class PipelineOutputCoordinatorTests
         await scope.DisposeAsync();
 
         await Assert.That(string.Join(",", events))
-            .IsEqualTo("progress,retained,deferred,unattributed");
+            .IsEqualTo("retained,scheduled,progress,deferred,unattributed");
+        outputCoordinator.VerifyAll();
     }
 
     private sealed class RecordingProgressExecutor(List<string> events) : IPrintProgressExecutor

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -1,0 +1,51 @@
+using ModularPipelines.Console;
+using ModularPipelines.Engine.Executors;
+using ModularPipelines.Helpers;
+using ModularPipelines.Logging;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class PipelineOutputCoordinatorTests
+{
+    [Test]
+    public async Task Dispose_FlushesRetainedModuleWritesBeforeDeferredBuffers()
+    {
+        var events = new List<string>();
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator.Setup(x => x.FlushPendingWritesAsync())
+            .Callback(() => events.Add("retained"))
+            .Returns(Task.CompletedTask);
+        consoleCoordinator.Setup(x => x.FlushModuleOutput()).Callback(() => events.Add("unattributed"));
+
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator.Setup(x => x.FlushDeferredAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => events.Add("deferred"))
+            .Returns(Task.CompletedTask);
+
+        var coordinator = new PipelineOutputCoordinator(
+            new RecordingProgressExecutor(events),
+            Mock.Of<IConsolePrinter>(),
+            Mock.Of<IInternalSummaryLogger>(),
+            Mock.Of<IExceptionBuffer>(),
+            consoleCoordinator.Object,
+            outputCoordinator.Object);
+        var scope = await coordinator.InitializeAsync();
+
+        await scope.DisposeAsync();
+
+        await Assert.That(string.Join(",", events))
+            .IsEqualTo("progress,retained,deferred,unattributed");
+    }
+
+    private sealed class RecordingProgressExecutor(List<string> events) : IPrintProgressExecutor
+    {
+        public Task<IPrintProgressExecutor> InitializeAsync() => Task.FromResult<IPrintProgressExecutor>(this);
+
+        public ValueTask DisposeAsync()
+        {
+            events.Add("progress");
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
+using ModularPipelines.Engine.BuildSystemFormatters;
 using ModularPipelines.Options;
 using Moq;
 
@@ -134,6 +135,15 @@ public class SecretMaskingPatternTests
         writer.WriteLine("def");
 
         await Assert.That(realConsole.ToString()).IsEqualTo($"**********{Environment.NewLine}");
+    }
+
+    [Test]
+    [Arguments("a%b", "::add-mask::a%25b")]
+    [Arguments("line 1\r\nline 2", "::add-mask::line 1%0D%0Aline 2")]
+    [Arguments("a%25b", "::add-mask::a%2525b")]
+    public async Task GitHubActionsMaskCommand_EscapesWorkflowCommandData(string value, string expected)
+    {
+        await Assert.That(new GitHubActionsFormatter().GetMaskSecretCommand(value)).IsEqualTo(expected);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -113,6 +113,30 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrites_Retain_CompleteSecret_ThatPrefixesLongerSecret()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("abc");
+        provider.AddSecret("abcdef");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("abc");
+
+        await Assert.That(realConsole.ToString()).IsEmpty();
+
+        writer.WriteLine("def");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo($"**********{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task DirectConsoleWrite_WithoutNewline_IsImmediate()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -190,6 +190,57 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrites_Mask_MultilineSecrets_SplitAcrossLines()
+    {
+        var secret = $"private-key-line-1{Environment.NewLine}private-key-line-2";
+        var provider = CreateProvider(out _);
+        provider.AddSecret(secret);
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.WriteLine("private-key-line-1");
+
+        await Assert.That(realConsole.ToString()).IsEmpty();
+
+        writer.WriteLine("private-key-line-2");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo($"**********{Environment.NewLine}");
+    }
+
+    [Test]
+    public void BufferedConsoleWrites_Mask_MultilineSecrets_SplitAcrossLines()
+    {
+        var secret = $"private-key-line-1{Environment.NewLine}private-key-line-2";
+        var provider = CreateProvider(out _);
+        provider.AddSecret(secret);
+        var outputBuffer = new Mock<IModuleOutputBuffer>();
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetUnattributedBuffer()).Returns(outputBuffer.Object);
+
+        using var writer = new CoordinatedTextWriter(
+            coordinator.Object,
+            new StringWriter(),
+            () => true,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.WriteLine("private-key-line-1");
+
+        outputBuffer.Verify(x => x.WriteLine(It.IsAny<string>()), Times.Never);
+
+        writer.WriteLine("private-key-line-2");
+
+        outputBuffer.Verify(x => x.WriteLine("**********"), Times.Once);
+        outputBuffer.Verify(x => x.WriteLine(It.Is<string>(value => value.Contains("private-key"))), Times.Never);
+    }
+
+    [Test]
     public async Task DirectConsoleWrite_WithoutNewline_IsImmediate()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -137,6 +137,49 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrites_Mask_MultilineSecrets_Before_Splitting_Lines()
+    {
+        var secret = $"private-key-line-1{Environment.NewLine}private-key-line-2";
+        var provider = CreateProvider(out _);
+        provider.AddSecret(secret);
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.WriteLine(secret);
+
+        await Assert.That(realConsole.ToString()).IsEqualTo($"**********{Environment.NewLine}");
+    }
+
+    [Test]
+    public void BufferedConsoleWrites_Mask_MultilineSecrets_Before_Splitting_Lines()
+    {
+        var secret = $"private-key-line-1{Environment.NewLine}private-key-line-2";
+        var provider = CreateProvider(out _);
+        provider.AddSecret(secret);
+        var outputBuffer = new Mock<IModuleOutputBuffer>();
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetUnattributedBuffer()).Returns(outputBuffer.Object);
+
+        using var writer = new CoordinatedTextWriter(
+            coordinator.Object,
+            new StringWriter(),
+            () => true,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.WriteLine(secret);
+
+        outputBuffer.Verify(x => x.WriteLine("**********"), Times.Once);
+        outputBuffer.Verify(x => x.WriteLine(It.Is<string>(value => value.Contains("private-key"))), Times.Never);
+    }
+
+    [Test]
     public async Task DirectConsoleWrite_WithoutNewline_IsImmediate()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -147,6 +147,36 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    [Arguments("abcdef", "cde", "abcde", "f")]
+    [Arguments("abc\ndef", "c\nde", "abc\nde", "f")]
+    public async Task DirectConsoleWrites_Retain_WholePrefix_Before_InnerSecretMatch(
+        string longerSecret,
+        string innerSecret,
+        string firstChunk,
+        string secondChunk)
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret(longerSecret);
+        provider.AddSecret(innerSecret);
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write(firstChunk);
+
+        await Assert.That(realConsole.ToString()).IsEmpty();
+
+        writer.Write(secondChunk);
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("**********");
+    }
+
+    [Test]
     [Arguments("a%b", "::add-mask::a%25b")]
     [Arguments("line 1\r\nline 2", "::add-mask::line 1%0D%0Aline 2")]
     [Arguments("a%25b", "::add-mask::a%2525b")]

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -82,7 +82,8 @@ public class SecretMaskingPatternTests
             coordinator.Object,
             new StringWriter(),
             () => true,
-            obfuscator);
+            obfuscator,
+            provider);
 
         writer.Write("split-");
         writer.WriteLine("secret");
@@ -102,12 +103,81 @@ public class SecretMaskingPatternTests
             Mock.Of<IConsoleCoordinator>(),
             realConsole,
             () => false,
-            CreateObfuscator(provider));
+            CreateObfuscator(provider),
+            provider);
 
         writer.Write("split-");
         writer.WriteLine("secret");
 
         await Assert.That(realConsole.ToString()).IsEqualTo($"**********{Environment.NewLine}");
+    }
+
+    [Test]
+    public async Task DirectConsoleWrite_WithoutNewline_IsImmediate()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("split-secret");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("Enter value: ");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("Enter value: ");
+    }
+
+    [Test]
+    public async Task DirectConsoleWrite_OnlyRetainsPotentialSecretPrefix()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("split-secret");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("before split-");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("before ");
+
+        writer.Write("secret after");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("before ********** after");
+    }
+
+    [Test]
+    public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("split-secret");
+        var realConsole = new StringWriter();
+        var outputBuffer = new Mock<IModuleOutputBuffer>();
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetUnattributedBuffer()).Returns(outputBuffer.Object);
+        var shouldBuffer = false;
+
+        using var writer = new CoordinatedTextWriter(
+            coordinator.Object,
+            realConsole,
+            () => shouldBuffer,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("split-");
+        shouldBuffer = true;
+        writer.WriteLine("secret");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo($"**********{Environment.NewLine}");
+        outputBuffer.Verify(x => x.WriteLine(It.IsAny<string>()), Times.Never);
     }
 
     private static SecretProvider CreateProvider(

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -3,6 +3,7 @@ using ModularPipelines.Attributes;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.BuildSystemFormatters;
+using ModularPipelines.Logging;
 using ModularPipelines.Options;
 using Moq;
 
@@ -16,6 +17,14 @@ public class SecretMaskingPatternTests
     {
         [SecretValue]
         public string Value { get; init; } = Secret;
+    }
+
+    private sealed class FirstModule
+    {
+    }
+
+    private sealed class SecondModule
+    {
     }
 
     [Test]
@@ -238,6 +247,48 @@ public class SecretMaskingPatternTests
 
         outputBuffer.Verify(x => x.WriteLine("**********"), Times.Once);
         outputBuffer.Verify(x => x.WriteLine(It.Is<string>(value => value.Contains("private-key"))), Times.Never);
+    }
+
+    [Test]
+    public void BufferedConsoleWrites_Isolate_Retained_Secret_Prefixes_Per_Module()
+    {
+        var secret = $"private-key-line-1{Environment.NewLine}private-key-line-2";
+        var provider = CreateProvider(out _);
+        provider.AddSecret(secret);
+        var firstBuffer = new Mock<IModuleOutputBuffer>();
+        var secondBuffer = new Mock<IModuleOutputBuffer>();
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetModuleBuffer(typeof(FirstModule))).Returns(firstBuffer.Object);
+        coordinator.Setup(x => x.GetModuleBuffer(typeof(SecondModule))).Returns(secondBuffer.Object);
+
+        var previousModule = ModuleLogger.CurrentModuleType.Value;
+        try
+        {
+            using var writer = new CoordinatedTextWriter(
+                coordinator.Object,
+                new StringWriter(),
+                () => true,
+                CreateObfuscator(provider),
+                provider);
+
+            ModuleLogger.CurrentModuleType.Value = typeof(FirstModule);
+            writer.WriteLine("private-key-line-1");
+
+            ModuleLogger.CurrentModuleType.Value = typeof(SecondModule);
+            writer.WriteLine("second-module-output");
+
+            ModuleLogger.CurrentModuleType.Value = typeof(FirstModule);
+            writer.WriteLine("private-key-line-2");
+        }
+        finally
+        {
+            ModuleLogger.CurrentModuleType.Value = previousModule;
+        }
+
+        firstBuffer.Verify(x => x.WriteLine("**********"), Times.Once);
+        firstBuffer.Verify(x => x.WriteLine(It.Is<string>(value => value.Contains("private-key"))), Times.Never);
+        secondBuffer.Verify(x => x.WriteLine("second-module-output"), Times.Once);
+        secondBuffer.Verify(x => x.WriteLine(It.Is<string>(value => value.Contains("private-key"))), Times.Never);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1,0 +1,138 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
+using ModularPipelines.Console;
+using ModularPipelines.Engine;
+using ModularPipelines.Options;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Logging;
+
+public class SecretMaskingPatternTests
+{
+    private const string Secret = "p@ss word\"value";
+
+    private sealed class SecretOptions
+    {
+        [SecretValue]
+        public string Value { get; init; } = Secret;
+    }
+
+    [Test]
+    public async Task RegisteredSecret_MasksCommonEncodedForms()
+    {
+        var provider = CreateProvider(out var nativeMasker);
+        provider.AddSecret(Secret);
+        var obfuscator = CreateObfuscator(provider);
+        var patterns = SecretMaskingPatternGenerator.Generate(Secret);
+
+        foreach (var pattern in patterns)
+        {
+            await Assert.That(obfuscator.Obfuscate($"before {pattern} after", null))
+                .IsEqualTo("before ********** after");
+        }
+
+        nativeMasker.Verify(x => x.MaskSecrets(It.Is<IEnumerable<string>>(
+            values => patterns.All(pattern => values.Contains(pattern)))));
+    }
+
+    [Test]
+    public async Task OptionsObject_MasksCommonEncodedFormsWithoutPriorRegistration()
+    {
+        var provider = CreateProvider(out _);
+        var obfuscator = CreateObfuscator(provider);
+
+        foreach (var pattern in SecretMaskingPatternGenerator.Generate(Secret))
+        {
+            await Assert.That(obfuscator.Obfuscate(pattern, new SecretOptions()))
+                .IsEqualTo("**********");
+        }
+    }
+
+    [Test]
+    public async Task ShortSecret_RequestsNativeMaskingAndLogsWarningWithoutValue()
+    {
+        var logger = new Mock<ILogger<SecretProvider>>();
+        var provider = CreateProvider(out var nativeMasker, logger, minimumSecretLength: 3);
+
+        provider.AddSecret("qz");
+
+        await Assert.That(provider.Secrets).IsEmpty();
+        nativeMasker.Verify(x => x.MaskSecrets(It.Is<IEnumerable<string>>(values => values.Contains("qz"))));
+        logger.Verify(x => x.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((state, _) =>
+                state.ToString()!.Contains("length 2", StringComparison.Ordinal)
+                && !state.ToString()!.Contains("qz", StringComparison.Ordinal)),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+    }
+
+    [Test]
+    public void BufferedConsoleWrites_MaskSecretSplitAcrossChunks()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("split-secret");
+        var obfuscator = CreateObfuscator(provider);
+        var outputBuffer = new Mock<IModuleOutputBuffer>();
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetUnattributedBuffer()).Returns(outputBuffer.Object);
+
+        using var writer = new CoordinatedTextWriter(
+            coordinator.Object,
+            new StringWriter(),
+            () => true,
+            obfuscator);
+
+        writer.Write("split-");
+        writer.WriteLine("secret");
+
+        outputBuffer.Verify(x => x.WriteLine("**********"), Times.Once);
+        outputBuffer.Verify(x => x.WriteLine(It.Is<string>(value => value.Contains("split-secret"))), Times.Never);
+    }
+
+    [Test]
+    public async Task DirectConsoleWrites_MaskSecretSplitAcrossChunks()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("split-secret");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider));
+
+        writer.Write("split-");
+        writer.WriteLine("secret");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo($"**********{Environment.NewLine}");
+    }
+
+    private static SecretProvider CreateProvider(
+        out Mock<IBuildSystemSecretMasker> nativeMasker,
+        Mock<ILogger<SecretProvider>>? logger = null,
+        int minimumSecretLength = 1)
+    {
+        nativeMasker = new Mock<IBuildSystemSecretMasker>();
+        var optionsProvider = new Mock<IOptionsProvider>();
+        optionsProvider.Setup(x => x.GetOptions()).Returns([]);
+
+        return new SecretProvider(
+            optionsProvider.Object,
+            nativeMasker.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
+            {
+                MinimumSecretLength = minimumSecretLength,
+            }),
+            logger?.Object ?? Mock.Of<ILogger<SecretProvider>>());
+    }
+
+    private static SecretObfuscator CreateObfuscator(ISecretProvider provider)
+    {
+        return new SecretObfuscator(
+            provider,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+    }
+}


### PR DESCRIPTION
## Summary
- mask Base64, percent/form URL-encoded, and JSON-escaped secret representations
- buffer partial console writes until line completion so secrets split across chunks are masked
- warn when framework masking excludes a short secret while still requesting native CI masking

## Validation
- dotnet build test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj --no-restore`n- 60 affected unit tests across secret masking, obfuscation, command logging, and module logging
- 5 focused tests after rebase

Closes #2994