### PR TITLE
Fix CI log group output ordering

### DIFF
--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Engine;
@@ -66,6 +67,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     // Logger for output
     private ILogger? _outputLogger;
     private readonly IOutputCoordinator _outputCoordinator;
+    private readonly ISpectreConsoleLoggerControl _loggerControl;
 
     public ConsoleCoordinator(
         IBuildSystemFormatterProvider formatterProvider,
@@ -76,7 +78,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         ILoggerFactory loggerFactory,
         IBuildSystemDetector buildSystemDetector,
         IServiceProvider serviceProvider,
-        IOutputCoordinator outputCoordinator)
+        IOutputCoordinator outputCoordinator,
+        ISpectreConsoleLoggerControl loggerControl)
     {
         _formatterProvider = formatterProvider;
         _resultsPrinter = resultsPrinter;
@@ -87,6 +90,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         _buildSystemDetector = buildSystemDetector;
         _serviceProvider = serviceProvider;
         _outputCoordinator = outputCoordinator;
+        _loggerControl = loggerControl;
         _unattributedBuffer = new ModuleOutputBuffer("Pipeline", typeof(void));
     }
 
@@ -326,7 +330,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     }
 
     /// <inheritdoc />
-    public void FlushModuleOutput()
+    public async Task FlushModuleOutputAsync()
     {
         // Output is now flushed immediately when modules complete.
         // This method remains for API compatibility but only flushes
@@ -342,7 +346,9 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         if (_unattributedBuffer.HasOutput)
         {
             var unattributedLogger = _outputLogger ?? _loggerFactory.CreateLogger("ModularPipelines.Output");
-            _unattributedBuffer.FlushTo(_originalConsoleOut, formatter, unattributedLogger);
+            await _unattributedBuffer
+                .FlushToAsync(_originalConsoleOut, formatter, unattributedLogger, _loggerControl)
+                .ConfigureAwait(false);
         }
     }
 
@@ -401,11 +407,11 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         {
             try
             {
-                FlushModuleOutput();
+                await FlushModuleOutputAsync().ConfigureAwait(false);
             }
             catch (InvalidOperationException)
             {
-                // Ignore if not installed - FlushModuleOutput requires installation
+                // Ignore if not installed - FlushModuleOutputAsync requires installation
             }
         }
 

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -129,18 +129,19 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                 _outputLogger = _loggerFactory.CreateLogger("ModularPipelines.Output");
 
                 // Install our intercepting writers
-                // Buffer output when progress is active AND we're not in the middle of flushing
+                // Buffer module output while the coordinated output phase is active. Flush paths
+                // write to the captured real console, so unrelated module output remains buffered.
                 _coordinatedOut = new CoordinatedTextWriter(
                     this,
                     _originalConsoleOut,
-                    () => _isProgressActive && !_outputCoordinator.IsFlushing,
+                    () => _isProgressActive,
                     _secretObfuscator,
                     _secretProvider);
 
                 _coordinatedError = new CoordinatedTextWriter(
                     this,
                     _originalConsoleError,
-                    () => _isProgressActive && !_outputCoordinator.IsFlushing,
+                    () => _isProgressActive,
                     _secretObfuscator,
                     _secretProvider);
 

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -27,7 +27,6 @@ namespace ModularPipelines.Console;
 [ExcludeFromCodeCoverage]
 internal class CoordinatedTextWriter : TextWriter
 {
-    private static readonly object UnattributedContext = new();
     private static readonly AsyncLocal<bool> DirectWriteScope = new();
 
     private readonly IConsoleCoordinator _coordinator;
@@ -35,7 +34,7 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly Func<bool> _shouldBuffer;
     private readonly ISecretObfuscator _secretObfuscator;
     private readonly ISecretProvider _secretProvider;
-    private readonly Dictionary<object, LineBufferState> _lineBuffers = [];
+    private readonly Dictionary<LineBufferKey, LineBufferState> _lineBuffers = [];
     private readonly object _lineBufferLock = new();
 
     /// <summary>
@@ -142,7 +141,7 @@ internal class CoordinatedTextWriter : TextWriter
     private LineBufferState GetLineBufferState()
     {
         var moduleType = ModuleLogger.CurrentModuleType.Value;
-        var key = (object?) moduleType ?? UnattributedContext;
+        var key = new LineBufferKey(moduleType, DirectWriteScope.Value);
 
         if (!_lineBuffers.TryGetValue(key, out var state))
         {
@@ -391,6 +390,8 @@ internal class CoordinatedTextWriter : TextWriter
 
         public bool? ShouldBuffer { get; set; }
     }
+
+    private readonly record struct LineBufferKey(Type? ModuleType, bool IsDirectWrite);
 
     private sealed class DirectWriteScopeRestorer(bool previousValue) : IDisposable
     {

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -28,6 +28,7 @@ namespace ModularPipelines.Console;
 internal class CoordinatedTextWriter : TextWriter
 {
     private static readonly object UnattributedContext = new();
+    private static readonly AsyncLocal<bool> DirectWriteScope = new();
 
     private readonly IConsoleCoordinator _coordinator;
     private readonly TextWriter _realConsole;
@@ -125,7 +126,7 @@ internal class CoordinatedTextWriter : TextWriter
     private void WriteCore(string value, bool appendNewLine)
     {
         var state = GetLineBufferState();
-        var shouldBuffer = GetBufferMode(state, _shouldBuffer());
+        var shouldBuffer = GetBufferMode(state, ShouldBuffer());
         state.Buffer.Append(value);
 
         if (appendNewLine)
@@ -343,7 +344,7 @@ internal class CoordinatedTextWriter : TextWriter
         {
             foreach (var state in _lineBuffers.Values.Where(state => state.Buffer.Length > 0))
             {
-                var shouldBuffer = state.ShouldBuffer ?? _shouldBuffer();
+                var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
                 ObfuscateCompletePatterns(state, GetSecretPatterns());
                 FlushSafePrefix(state, state.Buffer.Length, shouldBuffer);
                 FlushPartialLine(state, shouldBuffer);
@@ -373,6 +374,15 @@ internal class CoordinatedTextWriter : TextWriter
         base.Dispose(disposing);
     }
 
+    internal static IDisposable BeginDirectWrite()
+    {
+        var previousValue = DirectWriteScope.Value;
+        DirectWriteScope.Value = true;
+        return new DirectWriteScopeRestorer(previousValue);
+    }
+
+    private bool ShouldBuffer() => !DirectWriteScope.Value && _shouldBuffer();
+
     private sealed class LineBufferState(Type? moduleType)
     {
         public Type? ModuleType { get; } = moduleType;
@@ -380,5 +390,13 @@ internal class CoordinatedTextWriter : TextWriter
         public StringBuilder Buffer { get; } = new();
 
         public bool? ShouldBuffer { get; set; }
+    }
+
+    private sealed class DirectWriteScopeRestorer(bool previousValue) : IDisposable
+    {
+        public void Dispose()
+        {
+            DirectWriteScope.Value = previousValue;
+        }
     }
 }

--- a/src/ModularPipelines/Console/IConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/IConsoleCoordinator.cs
@@ -17,7 +17,7 @@ namespace ModularPipelines.Console;
 /// 2. BeginProgressAsync() - Starts progress display phase
 /// 3. [Pipeline executes] - All output buffered per-module
 /// 4. ProgressSession disposed - Ends progress phase
-/// 5. FlushModuleOutput() - Writes buffered output in order
+/// 5. FlushModuleOutputAsync() - Writes buffered output in order
 /// 6. WriteResults() - Prints results table
 /// 7. WriteExceptions() - Prints deferred exceptions
 /// 8. Uninstall() - Restores original console
@@ -81,7 +81,7 @@ internal interface IConsoleCoordinator : IAsyncDisposable
     /// Flushes any remaining unattributed output.
     /// Module output is flushed immediately when modules complete.
     /// </summary>
-    void FlushModuleOutput();
+    Task FlushModuleOutputAsync();
 
     /// <summary>
     /// Writes the pipeline results table.

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -1,3 +1,4 @@
+using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 
@@ -67,5 +68,10 @@ internal interface IModuleOutputBuffer
     /// <param name="console">The console to write to.</param>
     /// <param name="formatter">The CI-specific formatter for log groups.</param>
     /// <param name="logger">The logger for structured log output.</param>
-    void FlushTo(TextWriter console, IBuildSystemFormatter formatter, ILogger logger);
+    /// <param name="loggerControl">Coordinates queued log rendering with direct console writes.</param>
+    Task FlushToAsync(
+        TextWriter console,
+        IBuildSystemFormatter formatter,
+        ILogger logger,
+        ISpectreConsoleLoggerControl loggerControl);
 }

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -68,10 +68,12 @@ internal interface IModuleOutputBuffer
     /// <param name="console">The console to write to.</param>
     /// <param name="formatter">The CI-specific formatter for log groups.</param>
     /// <param name="logger">The logger for structured log output.</param>
-    /// <param name="loggerControl">Coordinates queued log rendering with direct console writes.</param>
+    /// <param name="loggerControl">Coordinates log rendering with direct console writes.</param>
+    /// <param name="cancellationToken">Cancellation token for the flush operation.</param>
     Task FlushToAsync(
         TextWriter console,
         IBuildSystemFormatter formatter,
         ILogger logger,
-        ISpectreConsoleLoggerControl loggerControl);
+        ISpectreConsoleLoggerControl loggerControl,
+        CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Console/IOutputCoordinator.cs
+++ b/src/ModularPipelines/Console/IOutputCoordinator.cs
@@ -7,12 +7,6 @@ namespace ModularPipelines.Console;
 internal interface IOutputCoordinator
 {
     /// <summary>
-    /// Gets whether output flushing is currently in progress.
-    /// When true, console writes should bypass buffering and go directly to the real console.
-    /// </summary>
-    bool IsFlushing { get; }
-
-    /// <summary>
     /// Sets the progress controller for pause/resume coordination.
     /// Must be called before any modules complete.
     /// </summary>

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -187,7 +187,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 }
             }
         }
-        catch (OperationCanceledException)
+        catch
         {
             RestoreUnrenderedOutputs(outputs, renderedCount);
             throw;

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -3,6 +3,7 @@ using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 using ModularPipelines.Helpers;
+using Spectre.Console;
 
 namespace ModularPipelines.Console;
 
@@ -121,12 +122,14 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             exception = _exception;
         }
 
+        var directConsole = CreateDirectConsole(console);
+
         // Write section header (CI group start)
         var header = FormatHeader(exception);
         var startCommand = formatter.GetStartBlockCommand(header);
         if (startCommand != null)
         {
-            WriteDirect(console, loggerControl.SynchronizationLock, startCommand);
+            WriteDirect(directConsole, console, loggerControl.SynchronizationLock, startCommand);
         }
 
         // Write all buffered output
@@ -143,7 +146,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                     hasPendingLogEvents = false;
                 }
 
-                WriteDirect(console, loggerControl.SynchronizationLock, output.StringValue);
+                WriteDirect(directConsole, console, loggerControl.SynchronizationLock, output.StringValue);
             }
             else if (output.LogEvent.HasValue)
             {
@@ -188,7 +191,22 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         return $"{_moduleName} \u2713 ({durationText})";
     }
 
