### PR TITLE
Bound command execution to 30 minutes by default

### DIFF
--- a/src/ModularPipelines/Context/CommandLineExecutor.cs
+++ b/src/ModularPipelines/Context/CommandLineExecutor.cs
@@ -41,7 +41,7 @@ internal sealed class CommandLineExecutor : ICommandLineExecutor
             command = command.WithCredentials(options.CommandLineCredentials.ToCliWrapCredentials());
         }
 
-        var timeout = options?.ExecutionTimeout ?? TimeSpan.FromMinutes(30);
+        var timeout = options?.ExecutionTimeout ?? CommandExecutionOptions.DefaultExecutionTimeout;
         using var timeoutCts = new CancellationTokenSource(timeout);
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
 

--- a/src/ModularPipelines/Options/CommandExecutionOptions.cs
+++ b/src/ModularPipelines/Options/CommandExecutionOptions.cs
@@ -47,8 +47,9 @@ public record CommandExecutionOptions
 
     /// <summary>
     /// Gets or sets the maximum time allowed for the command to complete.
+    /// Defaults to 30 minutes.
     /// </summary>
-    public TimeSpan? ExecutionTimeout { get; init; }
+    public TimeSpan? ExecutionTimeout { get; init; } = TimeSpan.FromMinutes(30);
 
     /// <summary>
     /// Gets or sets the time to wait for graceful shutdown before forcefully terminating.

--- a/src/ModularPipelines/Options/CommandExecutionOptions.cs
+++ b/src/ModularPipelines/Options/CommandExecutionOptions.cs
@@ -5,6 +5,8 @@ namespace ModularPipelines.Options;
 /// </summary>
 public record CommandExecutionOptions
 {
+    internal static TimeSpan DefaultExecutionTimeout { get; } = TimeSpan.FromMinutes(30);
+
     /// <summary>
     /// Gets any EnvironmentVariables to pass to the command.
     /// </summary>
@@ -49,7 +51,7 @@ public record CommandExecutionOptions
     /// Gets or sets the maximum time allowed for the command to complete.
     /// Defaults to 30 minutes.
     /// </summary>
-    public TimeSpan? ExecutionTimeout { get; init; } = TimeSpan.FromMinutes(30);
+    public TimeSpan? ExecutionTimeout { get; init; } = DefaultExecutionTimeout;
 
     /// <summary>
     /// Gets or sets the time to wait for graceful shutdown before forcefully terminating.

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -12,6 +12,23 @@ namespace ModularPipelines.UnitTests.Helpers;
 
 public class CommandTests : TestBase
 {
+    [Test]
+    public async Task Command_Execution_Default_Timeout_Is_Thirty_Minutes()
+    {
+        var executionOptions = new CommandExecutionOptions();
+
+        await Assert.That(executionOptions.ExecutionTimeout).IsEqualTo(TimeSpan.FromMinutes(30));
+    }
+
+    [Test]
+    public async Task Command_Execution_Timeout_Can_Be_Overridden()
+    {
+        var timeout = TimeSpan.FromMinutes(5);
+        var executionOptions = new CommandExecutionOptions { ExecutionTimeout = timeout };
+
+        await Assert.That(executionOptions.ExecutionTimeout).IsEqualTo(timeout);
+    }
+
     private class CommandEchoModule : Module<CommandResult>
     {
         protected internal override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -17,7 +17,10 @@ public class CommandTests : TestBase
     {
         var executionOptions = new CommandExecutionOptions();
 
-        await Assert.That(executionOptions.ExecutionTimeout).IsEqualTo(TimeSpan.FromMinutes(30));
+        await Assert.That(CommandExecutionOptions.DefaultExecutionTimeout)
+            .IsEqualTo(TimeSpan.FromMinutes(30));
+        await Assert.That(executionOptions.ExecutionTimeout)
+            .IsEqualTo(CommandExecutionOptions.DefaultExecutionTimeout);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- default `CommandExecutionOptions.ExecutionTimeout` to 30 minutes
- centralize that default for both option construction and the executor fallback
- preserve per-command timeout overrides
- retain the existing 60-minute `.NET` workflow job timeout and `if: always()` hang-dump upload already present on main

## Validation

- Release core build: 0 warnings, 0 errors
- `CommandTests`: 9/9 after rebase
- scoped `dotnet format` and `git diff --check`

Closes #3175