### PR TITLE
Gate build unit tests to Linux

### DIFF
--- a/docs/docs/distributed/capabilities.md
+++ b/docs/docs/distributed/capabilities.md
@@ -127,7 +127,7 @@ public class RestoreModule : Module<string> { ... }
 public class LinuxBuildModule : Module<string> { ... }
 
 // Only on Windows workers
-[RequiresCapability("windows")]
+[RunOnWindowsOnly]
 [DependsOn<RestoreModule>]
 public class WindowsBuildModule : Module<string> { ... }
 

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Build.Modules.UnitTests;
 
 [DependsOn<BuildSolutionsModule>(Optional = true)]
 [ConsumesArtifact(typeof(BuildSolutionsModule), "build-output", RestorePath = "../../")]
-[RequiresCapability("linux")]
+[RunOnLinuxOnly]
 public abstract class RunUnitTestModule : Module<CommandResult>
 {
     private readonly IOptions<PipelineSettings> _pipelineSettings;


### PR DESCRIPTION
## Summary
- gate `RunUnitTestModule` with `RunOnLinuxOnly` so standalone runs skip it off Linux
- teach the mixed distributed-pipeline example the same safe OS-condition pattern
- retain distributed routing because OS-only conditions automatically derive worker capabilities

## Validation
- `dotnet build src/ModularPipelines.Build/ModularPipelines.Build.csproj -c Release --no-restore -maxcpucount:1 --verbosity:minimal -nodeReuse:false -p:UseSharedCompilation=false` (311 existing warnings, 0 errors)
- `dotnet format whitespace src/ModularPipelines.Build/ModularPipelines.Build.csproj --verify-no-changes --include src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs --no-restore`
- `git diff --check`

Closes #3186