### PR TITLE
Standardize module timing logs

### DIFF
--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
+using ModularPipelines.Helpers;
 using Spectre.Console;
 
 namespace ModularPipelines.Console;
@@ -157,16 +158,14 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private string FormatHeader(Exception? exception)
     {
         var duration = DateTime.UtcNow - _startTimeUtc;
-        var durationStr = duration.TotalSeconds >= 60
-            ? $"{duration.TotalMinutes:F1}m"
-            : $"{duration.TotalSeconds:F1}s";
+        var durationText = duration.ToDisplayString();
 
         if (exception != null)
         {
-            return $"{_moduleName} \u2717 ({durationStr}) - {exception.GetType().Name}";
+            return $"{_moduleName} \u2717 ({durationText}) - {exception.GetType().Name}";
         }
 
-        return $"{_moduleName} \u2713 ({durationStr})";
+        return $"{_moduleName} \u2713 ({durationText})";
     }
 
     private static void WriteWithMarkup(string? value)

--- a/src/ModularPipelines/Engine/ModuleCompletionLogState.cs
+++ b/src/ModularPipelines/Engine/ModuleCompletionLogState.cs
@@ -1,0 +1,55 @@
+using System.Collections;
+using ModularPipelines.Helpers;
+
+namespace ModularPipelines.Engine;
+
+internal sealed class ModuleCompletionLogState : IReadOnlyList<KeyValuePair<string, object?>>
+{
+    private const string FormatWithDuration =
+        "Module {ModuleName} completed after {DurationText} with lock keys: {Keys} (Active: Q={Queued}, E={Executing})";
+    private const string FormatWithoutDuration =
+        "Module {ModuleName} completed with lock keys: {Keys} (Active: Q={Queued}, E={Executing})";
+
+    private readonly KeyValuePair<string, object?>[] _properties;
+
+    public ModuleCompletionLogState(
+        string moduleName,
+        TimeSpan? duration,
+        string lockKeys,
+        int queued,
+        int executing)
+    {
+        var durationText = duration?.ToDisplayString();
+        var durationClause = durationText is null ? string.Empty : $" after {durationText}";
+        Message = $"Module {moduleName} completed{durationClause} with lock keys: {lockKeys} (Active: Q={queued}, E={executing})";
+
+        var properties = new List<KeyValuePair<string, object?>>
+        {
+            new("ModuleName", moduleName),
+            new("Keys", lockKeys),
+            new("Queued", queued),
+            new("Executing", executing),
+        };
+
+        if (duration.HasValue)
+        {
+            properties.Add(new("DurationText", durationText));
+            properties.Add(new("Duration", duration.Value));
+            properties.Add(new("ExecutionTime", duration.Value.TotalMilliseconds));
+        }
+
+        properties.Add(new("{OriginalFormat}", duration.HasValue ? FormatWithDuration : FormatWithoutDuration));
+        _properties = properties.ToArray();
+    }
+
+    public string Message { get; }
+
+    public int Count => _properties.Length;
+
+    public KeyValuePair<string, object?> this[int index] => _properties[index];
+
+    public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() =>
+        ((IEnumerable<KeyValuePair<string, object?>>) _properties).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => _properties.GetEnumerator();
+}

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -115,7 +115,10 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             executionContext.StartTime = DateTimeOffset.UtcNow;
             executionContext.Stopwatch.Start();
 
-            logger.LogDebug("Module {ModuleName} execution started at {StartTime}", moduleName, executionContext.StartTime);
+            logger.LogDebug(
+                "Module {ModuleName} execution started at {StartTime}",
+                moduleName,
+                executionContext.StartTime.ToString("O"));
 
             // Execute with timeout and retry
             var result = await ExecuteWithPolicies(module, config, executionContext, moduleContext).ConfigureAwait(false);
@@ -131,7 +134,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             // Save to history if applicable
             await SaveToHistory(module, moduleResult, moduleContext).ConfigureAwait(false);
 
