### PR TITLE
Recover distributed work on dropped worker connections (fixes master hang)

### DIFF
--- a/src/ModularPipelines.Build/Program.cs
+++ b/src/ModularPipelines.Build/Program.cs
@@ -144,6 +144,12 @@ file static class BuildPipelineConfiguration
         {
             o.InstanceIndex = instanceIndex;
             o.TotalInstances = totalInstances;
+
+            // Bound how long the master waits for a distributed module result. The library
+            // default is 0 (wait forever); if a worker dies or drops its connection after
+            // being assigned a module, the master would otherwise hang indefinitely (see #3174).
+            // A generous bound converts that hang into a diagnosable failure instead.
+            o.ModuleResultTimeoutSeconds = 2700;
         });
         builder.AddSignalRDistributedCoordinator(o =>
         {


### PR DESCRIPTION
Fixes #3174.

The distributed pipeline master hung ~50 min because a dropped worker connection **lost the work that worker was doing** and the master waited forever. This PR makes dropped connections recoverable, at three layers:

## 1. Recover in-flight work on disconnect (root cause)

- **`DistributedPipelineHub.OnDisconnectedAsync`** re-enqueues the disconnected worker's in-flight module (previously a literal `// TODO`), wakes the master's dequeue loop, and nudges an idle worker to take it — guarded so a result that raced the disconnect isn't double-run.
- **`WorkerState`** now tracks `CurrentAssignment` (set on dispatch in both dispatch paths; cleared on result) so there's something to re-enqueue.
- **Assignment dispatch** re-queues the module if `SendAsync` throws, instead of leaving the worker busy with lost work.
- **`SignalRWorkerCoordinator`** re-registers and re-requests work on `HubConnection.Reconnected`, so a reconnected worker (new connection id) resumes receiving assignments instead of being orphaned.

## 2. Detect drops ASAP (not on a timeout)

Re-queuing is only as fast as the drop is noticed. Graceful disconnects and socket closes fire `OnDisconnectedAsync` immediately, but a **silent** drop (crashed/partitioned worker whose close is masked by the cloudflared tunnel) previously waited for SignalR's **30s default** `ClientTimeoutInterval`. Now tuned (and configurable via `SignalRDistributedOptions`):
- `KeepAliveIntervalSeconds` = 5s (was 15s) — ping cadence both directions.
- `PeerTimeoutSeconds` = 15s (was 30s) — server `ClientTimeoutInterval` + worker `ServerTimeout`.

So a silent drop is detected in ~15s instead of ~30s, and the re-queue fires then — **not** on the backstop below. Values are conservative to avoid false-dropping healthy-but-busy workers.

## 3. Backstop for the unrecoverable case

`ModuleResultTimeoutSeconds = 2700` in the build pipeline's `AddDistributedMode` config, so that if a result truly can never be produced (e.g. the only capability-matched worker is gone for good), the master fails with a diagnosable timeout instead of hanging forever. Does not change the library's documented `0 = wait forever` default for other consumers.

## Caveats

- **At-least-once execution**: a module whose worker dies mid-run may re-run on another node. Pipeline build/test modules are idempotent, so this is acceptable — flagged explicitly as a semantics change.
- **Not built/tested locally** (no .NET SDK in the working environment). Verified types/namespaces resolve and the repo doesn't treat warnings as errors, so it should compile — but the concurrency here is subtle and warrants a careful review + a real CI run.
- CI `timeout-minutes` hardening (so any future hang fails fast) is the separate #3177 / #3175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)