### PR TITLE
Fence distributed reconnect redispatch handoff

### DIFF
--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
@@ -115,6 +115,11 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
                 continue;
             }
 
+            if (!_state.TryClaimRedispatch(assignment))
+            {
+                continue;
+            }
+
             return assignment;
         }
 
@@ -199,12 +204,17 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
             }
 
             // Try to claim this worker
-            if (worker.TryMarkBusy())
+            if (worker.TryAssign(assignment))
             {
                 _logger.LogDebug("Pushing {Module} to worker {Index}",
                     assignment.ModuleTypeName, worker.Registration.WorkerIndex);
 
-                worker.SetAssignment(assignment);
+                if (!_state.TryClaimRedispatch(assignment))
+                {
+                    worker.TryCompleteAssignment(assignment.ModuleTypeName);
+                    continue;
+                }
+
                 try
                 {
                     await _hubContext.Clients.Client(worker.ConnectionId)
@@ -215,8 +225,8 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
                 {
                     _logger.LogWarning(ex, "Failed to push assignment to worker {Index}, marking idle",
                         worker.Registration.WorkerIndex);
-                    worker.ClearAssignment();
-                    worker.MarkIdle();
+                    worker.TryCompleteAssignment(assignment.ModuleTypeName);
+                    _state.ReturnRedispatchToQueue(assignment);
                 }
             }
         }

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
@@ -130,9 +130,9 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
     {
         // Master receives results through the hub's PublishResult method.
         // This is called when the master itself produces a result (e.g., modules executed locally by the master's worker loop).
-        if (_state.ResultWaiters.TryGetValue(result.ModuleTypeName, out var tcs))
+        foreach (var worker in _state.CompleteResult(result))
         {
-            tcs.TrySetResult(result);
+            worker.TryCompleteAssignment(result.ModuleTypeName);
         }
 
         return Task.CompletedTask;

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
@@ -209,7 +209,7 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
                 _logger.LogDebug("Pushing {Module} to worker {Index}",
                     assignment.ModuleTypeName, worker.Registration.WorkerIndex);
 
-                if (!_state.TryClaimRedispatch(assignment))
+                if (!_state.TryClaimRedispatch(assignment, worker))
                 {
                     worker.TryCompleteAssignment(assignment.ModuleTypeName);
                     continue;

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
@@ -226,7 +226,7 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
                     _logger.LogWarning(ex, "Failed to push assignment to worker {Index}, marking idle",
                         worker.Registration.WorkerIndex);
                     worker.TryCompleteAssignment(assignment.ModuleTypeName);
-                    if (!_state.TryReturnRedispatchToQueue(assignment))
+                    if (!_state.TryReturnRedispatchToQueue(assignment, worker))
                     {
                         return true;
                     }

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
@@ -126,16 +126,14 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
         return null;
     }
 
-    public Task PublishResultAsync(SerializedModuleResult result, CancellationToken cancellationToken)
+    public async Task PublishResultAsync(SerializedModuleResult result, CancellationToken cancellationToken)
     {
         // Master receives results through the hub's PublishResult method.
         // This is called when the master itself produces a result (e.g., modules executed locally by the master's worker loop).
-        foreach (var worker in _state.CompleteResult(result))
+        foreach (var worker in await _state.CompleteResultAsync(result))
         {
             worker.TryCompleteAssignment(result.ModuleTypeName);
         }
-
-        return Task.CompletedTask;
     }
 
     public async Task<SerializedModuleResult> WaitForResultAsync(string moduleTypeName, CancellationToken cancellationToken)
@@ -209,6 +207,8 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
                 _logger.LogDebug("Pushing {Module} to worker {Index}",
                     assignment.ModuleTypeName, worker.Registration.WorkerIndex);
 
+                using var deliveryFence =
+                    await _state.EnterAssignmentDeliveryFenceAsync(assignment.ModuleTypeName);
                 if (!_state.TryClaimRedispatch(assignment, worker))
                 {
                     worker.TryCompleteAssignment(assignment.ModuleTypeName);

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRMasterCoordinator.cs
@@ -226,7 +226,10 @@ internal class SignalRMasterCoordinator : IDistributedCoordinator
                     _logger.LogWarning(ex, "Failed to push assignment to worker {Index}, marking idle",
                         worker.Registration.WorkerIndex);
                     worker.TryCompleteAssignment(assignment.ModuleTypeName);
-                    _state.ReturnRedispatchToQueue(assignment);
+                    if (!_state.TryReturnRedispatchToQueue(assignment))
+                    {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRWorkerCoordinator.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Coordination/SignalRWorkerCoordinator.cs
@@ -16,6 +16,7 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
     private readonly Channel<ModuleAssignment> _assignmentChannel;
 
     private WorkerRegistration? _lastRegistration;
+    private ModuleAssignment? _inFlightAssignment;
     private volatile bool _awaitingAssignment;
 
     public SignalRWorkerCoordinator(HubConnection connection, ILogger<SignalRWorkerCoordinator> logger)
@@ -90,6 +91,12 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
     public async Task PublishResultAsync(SerializedModuleResult result, CancellationToken cancellationToken)
     {
         await _connection.InvokeAsync(HubMethodNames.PublishResult, result, cancellationToken);
+
+        var assignment = Volatile.Read(ref _inFlightAssignment);
+        if (assignment?.ModuleTypeName == result.ModuleTypeName)
+        {
+            Interlocked.CompareExchange(ref _inFlightAssignment, null, assignment);
+        }
     }
 
     public Task<SerializedModuleResult> WaitForResultAsync(string moduleTypeName, CancellationToken cancellationToken)
@@ -101,7 +108,11 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
     public async Task RegisterWorkerAsync(WorkerRegistration registration, CancellationToken cancellationToken)
     {
         _lastRegistration = registration;
-        await _connection.InvokeAsync(HubMethodNames.RegisterWorker, registration, cancellationToken);
+        await _connection.InvokeAsync(
+            HubMethodNames.RegisterWorker,
+            registration,
+            Volatile.Read(ref _inFlightAssignment)?.ModuleTypeName,
+            cancellationToken);
         _logger.LogInformation("Worker {Index} registered with master via SignalR", registration.WorkerIndex);
     }
 
@@ -119,7 +130,10 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
                 "Reconnected to master (connection {ConnectionId}); re-registering worker {Index}",
                 connectionId, registration.WorkerIndex);
 
-            await _connection.InvokeAsync(HubMethodNames.RegisterWorker, registration);
+            await _connection.InvokeAsync(
+                HubMethodNames.RegisterWorker,
+                registration,
+                Volatile.Read(ref _inFlightAssignment)?.ModuleTypeName);
 
             // Only re-request work if we're idle and waiting for an assignment. If we're
             // mid-execution, the master restored our in-flight module on re-registration;
@@ -151,6 +165,7 @@ internal class SignalRWorkerCoordinator : IDistributedCoordinator
     private void OnReceiveAssignment(ModuleAssignment assignment)
     {
         _logger.LogDebug("Received assignment: {Module}", assignment.ModuleTypeName);
+        Volatile.Write(ref _inFlightAssignment, assignment);
         _assignmentChannel.Writer.TryWrite(assignment);
     }
 

--- a/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
@@ -206,7 +206,7 @@ internal class DistributedPipelineHub(
                 _logger.LogDebug("Assigning {Module} to worker {Index}",
                     assignment.ModuleTypeName, workerState.Registration.WorkerIndex);
 
-                if (!state.TryClaimRedispatch(assignment))
+                if (!state.TryClaimRedispatch(assignment, workerState))
                 {
                     workerState.TryCompleteAssignment(assignment.ModuleTypeName);
                     continue;

--- a/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
@@ -223,7 +223,7 @@ internal class DistributedPipelineHub(
                     _logger.LogWarning(ex, "Failed to assign {Module} to worker {Index}; re-queuing",
                         assignment.ModuleTypeName, workerState.Registration.WorkerIndex);
                     workerState.TryCompleteAssignment(assignment.ModuleTypeName);
-                    if (state.TryReturnRedispatchToQueue(assignment))
+                    if (state.TryReturnRedispatchToQueue(assignment, workerState))
                     {
                         state.PendingAssignments.Enqueue(assignment);
 

--- a/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
@@ -64,7 +64,7 @@ internal class DistributedPipelineHub(
 
         // 1. Complete the result and atomically capture workers involved in reconnect
         // recovery before a concurrent registration can start tracking the assignment.
-        var workersToRelease = state.CompleteResult(result).ToHashSet();
+        var workersToRelease = (await state.CompleteResultAsync(result)).ToHashSet();
         if (state.Workers.TryGetValue(Context.ConnectionId, out var sendingWorker))
         {
             workersToRelease.Add(sendingWorker);
@@ -206,6 +206,8 @@ internal class DistributedPipelineHub(
                 _logger.LogDebug("Assigning {Module} to worker {Index}",
                     assignment.ModuleTypeName, workerState.Registration.WorkerIndex);
 
+                using var deliveryFence =
+                    await state.EnterAssignmentDeliveryFenceAsync(assignment.ModuleTypeName);
                 if (!state.TryClaimRedispatch(assignment, workerState))
                 {
                     workerState.TryCompleteAssignment(assignment.ModuleTypeName);

--- a/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
@@ -34,19 +34,26 @@ internal class DistributedPipelineHub(
         // within the grace window. Cancel the pending re-enqueue and restore its busy
         // state so the master keeps awaiting the original result instead of running the
         // module a second time.
-        if (state.PendingReconnects.TryRemove(registration.WorkerIndex, out var pending))
+        var pending = state.GetPendingReconnect(registration.WorkerIndex);
+        if (pending is not null)
         {
-            pending.Cts.Cancel();
-            pending.Cts.Dispose();
+            var resumed = pending.TryResume();
+            pending.CancelDelay();
 
             if (state.ResultWaiters.TryGetValue(pending.Assignment.ModuleTypeName, out var waiter)
                 && !waiter.Task.IsCompleted)
             {
-                workerState.TryMarkBusy();
-                workerState.SetAssignment(pending.Assignment);
+                workerState.TryAssign(pending.Assignment);
                 _logger.LogInformation(
-                    "Worker {Index} reconnected within grace; resuming in-flight {Module}",
-                    registration.WorkerIndex, pending.Assignment.ModuleTypeName);
+                    resumed
+                        ? "Worker {Index} reclaimed in-flight {Module}"
+                        : "Worker {Index} reconnected after {Module} was claimed for redispatch; tracking its original execution",
+                    registration.WorkerIndex,
+                    pending.Assignment.ModuleTypeName);
+            }
+            else
+            {
+                state.CompletePendingReconnect(pending.Assignment.ModuleTypeName);
             }
         }
 
@@ -76,12 +83,17 @@ internal class DistributedPipelineHub(
         // 2. Broadcast ReceiveDependencyResult to all workers for CompletionSource pre-population
         await Clients.Others.SendAsync(HubMethodNames.ReceiveDependencyResult, result);
 
-        // 3. Mark the sending worker as idle and try to assign pending work
-        if (state.Workers.TryGetValue(Context.ConnectionId, out var workerState))
+        state.CompletePendingReconnect(result.ModuleTypeName);
+
+        // 3. Mark every worker tracked against this assignment as idle. Normally this
+        // is only the sender; recovery can temporarily track both the original worker
+        // and a retry worker until the first result wins.
+        foreach (var workerState in state.Workers.Values)
         {
-            workerState.ClearAssignment();
-            workerState.MarkIdle();
-            await TryAssignPendingWork(workerState, state);
+            if (workerState.TryCompleteAssignment(result.ModuleTypeName))
+            {
+                await TryAssignPendingWork(workerState, state);
+            }
         }
     }
 
@@ -118,9 +130,8 @@ internal class DistributedPipelineHub(
                 && _masterState.ResultWaiters.TryGetValue(inflight.ModuleTypeName, out var waiter)
                 && !waiter.Task.IsCompleted)
             {
-                var cts = new CancellationTokenSource();
-                _masterState.PendingReconnects[workerIndex] = (inflight, cts);
-                _ = ReEnqueueAfterGraceAsync(_masterState, _logger, workerIndex, inflight, cts.Token);
+                var pending = _masterState.TrackPendingReconnect(workerIndex, inflight);
+                _ = ReEnqueueAfterGraceAsync(_masterState, _logger, pending);
             }
         }
 
@@ -136,40 +147,38 @@ internal class DistributedPipelineHub(
     private static async Task ReEnqueueAfterGraceAsync(
         SignalRMasterState state,
         ILogger logger,
-        int workerIndex,
-        ModuleAssignment assignment,
-        CancellationToken graceToken)
+        PendingReconnect pending)
     {
         try
         {
-            await Task.Delay(state.ReconnectGracePeriod, graceToken);
+            await Task.Delay(state.ReconnectGracePeriod, pending.DelayToken);
         }
         catch (OperationCanceledException)
         {
             return; // Worker reconnected within the grace window — keep awaiting its result.
         }
 
-        // Claim the pending entry. If it's already gone, RegisterWorker won the race
-        // (the worker reconnected) — do not re-enqueue.
-        if (!state.PendingReconnects.TryRemove(workerIndex, out var pending))
+        // Make the retry available without claiming it. A simultaneous reconnect may
+        // still atomically reclaim it until an executor claims the queued assignment.
+        if (!pending.TryMakeAvailableForRedispatch())
         {
             return;
         }
 
-        pending.Cts.Dispose();
-
         // Skip if the result arrived in the meantime.
-        if (state.ResultWaiters.TryGetValue(assignment.ModuleTypeName, out var waiter)
+        if (state.ResultWaiters.TryGetValue(pending.Assignment.ModuleTypeName, out var waiter)
             && waiter.Task.IsCompleted)
         {
+            state.CompletePendingReconnect(pending.Assignment.ModuleTypeName);
             return;
         }
 
         logger.LogWarning(
             "Reconnect grace elapsed for worker {Index}; re-enqueuing in-flight module {Module}",
-            workerIndex, assignment.ModuleTypeName);
+            pending.WorkerIndex,
+            pending.Assignment.ModuleTypeName);
 
-        state.PendingAssignments.Enqueue(assignment);
+        state.PendingAssignments.Enqueue(pending.Assignment);
         state.WorkAvailable.Release();
     }
 
@@ -202,11 +211,17 @@ internal class DistributedPipelineHub(
             }
 
             // Assign to this worker
-            if (workerState.TryMarkBusy())
+            if (workerState.TryAssign(assignment))
             {
                 _logger.LogDebug("Assigning {Module} to worker {Index}",
                     assignment.ModuleTypeName, workerState.Registration.WorkerIndex);
-                workerState.SetAssignment(assignment);
+
+                if (!state.TryClaimRedispatch(assignment))
+                {
+                    workerState.TryCompleteAssignment(assignment.ModuleTypeName);
+                    continue;
+                }
+
                 try
                 {
                     await Clients.Client(workerState.ConnectionId)
@@ -217,8 +232,8 @@ internal class DistributedPipelineHub(
                     // Send failed — undo the claim and re-queue so the module isn't lost.
                     _logger.LogWarning(ex, "Failed to assign {Module} to worker {Index}; re-queuing",
                         assignment.ModuleTypeName, workerState.Registration.WorkerIndex);
-                    workerState.ClearAssignment();
-                    workerState.MarkIdle();
+                    workerState.TryCompleteAssignment(assignment.ModuleTypeName);
+                    state.ReturnRedispatchToQueue(assignment);
                     state.PendingAssignments.Enqueue(assignment);
 
                     // Wake the master's dequeue loop so the re-queued work is picked up

--- a/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
@@ -37,13 +37,10 @@ internal class DistributedPipelineHub(
         if (state.TryRestoreReconnect(
                 workerState,
                 resumingModuleTypeName,
-                out var recoveredAssignment,
-                out var resumed))
+                out var recoveredAssignment))
         {
             _logger.LogInformation(
-                resumed
-                    ? "Worker {Index} reclaimed in-flight {Module}"
-                    : "Worker {Index} reconnected after {Module} was claimed for redispatch; tracking its original execution",
+                "Worker {Index} reclaimed in-flight {Module}",
                 registration.WorkerIndex,
                 recoveredAssignment!.ModuleTypeName);
         }
@@ -120,8 +117,11 @@ internal class DistributedPipelineHub(
                 && _masterState.ResultWaiters.TryGetValue(inflight.ModuleTypeName, out var waiter)
                 && !waiter.Task.IsCompleted)
             {
-                var pending = _masterState.TrackPendingReconnect(workerIndex, inflight);
-                _ = ReEnqueueAfterGraceAsync(_masterState, _logger, pending);
+                var pending = _masterState.TrackPendingReconnect(workerState, inflight);
+                if (pending is not null)
+                {
+                    _ = ReEnqueueAfterGraceAsync(_masterState, _logger, pending);
+                }
             }
         }
 
@@ -223,12 +223,14 @@ internal class DistributedPipelineHub(
                     _logger.LogWarning(ex, "Failed to assign {Module} to worker {Index}; re-queuing",
                         assignment.ModuleTypeName, workerState.Registration.WorkerIndex);
                     workerState.TryCompleteAssignment(assignment.ModuleTypeName);
-                    state.ReturnRedispatchToQueue(assignment);
-                    state.PendingAssignments.Enqueue(assignment);
+                    if (state.TryReturnRedispatchToQueue(assignment))
+                    {
+                        state.PendingAssignments.Enqueue(assignment);
 
-                    // Wake the master's dequeue loop so the re-queued work is picked up
-                    // promptly instead of stalling until an unrelated event.
-                    state.WorkAvailable.Release();
+                        // Wake the master's dequeue loop so the re-queued work is picked up
+                        // promptly instead of stalling until an unrelated event.
+                        state.WorkAvailable.Release();
+                    }
                 }
 
                 return;

--- a/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
@@ -18,7 +18,9 @@ internal class DistributedPipelineHub(
     /// <summary>
     /// Called by workers to register their capabilities.
     /// </summary>
-    public async Task RegisterWorker(WorkerRegistration registration)
+    public async Task RegisterWorker(
+        WorkerRegistration registration,
+        string? resumingModuleTypeName)
     {
         var state = _masterState;
         var connectionId = Context.ConnectionId;
@@ -29,13 +31,12 @@ internal class DistributedPipelineHub(
             Registration = registration,
         };
 
-        // If this worker (identified by its stable index, not the connection id) had an
-        // in-flight module pending re-enqueue after a disconnect, it has reconnected
-        // within the grace window. Cancel the pending re-enqueue and restore its busy
-        // state so the master keeps awaiting the original result instead of running the
-        // module a second time.
+        // A reconnect may restore work only when the worker claims the same in-flight
+        // module. The stable index alone is insufficient because a replacement process
+        // can reuse it without owning the original execution.
         if (state.TryRestoreReconnect(
                 workerState,
+                resumingModuleTypeName,
                 out var recoveredAssignment,
                 out var resumed))
         {
@@ -111,8 +112,9 @@ internal class DistributedPipelineHub(
             // Don't re-enqueue in-flight work immediately: the worker may just be blipping
             // and auto-reconnecting, and re-running a module (with side effects) is unsafe.
             // Instead schedule a re-enqueue after a grace period; if the worker reconnects
-            // within that window, RegisterWorker cancels it. If the result already came back
-            // the assignment is null (cleared in PublishResult) or its waiter is complete.
+            // within that window and claims the assignment, RegisterWorker cancels it.
+            // If the result already came back, the assignment is null (cleared in
+            // PublishResult) or its waiter is complete.
             var inflight = workerState.ClearAssignment();
             if (inflight is not null
                 && _masterState.ResultWaiters.TryGetValue(inflight.ModuleTypeName, out var waiter)
@@ -128,9 +130,9 @@ internal class DistributedPipelineHub(
 
     /// <summary>
     /// After the reconnect grace period, re-enqueues a disconnected worker's in-flight
-    /// module unless it reconnected (RegisterWorker removed the pending entry) or its
-    /// result already arrived. Uses only shared state + logger so it is safe to run
-    /// detached from the (transient) hub instance that scheduled it.
+    /// module unless it reconnected and reclaimed the assignment or its result already
+    /// arrived. Uses only shared state + logger so it is safe to run detached from the
+    /// (transient) hub instance that scheduled it.
     /// </summary>
     private static async Task ReEnqueueAfterGraceAsync(
         SignalRMasterState state,

--- a/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/DistributedPipelineHub.cs
@@ -34,27 +34,17 @@ internal class DistributedPipelineHub(
         // within the grace window. Cancel the pending re-enqueue and restore its busy
         // state so the master keeps awaiting the original result instead of running the
         // module a second time.
-        var pending = state.GetPendingReconnect(registration.WorkerIndex);
-        if (pending is not null)
+        if (state.TryRestoreReconnect(
+                workerState,
+                out var recoveredAssignment,
+                out var resumed))
         {
-            var resumed = pending.TryResume();
-            pending.CancelDelay();
-
-            if (state.ResultWaiters.TryGetValue(pending.Assignment.ModuleTypeName, out var waiter)
-                && !waiter.Task.IsCompleted)
-            {
-                workerState.TryAssign(pending.Assignment);
-                _logger.LogInformation(
-                    resumed
-                        ? "Worker {Index} reclaimed in-flight {Module}"
-                        : "Worker {Index} reconnected after {Module} was claimed for redispatch; tracking its original execution",
-                    registration.WorkerIndex,
-                    pending.Assignment.ModuleTypeName);
-            }
-            else
-            {
-                state.CompletePendingReconnect(pending.Assignment.ModuleTypeName);
-            }
+            _logger.LogInformation(
+                resumed
+                    ? "Worker {Index} reclaimed in-flight {Module}"
+                    : "Worker {Index} reconnected after {Module} was claimed for redispatch; tracking its original execution",
+                registration.WorkerIndex,
+                recoveredAssignment!.ModuleTypeName);
         }
 
         state.Workers[connectionId] = workerState;
@@ -74,21 +64,19 @@ internal class DistributedPipelineHub(
         _logger.LogDebug("Received result for {Module} from worker {Worker}",
             result.ModuleTypeName, result.WorkerIndex);
 
-        // 1. Complete the result TCS (for master's WaitForResultAsync)
-        if (state.ResultWaiters.TryGetValue(result.ModuleTypeName, out var tcs))
+        // 1. Complete the result and atomically capture workers involved in reconnect
+        // recovery before a concurrent registration can start tracking the assignment.
+        var workersToRelease = state.CompleteResult(result).ToHashSet();
+        if (state.Workers.TryGetValue(Context.ConnectionId, out var sendingWorker))
         {
-            tcs.TrySetResult(result);
+            workersToRelease.Add(sendingWorker);
         }
 
         // 2. Broadcast ReceiveDependencyResult to all workers for CompletionSource pre-population
         await Clients.Others.SendAsync(HubMethodNames.ReceiveDependencyResult, result);
 
-        state.CompletePendingReconnect(result.ModuleTypeName);
-
-        // 3. Mark every worker tracked against this assignment as idle. Normally this
-        // is only the sender; recovery can temporarily track both the original worker
-        // and a retry worker until the first result wins.
-        foreach (var workerState in state.Workers.Values)
+        // 3. Mark the sender and any reconnected original worker idle.
+        foreach (var workerState in workersToRelease)
         {
             if (workerState.TryCompleteAssignment(result.ModuleTypeName))
             {

--- a/src/ModularPipelines.Distributed.SignalR/Hub/PendingReconnect.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/PendingReconnect.cs
@@ -19,7 +19,7 @@ internal sealed class PendingReconnect(
 {
     private readonly CancellationTokenSource _delayCancellation = new();
     private readonly HashSet<WorkerState> _trackedWorkers = [];
-    private int _state = (int)PendingReconnectState.WaitingForReconnect;
+    private int _state = (int) PendingReconnectState.WaitingForReconnect;
     private int _disposed;
 
     public int WorkerIndex { get; } = workerIndex;
@@ -29,7 +29,7 @@ internal sealed class PendingReconnect(
     public CancellationToken DelayToken => _delayCancellation.Token;
 
     private PendingReconnectState State =>
-        (PendingReconnectState)Volatile.Read(ref _state);
+        (PendingReconnectState) Volatile.Read(ref _state);
 
     public bool TryMakeAvailableForRedispatch()
     {
@@ -77,7 +77,7 @@ internal sealed class PendingReconnect(
 
     public IReadOnlyList<WorkerState> Complete()
     {
-        Interlocked.Exchange(ref _state, (int)PendingReconnectState.Completed);
+        Interlocked.Exchange(ref _state, (int) PendingReconnectState.Completed);
         return _trackedWorkers.ToArray();
     }
 
@@ -113,6 +113,6 @@ internal sealed class PendingReconnect(
 
     private bool TryTransition(PendingReconnectState from, PendingReconnectState to)
     {
-        return Interlocked.CompareExchange(ref _state, (int)to, (int)from) == (int)from;
+        return Interlocked.CompareExchange(ref _state, (int) to, (int) from) == (int) from;
     }
 }

--- a/src/ModularPipelines.Distributed.SignalR/Hub/PendingReconnect.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/PendingReconnect.cs
@@ -19,6 +19,7 @@ internal sealed class PendingReconnect(
 {
     private readonly CancellationTokenSource _delayCancellation = new();
     private readonly HashSet<WorkerState> _trackedWorkers = [];
+    private WorkerState? _redispatchClaimant;
     private int _state = (int) PendingReconnectState.WaitingForReconnect;
     private int _disposed;
 
@@ -62,11 +63,23 @@ internal sealed class PendingReconnect(
             PendingReconnectState.Redispatched);
     }
 
-    public bool TryReturnToQueue()
+    public bool TryReturnToQueue(WorkerState? claimant = null)
     {
-        return TryTransition(
-            PendingReconnectState.Redispatched,
-            PendingReconnectState.AvailableForRedispatch);
+        if (!TryTransition(
+                PendingReconnectState.Redispatched,
+                PendingReconnectState.AvailableForRedispatch))
+        {
+            return false;
+        }
+
+        if (claimant is not null
+            && ReferenceEquals(_redispatchClaimant, claimant))
+        {
+            _trackedWorkers.Remove(claimant);
+            _redispatchClaimant = null;
+        }
+
+        return true;
     }
 
     public IReadOnlyList<WorkerState> Complete()
@@ -80,6 +93,12 @@ internal sealed class PendingReconnect(
         _trackedWorkers.Add(worker);
     }
 
+    public void TrackRedispatchClaimant(WorkerState worker)
+    {
+        _redispatchClaimant = worker;
+        TrackWorker(worker);
+    }
+
     public void TrackWorkers(IEnumerable<WorkerState> workers)
     {
         _trackedWorkers.UnionWith(workers);
@@ -88,6 +107,11 @@ internal sealed class PendingReconnect(
     public bool IsTracking(WorkerState worker)
     {
         return _trackedWorkers.Contains(worker);
+    }
+
+    public bool IsRedispatchClaimant(WorkerState worker)
+    {
+        return ReferenceEquals(_redispatchClaimant, worker);
     }
 
     public void UntrackWorker(WorkerState worker)

--- a/src/ModularPipelines.Distributed.SignalR/Hub/PendingReconnect.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/PendingReconnect.cs
@@ -18,6 +18,7 @@ internal sealed class PendingReconnect(
     ModuleAssignment assignment) : IDisposable
 {
     private readonly CancellationTokenSource _delayCancellation = new();
+    private readonly HashSet<WorkerState> _trackedWorkers = [];
     private int _state = (int)PendingReconnectState.WaitingForReconnect;
     private int _disposed;
 
@@ -74,9 +75,15 @@ internal sealed class PendingReconnect(
             PendingReconnectState.AvailableForRedispatch);
     }
 
-    public void Complete()
+    public IReadOnlyList<WorkerState> Complete()
     {
         Interlocked.Exchange(ref _state, (int)PendingReconnectState.Completed);
+        return _trackedWorkers.ToArray();
+    }
+
+    public void TrackWorker(WorkerState worker)
+    {
+        _trackedWorkers.Add(worker);
     }
 
     public void CancelDelay()

--- a/src/ModularPipelines.Distributed.SignalR/Hub/PendingReconnect.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/PendingReconnect.cs
@@ -28,8 +28,7 @@ internal sealed class PendingReconnect(
 
     public CancellationToken DelayToken => _delayCancellation.Token;
 
-    private PendingReconnectState State =>
-        (PendingReconnectState) Volatile.Read(ref _state);
+    public bool IsRedispatched => State == PendingReconnectState.Redispatched;
 
     public bool TryMakeAvailableForRedispatch()
     {
@@ -43,11 +42,6 @@ internal sealed class PendingReconnect(
         while (true)
         {
             var state = State;
-            if (state == PendingReconnectState.Resumed)
-            {
-                return true;
-            }
-
             if (state is not (PendingReconnectState.WaitingForReconnect
                 or PendingReconnectState.AvailableForRedispatch))
             {
@@ -86,6 +80,21 @@ internal sealed class PendingReconnect(
         _trackedWorkers.Add(worker);
     }
 
+    public void TrackWorkers(IEnumerable<WorkerState> workers)
+    {
+        _trackedWorkers.UnionWith(workers);
+    }
+
+    public bool IsTracking(WorkerState worker)
+    {
+        return _trackedWorkers.Contains(worker);
+    }
+
+    public void UntrackWorker(WorkerState worker)
+    {
+        _trackedWorkers.Remove(worker);
+    }
+
     public void CancelDelay()
     {
         if (Volatile.Read(ref _disposed) != 0)
@@ -110,6 +119,9 @@ internal sealed class PendingReconnect(
             _delayCancellation.Dispose();
         }
     }
+
+    private PendingReconnectState State =>
+        (PendingReconnectState) Volatile.Read(ref _state);
 
     private bool TryTransition(PendingReconnectState from, PendingReconnectState to)
     {

--- a/src/ModularPipelines.Distributed.SignalR/Hub/PendingReconnect.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/PendingReconnect.cs
@@ -1,0 +1,111 @@
+namespace ModularPipelines.Distributed.SignalR.Hub;
+
+internal enum PendingReconnectState
+{
+    WaitingForReconnect,
+    AvailableForRedispatch,
+    Resumed,
+    Redispatched,
+    Completed,
+}
+
+/// <summary>
+/// Coordinates the ownership handoff between a reconnecting worker and a retry
+/// dispatcher. A queued retry can still be reclaimed until a dispatcher claims it.
+/// </summary>
+internal sealed class PendingReconnect(
+    int workerIndex,
+    ModuleAssignment assignment) : IDisposable
+{
+    private readonly CancellationTokenSource _delayCancellation = new();
+    private int _state = (int)PendingReconnectState.WaitingForReconnect;
+    private int _disposed;
+
+    public int WorkerIndex { get; } = workerIndex;
+
+    public ModuleAssignment Assignment { get; } = assignment;
+
+    public CancellationToken DelayToken => _delayCancellation.Token;
+
+    private PendingReconnectState State =>
+        (PendingReconnectState)Volatile.Read(ref _state);
+
+    public bool TryMakeAvailableForRedispatch()
+    {
+        return TryTransition(
+            PendingReconnectState.WaitingForReconnect,
+            PendingReconnectState.AvailableForRedispatch);
+    }
+
+    public bool TryResume()
+    {
+        while (true)
+        {
+            var state = State;
+            if (state == PendingReconnectState.Resumed)
+            {
+                return true;
+            }
+
+            if (state is not (PendingReconnectState.WaitingForReconnect
+                or PendingReconnectState.AvailableForRedispatch))
+            {
+                return false;
+            }
+
+            if (TryTransition(state, PendingReconnectState.Resumed))
+            {
+                return true;
+            }
+        }
+    }
+
+    public bool TryClaimRedispatch()
+    {
+        return TryTransition(
+            PendingReconnectState.AvailableForRedispatch,
+            PendingReconnectState.Redispatched);
+    }
+
+    public bool TryReturnToQueue()
+    {
+        return TryTransition(
+            PendingReconnectState.Redispatched,
+            PendingReconnectState.AvailableForRedispatch);
+    }
+
+    public void Complete()
+    {
+        Interlocked.Exchange(ref _state, (int)PendingReconnectState.Completed);
+    }
+
+    public void CancelDelay()
+    {
+        if (Volatile.Read(ref _disposed) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            _delayCancellation.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Completion won the race with reconnect cancellation.
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) == 0)
+        {
+            _delayCancellation.Dispose();
+        }
+    }
+
+    private bool TryTransition(PendingReconnectState from, PendingReconnectState to)
+    {
+        return Interlocked.CompareExchange(ref _state, (int)to, (int)from) == (int)from;
+    }
+}

--- a/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
@@ -48,15 +48,37 @@ internal class SignalRMasterState
     /// </summary>
     public SemaphoreSlim WorkAvailable { get; } = new(0);
 
-    public PendingReconnect TrackPendingReconnect(int workerIndex, ModuleAssignment assignment)
+    public PendingReconnect? TrackPendingReconnect(
+        WorkerState disconnectedWorker,
+        ModuleAssignment assignment)
     {
-        var pending = new PendingReconnect(workerIndex, assignment);
+        PendingReconnect pending;
         PendingReconnect? previous;
 
         lock (_pendingReconnectLock)
         {
+            if (ResultWaiters.TryGetValue(assignment.ModuleTypeName, out var waiter)
+                && waiter.Task.IsCompleted)
+            {
+                return null;
+            }
+
             _pendingReconnects.TryGetValue(assignment.ModuleTypeName, out previous);
-            previous?.Complete();
+
+            // A late original participant is not the owner of an active redispatch.
+            // Its disconnect must not replace that claim and schedule a third execution.
+            if (previous is { IsRedispatched: true }
+                && previous.IsTracking(disconnectedWorker))
+            {
+                previous.UntrackWorker(disconnectedWorker);
+                return null;
+            }
+
+            pending = new PendingReconnect(
+                disconnectedWorker.Registration.WorkerIndex,
+                assignment);
+            var trackedWorkers = previous?.Complete() ?? [];
+            pending.TrackWorkers(trackedWorkers.Where(worker => worker != disconnectedWorker));
             _pendingReconnects[assignment.ModuleTypeName] = pending;
         }
 
@@ -77,14 +99,12 @@ internal class SignalRMasterState
     public bool TryRestoreReconnect(
         WorkerState worker,
         string? resumingModuleTypeName,
-        out ModuleAssignment? assignment,
-        out bool resumed)
+        out ModuleAssignment? assignment)
     {
         PendingReconnect? pending;
         PendingReconnect? completedPending = null;
         var restored = false;
         assignment = null;
-        resumed = false;
 
         lock (_pendingReconnectLock)
         {
@@ -98,13 +118,20 @@ internal class SignalRMasterState
                 if (ResultWaiters.TryGetValue(pending.Assignment.ModuleTypeName, out var waiter)
                     && !waiter.Task.IsCompleted)
                 {
-                    resumed = pending.TryResume();
                     assignment = pending.Assignment;
 
                     if (worker.TryAssign(assignment))
                     {
-                        pending.TrackWorker(worker);
-                        restored = true;
+                        if (pending.TryResume())
+                        {
+                            pending.TrackWorker(worker);
+                            restored = true;
+                        }
+                        else
+                        {
+                            worker.TryCompleteAssignment(assignment.ModuleTypeName);
+                            assignment = null;
+                        }
                     }
                 }
                 else if (_pendingReconnects.Remove(
@@ -116,31 +143,47 @@ internal class SignalRMasterState
             }
         }
 
-        pending?.CancelDelay();
+        if (restored)
+        {
+            pending?.CancelDelay();
+        }
+
         completedPending?.Dispose();
         return restored;
     }
 
     public bool TryClaimRedispatch(ModuleAssignment assignment)
     {
-        PendingReconnect? pending;
         lock (_pendingReconnectLock)
         {
-            _pendingReconnects.TryGetValue(assignment.ModuleTypeName, out pending);
-        }
+            if (ResultWaiters.TryGetValue(assignment.ModuleTypeName, out var waiter)
+                && waiter.Task.IsCompleted)
+            {
+                return false;
+            }
 
-        return pending is null || pending.TryClaimRedispatch();
+            return !_pendingReconnects.TryGetValue(
+                       assignment.ModuleTypeName,
+                       out var pending)
+                   || pending.TryClaimRedispatch();
+        }
     }
 
-    public void ReturnRedispatchToQueue(ModuleAssignment assignment)
+    public bool TryReturnRedispatchToQueue(ModuleAssignment assignment)
     {
-        PendingReconnect? pending;
         lock (_pendingReconnectLock)
         {
-            _pendingReconnects.TryGetValue(assignment.ModuleTypeName, out pending);
-        }
+            if (ResultWaiters.TryGetValue(assignment.ModuleTypeName, out var waiter)
+                && waiter.Task.IsCompleted)
+            {
+                return false;
+            }
 
-        pending?.TryReturnToQueue();
+            return !_pendingReconnects.TryGetValue(
+                       assignment.ModuleTypeName,
+                       out var pending)
+                   || pending.TryReturnToQueue();
+        }
     }
 
     public void CompletePendingReconnect(string moduleTypeName)

--- a/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
@@ -76,6 +76,7 @@ internal class SignalRMasterState
 
     public bool TryRestoreReconnect(
         WorkerState worker,
+        string? resumingModuleTypeName,
         out ModuleAssignment? assignment,
         out bool resumed)
     {
@@ -89,7 +90,8 @@ internal class SignalRMasterState
         {
             pending = _pendingReconnects.Values
                 .FirstOrDefault(candidate =>
-                    candidate.WorkerIndex == worker.Registration.WorkerIndex);
+                    candidate.WorkerIndex == worker.Registration.WorkerIndex
+                    && candidate.Assignment.ModuleTypeName == resumingModuleTypeName);
 
             if (pending is not null)
             {

--- a/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
@@ -68,7 +68,8 @@ internal class SignalRMasterState
             // A late original participant is not the owner of an active redispatch.
             // Its disconnect must not replace that claim and schedule a third execution.
             if (previous is { IsRedispatched: true }
-                && previous.IsTracking(disconnectedWorker))
+                && previous.IsTracking(disconnectedWorker)
+                && !previous.IsRedispatchClaimant(disconnectedWorker))
             {
                 previous.UntrackWorker(disconnectedWorker);
                 return null;
@@ -176,14 +177,16 @@ internal class SignalRMasterState
 
             if (worker is not null)
             {
-                pending.TrackWorker(worker);
+                pending.TrackRedispatchClaimant(worker);
             }
 
             return true;
         }
     }
 
-    public bool TryReturnRedispatchToQueue(ModuleAssignment assignment)
+    public bool TryReturnRedispatchToQueue(
+        ModuleAssignment assignment,
+        WorkerState? worker = null)
     {
         lock (_pendingReconnectLock)
         {
@@ -196,7 +199,7 @@ internal class SignalRMasterState
             return !_pendingReconnects.TryGetValue(
                        assignment.ModuleTypeName,
                        out var pending)
-                   || pending.TryReturnToQueue();
+                   || pending.TryReturnToQueue(worker);
         }
     }
 

--- a/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
@@ -8,6 +8,9 @@ namespace ModularPipelines.Distributed.SignalR.Hub;
 /// </summary>
 internal class SignalRMasterState
 {
+    private readonly object _pendingReconnectLock = new();
+    private readonly Dictionary<string, PendingReconnect> _pendingReconnects = new();
+
     /// <summary>
     /// Connected workers indexed by SignalR connection ID.
     /// </summary>
@@ -29,14 +32,6 @@ internal class SignalRMasterState
     public ConcurrentDictionary<string, TaskCompletionSource<SerializedModuleResult>> ResultWaiters { get; } = new();
 
     /// <summary>
-    /// Workers that disconnected with an in-flight assignment, keyed by worker index
-    /// (stable across reconnects). The assignment is re-enqueued only after
-    /// <see cref="ReconnectGracePeriod"/> elapses; if the worker reconnects first, the
-    /// pending re-enqueue is cancelled so the module isn't run twice on a transient blip.
-    /// </summary>
-    public ConcurrentDictionary<int, (ModuleAssignment Assignment, CancellationTokenSource Cts)> PendingReconnects { get; } = new();
-
-    /// <summary>
     /// How long to wait for a disconnected worker to reconnect before re-enqueuing its
     /// in-flight work. Should exceed the client's total auto-reconnect window.
     /// </summary>
@@ -52,4 +47,69 @@ internal class SignalRMasterState
     /// Used by <see cref="Coordination.SignalRMasterCoordinator.DequeueModuleAsync"/> to avoid polling.
     /// </summary>
     public SemaphoreSlim WorkAvailable { get; } = new(0);
+
+    public PendingReconnect TrackPendingReconnect(int workerIndex, ModuleAssignment assignment)
+    {
+        var pending = new PendingReconnect(workerIndex, assignment);
+        PendingReconnect? previous;
+
+        lock (_pendingReconnectLock)
+        {
+            _pendingReconnects.TryGetValue(assignment.ModuleTypeName, out previous);
+            previous?.Complete();
+            _pendingReconnects[assignment.ModuleTypeName] = pending;
+        }
+
+        previous?.CancelDelay();
+        previous?.Dispose();
+        return pending;
+    }
+
+    public PendingReconnect? GetPendingReconnect(int workerIndex)
+    {
+        lock (_pendingReconnectLock)
+        {
+            return _pendingReconnects.Values
+                .FirstOrDefault(pending => pending.WorkerIndex == workerIndex);
+        }
+    }
+
+    public bool TryClaimRedispatch(ModuleAssignment assignment)
+    {
+        PendingReconnect? pending;
+        lock (_pendingReconnectLock)
+        {
+            _pendingReconnects.TryGetValue(assignment.ModuleTypeName, out pending);
+        }
+
+        return pending is null || pending.TryClaimRedispatch();
+    }
+
+    public void ReturnRedispatchToQueue(ModuleAssignment assignment)
+    {
+        PendingReconnect? pending;
+        lock (_pendingReconnectLock)
+        {
+            _pendingReconnects.TryGetValue(assignment.ModuleTypeName, out pending);
+        }
+
+        pending?.TryReturnToQueue();
+    }
+
+    public void CompletePendingReconnect(string moduleTypeName)
+    {
+        PendingReconnect? pending;
+        lock (_pendingReconnectLock)
+        {
+            if (!_pendingReconnects.Remove(moduleTypeName, out pending))
+            {
+                return;
+            }
+
+            pending.Complete();
+        }
+
+        pending.CancelDelay();
+        pending.Dispose();
+    }
 }

--- a/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
@@ -74,6 +74,51 @@ internal class SignalRMasterState
         }
     }
 
+    public bool TryRestoreReconnect(
+        WorkerState worker,
+        out ModuleAssignment? assignment,
+        out bool resumed)
+    {
+        PendingReconnect? pending;
+        PendingReconnect? completedPending = null;
+        var restored = false;
+        assignment = null;
+        resumed = false;
+
+        lock (_pendingReconnectLock)
+        {
+            pending = _pendingReconnects.Values
+                .FirstOrDefault(candidate =>
+                    candidate.WorkerIndex == worker.Registration.WorkerIndex);
+
+            if (pending is not null)
+            {
+                if (ResultWaiters.TryGetValue(pending.Assignment.ModuleTypeName, out var waiter)
+                    && !waiter.Task.IsCompleted)
+                {
+                    resumed = pending.TryResume();
+                    assignment = pending.Assignment;
+
+                    if (worker.TryAssign(assignment))
+                    {
+                        pending.TrackWorker(worker);
+                        restored = true;
+                    }
+                }
+                else if (_pendingReconnects.Remove(
+                             pending.Assignment.ModuleTypeName,
+                             out completedPending))
+                {
+                    completedPending.Complete();
+                }
+            }
+        }
+
+        pending?.CancelDelay();
+        completedPending?.Dispose();
+        return restored;
+    }
+
     public bool TryClaimRedispatch(ModuleAssignment assignment)
     {
         PendingReconnect? pending;
@@ -111,5 +156,28 @@ internal class SignalRMasterState
 
         pending.CancelDelay();
         pending.Dispose();
+    }
+
+    public IReadOnlyList<WorkerState> CompleteResult(SerializedModuleResult result)
+    {
+        PendingReconnect? pending = null;
+        IReadOnlyList<WorkerState> trackedWorkers = [];
+
+        lock (_pendingReconnectLock)
+        {
+            if (ResultWaiters.TryGetValue(result.ModuleTypeName, out var waiter))
+            {
+                waiter.TrySetResult(result);
+            }
+
+            if (_pendingReconnects.Remove(result.ModuleTypeName, out pending))
+            {
+                trackedWorkers = pending.Complete();
+            }
+        }
+
+        pending?.CancelDelay();
+        pending?.Dispose();
+        return trackedWorkers;
     }
 }

--- a/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
@@ -152,7 +152,9 @@ internal class SignalRMasterState
         return restored;
     }
 
-    public bool TryClaimRedispatch(ModuleAssignment assignment)
+    public bool TryClaimRedispatch(
+        ModuleAssignment assignment,
+        WorkerState? worker = null)
     {
         lock (_pendingReconnectLock)
         {
@@ -162,10 +164,22 @@ internal class SignalRMasterState
                 return false;
             }
 
-            return !_pendingReconnects.TryGetValue(
-                       assignment.ModuleTypeName,
-                       out var pending)
-                   || pending.TryClaimRedispatch();
+            if (!_pendingReconnects.TryGetValue(assignment.ModuleTypeName, out var pending))
+            {
+                return true;
+            }
+
+            if (!pending.TryClaimRedispatch())
+            {
+                return false;
+            }
+
+            if (worker is not null)
+            {
+                pending.TrackWorker(worker);
+            }
+
+            return true;
         }
     }
 

--- a/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/SignalRMasterState.cs
@@ -10,6 +10,7 @@ internal class SignalRMasterState
 {
     private readonly object _pendingReconnectLock = new();
     private readonly Dictionary<string, PendingReconnect> _pendingReconnects = new();
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _assignmentDeliveryFences = new();
 
     /// <summary>
     /// Connected workers indexed by SignalR connection ID.
@@ -203,6 +204,15 @@ internal class SignalRMasterState
         }
     }
 
+    public async Task<IDisposable> EnterAssignmentDeliveryFenceAsync(string moduleTypeName)
+    {
+        var deliveryFence = _assignmentDeliveryFences.GetOrAdd(
+            moduleTypeName,
+            _ => new SemaphoreSlim(1, 1));
+        await deliveryFence.WaitAsync();
+        return new SemaphoreReleaser(deliveryFence);
+    }
+
     public void CompletePendingReconnect(string moduleTypeName)
     {
         PendingReconnect? pending;
@@ -220,7 +230,13 @@ internal class SignalRMasterState
         pending.Dispose();
     }
 
-    public IReadOnlyList<WorkerState> CompleteResult(SerializedModuleResult result)
+    public async Task<IReadOnlyList<WorkerState>> CompleteResultAsync(SerializedModuleResult result)
+    {
+        using var deliveryFence = await EnterAssignmentDeliveryFenceAsync(result.ModuleTypeName);
+        return CompleteResult(result);
+    }
+
+    private IReadOnlyList<WorkerState> CompleteResult(SerializedModuleResult result)
     {
         PendingReconnect? pending = null;
         IReadOnlyList<WorkerState> trackedWorkers = [];
@@ -241,5 +257,13 @@ internal class SignalRMasterState
         pending?.CancelDelay();
         pending?.Dispose();
         return trackedWorkers;
+    }
+
+    private sealed class SemaphoreReleaser(SemaphoreSlim semaphore) : IDisposable
+    {
+        public void Dispose()
+        {
+            semaphore.Release();
+        }
     }
 }

--- a/src/ModularPipelines.Distributed.SignalR/Hub/WorkerState.cs
+++ b/src/ModularPipelines.Distributed.SignalR/Hub/WorkerState.cs
@@ -6,18 +6,17 @@ namespace ModularPipelines.Distributed.SignalR.Hub;
 internal class WorkerState
 {
     public required string ConnectionId { get; init; }
+
     public required WorkerRegistration Registration { get; init; }
 
     /// <summary>
     /// 0 = idle, 1 = busy. Updated via <see cref="System.Threading.Interlocked.CompareExchange(ref int, int, int)"/>.
     /// </summary>
-    public int BusyFlag;
+    private int _busyFlag;
 
     private ModuleAssignment? _currentAssignment;
 
-    public bool TryMarkBusy() => Interlocked.CompareExchange(ref BusyFlag, 1, 0) == 0;
-    public void MarkIdle() => Interlocked.Exchange(ref BusyFlag, 0);
-    public bool IsIdle => Volatile.Read(ref BusyFlag) == 0;
+    public bool IsIdle => Volatile.Read(ref _busyFlag) == 0;
 
     /// <summary>
     /// The assignment this worker is currently executing, if any. Set when work is
@@ -26,10 +25,52 @@ internal class WorkerState
     /// </summary>
     public ModuleAssignment? CurrentAssignment => Volatile.Read(ref _currentAssignment);
 
-    public void SetAssignment(ModuleAssignment assignment) => Volatile.Write(ref _currentAssignment, assignment);
+    /// <summary>
+    /// Atomically claims this worker and records the assignment.
+    /// </summary>
+    public bool TryAssign(ModuleAssignment assignment)
+    {
+        if (Interlocked.CompareExchange(ref _busyFlag, 1, 0) != 0)
+        {
+            return false;
+        }
+
+        if (Interlocked.CompareExchange(ref _currentAssignment, assignment, null) is null)
+        {
+            return true;
+        }
+
+        Interlocked.Exchange(ref _busyFlag, 0);
+        return false;
+    }
 
     /// <summary>
     /// Atomically clears and returns the current assignment.
     /// </summary>
     public ModuleAssignment? ClearAssignment() => Interlocked.Exchange(ref _currentAssignment, null);
+
+    /// <summary>
+    /// Clears this worker only when the result belongs to its tracked assignment.
+    /// </summary>
+    public bool TryCompleteAssignment(string moduleTypeName)
+    {
+        while (true)
+        {
+            var assignment = CurrentAssignment;
+            if (assignment is null
+                || !string.Equals(
+                    assignment.ModuleTypeName,
+                    moduleTypeName,
+                    StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (Interlocked.CompareExchange(ref _currentAssignment, null, assignment) == assignment)
+            {
+                Interlocked.Exchange(ref _busyFlag, 0);
+                return true;
+            }
+        }
+    }
 }

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/DistributedPipelineHubTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/DistributedPipelineHubTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Distributed.SignalR.Hub;
+using Moq;
+
+namespace ModularPipelines.Distributed.SignalR.UnitTests;
+
+public class DistributedPipelineHubTests
+{
+    [Test]
+    public async Task PublishResult_Does_Not_Clear_A_Different_Current_Assignment()
+    {
+        var state = new SignalRMasterState();
+        var worker = new WorkerState
+        {
+            ConnectionId = "connection-1",
+            Registration = new WorkerRegistration(1, [], DateTimeOffset.UtcNow),
+        };
+        worker.TryAssign(CreateAssignment("CurrentModule"));
+        state.Workers[worker.ConnectionId] = worker;
+
+        var context = new Mock<HubCallerContext>();
+        context.SetupGet(x => x.ConnectionId).Returns(worker.ConnectionId);
+
+        var otherClients = new Mock<IClientProxy>();
+        otherClients
+            .Setup(x => x.SendCoreAsync(
+                It.IsAny<string>(),
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var clients = new Mock<IHubCallerClients>();
+        clients.SetupGet(x => x.Others).Returns(otherClients.Object);
+
+        var hub = new DistributedPipelineHub(
+            state,
+            NullLogger<DistributedPipelineHub>.Instance)
+        {
+            Context = context.Object,
+            Clients = clients.Object,
+        };
+
+        await hub.PublishResult(CreateResult("PreviousModule"));
+
+        await Assert.That(worker.CurrentAssignment?.ModuleTypeName)
+            .IsEqualTo("CurrentModule");
+        await Assert.That(worker.IsIdle).IsFalse();
+    }
+
+    private static ModuleAssignment CreateAssignment(string moduleTypeName)
+    {
+        return new ModuleAssignment(
+            moduleTypeName,
+            "System.String",
+            [],
+            null,
+            DateTimeOffset.UtcNow,
+            new ModuleAssignmentConfig(null, 0, false));
+    }
+
+    private static SerializedModuleResult CreateResult(string moduleTypeName)
+    {
+        return new SerializedModuleResult(
+            moduleTypeName,
+            "System.String",
+            1,
+            "{}",
+            DateTimeOffset.UtcNow);
+    }
+}

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRIntegrationTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRIntegrationTests.cs
@@ -51,7 +51,7 @@ public class SignalRIntegrationTests
                 Capabilities: new HashSet<string> { "linux", "x64" },
                 RegisteredAt: DateTimeOffset.UtcNow);
 
-            await connection.InvokeAsync(HubMethodNames.RegisterWorker, registration);
+            await connection.InvokeAsync(HubMethodNames.RegisterWorker, registration, null);
 
             // Assert — master state should have the worker
             await Assert.That(masterState.Registrations.Count).IsEqualTo(1);
@@ -86,7 +86,8 @@ public class SignalRIntegrationTests
 
             // Register first (required by hub)
             await connection.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow));
+                new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow),
+                null);
 
             // Pre-create a result waiter
             var tcs = new TaskCompletionSource<SerializedModuleResult>(
@@ -146,7 +147,8 @@ public class SignalRIntegrationTests
 
             // Register as idle worker
             await connection.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(1, new HashSet<string> { "linux" }, DateTimeOffset.UtcNow));
+                new WorkerRegistration(1, new HashSet<string> { "linux" }, DateTimeOffset.UtcNow),
+                null);
 
             // Enqueue work via master state (simulating master coordinator)
             var moduleAssignment = new ModuleAssignment(
@@ -230,11 +232,14 @@ public class SignalRIntegrationTests
             await Task.WhenAll(worker1.StartAsync(), worker2.StartAsync(), worker3.StartAsync());
 
             await worker1.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(1, new HashSet<string> { "linux" }, DateTimeOffset.UtcNow));
+                new WorkerRegistration(1, new HashSet<string> { "linux" }, DateTimeOffset.UtcNow),
+                null);
             await worker2.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(2, new HashSet<string> { "windows" }, DateTimeOffset.UtcNow));
+                new WorkerRegistration(2, new HashSet<string> { "windows" }, DateTimeOffset.UtcNow),
+                null);
             await worker3.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(3, new HashSet<string> { "linux", "docker" }, DateTimeOffset.UtcNow));
+                new WorkerRegistration(3, new HashSet<string> { "linux", "docker" }, DateTimeOffset.UtcNow),
+                null);
 
             // Enqueue 3 modules with different capability requirements
             var windowsModule = new ModuleAssignment(
@@ -317,9 +322,11 @@ public class SignalRIntegrationTests
             await Task.WhenAll(worker1.StartAsync(), worker2.StartAsync());
 
             await worker1.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow));
+                new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow),
+                null);
             await worker2.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(2, new HashSet<string>(), DateTimeOffset.UtcNow));
+                new WorkerRegistration(2, new HashSet<string>(), DateTimeOffset.UtcNow),
+                null);
 
             // Pre-create result waiter for the master side
             masterState.ResultWaiters["BuildModule"] = new TaskCompletionSource<SerializedModuleResult>(
@@ -386,7 +393,8 @@ public class SignalRIntegrationTests
 
             await worker.StartAsync();
             await worker.InvokeAsync(HubMethodNames.RegisterWorker,
-                new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow));
+                new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow),
+                null);
 
             // Set up result waiters and enqueue 3 modules
             var modules = new[] { "ModuleA", "ModuleB", "ModuleC" };

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
@@ -80,9 +80,13 @@ public class SignalRMasterCoordinatorTests
             new TaskCompletionSource<SerializedModuleResult>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var pending = state.TrackPendingReconnect(1, assignment);
+        var disconnectedWorker = new WorkerState
+        {
+            ConnectionId = "disconnected-worker",
+            Registration = new WorkerRegistration(1, [], DateTimeOffset.UtcNow),
+        };
+        var pending = state.TrackPendingReconnect(disconnectedWorker, assignment)!;
         pending.TryMakeAvailableForRedispatch();
-        pending.TryClaimRedispatch();
 
         var worker = new WorkerState
         {
@@ -93,7 +97,6 @@ public class SignalRMasterCoordinatorTests
         var restored = state.TryRestoreReconnect(
             worker,
             assignment.ModuleTypeName,
-            out _,
             out _);
         await coordinator.PublishResultAsync(CreateResult("TestModule"), CancellationToken.None);
 

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
@@ -71,6 +71,34 @@ public class SignalRMasterCoordinatorTests
     }
 
     [Test]
+    public async Task PublishResult_Releases_Worker_Tracked_By_Pending_Reconnect()
+    {
+        var state = new SignalRMasterState();
+        var coordinator = CreateCoordinator(state);
+        var assignment = CreateAssignment("TestModule");
+        state.ResultWaiters[assignment.ModuleTypeName] =
+            new TaskCompletionSource<SerializedModuleResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var pending = state.TrackPendingReconnect(1, assignment);
+        pending.TryMakeAvailableForRedispatch();
+        pending.TryClaimRedispatch();
+
+        var worker = new WorkerState
+        {
+            ConnectionId = "reconnected-worker",
+            Registration = new WorkerRegistration(1, [], DateTimeOffset.UtcNow),
+        };
+
+        var restored = state.TryRestoreReconnect(worker, out _, out _);
+        await coordinator.PublishResultAsync(CreateResult("TestModule"), CancellationToken.None);
+
+        await Assert.That(restored).IsTrue();
+        await Assert.That(worker.IsIdle).IsTrue();
+        await Assert.That(state.GetPendingReconnect(1)).IsNull();
+    }
+
+    [Test]
     public async Task WaitForResult_Cancellable()
     {
         var coordinator = CreateCoordinator();

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
@@ -230,6 +230,77 @@ public class SignalRMasterCoordinatorTests
     }
 
     [Test]
+    public async Task Result_Cannot_Release_Redispatch_Worker_Until_Delivery_Completes()
+    {
+        var state = new SignalRMasterState();
+        var assignment = CreateAssignment("TestModule");
+        state.ResultWaiters[assignment.ModuleTypeName] =
+            new TaskCompletionSource<SerializedModuleResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var disconnectedWorker = new WorkerState
+        {
+            ConnectionId = "disconnected-worker",
+            Registration = new WorkerRegistration(1, [], DateTimeOffset.UtcNow),
+        };
+        var pending = state.TrackPendingReconnect(disconnectedWorker, assignment)!;
+        pending.TryMakeAvailableForRedispatch();
+
+        var retryWorker = new WorkerState
+        {
+            ConnectionId = "retry-worker",
+            Registration = new WorkerRegistration(2, [], DateTimeOffset.UtcNow),
+        };
+        state.Workers[retryWorker.ConnectionId] = retryWorker;
+
+        var deliveryStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var allowDelivery = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var clientProxy = new Mock<ISingleClientProxy>();
+        clientProxy
+            .Setup(client => client.SendCoreAsync(
+                HubMethodNames.ReceiveAssignment,
+                It.IsAny<object?[]>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(async () =>
+            {
+                deliveryStarted.SetResult();
+                await allowDelivery.Task;
+            });
+
+        var clients = new Mock<IHubClients>();
+        clients.Setup(client => client.Client(retryWorker.ConnectionId))
+            .Returns(clientProxy.Object);
+        var hubContext = new Mock<IHubContext<DistributedPipelineHub>>();
+        hubContext.Setup(context => context.Clients).Returns(clients.Object);
+        var coordinator = new SignalRMasterCoordinator(
+            hubContext.Object,
+            state,
+            NullLogger<SignalRMasterCoordinator>.Instance);
+
+        var enqueueTask = coordinator.EnqueueModuleAsync(
+            assignment,
+            CancellationToken.None);
+        await deliveryStarted.Task;
+
+        var publishTask = coordinator.PublishResultAsync(
+            CreateResult(assignment.ModuleTypeName),
+            CancellationToken.None);
+        await Task.Yield();
+
+        await Assert.That(publishTask.IsCompleted).IsFalse();
+        await Assert.That(retryWorker.IsIdle).IsFalse();
+        await Assert.That(retryWorker.TryAssign(CreateAssignment("NextModule"))).IsFalse();
+
+        allowDelivery.SetResult();
+        await enqueueTask;
+        await publishTask;
+
+        await Assert.That(retryWorker.IsIdle).IsTrue();
+    }
+
+    [Test]
     public async Task EnqueueModule_Queues_When_No_Capability_Match()
     {
         var state = new SignalRMasterState();

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterCoordinatorTests.cs
@@ -90,7 +90,11 @@ public class SignalRMasterCoordinatorTests
             Registration = new WorkerRegistration(1, [], DateTimeOffset.UtcNow),
         };
 
-        var restored = state.TryRestoreReconnect(worker, out _, out _);
+        var restored = state.TryRestoreReconnect(
+            worker,
+            assignment.ModuleTypeName,
+            out _,
+            out _);
         await coordinator.PublishResultAsync(CreateResult("TestModule"), CancellationToken.None);
 
         await Assert.That(restored).IsTrue();

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
@@ -134,6 +134,53 @@ public class SignalRMasterStateTests
         state.CompletePendingReconnect(assignment.ModuleTypeName);
     }
 
+    [Test]
+    public async Task ResultCompletion_And_ReconnectRegistration_Cannot_Leave_Worker_Busy()
+    {
+        for (var i = 0; i < 100; i++)
+        {
+            var state = new SignalRMasterState();
+            var assignment = CreateAssignment();
+            state.ResultWaiters[assignment.ModuleTypeName] =
+                new TaskCompletionSource<SerializedModuleResult>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var pending = state.TrackPendingReconnect(1, assignment);
+            pending.TryMakeAvailableForRedispatch();
+            pending.TryClaimRedispatch();
+
+            var worker = new WorkerState
+            {
+                ConnectionId = $"connection-{i}",
+                Registration = new WorkerRegistration(1, [], DateTimeOffset.UtcNow),
+            };
+
+            var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var reconnect = Task.Run(async () =>
+            {
+                await start.Task;
+                return state.TryRestoreReconnect(worker, out _, out _);
+            });
+            var completion = Task.Run(async () =>
+            {
+                await start.Task;
+                return state.CompleteResult(CreateResult());
+            });
+
+            start.SetResult();
+            var reconnectRestored = await reconnect;
+            var workersToRelease = await completion;
+
+            foreach (var trackedWorker in workersToRelease)
+            {
+                trackedWorker.TryCompleteAssignment(assignment.ModuleTypeName);
+            }
+
+            await Assert.That(worker.IsIdle).IsTrue();
+            await Assert.That(reconnectRestored).IsEqualTo(workersToRelease.Contains(worker));
+        }
+    }
+
     private static ModuleAssignment CreateAssignment()
     {
         return new ModuleAssignment(
@@ -143,5 +190,15 @@ public class SignalRMasterStateTests
             null,
             DateTimeOffset.UtcNow,
             new ModuleAssignmentConfig(null, 0, false));
+    }
+
+    private static SerializedModuleResult CreateResult()
+    {
+        return new SerializedModuleResult(
+            "TestModule",
+            "System.String",
+            1,
+            "{}",
+            DateTimeOffset.UtcNow);
     }
 }

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
@@ -199,7 +199,7 @@ public class SignalRMasterStateTests
             var completion = Task.Run(async () =>
             {
                 await start.Task;
-                return state.CompleteResult(CreateResult());
+                return await state.CompleteResultAsync(CreateResult());
             });
 
             start.SetResult();
@@ -251,7 +251,7 @@ public class SignalRMasterStateTests
         var pending = state.TrackPendingReconnect(CreateWorker(), assignment)!;
         pending.TryMakeAvailableForRedispatch();
 
-        state.CompleteResult(CreateResult());
+        await state.CompleteResultAsync(CreateResult());
 
         await Assert.That(state.TryClaimRedispatch(assignment)).IsFalse();
     }
@@ -268,7 +268,7 @@ public class SignalRMasterStateTests
         first.TrackWorker(trackedWorker);
 
         var replacement = state.TrackPendingReconnect(replacementOwner, assignment);
-        var workersToRelease = state.CompleteResult(CreateResult());
+        var workersToRelease = await state.CompleteResultAsync(CreateResult());
 
         await Assert.That(replacement).IsNotNull();
         await Assert.That(workersToRelease).Contains(trackedWorker);
@@ -305,7 +305,7 @@ public class SignalRMasterStateTests
         pending.TryMakeAvailableForRedispatch();
         state.TryClaimRedispatch(assignment);
 
-        state.CompleteResult(CreateResult());
+        await state.CompleteResultAsync(CreateResult());
 
         await Assert.That(state.TryReturnRedispatchToQueue(assignment)).IsFalse();
     }
@@ -325,7 +325,7 @@ public class SignalRMasterStateTests
 
         await Assert.That(state.TryClaimRedispatch(assignment, retryWorker)).IsTrue();
 
-        var workersToRelease = state.CompleteResult(CreateResult());
+        var workersToRelease = await state.CompleteResultAsync(CreateResult());
         foreach (var worker in workersToRelease)
         {
             worker.TryCompleteAssignment(assignment.ModuleTypeName);

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
@@ -5,47 +5,47 @@ namespace ModularPipelines.Distributed.SignalR.UnitTests;
 public class SignalRMasterStateTests
 {
     [Test]
-    public async Task WorkerState_TryMarkBusy_Returns_True_When_Idle()
+    public async Task WorkerState_TryAssign_Returns_True_When_Idle()
     {
         var worker = new WorkerState
         {
             ConnectionId = "conn-1",
-            Registration = new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, [], DateTimeOffset.UtcNow),
         };
 
-        var result = worker.TryMarkBusy();
+        var result = worker.TryAssign(CreateAssignment());
         await Assert.That(result).IsTrue();
         await Assert.That(worker.IsIdle).IsFalse();
     }
 
     [Test]
-    public async Task WorkerState_TryMarkBusy_Returns_False_When_Already_Busy()
+    public async Task WorkerState_TryAssign_Returns_False_When_Already_Busy()
     {
         var worker = new WorkerState
         {
             ConnectionId = "conn-1",
-            Registration = new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, [], DateTimeOffset.UtcNow),
         };
 
-        worker.TryMarkBusy(); // First call succeeds
-        var result = worker.TryMarkBusy(); // Second call should fail
+        worker.TryAssign(CreateAssignment());
+        var result = worker.TryAssign(CreateAssignment());
 
         await Assert.That(result).IsFalse();
     }
 
     [Test]
-    public async Task WorkerState_MarkIdle_Resets_BusyFlag()
+    public async Task WorkerState_TryCompleteAssignment_Resets_BusyFlag()
     {
         var worker = new WorkerState
         {
             ConnectionId = "conn-1",
-            Registration = new WorkerRegistration(1, new HashSet<string>(), DateTimeOffset.UtcNow),
+            Registration = new WorkerRegistration(1, [], DateTimeOffset.UtcNow),
         };
 
-        worker.TryMarkBusy();
+        worker.TryAssign(CreateAssignment());
         await Assert.That(worker.IsIdle).IsFalse();
 
-        worker.MarkIdle();
+        worker.TryCompleteAssignment("TestModule");
         await Assert.That(worker.IsIdle).IsTrue();
     }
 
@@ -60,11 +60,11 @@ public class SignalRMasterStateTests
             state.Workers[$"conn-{i}"] = new WorkerState
             {
                 ConnectionId = $"conn-{i}",
-                Registration = new WorkerRegistration(i, new HashSet<string>(), DateTimeOffset.UtcNow),
+                Registration = new WorkerRegistration(i, [], DateTimeOffset.UtcNow),
             };
-            state.Registrations[i] = new WorkerRegistration(i, new HashSet<string>(), DateTimeOffset.UtcNow);
+            state.Registrations[i] = new WorkerRegistration(i, [], DateTimeOffset.UtcNow);
             state.PendingAssignments.Enqueue(new ModuleAssignment(
-                $"Module{i}", "System.String", new HashSet<string>(),
+                $"Module{i}", "System.String", [],
                 null, DateTimeOffset.UtcNow, new ModuleAssignmentConfig(null, 0, false)));
             state.ResultWaiters[$"Module{i}"] = new TaskCompletionSource<SerializedModuleResult>();
         }));
@@ -85,5 +85,63 @@ public class SignalRMasterStateTests
 
         state.IsCompleted = true;
         await Assert.That(state.IsCompleted).IsTrue();
+    }
+
+    [Test]
+    public async Task PendingReconnect_Allows_Exactly_One_Resume_Or_Redispatch()
+    {
+        using var pending = new PendingReconnect(
+            1,
+            new ModuleAssignment(
+                "TestModule",
+                "System.String",
+                [],
+                null,
+                DateTimeOffset.UtcNow,
+                new ModuleAssignmentConfig(null, 0, false)));
+
+        await Assert.That(pending.TryMakeAvailableForRedispatch()).IsTrue();
+
+        var start = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var resume = Task.Run(async () =>
+        {
+            await start.Task;
+            return pending.TryResume();
+        });
+        var redispatch = Task.Run(async () =>
+        {
+            await start.Task;
+            return pending.TryClaimRedispatch();
+        });
+
+        start.SetResult();
+        var results = await Task.WhenAll(resume, redispatch);
+
+        await Assert.That(results.Count(result => result)).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Reconnect_Reclaims_Queued_Retry_Until_Dispatch_Claims_It()
+    {
+        var state = new SignalRMasterState();
+        var assignment = CreateAssignment();
+        var pending = state.TrackPendingReconnect(1, assignment);
+
+        await Assert.That(pending.TryMakeAvailableForRedispatch()).IsTrue();
+        await Assert.That(pending.TryResume()).IsTrue();
+        await Assert.That(state.TryClaimRedispatch(assignment)).IsFalse();
+
+        state.CompletePendingReconnect(assignment.ModuleTypeName);
+    }
+
+    private static ModuleAssignment CreateAssignment()
+    {
+        return new ModuleAssignment(
+            "TestModule",
+            "System.String",
+            [],
+            null,
+            DateTimeOffset.UtcNow,
+            new ModuleAssignmentConfig(null, 0, false));
     }
 }

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
@@ -135,6 +135,29 @@ public class SignalRMasterStateTests
     }
 
     [Test]
+    public async Task ReplacementWorker_Cannot_Reclaim_Queued_Retry_By_Index()
+    {
+        var state = new SignalRMasterState();
+        var assignment = CreateAssignment();
+        var pending = state.TrackPendingReconnect(1, assignment);
+        var replacement = new WorkerState
+        {
+            ConnectionId = "replacement",
+            Registration = new WorkerRegistration(1, [], DateTimeOffset.UtcNow),
+        };
+
+        await Assert.That(pending.TryMakeAvailableForRedispatch()).IsTrue();
+
+        var restored = state.TryRestoreReconnect(replacement, null, out _, out _);
+
+        await Assert.That(restored).IsFalse();
+        await Assert.That(replacement.IsIdle).IsTrue();
+        await Assert.That(state.TryClaimRedispatch(assignment)).IsTrue();
+
+        state.CompletePendingReconnect(assignment.ModuleTypeName);
+    }
+
+    [Test]
     public async Task ResultCompletion_And_ReconnectRegistration_Cannot_Leave_Worker_Busy()
     {
         for (var i = 0; i < 100; i++)
@@ -159,7 +182,11 @@ public class SignalRMasterStateTests
             var reconnect = Task.Run(async () =>
             {
                 await start.Task;
-                return state.TryRestoreReconnect(worker, out _, out _);
+                return state.TryRestoreReconnect(
+                    worker,
+                    assignment.ModuleTypeName,
+                    out _,
+                    out _);
             });
             var completion = Task.Run(async () =>
             {

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
@@ -310,6 +310,31 @@ public class SignalRMasterStateTests
         await Assert.That(state.TryReturnRedispatchToQueue(assignment)).IsFalse();
     }
 
+    [Test]
+    public async Task First_Result_Releases_Remote_Redispatch_Worker()
+    {
+        var state = new SignalRMasterState();
+        var assignment = CreateAssignment();
+        var retryWorker = CreateWorker(2, "retry");
+        state.ResultWaiters[assignment.ModuleTypeName] =
+            new TaskCompletionSource<SerializedModuleResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        var pending = state.TrackPendingReconnect(CreateWorker(), assignment)!;
+        pending.TryMakeAvailableForRedispatch();
+        await Assert.That(retryWorker.TryAssign(assignment)).IsTrue();
+
+        await Assert.That(state.TryClaimRedispatch(assignment, retryWorker)).IsTrue();
+
+        var workersToRelease = state.CompleteResult(CreateResult());
+        foreach (var worker in workersToRelease)
+        {
+            worker.TryCompleteAssignment(assignment.ModuleTypeName);
+        }
+
+        await Assert.That(workersToRelease).Contains(retryWorker);
+        await Assert.That(retryWorker.IsIdle).IsTrue();
+    }
+
     private static WorkerState CreateWorker(
         int workerIndex = 1,
         string connectionId = "connection")

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
@@ -335,6 +335,39 @@ public class SignalRMasterStateTests
         await Assert.That(retryWorker.IsIdle).IsTrue();
     }
 
+    [Test]
+    public async Task Redispatch_Claimant_Disconnect_Starts_New_Reconnect_Grace()
+    {
+        var state = new SignalRMasterState();
+        var assignment = CreateAssignment();
+        var retryWorker = CreateWorker(2, "retry");
+        var pending = state.TrackPendingReconnect(CreateWorker(), assignment)!;
+        pending.TryMakeAvailableForRedispatch();
+        await Assert.That(retryWorker.TryAssign(assignment)).IsTrue();
+        await Assert.That(state.TryClaimRedispatch(assignment, retryWorker)).IsTrue();
+
+        var replacement = state.TrackPendingReconnect(retryWorker, assignment);
+
+        await Assert.That(replacement).IsNotNull();
+        await Assert.That(state.GetPendingReconnect(retryWorker.Registration.WorkerIndex))
+            .IsSameReferenceAs(replacement);
+    }
+
+    [Test]
+    public async Task Failed_Redispatch_Untracks_Remote_Claimant()
+    {
+        var state = new SignalRMasterState();
+        var assignment = CreateAssignment();
+        var retryWorker = CreateWorker(2, "retry");
+        var pending = state.TrackPendingReconnect(CreateWorker(), assignment)!;
+        pending.TryMakeAvailableForRedispatch();
+        await Assert.That(state.TryClaimRedispatch(assignment, retryWorker)).IsTrue();
+
+        await Assert.That(pending.IsTracking(retryWorker)).IsTrue();
+        await Assert.That(state.TryReturnRedispatchToQueue(assignment, retryWorker)).IsTrue();
+        await Assert.That(pending.IsTracking(retryWorker)).IsFalse();
+    }
+
     private static WorkerState CreateWorker(
         int workerIndex = 1,
         string connectionId = "connection")

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/SignalRMasterStateTests.cs
@@ -121,11 +121,20 @@ public class SignalRMasterStateTests
     }
 
     [Test]
+    public async Task PendingReconnect_Allows_Only_One_Resume_Owner()
+    {
+        using var pending = new PendingReconnect(1, CreateAssignment());
+
+        await Assert.That(pending.TryResume()).IsTrue();
+        await Assert.That(pending.TryResume()).IsFalse();
+    }
+
+    [Test]
     public async Task Reconnect_Reclaims_Queued_Retry_Until_Dispatch_Claims_It()
     {
         var state = new SignalRMasterState();
         var assignment = CreateAssignment();
-        var pending = state.TrackPendingReconnect(1, assignment);
+        var pending = state.TrackPendingReconnect(CreateWorker(), assignment)!;
 
         await Assert.That(pending.TryMakeAvailableForRedispatch()).IsTrue();
         await Assert.That(pending.TryResume()).IsTrue();
@@ -139,7 +148,7 @@ public class SignalRMasterStateTests
     {
         var state = new SignalRMasterState();
         var assignment = CreateAssignment();
-        var pending = state.TrackPendingReconnect(1, assignment);
+        var pending = state.TrackPendingReconnect(CreateWorker(), assignment)!;
         var replacement = new WorkerState
         {
             ConnectionId = "replacement",
@@ -148,7 +157,7 @@ public class SignalRMasterStateTests
 
         await Assert.That(pending.TryMakeAvailableForRedispatch()).IsTrue();
 
-        var restored = state.TryRestoreReconnect(replacement, null, out _, out _);
+        var restored = state.TryRestoreReconnect(replacement, null, out _);
 
         await Assert.That(restored).IsFalse();
         await Assert.That(replacement.IsIdle).IsTrue();
@@ -168,7 +177,7 @@ public class SignalRMasterStateTests
                 new TaskCompletionSource<SerializedModuleResult>(
                     TaskCreationOptions.RunContinuationsAsynchronously);
 
-            var pending = state.TrackPendingReconnect(1, assignment);
+            var pending = state.TrackPendingReconnect(CreateWorker(), assignment)!;
             pending.TryMakeAvailableForRedispatch();
             pending.TryClaimRedispatch();
 
@@ -185,7 +194,6 @@ public class SignalRMasterStateTests
                 return state.TryRestoreReconnect(
                     worker,
                     assignment.ModuleTypeName,
-                    out _,
                     out _);
             });
             var completion = Task.Run(async () =>
@@ -206,6 +214,111 @@ public class SignalRMasterStateTests
             await Assert.That(worker.IsIdle).IsTrue();
             await Assert.That(reconnectRestored).IsEqualTo(workersToRelease.Contains(worker));
         }
+    }
+
+    [Test]
+    public async Task Redispatched_Assignment_Cannot_Be_Reclaimed_By_Late_Reconnect()
+    {
+        var state = new SignalRMasterState();
+        var assignment = CreateAssignment();
+        state.ResultWaiters[assignment.ModuleTypeName] =
+            new TaskCompletionSource<SerializedModuleResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        var pending = state.TrackPendingReconnect(CreateWorker(), assignment)!;
+        var reconnect = CreateWorker(connectionId: "reconnect");
+
+        pending.TryMakeAvailableForRedispatch();
+        await Assert.That(state.TryClaimRedispatch(assignment)).IsTrue();
+
+        var restored = state.TryRestoreReconnect(
+            reconnect,
+            assignment.ModuleTypeName,
+            out var restoredAssignment);
+
+        await Assert.That(restored).IsFalse();
+        await Assert.That(restoredAssignment).IsNull();
+        await Assert.That(reconnect.IsIdle).IsTrue();
+    }
+
+    [Test]
+    public async Task Completed_Assignment_Cannot_Be_Claimed_After_Pending_Record_Is_Removed()
+    {
+        var state = new SignalRMasterState();
+        var assignment = CreateAssignment();
+        state.ResultWaiters[assignment.ModuleTypeName] =
+            new TaskCompletionSource<SerializedModuleResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        var pending = state.TrackPendingReconnect(CreateWorker(), assignment)!;
+        pending.TryMakeAvailableForRedispatch();
+
+        state.CompleteResult(CreateResult());
+
+        await Assert.That(state.TryClaimRedispatch(assignment)).IsFalse();
+    }
+
+    [Test]
+    public async Task Replacing_Pending_Reconnect_Preserves_Other_Tracked_Workers()
+    {
+        var state = new SignalRMasterState();
+        var assignment = CreateAssignment();
+        var firstOwner = CreateWorker(connectionId: "first-owner");
+        var trackedWorker = CreateWorker(2, "tracked");
+        var replacementOwner = CreateWorker(3, "replacement-owner");
+        var first = state.TrackPendingReconnect(firstOwner, assignment)!;
+        first.TrackWorker(trackedWorker);
+
+        var replacement = state.TrackPendingReconnect(replacementOwner, assignment);
+        var workersToRelease = state.CompleteResult(CreateResult());
+
+        await Assert.That(replacement).IsNotNull();
+        await Assert.That(workersToRelease).Contains(trackedWorker);
+    }
+
+    [Test]
+    public async Task Tracked_Original_Disconnect_Does_Not_Replace_Active_Redispatch()
+    {
+        var state = new SignalRMasterState();
+        var assignment = CreateAssignment();
+        var original = CreateWorker(connectionId: "original");
+        var pending = state.TrackPendingReconnect(original, assignment)!;
+        pending.TrackWorker(original);
+        pending.TryMakeAvailableForRedispatch();
+        pending.TryClaimRedispatch();
+
+        var replacement = state.TrackPendingReconnect(original, assignment);
+
+        await Assert.That(replacement).IsNull();
+        await Assert.That(state.GetPendingReconnect(original.Registration.WorkerIndex))
+            .IsSameReferenceAs(pending);
+        await Assert.That(state.TryReturnRedispatchToQueue(assignment)).IsTrue();
+    }
+
+    [Test]
+    public async Task Failed_Redispatch_Is_Not_Requeued_After_Result_Completes()
+    {
+        var state = new SignalRMasterState();
+        var assignment = CreateAssignment();
+        state.ResultWaiters[assignment.ModuleTypeName] =
+            new TaskCompletionSource<SerializedModuleResult>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+        var pending = state.TrackPendingReconnect(CreateWorker(), assignment)!;
+        pending.TryMakeAvailableForRedispatch();
+        state.TryClaimRedispatch(assignment);
+
+        state.CompleteResult(CreateResult());
+
+        await Assert.That(state.TryReturnRedispatchToQueue(assignment)).IsFalse();
+    }
+
+    private static WorkerState CreateWorker(
+        int workerIndex = 1,
+        string connectionId = "connection")
+    {
+        return new WorkerState
+        {
+            ConnectionId = connectionId,
+            Registration = new WorkerRegistration(workerIndex, [], DateTimeOffset.UtcNow),
+        };
     }
 
     private static ModuleAssignment CreateAssignment()


### PR DESCRIPTION
## Summary - make reconnect and redispatch claims mutually exclusive after the grace period - atomically fence result completion against late worker registration - explicitly track reconnected workers so hub and master-local results release every participant - prevent stale results from clearing newer assignments - add deterministic coverage for reconnect races and master-local retry completion  Follow-up to #3178, which merged while its blocking review feedback was being addressed.  ## Testing - `dotnet build test/ModularPipelines.Distributed.SignalR.UnitTests/ModularPipelines.Distributed.SignalR.UnitTests.csproj -c Release --no-restore` (0 errors) - `dotnet run --project test/ModularPipelines.Distributed.SignalR.UnitTests/ModularPipelines.Distributed.SignalR.UnitTests.csproj -c Release --framework net10.0 --no-build` (30/30 passed) - targeted `dotnet format` for all changed C# files - `git diff --check`

Closes #3180