-            logger.LogDebug("Module succeeded after {Duration}", executionContext.Duration);
+            logger.LogDebug("Module succeeded after {Duration}", executionContext.Duration.ToDisplayString());
 
             executionContext.SetTypedResult(moduleResult);
 

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -116,9 +116,9 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             executionContext.Stopwatch.Start();
 
             logger.LogDebug(
-                "Module {ModuleName} execution started at {StartTime}",
+                "Module {ModuleName} execution started at {StartTime:O}",
                 moduleName,
-                executionContext.StartTime.ToString("O"));
+                executionContext.StartTime);
 
             // Execute with timeout and retry
             var result = await ExecuteWithPolicies(module, config, executionContext, moduleContext).ConfigureAwait(false);
@@ -133,8 +133,6 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
             // Save to history if applicable
             await SaveToHistory(module, moduleResult, moduleContext).ConfigureAwait(false);
-
-            logger.LogDebug("Module succeeded after {Duration}", executionContext.Duration.ToDisplayString());
 
             executionContext.SetTypedResult(moduleResult);
 

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -204,17 +204,26 @@ internal class ModuleStateTracker : IModuleStateTracker
         _metricsCollector.RecordModuleCompleted(moduleType, completionTime, success, wasSkipped, status);
         _metricsCollector.RecordConcurrencySnapshot(executingCount, completionTime);
 
-        // Logging outside lock - use plain text, not markup (markup causes double-escaping issues)
         var lockKeys = state.RequiredLockKeys.Length == 0
             ? "(none)"
             : string.Join(", ", state.RequiredLockKeys);
-
-        _logger.LogDebug(
-            "Module {ModuleName} completed with lock keys: {Keys} (Active: Q={Queued}, E={Executing})",
+        var executionTime = state.ExecutionStartTime.HasValue
+            ? completionTime - state.ExecutionStartTime.Value
+            : (TimeSpan?) null;
+        var completionLog = new ModuleCompletionLogState(
             state.ModuleType.Name,
+            executionTime,
             lockKeys,
             queuedCount,
             executingCount);
+
+        // Logging outside lock - use plain text, not markup (markup causes double-escaping issues)
+        _logger.Log(
+            LogLevel.Debug,
+            default,
+            completionLog,
+            null,
+            static (state, _) => state.Message);
 
         // Log dependent module updates outside lock
         LogDependentModuleUpdates(state, dependentUpdates);

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -216,17 +216,6 @@ internal class ModuleStateTracker : IModuleStateTracker
             queuedCount,
             executingCount);
 
-        var moduleName = state.ModuleType.Name;
-
-        if (state.ExecutionStartTime.HasValue && state.CompletionTime.HasValue)
-        {
-            var executionTime = state.CompletionTime.Value - state.ExecutionStartTime.Value;
-            _logger.LogDebug(
-                "Module {ModuleName} completed after {ExecutionTime}ms",
-                moduleName,
-                executionTime.TotalMilliseconds);
-        }
-
         // Log dependent module updates outside lock
         LogDependentModuleUpdates(state, dependentUpdates);
 

--- a/src/ModularPipelines/Helpers/TimeSpanFormatter.cs
+++ b/src/ModularPipelines/Helpers/TimeSpanFormatter.cs
@@ -39,6 +39,6 @@ internal static class TimeSpanFormatter
 
     private static string Hours(TimeSpan timeSpan)
     {
-        return timeSpan.Hours.ToString("0") + "h";
+        return ((long) timeSpan.TotalHours).ToString("0") + "h";
     }
 }

--- a/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
+++ b/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
@@ -58,7 +58,16 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
                 continue;
             }
 
-            var valueString = value.ToString() ?? string.Empty;
+            if (value is not string valueString)
+            {
+                if (value.GetType().IsValueType)
+                {
+                    continue;
+                }
+
+                valueString = value.ToString() ?? string.Empty;
+            }
+
             values[index] = _secretObfuscator.Obfuscate(valueString, null);
         }
     }

--- a/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
+++ b/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
@@ -1,16 +1,13 @@
-using System.Reflection;
 using ModularPipelines.Engine;
 
 namespace ModularPipelines.Logging;
 
 /// <summary>