-    private static void WriteDirect(TextWriter console, object synchronizationLock, string? value)
+    private static IAnsiConsole CreateDirectConsole(TextWriter writer)
+    {
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(writer),
+        });
+        console.Profile.Width = AnsiConsole.Profile.Width;
+        console.Profile.Capabilities = AnsiConsole.Profile.Capabilities;
+        return console;
+    }
+
+    private static void WriteDirect(
+        IAnsiConsole directConsole,
+        TextWriter console,
+        object synchronizationLock,
+        string? value)
     {
         if (string.IsNullOrEmpty(value))
         {
@@ -197,7 +215,15 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         lock (synchronizationLock)
         {
-            console.WriteLine(value);
+            try
+            {
+                directConsole.MarkupLine(value);
+            }
+            catch (Exception)
+            {
+                // CI workflow commands and arbitrary output can contain brackets that are not Spectre markup.
+                console.WriteLine(value);
+            }
         }
     }
 }

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -101,11 +101,12 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     /// <inheritdoc />
-    public async Task FlushToAsync(
+    public Task FlushToAsync(
         TextWriter console,
         IBuildSystemFormatter formatter,
         ILogger logger,
-        ISpectreConsoleLoggerControl loggerControl)
+        ISpectreConsoleLoggerControl loggerControl,
+        CancellationToken cancellationToken = default)
     {
         List<BufferedOutput> outputs;
         Exception? exception;
@@ -114,7 +115,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             if (_outputs.Count == 0)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             outputs = new List<BufferedOutput>(_outputs);
@@ -124,50 +125,41 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         var directConsole = CreateDirectConsole(console);
 
-        // Write section header (CI group start)
-        var header = FormatHeader(exception);
-        var startCommand = formatter.GetStartBlockCommand(header);
-        if (startCommand != null)
-        {
-            WriteDirect(directConsole, console, loggerControl.SynchronizationLock, startCommand);
-        }
-
-        // Write all buffered output
-        // Log events go to the logger which handles both console (via SpectreConsole) and file output
-        // String output (from Console.WriteLine interception) goes directly to console
-        var hasPendingLogEvents = false;
-        foreach (var output in outputs)
-        {
-            if (output.IsString)
-            {
-                if (hasPendingLogEvents)
-                {
-                    await loggerControl.FlushAsync().ConfigureAwait(false);
-                    hasPendingLogEvents = false;
-                }
-
-                WriteDirect(directConsole, console, loggerControl.SynchronizationLock, output.StringValue);
-            }
-            else if (output.LogEvent.HasValue)
-            {
-                var logEvent = output.LogEvent.Value;
-
-                // Write to logger - this handles console output (via SpectreConsole) and file loggers
-                logger.Log(logEvent.Level, logEvent.EventId, logEvent.State, logEvent.Exception,
-                    (state, ex) => logEvent.Formatter(state, ex));
-                hasPendingLogEvents = true;
-            }
-        }
-
-        if (hasPendingLogEvents)
-        {
-            await loggerControl.FlushAsync().ConfigureAwait(false);
-        }
-
-        // Write section footer (CI group end)
-        var endCommand = formatter.GetEndBlockCommand(header);
         lock (loggerControl.SynchronizationLock)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Keep the synchronization gate for the complete group. MEL.Spectre uses
+            // synchronous rendering, so unrelated logger calls cannot enter this group.
+            var header = FormatHeader(exception);
+            var startCommand = formatter.GetStartBlockCommand(header);
+            if (startCommand != null)
+            {
+                WriteDirect(directConsole, console, startCommand);
+            }
+
+            foreach (var output in outputs)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (output.IsString)
+                {
+                    WriteDirect(directConsole, console, output.StringValue);
+                }
+                else if (output.LogEvent.HasValue)
+                {
+                    var logEvent = output.LogEvent.Value;
+
+                    // Synchronous MEL.Spectre rendering preserves this buffer's position
+                    // while other providers (for example file logging) still receive the event.
+                    logger.Log(logEvent.Level, logEvent.EventId, logEvent.State, logEvent.Exception,
+                        (state, ex) => logEvent.Formatter(state, ex));
+                }
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var endCommand = formatter.GetEndBlockCommand(header);
             if (endCommand != null)
             {
                 console.WriteLine(endCommand);
@@ -176,6 +168,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             // Add blank line between module sections for visual separation
             console.WriteLine();
         }
+
+        return Task.CompletedTask;
     }
 
     private string FormatHeader(Exception? exception)
@@ -205,7 +199,6 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private static void WriteDirect(
         IAnsiConsole directConsole,
         TextWriter console,
-        object synchronizationLock,
         string? value)
     {
         if (string.IsNullOrEmpty(value))
@@ -213,17 +206,14 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             return;
         }
 
-        lock (synchronizationLock)
+        try
         {
-            try
-            {
-                directConsole.MarkupLine(value);
-            }
-            catch (Exception)
-            {
-                // CI workflow commands and arbitrary output can contain brackets that are not Spectre markup.
-                console.WriteLine(value);
-            }
+            directConsole.MarkupLine(value);
+        }
+        catch (Exception)
+        {
+            // CI workflow commands and arbitrary output can contain brackets that are not Spectre markup.
+            console.WriteLine(value);
         }
     }
 }

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
+using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 using ModularPipelines.Helpers;
-using Spectre.Console;
 
 namespace ModularPipelines.Console;
 
@@ -100,7 +100,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     /// <inheritdoc />
-    public void FlushTo(TextWriter console, IBuildSystemFormatter formatter, ILogger logger)
+    public async Task FlushToAsync(
+        TextWriter console,
+        IBuildSystemFormatter formatter,
+        ILogger logger,
+        ISpectreConsoleLoggerControl loggerControl)
     {
         List<BufferedOutput> outputs;
         Exception? exception;
@@ -122,17 +126,24 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         var startCommand = formatter.GetStartBlockCommand(header);
         if (startCommand != null)
         {
-            WriteWithMarkup(startCommand);
+            WriteDirect(console, loggerControl.SynchronizationLock, startCommand);
         }
 
         // Write all buffered output
         // Log events go to the logger which handles both console (via SpectreConsole) and file output
         // String output (from Console.WriteLine interception) goes directly to console
+        var hasPendingLogEvents = false;
         foreach (var output in outputs)
         {
             if (output.IsString)
             {
-                WriteWithMarkup(output.StringValue);
+                if (hasPendingLogEvents)
+                {
+                    await loggerControl.FlushAsync().ConfigureAwait(false);
+                    hasPendingLogEvents = false;
+                }
+
+                WriteDirect(console, loggerControl.SynchronizationLock, output.StringValue);
             }
             else if (output.LogEvent.HasValue)
             {
@@ -141,18 +152,27 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 // Write to logger - this handles console output (via SpectreConsole) and file loggers
                 logger.Log(logEvent.Level, logEvent.EventId, logEvent.State, logEvent.Exception,
                     (state, ex) => logEvent.Formatter(state, ex));
+                hasPendingLogEvents = true;
             }
+        }
+
+        if (hasPendingLogEvents)
+        {
+            await loggerControl.FlushAsync().ConfigureAwait(false);
         }
 
         // Write section footer (CI group end)
         var endCommand = formatter.GetEndBlockCommand(header);
-        if (endCommand != null)
+        lock (loggerControl.SynchronizationLock)
         {
-            console.WriteLine(endCommand);
-        }
+            if (endCommand != null)
+            {
+                console.WriteLine(endCommand);
+            }
 
-        // Add blank line between module sections for visual separation
-        console.WriteLine();
+            // Add blank line between module sections for visual separation
+            console.WriteLine();
+        }
     }
 
     private string FormatHeader(Exception? exception)
@@ -168,22 +188,16 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         return $"{_moduleName} \u2713 ({durationText})";
     }
 
-    private static void WriteWithMarkup(string? value)
+    private static void WriteDirect(TextWriter console, object synchronizationLock, string? value)
     {
         if (string.IsNullOrEmpty(value))
         {
             return;
         }
 
-        try
+        lock (synchronizationLock)
         {
-            AnsiConsole.MarkupLine(value);
-        }
-        catch (Exception)
-        {
-            // Fall back to plain console output if markup parsing fails
-            // This handles CI formatters that use brackets in their syntax (e.g., ##[group])
-            System.Console.WriteLine(value);
+            console.WriteLine(value);
         }
     }
 }

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -124,52 +124,89 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
 
         var directConsole = CreateDirectConsole(console);
+        var renderedCount = 0;
 
-        lock (loggerControl.SynchronizationLock)
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Keep the synchronization gate for the complete group. MEL.Spectre uses
-            // synchronous rendering, so unrelated logger calls cannot enter this group.
-            var header = FormatHeader(exception);
-            var startCommand = formatter.GetStartBlockCommand(header);
-            if (startCommand != null)
+            lock (loggerControl.SynchronizationLock)
             {
-                WriteDirect(directConsole, console, startCommand);
-            }
+                var header = FormatHeader(exception);
+                var startCommand = formatter.GetStartBlockCommand(header);
+                var endCommand = formatter.GetEndBlockCommand(header);
+                var groupStarted = false;
+                var flushCompleted = false;
 
-            foreach (var output in outputs)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                if (output.IsString)
+                try
                 {
-                    WriteDirect(directConsole, console, output.StringValue);
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    // Keep the synchronization gate for the complete group. MEL.Spectre uses
+                    // synchronous rendering, so unrelated logger calls cannot enter this group.
+                    if (startCommand != null)
+                    {
+                        WriteDirect(directConsole, console, startCommand);
+                        groupStarted = true;
+                    }
+
+                    foreach (var output in outputs)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+
+                        if (output.IsString)
+                        {
+                            WriteDirect(directConsole, console, output.StringValue);
+                        }
+                        else if (output.LogEvent.HasValue)
+                        {
+                            var logEvent = output.LogEvent.Value;
+
+                            // Synchronous MEL.Spectre rendering preserves this buffer's position
+                            // while other providers (for example file logging) still receive the event.
+                            logger.Log(logEvent.Level, logEvent.EventId, logEvent.State, logEvent.Exception,
+                                (state, ex) => logEvent.Formatter(state, ex));
+                        }
+
+                        renderedCount++;
+                    }
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    flushCompleted = true;
                 }
-                else if (output.LogEvent.HasValue)
+                finally
                 {
-                    var logEvent = output.LogEvent.Value;
+                    if (groupStarted && endCommand != null)
+                    {
+                        console.WriteLine(endCommand);
+                    }
 
-                    // Synchronous MEL.Spectre rendering preserves this buffer's position
-                    // while other providers (for example file logging) still receive the event.
-                    logger.Log(logEvent.Level, logEvent.EventId, logEvent.State, logEvent.Exception,
-                        (state, ex) => logEvent.Formatter(state, ex));
+                    if (groupStarted || flushCompleted)
+                    {
+                        // Add blank line between module sections for visual separation.
+                        console.WriteLine();
+                    }
                 }
             }
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var endCommand = formatter.GetEndBlockCommand(header);
-            if (endCommand != null)
-            {
-                console.WriteLine(endCommand);
-            }
-
-            // Add blank line between module sections for visual separation
-            console.WriteLine();
+        }
+        catch (OperationCanceledException)
+        {
+            RestoreUnrenderedOutputs(outputs, renderedCount);
+            throw;
         }
 
         return Task.CompletedTask;
