### PR TITLE
Actually recover dropped worker connections (re-enqueue + reconnect + fast detection)

### DIFF
--- a/src/ModularPipelines.Distributed.SignalR/Configuration/SignalRDistributedOptions.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Configuration/SignalRDistributedOptions.cs
@@ -31,6 +31,14 @@ public class SignalRDistributedOptions
     public int MaxReconnectAttempts { get; set; } = 5;
 
     /// <summary>
+    /// How long (seconds) the master waits for a disconnected worker to reconnect before
+    /// re-enqueuing its in-flight module. Should exceed the total auto-reconnect window
+    /// (exponential backoff over <see cref="MaxReconnectAttempts"/>) so a transient blip
+    /// doesn't cause the module to run twice. Default 45s.
+    /// </summary>
+    public int ReconnectGraceSeconds { get; set; } = 45;
+
+    /// <summary>
     /// How often each side sends a keep-alive ping (seconds). Lower values let a
     /// silent connection drop (e.g. a crashed/partitioned worker whose socket close
     /// is masked by the tunnel) be detected sooner, so its in-flight work is

--- a/src/ModularPipelines.Distributed.SignalR/Configuration/SignalRDistributedOptions.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Configuration/SignalRDistributedOptions.cs
@@ -31,6 +31,25 @@ public class SignalRDistributedOptions
     public int MaxReconnectAttempts { get; set; } = 5;
 
     /// <summary>
+    /// How often each side sends a keep-alive ping (seconds). Lower values let a
+    /// silent connection drop (e.g. a crashed/partitioned worker whose socket close
+    /// is masked by the tunnel) be detected sooner, so its in-flight work is
+    /// re-queued faster. Applied to both the server's KeepAliveInterval and the
+    /// worker connection's KeepAliveInterval. Default 5s (SignalR default is 15s).
+    /// </summary>
+    public int KeepAliveIntervalSeconds { get; set; } = 5;
+
+    /// <summary>
+    /// How long a side waits without any message before declaring the peer gone
+    /// (seconds). Applied to the server's ClientTimeoutInterval (how fast the master
+    /// detects a dead worker and re-queues its work) and the worker connection's
+    /// ServerTimeout (how fast a worker detects a dead master and reconnects).
+    /// Should be at least twice <see cref="KeepAliveIntervalSeconds"/>. Default 15s
+    /// (SignalR default is 30s).
+    /// </summary>
+    public int PeerTimeoutSeconds { get; set; } = 15;
+
+    /// <summary>
     /// Maximum size in bytes for a single SignalR message (default 1MB).
     /// Increase for large module results.
     /// </summary>

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRDistributedCoordinatorFactory.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRDistributedCoordinatorFactory.cs
@@ -156,7 +156,15 @@ internal class SignalRDistributedCoordinatorFactory : IDistributedCoordinatorFac
                 new RetryPolicy(_options.MaxReconnectAttempts));
         }
 
-        return builder.Build();
+        var connection = builder.Build();
+
+        // Ping the master frequently and give up on it quickly, so a dead master is
+        // detected fast (triggering reconnect) and the master in turn detects a dead
+        // worker fast (via the frequent pings) and re-queues its in-flight work.
+        connection.KeepAliveInterval = TimeSpan.FromSeconds(_options.KeepAliveIntervalSeconds);
+        connection.ServerTimeout = TimeSpan.FromSeconds(_options.PeerTimeoutSeconds);
+
+        return connection;
     }
 
     /// <summary>

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRDistributedCoordinatorFactory.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRDistributedCoordinatorFactory.cs
@@ -62,7 +62,10 @@ internal class SignalRDistributedCoordinatorFactory : IDistributedCoordinatorFac
 
     private async Task<IDistributedCoordinator> CreateMasterCoordinatorAsync(CancellationToken cancellationToken)
     {
-        var masterState = new SignalRMasterState();
+        var masterState = new SignalRMasterState
+        {
+            ReconnectGracePeriod = TimeSpan.FromSeconds(_options.ReconnectGraceSeconds),
+        };
 
         // Start the SignalR server
         _serverHost = new MasterServerHost();

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
@@ -189,6 +189,7 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
                 _logger.LogDebug("Pushing {Module} to worker {Index}",
                     assignment.ModuleTypeName, worker.Registration.WorkerIndex);
 
+                worker.SetAssignment(assignment);
                 try
                 {
                     await _hubContext.Clients.Client(worker.ConnectionId)
@@ -199,6 +200,7 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
                 {
                     _logger.LogWarning(ex, "Failed to push assignment to worker {Index}, marking idle",
                         worker.Registration.WorkerIndex);
+                    worker.ClearAssignment();
                     worker.MarkIdle();
                 }
             }

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
@@ -100,6 +100,14 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
                 break;
             }
 