-/// Handles obfuscation of values within FormattedLogValues objects using reflection.
-/// This class intercepts Microsoft.Extensions.Logging internal structures to mask secrets.
+/// Handles obfuscation of values within structured logging state.
 /// </summary>
 /// <remarks>
-/// This class uses reflection to access the internal "_values" field of FormattedLogValues,
-/// which is an implementation detail of Microsoft.Extensions.Logging. It applies secret
-/// obfuscation to all string values before they are logged, preventing sensitive data leakage.
+/// Structured values keep their original type when their string representation contains no
+/// secrets. Values containing secrets are replaced with their obfuscated string representation.
 /// </remarks>
 /// <example>
 /// <code>
@@ -25,9 +22,6 @@ namespace ModularPipelines.Logging;
 /// </example>
 internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
 {
-    private const string FormattedLogValuesTypeName = "Microsoft.Extensions.Logging.FormattedLogValues";
-    private const string ValuesFieldName = "_values";
-
     private readonly ISecretObfuscator _secretObfuscator;
 
     public FormattedLogValuesObfuscator(ISecretObfuscator secretObfuscator)
@@ -35,41 +29,35 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
         _secretObfuscator = secretObfuscator;
     }
 
-    public void TryObfuscateValues(object state)
+    public object TryObfuscateValues(object state)
     {
-        if (state?.GetType().FullName != FormattedLogValuesTypeName)
+        if (state is not IReadOnlyList<KeyValuePair<string, object?>> values)
         {
-            return;
+            return state;
         }
 
-        var valuesField = state.GetType().GetField(ValuesFieldName, BindingFlags.NonPublic | BindingFlags.Instance);
-        if (valuesField == null)
-        {
-            return;
-        }
+        KeyValuePair<string, object?>[]? obfuscatedValues = null;
 
-        var values = valuesField.GetValue(state) as object?[] ?? Array.Empty<object?>();
-
-        for (var index = 0; index < values.Length; index++)
+        for (var index = 0; index < values.Count; index++)
         {
-            var value = values[index];
-            if (value is null)
+            var property = values[index];
+            if (property.Value is null || property.Key.Equals("{OriginalFormat}", StringComparison.Ordinal))
             {
                 continue;
             }
 
-            if (value is not string valueString)
+            var originalValue = property.Value.ToString() ?? string.Empty;
+            var obfuscatedValue = _secretObfuscator.Obfuscate(originalValue, null);
+            if (obfuscatedValue.Equals(originalValue, StringComparison.Ordinal))
             {
-                if (value.GetType().IsValueType)
-                {
-                    continue;
-                }
-
-                valueString = value.ToString() ?? string.Empty;
+                continue;
             }
 
-            values[index] = _secretObfuscator.Obfuscate(valueString, null);
+            obfuscatedValues ??= values.ToArray();
+            obfuscatedValues[index] = new KeyValuePair<string, object?>(property.Key, obfuscatedValue);
         }
+
+        return obfuscatedValues ?? state;
     }
 }
 
@@ -79,8 +67,9 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
 internal interface IFormattedLogValuesObfuscator
 {
     /// <summary>
-    /// Attempts to obfuscate values within a FormattedLogValues object.
+    /// Attempts to obfuscate values within structured logging state.
     /// </summary>
     /// <param name="state">The state object to obfuscate.</param>
-    void TryObfuscateValues(object state);
+    /// <returns>The original state when unchanged; otherwise, sanitized structured state.</returns>
+    object TryObfuscateValues(object state);
 }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -112,13 +112,12 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
                 return;
             }
 
-            _formattedLogValuesObfuscator.TryObfuscateValues(state!);
-
-            var mappedFormatter = MapFormatter(formatter);
+            var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state!);
+            var mappedFormatter = MapFormatter(formatter, state);
 
             // Write to buffer for ordered module output during pipeline execution
             // Output will be flushed to console and loggers when the module completes
-            _buffer.AddLogEvent(logLevel, eventId, state!, exception, mappedFormatter);
+            _buffer.AddLogEvent(logLevel, eventId, obfuscatedState, exception, mappedFormatter);
 
             LastLogWritten = DateTime.UtcNow;
         }
@@ -212,16 +211,18 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
         _buffer.WriteLine(obfuscated);
     }
 
