### PR TITLE
fix: generate BuildCommandLine as virtual/override instead of hiding base member (#3080)

### DIFF
--- a/src/ModularPipelines.SourceGenerator/BuildMethodGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/BuildMethodGenerator.cs
@@ -56,7 +56,7 @@ internal static class BuildMethodGenerator
         sb.AppendLine("    /// <summary>");
         sb.AppendLine("    /// Builds the command line arguments from this options instance.");
         sb.AppendLine("    /// </summary>");
-        sb.AppendLine("    public ModularPipelines.Models.CommandLine BuildCommandLine()");
+        sb.AppendLine($"    public {info.BuildMethodModifier}ModularPipelines.Models.CommandLine BuildCommandLine()");
         sb.AppendLine("    {");
         sb.AppendLine("        var args = new System.Collections.Generic.List<string>();");
 

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -130,15 +130,29 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
     /// </summary>
     private static string GetBuildMethodModifier(INamedTypeSymbol type, Compilation compilation)
     {
+        var commandLineType = compilation.GetTypeByMetadataName("ModularPipelines.Models.CommandLine");
+
         for (var current = type.BaseType; current is not null; current = current.BaseType)
         {
             // Ancestor compiled in another assembly: its generated method is visible as metadata.
+            // Only methods a derived type in another assembly can actually hide or override matter:
+            // instance, parameterless, non-generic, and at least protected.
             var existing = current.GetMembers("BuildCommandLine")
                 .OfType<IMethodSymbol>()
-                .FirstOrDefault(m => m.Parameters.IsEmpty && !m.IsStatic);
+                .FirstOrDefault(m => m.Parameters.IsEmpty
+                    && !m.IsStatic
+                    && !m.IsGenericMethod
+                    && m.DeclaredAccessibility is Accessibility.Public or Accessibility.Protected or Accessibility.ProtectedOrInternal);
             if (existing is not null)
             {
-                return existing.IsVirtual || existing.IsOverride ? "override " : "new ";
+                // Override only a live slot with the matching return type; anything else
+                // (non-virtual, sealed override, different return type) must be hidden with
+                // "new" to keep the consuming project compiling.
+                var returnsCommandLine = commandLineType is not null
+                    && SymbolEqualityComparer.Default.Equals(existing.ReturnType, commandLineType);
+                var overridable = (existing.IsVirtual || existing.IsAbstract || existing.IsOverride)
+                    && !existing.IsSealed;
+                return returnsCommandLine && overridable ? "override " : "new ";
             }
 
             // Ancestor in the current compilation: its generated method is not visible to us,

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -147,12 +147,18 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             {
                 // Override only a live slot with the matching return type; anything else
                 // (non-virtual, sealed override, different return type) must be hidden with
-                // "new" to keep the consuming project compiling.
+                // "new" to keep the consuming project compiling. The hidden method opens a
+                // fresh virtual slot so generated descendants can still emit "override".
                 var returnsCommandLine = commandLineType is not null
                     && SymbolEqualityComparer.Default.Equals(existing.ReturnType, commandLineType);
                 var overridable = (existing.IsVirtual || existing.IsAbstract || existing.IsOverride)
                     && !existing.IsSealed;
-                return returnsCommandLine && overridable ? "override " : "new ";
+                if (returnsCommandLine && overridable)
+                {
+                    return "override ";
+                }
+
+                return type.IsSealed ? "new " : "new virtual ";
             }
 
             // Ancestor in the current compilation: its generated method is not visible to us,

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -145,14 +145,17 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     && m.DeclaredAccessibility is Accessibility.Public or Accessibility.Protected or Accessibility.ProtectedOrInternal);
             if (existing is not null)
             {
-                // Override only a live slot with the matching return type; anything else
-                // (non-virtual, sealed override, different return type) must be hidden with
-                // "new" to keep the consuming project compiling. The hidden method opens a
-                // fresh virtual slot so generated descendants can still emit "override".
+                // Override only a public live slot with the matching return type — the
+                // generated method is always public, and an override cannot change the
+                // inherited accessibility. Anything else (non-virtual, sealed override,
+                // protected, different return type) must be hidden with "new" to keep the
+                // consuming project compiling. The hidden method opens a fresh virtual slot
+                // so generated descendants can still emit "override".
                 var returnsCommandLine = commandLineType is not null
                     && SymbolEqualityComparer.Default.Equals(existing.ReturnType, commandLineType);
                 var overridable = (existing.IsVirtual || existing.IsAbstract || existing.IsOverride)
-                    && !existing.IsSealed;
+                    && !existing.IsSealed
+                    && existing.DeclaredAccessibility == Accessibility.Public;
                 if (returnsCommandLine && overridable)
                 {
                     return "override ";

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -117,8 +117,76 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             SubCommandParts: subCommandParts,
             Properties: properties,
             IsPartial: isPartial,
-            Location: typeDeclaration.Identifier.GetLocation()
+            Location: typeDeclaration.Identifier.GetLocation(),
+            BuildMethodModifier: GetBuildMethodModifier(typeSymbol, semanticModel.Compilation)
         );
+    }
+
+    /// <summary>
+    /// Determines the modifier for the generated BuildCommandLine() method so that
+    /// derived options classes override the base method instead of hiding it (CS0108).
+    /// Base-most generated classes get "virtual "; classes whose ancestor also gets a
+    /// generated method get "override "; sealed base-most classes get no modifier.
+    /// </summary>
+    private static string GetBuildMethodModifier(INamedTypeSymbol type, Compilation compilation)
+    {
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            // Ancestor compiled in another assembly: its generated method is visible as metadata.
+            var existing = current.GetMembers("BuildCommandLine")
+                .OfType<IMethodSymbol>()
+                .FirstOrDefault(m => m.Parameters.IsEmpty && !m.IsStatic);
+            if (existing is not null)
+            {
+                return existing.IsVirtual || existing.IsOverride ? "override " : "new ";
+            }
+
+            // Ancestor in the current compilation: its generated method is not visible to us,
+            // so predict whether GenerateCode will emit one for it.
+            if (WouldGenerateBuildMethod(current, compilation))
+            {
+                return "override ";
+            }
+        }
+
+        return type.IsSealed ? string.Empty : "virtual ";
+    }
+
+    /// <summary>
+    /// Predicts whether GenerateCode will emit a BuildCommandLine() method for the given
+    /// source-declared type, mirroring the checks in GetOptionsClassInfo and GenerateCode.
+    /// </summary>
+    private static bool WouldGenerateBuildMethod(INamedTypeSymbol type, Compilation compilation)
+    {
+        if (!InheritsFromCommandLineToolOptions(type, compilation))
+        {
+            return false;
+        }
+
+        if (GetToolName(type) is null && GetCliProperties(type).Count == 0)
+        {
+            return false;
+        }
+
+        return IsDeclaredPartial(type);
+    }
+
+    /// <summary>
+    /// Checks whether any declaration of the type carries the partial keyword.
+    /// GenerateCode skips non-partial types, so they never receive a generated method.
+    /// </summary>
+    private static bool IsDeclaredPartial(INamedTypeSymbol type)
+    {
+        foreach (var reference in type.DeclaringSyntaxReferences)
+        {
+            if (reference.GetSyntax() is TypeDeclarationSyntax declaration
+                && declaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/ModularPipelines.SourceGenerator/OptionsClassInfo.cs
+++ b/src/ModularPipelines.SourceGenerator/OptionsClassInfo.cs
@@ -12,7 +12,8 @@ internal sealed record OptionsClassInfo(
     IReadOnlyList<string> SubCommandParts,
     IReadOnlyList<CliPropertyInfo> Properties,
     bool IsPartial,
-    Location Location
+    Location Location,
+    string BuildMethodModifier
 );
 
 /// <summary>


### PR DESCRIPTION
## Summary

Fixes #3080.

`CommandOptionsGenerator` emitted `public ModularPipelines.Models.CommandLine BuildCommandLine()` unconditionally. In `[CliTool]` hierarchies (`BashOptions` → `BashCommandOptions`, `AptGetOptions` → `AptGetInstallOptions`, ...) both levels get a generated method, so the derived one hid the base one:

```
BashCommandOptions.g.cs(14,48): warning CS0108: 'BashCommandOptions.BuildCommandLine()' hides inherited member 'BashOptions.BuildCommandLine()'. Use the new keyword if hiding was intended.
```

Beyond the noise, hiding means a base-typed reference statically binds to the base implementation — wrong dispatch the moment anything consumes these methods polymorphically (nothing in-repo calls them yet; the property-extraction side of this generator is still stubbed).

## Change

`GetBuildMethodModifier` walks the base-type chain and picks:

| Situation | Emitted modifier |
|---|---|
| No ancestor gets a generated method | `virtual` (omitted if the class is `sealed`) |
| Ancestor in the same compilation will get one (predicted via the same partial + `[CliTool]`/property checks `GenerateCode` uses) | `override` |
| Ancestor in a referenced assembly already exposes a parameterless `BuildCommandLine` in metadata | `override` if that method is virtual/override; `new` as a compile-safe fallback for assemblies built with the old generator |

`OptionsClassInfo` carries the modifier as a string, so incremental-generator caching semantics are unchanged (still a value-equatable record).

## Verification

- `dotnet build src/ModularPipelines -c Release --no-incremental`: CS0108 count drops 30 → 0, no errors, no new warnings (remaining CS8600/8602/8604/8620 are the handwritten-code set tracked by #3081).
- Reflection on the built assembly confirms real overriding, not re-hiding:
  - `BashOptions.BuildCommandLine` — declared on `BashOptions`, virtual
  - `BashCommandOptions.BuildCommandLine` — declared on `BashCommandOptions`, `GetBaseDefinition()` = `BashOptions`