### PR TITLE
Mask secrets in structured log templates

### DIFF
--- a/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
+++ b/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
@@ -41,7 +41,7 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
         for (var index = 0; index < values.Count; index++)
         {
             var property = values[index];
-            if (property.Value is null || property.Key.Equals("{OriginalFormat}", StringComparison.Ordinal))
+            if (property.Value is null)
             {
                 continue;
             }

--- a/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
@@ -8,6 +8,29 @@ namespace ModularPipelines.UnitTests.Logging;
 public class FormattedLogValuesObfuscatorTests
 {
     [Test]
+    public async Task TryObfuscateValues_MasksSecretsInOriginalFormat()
+    {
+        const string secret = "literal-secret";
+        var logger = new Mock<ILogger>();
+        logger.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(true);
+        logger.Object.LogDebug("Token literal-secret for {Resource}", "repository");
+
+        var state = logger.Invocations.Single(x => x.Method.Name == nameof(ILogger.Log)).Arguments[2];
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) => (value ?? string.Empty).Replace(secret, "********", StringComparison.Ordinal));
+
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object).TryObfuscateValues(state);
+        var properties = ((IReadOnlyList<KeyValuePair<string, object?>>) obfuscatedState)
+            .ToDictionary(x => x.Key, x => x.Value);
+
+        await Assert.That(properties["{OriginalFormat}"]).IsEqualTo("Token ******** for {Resource}");
+        await Assert.That(properties["Resource"]).IsTypeOf<string>();
+        await Assert.That(properties["Resource"]).IsEqualTo("repository");
+    }
+
+    [Test]
     public async Task TryObfuscateValues_PreservesUnmaskedStructuredValueTypes()
     {
         var startTime = DateTimeOffset.UtcNow;


### PR DESCRIPTION
## Summary
- include `{OriginalFormat}` in structured-state secret obfuscation
- preserve unchanged structured values and placeholder/value types
- add a regression proving downstream state masks literal template secrets without altering placeholders

## Testing
- `FormattedLogValuesObfuscatorTests`: 4 passed
- `ModularPipelines.UnitTests`: 1,017 passed, 6 skipped, 1 known worktree-name failure (`GitRootDirectory`)
- `dotnet format whitespace` on touched projects
- `git diff --check`

Closes #3113