-    private Func<object, Exception?, string> MapFormatter<TState>(Func<TState, Exception?, string>? formatter)
+    private Func<object, Exception?, string> MapFormatter<TState>(
+        Func<TState, Exception?, string>? formatter,
+        TState originalState)
     {
         if (formatter is null)
         {
             return (_, _) => string.Empty;
         }
 
-        return (o, exception) =>
+        return (_, exception) =>
         {
-            var formattedString = formatter.Invoke((TState) o, exception);
+            var formattedString = formatter.Invoke(originalState, exception);
             return _secretObfuscator.Obfuscate(formattedString, null) ?? string.Empty;
         };
     }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleCompletionLogStateTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleCompletionLogStateTests.cs
@@ -1,0 +1,22 @@
+using ModularPipelines.Engine;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class ModuleCompletionLogStateTests
+{
+    [Test]
+    public async Task CompletionLog_PreservesStructuredDurationValues()
+    {
+        var duration = TimeSpan.FromMilliseconds(23_737);
+        var state = new ModuleCompletionLogState("ExampleModule", duration, "(none)", 1, 2);
+
+        var properties = state.ToDictionary(x => x.Key, x => x.Value);
+
+        await Assert.That(state.Message).IsEqualTo(
+            "Module ExampleModule completed after 23s & 737ms with lock keys: (none) (Active: Q=1, E=2)");
+        await Assert.That(properties["Duration"]).IsTypeOf<TimeSpan>();
+        await Assert.That(properties["Duration"]).IsEqualTo(duration);
+        await Assert.That(properties["ExecutionTime"]).IsTypeOf<double>();
+        await Assert.That(properties["ExecutionTime"]).IsEqualTo(duration.TotalMilliseconds);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Helpers/TimeSpanFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/TimeSpanFormatterTests.cs
@@ -1,0 +1,23 @@
+using ModularPipelines.Helpers;
+
+namespace ModularPipelines.UnitTests.Helpers;
+
+public class TimeSpanFormatterTests
+{
+    [Test]
+    [Arguments(0, 0, 0, 849, "849ms")]
+    [Arguments(0, 0, 23, 737, "23s & 737ms")]
+    [Arguments(0, 9, 42, 0, "9m & 42s")]
+    [Arguments(2, 3, 0, 0, "2h & 3m")]
+    public async Task ToDisplayString_UsesOneReadableFormat(
+        int hours,
+        int minutes,
+        int seconds,
+        int milliseconds,
+        string expected)
+    {
+        var duration = new TimeSpan(0, hours, minutes, seconds, milliseconds);
+
+        await Assert.That(duration.ToDisplayString()).IsEqualTo(expected);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Helpers/TimeSpanFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/TimeSpanFormatterTests.cs
@@ -20,4 +20,12 @@ public class TimeSpanFormatterTests
 
         await Assert.That(duration.ToDisplayString()).IsEqualTo(expected);
     }
+
+    [Test]
+    public async Task ToDisplayString_IncludesDaysAsTotalHours()
+    {
+        var duration = TimeSpan.FromHours(25.5);
+
+        await Assert.That(duration.ToDisplayString()).IsEqualTo("25h & 30m");
+    }
 }

--- a/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
@@ -8,7 +8,7 @@ namespace ModularPipelines.UnitTests.Logging;
 public class FormattedLogValuesObfuscatorTests
 {
     [Test]
-    public async Task TryObfuscateValues_PreservesStructuredValueTypes()
+    public async Task TryObfuscateValues_PreservesUnmaskedStructuredValueTypes()
     {
         var startTime = DateTimeOffset.UtcNow;
         var logger = new Mock<ILogger>();
@@ -24,12 +24,49 @@ public class FormattedLogValuesObfuscatorTests
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns((string? value, object? _) => value == "secret" ? "********" : value ?? string.Empty);
 
-        new FormattedLogValuesObfuscator(secretObfuscator.Object).TryObfuscateValues(state);
-        var properties = ((IReadOnlyList<KeyValuePair<string, object?>>) state)
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object).TryObfuscateValues(state);
+        var properties = ((IReadOnlyList<KeyValuePair<string, object?>>) obfuscatedState)
             .ToDictionary(x => x.Key, x => x.Value);
 
         await Assert.That(properties["StartTime"]).IsTypeOf<DateTimeOffset>();
         await Assert.That(properties["StartTime"]).IsEqualTo(startTime);
         await Assert.That(properties["Secret"]).IsEqualTo("********");
+    }
+
+    [Test]
+    public async Task TryObfuscateValues_MasksValueTypeSecrets()
+    {
+        var secret = Guid.NewGuid();
+        var logger = new Mock<ILogger>();
+        logger.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(true);
+        logger.Object.LogDebug("Token: {Token}", secret);
+
+        var state = logger.Invocations.Single(x => x.Method.Name == nameof(ILogger.Log)).Arguments[2];
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) => value == secret.ToString() ? "********" : value ?? string.Empty);
+
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object).TryObfuscateValues(state);
+        var properties = ((IReadOnlyList<KeyValuePair<string, object?>>) obfuscatedState)
+            .ToDictionary(x => x.Key, x => x.Value);
+
+        await Assert.That(properties["Token"]).IsEqualTo("********");
+    }
+
+    [Test]
+    public async Task TryObfuscateValues_MasksCustomStructuredLogStates()
+    {
+        var state = new ModuleCompletionLogState("secret", TimeSpan.FromSeconds(1), "(none)", 0, 0);
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) => value == "secret" ? "********" : value ?? string.Empty);
+
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object).TryObfuscateValues(state);
+        var properties = ((IReadOnlyList<KeyValuePair<string, object?>>) obfuscatedState)
+            .ToDictionary(x => x.Key, x => x.Value);
+
+        await Assert.That(properties["ModuleName"]).IsEqualTo("********");
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Engine;
+using ModularPipelines.Logging;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Logging;
+
+public class FormattedLogValuesObfuscatorTests
+{
+    [Test]
+    public async Task TryObfuscateValues_PreservesStructuredValueTypes()
+    {
+        var startTime = DateTimeOffset.UtcNow;
+        var logger = new Mock<ILogger>();
+        logger.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(true);
+        if (logger.Object.IsEnabled(LogLevel.Debug))
+        {
+            logger.Object.LogDebug("Started at {StartTime:O} with {Secret}", startTime, "secret");
+        }
+
+        var state = logger.Invocations.Single(x => x.Method.Name == nameof(ILogger.Log)).Arguments[2];
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) => value == "secret" ? "********" : value ?? string.Empty);
+
+        new FormattedLogValuesObfuscator(secretObfuscator.Object).TryObfuscateValues(state);
+        var properties = ((IReadOnlyList<KeyValuePair<string, object?>>) state)
+            .ToDictionary(x => x.Key, x => x.Value);
+
+        await Assert.That(properties["StartTime"]).IsTypeOf<DateTimeOffset>();
+        await Assert.That(properties["StartTime"]).IsEqualTo(startTime);
+        await Assert.That(properties["Secret"]).IsEqualTo("********");
+    }
+}

--- a/test/ModularPipelines.UnitTests/Logging/ModuleStateLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleStateLoggingTests.cs
@@ -25,8 +25,8 @@ public class ModuleStateLoggingTests
         await host.RunAsync();
         await host.DisposeAsync();
 
-        await Assert.That(logs.ToString()).Contains(
-            "Module ModuleWithoutLocks completed with lock keys: (none)");
+        await Assert.That(logs.ToString()).Contains("Module ModuleWithoutLocks completed after");
+        await Assert.That(logs.ToString()).Contains("with lock keys: (none)");
     }
 
     private sealed class ModuleWithoutLocks : Module<bool>


### PR DESCRIPTION
## Summary
- format module durations through the shared readable formatter
- emit module start times in ISO 8601 round-trip format
- remove the duplicate state-tracker completion log
- cover representative duration formats

## Tests
- dotnet build test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj --no-restore --nologo -v:minimal
- 27 focused unit tests (TimeSpanFormatterTests, FailedPipelineTests, SyncModuleTests)

Closes #3070