### PR TITLE
Stop formatting commits from pull request CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@
 You know the drill. You write some YAML, push it, wait for CI to start, watch it fail on a typo, fix it, push again, wait again. Repeat until you lose the will to live.
 
 YAML pipelines are:
-- **Impossible to debug locally** - "Works on my machine" but fails mysteriously in CI
-- **No compile-time safety** - Typos in variable names? Enjoy your 10-minute feedback loop
-- **Copy-paste hell** - Reusing logic means duplicating YAML and hoping you update all the copies
-- **Vendor lock-in** - Switching from GitHub Actions to Azure Pipelines? Rewrite everything
+
+* **Impossible to debug locally** - "Works on my machine" but fails mysteriously in CI
+* **No compile-time safety** - Typos in variable names? Enjoy your 10-minute feedback loop
+* **Copy-paste hell** - Reusing logic means duplicating YAML and hoping you update all the copies
+* **Vendor lock-in** - Switching from GitHub Actions to Azure Pipelines? Rewrite everything
 
 ## The Solution
 
@@ -44,24 +45,31 @@ public class PublishModule : Module<CommandResult>
 ## Why Developers Choose ModularPipelines
 
 ### Your IDE Actually Helps You
+
 Intellisense, refactoring, compile-time errors. Your pipeline code gets the same treatment as your application code. Rename a module? Your IDE updates all the references. Typo in an option? Red squiggle before you even save.
 
 ### Run Locally, Push Confidently
+
 Test your entire pipeline on your machine before pushing. No more "let me push and see if it works" commits. Debug failures in your IDE instead of reading logs from a build agent.
 
 ### Automatic Parallelization
+
 Modules declare their dependencies with attributes. ModularPipelines figures out what can run in parallel and maximizes throughput. No more manually orchestrating parallel jobs.
 
 ### Switch Build Systems Without Rewriting
+
 Your pipeline logic lives in C#, not in vendor-specific YAML. Moving from GitHub Actions to Azure Pipelines to TeamCity? Change one line - your modules stay the same.
 
 ### Full Dependency Injection
+
 Inject services, configuration, and secrets the same way you do in ASP.NET Core. Mock dependencies for testing. No more environment variable gymnastics.
 
 ### Secrets Stay Secret
+
 Secrets are automatically obfuscated in logs. No more accidentally exposing API keys in build output.
 
 ### Modules Share Data
+
 Modules return strongly-typed results that other modules can consume. No shared mutable state - just clean data flow.
 
 ```csharp
@@ -89,11 +97,13 @@ public class PublishModule : Module
 ```
 
 ### Catch Mistakes at Compile Time
+
 Built-in Roslyn analyzers catch common mistakes before you even run:
-- Missing `[DependsOn]` when calling `GetModule<T>()`
-- Circular dependencies between modules
-- Forgetting to `await` module results
-- Using `Console.Write` instead of the logging system
+
+* Missing `[DependsOn]` when calling `GetModule<T>()`
+* Circular dependencies between modules
+* Forgetting to `await` module results
+* Using `Console.Write` instead of the logging system
 
 ## [Full Documentation](https://thomhurst.github.io/ModularPipelines)
 
