### PR TITLE
Regenerate Kind positional arguments

### DIFF
--- a/src/ModularPipelines.Kind/AssemblyInfo.Generated.cs
+++ b/src/ModularPipelines.Kind/AssemblyInfo.Generated.cs
@@ -8,4 +8,4 @@
 using System.Reflection;
 
 [assembly: AssemblyMetadata("ModularPipelines.OptionsGenerator.Tool", "kind")]
-[assembly: AssemblyMetadata("ModularPipelines.OptionsGenerator.GeneratedAt", "2026-07-19T03:13:59.2936146Z")]
+[assembly: AssemblyMetadata("ModularPipelines.OptionsGenerator.Version", "2.0.0")]

--- a/src/ModularPipelines.Kind/Enums/KindBuildNodeImageType.Generated.cs
+++ b/src/ModularPipelines.Kind/Enums/KindBuildNodeImageType.Generated.cs
@@ -6,28 +6,28 @@
 #nullable enable
 
 using System.CodeDom.Compiler;
-using System.ComponentModel;
+using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Kind.Enums;
 
 /// <summary>
 /// Allowed values for the --type option.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum KindBuildNodeImageType
 {
-    [Description("url")]
+    [EnumValue("url")]
     Url,
 
-    [Description("file")]
+    [EnumValue("file")]
     File,
 
-    [Description("release")]
+    [EnumValue("release")]
     Release,
 
-    [Description("ci")]
+    [EnumValue("ci")]
     Ci,
 
-    [Description("source' as the type of build")]
+    [EnumValue("source' as the type of build")]
     SourceAsTheTypeOfBuild
 }

--- a/src/ModularPipelines.Kind/Enums/KindBuildNodeImageType.Generated.cs
+++ b/src/ModularPipelines.Kind/Enums/KindBuildNodeImageType.Generated.cs
@@ -28,6 +28,6 @@ public enum KindBuildNodeImageType
     [EnumValue("ci")]
     Ci,
 
-    [EnumValue("source' as the type of build")]
-    SourceAsTheTypeOfBuild
+    [EnumValue("source")]
+    Source
 }

--- a/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
+++ b/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
@@ -18,7 +18,7 @@ namespace ModularPipelines.Kind.Extensions;
 /// <summary>
 /// Generated extensions for registering kind services.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public static class KindExtensions
 {
 #pragma warning disable CA2255

--- a/src/ModularPipelines.Kind/Options/KindBuildNodeImageOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindBuildNodeImageOptions.Generated.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Build the node image which contains Kubernetes build artifacts and other kind requirements.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("build", "node-image")]
 public record KindBuildNodeImageOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindBuildOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Build one of [node-image]
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("build")]
 public record KindBuildOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindCreateClusterOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindCreateClusterOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Creates a local Kubernetes cluster using Docker container 'nodes'
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("create", "cluster")]
 public record KindCreateClusterOptions : KindOptions
@@ -57,7 +57,7 @@ public record KindCreateClusterOptions : KindOptions
     public bool? Retain { get; set; }
 
     /// <summary>
-    /// The length of time to wait for control plane node to be ready (default 0s). Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h).
+    /// wait for control plane node to be ready (default 0s)
     /// </summary>
     [CliOption("--wait", Format = OptionFormat.EqualsSeparated)]
     public string? Wait { get; set; }

--- a/src/ModularPipelines.Kind/Options/KindCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindCreateOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Creates one of local Kubernetes cluster (cluster)
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("create")]
 public record KindCreateOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindDeleteClusterOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindDeleteClusterOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Deletes a Kind cluster from the system.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("delete", "cluster")]
 public record KindDeleteClusterOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindDeleteClustersOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindDeleteClustersOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Deletes one or more Kind clusters from the system.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("delete", "clusters")]
 public record KindDeleteClustersOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindDeleteOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Deletes one of [cluster]
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("delete")]
 public record KindDeleteOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindExportKubeconfigOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindExportKubeconfigOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Exports cluster kubeconfig
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("export", "kubeconfig")]
 public record KindExportKubeconfigOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindExportLogsOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindExportLogsOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Exports logs to a tempdir or [output-dir] if specified
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("export", "logs")]
 public record KindExportLogsOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindExportOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindExportOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Exports one of [kubeconfig, logs]
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("export")]
 public record KindExportOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindGetKubeconfigOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindGetKubeconfigOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Prints cluster kubeconfig
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("get", "kubeconfig")]
 public record KindGetKubeconfigOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindGetNodesOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindGetNodesOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Lists existing kind nodes by their name
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("get", "nodes")]
 public record KindGetNodesOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindGetOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindGetOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Gets one of [clusters, nodes, kubeconfig]
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("get")]
 public record KindGetOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindLoadDockerImageOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindLoadDockerImageOptions.Generated.cs
