### PR TITLE
Suppress unchanged scheduler status logs

### DIFF
--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -293,8 +293,7 @@ internal static class DependencyInjectionSetup
             .AddSingleton<Engine.Execution.IAlwaysRunHandler, Engine.Execution.AlwaysRunHandler>()
 
             // Module scheduling components (SRP extraction from ModuleScheduler)
-            .AddSingleton<Engine.Scheduling.IModuleConstraintEvaluator, Engine.Scheduling.ModuleConstraintEvaluator>()
-            .AddSingleton<Engine.Scheduling.ISchedulerStatusReporter, Engine.Scheduling.SchedulerStatusReporter>();
+            .AddSingleton<Engine.Scheduling.IModuleConstraintEvaluator, Engine.Scheduling.ModuleConstraintEvaluator>();
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/ModuleSchedulerFactory.cs
+++ b/src/ModularPipelines/Engine/ModuleSchedulerFactory.cs
@@ -18,7 +18,7 @@ internal class ModuleSchedulerFactory : IModuleSchedulerFactory
     private readonly IModuleMetadataRegistry _metadataRegistry;
     private readonly IMetricsCollector _metricsCollector;
     private readonly IModuleConstraintEvaluator _constraintEvaluator;
-    private readonly ISchedulerStatusReporter _statusReporter;
+    private readonly ILoggerFactory _loggerFactory;
 
     public ModuleSchedulerFactory(
         ILogger<ModuleScheduler> logger,
@@ -28,7 +28,7 @@ internal class ModuleSchedulerFactory : IModuleSchedulerFactory
         IModuleMetadataRegistry metadataRegistry,
         IMetricsCollector metricsCollector,
         IModuleConstraintEvaluator constraintEvaluator,
-        ISchedulerStatusReporter statusReporter)
+        ILoggerFactory loggerFactory)
     {
         _logger = logger;
         _timeProvider = timeProvider;
@@ -37,11 +37,23 @@ internal class ModuleSchedulerFactory : IModuleSchedulerFactory
         _metadataRegistry = metadataRegistry;
         _metricsCollector = metricsCollector;
         _constraintEvaluator = constraintEvaluator;
-        _statusReporter = statusReporter;
+        _loggerFactory = loggerFactory;
     }
 
     public IModuleScheduler Create()
     {
-        return new ModuleScheduler(_logger, _timeProvider, _schedulerOptions, _dependencyRegistry, _metadataRegistry, _metricsCollector, _constraintEvaluator, _statusReporter);
+        var statusReporter = new SchedulerStatusReporter(
+            _loggerFactory.CreateLogger<SchedulerStatusReporter>(),
+            _timeProvider);
+
+        return new ModuleScheduler(
+            _logger,
+            _timeProvider,
+            _schedulerOptions,
+            _dependencyRegistry,
+            _metadataRegistry,
+            _metricsCollector,
+            _constraintEvaluator,
+            statusReporter);
     }
 }

--- a/src/ModularPipelines/Engine/Scheduling/SchedulerStatusReporter.cs
+++ b/src/ModularPipelines/Engine/Scheduling/SchedulerStatusReporter.cs
@@ -4,7 +4,7 @@ using ModularPipelines.Helpers;
 namespace ModularPipelines.Engine.Scheduling;
 
 /// <summary>
-/// Reports scheduler status at regular intervals for diagnostic purposes.
+/// Reports scheduler status changes at regular check intervals for diagnostic purposes.
 /// </summary>
 /// <remarks>
 /// This class encapsulates the periodic status logging responsibility
