### PR TITLE
Suppress cancellation logs after successful runs

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -157,11 +157,7 @@ internal class ModuleExecutor : IModuleExecutor
 
     private void RegisterCancellationCallback(CancellationTokenSource cancellationTokenSource, IModuleScheduler scheduler)
     {
-        cancellationTokenSource.Token.Register(() =>
-        {
-            _logger.LogDebug("Cancellation triggered - cancelling all pending modules");
-            scheduler.CancelPendingModules();
-        });
+        cancellationTokenSource.Token.Register(scheduler.CancelPendingModules);
     }
 
     private async Task<Exception?> ExecuteWorkerPoolAsync(

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -262,7 +262,10 @@ internal class ModuleStateTracker : IModuleStateTracker
         }
 
         // Logging outside lock
-        _logger.LogDebug("Cancelling {Count} pending/queued modules due to pipeline cancellation (excluding AlwaysRun modules)", cancelledModules.Count);
+        if (cancelledModules.Count > 0)
+        {
+            _logger.LogDebug("Cancelling {Count} pending/queued modules due to pipeline cancellation (excluding AlwaysRun modules)", cancelledModules.Count);
+        }
 
         foreach (var (moduleState, originalState) in cancelledModules)
         {

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -1,10 +1,13 @@
+using System.Collections.Concurrent;
 using System.Text;
 using System.Threading.Channels;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Execution;
+using ModularPipelines.Engine.Scheduling;
 using ModularPipelines.Helpers;
 using ModularPipelines.Interfaces;
+using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.UnitTests.Logging;
@@ -51,7 +54,52 @@ public class ModuleExecutorLoggingTests
 
         var logOutput = logs.ToString();
         await Assert.That(logOutput).DoesNotContain("Cancellation triggered");
-        await Assert.That(logOutput).DoesNotContain("Cancelling 0 pending");
         scheduler.Verify(x => x.CancelPendingModules(), Times.Once);
+    }
+
+    [Test]
+    public async Task CancelPendingModules_WithNoCancellableModules_DoesNotLogCancellation()
+    {
+        var logs = new StringBuilder();
+        var moduleStates = new ConcurrentDictionary<Type, ModuleState>();
+        var tracker = CreateModuleStateTracker(logs, moduleStates);
+
+        tracker.CancelPendingModules();
+
+        await Assert.That(logs.ToString()).DoesNotContain("Cancelling");
+    }
+
+    [Test]
+    public async Task CancelPendingModules_WithPendingModule_LogsCancellation()
+    {
+        var logs = new StringBuilder();
+        var module = new Mock<IModule>();
+        module.SetupGet(x => x.ModuleRunType).Returns(ModuleRunType.OnSuccessfulDependencies);
+        var state = new ModuleState(module.Object, typeof(IModule));
+        var moduleStates = new ConcurrentDictionary<Type, ModuleState>();
+        moduleStates[state.ModuleType] = state;
+        var tracker = CreateModuleStateTracker(logs, moduleStates);
+
+        tracker.CancelPendingModules();
+
+        await Assert.That(logs.ToString()).Contains("Cancelling 1 pending/queued modules");
+    }
+
+    private static ModuleStateTracker CreateModuleStateTracker(
+        StringBuilder logs,
+        ConcurrentDictionary<Type, ModuleState> moduleStates)
+    {
+        return new ModuleStateTracker(
+            new StringLogger<ModuleStateTracker>(logs),
+            TimeProvider.System,
+            Mock.Of<IMetricsCollector>(),
+            Mock.Of<IModuleConstraintEvaluator>(),
+            moduleStates,
+            [],
+            [],
+            new ModuleStateQueries(moduleStates),
+            new ReaderWriterLockSlim(),
+            new SemaphoreSlim(0),
+            () => false);
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -1,0 +1,57 @@
+using System.Text;
+using System.Threading.Channels;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Execution;
+using ModularPipelines.Helpers;
+using ModularPipelines.Interfaces;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+using ModularPipelines.UnitTests.Logging;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class ModuleExecutorLoggingTests
+{
+    [Test]
+    public async Task SuccessfulCompletion_DoesNotLogCancellation()
+    {
+        var logs = new StringBuilder();
+        var readyModules = Channel.CreateUnbounded<ModuleState>();
+        readyModules.Writer.Complete();
+
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler.SetupGet(x => x.ReadyModules).Returns(readyModules.Reader);
+        scheduler.Setup(x => x.RunSchedulerAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var schedulerFactory = new Mock<IModuleSchedulerFactory>();
+        schedulerFactory.Setup(x => x.Create()).Returns(scheduler.Object);
+
+        var registrationEvents = new Mock<IRegistrationEventExecutor>();
+        registrationEvents.Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(Task.CompletedTask);
+
+        var parallelLimitProvider = new Mock<IParallelLimitProvider>();
+        parallelLimitProvider.Setup(x => x.GetMaxDegreeOfParallelism()).Returns(1);
+
+        var executor = new ModuleExecutor(
+            schedulerFactory.Object,
+            Mock.Of<IModuleRunner>(),
+            Mock.Of<IAlwaysRunHandler>(),
+            Mock.Of<IModuleResultRegistrar>(),
+            parallelLimitProvider.Object,
+            registrationEvents.Object,
+            Mock.Of<IMetricsCollector>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
+            new StringLogger<ModuleExecutor>(logs));
+
+        await executor.ExecuteAsync([Mock.Of<IModule>()]);
+
+        var logOutput = logs.ToString();
+        await Assert.That(logOutput).DoesNotContain("Cancellation triggered");
+        await Assert.That(logOutput).DoesNotContain("Cancelling 0 pending");
+        scheduler.Verify(x => x.CancelPendingModules(), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary

- remove the generic cancellation message from the scheduler cleanup callback
- suppress pending-module cancellation logs when no modules were affected
- cover successful completion cleanup with a focused logging regression test

Closes #3069.

## Verification

- `dotnet build test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj --no-restore`
- 12 module-executor, failed-pipeline, and cancellation-token tests