### PR TITLE
Remove duplicate logger line breaks

### DIFF
--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -100,7 +100,7 @@ internal static class DependencyInjectionSetup
     {
         // Console width and CI capabilities are configured by ConsoleCoordinator.
         config.Console = console;
-        config.Template = "[{Level:u4}] {Message}{NewLine}{Exception}";
+        config.Template = "[{Level:u4}] {Message}";
         config.ExceptionFormats = ExceptionFormats.Default;
         config.AllowMarkupInMessageTemplate = true;
     }

--- a/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
@@ -19,6 +19,7 @@ public class SpectreConsoleLoggerTests
 
         var output = writer.ToString();
         await Assert.That(output).Contains("One log entry");
+        await Assert.That(output).EndsWith(Environment.NewLine);
         await Assert.That(output).DoesNotContain(Environment.NewLine + Environment.NewLine);
     }
 

--- a/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
@@ -9,13 +9,49 @@ namespace ModularPipelines.UnitTests.Logging;
 public class SpectreConsoleLoggerTests
 {
     [Test]
+    public async Task Terminates_Each_Log_Entry_Once()
+    {
+        var writer = new StringWriter();
+        await using var provider = CreateProvider(writer, AnsiSupport.No, ColorSystemSupport.NoColors);
+        var logger = provider.GetRequiredService<ILogger<SpectreConsoleLoggerTests>>();
+
+        logger.LogInformation("One log entry");
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("One log entry");
+        await Assert.That(output).DoesNotContain(Environment.NewLine + Environment.NewLine);
+    }
+
+    [Test]
     public async Task Renders_Markup_Level_And_Exception_Details()
     {
         var writer = new StringWriter();
+        await using var provider = CreateProvider(writer, AnsiSupport.Yes, ColorSystemSupport.Standard);
+        var logger = provider.GetRequiredService<ILogger<SpectreConsoleLoggerTests>>();
+        var exception = CaptureException();
+
+        logger.LogError(exception, "Failure in [bold]pipeline[/]");
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("FAIL");
+        await Assert.That(output).Contains("Failure in");
+        await Assert.That(output).Contains("pipeline");
+        await Assert.That(output).Contains(nameof(InvalidOperationException));
+        await Assert.That(output).Contains("logger failure");
+        await Assert.That(output).Contains(nameof(CaptureException));
+        await Assert.That(output).Contains("\u001b[");
+        await Assert.That(output).DoesNotContain("[bold]");
+    }
+
+    private static ServiceProvider CreateProvider(
+        StringWriter writer,
+        AnsiSupport ansiSupport,
+        ColorSystemSupport colorSystemSupport)
+    {
         var console = AnsiConsole.Create(new AnsiConsoleSettings
         {
-            Ansi = AnsiSupport.Yes,
-            ColorSystem = ColorSystemSupport.Standard,
+            Ansi = ansiSupport,
+            ColorSystem = colorSystemSupport,
             Interactive = InteractionSupport.No,
             Out = new AnsiConsoleOutput(writer),
         });
@@ -32,21 +68,7 @@ public class SpectreConsoleLoggerTests
             });
         });
 
-        await using var provider = services.BuildServiceProvider();
-        var logger = provider.GetRequiredService<ILogger<SpectreConsoleLoggerTests>>();
-        var exception = CaptureException();
-
-        logger.LogError(exception, "Failure in [bold]pipeline[/]");
-
-        var output = writer.ToString();
-        await Assert.That(output).Contains("FAIL");
-        await Assert.That(output).Contains("Failure in");
-        await Assert.That(output).Contains("pipeline");
-        await Assert.That(output).Contains(nameof(InvalidOperationException));
-        await Assert.That(output).Contains("logger failure");
-        await Assert.That(output).Contains(nameof(CaptureException));
-        await Assert.That(output).Contains("\u001b[");
-        await Assert.That(output).DoesNotContain("[bold]");
+        return services.BuildServiceProvider();
     }
 
     private static Exception CaptureException()


### PR DESCRIPTION
## Summary
- remove Serilog-style newline and exception tokens from the MEL.Spectre template
- retain MEL.Spectre's separate exception rendering
- verify each ordinary log entry has one line terminator

## Validation
- focused format verification
- unit-test project build
- 2 focused Spectre logger tests

Closes #3066