@@ -16,12 +16,14 @@ namespace ModularPipelines.Engine.Scheduling;
 /// </remarks>
 internal class SchedulerStatusReporter : ISchedulerStatusReporter
 {
-    private static readonly TimeSpan StatusLogInterval = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan StatusCheckInterval = TimeSpan.FromSeconds(15);
 
     private readonly ILogger<SchedulerStatusReporter> _logger;
     private readonly TimeProvider _timeProvider;
+    private readonly object _statusLock = new();
 
-    private DateTimeOffset _lastStatusLogTime;
+    private DateTimeOffset _lastStatusCheckTime;
+    private SchedulerStatusSnapshot? _lastSnapshot;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SchedulerStatusReporter"/> class.
@@ -38,45 +40,63 @@ internal class SchedulerStatusReporter : ISchedulerStatusReporter
     public void LogStatusIfIntervalElapsed(ModuleStateQueries stateQueries, ReaderWriterLockSlim stateLock)
     {
         var now = _timeProvider.GetUtcNow();
-        if (now - _lastStatusLogTime < StatusLogInterval)
+        lock (_statusLock)
         {
-            return;
+            if (now - _lastStatusCheckTime < StatusCheckInterval)
+            {
+                return;
+            }
+
+            _lastStatusCheckTime = now;
         }
 
-        _lastStatusLogTime = now;
-
         // Consolidate all state queries under a single read lock to reduce contention
-        ModuleStateStatistics stats;
-        ModuleState[] pending;
-        ModuleState[] executing;
+        SchedulerStatusSnapshot snapshot;
 
         stateLock.EnterReadLock();
         try
         {
-            stats = stateQueries.GetStatistics();
-            pending = stateQueries.GetPendingModules().ToArray();
-            executing = stateQueries.GetExecutingModules().ToArray();
+            snapshot = new SchedulerStatusSnapshot(
+                stateQueries.GetStatistics(),
+                string.Join(", ", stateQueries.GetPendingModules()
+                    .Select(FormatModuleWithDependencyCount)
+                    .Order(StringComparer.Ordinal)),
+                string.Join(", ", stateQueries.GetExecutingModules()
+                    .Select(m => m.ModuleType.Name)
+                    .Order(StringComparer.Ordinal)));
         }
         finally
         {
             stateLock.ExitReadLock();
         }
 
+        lock (_statusLock)
+        {
+            if (snapshot == _lastSnapshot)
+            {
+                return;
+            }
+
+            _lastSnapshot = snapshot;
+        }
+
         // All logging outside lock to avoid holding lock during I/O
         _logger.LogDebug(
             "Scheduler waiting: Total={Total}, Queued={Queued}, Executing={Executing}, Completed={Completed}, Pending={Pending}",
-            stats.Total, stats.Queued, stats.Executing, stats.Completed, stats.Pending);
+            snapshot.Statistics.Total,
+            snapshot.Statistics.Queued,
+            snapshot.Statistics.Executing,
+            snapshot.Statistics.Completed,
+            snapshot.Statistics.Pending);
 
-        if (pending.Length > 0)
+        if (snapshot.PendingModules.Length > 0)
         {
-            _logger.LogDebug("Pending modules: {Modules}",
-                string.Join(", ", pending.Select(FormatModuleWithDependencyCount)));
+            _logger.LogDebug("Pending modules: {Modules}", snapshot.PendingModules);
         }
 
-        if (executing.Length > 0)
+        if (snapshot.ExecutingModules.Length > 0)
         {
-            _logger.LogDebug("Executing modules: {Modules}",
-                string.Join(", ", executing.Select(m => m.ModuleType.Name)));
+            _logger.LogDebug("Executing modules: {Modules}", snapshot.ExecutingModules);
         }
     }
 
@@ -84,4 +104,9 @@ internal class SchedulerStatusReporter : ISchedulerStatusReporter
     {
         return $"{m.ModuleType.Name} (deps: {m.UnresolvedDependencies.Count})";
     }
+
+    private sealed record SchedulerStatusSnapshot(
+        ModuleStateStatistics Statistics,
+        string PendingModules,
+        string ExecutingModules);
 }

--- a/src/ModularPipelines/Engine/Scheduling/SchedulerStatusReporter.cs
+++ b/src/ModularPipelines/Engine/Scheduling/SchedulerStatusReporter.cs
@@ -40,6 +40,8 @@ internal class SchedulerStatusReporter : ISchedulerStatusReporter
     public void LogStatusIfIntervalElapsed(ModuleStateQueries stateQueries, ReaderWriterLockSlim stateLock)
     {
         var now = _timeProvider.GetUtcNow();
+        SchedulerStatusSnapshot snapshot;
+
         lock (_statusLock)
         {
             if (now - _lastStatusCheckTime < StatusCheckInterval)
@@ -48,30 +50,30 @@ internal class SchedulerStatusReporter : ISchedulerStatusReporter
             }
 
             _lastStatusCheckTime = now;
-        }
 
-        // Consolidate all state queries under a single read lock to reduce contention
-        SchedulerStatusSnapshot snapshot;
+            if (!_logger.IsEnabled(LogLevel.Debug))
+            {
+                return;
+            }
 
