### PR TITLE
Fill empty values in diagnostic logs

### DIFF
--- a/src/ModularPipelines.Git/Attributes/BranchConditionHelper.cs
+++ b/src/ModularPipelines.Git/Attributes/BranchConditionHelper.cs
@@ -18,7 +18,7 @@ internal static class BranchConditionHelper
         string logMessageFormat)
     {
         var currentBranchName = pipelineContext.Git().Information.BranchName;
-        pipelineContext.Logger.LogDebug(logMessageFormat, currentBranchName, expectedBranchName);
+        pipelineContext.Logger.LogDebug(logMessageFormat, GetDisplayBranchName(currentBranchName), expectedBranchName);
         return currentBranchName == expectedBranchName;
     }
 
@@ -31,7 +31,12 @@ internal static class BranchConditionHelper
         string logMessageFormat)
     {
         var currentBranchName = pipelineContext.Git().Information.BranchName;
-        pipelineContext.Logger.LogDebug(logMessageFormat, currentBranchName, expectedPrefix);
+        pipelineContext.Logger.LogDebug(logMessageFormat, GetDisplayBranchName(currentBranchName), expectedPrefix);
         return currentBranchName?.StartsWith(expectedPrefix) ?? false;
+    }
+
+    private static string GetDisplayBranchName(string? branchName)
+    {
+        return string.IsNullOrWhiteSpace(branchName) ? "(detached)" : branchName;
     }
 }

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -205,10 +205,14 @@ internal class ModuleStateTracker : IModuleStateTracker
         _metricsCollector.RecordConcurrencySnapshot(executingCount, completionTime);
 
         // Logging outside lock - use plain text, not markup (markup causes double-escaping issues)
+        var lockKeys = state.RequiredLockKeys.Length == 0
+            ? "(none)"
+            : string.Join(", ", state.RequiredLockKeys);
+
         _logger.LogDebug(
             "Module {ModuleName} completed with lock keys: {Keys} (Active: Q={Queued}, E={Executing})",
             state.ModuleType.Name,
-            string.Join(", ", state.RequiredLockKeys),
+            lockKeys,
             queuedCount,
             executingCount);
 

--- a/test/ModularPipelines.UnitTests/Attributes/BranchConditionLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/BranchConditionLoggingTests.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using ModularPipelines.Context;
+using ModularPipelines.Context.Domains;
+using ModularPipelines.Git;
+using ModularPipelines.Git.Attributes;
+using ModularPipelines.Logging;
+
+namespace ModularPipelines.UnitTests.Attributes;
+
+public class BranchConditionLoggingTests
+{
+    [Test]
+    public async Task RunIfBranch_UsesDetachedPlaceholderForEmptyBranch()
+    {
+        var logger = new Mock<IModuleLogger>();
+        logger.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(true);
+        var gitInformation = Mock.Of<IGitInformation>(x => x.BranchName == string.Empty);
+        var git = Mock.Of<IGit>(x => x.Information == gitInformation);
+        var services = new Mock<IServicesContext>();
+        services.Setup(x => x.Get<IGit>()).Returns(git);
+        var context = Mock.Of<IPipelineHookContext>(x =>
+            x.Logger == logger.Object &&
+            x.Services == services.Object);
+
+        var result = await new RunIfBranchAttribute("main").Condition(context);
+        var logMessage = logger.Invocations
+            .Single(x => x.Method.Name == nameof(ILogger.Log))
+            .Arguments[2]
+            .ToString();
+
+        await Assert.That(result).IsFalse();
+        await Assert.That(logMessage).IsEqualTo("Current Branch: (detached) | Can run on: main");
+    }
+}

--- a/test/ModularPipelines.UnitTests/Logging/ModuleStateLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleStateLoggingTests.cs
@@ -1,0 +1,41 @@
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+using ModularPipelines.TestHelpers;
+
+namespace ModularPipelines.UnitTests.Logging;
+
+public class ModuleStateLoggingTests
+{
+    [Test]
+    public async Task CompletedModule_UsesPlaceholderWhenThereAreNoLockKeys()
+    {
+        var logs = new StringBuilder();
+        var host = await TestPipelineHostBuilder.Create()
+            .ConfigureServices((_, services) =>
+            {
+                services.AddSingleton(logs);
+                services.AddSingleton(typeof(ILogger<>), typeof(StringLogger<>));
+            })
+            .AddModule<ModuleWithoutLocks>()
+            .BuildHostAsync();
+
+        await host.RunAsync();
+        await host.DisposeAsync();
+
+        await Assert.That(logs.ToString()).Contains(
+            "Module ModuleWithoutLocks completed with lock keys: (none)");
+    }
+
+    private sealed class ModuleWithoutLocks : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- render detached or unavailable Git branches as \(detached)\`n- render modules without lock keys as \(none)\`n- preserve branch condition behavior while improving diagnostics
- add regression coverage for both rendered log lines

## Tests
- dotnet build test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj --no-restore --nologo -v:minimal
- 2 focused regression tests

Closes #3072