@@ -146,6 +156,7 @@ public class TestModule : Module<CommandResult>
 ```
 
 Run it:
+
 ```bash
 dotnet run
 ```
@@ -208,21 +219,21 @@ ModularPipelines takes a different approach: each unit of work is a self-contain
 
 ## Features at a Glance
 
-- **Parallel execution** - Automatic based on declared dependencies
-- **Module data sharing** - Strongly-typed results flow between modules
-- **Roslyn analyzers** - Catch mistakes at compile time, not runtime
-- **Conditional dependencies** - `DependsOnIf<T>()` for dynamic dependency graphs
-- **Dependency management** - Circular dependency detection built-in
-- **Strong typing** - Pass data between modules with compile-time safety
-- **Debug locally** - Set breakpoints, inspect variables, fix issues before pushing
-- **Build agent agnostic** - Same code runs on GitHub, Azure, TeamCity, or your laptop
-- **Secret obfuscation** - Automatic masking in logs
-- **Hooks** - Run code before/after any module
-- **Skip conditions** - Dynamically skip modules based on custom logic
-- **Retry policies** - Configurable retry with Polly integration
-- **Requirements validation** - Check prerequisites before running
-- **Progress reporting** - Real-time console output with parallel execution visualization
-- **Source controlled** - Your pipeline is code, version it like code
+* **Parallel execution** - Automatic based on declared dependencies
+* **Module data sharing** - Strongly-typed results flow between modules
+* **Roslyn analyzers** - Catch mistakes at compile time, not runtime
+* **Conditional dependencies** - `DependsOnIf<T>()` for dynamic dependency graphs
+* **Dependency management** - Circular dependency detection built-in
+* **Strong typing** - Pass data between modules with compile-time safety
+* **Debug locally** - Set breakpoints, inspect variables, fix issues before pushing
+* **Build agent agnostic** - Same code runs on GitHub, Azure, TeamCity, or your laptop
+* **Secret obfuscation** - Automatic masking in logs
+* **Hooks** - Run code before/after any module
+* **Skip conditions** - Dynamically skip modules based on custom logic
+* **Retry policies** - Configurable retry with Polly integration
+* **Requirements validation** - Check prerequisites before running
+* **Progress reporting** - Real-time console output with parallel execution visualization
+* **Source controlled** - Your pipeline is code, version it like code
 
 ## Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 **Write CI/CD pipelines in C#. Debug them locally. Ship with confidence.**
 
 [![nuget](https://img.shields.io/nuget/v/ModularPipelines.svg)](https://www.nuget.org/packages/ModularPipelines/)
-[![Generate CLI Options](https://github.com/thomhurst/ModularPipelines/actions/workflows/generate-cli-options.yml/badge.svg?event=schedule)](https://github.com/thomhurst/ModularPipelines/actions/workflows/generate-cli-options.yml)
 
 ![Nuget](https://img.shields.io/nuget/dt/ModularPipelines) ![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/thomhurst/ModularPipelines/dotnet.yml) ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/thomhurst/ModularPipelines/main) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/5f14420d97304b42a9e96861a4c0fec4)](https://app.codacy.com/gh/thomhurst/ModularPipelines/dashboard?utm_source=gh\&utm_medium=referral\&utm_content=\&utm_campaign=Badge_grade) [![CodeFactor](https://www.codefactor.io/repository/github/thomhurst/modularpipelines/badge)](https://www.codefactor.io/repository/github/thomhurst/modularpipelines) ![License](https://img.shields.io/github/license/thomhurst/ModularPipelines) [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/5f14420d97304b42a9e96861a4c0fec4)](https://app.codacy.com/gh/thomhurst/ModularPipelines/dashboard?utm_source=gh\&utm_medium=referral\&utm_content=\&utm_campaign=Badge_coverage) [![codecov](https://codecov.io/gh/thomhurst/ModularPipelines/graph/badge.svg?token=QC48Q6JOM4)](https://codecov.io/gh/thomhurst/ModularPipelines)
 
@@ -183,26 +182,31 @@ ModularPipelines has strongly-typed wrappers for the tools you already use:
 | --- | --- | --- |
 | ModularPipelines | Write your pipelines in C#! | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.svg)](https://www.nuget.org/packages/ModularPipelines/) |
 | ModularPipelines.AmazonWebServices | Helpers for interacting with Amazon Web Services. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.AmazonWebServices.svg)](https://www.nuget.org/packages/ModularPipelines.AmazonWebServices/) |
+| ModularPipelines.Ansible | Helpers for interacting with Ansible configuration management CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Ansible.svg)](https://www.nuget.org/packages/ModularPipelines.Ansible/) |
 | ModularPipelines.Azure | Helpers for interacting with Azure. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Azure.svg)](https://www.nuget.org/packages/ModularPipelines.Azure/) |
 | ModularPipelines.Azure.Pipelines | Helpers for interacting with Azure Pipeline agents. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Azure.Pipelines.svg)](https://www.nuget.org/packages/ModularPipelines.Azure.Pipelines/) |
 | ModularPipelines.Chocolatey | Helpers for interacting with the Chocolatey CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Chocolatey.svg)](https://www.nuget.org/packages/ModularPipelines.Chocolatey/) |
 | ModularPipelines.Cmd | Helpers for interacting with the Windows cmd process. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Cmd.svg)](https://www.nuget.org/packages/ModularPipelines.Cmd/) |
+| ModularPipelines.Cosign | Helpers for interacting with Cosign CLI for container signing and verification. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Cosign.svg)](https://www.nuget.org/packages/ModularPipelines.Cosign/) |
 | ModularPipelines.Docker | Helpers for interacting with the Docker CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Docker.svg)](https://www.nuget.org/packages/ModularPipelines.Docker/) |
 | ModularPipelines.DotNet | Helpers for interacting with dotnet CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.DotNet.svg)](https://www.nuget.org/packages/ModularPipelines.DotNet/) |
+| ModularPipelines.Eksctl | Helpers for interacting with eksctl Amazon EKS cluster management CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Eksctl.svg)](https://www.nuget.org/packages/ModularPipelines.Eksctl/) |
 | ModularPipelines.Email | Helpers for sending emails. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Email.svg)](https://www.nuget.org/packages/ModularPipelines.Email/) |
 | ModularPipelines.Ftp | Helpers for downloading and uploading via FTP. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Ftp.svg)](https://www.nuget.org/packages/ModularPipelines.Ftp/) |
+| ModularPipelines.Yarn | Helpers for interacting with Yarn CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Yarn.svg)](https://www.nuget.org/packages/ModularPipelines.Yarn/) |
+| ModularPipelines.Node | Helpers for interacting with node / npm CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Node.svg)](https://www.nuget.org/packages/ModularPipelines.Node/) |
 | ModularPipelines.Git | Helpers for interacting with git. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Git.svg)](https://www.nuget.org/packages/ModularPipelines.Git/) |
 | ModularPipelines.GitHub | Helpers for interacting with GitHub Actions build agents. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.GitHub.svg)](https://www.nuget.org/packages/ModularPipelines.GitHub/) |
 | ModularPipelines.Google | Helpers for interacting with the Google gcloud CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Google.svg)](https://www.nuget.org/packages/ModularPipelines.Google/) |
+| ModularPipelines.Hadolint | Helpers for interacting with Hadolint Dockerfile linter CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Hadolint.svg)](https://www.nuget.org/packages/ModularPipelines.Hadolint/) |
 | ModularPipelines.Helm | Helpers for interacting with Helm CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Helm.svg)](https://www.nuget.org/packages/ModularPipelines.Helm/) |
 | ModularPipelines.Kubernetes | Helpers for interacting with kubectl CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Kubernetes.svg)](https://www.nuget.org/packages/ModularPipelines.Kubernetes/) |
 | ModularPipelines.MicrosoftTeams | Helpers for sending Microsoft Teams cards. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.MicrosoftTeams.svg)](https://www.nuget.org/packages/ModularPipelines.MicrosoftTeams/) |
-| ModularPipelines.Node | Helpers for interacting with node / npm CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Node.svg)](https://www.nuget.org/packages/ModularPipelines.Node/) |
 | ModularPipelines.Slack | Helpers for sending Slack cards. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Slack.svg)](https://www.nuget.org/packages/ModularPipelines.Slack/) |
 | ModularPipelines.TeamCity | Helpers for interacting with TeamCity build agents. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.TeamCity.svg)](https://www.nuget.org/packages/ModularPipelines.TeamCity/) |
 | ModularPipelines.Terraform | Helpers for interacting with Terraform CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Terraform.svg)](https://www.nuget.org/packages/ModularPipelines.Terraform/) |
 | ModularPipelines.WinGet | Helpers for interacting with the Windows Package Manager. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.WinGet.svg)](https://www.nuget.org/packages/ModularPipelines.WinGet/) |
-| ModularPipelines.Yarn | Helpers for interacting with Yarn CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Yarn.svg)](https://www.nuget.org/packages/ModularPipelines.Yarn/) |
+| ModularPipelines.Distributed.Redis | Redis-based distributed coordinator for ModularPipelines. Enables multi-process and multi-machine pipeline execution using Redis for coordination. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Distributed.Redis.svg)](https://www.nuget.org/packages/ModularPipelines.Distributed.Redis/) |
 
 ## How Does This Compare to Cake / Nuke?
 

--- a/README_Template.md
+++ b/README_Template.md
@@ -11,10 +11,11 @@
 You know the drill. You write some YAML, push it, wait for CI to start, watch it fail on a typo, fix it, push again, wait again. Repeat until you lose the will to live.
 
 YAML pipelines are:
-- **Impossible to debug locally** - "Works on my machine" but fails mysteriously in CI
-- **No compile-time safety** - Typos in variable names? Enjoy your 10-minute feedback loop
-- **Copy-paste hell** - Reusing logic means duplicating YAML and hoping you update all the copies
-- **Vendor lock-in** - Switching from GitHub Actions to Azure Pipelines? Rewrite everything
+
+* **Impossible to debug locally** - "Works on my machine" but fails mysteriously in CI
+* **No compile-time safety** - Typos in variable names? Enjoy your 10-minute feedback loop
+* **Copy-paste hell** - Reusing logic means duplicating YAML and hoping you update all the copies
+* **Vendor lock-in** - Switching from GitHub Actions to Azure Pipelines? Rewrite everything
 
 ## The Solution
 
@@ -43,24 +44,31 @@ public class PublishModule : Module<CommandResult>
 ## Why Developers Choose ModularPipelines
 
 ### Your IDE Actually Helps You
+
 Intellisense, refactoring, compile-time errors. Your pipeline code gets the same treatment as your application code. Rename a module? Your IDE updates all the references. Typo in an option? Red squiggle before you even save.
 
 ### Run Locally, Push Confidently
+
 Test your entire pipeline on your machine before pushing. No more "let me push and see if it works" commits. Debug failures in your IDE instead of reading logs from a build agent.
 
 ### Automatic Parallelization
+
 Modules declare their dependencies with attributes. ModularPipelines figures out what can run in parallel and maximizes throughput. No more manually orchestrating parallel jobs.
 
 ### Switch Build Systems Without Rewriting
+
 Your pipeline logic lives in C#, not in vendor-specific YAML. Moving from GitHub Actions to Azure Pipelines to TeamCity? Change one line - your modules stay the same.
 
 ### Full Dependency Injection
+
 Inject services, configuration, and secrets the same way you do in ASP.NET Core. Mock dependencies for testing. No more environment variable gymnastics.
 
 ### Secrets Stay Secret
+
 Secrets are automatically obfuscated in logs. No more accidentally exposing API keys in build output.
 
 ### Modules Share Data
+
 Modules return strongly-typed results that other modules can consume. No shared mutable state - just clean data flow.
 
 ```csharp