-        stateLock.EnterReadLock();
-        try
-        {
-            snapshot = new SchedulerStatusSnapshot(
-                stateQueries.GetStatistics(),
-                string.Join(", ", stateQueries.GetPendingModules()
-                    .Select(FormatModuleWithDependencyCount)
-                    .Order(StringComparer.Ordinal)),
-                string.Join(", ", stateQueries.GetExecutingModules()
-                    .Select(m => m.ModuleType.Name)
-                    .Order(StringComparer.Ordinal)));
-        }
-        finally
-        {
-            stateLock.ExitReadLock();
-        }
+            // Consolidate all state queries under a single read lock to reduce contention
+            stateLock.EnterReadLock();
+            try
+            {
+                snapshot = new SchedulerStatusSnapshot(
+                    stateQueries.GetStatistics(),
+                    string.Join(", ", stateQueries.GetPendingModules()
+                        .Select(FormatModuleWithDependencyCount)
+                        .Order(StringComparer.Ordinal)),
+                    string.Join(", ", stateQueries.GetExecutingModules()
+                        .Select(m => FormatModuleType(m.ModuleType))
+                        .Order(StringComparer.Ordinal)));
+            }
+            finally
+            {
+                stateLock.ExitReadLock();
+            }
 
-        lock (_statusLock)
-        {
             if (snapshot == _lastSnapshot)
             {
                 return;
@@ -102,8 +104,10 @@ internal class SchedulerStatusReporter : ISchedulerStatusReporter
 
     private static string FormatModuleWithDependencyCount(ModuleState m)
     {
-        return $"{m.ModuleType.Name} (deps: {m.UnresolvedDependencies.Count})";
+        return $"{FormatModuleType(m.ModuleType)} (deps: {m.UnresolvedDependencies.Count})";
     }
+
+    private static string FormatModuleType(Type moduleType) => moduleType.FullName ?? moduleType.Name;
 
     private sealed record SchedulerStatusSnapshot(
         ModuleStateStatistics Statistics,

--- a/test/ModularPipelines.UnitTests/Engine/Scheduling/SchedulerStatusReporterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Scheduling/SchedulerStatusReporterTests.cs
@@ -1,0 +1,110 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Scheduling;
+using ModularPipelines.Modules;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine.Scheduling;
+
+public class SchedulerStatusReporterTests
+{
+    private static readonly DateTimeOffset StartTime = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+    [Test]
+    public async Task Unchanged_Status_Is_Not_Logged_Again()
+    {
+        var state = CreateModuleState(typeof(ExecutingModule), ModuleExecutionState.Executing);
+        var states = new ConcurrentDictionary<Type, ModuleState>([new(typeof(ExecutingModule), state)]);
+        var logger = new RecordingLogger<SchedulerStatusReporter>();
+        var timeProvider = new FakeTimeProvider(StartTime);
+        var reporter = new SchedulerStatusReporter(logger, timeProvider);
+        var stateQueries = new ModuleStateQueries(states);
+        using var stateLock = new ReaderWriterLockSlim();
+
+        reporter.LogStatusIfIntervalElapsed(stateQueries, stateLock);
+        timeProvider.Advance(TimeSpan.FromSeconds(15));
+        reporter.LogStatusIfIntervalElapsed(stateQueries, stateLock);
+
+        await Assert.That(logger.Messages).Count().IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Changed_Status_Is_Logged_After_Interval()
+    {
+        var state = CreateModuleState(typeof(ExecutingModule), ModuleExecutionState.Executing);
+        var states = new ConcurrentDictionary<Type, ModuleState>([new(typeof(ExecutingModule), state)]);
+        var logger = new RecordingLogger<SchedulerStatusReporter>();
+        var timeProvider = new FakeTimeProvider(StartTime);
+        var reporter = new SchedulerStatusReporter(logger, timeProvider);
+        var stateQueries = new ModuleStateQueries(states);
+        using var stateLock = new ReaderWriterLockSlim();
+
+        reporter.LogStatusIfIntervalElapsed(stateQueries, stateLock);
+        state.State = ModuleExecutionState.Completed;
+        timeProvider.Advance(TimeSpan.FromSeconds(15));
+        reporter.LogStatusIfIntervalElapsed(stateQueries, stateLock);
+
+        await Assert.That(logger.Messages).Count().IsEqualTo(3);
+        await Assert.That(logger.Messages[^1]).Contains("Completed=1");
+    }
+
+    [Test]
+    public async Task Changed_Dependency_Count_Is_Logged_When_Statistics_Are_Unchanged()
+    {
+        var state = CreateModuleState(typeof(PendingModule), ModuleExecutionState.Pending);
+        state.UnresolvedDependencies.Add(typeof(DependencyModule));
+        var states = new ConcurrentDictionary<Type, ModuleState>([new(typeof(PendingModule), state)]);
+        var logger = new RecordingLogger<SchedulerStatusReporter>();
+        var timeProvider = new FakeTimeProvider(StartTime);
+        var reporter = new SchedulerStatusReporter(logger, timeProvider);
+        var stateQueries = new ModuleStateQueries(states);
+        using var stateLock = new ReaderWriterLockSlim();
+
+        reporter.LogStatusIfIntervalElapsed(stateQueries, stateLock);
+        state.UnresolvedDependencies.Clear();
+        timeProvider.Advance(TimeSpan.FromSeconds(15));
+        reporter.LogStatusIfIntervalElapsed(stateQueries, stateLock);
+
+        await Assert.That(logger.Messages).Count().IsEqualTo(4);
+        await Assert.That(logger.Messages[^1]).Contains("deps: 0");
+    }
+
+    private static ModuleState CreateModuleState(Type moduleType, ModuleExecutionState executionState)
+    {
+        return new ModuleState(new Mock<IModule>().Object, moduleType)
+        {
+            State = executionState,
+        };
+    }
+
+    private sealed class ExecutingModule;
+
+    private sealed class PendingModule;
+
+    private sealed class DependencyModule;
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/Scheduling/SchedulerStatusReporterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Scheduling/SchedulerStatusReporterTests.cs
@@ -71,6 +71,29 @@ public class SchedulerStatusReporterTests
         await Assert.That(logger.Messages[^1]).Contains("deps: 0");
     }
 
+    [Test]
+    public async Task Different_Module_With_Same_Simple_Name_Is_Logged()
+    {
+        var firstState = CreateModuleState(typeof(FirstContainer.SameNameModule), ModuleExecutionState.Executing);
+        var states = new ConcurrentDictionary<Type, ModuleState>(
+            [new(typeof(FirstContainer.SameNameModule), firstState)]);
+        var logger = new RecordingLogger<SchedulerStatusReporter>();
+        var timeProvider = new FakeTimeProvider(StartTime);
+        var reporter = new SchedulerStatusReporter(logger, timeProvider);
+        var stateQueries = new ModuleStateQueries(states);
+        using var stateLock = new ReaderWriterLockSlim();
+
+        reporter.LogStatusIfIntervalElapsed(stateQueries, stateLock);
+        states.TryRemove(typeof(FirstContainer.SameNameModule), out _);
+        var secondState = CreateModuleState(typeof(SecondContainer.SameNameModule), ModuleExecutionState.Executing);
+        states[typeof(SecondContainer.SameNameModule)] = secondState;
+        timeProvider.Advance(TimeSpan.FromSeconds(15));
+        reporter.LogStatusIfIntervalElapsed(stateQueries, stateLock);
+
+        await Assert.That(logger.Messages).Count().IsEqualTo(4);
+        await Assert.That(logger.Messages[^1]).Contains(typeof(SecondContainer.SameNameModule).FullName!);
+    }
+
     private static ModuleState CreateModuleState(Type moduleType, ModuleExecutionState executionState)
     {
         return new ModuleState(new Mock<IModule>().Object, moduleType)
@@ -84,6 +107,16 @@ public class SchedulerStatusReporterTests
     private sealed class PendingModule;
 
     private sealed class DependencyModule;
+
+    private sealed class FirstContainer
+    {
+        public sealed class SameNameModule;
+    }
+
+    private sealed class SecondContainer
+    {
+        public sealed class SameNameModule;
+    }
 
     private sealed class RecordingLogger<T> : ILogger<T>
     {


### PR DESCRIPTION
## Summary
- compare scheduler status snapshots at each 15-second check
- log only when counts, pending dependencies, or executing modules change
- normalize module ordering and cover unchanged/changed behavior

## Validation
- dotnet build test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj --no-restore -m:1 /nodeReuse:false`n- 3 focused SchedulerStatusReporterTests passed

Closes #3068