+    }
+
+    private void RestoreUnrenderedOutputs(List<BufferedOutput> outputs, int renderedCount)
+    {
+        if (renderedCount >= outputs.Count)
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            _outputs.InsertRange(0, outputs.Skip(renderedCount));
+        }
     }
 
     private string FormatHeader(Exception? exception)

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -128,7 +128,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         try
         {
-            lock (loggerControl.SynchronizationLock)
+            var synchronizationLock = loggerControl.SynchronizationLock;
+            EnterSynchronizationLock(synchronizationLock, cancellationToken);
+            try
             {
                 var header = FormatHeader(exception);
                 var startCommand = formatter.GetStartBlockCommand(header);
@@ -186,6 +188,10 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                     }
                 }
             }
+            finally
+            {
+                Monitor.Exit(synchronizationLock);
+            }
         }
         catch
         {
@@ -194,6 +200,17 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
 
         return Task.CompletedTask;
+    }
+
+    private static void EnterSynchronizationLock(
+        object synchronizationLock,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        while (!Monitor.TryEnter(synchronizationLock, millisecondsTimeout: 50))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+        }
     }
 
     private void RestoreUnrenderedOutputs(List<BufferedOutput> outputs, int renderedCount)

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -144,7 +144,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                     break;
                 }
 
-                await FlushBufferAsync(output.Buffer, formatter).ConfigureAwait(false);
+                await FlushBufferAsync(output.Buffer, formatter, cancellationToken).ConfigureAwait(false);
             }
         }
         finally
@@ -218,7 +218,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                     await _progressController.PauseAsync().ConfigureAwait(false);
                     try
                     {
-                        await FlushBufferAsync(pending.Buffer, formatter).ConfigureAwait(false);
+                        await FlushBufferAsync(pending.Buffer, formatter, cancellationToken).ConfigureAwait(false);
                     }
                     finally
                     {
@@ -245,13 +245,16 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         }
     }
 
-    private Task FlushBufferAsync(IModuleOutputBuffer buffer, IBuildSystemFormatter formatter)
+    private Task FlushBufferAsync(
+        IModuleOutputBuffer buffer,
+        IBuildSystemFormatter formatter,
+        CancellationToken cancellationToken)
     {
         var loggerType = typeof(ILogger<>).MakeGenericType(buffer.ModuleType);
         var moduleLogger = (ILogger)_serviceProvider.GetService(loggerType)
                            ?? _loggerFactory.CreateLogger(buffer.ModuleType);
 
-        return buffer.FlushToAsync(_console, formatter, moduleLogger, _loggerControl);
+        return buffer.FlushToAsync(_console, formatter, moduleLogger, _loggerControl, cancellationToken);
     }
 
     private sealed class PendingFlush

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -151,7 +151,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                     .ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException)
+        catch
         {
             lock (_deferredLock)
             {

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 
@@ -15,6 +16,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger _logger;
     private readonly TextWriter _console;
+    private readonly ISpectreConsoleLoggerControl _loggerControl;
 
     private readonly object _queueLock = new();
     private readonly Queue<PendingFlush> _pendingQueue = new();
@@ -39,11 +41,13 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     public OutputCoordinator(
         IBuildSystemFormatterProvider formatterProvider,
         ILoggerFactory loggerFactory,
-        IServiceProvider serviceProvider)
+        IServiceProvider serviceProvider,
+        ISpectreConsoleLoggerControl loggerControl)
     {
         _formatterProvider = formatterProvider ?? throw new ArgumentNullException(nameof(formatterProvider));
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        _loggerControl = loggerControl ?? throw new ArgumentNullException(nameof(loggerControl));
         _logger = loggerFactory.CreateLogger<OutputCoordinator>();
         _console = System.Console.Out;
     }
@@ -147,7 +151,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                         break;
                     }
 
-                    FlushBuffer(output.Buffer, formatter);
+                    await FlushBufferAsync(output.Buffer, formatter).ConfigureAwait(false);
                 }
             }
             finally
@@ -227,7 +231,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                     _isFlushingOutput = true;
                     try
                     {
-                        FlushBuffer(pending.Buffer, formatter);
+                        await FlushBufferAsync(pending.Buffer, formatter).ConfigureAwait(false);
                     }
                     finally
                     {
@@ -255,13 +259,13 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         }
     }
 
-    private void FlushBuffer(IModuleOutputBuffer buffer, IBuildSystemFormatter formatter)
+    private Task FlushBufferAsync(IModuleOutputBuffer buffer, IBuildSystemFormatter formatter)
     {
         var loggerType = typeof(ILogger<>).MakeGenericType(buffer.ModuleType);
         var moduleLogger = (ILogger)_serviceProvider.GetService(loggerType)
                            ?? _loggerFactory.CreateLogger(buffer.ModuleType);
 
-        buffer.FlushTo(_console, formatter, moduleLogger);
+        return buffer.FlushToAsync(_console, formatter, moduleLogger, _loggerControl);
     }
 
     private sealed class PendingFlush

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -11,6 +11,8 @@ namespace ModularPipelines.Console;
 [ExcludeFromCodeCoverage]
 internal sealed class OutputCoordinator : IOutputCoordinator
 {
+    private const int MaxFlushAttempts = 2;
+
     private readonly IBuildSystemFormatterProvider _formatterProvider;
     private readonly ILoggerFactory _loggerFactory;
     private readonly IServiceProvider _serviceProvider;
@@ -247,28 +249,26 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     {
         try
         {
-            var cancellationToken = pending.CancellationToken;
-            cancellationToken.ThrowIfCancellationRequested();
-
-            await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-            try
+            for (var attempt = 1; attempt <= MaxFlushAttempts; attempt++)
             {
-                await _progressController.PauseAsync().ConfigureAwait(false);
                 try
                 {
-                    await FlushBufferAsync(pending.Buffer, formatter, cancellationToken).ConfigureAwait(false);
+                    await FlushPendingOnceAsync(pending, formatter).ConfigureAwait(false);
+                    pending.CompletionSource.TrySetResult();
+                    return;
                 }
-                finally
+                catch (OperationCanceledException)
                 {
-                    await _progressController.ResumeAsync().ConfigureAwait(false);
+                    throw;
+                }
+                catch (Exception ex) when (attempt < MaxFlushAttempts)
+                {
+                    _logger.LogWarning(
+                        ex,
+                        "Failed to flush output for {ModuleType}; retrying",
+                        pending.Buffer.ModuleType.Name);
                 }
             }
-            finally
-            {
-                _writeLock.Release();
-            }
-
-            pending.CompletionSource.TrySetResult();
         }
         catch (OperationCanceledException ex)
         {
@@ -276,9 +276,32 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         }
         catch (Exception ex)
         {
-            // Log error but don't fail - module execution already succeeded
             _logger.LogError(ex, "Failed to flush output for {ModuleType}", pending.Buffer.ModuleType.Name);
-            pending.CompletionSource.TrySetResult();
+            pending.CompletionSource.TrySetException(ex);
+        }
+    }
+
+    private async Task FlushPendingOnceAsync(PendingFlush pending, IBuildSystemFormatter formatter)
+    {
+        var cancellationToken = pending.CancellationToken;
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _progressController.PauseAsync().ConfigureAwait(false);
+            try
+            {
+                await FlushBufferAsync(pending.Buffer, formatter, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                await _progressController.ResumeAsync().ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            _writeLock.Release();
         }
     }
 

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -192,11 +192,11 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
         if (shouldProcess)
         {
-            await ProcessQueueAsync().ConfigureAwait(false);
+            _ = ProcessQueueAsync();
         }
 
-        // Every caller observes the outcome of its own buffer. The caller that starts
-        // queue processing must not mistake a canceled flush for successful drainage.
+        // Every caller observes only the outcome of its own buffer. Queue processing
+        // continues independently so the owner is not held behind later buffers.
         await pending.CompletionSource.Task.ConfigureAwait(false);
     }
 

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -192,7 +192,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
         if (shouldProcess)
         {
-            _ = ProcessQueueAsync();
+            ScheduleQueueProcessing();
         }
 
         // Every caller observes only the outcome of its own buffer. Queue processing
@@ -225,9 +225,14 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         {
             if (ReleaseQueueOwnership())
             {
-                _ = ProcessQueueAsync();
+                ScheduleQueueProcessing();
             }
         }
+    }
+
+    private void ScheduleQueueProcessing()
+    {
+        _ = Task.Run(ProcessQueueAsync);
     }
 
     private PendingFlush? DequeuePendingFlush()

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -151,12 +151,18 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                     .ConfigureAwait(false);
             }
         }
+        catch (OperationCanceledException)
+        {
+            RequeueDeferredOutputs(toFlush.Skip(nextOutputIndex));
+
+            throw;
+        }
         catch
         {
-            lock (_deferredLock)
-            {
-                _deferredOutputs.InsertRange(0, toFlush.Skip(nextOutputIndex));
-            }
+            // A sink may have accepted part of the current buffer before throwing.
+            // Retrying that buffer could duplicate delivered output, so only retain
+            // buffers that have not started rendering.
+            RequeueDeferredOutputs(toFlush.Skip(nextOutputIndex + 1));
 
             throw;
         }
@@ -216,7 +222,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         {
             foreach (var pending in DrainPendingFlushes())
             {
-                pending.CompletionSource.TrySetResult();
+                pending.CompletionSource.TrySetException(ex);
             }
 
             _logger.LogError(ex, "Output queue processing terminated unexpectedly");
@@ -296,6 +302,14 @@ internal sealed class OutputCoordinator : IOutputCoordinator
             var pending = _pendingQueue.ToArray();
             _pendingQueue.Clear();
             return pending;
+        }
+    }
+
+    private void RequeueDeferredOutputs(IEnumerable<DeferredModuleOutput> outputs)
+    {
+        lock (_deferredLock)
+        {
+            _deferredOutputs.InsertRange(0, outputs);
         }
     }
 

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -203,6 +203,8 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
         // Every caller observes only the outcome of its own buffer. Queue processing
         // continues independently so the owner is not held behind later buffers.
