### PR TITLE
Normalize scalar character secrets

### DIFF
--- a/docs/docs/how-to/secrets.md
+++ b/docs/docs/how-to/secrets.md
@@ -13,6 +13,11 @@ If you have any sensitive/secret data stored in these classes, you can attribute
 
 This attribute, combined with the `IModuleLogger`, means that if that value is ever attempted to be written to logs, it'll be censored out, so that secret values aren't visible to those unauthorised.
 
+`[SecretValue]` supports scalar strings, character sequences such as `char[]`,
+`IEnumerable<char>`, `Memory<char>`, and `ReadOnlyMemory<char>`, and collections of
+secret values. Character sequences are treated as one secret, while secret
+collections are masked item by item.
+
 ## Example
 
 ```csharp

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -144,7 +144,7 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
 
         if (secretValueKeys.Count == 0)
         {
-            foreach (var secret in FlattenSecrets(propertyValue))
+            foreach (var secret in NormalizeSecrets(propertyValue))
             {
                 if (!string.IsNullOrWhiteSpace(secret))
                 {
@@ -170,18 +170,32 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
         }
     }
 
-    private static IEnumerable<string?> FlattenSecrets(object? value)
+    private static IEnumerable<string?> NormalizeSecrets(object? value)
     {
-        if (value is string || value is not IEnumerable enumerable)
+        if (value is string || value is IEnumerable<char> || value is not IEnumerable enumerable)
         {
-            yield return value?.ToString();
+            yield return NormalizeSecret(value);
             yield break;
         }
 
         foreach (var item in enumerable)
         {
-            yield return item?.ToString();
+            yield return NormalizeSecret(item);
         }
+    }
+
+    private static string? NormalizeSecret(object? value)
+    {
+        return value switch
+        {
+            null => null,
+            string secret => secret,
+            char[] characters => new string(characters),
+            Memory<char> characters => characters.ToString(),
+            ReadOnlyMemory<char> characters => characters.ToString(),
+            IEnumerable<char> characters => new string(characters.ToArray()),
+            _ => value.ToString(),
+        };
     }
 
     public Task InitializeAsync()

--- a/test/ModularPipelines.UnitTests/Attributes/SecretValueNormalizationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/SecretValueNormalizationTests.cs
@@ -1,0 +1,122 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
+using ModularPipelines.Engine;
+using ModularPipelines.Options;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Attributes;
+
+internal class GeneratedCharacterSecretOptions
+{
+    [SecretValue]
+    public string StringSecret { get; init; } = "string-secret";
+
+    [SecretValue]
+    public char[] CharacterArraySecret { get; init; } = "array-secret".ToCharArray();
+
+    [SecretValue]
+    public IEnumerable<char> CharacterEnumerableSecret { get; init; } =
+        "enumerable-secret".ToCharArray().Where(_ => true);
+
+    [SecretValue]
+    public Memory<char> MemorySecret { get; init; } = "memory-secret".ToCharArray().AsMemory();
+
+    [SecretValue]
+    public ReadOnlyMemory<char> ReadOnlyMemorySecret { get; init; } =
+        "read-only-memory-secret".ToCharArray().AsMemory();
+
+    [SecretValue]
+    public ArraySegment<char> CharacterSegmentSecret { get; init; } =
+        new("segment-secret".ToCharArray());
+
+    [SecretValue]
+    public IEnumerable<string> SecretCollection { get; init; } =
+        ["collection-secret-one", "collection-secret-two"];
+}
+
+internal sealed class ReflectionCharacterSecretOptions : GeneratedCharacterSecretOptions
+{
+    [SecretValue]
+    private string InaccessibleSecret => " ";
+}
+
+public class SecretValueNormalizationTests
+{
+    private static readonly string[] CharacterSecrets =
+    [
+        "array-secret",
+        "enumerable-secret",
+        "memory-secret",
+        "read-only-memory-secret",
+        "segment-secret",
+    ];
+
+    private static readonly string[] ExpectedSecrets =
+    [
+        "string-secret",
+        .. CharacterSecrets,
+        "collection-secret-one",
+        "collection-secret-two",
+    ];
+
+    [Test]
+    public async Task GeneratedMetadata_NormalizesCharacterSequencesAndCollections()
+    {
+        var provider = CreateProvider(out _);
+        var metadataFound = GeneratedSecretMetadata.TryGetAccessors(
+            typeof(GeneratedCharacterSecretOptions),
+            out _);
+
+        var secrets = provider.GetSecretsInObject(new GeneratedCharacterSecretOptions()).ToList();
+
+        await Assert.That(metadataFound).IsTrue();
+        await Assert.That(secrets).IsEquivalentTo(ExpectedSecrets);
+    }
+
+    [Test]
+    public async Task ReflectionFallback_NormalizesCharacterSequencesAndCollections()
+    {
+        var provider = CreateProvider(out _);
+        var metadataFound = GeneratedSecretMetadata.TryGetAccessors(
+            typeof(ReflectionCharacterSecretOptions),
+            out _);
+
+        var secrets = provider.GetSecretsInObject(new ReflectionCharacterSecretOptions()).ToList();
+
+        await Assert.That(metadataFound).IsFalse();
+        await Assert.That(secrets).IsEquivalentTo(ExpectedSecrets);
+    }
+
+    [Test]
+    public async Task NativeMasker_ReceivesWholeCharacterSecretsOnce()
+    {
+        var provider = CreateProvider(out var nativeMasker);
+        var options = new GeneratedCharacterSecretOptions();
+
+        provider.AddSecrets(provider.GetSecretsInObject(options));
+
+        var registeredSecrets = nativeMasker.Invocations
+            .SelectMany(invocation => (IEnumerable<string>) invocation.Arguments[0])
+            .ToList();
+
+        foreach (var characterSecret in CharacterSecrets)
+        {
+            await Assert.That(registeredSecrets.Count(secret => secret == characterSecret)).IsEqualTo(1);
+        }
+
+        await Assert.That(registeredSecrets.Where(secret => secret.Length == 1)).IsEmpty();
+    }
+
+    private static SecretProvider CreateProvider(out Mock<IBuildSystemSecretMasker> nativeMasker)
+    {
+        nativeMasker = new Mock<IBuildSystemSecretMasker>();
+        var optionsProvider = new Mock<IOptionsProvider>();
+        optionsProvider.Setup(x => x.GetOptions()).Returns([]);
+
+        return new SecretProvider(
+            optionsProvider.Object,
+            nativeMasker.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()),
+            Mock.Of<ILogger<SecretProvider>>());
+    }
+}


### PR DESCRIPTION
## Summary
- normalize character-backed `[SecretValue]` values before generic collection flattening
- keep generated metadata and reflection fallback behavior identical
- document supported scalar, character-sequence, and collection shapes

## Validation
- `dotnet build src/ModularPipelines/ModularPipelines.csproj --framework net10.0 --no-restore --maxcpucount:1 --property:UseSharedCompilation=false`
- focused `SecretValueNormalizationTests`: 3/3 passed
- adjacent generated metadata + secret masking suites: 49/49 passed
- targeted `dotnet format` for changed C# files
- `git diff --check`

Closes #3172