@@ -19,7 +19,7 @@ namespace ModularPipelines.Kind.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("load", "docker-image")]
 public record KindLoadDockerImageOptions(
-    [property: CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)] string Image
+    [property: CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)] IEnumerable<string> Image
 ) : KindOptions
 {
     /// <summary>

--- a/src/ModularPipelines.Kind/Options/KindLoadDockerImageOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindLoadDockerImageOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Loads docker images from host into all or specified nodes by name
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("load", "docker-image")]
 public record KindLoadDockerImageOptions(
@@ -51,8 +51,5 @@ public record KindLoadDockerImageOptions(
     /// </summary>
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
-
-    [CliArgument(1, Placement = ArgumentPlacement.BeforeOptions)]
-    public string? Image { get; set; }
 
 }

--- a/src/ModularPipelines.Kind/Options/KindLoadImageArchiveOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindLoadImageArchiveOptions.Generated.cs
@@ -13,18 +13,30 @@ using ModularPipelines.Kind.Options;
 namespace ModularPipelines.Kind.Options;
 
 /// <summary>
-/// Lists existing kind clusters by their name
+/// Loads docker image from archive into all or specified nodes by name
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("get", "clusters")]
-public record KindGetClustersOptions : KindOptions
+[CliSubCommand("load", "image-archive")]
+public record KindLoadImageArchiveOptions : KindOptions
 {
     /// <summary>
-    /// help for clusters
+    /// help for image-archive
     /// </summary>
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
+
+    /// <summary>
+    /// the cluster context name (default "kind")
+    /// </summary>
+    [CliOption("--name", ShortForm = "-n", Format = OptionFormat.EqualsSeparated)]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// comma separated list of nodes to load images into
+    /// </summary>
+    [CliOption("--nodes", Format = OptionFormat.EqualsSeparated, AllowMultiple = true)]
+    public IEnumerable<string>? Nodes { get; set; }
 
     /// <summary>
     /// silence all stderr output

--- a/src/ModularPipelines.Kind/Options/KindLoadImageArchiveOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindLoadImageArchiveOptions.Generated.cs
@@ -18,7 +18,9 @@ namespace ModularPipelines.Kind.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("load", "image-archive")]
-public record KindLoadImageArchiveOptions : KindOptions
+public record KindLoadImageArchiveOptions(
+    [property: CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)] string ImageTar
+) : KindOptions
 {
     /// <summary>
     /// help for image-archive

--- a/src/ModularPipelines.Kind/Options/KindLoadOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindLoadOptions.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Options;
 /// <summary>
 /// Loads images into node from an archive or image on host
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("load")]
 public record KindLoadOptions : KindOptions

--- a/src/ModularPipelines.Kind/Options/KindOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindOptions.Generated.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Kind.Options;
 /// Base options class for kind CLI commands.
 /// Contains global flags that apply to all commands.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliTool("kind")]
 public abstract record KindOptions : CommandLineToolOptions