+        using var cancellationRegistration = cancellationToken.Register(
+            () => pending.CompletionSource.TrySetCanceled(cancellationToken));
         await pending.CompletionSource.Task.ConfigureAwait(false);
     }
 

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -11,8 +11,6 @@ namespace ModularPipelines.Console;
 [ExcludeFromCodeCoverage]
 internal sealed class OutputCoordinator : IOutputCoordinator
 {
-    private const int MaxFlushAttempts = 2;
-
     private readonly IBuildSystemFormatterProvider _formatterProvider;
     private readonly ILoggerFactory _loggerFactory;
     private readonly IServiceProvider _serviceProvider;
@@ -249,26 +247,12 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     {
         try
         {
-            for (var attempt = 1; attempt <= MaxFlushAttempts; attempt++)
-            {
-                try
-                {
-                    await FlushPendingOnceAsync(pending, formatter).ConfigureAwait(false);
-                    pending.CompletionSource.TrySetResult();
-                    return;
-                }
-                catch (OperationCanceledException)
-                {
-                    throw;
-                }
-                catch (Exception ex) when (attempt < MaxFlushAttempts)
-                {
-                    _logger.LogWarning(
-                        ex,
-                        "Failed to flush output for {ModuleType}; retrying",
-                        pending.Buffer.ModuleType.Name);
-                }
-            }
+            // Output sinks are not transactional. A provider can deliver an event and
+            // then throw, so retrying here could duplicate output already accepted by
+            // that provider. Preserve the buffer's unrendered tail and surface failure
+            // to the caller instead.
+            await FlushPendingOnceAsync(pending, formatter).ConfigureAwait(false);
+            pending.CompletionSource.TrySetResult();
         }
         catch (OperationCanceledException ex)
         {
@@ -336,7 +320,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         CancellationToken cancellationToken)
     {
         var loggerType = typeof(ILogger<>).MakeGenericType(buffer.ModuleType);
-        var moduleLogger = (ILogger)_serviceProvider.GetService(loggerType)
+        var moduleLogger = (ILogger) _serviceProvider.GetService(loggerType)
                            ?? _loggerFactory.CreateLogger(buffer.ModuleType);
 
         using var directWrite = CoordinatedTextWriter.BeginDirectWrite();
@@ -348,7 +332,9 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     private sealed class PendingFlush
     {
         public IModuleOutputBuffer Buffer { get; }
+
         public CancellationToken CancellationToken { get; }
+
         public TaskCompletionSource CompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public PendingFlush(IModuleOutputBuffer buffer, CancellationToken cancellationToken)

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -202,62 +202,103 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
     private async Task ProcessQueueAsync()
     {
-        var formatter = _formatterProvider.GetFormatter();
-
-        while (true)
+        try
         {
+            var formatter = _formatterProvider.GetFormatter();
             PendingFlush? pending;
 
-            lock (_queueLock)
+            while ((pending = DequeuePendingFlush()) is not null)
             {
-                if (_pendingQueue.Count == 0)
-                {
-                    _isProcessingQueue = false;
-                    return;
-                }
-
-                pending = _pendingQueue.Dequeue();
+                await ProcessPendingFlushAsync(pending, formatter).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            foreach (var pending in DrainPendingFlushes())
+            {
+                pending.CompletionSource.TrySetResult();
             }
 
+            _logger.LogError(ex, "Output queue processing terminated unexpectedly");
+        }
+        finally
+        {
+            if (ReleaseQueueOwnership())
+            {
+                _ = ProcessQueueAsync();
+            }
+        }
+    }
+
+    private PendingFlush? DequeuePendingFlush()
+    {
+        lock (_queueLock)
+        {
+            return _pendingQueue.Count == 0 ? null : _pendingQueue.Dequeue();
+        }
+    }
+
+    private async Task ProcessPendingFlushAsync(PendingFlush pending, IBuildSystemFormatter formatter)
+    {
+        try
+        {
+            var cancellationToken = pending.CancellationToken;
+            cancellationToken.ThrowIfCancellationRequested();
+
+            await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                var cancellationToken = pending.CancellationToken;
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    pending.CompletionSource.TrySetCanceled(cancellationToken);
-                    continue;
-                }
-
-                await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+                await _progressController.PauseAsync().ConfigureAwait(false);
                 try
                 {
-                    await _progressController.PauseAsync().ConfigureAwait(false);
-                    try
-                    {
-                        await FlushBufferAsync(pending.Buffer, formatter, cancellationToken).ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        await _progressController.ResumeAsync().ConfigureAwait(false);
-                    }
+                    await FlushBufferAsync(pending.Buffer, formatter, cancellationToken).ConfigureAwait(false);
                 }
                 finally
                 {
-                    _writeLock.Release();
+                    await _progressController.ResumeAsync().ConfigureAwait(false);
                 }
+            }
+            finally
+            {
+                _writeLock.Release();
+            }
 
-                pending.CompletionSource.TrySetResult();
-            }
-            catch (OperationCanceledException ex)
+            pending.CompletionSource.TrySetResult();
+        }
+        catch (OperationCanceledException ex)
+        {
+            pending.CompletionSource.TrySetCanceled(ex.CancellationToken);
+        }
+        catch (Exception ex)
+        {
+            // Log error but don't fail - module execution already succeeded
+            _logger.LogError(ex, "Failed to flush output for {ModuleType}", pending.Buffer.ModuleType.Name);
+            pending.CompletionSource.TrySetResult();
+        }
+    }
+
+    private PendingFlush[] DrainPendingFlushes()
+    {
+        lock (_queueLock)
+        {
+            var pending = _pendingQueue.ToArray();
+            _pendingQueue.Clear();
+            return pending;
+        }
+    }
+
+    private bool ReleaseQueueOwnership()
+    {
+        lock (_queueLock)
+        {
+            _isProcessingQueue = false;
+            if (_pendingQueue.Count == 0)
             {
-                pending.CompletionSource.TrySetCanceled(ex.CancellationToken);
+                return false;
             }
-            catch (Exception ex)
-            {
-                // Log error but don't fail - module execution already succeeded
-                _logger.LogError(ex, "Failed to flush output for {ModuleType}", pending.Buffer.ModuleType.Name);
-                pending.CompletionSource.TrySetResult();
-            }
+
+            _isProcessingQueue = true;
+            return true;
         }
     }
 

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -151,7 +151,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                     .ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             RequeueDeferredOutputs(toFlush.Skip(nextOutputIndex));
 

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -177,7 +177,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
             return;
         }
 
-        var pending = new PendingFlush(buffer);
+        var pending = new PendingFlush(buffer, cancellationToken);
         bool shouldProcess;
 
         lock (_queueLock)
@@ -192,7 +192,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
         if (shouldProcess)
         {
-            await ProcessQueueAsync(cancellationToken).ConfigureAwait(false);
+            await ProcessQueueAsync().ConfigureAwait(false);
         }
 
         // Every caller observes the outcome of its own buffer. The caller that starts
@@ -200,7 +200,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         await pending.CompletionSource.Task.ConfigureAwait(false);
     }
 
-    private async Task ProcessQueueAsync(CancellationToken cancellationToken)
+    private async Task ProcessQueueAsync()
     {
         var formatter = _formatterProvider.GetFormatter();
 
@@ -221,6 +221,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
             try
             {
+                var cancellationToken = pending.CancellationToken;
                 if (cancellationToken.IsCancellationRequested)
                 {
                     pending.CompletionSource.TrySetCanceled(cancellationToken);
@@ -278,11 +279,13 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     private sealed class PendingFlush
     {
         public IModuleOutputBuffer Buffer { get; }
+        public CancellationToken CancellationToken { get; }
         public TaskCompletionSource CompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public PendingFlush(IModuleOutputBuffer buffer)
+        public PendingFlush(IModuleOutputBuffer buffer, CancellationToken cancellationToken)
         {
             Buffer = buffer;
+            CancellationToken = cancellationToken;
         }
     }
 }

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -28,7 +28,6 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
     private IProgressController _progressController = NoOpProgressController.Instance;
     private bool _isProcessingQueue;
-    private volatile bool _isFlushingOutput;
     private volatile bool _isProgressActive;
     private readonly List<DeferredModuleOutput> _deferredOutputs = new();
 
@@ -51,9 +50,6 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         _logger = loggerFactory.CreateLogger<OutputCoordinator>();
         _console = System.Console.Out;
     }
-
-    /// <inheritdoc />
-    public bool IsFlushing => _isFlushingOutput;
 
     /// <inheritdoc />
     public void SetProgressController(IProgressController controller)
@@ -141,22 +137,14 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            _isFlushingOutput = true;
-            try
+            foreach (var output in toFlush)
             {
-                foreach (var output in toFlush)
+                if (cancellationToken.IsCancellationRequested)
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        break;
-                    }
-
-                    await FlushBufferAsync(output.Buffer, formatter).ConfigureAwait(false);
+                    break;
                 }
-            }
-            finally
-            {
-                _isFlushingOutput = false;
+
+                await FlushBufferAsync(output.Buffer, formatter).ConfigureAwait(false);
             }
         }
         finally
@@ -228,14 +216,12 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                 try
                 {
                     await _progressController.PauseAsync().ConfigureAwait(false);
-                    _isFlushingOutput = true;
                     try
                     {
                         await FlushBufferAsync(pending.Buffer, formatter).ConfigureAwait(false);
                     }
                     finally
                     {
-                        _isFlushingOutput = false;
                         await _progressController.ResumeAsync().ConfigureAwait(false);
                     }
                 }

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -194,11 +194,10 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         {
             await ProcessQueueAsync(cancellationToken).ConfigureAwait(false);
         }
-        else
-        {
-            // Wait for our buffer to be flushed by the current flusher
-            await pending.CompletionSource.Task.ConfigureAwait(false);
-        }
+
+        // Every caller observes the outcome of its own buffer. The caller that starts
+        // queue processing must not mistake a canceled flush for successful drainage.
+        await pending.CompletionSource.Task.ConfigureAwait(false);
     }
 
     private async Task ProcessQueueAsync(CancellationToken cancellationToken)

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -134,22 +134,38 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
         var formatter = _formatterProvider.GetFormatter();
 
-        await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var nextOutputIndex = 0;
+        var lockTaken = false;
         try
         {
-            foreach (var output in toFlush)
-            {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    break;
-                }
+            await _writeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            lockTaken = true;
 
-                await FlushBufferAsync(output.Buffer, formatter, cancellationToken).ConfigureAwait(false);
+            for (; nextOutputIndex < toFlush.Count; nextOutputIndex++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await FlushBufferAsync(
+                        toFlush[nextOutputIndex].Buffer,
+                        formatter,
+                        cancellationToken)
+                    .ConfigureAwait(false);
             }
+        }
+        catch (OperationCanceledException)
+        {
+            lock (_deferredLock)
+            {
+                _deferredOutputs.InsertRange(0, toFlush.Skip(nextOutputIndex));
+            }
+
+            throw;
         }
         finally
         {
-            _writeLock.Release();
+            if (lockTaken)
+            {
+                _writeLock.Release();
+            }
         }
     }
 
@@ -245,7 +261,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         }
     }
 
-    private Task FlushBufferAsync(
+    private async Task FlushBufferAsync(
         IModuleOutputBuffer buffer,
         IBuildSystemFormatter formatter,
         CancellationToken cancellationToken)
@@ -254,7 +270,10 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         var moduleLogger = (ILogger)_serviceProvider.GetService(loggerType)
                            ?? _loggerFactory.CreateLogger(buffer.ModuleType);
 
-        return buffer.FlushToAsync(_console, formatter, moduleLogger, _loggerControl, cancellationToken);
+        using var directWrite = CoordinatedTextWriter.BeginDirectWrite();
+        await buffer
+            .FlushToAsync(_console, formatter, moduleLogger, _loggerControl, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private sealed class PendingFlush

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -110,6 +110,7 @@ internal static class DependencyInjectionSetup
                 placeholders.ForName("CommandOutput", Style.Plain);
                 placeholders.ForName("CommandError", Style.Plain);
             });
+        config.WriteMode = WriteMode.Synchronous;
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Engine.Executors;
 /// 2. Progress - Show progress display while buffering module output
 /// 3. Flush - End progress and flush buffered output
 /// 4. Results - Print results table
