### PR TITLE
Remove redundant System.Text.Json references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -80,7 +80,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
     <PackageVersion Include="StackExchange.Redis" Version="3.0.17" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.6" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions" Version="22.2.0" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions.TestingHelpers" Version="22.2.0" />
     <PackageVersion Include="TUnit" Version="1.61.29" />

--- a/src/ModularPipelines.Build/ModularPipelines.Build.csproj
+++ b/src/ModularPipelines.Build/ModularPipelines.Build.csproj
@@ -23,7 +23,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ModularPipelines.Analyzers\ModularPipelines.Analyzers\ModularPipelines.Analyzers.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />

--- a/src/ModularPipelines/ModularPipelines.csproj
+++ b/src/ModularPipelines/ModularPipelines.csproj
@@ -75,7 +75,6 @@
     </PackageReference>
     <PackageReference Include="Polly" />
     <PackageReference Include="Spectre.Console" />
-    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="EnumerableAsyncProcessor" />
     <PackageReference Include="Initialization.Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="MEL.Spectre" />

--- a/test/ModularPipelines.TestHelpers/ModularPipelines.TestHelpers.csproj
+++ b/test/ModularPipelines.TestHelpers/ModularPipelines.TestHelpers.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Azure.ResourceManager" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
-    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="TUnit.Core" />
     <PackageReference Include="TUnit.Assertions" />
   </ItemGroup>

--- a/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
+++ b/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="NReco.Logging.File" />
     <PackageReference Include="RichardSzalay.MockHttp" />
-    <PackageReference Include="System.Text.Json" />
     <PackageReference Include="TestableIO.System.IO.Abstractions" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="TUnit" />


### PR DESCRIPTION
## Summary
- remove redundant `System.Text.Json` package references from all net10.0 projects that declared them
- remove the now-unused central package version
- eliminate the corresponding NU1510 restore/build warnings

## Test plan
- [x] `dotnet build ModularPipelines.sln -c Release`
- [x] verify zero `NU1510` warnings mentioning `System.Text.Json`

Closes #3083
