### PR TITLE
Leave streamed command output unstyled

### DIFF
--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -107,8 +107,8 @@ internal static class DependencyInjectionSetup
         config.Theme = new SpectreTheme()
             .WithPlaceholders(placeholders =>
             {
-                placeholders.ForName("Output", Style.Plain);
-                placeholders.ForName("Error", Style.Plain);
+                placeholders.ForName("CommandOutput", Style.Plain);
+                placeholders.ForName("CommandError", Style.Plain);
             });
     }
 

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -1,5 +1,6 @@
 using Initialization.Microsoft.Extensions.DependencyInjection.Extensions;
 using MEL.Spectre;
+using MEL.Spectre.Theme;
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -103,6 +104,12 @@ internal static class DependencyInjectionSetup
         config.Template = "[{Level:u4}] {Message}{NewLine}{Exception}";
         config.ExceptionFormats = ExceptionFormats.Default;
         config.AllowMarkupInMessageTemplate = true;
+        config.Theme = new SpectreTheme()
+            .WithPlaceholders(placeholders =>
+            {
+                placeholders.ForName("Output", Style.Plain);
+                placeholders.ForName("Error", Style.Plain);
+            });
     }
 
     /// <summary>

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -92,11 +92,10 @@ internal class CommandLogger : ICommandLogger
             ? _secretObfuscator.Obfuscate(input, execOpts)
             : LoggingConstants.CommandMask;
 
-        // Build the main command line with inline metadata
-        var mainLine = new StringBuilder();
-        mainLine.Append(workingDirectory);
-        mainLine.Append("> ");
-        mainLine.Append(obfuscatedInput);
+        var commandMessage = new StringBuilder();
+        commandMessage.Append(workingDirectory);
+        commandMessage.Append("> ");
+        commandMessage.Append(obfuscatedInput);
 
         // Add inline output for short, single-line output on successful commands
         var trimmedOutput = standardOutput.Trim();
@@ -106,23 +105,22 @@ internal class CommandLogger : ICommandLogger
             && options.Verbosity >= CommandLogVerbosity.Normal
             && options.ShowStandardOutput;
 
-        if (hasShortOutput && isSuccess)
-        {
-            mainLine.Append(" → ");
-            mainLine.Append(_secretObfuscator.Obfuscate(trimmedOutput, execOpts));
-        }
+        var inlineOutput = hasShortOutput && isSuccess
+            ? $" → {_secretObfuscator.Obfuscate(trimmedOutput, execOpts)}"
+            : string.Empty;
 
         // Add status indicator and metadata
+        var commandStatus = new StringBuilder();
         if (options.Verbosity >= CommandLogVerbosity.Detailed || options.ShowExitCode || options.ShowExecutionTime)
         {
-            mainLine.Append(' ');
-            mainLine.Append(isSuccess ? '✓' : '✗');
+            commandStatus.Append(' ');
+            commandStatus.Append(isSuccess ? '✓' : '✗');
 
             var hasMetadata = false;
             if (options.Verbosity >= CommandLogVerbosity.Detailed || options.ShowExecutionTime)
             {
-                mainLine.Append(" [");
-                mainLine.Append(runTime?.ToDisplayString() ?? "?");
+                commandStatus.Append(" [");
+                commandStatus.Append(runTime?.ToDisplayString() ?? "?");
                 hasMetadata = true;
             }
 
@@ -130,25 +128,29 @@ internal class CommandLogger : ICommandLogger
             {
                 if (hasMetadata)
                 {
-                    mainLine.Append(", ");
+                    commandStatus.Append(", ");
                 }
                 else
                 {
-                    mainLine.Append(" [");
+                    commandStatus.Append(" [");
                     hasMetadata = true;
                 }
 
-                mainLine.Append("exit ");
-                mainLine.Append(exitCode);
+                commandStatus.Append("exit ");
+                commandStatus.Append(exitCode);
             }
 
             if (hasMetadata)
             {
-                mainLine.Append(']');
+                commandStatus.Append(']');
             }
         }
 
-        Logger.LogInformation("{Message}", mainLine.ToString());
+        Logger.LogInformation(
+            "{CommandMessage}{CommandOutput}{CommandStatus}",
+            commandMessage.ToString(),
+            inlineOutput,
+            commandStatus.ToString());
 
         // Log multi-line or long output on separate lines (only if not already shown inline)
         if (!hasShortOutput && !string.IsNullOrWhiteSpace(trimmedOutput)
@@ -158,7 +160,7 @@ internal class CommandLogger : ICommandLogger
             var outputToLog = execOpts?.OutputLoggingManipulator is not null
                 ? execOpts.OutputLoggingManipulator(trimmedOutput)
                 : trimmedOutput;
-            Logger.LogInformation("  ↳ {Output}", _secretObfuscator.Obfuscate(outputToLog, execOpts));
+            Logger.LogInformation("  ↳ {CommandOutput}", _secretObfuscator.Obfuscate(outputToLog, execOpts));
         }
 
         // Log errors on separate line