-/// 5. Exceptions - Print deferred exceptions
+/// 5. Exceptions - Print deferred exceptions.
 /// </para>
 /// </remarks>
 internal class PipelineOutputCoordinator : IPipelineOutputCoordinator

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -122,7 +122,7 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
             await _outputCoordinator.FlushDeferredAsync().ConfigureAwait(false);
 
             // 5. Flush any unattributed output from coordinator.
-            _consoleCoordinator.FlushModuleOutput();
+            await _consoleCoordinator.FlushModuleOutputAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/ModularPipelines/Plugins/PluginRegistry.cs
+++ b/src/ModularPipelines/Plugins/PluginRegistry.cs
@@ -8,6 +8,7 @@ public static class PluginRegistry
 {
     private static readonly object Lock = new();
     private static readonly List<IModularPipelinesPlugin> Registered = [];
+    private static readonly AsyncLocal<List<IModularPipelinesPlugin>?> IsolatedRegistry = new();
 
     /// <summary>
     /// Gets all registered plugins, ordered by priority (ascending).
@@ -18,7 +19,7 @@ public static class PluginRegistry
         {
             lock (Lock)
             {
-                return Registered.OrderBy(p => p.Priority).ToList();
+                return GetActiveRegistry().OrderBy(p => p.Priority).ToList();
             }
         }
     }
@@ -34,12 +35,13 @@ public static class PluginRegistry
 
         lock (Lock)
         {
-            if (Registered.Any(p => p.Name == plugin.Name))
+            var registry = GetActiveRegistry();
+            if (registry.Any(p => p.Name == plugin.Name))
             {
                 throw new InvalidOperationException($"Plugin '{plugin.Name}' is already registered.");
             }
 
-            Registered.Add(plugin);
+            registry.Add(plugin);
         }
     }
 
@@ -50,7 +52,25 @@ public static class PluginRegistry
     {
         lock (Lock)
         {
-            Registered.Clear();
+            GetActiveRegistry().Clear();
+        }
+    }
+
+    internal static IDisposable BeginIsolatedScope()
+    {
+        var previousRegistry = IsolatedRegistry.Value;
+        IsolatedRegistry.Value = [];
+        return new IsolatedRegistryScope(previousRegistry);
+    }
+
+    private static List<IModularPipelinesPlugin> GetActiveRegistry() =>
+        IsolatedRegistry.Value ?? Registered;
+
+    private sealed class IsolatedRegistryScope(List<IModularPipelinesPlugin>? previousRegistry) : IDisposable
+    {
+        public void Dispose()
+        {
+            IsolatedRegistry.Value = previousRegistry;
         }
     }
 }

--- a/src/ModularPipelines/Plugins/PluginTestHelper.cs
+++ b/src/ModularPipelines/Plugins/PluginTestHelper.cs
@@ -6,8 +6,8 @@ namespace ModularPipelines.Plugins;
 public static class PluginTestHelper
 {
     /// <summary>
-    /// Creates an isolated plugin registry scope for testing.
-    /// Clears all registered plugins and restores them when disposed.
+    /// Creates an execution-context-local plugin registry scope for testing.
+    /// The empty isolated registry is replaced with the previous context when disposed.
     /// </summary>
     /// <returns>A disposable scope that restores the original plugins when disposed.</returns>
     /// <example>
@@ -22,29 +22,5 @@ public static class PluginTestHelper
     /// }
     /// </code>
     /// </example>
-    public static IDisposable IsolatedRegistry()
-    {
-        var snapshot = PluginRegistry.Plugins.ToList();
-        PluginRegistry.Clear();
-        return new RegistryRestorer(snapshot);
-    }
-
-    private sealed class RegistryRestorer : IDisposable
-    {
-        private readonly List<IModularPipelinesPlugin> _snapshot;
-
-        public RegistryRestorer(List<IModularPipelinesPlugin> snapshot)
-        {
-            _snapshot = snapshot;
-        }
-
-        public void Dispose()
-        {
-            PluginRegistry.Clear();
-            foreach (var plugin in _snapshot)
-            {
-                PluginRegistry.Register(plugin);
-            }
-        }
-    }
+    public static IDisposable IsolatedRegistry() => PluginRegistry.BeginIsolatedScope();
 }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -8,10 +8,10 @@ namespace ModularPipelines.UnitTests.Console;
 public class ModuleOutputBufferTests
 {
     [Test]
-    public async Task Flush_Waits_For_Queued_Logs_Before_Group_End()
+    public async Task Flush_Writes_Structured_Logs_Before_Group_End()
     {
         var writer = new StringWriter();
-        var loggerControl = new QueuedLoggerControl(writer);
+        var loggerControl = new SynchronousLoggerControl(writer);
         var buffer = CreateBufferWithStructuredLog();
 
         await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
@@ -25,10 +25,10 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
-    public async Task Flush_Waits_For_Queued_Logs_Before_Direct_Output_And_Group_End()
+    public async Task Flush_Preserves_Structured_And_Direct_Output_Order()
     {
         var writer = new StringWriter();
-        var loggerControl = new QueuedLoggerControl(writer);
+        var loggerControl = new SynchronousLoggerControl(writer);
         var buffer = CreateBufferWithStructuredLog();
         buffer.WriteLine("direct output");
 
@@ -50,7 +50,7 @@ public class ModuleOutputBufferTests
     public async Task Flush_Renders_Markup_For_Direct_Output()
     {
         var writer = new StringWriter();
-        var loggerControl = new QueuedLoggerControl(writer);
+        var loggerControl = new SynchronousLoggerControl(writer);
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
         buffer.WriteLine("[green]direct output[/]");
 
@@ -59,6 +59,60 @@ public class ModuleOutputBufferTests
         var output = writer.ToString();
         await Assert.That(output).Contains("direct output");
         await Assert.That(output).DoesNotContain("[green]");
+    }
+
+    [Test]
+    public async Task Flush_Keeps_Concurrent_Logs_Outside_Module_Group()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = CreateBufferWithStructuredLog();
+        Task? outsideLog = null;
+        using var gateAttemptCompleted = new ManualResetEventSlim();
+        loggerControl.AfterLog = () =>
+        {
+            outsideLog = Task.Run(() =>
+            {
+                if (!loggerControl.TryWrite("outside log", TimeSpan.FromMilliseconds(100)))
+                {
+                    gateAttemptCompleted.Set();
+                    loggerControl.Write("outside log");
+                }
+                else
+                {
+                    gateAttemptCompleted.Set();
+                }
+            });
+            gateAttemptCompleted.Wait();
+        };
+
+        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+        await outsideLog!;
+
+        var output = writer.ToString();
+        var groupEnd = output.IndexOf("::endgroup::", StringComparison.Ordinal);
+        var outside = output.IndexOf("outside log", StringComparison.Ordinal);
+
+        await Assert.That(groupEnd).IsGreaterThanOrEqualTo(0);
+        await Assert.That(outside).IsGreaterThan(groupEnd);
+    }
+
+    [Test]
+    public async Task Flush_Observes_Cancellation()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = CreateBufferWithStructuredLog();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await buffer.FlushToAsync(
+                writer,
+                new GitHubActionsFormatter(),
+                loggerControl,
+                loggerControl,
+                cancellationTokenSource.Token));
     }
 
     private static ModuleOutputBuffer CreateBufferWithStructuredLog()
@@ -73,11 +127,11 @@ public class ModuleOutputBufferTests
         return buffer;
     }
 
-    private sealed class QueuedLoggerControl(TextWriter writer) : ILogger, ISpectreConsoleLoggerControl
+    private sealed class SynchronousLoggerControl(TextWriter writer) : ILogger, ISpectreConsoleLoggerControl
     {
-        private readonly Queue<string> _pendingMessages = new();
-
         public object SynchronizationLock { get; } = new();
+
+        public Action? AfterLog { get; set; }
 
         public IDisposable? BeginScope<TState>(TState state)
             where TState : notnull
@@ -92,20 +146,36 @@ public class ModuleOutputBufferTests
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
-            _pendingMessages.Enqueue(formatter(state, exception));
+            Write(formatter(state, exception));
+            AfterLog?.Invoke();
         }
 
-        public Task FlushAsync(CancellationToken cancellationToken = default)
+        public void Write(string message)
         {
             lock (SynchronizationLock)
             {
-                while (_pendingMessages.TryDequeue(out var message))
-                {
-                    writer.WriteLine(message);
-                }
+                writer.WriteLine(message);
+            }
+        }
+
+        public bool TryWrite(string message, TimeSpan timeout)
+        {
+            if (!Monitor.TryEnter(SynchronizationLock, timeout))
+            {
+                return false;
             }
 
-            return Task.CompletedTask;
+            try
+            {
+                writer.WriteLine(message);
+                return true;
+            }
+            finally
+            {
+                Monitor.Exit(SynchronizationLock);
+            }
         }
+
+        public Task FlushAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -113,6 +113,37 @@ public class ModuleOutputBufferTests
                 loggerControl,
                 loggerControl,
                 cancellationTokenSource.Token));