@@ -88,11 +96,13 @@ public class PublishModule : Module
 ```
 
 ### Catch Mistakes at Compile Time
+
 Built-in Roslyn analyzers catch common mistakes before you even run:
-- Missing `[DependsOn]` when calling `GetModule<T>()`
-- Circular dependencies between modules
-- Forgetting to `await` module results
-- Using `Console.Write` instead of the logging system
+
+* Missing `[DependsOn]` when calling `GetModule<T>()`
+* Circular dependencies between modules
+* Forgetting to `await` module results
+* Using `Console.Write` instead of the logging system
 
 ## [Full Documentation](https://thomhurst.github.io/ModularPipelines)
 
@@ -145,6 +155,7 @@ public class TestModule : Module<CommandResult>
 ```
 
 Run it:
+
 ```bash
 dotnet run
 ```
@@ -184,21 +195,21 @@ ModularPipelines takes a different approach: each unit of work is a self-contain
 
 ## Features at a Glance
 
-- **Parallel execution** - Automatic based on declared dependencies
-- **Module data sharing** - Strongly-typed results flow between modules
-- **Roslyn analyzers** - Catch mistakes at compile time, not runtime
-- **Conditional dependencies** - `DependsOnIf<T>()` for dynamic dependency graphs
-- **Dependency management** - Circular dependency detection built-in
-- **Strong typing** - Pass data between modules with compile-time safety
-- **Debug locally** - Set breakpoints, inspect variables, fix issues before pushing
-- **Build agent agnostic** - Same code runs on GitHub, Azure, TeamCity, or your laptop
-- **Secret obfuscation** - Automatic masking in logs
-- **Hooks** - Run code before/after any module
-- **Skip conditions** - Dynamically skip modules based on custom logic
-- **Retry policies** - Configurable retry with Polly integration
-- **Requirements validation** - Check prerequisites before running
-- **Progress reporting** - Real-time console output with parallel execution visualization
-- **Source controlled** - Your pipeline is code, version it like code
+* **Parallel execution** - Automatic based on declared dependencies
+* **Module data sharing** - Strongly-typed results flow between modules
+* **Roslyn analyzers** - Catch mistakes at compile time, not runtime
+* **Conditional dependencies** - `DependsOnIf<T>()` for dynamic dependency graphs
+* **Dependency management** - Circular dependency detection built-in
+* **Strong typing** - Pass data between modules with compile-time safety
+* **Debug locally** - Set breakpoints, inspect variables, fix issues before pushing
+* **Build agent agnostic** - Same code runs on GitHub, Azure, TeamCity, or your laptop
+* **Secret obfuscation** - Automatic masking in logs
+* **Hooks** - Run code before/after any module
+* **Skip conditions** - Dynamically skip modules based on custom logic
+* **Retry policies** - Configurable retry with Polly integration
+* **Requirements validation** - Check prerequisites before running
+* **Progress reporting** - Real-time console output with parallel execution visualization
+* **Source controlled** - Your pipeline is code, version it like code
 
 ## Breaking Changes
 