+            // Skip work whose result already arrived (e.g. a disconnect re-enqueue that
+            // raced the original worker's result) so it isn't executed a second time.
+            if (_state.ResultWaiters.TryGetValue(assignment.ModuleTypeName, out var existingWaiter)
+                && existingWaiter.Task.IsCompleted)
+            {
+                continue;
+            }
+
             if (!CapabilityMatcher.CanExecute(assignment, workerCapabilities))
             {
                 // Re-enqueue — master can't handle this module
@@ -173,6 +181,13 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
 
     private async Task<bool> TryPushToIdleWorker(ModuleAssignment assignment)
     {
+        // Don't dispatch work whose result already arrived.
+        if (_state.ResultWaiters.TryGetValue(assignment.ModuleTypeName, out var existingWaiter)
+            && existingWaiter.Task.IsCompleted)
+        {
+            return true;
+        }
+
         foreach (var kvp in _state.Workers)
         {
             var worker = kvp.Value;

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRWorkerCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRWorkerCoordinator.cs
@@ -16,6 +16,7 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
     private readonly Channel<ModuleAssignment> _assignmentChannel;
 
     private WorkerRegistration? _lastRegistration;
+    private volatile bool _awaitingAssignment;
 
     public SignalRWorkerCoordinator(HubConnection connection, ILogger<SignalRWorkerCoordinator> logger)
     {
@@ -55,6 +56,12 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
     {
         try
         {
+            // Mark that we're waiting for an assignment. Used by the reconnect handler to
+            // decide whether to re-request work: if we're mid-execution (not awaiting), a
+            // reconnect must NOT request new work or the master would dispatch the module
+            // it already re-tracked for us, running it twice.
+            _awaitingAssignment = true;
+
             // Request work from master
             await _connection.InvokeAsync(HubMethodNames.RequestWork, workerCapabilities, cancellationToken);
 
@@ -63,6 +70,7 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
             {
                 if (_assignmentChannel.Reader.TryRead(out var assignment))
                 {
+                    _awaitingAssignment = false;
                     return assignment;
                 }
             }
@@ -72,6 +80,10 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
         catch (OperationCanceledException)
         {
             return null;
+        }
+        finally
+        {
+            _awaitingAssignment = false;
         }
     }
 
@@ -108,7 +120,14 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
                 connectionId, registration.WorkerIndex);
 
             await _connection.InvokeAsync(HubMethodNames.RegisterWorker, registration);
-            await _connection.InvokeAsync(HubMethodNames.RequestWork, registration.Capabilities);
+
+            // Only re-request work if we're idle and waiting for an assignment. If we're
+            // mid-execution, the master restored our in-flight module on re-registration;
+            // requesting work now would make it dispatch that module again (double run).
+            if (_awaitingAssignment)
+            {
+                await _connection.InvokeAsync(HubMethodNames.RequestWork, registration.Capabilities);
+            }
         }
         catch (Exception ex)
         {

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRWorkerCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRWorkerCoordinator.cs
@@ -15,6 +15,8 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
     private readonly ILogger<SignalRWorkerCoordinator> _logger;
     private readonly Channel<ModuleAssignment> _assignmentChannel;
 
+    private WorkerRegistration? _lastRegistration;
+
     public SignalRWorkerCoordinator(HubConnection connection, ILogger<SignalRWorkerCoordinator> logger)
     {
         _connection = connection;
@@ -29,6 +31,12 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
         _connection.On<ModuleAssignment>(HubMethodNames.ReceiveAssignment, OnReceiveAssignment);
         _connection.On<SerializedModuleResult>(HubMethodNames.ReceiveDependencyResult, OnReceiveDependencyResult);
         _connection.On(HubMethodNames.SignalCompletion, OnSignalCompletion);
+
+        // Automatic reconnect gives us a new connection id, and the master drops the old
+        // connection (re-queuing its in-flight work). Re-register under the new connection
+        // and ask for work again so the master resumes dispatching to us; otherwise a
+        // reconnected worker is orphaned and sits idle.
+        _connection.Reconnected += OnReconnectedAsync;
     }
 
     /// <summary>
@@ -80,8 +88,32 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
 
     public async Task RegisterWorkerAsync(WorkerRegistration registration, CancellationToken cancellationToken)
     {
+        _lastRegistration = registration;
         await _connection.InvokeAsync(HubMethodNames.RegisterWorker, registration, cancellationToken);
         _logger.LogInformation("Worker {Index} registered with master via SignalR", registration.WorkerIndex);
+    }
+
+    private async Task OnReconnectedAsync(string? connectionId)
+    {
+        var registration = _lastRegistration;
+        if (registration is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _logger.LogWarning(
+                "Reconnected to master (connection {ConnectionId}); re-registering worker {Index}",
+                connectionId, registration.WorkerIndex);
+
+            await _connection.InvokeAsync(HubMethodNames.RegisterWorker, registration);
+            await _connection.InvokeAsync(HubMethodNames.RequestWork, registration.Capabilities);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to re-register worker {Index} after reconnect", registration.WorkerIndex);
+        }
     }
 
     public Task<IReadOnlyList<WorkerRegistration>> GetRegisteredWorkersAsync(CancellationToken cancellationToken)

--- a/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
@@ -58,6 +58,7 @@ internal class DistributedPipelineHub(
         // 3. Mark the sending worker as idle and try to assign pending work
         if (state.Workers.TryGetValue(Context.ConnectionId, out var workerState))
         {
+            workerState.ClearAssignment();
             workerState.MarkIdle();
             await TryAssignPendingWork(workerState, state);
         }
@@ -78,17 +79,44 @@ internal class DistributedPipelineHub(
         await TryAssignPendingWork(workerState, state);
     }
 
-    public override Task OnDisconnectedAsync(Exception? exception)
+    public override async Task OnDisconnectedAsync(Exception? exception)
     {
         if (_masterState.Workers.TryRemove(Context.ConnectionId, out var workerState))
         {
             _logger.LogWarning("Worker {Index} disconnected (connection {ConnectionId})",
                 workerState.Registration.WorkerIndex, Context.ConnectionId);
 
-            // TODO: Re-enqueue in-flight work for the disconnected worker
+            // Re-enqueue any in-flight assignment so a surviving worker (or the master's own
+            // worker loop) can pick it up, instead of the master waiting forever for a result
+            // that will never arrive. If the result already came back the assignment is null
+            // (cleared in PublishResult) or its waiter is already completed, so we skip it.
+            var inflight = workerState.ClearAssignment();
+            if (inflight is not null
+                && _masterState.ResultWaiters.TryGetValue(inflight.ModuleTypeName, out var waiter)
+                && !waiter.Task.IsCompleted)
+            {
+                _logger.LogWarning(
+                    "Re-enqueuing in-flight module {Module} from disconnected worker {Index}",
+                    inflight.ModuleTypeName, workerState.Registration.WorkerIndex);
+
+                _masterState.PendingAssignments.Enqueue(inflight);
+
+                // Wake the master's own dequeue loop...
+                _masterState.WorkAvailable.Release();
+
+                // ...and nudge a currently-idle worker to pick it up immediately.
+                foreach (var kvp in _masterState.Workers)
+                {
+                    if (kvp.Value.IsIdle)
+                    {
+                        await TryAssignPendingWork(kvp.Value, _masterState);
+                        break;
+                    }
+                }
+            }
         }
 
-        return Task.CompletedTask;
+        await base.OnDisconnectedAsync(exception);
     }
 
     private async Task TryAssignPendingWork(WorkerState workerState, SignalRMasterState state)
@@ -115,8 +143,22 @@ internal class DistributedPipelineHub(
             {
                 _logger.LogDebug("Assigning {Module} to worker {Index}",
                     assignment.ModuleTypeName, workerState.Registration.WorkerIndex);
-                await Clients.Client(workerState.ConnectionId)
-                    .SendAsync(HubMethodNames.ReceiveAssignment, assignment);
+                workerState.SetAssignment(assignment);
+                try
+                {
+                    await Clients.Client(workerState.ConnectionId)
+                        .SendAsync(HubMethodNames.ReceiveAssignment, assignment);
+                }
+                catch (Exception ex)
+                {
+                    // Send failed — undo the claim and re-queue so the module isn't lost.
+                    _logger.LogWarning(ex, "Failed to assign {Module} to worker {Index}; re-queuing",
+                        assignment.ModuleTypeName, workerState.Registration.WorkerIndex);
+                    workerState.ClearAssignment();
+                    workerState.MarkIdle();
+                    state.PendingAssignments.Enqueue(assignment);
+                }
+
                 return;
             }
             else

--- a/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
@@ -130,6 +130,15 @@ internal class DistributedPipelineHub(
                 break;
             }
 
+            // Skip if this module's result already arrived (e.g. the original worker's
+            // result raced a disconnect re-enqueue). Prevents dispatching - and re-running
+            // the side effects of - work that is already complete.
+            if (state.ResultWaiters.TryGetValue(assignment.ModuleTypeName, out var existingWaiter)
+                && existingWaiter.Task.IsCompleted)
+            {
+                continue;
+            }
+
             // Check capability match
             if (!CapabilityMatcher.CanExecute(assignment, workerState.Registration))
             {
@@ -157,6 +166,10 @@ internal class DistributedPipelineHub(
                     workerState.ClearAssignment();
                     workerState.MarkIdle();
                     state.PendingAssignments.Enqueue(assignment);
+
+                    // Wake the master's dequeue loop so the re-queued work is picked up
+                    // promptly instead of stalling until an unrelated event.
+                    state.WorkAvailable.Release();
                 }
 
                 return;

--- a/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
@@ -29,6 +29,27 @@ internal class DistributedPipelineHub(
             Registration = registration,
         };
 
+        // If this worker (identified by its stable index, not the connection id) had an
+        // in-flight module pending re-enqueue after a disconnect, it has reconnected
+        // within the grace window. Cancel the pending re-enqueue and restore its busy
+        // state so the master keeps awaiting the original result instead of running the
+        // module a second time.
+        if (state.PendingReconnects.TryRemove(registration.WorkerIndex, out var pending))
+        {
+            pending.Cts.Cancel();
+            pending.Cts.Dispose();
+
+            if (state.ResultWaiters.TryGetValue(pending.Assignment.ModuleTypeName, out var waiter)
+                && !waiter.Task.IsCompleted)
+            {
+                workerState.TryMarkBusy();
+                workerState.SetAssignment(pending.Assignment);
+                _logger.LogInformation(
+                    "Worker {Index} reconnected within grace; resuming in-flight {Module}",
+                    registration.WorkerIndex, pending.Assignment.ModuleTypeName);
+            }
+        }
+
         state.Workers[connectionId] = workerState;
         state.Registrations[registration.WorkerIndex] = registration;
 
@@ -83,40 +104,73 @@ internal class DistributedPipelineHub(
     {
         if (_masterState.Workers.TryRemove(Context.ConnectionId, out var workerState))
         {
+            var workerIndex = workerState.Registration.WorkerIndex;
             _logger.LogWarning("Worker {Index} disconnected (connection {ConnectionId})",
-                workerState.Registration.WorkerIndex, Context.ConnectionId);
+                workerIndex, Context.ConnectionId);
 
-            // Re-enqueue any in-flight assignment so a surviving worker (or the master's own
-            // worker loop) can pick it up, instead of the master waiting forever for a result
-            // that will never arrive. If the result already came back the assignment is null
-            // (cleared in PublishResult) or its waiter is already completed, so we skip it.
+            // Don't re-enqueue in-flight work immediately: the worker may just be blipping
+            // and auto-reconnecting, and re-running a module (with side effects) is unsafe.
+            // Instead schedule a re-enqueue after a grace period; if the worker reconnects
+            // within that window, RegisterWorker cancels it. If the result already came back
+            // the assignment is null (cleared in PublishResult) or its waiter is complete.
             var inflight = workerState.ClearAssignment();
             if (inflight is not null
                 && _masterState.ResultWaiters.TryGetValue(inflight.ModuleTypeName, out var waiter)
                 && !waiter.Task.IsCompleted)
             {
-                _logger.LogWarning(
-                    "Re-enqueuing in-flight module {Module} from disconnected worker {Index}",
-                    inflight.ModuleTypeName, workerState.Registration.WorkerIndex);
-
-                _masterState.PendingAssignments.Enqueue(inflight);
-
-                // Wake the master's own dequeue loop...
-                _masterState.WorkAvailable.Release();
-
-                // ...and nudge a currently-idle worker to pick it up immediately.
-                foreach (var kvp in _masterState.Workers)
-                {
-                    if (kvp.Value.IsIdle)
-                    {
-                        await TryAssignPendingWork(kvp.Value, _masterState);
-                        break;
-                    }
-                }
+                var cts = new CancellationTokenSource();
+                _masterState.PendingReconnects[workerIndex] = (inflight, cts);
+                _ = ReEnqueueAfterGraceAsync(_masterState, _logger, workerIndex, inflight, cts.Token);
             }
         }
 
         await base.OnDisconnectedAsync(exception);
+    }
+
+    /// <summary>
+    /// After the reconnect grace period, re-enqueues a disconnected worker's in-flight
+    /// module unless it reconnected (RegisterWorker removed the pending entry) or its
+    /// result already arrived. Uses only shared state + logger so it is safe to run
+    /// detached from the (transient) hub instance that scheduled it.
+    /// </summary>
+    private static async Task ReEnqueueAfterGraceAsync(
+        SignalRMasterState state,
+        ILogger logger,
+        int workerIndex,
+        ModuleAssignment assignment,
+        CancellationToken graceToken)
+    {
+        try
+        {
+            await Task.Delay(state.ReconnectGracePeriod, graceToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return; // Worker reconnected within the grace window — keep awaiting its result.
+        }
+
+        // Claim the pending entry. If it's already gone, RegisterWorker won the race
+        // (the worker reconnected) — do not re-enqueue.
+        if (!state.PendingReconnects.TryRemove(workerIndex, out var pending))
+        {
+            return;
+        }
+
+        pending.Cts.Dispose();
+
+        // Skip if the result arrived in the meantime.
+        if (state.ResultWaiters.TryGetValue(assignment.ModuleTypeName, out var waiter)
+            && waiter.Task.IsCompleted)
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "Reconnect grace elapsed for worker {Index}; re-enqueuing in-flight module {Module}",
+            workerIndex, assignment.ModuleTypeName);
+
+        state.PendingAssignments.Enqueue(assignment);
+        state.WorkAvailable.Release();
     }
 
     private async Task TryAssignPendingWork(WorkerState workerState, SignalRMasterState state)

--- a/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
@@ -29,6 +29,20 @@ internal class SignalRMasterState
     public ConcurrentDictionary<string, TaskCompletionSource<SerializedModuleResult>> ResultWaiters { get; } = new();
 
     /// <summary>
+    /// Workers that disconnected with an in-flight assignment, keyed by worker index
+    /// (stable across reconnects). The assignment is re-enqueued only after
+    /// <see cref="ReconnectGracePeriod"/> elapses; if the worker reconnects first, the
+    /// pending re-enqueue is cancelled so the module isn't run twice on a transient blip.
+    /// </summary>
+    public ConcurrentDictionary<int, (ModuleAssignment Assignment, CancellationTokenSource Cts)> PendingReconnects { get; } = new();
+
+    /// <summary>
+    /// How long to wait for a disconnected worker to reconnect before re-enqueuing its
+    /// in-flight work. Should exceed the client's total auto-reconnect window.
+    /// </summary>
+    public TimeSpan ReconnectGracePeriod { get; set; } = TimeSpan.FromSeconds(45);
+
+    /// <summary>
     /// Volatile completion flag.
     /// </summary>
     public volatile bool IsCompleted;

--- a/src/ModularPipelines.Distributed.SignalR/Hub/WorkerState.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/WorkerState.cs
@@ -13,7 +13,23 @@ internal class WorkerState
     /// </summary>
     public int BusyFlag;
 
+    private ModuleAssignment? _currentAssignment;
+
     public bool TryMarkBusy() => Interlocked.CompareExchange(ref BusyFlag, 1, 0) == 0;
     public void MarkIdle() => Interlocked.Exchange(ref BusyFlag, 0);
     public bool IsIdle => Volatile.Read(ref BusyFlag) == 0;
+
+    /// <summary>
+    /// The assignment this worker is currently executing, if any. Set when work is
+    /// dispatched to the worker and cleared when its result is published. Read on
+    /// disconnect so in-flight work can be re-queued instead of lost.
+    /// </summary>
+    public ModuleAssignment? CurrentAssignment => Volatile.Read(ref _currentAssignment);
+
+    public void SetAssignment(ModuleAssignment assignment) => Volatile.Write(ref _currentAssignment, assignment);
+
+    /// <summary>
+    /// Atomically clears and returns the current assignment.
+    /// </summary>
+    public ModuleAssignment? ClearAssignment() => Interlocked.Exchange(ref _currentAssignment, null);
 }

--- a/src/ModularPipelines.Distributed.SignalR/Server/MasterServerHost.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Server/MasterServerHost.cs
@@ -46,6 +46,14 @@ internal class MasterServerHost : IAsyncDisposable
         {
             hubOptions.MaximumReceiveMessageSize = options.MaximumReceiveMessageSize;
             hubOptions.EnableDetailedErrors = true;
+
+            // Detect a dead/silent worker quickly so OnDisconnectedAsync fires and its
+            // in-flight work is re-queued ASAP, rather than lingering until SignalR's
+            // 30s default. KeepAliveInterval = how often the server pings workers;
+            // ClientTimeoutInterval = how long without a message before a worker is
+            // considered gone.
+            hubOptions.KeepAliveInterval = TimeSpan.FromSeconds(options.KeepAliveIntervalSeconds);
+            hubOptions.ClientTimeoutInterval = TimeSpan.FromSeconds(options.PeerTimeoutSeconds);
         }).AddJsonProtocol(jsonOptions =>
         {
             // Match the client's default STJ options: PascalCase, case-insensitive


### PR DESCRIPTION
Follow-up to #3176, which merged with **only** the `ModuleResultTimeoutSeconds = 2700` backstop — the actual detect-and-recover logic never reached `main` (its `OnDisconnectedAsync` still has the literal `// TODO`). This PR brings the real fix in.

## Recovery model: reconnect + grace period

When a worker's connection drops, the master **doesn't re-enqueue its in-flight module immediately** (that would double-run the module on a transient blip — unsafe for the non-idempotent version-tag / release / NuGet-publish modules). Instead:

- On disconnect, the master records the in-flight assignment in `PendingReconnects` (keyed by stable worker index) and schedules a re-enqueue after a **grace period** (`SignalRDistributedOptions.ReconnectGraceSeconds`, default 45s — exceeds the auto-reconnect backoff window).
- If the worker **reconnects within the window**, `RegisterWorker` cancels the pending re-enqueue and restores its busy state + in-flight assignment, so the master keeps awaiting the original result. No double run.
- If it **doesn't** reconnect, the grace task re-enqueues the module (woken via `WorkAvailable`) so it runs elsewhere. The `2700s` timeout backstop (already on `main`) remains for the truly-unrecoverable case.
- **`WorkerState`** tracks `CurrentAssignment`; **`SignalRWorkerCoordinator`** re-registers on `Reconnected` and only re-requests work if it was idle (so a worker still mid-execution doesn't trigger a duplicate dispatch).

## Faster detection

Keep-alive tuned + configurable (`KeepAliveIntervalSeconds` 5s, `PeerTimeoutSeconds` 15s) so a silent, tunnel-masked drop is noticed in ~15s rather than SignalR's ~30s default.

## Review feedback (Greptile P1s) — addressed

- **Result race enqueues completed work** → dispatch-time dedup: every dispatch path (hub `TryAssignPendingWork`, master `TryScanPendingQueue`, `TryPushToIdleWorker`) now skips an assignment whose result waiter is already completed.
- **Requeue omits consumer wakeup** → the failed-send re-queue now releases `WorkAvailable`.
- **Reconnect requests duplicate work** → the grace period above + the worker idle-guard. Residual: a reconnect landing in the exact millisecond the grace expires can still re-enqueue; the pending-entry `TryRemove` is the race arbiter (at most one of resume/re-enqueue wins) and dispatch-time dedup covers the common sub-case. Documented rather than hidden.

## Caveats
- **Not built/tested locally** (no .NET SDK here). This is subtle concurrency (timers, cancellation, keyed reconnect state) — it needs a careful review and a real CI run; I verified types/namespaces resolve and the repo doesn't treat warnings as errors.
- Killed hung jobs left no logs / zero hang-dumps, so I can't *prove* this clears the original hang — it fixes the identified defect (lost in-flight work + orphaned reconnect), which is the most likely cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)