+
+        await Assert.That(buffer.HasOutput).IsTrue();
+    }
+
+    [Test]
+    public async Task Flush_Cancellation_Closes_Group_And_Retains_Unrendered_Output()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = CreateBufferWithStructuredLog();
+        buffer.WriteLine("remaining output");
+        using var cancellationTokenSource = new CancellationTokenSource();
+        loggerControl.AfterLog = cancellationTokenSource.Cancel;
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await buffer.FlushToAsync(
+                writer,
+                new GitHubActionsFormatter(),
+                loggerControl,
+                loggerControl,
+                cancellationTokenSource.Token));
+
+        var cancelledOutput = writer.ToString();
+        await Assert.That(cancelledOutput.IndexOf("::endgroup::", StringComparison.Ordinal))
+            .IsGreaterThan(cancelledOutput.IndexOf("structured log", StringComparison.Ordinal));
+        await Assert.That(buffer.HasOutput).IsTrue();
+
+        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+
+        await Assert.That(writer.ToString()).Contains("remaining output");
+        await Assert.That(buffer.HasOutput).IsFalse();
     }
 
     private static ModuleOutputBuffer CreateBufferWithStructuredLog()

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -1,0 +1,96 @@
+using MEL.Spectre;
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Console;
+using ModularPipelines.Engine.BuildSystemFormatters;
+
+namespace ModularPipelines.UnitTests.Console;
+
+public class ModuleOutputBufferTests
+{
+    [Test]
+    public async Task Flush_Waits_For_Queued_Logs_Before_Group_End()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new QueuedLoggerControl(writer);
+        var buffer = CreateBufferWithStructuredLog();
+
+        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+
+        var output = writer.ToString();
+        var structuredLog = output.IndexOf("structured log", StringComparison.Ordinal);
+        var groupEnd = output.IndexOf("::endgroup::", StringComparison.Ordinal);
+
+        await Assert.That(structuredLog).IsGreaterThanOrEqualTo(0);
+        await Assert.That(groupEnd).IsGreaterThan(structuredLog);
+    }
+
+    [Test]
+    public async Task Flush_Waits_For_Queued_Logs_Before_Direct_Output_And_Group_End()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new QueuedLoggerControl(writer);
+        var buffer = CreateBufferWithStructuredLog();
+        buffer.WriteLine("direct output");
+
+        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+
+        var output = writer.ToString();
+        var groupStart = output.IndexOf("::group::", StringComparison.Ordinal);
+        var structuredLog = output.IndexOf("structured log", StringComparison.Ordinal);
+        var directOutput = output.IndexOf("direct output", StringComparison.Ordinal);
+        var groupEnd = output.IndexOf("::endgroup::", StringComparison.Ordinal);
+
+        await Assert.That(groupStart).IsGreaterThanOrEqualTo(0);
+        await Assert.That(structuredLog).IsGreaterThan(groupStart);
+        await Assert.That(directOutput).IsGreaterThan(structuredLog);
+        await Assert.That(groupEnd).IsGreaterThan(directOutput);
+    }
+
+    private static ModuleOutputBuffer CreateBufferWithStructuredLog()
+    {
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        buffer.AddLogEvent(
+            LogLevel.Information,
+            default,
+            "structured log",
+            null,
+            static (state, _) => state.ToString()!);
+        return buffer;
+    }
+
+    private sealed class QueuedLoggerControl(TextWriter writer) : ILogger, ISpectreConsoleLoggerControl
+    {
+        private readonly Queue<string> _pendingMessages = new();
+
+        public object SynchronizationLock { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            _pendingMessages.Enqueue(formatter(state, exception));
+        }
+
+        public Task FlushAsync(CancellationToken cancellationToken = default)
+        {
+            lock (SynchronizationLock)
+            {
+                while (_pendingMessages.TryDequeue(out var message))
+                {
+                    writer.WriteLine(message);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -170,6 +170,44 @@ public class ModuleOutputBufferTests
         await Assert.That(buffer.HasOutput).IsFalse();
     }
 
+    [Test]
+    public async Task Flush_CancellationInterruptsSynchronizationLockWait()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = CreateBufferWithStructuredLog();
+        var lockAcquired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lockHolder = Task.Run(() =>
+        {
+            lock (loggerControl.SynchronizationLock)
+            {
+                lockAcquired.TrySetResult();
+                releaseLock.Task.GetAwaiter().GetResult();
+            }
+        });
+
+        await lockAcquired.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        try
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                await buffer.FlushToAsync(
+                    writer,
+                    new GitHubActionsFormatter(),
+                    loggerControl,
+                    loggerControl,
+                    cancellationTokenSource.Token));
+        }
+        finally
+        {
+            releaseLock.TrySetResult();
+            await lockHolder;
+        }
+
+        await Assert.That(buffer.HasOutput).IsTrue();
+    }
+
     private static ModuleOutputBuffer CreateBufferWithStructuredLog()
     {
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -146,6 +146,30 @@ public class ModuleOutputBufferTests
         await Assert.That(buffer.HasOutput).IsFalse();
     }
 
+    [Test]
+    public async Task Flush_RenderingFailure_Retains_Unrendered_Output()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer)
+        {
+            LogException = new InvalidOperationException("render failed"),
+        };
+        var buffer = CreateBufferWithStructuredLog();
+        buffer.WriteLine("remaining output");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl));
+
+        await Assert.That(buffer.HasOutput).IsTrue();
+
+        loggerControl.LogException = null;
+        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+
+        await Assert.That(writer.ToString()).Contains("structured log");
+        await Assert.That(writer.ToString()).Contains("remaining output");
+        await Assert.That(buffer.HasOutput).IsFalse();
+    }
+
     private static ModuleOutputBuffer CreateBufferWithStructuredLog()
     {
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
@@ -164,6 +188,8 @@ public class ModuleOutputBufferTests
 
         public Action? AfterLog { get; set; }
 
+        public Exception? LogException { get; set; }
+
         public IDisposable? BeginScope<TState>(TState state)
             where TState : notnull
             => null;
@@ -177,6 +203,11 @@ public class ModuleOutputBufferTests
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
+            if (LogException is not null)
+            {
+                throw LogException;
+            }
+
             Write(formatter(state, exception));
             AfterLog?.Invoke();
         }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -46,6 +46,21 @@ public class ModuleOutputBufferTests
         await Assert.That(groupEnd).IsGreaterThan(directOutput);
     }
 
+    [Test]
+    public async Task Flush_Renders_Markup_For_Direct_Output()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new QueuedLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        buffer.WriteLine("[green]direct output[/]");
+
+        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("direct output");
+        await Assert.That(output).DoesNotContain("[green]");
+    }
+
     private static ModuleOutputBuffer CreateBufferWithStructuredLog()
     {
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -166,26 +166,15 @@ public class OutputCoordinatorTests
     }
 
     [Test]
-    public async Task ImmediateFlush_RetriesRestoredOutputAfterRenderingFailure()
+    public async Task ImmediateFlush_DoesNotRetryPartiallyDeliveredOutput()
     {
-        var buffer = new FailingOutputBuffer(failuresBeforeSuccess: 1);
-        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
-
-        await coordinator.EnqueueAndFlushAsync(buffer);
-
-        await Assert.That(buffer.FlushCount).IsEqualTo(2);
-    }
-
-    [Test]
-    public async Task ImmediateFlush_PropagatesRepeatedRenderingFailure()
-    {
-        var buffer = new FailingOutputBuffer(failuresBeforeSuccess: 2);
+        var buffer = new PartiallyDeliveringOutputBuffer();
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await coordinator.EnqueueAndFlushAsync(buffer));
 
-        await Assert.That(buffer.FlushCount).IsEqualTo(2);
+        await Assert.That(buffer.DeliveryCount).IsEqualTo(1);
     }
 
     private static OutputCoordinator CreateCoordinator(
@@ -368,13 +357,13 @@ public class OutputCoordinatorTests
         }
     }
 