--- a/src/ModularPipelines.Build/GitHelpers.cs
+++ b/src/ModularPipelines.Build/GitHelpers.cs
@@ -3,7 +3,6 @@ using ModularPipelines.Build.Settings;
 using ModularPipelines.Context;
 using ModularPipelines.Git.Extensions;
 using ModularPipelines.Git.Options;
-using ModularPipelines.GitHub.Extensions;
 using ModularPipelines.Options;
 
 namespace ModularPipelines.Build;
@@ -23,10 +22,10 @@ public static class GitHelpers
         await context.Git().Commands.Config(new GitConfigOptions
         {
             Local = true,
-            Arguments = new List<string>
-            {
+            Arguments =
+            [
                 "user.name", settings.GitUserName,
-            },
+            ],
         }, cancellationToken: cancellationToken);
     }
 
@@ -37,71 +36,20 @@ public static class GitHelpers
         await context.Git().Commands.Config(new GitConfigOptions
         {
             Local = true,
-            Arguments = new List<string>
-            {
-                "user.email", settings.GitUserEmail,
-            },
-        }, cancellationToken: cancellationToken);
-    }
-
-    public static async Task CheckoutBranch(IModuleContext context, string branchName, CancellationToken cancellationToken)
-    {
-        var settings = GetGitHubSettings(context);
-        var token = settings.StandardToken;
-
-        await context.Git().Commands.Remote(new GitRemoteOptions
-        {
             Arguments =
             [
-                "set-url", "origin",
-                $"https://x-access-token:{token}@github.com/{settings.RepositoryOwner}/{settings.RepositoryName}"
+                "user.email", settings.GitUserEmail,
             ],
-        }, null, cancellationToken);
-
-        await context.Git().Commands.Fetch(new GitFetchOptions(), cancellationToken: cancellationToken);
-
-        await context.Git().Commands
-            .Checkout(new GitCheckoutOptions(branchName), cancellationToken: cancellationToken);
-    }
-
-    public static async Task CommitAndPush(IModuleContext context, string? branchToPushTo, string message, string token,
-        CancellationToken cancellationToken)
-    {
-        var settings = GetGitHubSettings(context);
-
-        await context.Git().Commands.Pull(cancellationToken: cancellationToken);
-
-        await context.Git().Commands.Add(new GitAddOptions
-        {
-            All = true,
-        }, cancellationToken: cancellationToken);
-
-        await context.Git().Commands.Commit(new GitCommitOptions
-        {
-            Message = message,
-        }, cancellationToken: cancellationToken);
-
-        var author = context.GitHub().EnvironmentVariables.Actor ?? settings.RepositoryOwner;
-
-        var arguments = new List<string> { $"https://x-access-token:{token}@github.com/{author}/{settings.RepositoryName}.git" };
-
-        if (!string.IsNullOrEmpty(branchToPushTo))
-        {
-            arguments.Add(branchToPushTo);
-        }
-
-        await context.Git().Commands.Push(new GitPushOptions
-        {
-            Arguments = arguments,
         }, cancellationToken: cancellationToken);
     }
 
