### PR TITLE
Normalize module timing logs

### DIFF
--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
+using ModularPipelines.Helpers;
 using Spectre.Console;
 
 namespace ModularPipelines.Console;
@@ -157,9 +158,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private string FormatHeader(Exception? exception)
     {
         var duration = DateTime.UtcNow - _startTimeUtc;
-        var durationStr = duration.TotalSeconds >= 60
-            ? $"{duration.TotalMinutes:F1}m"
-            : $"{duration.TotalSeconds:F1}s";
+        var durationStr = duration.ToDisplayString();
 
         if (exception != null)
         {

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Configuration;
@@ -115,7 +116,10 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             executionContext.StartTime = DateTimeOffset.UtcNow;
             executionContext.Stopwatch.Start();
 
-            logger.LogDebug("Module {ModuleName} execution started at {StartTime}", moduleName, executionContext.StartTime);
+            logger.LogDebug(
+                "Module {ModuleName} execution started at {StartTime}",
+                moduleName,
+                executionContext.StartTime.ToString("O", CultureInfo.InvariantCulture));
 
             // Execute with timeout and retry
             var result = await ExecuteWithPolicies(module, config, executionContext, moduleContext).ConfigureAwait(false);
@@ -131,7 +135,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             // Save to history if applicable
             await SaveToHistory(module, moduleResult, moduleContext).ConfigureAwait(false);
 
-            logger.LogDebug("Module succeeded after {Duration}", executionContext.Duration);
+            logger.LogDebug("Module succeeded after {Duration}", executionContext.Duration.ToDisplayString());
 
             executionContext.SetTypedResult(moduleResult);
 

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -212,17 +212,6 @@ internal class ModuleStateTracker : IModuleStateTracker
             queuedCount,
             executingCount);
 
-        var moduleName = state.ModuleType.Name;
-
-        if (state.ExecutionStartTime.HasValue && state.CompletionTime.HasValue)
-        {
-            var executionTime = state.CompletionTime.Value - state.ExecutionStartTime.Value;
-            _logger.LogDebug(
-                "Module {ModuleName} completed after {ExecutionTime}ms",
-                moduleName,
-                executionTime.TotalMilliseconds);
-        }
-
         // Log dependent module updates outside lock
         LogDependentModuleUpdates(state, dependentUpdates);
 

--- a/test/ModularPipelines.UnitTests/Engine/DurationLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DurationLoggingTests.cs
@@ -1,0 +1,108 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Console;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Modules;
+using ModularPipelines.TestHelpers;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class DurationLoggingTests
+{
+    private const string DisplayDurationPattern = @"\d+(?:ms|s & \d+ms|m & \d+s|h & \d+m)";
+
+    [Test]
+    public async Task Module_Logs_Use_Consistent_Duration_And_Timestamp_Formats()
+    {
+        var moduleLogger = new RecordingLogger<SuccessfulModule>();
+        var schedulerLogger = new RecordingLogger<ModuleScheduler>();
+        var builder = TestPipelineHostBuilder.Create();
+        builder.Services.AddSingleton<ILogger<SuccessfulModule>>(moduleLogger);
+        builder.Services.AddSingleton<ILogger<ModuleScheduler>>(schedulerLogger);
+
+        await builder
+            .AddModule<SuccessfulModule>()
+            .ExecutePipelineAsync();
+
+        var startMessage = moduleLogger.Messages.Single(message => message.Contains("execution started at", StringComparison.Ordinal));
+        var startTime = startMessage[(startMessage.LastIndexOf(' ') + 1)..];
+        var isIso8601 = DateTimeOffset.TryParseExact(
+            startTime,
+            "O",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind,
+            out _);
+
+        var successMessage = moduleLogger.Messages.Single(message => message.StartsWith("Module succeeded after", StringComparison.Ordinal));
+
+        await Assert.That(isIso8601).IsTrue();
+        await Assert.That(Regex.IsMatch(successMessage, $"^Module succeeded after {DisplayDurationPattern}$")).IsTrue();
+        await Assert.That(schedulerLogger.Messages.Any(message => message.Contains("completed after", StringComparison.Ordinal))).IsFalse();
+    }
+
+    [Test]
+    public async Task Module_Group_Header_Uses_Display_Duration_Format()
+    {
+        var buffer = new ModuleOutputBuffer(typeof(SuccessfulModule));
+        var formatter = new CapturingFormatter();
+        buffer.WriteLine("output");
+
+        buffer.FlushTo(TextWriter.Null, formatter, NullLogger.Instance);
+
+        await Assert.That(formatter.Header).IsNotNull();
+        await Assert.That(Regex.IsMatch(
+            formatter.Header!,
+            $"^SuccessfulModule ✓ \\({DisplayDurationPattern}\\)$")).IsTrue();
+    }
+
+    private sealed class SuccessfulModule : Module
+    {
+        protected override Task ExecuteModuleAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public ConcurrentQueue<string> Messages { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Enqueue(formatter(state, exception));
+        }
+    }
+
+    private sealed class CapturingFormatter : IBuildSystemFormatter
+    {
+        public string? Header { get; private set; }
+
+        public string? GetStartBlockCommand(string name)
+        {
+            Header = name;
+            return null;
+        }
+
+        public string? GetEndBlockCommand(string name) => null;
+
+        public string? GetMaskSecretCommand(string secret) => null;
+    }
+}


### PR DESCRIPTION
## Summary
- format module durations through the shared display formatter
- emit execution start timestamps as invariant ISO-8601
- remove the duplicate scheduler completion-duration line
- align CI group header durations with summary output

## Validation
- dotnet build test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj --no-restore -m:1 /nodeReuse:false`n- 2 focused DurationLoggingTests passed

Closes #3070