@@ -170,7 +172,7 @@ internal class CommandLogger : ICommandLogger
             var errorToLog = execOpts?.OutputLoggingManipulator is not null
                 ? execOpts.OutputLoggingManipulator(standardError)
                 : standardError;
-            Logger.LogWarning("  ✗ {Error}", _secretObfuscator.Obfuscate(errorToLog, execOpts));
+            Logger.LogWarning("  ✗ {CommandError}", _secretObfuscator.Obfuscate(errorToLog, execOpts));
         }
 
         // Log working directory only at Diagnostic level (separate line, indented)

--- a/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
@@ -9,6 +9,19 @@ namespace ModularPipelines.UnitTests.Logging;
 public class SpectreConsoleLoggerTests
 {
     [Test]
+    public async Task Leaves_Command_Output_Unstyled()
+    {
+        var options = new SpectreConsoleLoggerOptions();
+
+        DependencyInjectionSetup.ConfigureSpectreConsoleLogger(options);
+
+        await Assert.That(options.Theme.Placeholders.Resolve("Output", "build output"))
+            .IsEqualTo(Style.Plain);
+        await Assert.That(options.Theme.Placeholders.Resolve("Error", "build error"))
+            .IsEqualTo(Style.Plain);
+    }
+
+    [Test]
     public async Task Renders_Markup_Level_And_Exception_Details()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
@@ -2,6 +2,10 @@ using MEL.Spectre;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.DependencyInjection;
+using ModularPipelines.Engine;
+using ModularPipelines.Logging;
+using ModularPipelines.Options;
+using Moq;
 using Spectre.Console;
 
 namespace ModularPipelines.UnitTests.Logging;
@@ -9,16 +13,57 @@ namespace ModularPipelines.UnitTests.Logging;
 public class SpectreConsoleLoggerTests
 {
     [Test]
-    public async Task Leaves_Command_Output_Unstyled()
+    public async Task Leaves_Only_Command_Output_Unstyled()
     {
         var options = new SpectreConsoleLoggerOptions();
 
         DependencyInjectionSetup.ConfigureSpectreConsoleLogger(options);
 
+        await Assert.That(options.Theme.Placeholders.Resolve("CommandOutput", "build output"))
+            .IsEqualTo(Style.Plain);
+        await Assert.That(options.Theme.Placeholders.Resolve("CommandError", "build error"))
+            .IsEqualTo(Style.Plain);
         await Assert.That(options.Theme.Placeholders.Resolve("Output", "build output"))
-            .IsEqualTo(Style.Plain);
+            .IsNotEqualTo(Style.Plain);
         await Assert.That(options.Theme.Placeholders.Resolve("Error", "build error"))
-            .IsEqualTo(Style.Plain);
+            .IsNotEqualTo(Style.Plain);
+    }
+
+    [Test]
+    public async Task Logs_Inline_Output_With_Command_Output_Placeholder()
+    {
+        var logger = new CapturingModuleLogger();
+        var loggerProvider = new Mock<IModuleLoggerProvider>();
+        loggerProvider.Setup(x => x.GetLogger()).Returns(logger);
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? value, object? _) => value ?? string.Empty);
+        var commandLogger = new CommandLogger(
+            loggerProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
+            secretObfuscator.Object);
+
+        commandLogger.Log(
+            null,
+            new CommandExecutionOptions
+            {
+                LogSettings = new CommandLoggingOptions
+                {
+                    Verbosity = CommandLogVerbosity.Normal,
+                    ShowCommandArguments = true,
+                    ShowStandardOutput = true,
+                },
+            },
+            "tool --version",
+            0,
+            null,
+            "short output",
+            string.Empty,
+            "C:\\repo");
+
+        await Assert.That(logger.Properties["CommandOutput"]?.ToString()).Contains("short output");
+        await Assert.That(logger.Properties["CommandMessage"]?.ToString()).DoesNotContain("short output");
     }
 
     [Test]
@@ -71,6 +116,35 @@ public class SpectreConsoleLoggerTests
         catch (Exception exception)
         {
             return exception;
+        }
+    }
+
+    private sealed class CapturingModuleLogger : IModuleLogger
+    {
+        public IReadOnlyDictionary<string, object?> Properties { get; private set; }
+            = new Dictionary<string, object?>();
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (state is not IEnumerable<KeyValuePair<string, object?>> properties)
+            {
+                throw new InvalidOperationException("Expected structured log state.");
+            }
+
+            Properties = properties.ToDictionary(x => x.Key, x => x.Value);
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public void Dispose()
+        {
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove MEL.Spectre's `Wheat1` string-placeholder style from command stdout and stderr
- preserve log-level styling and all other structured placeholder theming
- allow child-process ANSI colors to remain visually meaningful
- add regression coverage for both command-output placeholders

The generated-code nullable warning flood noted in the issue is already fixed on this base by #3092.

## Tests
- dotnet build test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj --no-restore --nologo -v:minimal
- 40 focused CommandLogger and SpectreConsoleLogger tests

Closes #3073
Closes #3074
