### PR TITLE
Remove handwritten framework warnings

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
@@ -12,7 +12,7 @@ internal static class SyntaxNodeExtensions
     {
         var compilationUnitSyntax = (CompilationUnitSyntax) documentRoot;
 
-        if (compilationUnitSyntax.Usings.Any(x => x.Name.ToFullString() == "ModularPipelines.Attributes"))
+        if (compilationUnitSyntax.Usings.Any(x => x.Name?.ToFullString() == "ModularPipelines.Attributes"))
         {
             return documentRoot;
         }

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRWorkerCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRWorkerCoordinator.cs
@@ -14,7 +14,6 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
     private readonly HubConnection _connection;
     private readonly ILogger<SignalRWorkerCoordinator> _logger;
     private readonly Channel<ModuleAssignment> _assignmentChannel;
-    private volatile bool _completed;
 
     public SignalRWorkerCoordinator(HubConnection connection, ILogger<SignalRWorkerCoordinator> logger)
     {
@@ -113,7 +112,6 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
     private void OnSignalCompletion()
     {
         _logger.LogInformation("Received completion signal from master");
-        _completed = true;
         _assignmentChannel.Writer.TryComplete();
     }
 }

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -336,7 +336,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         CancellationToken cancellationToken)
     {
         var loggerType = typeof(ILogger<>).MakeGenericType(buffer.ModuleType);
-        var moduleLogger = (ILogger) _serviceProvider.GetService(loggerType)
+        var moduleLogger = _serviceProvider.GetService(loggerType) as ILogger
                            ?? _loggerFactory.CreateLogger(buffer.ModuleType);
 
         using var directWrite = CoordinatedTextWriter.BeginDirectWrite();

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -127,7 +127,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             executionContext.RecordEndTime();
             executionContext.Status = Status.Successful;
 
-            moduleResult = ModuleResult<T>.CreateSuccess(result, executionContext);
+            moduleResult = ModuleResult<T>.CreateSuccess(result!, executionContext);
 
             module.CompletionSource.TrySetResult(moduleResult!);
 
@@ -234,7 +234,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
                 // Create a new result with UsedHistory status using record's 'with' expression
                 var usedHistoryResult = historicalResult with { ModuleStatus = Status.UsedHistory };
                 executionContext.SetTypedResult(usedHistoryResult);
-                module.CompletionSource.TrySetResult(usedHistoryResult);
+                module.CompletionSource.TrySetResult(usedHistoryResult!);
                 logger.LogDebug("Using historical result for skipped module");
                 return usedHistoryResult;
             }
@@ -242,7 +242,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         var skippedResult = ModuleResult<T>.CreateSkipped(skipDecision, executionContext);
         executionContext.SetTypedResult(skippedResult);
-        module.CompletionSource.TrySetResult(skippedResult);
+        module.CompletionSource.TrySetResult(skippedResult!);
 
         logger.LogInformation("Module {ModuleName} skipped: {Reason}",
             executionContext.ModuleType.Name,


### PR DESCRIPTION
## Summary
- use null-safe service and Roslyn syntax lookups
- make the existing nullable module-result boundaries explicit
- remove the unused SignalR worker completion field

## Validation
- affected Release builds: core, analyzer code fixes, SignalR — target CS8600/CS8602/CS8604/CS8620/CS0414 diagnostics: none
- ReturnNothingTests: 3/3
- SyncModuleTests: 17/17
- SignalRWorkerCoordinatorTests: 2/2

Closes #3081