### PR TITLE
Clarify scheduler cancellation logs

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -157,11 +157,7 @@ internal class ModuleExecutor : IModuleExecutor
 
     private void RegisterCancellationCallback(CancellationTokenSource cancellationTokenSource, IModuleScheduler scheduler)
     {
-        cancellationTokenSource.Token.Register(() =>
-        {
-            _logger.LogDebug("Cancellation triggered - cancelling all pending modules");
-            scheduler.CancelPendingModules();
-        });
+        cancellationTokenSource.Token.Register(scheduler.CancelPendingModules);
     }
 
     private async Task<Exception?> ExecuteWorkerPoolAsync(
@@ -194,8 +190,11 @@ internal class ModuleExecutor : IModuleExecutor
                     }
                     catch (Exception ex) when (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                     {
-                        Interlocked.CompareExchange(ref firstException, ex, null);
-                        cancellationTokenSource.Cancel();
+                        if (Interlocked.CompareExchange(ref firstException, ex, null) == null)
+                        {
+                            _logger.LogDebug("Module failure triggered cancellation - cancelling all pending modules");
+                            cancellationTokenSource.Cancel();
+                        }
                     }
                 }).ConfigureAwait(false);
         }

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -262,6 +262,11 @@ internal class ModuleStateTracker : IModuleStateTracker
         }
 
         // Logging outside lock
+        if (cancelledModules.Count == 0)
+        {
+            return;
+        }
+
         _logger.LogDebug("Cancelling {Count} pending/queued modules due to pipeline cancellation (excluding AlwaysRun modules)", cancelledModules.Count);
 
         foreach (var (moduleState, originalState) in cancelledModules)

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Modules;
+using ModularPipelines.TestHelpers;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class ModuleExecutorLoggingTests
+{
+    [Test]
+    public async Task Successful_Pipeline_Does_Not_Log_Cancellation()
+    {
+        var executorLogger = new RecordingLogger<ModuleExecutor>();
+        var stateTrackerLogger = new RecordingLogger<ModuleStateTracker>();
+        var builder = TestPipelineHostBuilder.Create();
+        builder.Services.AddSingleton<ILogger<ModuleExecutor>>(executorLogger);
+        builder.Services.AddSingleton<ILogger<ModuleStateTracker>>(stateTrackerLogger);
+
+        await builder
+            .AddModule<SuccessfulModule>()
+            .ExecutePipelineAsync();
+
+        var cancellationWasLogged = executorLogger.Messages
+            .Concat(stateTrackerLogger.Messages)
+            .Any(message => message.Contains("cancell", StringComparison.OrdinalIgnoreCase));
+
+        await Assert.That(cancellationWasLogged).IsFalse();
+    }
+
+    [Test]
+    public async Task Failed_Pipeline_Logs_Cancellation_Cause()
+    {
+        var logger = new RecordingLogger<ModuleExecutor>();
+        var builder = TestPipelineHostBuilder.Create();
+        builder.Services.AddSingleton<ILogger<ModuleExecutor>>(logger);
+
+        await Assert.That(() => builder
+                .AddModule<FailingModule>()
+                .ExecutePipelineAsync())
+            .ThrowsException();
+
+        var failureCancellationWasLogged = logger.Messages.Any(message =>
+            message.Contains("Module failure triggered cancellation", StringComparison.Ordinal));
+
+        await Assert.That(failureCancellationWasLogged).IsTrue();
+    }
+
+    private sealed class SuccessfulModule : Module
+    {
+        protected override Task ExecuteModuleAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FailingModule : Module
+    {
+        protected override Task ExecuteModuleAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            throw new InvalidOperationException("Expected test failure");
+        }
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public ConcurrentQueue<string> Messages { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Enqueue(formatter(state, exception));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- keep normal scheduler token cleanup silent
- log cancellation wording only when a module failure triggers it
- suppress zero-module cancellation summaries
- cover successful and failed pipeline logging

## Validation
- dotnet build test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj --no-restore -m:1 /nodeReuse:false`n- 2 focused ModuleExecutorLoggingTests passed

Closes #3069