### PR TITLE
Fix/diagnose CI master reclaim: per-solution logging + cap MSBuild parallelism (#3179)

### DIFF
--- a/src/ModularPipelines.Build/Modules/BuildSolutionsModule.cs
+++ b/src/ModularPipelines.Build/Modules/BuildSolutionsModule.cs
@@ -1,4 +1,4 @@
-using EnumerableAsyncProcessor.Extensions;
+using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
 using ModularPipelines.DotNet.Extensions;
@@ -27,16 +27,32 @@ public class BuildSolutionsModule : Module<CommandResult[]>
     {
         var gitRoot = context.Git().RootDirectory.Path;
 
-        // Build all solutions with --no-restore (workflow already restored)
-        var results = await Solutions
-            .ToAsyncProcessorBuilder()
-            .SelectAsync(async solution => await context.DotNet().Build(new DotNetBuildOptions
+        // Build all solutions serially with --no-restore (workflow already restored).
+        // Log each solution before/after so that if the job dies mid-build (e.g. the
+        // master runner being reclaimed during the heavy All.sln build - see #3179) the
+        // log shows exactly which solution was building, instead of an opaque silent gap.
+        // Command output is buffered until completion, so these module-level logs are the
+        // reliable progress signal.
+        var results = new List<CommandResult>(Solutions.Length);
+        for (var index = 0; index < Solutions.Length; index++)
+        {
+            var solution = Solutions[index];
+            context.Logger.LogInformation(
+                "Building solution {Number}/{Total}: {Solution}", index + 1, Solutions.Length, solution);
+
+            var result = await context.DotNet().Build(new DotNetBuildOptions
             {
                 ProjectSolution = Path.Combine(gitRoot, solution),
                 Configuration = "Release",
                 NoRestore = true,
-            }, cancellationToken: cancellationToken))
-            .ProcessOneAtATime();
+            }, cancellationToken: cancellationToken);
+
+            context.Logger.LogInformation(
+                "Finished solution {Number}/{Total}: {Solution} (exit code {ExitCode})",
+                index + 1, Solutions.Length, solution, result.ExitCode);
+
+            results.Add(result);
+        }
 
         // Stage bin/Release/ output for artifact sharing
         var stagingDir = Path.Combine(gitRoot, "_build-staging");
@@ -73,7 +89,7 @@ public class BuildSolutionsModule : Module<CommandResult[]>
             CopyDirectory(releaseDir, stagingDest);
         }
 
-        return results;
+        return results.ToArray();
     }
 
     private static void CopyDirectory(string sourceDir, string destDir)

--- a/src/ModularPipelines.Build/Modules/BuildSolutionsModule.cs
+++ b/src/ModularPipelines.Build/Modules/BuildSolutionsModule.cs
@@ -45,6 +45,14 @@ public class BuildSolutionsModule : Module<CommandResult[]>
                 ProjectSolution = Path.Combine(gitRoot, solution),
                 Configuration = "Release",
                 NoRestore = true,
+
+                // Cap MSBuild parallelism so the build doesn't saturate every core on the
+                // master runner. When it does, the GitHub runner agent can miss its
+                // heartbeat and the job is killed with "The runner has received a shutdown
+                // signal" (see #3179) - observed at wildly varying times, which fits agent
+                // starvation rather than a deterministic OOM. Leaving a core free keeps the
+                // agent responsive. Tune if runner size changes.
+                Arguments = ["-maxcpucount:2"],
             }, cancellationToken: cancellationToken);
 
             context.Logger.LogInformation(


### PR DESCRIPTION
Targets #3179 (the `pipeline (ubuntu-latest)` master CI blocker).

## Refined diagnosis

The master is killed with `The runner has received a shutdown signal / The operation was canceled` during `BuildSolutionsModule`, at **wildly varying times (~2.5, 14, 19, 50 min)**. A 2.5-min reclaim rules out OOM from the heavy `All.sln` build. That variance fits **runner-agent heartbeat starvation**: `dotnet build` saturates every core, the GitHub runner agent misses its heartbeat, and GitHub reclaims the runner (which is exactly the message it emits). Output is buffered at `Normal` verbosity, so the build logs nothing before the kill — hence the opaque gap.

## Changes (both in `BuildSolutionsModule`)

1. **Per-solution progress logging** — build each solution in an explicit serial loop logging before/after (`Building solution N/6: X` / `Finished … (exit code)`). These flush immediately, so if it still dies we see exactly which solution and how far it got. Behaviour otherwise unchanged (builds were already serial).
2. **Cap MSBuild parallelism** — pass `-maxcpucount:2` to each `dotnet build` so a core stays free for the runner agent to keep heartbeating.

## Why this shape

The two changes are complementary and self-validating: if starvation is the cause, capping parallelism turns the master job green; if it isn't, the logging pinpoints the stuck solution for the next iteration. Both are low-risk — one is logging-only, the other a single build flag. `-maxcpucount:2` assumes a ~4-core runner; tune if that changes.

Not compiled locally (no .NET SDK in this environment); CI is the validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)