### PR TITLE
Add timeout-minutes to the .NET pipeline job to bound hangs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,6 +40,11 @@ jobs:
             check_name: pipeline (ubuntu-latest, 4)
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    # Bound the job so a hung pipeline (e.g. the distributed master waiting on a
+    # departed worker - see #3174) fails fast instead of tying up a runner for the
+    # default 6 hours. The "Upload Hang Dumps" step runs on if:always() so dumps are
+    # still collected when this timeout trips.
+    timeout-minutes: 60
     env:
       NUGET_PACKAGES: ${{ matrix.os == 'windows-latest' && 'E:\nuget' || null }}
 


### PR DESCRIPTION
Addresses the CI-hardening part of #3175.

## Problem

The `pipeline` job in `.github/workflows/dotnet.yml` has no `timeout-minutes`, so GitHub's default **6-hour** job timeout applies. When the distributed master hangs waiting on a departed worker (#3174), the job ties up a runner for far too long instead of failing fast.

## Change

Add `timeout-minutes: 60` to the job. The existing **Upload Hang Dumps** step already runs on `if: always()`, so hang dumps are still collected when the timeout trips (aiding diagnosis of #3174).

## Notes

- This is defense-in-depth — it **bounds** a hang's blast radius; it does not fix the underlying distributed hang (that's #3174 / #3176).
- `60` minutes is a conservative bound above normal run time; adjust if legitimate runs ever approach it.
- The second item in #3175 (giving `Command.Of` a default execution timeout to match `CommandLineExecutor`'s 30-min default) is intentionally **not** included here — it's a behavioral change to core command execution that warrants local build/test validation, which wasn't available in this environment. Left for a separate, tested change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KayGZtGoXLVALeiPHXRWdx)_