--- a/src/ModularPipelines.Kind/Services/IKind.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/IKind.Generated.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// Generated interface for kind CLI commands.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public partial interface IKind
 {
     #region Sub-domain Services

--- a/src/ModularPipelines.Kind/Services/Kind.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/Kind.Generated.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// Generated implementation for kind CLI commands.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 internal partial class Kind : IKind
 {
     private readonly ICommand _command;

--- a/src/ModularPipelines.Kind/Services/KindBuild.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/KindBuild.Generated.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind build commands.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public class KindBuild
 {
     private readonly ICommand _command;

--- a/src/ModularPipelines.Kind/Services/KindCreate.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/KindCreate.Generated.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind create commands.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public class KindCreate
 {
     private readonly ICommand _command;

--- a/src/ModularPipelines.Kind/Services/KindDelete.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/KindDelete.Generated.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind delete commands.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public class KindDelete
 {
     private readonly ICommand _command;

--- a/src/ModularPipelines.Kind/Services/KindExport.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/KindExport.Generated.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind export commands.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public class KindExport
 {
     private readonly ICommand _command;

--- a/src/ModularPipelines.Kind/Services/KindGet.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/KindGet.Generated.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind get commands.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public class KindGet
 {
     private readonly ICommand _command;

--- a/src/ModularPipelines.Kind/Services/KindLoad.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/KindLoad.Generated.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind load commands.
 /// </summary>
-[GeneratedCode("ModularPipelines.OptionsGenerator", "")]
+[GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public class KindLoad
 {
     private readonly ICommand _command;
@@ -59,6 +59,21 @@ public class KindLoad
         CancellationToken cancellationToken = default)
     {
         return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken);
+    }
+
+    /// <summary>
+    /// Loads docker image from archive into all or specified nodes by name
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public virtual async Task<CommandResult> ImageArchive(
+        KindLoadImageArchiveOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineTool(options ?? new KindLoadImageArchiveOptions(), executionOptions, cancellationToken);
     }
 
     #endregion

--- a/src/ModularPipelines.Kind/Services/KindLoad.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/KindLoad.Generated.cs
@@ -69,11 +69,11 @@ public class KindLoad
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> ImageArchive(
-        KindLoadImageArchiveOptions? options = null,
+        KindLoadImageArchiveOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineTool(options ?? new KindLoadImageArchiveOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineTool(options, executionOptions, cancellationToken);
     }
 
     #endregion

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -140,6 +140,40 @@ public class GeneratorHardeningTests
 
     #endregion
 
+    #region Positional argument deduplication
+
+    [Test]
+    public async Task OptionsClassGenerator_Deduplicates_Required_And_Optional_Positionals()
+    {
+        var command = Command("ToolLoadOptions", "ToolOptions") with
+        {
+            PositionalArguments =
+            [
+                new CliPositionalArgument
+                {
+                    PropertyName = "Image",
+                    CSharpType = "string",
+                    PositionIndex = 0,
+                    IsRequired = true,
+                },
+                new CliPositionalArgument
+                {
+                    PropertyName = "Image",
+                    CSharpType = "string?",
+                    PositionIndex = 1,
+                },
+            ],
+        };
+
+        var generated = (await new OptionsClassGenerator().GenerateAsync(Tool(command))).Single().Content;
+
+        await Assert.That(generated).Contains("[property: CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)] string Image");
+        await Assert.That(generated).DoesNotContain("public string? Image { get; set; }");
+        await Assert.That(generated.Split("CliArgument(")).Count().IsEqualTo(2);
+    }
+
+    #endregion
+
     #region Compatibility properties
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -159,7 +159,7 @@ public class GeneratorHardeningTests
                 new CliPositionalArgument
                 {
                     PropertyName = "Image",
-                    CSharpType = "string?",
+                    CSharpType = "IEnumerable<string>?",
                     PositionIndex = 1,
                 },
             ],
@@ -167,7 +167,7 @@ public class GeneratorHardeningTests
 
         var generated = (await new OptionsClassGenerator().GenerateAsync(Tool(command))).Single().Content;
 
-        await Assert.That(generated).Contains("[property: CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)] string Image");
+        await Assert.That(generated).Contains("[property: CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)] IEnumerable<string> Image");
         await Assert.That(generated).DoesNotContain("public string? Image { get; set; }");
         await Assert.That(generated.Split("CliArgument(")).Count().IsEqualTo(2);
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KindCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KindCliScraperTests.cs
@@ -1,0 +1,82 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class KindCliScraperTests
+{
+    [Test]
+    public async Task Docker_Image_Positionals_Are_One_Required_Collection()
+    {
+        var command = await Parse(
+            ["kind", "load", "docker-image"],
+            """
+            Loads docker images from host into all or specified nodes by name
+
+            Usage:
+              kind load docker-image <IMAGE> [IMAGE...] [flags]
+            """);
+
+        var positional = command.PositionalArguments.Single();
+        await Assert.That(positional.PropertyName).IsEqualTo("Image");
+        await Assert.That(positional.CSharpType).IsEqualTo("IEnumerable<string>");
+        await Assert.That(positional.IsRequired).IsTrue();
+    }
+
+    [Test]
+    public async Task Image_Archive_Dotted_Positional_Is_Required()
+    {
+        var command = await Parse(
+            ["kind", "load", "image-archive"],
+            """
+            Loads docker image from archive into all or specified nodes by name
+
+            Usage:
+              kind load image-archive <IMAGE.tar> [flags]
+            """);
+
+        var positional = command.PositionalArguments.Single();
+        await Assert.That(positional.PropertyName).IsEqualTo("ImageTar");
+        await Assert.That(positional.CSharpType).IsEqualTo("string");
+        await Assert.That(positional.IsRequired).IsTrue();
+    }
+
+    [Test]
+    public async Task Node_Image_Source_Enum_Excludes_Description_Suffix()
+    {
+        var command = await Parse(
+            ["kind", "build", "node-image"],
+            """
+            Build the node image
+
+            Usage:
+              kind build node-image [kubernetes-source] [flags]
+
+            Flags:
+                  --type string   optionally specify one of 'url', 'file', 'release', 'ci' or 'source' as the type of build
+            """);
+
+        var values = command.Options.Single(option => option.SwitchName == "--type").EnumDefinition!.Values;
+        await Assert.That(values.Select(value => value.CliValue))
+            .IsEquivalentTo(["url", "file", "release", "ci", "source"]);
+    }
+
+    private static async Task<CliCommandDefinition> Parse(string[] commandPath, string helpText) =>
+        (await new TestKindCliScraper().Parse(commandPath, helpText))!;
+
+    private sealed class TestKindCliScraper : KindCliScraper
+    {
+        public TestKindCliScraper()
+            : base(
+                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<KindCliScraper>.Instance)
+        {
+        }
+
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -49,10 +49,11 @@ public class OptionsClassGenerator : ICodeGenerator
         // Class declaration. The returned set contains the names emitted as
         // primary-constructor parameters, so a name scraped as both required and
         // optional can't produce two members (CS0102).
-        var existingPropertyNames = GenerateClassDeclaration(sb, command);
+        var positionalArguments = CliPositionalArgument.MergeDuplicates(command.PositionalArguments);
+        var existingPropertyNames = GenerateClassDeclaration(sb, command, positionalArguments);
 
         sb.AppendLine("{");
-        GenerateProperties(sb, command, existingPropertyNames);
+        GenerateProperties(sb, command, positionalArguments, existingPropertyNames);
         sb.AppendLine("}");
 
         return sb.ToString();
@@ -102,6 +103,7 @@ public class OptionsClassGenerator : ICodeGenerator
     private static void GenerateProperties(
         StringBuilder sb,
         CliCommandDefinition command,
+        IReadOnlyList<CliPositionalArgument> positionalArguments,
         HashSet<string> existingPropertyNames)
     {
         // Properties for non-required options
@@ -116,7 +118,7 @@ public class OptionsClassGenerator : ICodeGenerator
         }
 
         // Positional arguments - skip duplicates
-        foreach (var positional in command.PositionalArguments.Where(p => !p.IsRequired))
+        foreach (var positional in positionalArguments.Where(p => !p.IsRequired))
         {
             if (existingPropertyNames.Contains(positional.PropertyName))
             {
@@ -151,10 +153,13 @@ public class OptionsClassGenerator : ICodeGenerator
     /// Emits the class declaration and returns the member names emitted as
     /// primary-constructor parameters, so property emission can skip duplicates.
     /// </summary>
-    private static HashSet<string> GenerateClassDeclaration(StringBuilder sb, CliCommandDefinition command)
+    private static HashSet<string> GenerateClassDeclaration(
+        StringBuilder sb,
+        CliCommandDefinition command,
+        IReadOnlyList<CliPositionalArgument> positionalArguments)
     {
         var requiredOptions = command.RequiredOptions;
-        var requiredPositionals = command.PositionalArguments.Where(p => p.IsRequired).ToList();
+        var requiredPositionals = positionalArguments.Where(p => p.IsRequired).ToList();
         var existingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         if (requiredOptions.Count > 0 || requiredPositionals.Count > 0)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliPositionalArgument.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliPositionalArgument.cs
@@ -5,6 +5,27 @@ namespace ModularPipelines.OptionsGenerator.Models;
 /// </summary>
 public record CliPositionalArgument
 {
+    public static IReadOnlyList<CliPositionalArgument> MergeDuplicates(
+        IEnumerable<CliPositionalArgument> positionalArguments) =>
+        positionalArguments
+            .GroupBy(argument => argument.PropertyName, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                var first = group.OrderBy(argument => argument.PositionIndex).First();
+                var required = group.Any(argument => argument.IsRequired);
+                var collection = group.FirstOrDefault(argument =>
+                    argument.CSharpType.StartsWith("IEnumerable<", StringComparison.Ordinal));
+                var type = (collection ?? first).CSharpType.TrimEnd('?');
+
+                return first with
+                {
+                    CSharpType = required ? type : $"{type}?",
+                    IsRequired = required,
+                };
+            })
+            .OrderBy(argument => argument.PositionIndex)
+            .ToList();
+
     /// <summary>
     /// Placeholder name in documentation (e.g., "[<PROJECT>]").
     /// </summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -569,12 +569,27 @@ public abstract partial class CobraCliScraper : CliScraperBase
             .Replace(" or ", "|")
             .Replace(" and ", "|")
             .Split(['|', ','], StringSplitOptions.RemoveEmptyEntries)
-            .Select(v => v.Trim().Trim('"', '\'', '`'))
+            .Select(ExtractQuotedEnumValue)
             // Remove any embedded newlines, carriage returns, or other control characters
             .Select(SanitizeEnumValue)
             .Where(v => !string.IsNullOrWhiteSpace(v) && v.Length < 30)
             .Distinct()
             .ToArray();
+    }
+
+    private static string ExtractQuotedEnumValue(string value)
+    {
+        var trimmed = value.Trim();
+        if (trimmed.Length > 1 && trimmed[0] is '"' or '\'' or '`')
+        {
+            var closingQuote = trimmed.IndexOf(trimmed[0], 1);
+            if (closingQuote > 1)
+            {
+                return trimmed[1..closingQuote];
+            }
+        }
+
+        return trimmed.Trim('"', '\'', '`');
     }
 
     /// <summary>
@@ -699,9 +714,9 @@ public abstract partial class CobraCliScraper : CliScraperBase
         {
             var argName = match.Groups["name"].Value;
             var isRequired = match.Value.StartsWith('<'); // <NAME> is required, [NAME] is optional
-            var isMultiple = match.Value.Contains("...", StringComparison.Ordinal);
+            var isMultiple = match.Groups["multiple"].Success;
 
-            var propertyName = NormalizePropertyName(argName);
+            var propertyName = NormalizePropertyName(argName.Replace('.', '-'));
             if (propertyName is null)
             {
                 continue;
@@ -724,7 +739,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
             });
         }
 
-        return args;
+        return CliPositionalArgument.MergeDuplicates(args).ToList();
     }
 
     /// <summary>
@@ -925,7 +940,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// <summary>
     /// Matches positional arguments in usage: [NAME], &lt;NAME&gt;, or [NAME...].
     /// </summary>
-    [GeneratedRegex(@"[\[<](?<name>[A-Z_-]+)(?:\.\.\.)?[\]>]")]
+    [GeneratedRegex(@"[\[<](?<name>[A-Z][A-Za-z0-9_.-]*?)(?<multiple>\.\.\.)?[\]>]")]
     private static partial Regex PositionalArgPattern();
 
     /// <summary>


### PR DESCRIPTION
## Summary
- regenerate the Kind integration from the official v0.32.0 binary through the options generator
- remove the duplicate `Image` positional argument and restore the generated `load image-archive` command
- add a generator regression for required and optional positional arguments sharing a property name

## Test plan
- options generator tests: 359 passed
- `dotnet build src/ModularPipelines.Kind/ModularPipelines.Kind.csproj -c Release`: 0 errors
- Kind build output contains zero CS0657 or CS8907 warnings

Closes #3079