-    public static async Task<bool> HasUncommittedChanges(IModuleContext context)
+    public static async Task<bool> HasUncommittedChanges(IModuleContext context, IEnumerable<string> paths)
     {
         var result = await context.Git().Commands.Diff(
             new GitDiffOptions
             {
                 Quiet = true,
+                Arguments = ["--", .. paths],
             },
             new CommandExecutionOptions
             {

--- a/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
+++ b/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
@@ -1,13 +1,8 @@
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
-using ModularPipelines.Build.Attributes;
-using ModularPipelines.Build.Settings;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Extensions;
 using ModularPipelines.Git.Extensions;
-using ModularPipelines.GitHub.Attributes;
 using ModularPipelines.GitHub.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -16,30 +11,16 @@ using ModularPipelines.Node.Models;
 
 namespace ModularPipelines.Build.Modules;
 
-[SkipIfNoGitHubToken]
-[SkipIfNoStandardGitHubToken]
 [RunOnLinuxOnly]
 [DependsOn<GenerateReadMeModule>]
 public class FormatMarkdownModule : Module<CommandResult>
 {
-    private readonly IOptions<GitHubSettings> _gitHubSettings;
-
-    public FormatMarkdownModule(IOptions<GitHubSettings> gitHubSettings)
-    {
-        _gitHubSettings = gitHubSettings;
-    }
-
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
         .WithSkipWhen(ctx =>
         {
             if (ctx.GitHub().EnvironmentVariables.EventName != "pull_request")
             {
                 return SkipDecision.Skip("Not a pull request");
-            }
-
-            if (string.IsNullOrEmpty(_gitHubSettings.Value.StandardToken))
-            {
-                return SkipDecision.Skip("No authentication token for git");
             }
 
             return SkipDecision.DoNotSkip;
@@ -83,22 +64,11 @@ public class FormatMarkdownModule : Module<CommandResult>
             }, cancellationToken);
         }
 
-        if (!await GitHelpers.HasUncommittedChanges(context))
+        if (await GitHelpers.HasUncommittedChanges(context))
         {
-            return null;
+            throw new InvalidOperationException(
+                "Markdown files are not formatted. Run FormatMarkdownModule locally and commit the changes.");
         }
-
-        var branchTriggeringPullRequest = context.GitHub().EnvironmentVariables.HeadRef!;
-
-        await GitHelpers.SetUserCommitInformation(context, cancellationToken);
-
-        await GitHelpers.CheckoutBranch(context, branchTriggeringPullRequest, cancellationToken);
-
-        await GitHelpers.CommitAndPush(context, branchTriggeringPullRequest, "Formatting Markdown", _gitHubSettings.Value.StandardToken!,
-            cancellationToken);
-
-        // Log that we're completing early - the git push will trigger a new run
-        context.Logger.LogInformation("Formatting Markdown complete. The git push will trigger a new run with the formatted markdown.");
 
         return null;
     }

--- a/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
+++ b/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
@@ -64,7 +64,7 @@ public class FormatMarkdownModule : Module<CommandResult>
             }, cancellationToken);
         }
 