-    private sealed class FailingOutputBuffer(int failuresBeforeSuccess) : IModuleOutputBuffer
+    private sealed class PartiallyDeliveringOutputBuffer : IModuleOutputBuffer
     {
-        public Type ModuleType => typeof(FailingOutputBuffer);
+        public Type ModuleType => typeof(PartiallyDeliveringOutputBuffer);
 
         public bool HasOutput => true;
 
-        public int FlushCount { get; private set; }
+        public int DeliveryCount { get; private set; }
 
         public void WriteLine(string message)
         {
@@ -400,13 +389,8 @@ public class OutputCoordinatorTests
             ISpectreConsoleLoggerControl loggerControl,
             CancellationToken cancellationToken = default)
         {
-            FlushCount++;
-            if (FlushCount <= failuresBeforeSuccess)
-            {
-                throw new InvalidOperationException("render failed");
-            }
-
-            return Task.CompletedTask;
+            DeliveryCount++;
+            throw new InvalidOperationException("provider failed after partial delivery");
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -76,6 +76,26 @@ public class OutputCoordinatorTests
         await Assert.That(buffer.FlushCount).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task ImmediateFlush_DoesNotApplyOwnerCancellationToLaterBuffers()
+    {
+        using var ownerCancellation = new CancellationTokenSource();
+        var firstBuffer = new BlockingOutputBuffer();
+        var secondBuffer = new CancellingOutputBuffer();
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        var ownerFlush = coordinator.EnqueueAndFlushAsync(firstBuffer, ownerCancellation.Token);
+        await firstBuffer.FlushStarted.Task;
+        var secondFlush = coordinator.EnqueueAndFlushAsync(secondBuffer);
+
+        await ownerCancellation.CancelAsync();
+        firstBuffer.ReleaseFlush.TrySetResult();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await ownerFlush);
+        await secondFlush;
+        await Assert.That(secondBuffer.FlushCount).IsEqualTo(1);
+    }
+
     private static OutputCoordinator CreateCoordinator(ILoggerFactory loggerFactory)
     {
         var formatterProvider = new Mock<IBuildSystemFormatterProvider>();
@@ -167,6 +187,46 @@ public class OutputCoordinatorTests
             }
 
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class BlockingOutputBuffer : IModuleOutputBuffer
+    {
+        public Type ModuleType => typeof(BlockingOutputBuffer);
+
+        public bool HasOutput => true;
+
+        public TaskCompletionSource FlushStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseFlush { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void WriteLine(string message)
+        {
+        }
+
+        public void AddLogEvent(
+            LogLevel level,
+            EventId eventId,
+            object state,
+            Exception? exception,
+            Func<object, Exception?, string> formatter)
+        {
+        }
+
+        public void SetException(Exception exception)
+        {
+        }
+
+        public async Task FlushToAsync(
+            TextWriter console,
+            IBuildSystemFormatter formatter,
+            ILogger logger,
+            ISpectreConsoleLoggerControl loggerControl,
+            CancellationToken cancellationToken = default)
+        {
+            FlushStarted.TrySetResult();
+            await ReleaseFlush.Task;
+            cancellationToken.ThrowIfCancellationRequested();
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -96,6 +96,27 @@ public class OutputCoordinatorTests
         await Assert.That(secondBuffer.FlushCount).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task ImmediateFlush_OwnerReturnsBeforeLaterBufferCompletes()
+    {
+        var firstBuffer = new BlockingOutputBuffer();
+        var secondBuffer = new BlockingOutputBuffer();
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        var ownerFlush = coordinator.EnqueueAndFlushAsync(firstBuffer);
+        await firstBuffer.FlushStarted.Task;
+        var secondFlush = coordinator.EnqueueAndFlushAsync(secondBuffer);
+
+        firstBuffer.ReleaseFlush.TrySetResult();
+        await secondBuffer.FlushStarted.Task;
+
+        var completedTask = await Task.WhenAny(ownerFlush, Task.Delay(TimeSpan.FromSeconds(1)));
+        secondBuffer.ReleaseFlush.TrySetResult();
+        await secondFlush;
+
+        await Assert.That(completedTask).IsSameReferenceAs(ownerFlush);
+    }
+
     private static OutputCoordinator CreateCoordinator(ILoggerFactory loggerFactory)
     {
         var formatterProvider = new Mock<IBuildSystemFormatterProvider>();

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -1,0 +1,159 @@
+using MEL.Spectre;
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Console;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.BuildSystemFormatters;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Console;
+
+public class OutputCoordinatorTests
+{
+    [Test]
+    public async Task ImmediateFlush_BypassesConsoleBufferingForReplayedLogs()
+    {
+        var directOutput = new StringWriter();
+        var bufferedOutput = new Mock<IModuleOutputBuffer>();
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator.Setup(x => x.GetUnattributedBuffer()).Returns(bufferedOutput.Object);
+
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? input, object? _) => input ?? string.Empty);
+
+        var coordinatedWriter = new CoordinatedTextWriter(
+            consoleCoordinator.Object,
+            directOutput,
+            () => true,
+            secretObfuscator.Object);
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(coordinatedWriter));
+        var moduleBuffer = new ModuleOutputBuffer(typeof(OutputCoordinatorTests));
+        moduleBuffer.AddLogEvent(
+            LogLevel.Information,
+            default,
+            "replayed log",
+            null,
+            static (state, _) => state.ToString()!);
+
+        await coordinator.EnqueueAndFlushAsync(moduleBuffer);
+
+        await Assert.That(directOutput.ToString()).Contains("replayed log");
+        bufferedOutput.Verify(x => x.WriteLine(It.IsAny<string>()), Times.Never);
+    }
+
+    [Test]
+    public async Task DeferredFlush_CancellationRequeuesCurrentAndRemainingOutputs()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var firstBuffer = new CancellingOutputBuffer(cancellationTokenSource);
+        var secondBuffer = new CancellingOutputBuffer();
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+        coordinator.SetProgressActive(true);
+        await coordinator.OnModuleCompletedAsync(firstBuffer, firstBuffer.ModuleType);
+        await coordinator.OnModuleCompletedAsync(secondBuffer, secondBuffer.ModuleType);
+        coordinator.SetProgressActive(false);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await coordinator.FlushDeferredAsync(cancellationTokenSource.Token));
+
+        await coordinator.FlushDeferredAsync();
+
+        await Assert.That(firstBuffer.FlushCount).IsEqualTo(2);
+        await Assert.That(secondBuffer.FlushCount).IsEqualTo(1);
+    }
+
+    private static OutputCoordinator CreateCoordinator(ILoggerFactory loggerFactory)
+    {
+        var formatterProvider = new Mock<IBuildSystemFormatterProvider>();
+        formatterProvider.Setup(x => x.GetFormatter()).Returns(new DefaultFormatter());
+
+        var serviceProvider = new Mock<IServiceProvider>();
+        var loggerControl = new Mock<ISpectreConsoleLoggerControl>();
+        loggerControl.SetupGet(x => x.SynchronizationLock).Returns(new object());
+
+        return new OutputCoordinator(
+            formatterProvider.Object,
+            loggerFactory,
+            serviceProvider.Object,
+            loggerControl.Object);
+    }
+
+    private sealed class ConsoleWritingLoggerFactory(TextWriter writer) : ILoggerFactory
+    {
+        private readonly ILogger _logger = new ConsoleWritingLogger(writer);
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName) => _logger;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class ConsoleWritingLogger(TextWriter writer) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            writer.WriteLine(formatter(state, exception));
+        }
+    }
+
+    private sealed class CancellingOutputBuffer(CancellationTokenSource? cancellationTokenSource = null)
+        : IModuleOutputBuffer
+    {
+        public Type ModuleType => typeof(CancellingOutputBuffer);
+
+        public int FlushCount { get; private set; }
+
+        public bool HasOutput => true;
+
+        public void WriteLine(string message)
+        {
+        }
+
+        public void AddLogEvent(
+            LogLevel level,
+            EventId eventId,
+            object state,
+            Exception? exception,
+            Func<object, Exception?, string> formatter)
+        {
+        }
+
+        public void SetException(Exception exception)
+        {
+        }
+
+        public Task FlushToAsync(
+            TextWriter console,
+            IBuildSystemFormatter formatter,
+            ILogger logger,
+            ISpectreConsoleLoggerControl loggerControl,
+            CancellationToken cancellationToken = default)
+        {
+            FlushCount++;
+            if (FlushCount == 1 && cancellationTokenSource != null)
+            {
+                cancellationTokenSource.Cancel();
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -118,6 +118,34 @@ public class OutputCoordinatorTests
     }
 
     [Test]
+    public async Task ImmediateFlush_ProcessorStartsOutsideCallersStack()
+    {
+        var buffer = new SynchronouslyBlockingOutputBuffer();
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+        var invocation = Task.Factory.StartNew(
+            () => coordinator.EnqueueAndFlushAsync(buffer),
+            CancellationToken.None,
+            TaskCreationOptions.DenyChildAttach,
+            TaskScheduler.Default);
+
+        await buffer.FlushStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        var returnedBeforeRelease = false;
+        try
+        {
+            returnedBeforeRelease = ReferenceEquals(
+                await Task.WhenAny(invocation, Task.Delay(TimeSpan.FromSeconds(1))),
+                invocation);
+        }
+        finally
+        {
+            buffer.ReleaseFlush.TrySetResult();
+        }
+
+        await await invocation;
+        await Assert.That(returnedBeforeRelease).IsTrue();
+    }
+
+    [Test]
     public async Task ImmediateFlush_UnexpectedProcessorFailureDoesNotWedgeQueue()
     {
         var formatterProvider = new Mock<IBuildSystemFormatterProvider>();
@@ -274,6 +302,46 @@ public class OutputCoordinatorTests
             FlushStarted.TrySetResult();
             await ReleaseFlush.Task;
             cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+
+    private sealed class SynchronouslyBlockingOutputBuffer : IModuleOutputBuffer
+    {
+        public Type ModuleType => typeof(SynchronouslyBlockingOutputBuffer);
+
+        public bool HasOutput => true;
+
+        public TaskCompletionSource FlushStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseFlush { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void WriteLine(string message)
+        {
+        }
+
+        public void AddLogEvent(
+            LogLevel level,
+            EventId eventId,
+            object state,
+            Exception? exception,
+            Func<object, Exception?, string> formatter)
+        {
+        }
+
+        public void SetException(Exception exception)
+        {
+        }
+
+        public Task FlushToAsync(
+            TextWriter console,
+            IBuildSystemFormatter formatter,
+            ILogger logger,
+            ISpectreConsoleLoggerControl loggerControl,
+            CancellationToken cancellationToken = default)
+        {
+            FlushStarted.TrySetResult();
+            ReleaseFlush.Task.Wait(TimeSpan.FromSeconds(5), cancellationToken);
+            return Task.CompletedTask;
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -10,7 +10,7 @@ namespace ModularPipelines.UnitTests.Console;
 public class OutputCoordinatorTests
 {
     [Test]
-    public async Task ImmediateFlush_BypassesConsoleBufferingForReplayedLogs()
+    public async Task ImmediateFlush_BypassesStickyPartialLineBufferingForReplayedLogs()
     {
         var directOutput = new StringWriter();
         var bufferedOutput = new Mock<IModuleOutputBuffer>();
@@ -28,6 +28,7 @@ public class OutputCoordinatorTests
             () => true,
             secretObfuscator.Object,
             Mock.Of<ISecretProvider>());
+        coordinatedWriter.Write("partial");
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(coordinatedWriter));
         var moduleBuffer = new ModuleOutputBuffer(typeof(OutputCoordinatorTests));
         moduleBuffer.AddLogEvent(
@@ -38,9 +39,11 @@ public class OutputCoordinatorTests
             static (state, _) => state.ToString()!);
 
         await coordinator.EnqueueAndFlushAsync(moduleBuffer);
+        await coordinatedWriter.FlushAsync();
 
         await Assert.That(directOutput.ToString()).Contains("replayed log");
-        bufferedOutput.Verify(x => x.WriteLine(It.IsAny<string>()), Times.Never);
+        await Assert.That(directOutput.ToString()).DoesNotContain("partial");
+        bufferedOutput.Verify(x => x.WriteLine("partial"), Times.Once);
     }
 
     [Test]
@@ -135,6 +138,29 @@ public class OutputCoordinatorTests
         await Assert.ThrowsAsync<OperationCanceledException>(async () => await ownerFlush);
         await secondFlush;
         await Assert.That(secondBuffer.FlushCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task ImmediateFlush_QueuedCallerObservesCancellationWhileWaiting()
+    {
+        using var queuedCancellation = new CancellationTokenSource();
+        var firstBuffer = new BlockingOutputBuffer();
+        var queuedBuffer = new CancellingOutputBuffer();
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        var firstFlush = coordinator.EnqueueAndFlushAsync(firstBuffer);
+        await firstBuffer.FlushStarted.Task;
+        var queuedFlush = coordinator.EnqueueAndFlushAsync(queuedBuffer, queuedCancellation.Token);
+
+        await queuedCancellation.CancelAsync();
+        var completedTask = await Task.WhenAny(queuedFlush, Task.Delay(TimeSpan.FromSeconds(1)));
+
+        firstBuffer.ReleaseFlush.TrySetResult();
+        await firstFlush;
+
+        await Assert.That(completedTask).IsSameReferenceAs(queuedFlush);
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await queuedFlush);
+        await Assert.That(queuedBuffer.FlushCount).IsEqualTo(0);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -64,6 +64,26 @@ public class OutputCoordinatorTests
     }
 
     [Test]
+    public async Task DeferredFlush_FailureRequeuesCurrentAndRemainingOutputs()
+    {
+        var firstBuffer = new FailingOnceOutputBuffer();
+        var secondBuffer = new CancellingOutputBuffer();
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+        coordinator.SetProgressActive(true);
+        await coordinator.OnModuleCompletedAsync(firstBuffer, firstBuffer.ModuleType);
+        await coordinator.OnModuleCompletedAsync(secondBuffer, secondBuffer.ModuleType);
+        coordinator.SetProgressActive(false);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await coordinator.FlushDeferredAsync());
+
+        await coordinator.FlushDeferredAsync();
+
+        await Assert.That(firstBuffer.FlushCount).IsEqualTo(2);
+        await Assert.That(secondBuffer.FlushCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ImmediateFlush_PropagatesCancellationToQueueOwner()
     {
         using var cancellationTokenSource = new CancellationTokenSource();
@@ -271,6 +291,48 @@ public class OutputCoordinatorTests
             {
                 cancellationTokenSource.Cancel();
                 cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailingOnceOutputBuffer : IModuleOutputBuffer
+    {
+        public Type ModuleType => typeof(FailingOnceOutputBuffer);
+
+        public int FlushCount { get; private set; }
+
+        public bool HasOutput => true;
+
+        public void WriteLine(string message)
+        {
+        }
+
+        public void AddLogEvent(
+            LogLevel level,
+            EventId eventId,
+            object state,
+            Exception? exception,
+            Func<object, Exception?, string> formatter)
+        {
+        }
+
+        public void SetException(Exception exception)
+        {
+        }
+
+        public Task FlushToAsync(
+            TextWriter console,
+            IBuildSystemFormatter formatter,
+            ILogger logger,
+            ISpectreConsoleLoggerControl loggerControl,
+            CancellationToken cancellationToken = default)
+        {
+            FlushCount++;
+            if (FlushCount == 1)
+            {
+                throw new InvalidOperationException("simulated deferred flush failure");
             }
 
             return Task.CompletedTask;

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -117,17 +117,43 @@ public class OutputCoordinatorTests
         await Assert.That(completedTask).IsSameReferenceAs(ownerFlush);
     }
 
-    private static OutputCoordinator CreateCoordinator(ILoggerFactory loggerFactory)
+    [Test]
+    public async Task ImmediateFlush_UnexpectedProcessorFailureDoesNotWedgeQueue()
     {
         var formatterProvider = new Mock<IBuildSystemFormatterProvider>();
-        formatterProvider.Setup(x => x.GetFormatter()).Returns(new DefaultFormatter());
+        formatterProvider.SetupSequence(x => x.GetFormatter())
+            .Throws<InvalidOperationException>()
+            .Returns(new DefaultFormatter());
+        var coordinator = CreateCoordinator(
+            new ConsoleWritingLoggerFactory(TextWriter.Null),
+            formatterProvider.Object);
+        var abandonedBuffer = new CancellingOutputBuffer();
+        var recoveredBuffer = new CancellingOutputBuffer();
+
+        await coordinator.EnqueueAndFlushAsync(abandonedBuffer).WaitAsync(TimeSpan.FromSeconds(1));
+        await coordinator.EnqueueAndFlushAsync(recoveredBuffer).WaitAsync(TimeSpan.FromSeconds(1));
+
+        await Assert.That(abandonedBuffer.FlushCount).IsEqualTo(0);
+        await Assert.That(recoveredBuffer.FlushCount).IsEqualTo(1);
+    }
+
+    private static OutputCoordinator CreateCoordinator(
+        ILoggerFactory loggerFactory,
+        IBuildSystemFormatterProvider? formatterProvider = null)
+    {
+        if (formatterProvider is null)
+        {
+            var formatterProviderMock = new Mock<IBuildSystemFormatterProvider>();
+            formatterProviderMock.Setup(x => x.GetFormatter()).Returns(new DefaultFormatter());
+            formatterProvider = formatterProviderMock.Object;
+        }
 
         var serviceProvider = new Mock<IServiceProvider>();
         var loggerControl = new Mock<ISpectreConsoleLoggerControl>();
         loggerControl.SetupGet(x => x.SynchronizationLock).Returns(new object());
 
         return new OutputCoordinator(
-            formatterProvider.Object,
+            formatterProvider,
             loggerFactory,
             serviceProvider.Object,
             loggerControl.Object);

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -85,6 +85,26 @@ public class OutputCoordinatorTests
     }
 
     [Test]
+    public async Task DeferredFlush_ProviderCancellationOnlyRequeuesUnstartedOutputs()
+    {
+        var firstBuffer = new FailingOnceOutputBuffer(new OperationCanceledException("provider cancelled"));
+        var secondBuffer = new CancellingOutputBuffer();
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+        coordinator.SetProgressActive(true);
+        await coordinator.OnModuleCompletedAsync(firstBuffer, firstBuffer.ModuleType);
+        await coordinator.OnModuleCompletedAsync(secondBuffer, secondBuffer.ModuleType);
+        coordinator.SetProgressActive(false);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await coordinator.FlushDeferredAsync());
+
+        await coordinator.FlushDeferredAsync();
+
+        await Assert.That(firstBuffer.FlushCount).IsEqualTo(1);
+        await Assert.That(secondBuffer.FlushCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ImmediateFlush_PropagatesCancellationToQueueOwner()
     {
         using var cancellationTokenSource = new CancellationTokenSource();
@@ -297,7 +317,7 @@ public class OutputCoordinatorTests
         }
     }
 
-    private sealed class FailingOnceOutputBuffer : IModuleOutputBuffer
+    private sealed class FailingOnceOutputBuffer(Exception? exception = null) : IModuleOutputBuffer
     {
         public Type ModuleType => typeof(FailingOnceOutputBuffer);
 
@@ -332,7 +352,7 @@ public class OutputCoordinatorTests
             FlushCount++;
             if (FlushCount == 1)
             {
-                throw new InvalidOperationException("simulated deferred flush failure");
+                throw exception ?? new InvalidOperationException("simulated deferred flush failure");
             }
 
             return Task.CompletedTask;

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -26,7 +26,8 @@ public class OutputCoordinatorTests
             consoleCoordinator.Object,
             directOutput,
             () => true,
-            secretObfuscator.Object);
+            secretObfuscator.Object,
+            Mock.Of<ISecretProvider>());
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(coordinatedWriter));
         var moduleBuffer = new ModuleOutputBuffer(typeof(OutputCoordinatorTests));
         moduleBuffer.AddLogEvent(
@@ -64,7 +65,7 @@ public class OutputCoordinatorTests
     }
 
     [Test]
-    public async Task DeferredFlush_FailureRequeuesCurrentAndRemainingOutputs()
+    public async Task DeferredFlush_FailureOnlyRequeuesUnstartedOutputs()
     {
         var firstBuffer = new FailingOnceOutputBuffer();
         var secondBuffer = new CancellingOutputBuffer();
@@ -79,7 +80,7 @@ public class OutputCoordinatorTests
 
         await coordinator.FlushDeferredAsync();
 
-        await Assert.That(firstBuffer.FlushCount).IsEqualTo(2);
+        await Assert.That(firstBuffer.FlushCount).IsEqualTo(1);
         await Assert.That(secondBuffer.FlushCount).IsEqualTo(1);
     }
 
@@ -166,7 +167,7 @@ public class OutputCoordinatorTests
     }
 
     [Test]
-    public async Task ImmediateFlush_UnexpectedProcessorFailureDoesNotWedgeQueue()
+    public async Task ImmediateFlush_UnexpectedProcessorFailureFailsPendingRequestWithoutWedge()
     {
         var formatterProvider = new Mock<IBuildSystemFormatterProvider>();
         formatterProvider.SetupSequence(x => x.GetFormatter())
@@ -176,13 +177,12 @@ public class OutputCoordinatorTests
             new ConsoleWritingLoggerFactory(TextWriter.Null),
             formatterProvider.Object);
         var abandonedBuffer = new CancellingOutputBuffer();
-        var recoveredBuffer = new CancellingOutputBuffer();
 
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await coordinator.EnqueueAndFlushAsync(abandonedBuffer).WaitAsync(TimeSpan.FromSeconds(1)));
         await coordinator.EnqueueAndFlushAsync(abandonedBuffer).WaitAsync(TimeSpan.FromSeconds(1));
-        await coordinator.EnqueueAndFlushAsync(recoveredBuffer).WaitAsync(TimeSpan.FromSeconds(1));
 
-        await Assert.That(abandonedBuffer.FlushCount).IsEqualTo(0);
-        await Assert.That(recoveredBuffer.FlushCount).IsEqualTo(1);
+        await Assert.That(abandonedBuffer.FlushCount).IsEqualTo(1);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -165,6 +165,29 @@ public class OutputCoordinatorTests
         await Assert.That(recoveredBuffer.FlushCount).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task ImmediateFlush_RetriesRestoredOutputAfterRenderingFailure()
+    {
+        var buffer = new FailingOutputBuffer(failuresBeforeSuccess: 1);
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        await coordinator.EnqueueAndFlushAsync(buffer);
+
+        await Assert.That(buffer.FlushCount).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task ImmediateFlush_PropagatesRepeatedRenderingFailure()
+    {
+        var buffer = new FailingOutputBuffer(failuresBeforeSuccess: 2);
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await coordinator.EnqueueAndFlushAsync(buffer));
+
+        await Assert.That(buffer.FlushCount).IsEqualTo(2);
+    }
+
     private static OutputCoordinator CreateCoordinator(
         ILoggerFactory loggerFactory,
         IBuildSystemFormatterProvider? formatterProvider = null)
@@ -341,6 +364,48 @@ public class OutputCoordinatorTests
         {
             FlushStarted.TrySetResult();
             ReleaseFlush.Task.Wait(TimeSpan.FromSeconds(5), cancellationToken);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailingOutputBuffer(int failuresBeforeSuccess) : IModuleOutputBuffer
+    {
+        public Type ModuleType => typeof(FailingOutputBuffer);
+
+        public bool HasOutput => true;
+
+        public int FlushCount { get; private set; }
+
+        public void WriteLine(string message)
+        {
+        }
+
+        public void AddLogEvent(
+            LogLevel level,
+            EventId eventId,
+            object state,
+            Exception? exception,
+            Func<object, Exception?, string> formatter)
+        {
+        }
+
+        public void SetException(Exception exception)
+        {
+        }
+
+        public Task FlushToAsync(
+            TextWriter console,
+            IBuildSystemFormatter formatter,
+            ILogger logger,
+            ISpectreConsoleLoggerControl loggerControl,
+            CancellationToken cancellationToken = default)
+        {
+            FlushCount++;
+            if (FlushCount <= failuresBeforeSuccess)
+            {
+                throw new InvalidOperationException("render failed");
+            }
+
             return Task.CompletedTask;
         }
     }

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -63,6 +63,19 @@ public class OutputCoordinatorTests
         await Assert.That(secondBuffer.FlushCount).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task ImmediateFlush_PropagatesCancellationToQueueOwner()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var buffer = new CancellingOutputBuffer(cancellationTokenSource);
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await coordinator.EnqueueAndFlushAsync(buffer, cancellationTokenSource.Token));
+
+        await Assert.That(buffer.FlushCount).IsEqualTo(1);
+    }
+
     private static OutputCoordinator CreateCoordinator(ILoggerFactory loggerFactory)
     {
         var formatterProvider = new Mock<IBuildSystemFormatterProvider>();

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -18,7 +18,9 @@ public class PipelineOutputCoordinatorTests
         consoleCoordinator.Setup(x => x.FlushPendingWritesAsync())
             .Callback(() => events.Add("retained"))
             .ReturnsAsync([retainedBuffer.Object]);
-        consoleCoordinator.Setup(x => x.FlushModuleOutput()).Callback(() => events.Add("unattributed"));
+        consoleCoordinator.Setup(x => x.FlushModuleOutputAsync())
+            .Callback(() => events.Add("unattributed"))
+            .Returns(Task.CompletedTask);
 
         var outputCoordinator = new Mock<IOutputCoordinator>();
         outputCoordinator

--- a/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
@@ -13,6 +13,16 @@ namespace ModularPipelines.UnitTests.Logging;
 public class SpectreConsoleLoggerTests
 {
     [Test]
+    public async Task Configuration_Uses_Synchronous_Output()
+    {
+        var options = new SpectreConsoleLoggerOptions();
+
+        DependencyInjectionSetup.ConfigureSpectreConsoleLogger(options, AnsiConsole.Console);
+
+        await Assert.That(options.WriteMode).IsEqualTo(WriteMode.Synchronous);
+    }
+
+    [Test]
     public async Task Terminates_Each_Log_Entry_Once()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Plugins/PluginRegistryTests.cs
+++ b/test/ModularPipelines.UnitTests/Plugins/PluginRegistryTests.cs
@@ -99,6 +99,29 @@ public class PluginRegistryTests
         }
     }
 
+    [Test]
+    public async Task IsolatedRegistry_DoesNotLeakIntoParallelExecutionContexts()
+    {
+        using var parentScope = PluginTestHelper.IsolatedRegistry();
+        var pluginRegistered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePluginScope = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var pluginTask = Task.Run(async () =>
+        {
+            using var childScope = PluginTestHelper.IsolatedRegistry();
+            PluginRegistry.Register(new TestPlugin("ScopedPlugin"));
+            pluginRegistered.TrySetResult();
+            await releasePluginScope.Task;
+        });
+
+        await pluginRegistered.Task;
+        var visiblePluginNames = PluginRegistry.Plugins.Select(plugin => plugin.Name).ToList();
+        releasePluginScope.TrySetResult();
+        await pluginTask;
+
+        await Assert.That(visiblePluginNames).DoesNotContain("ScopedPlugin");
+    }
+
     private class TestPlugin : IModularPipelinesPlugin
     {
         private readonly int _priority;


### PR DESCRIPTION
## Summary
- await MEL.Spectre logger rendering before closing CI groups
- serialize direct console writes through the logger synchronization gate
- preserve ordering between structured logs and intercepted console output

## Validation
- focused format verification on touched files
- unit-test project build
- 4 focused console/output tests

Closes #3064
Closes #3065