-        if (await GitHelpers.HasUncommittedChanges(context))
+        if (await GitHelpers.HasUncommittedChanges(context, filesToFormat))
         {
             throw new InvalidOperationException(
                 "Markdown files are not formatted. Run FormatMarkdownModule locally and commit the changes.");

--- a/src/ModularPipelines.Build/Modules/GenerateReadMeModule.cs
+++ b/src/ModularPipelines.Build/Modules/GenerateReadMeModule.cs
@@ -42,7 +42,8 @@ public class GenerateReadMeModule : Module<IDictionary<string, object>>
                 $"| {moduleName} | {moduleDescription} | [![nuget](https://img.shields.io/nuget/v/{moduleName}.svg)](https://www.nuget.org/packages/{moduleName}/) |");
         }
 
-        var updatedContents = readmeTemplateContents.Replace("%%% AVAILABLE MODULES PLACEHOLDER %%%", generatedContentStringBuilder.ToString());
+        var generatedContent = generatedContentStringBuilder.ToString().TrimEnd('\r', '\n');
+        var updatedContents = readmeTemplateContents.Replace("%%% AVAILABLE MODULES PLACEHOLDER %%%", generatedContent);
 
         if (updatedContents == readMeActualOriginalContents)
         {


### PR DESCRIPTION
## Summary
- remove GitHub token requirements and all checkout/commit/push behavior from markdown validation
- keep remark formatting active on pull requests
- fail with an actionable message when formatting changes are required

## Validation
- focused format verification
- ModularPipelines.Build project build

Closes #3067