### PR TITLE
Close standalone-execution gaps for OS-only modules

### DIFF
--- a/docs/docs/distributed/capabilities.md
+++ b/docs/docs/distributed/capabilities.md
@@ -126,8 +126,8 @@ public class RestoreModule : Module<string> { ... }
 [DependsOn<RestoreModule>]
 public class LinuxBuildModule : Module<string> { ... }
 
-// Only on Windows workers
-[RequiresCapability("windows")]
+// Only on Windows workers (auto-detected from [RunOnWindowsOnly])
+[RunOnWindowsOnly]
 [DependsOn<RestoreModule>]
 public class WindowsBuildModule : Module<string> { ... }
 

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
@@ -15,6 +15,7 @@ namespace ModularPipelines.Build.Modules.UnitTests;
 
 [DependsOn<BuildSolutionsModule>(Optional = true)]
 [ConsumesArtifact(typeof(BuildSolutionsModule), "build-output", RestorePath = "../../")]
+[RunOnLinuxOnly]
 [RequiresCapability("linux")]
 public abstract class RunUnitTestModule : Module<CommandResult>
 {

--- a/src/ModularPipelines/Attributes/OperatingSystemConditions.cs
+++ b/src/ModularPipelines/Attributes/OperatingSystemConditions.cs
@@ -1,0 +1,36 @@
+namespace ModularPipelines.Attributes;
+
+/// <summary>
+/// Single source of truth mapping the OS-only mandatory run conditions
+/// (<see cref="RunOnWindowsOnlyAttribute"/>, <see cref="RunOnLinuxOnlyAttribute"/>,
+/// <see cref="RunOnMacOSOnlyAttribute"/>) to their operating-system capability identifier.
+/// Both the condition handler (which decides whether to defer an OS condition to a worker)
+/// and the distributed work publisher (which stamps the OS capability onto an assignment)
+/// consume this, so the two paths cannot drift as new operating systems are added.
+/// </summary>
+internal static class OperatingSystemConditions
+{
+    /// <summary>Capability identifier for Windows-only modules.</summary>
+    public const string Windows = "windows";
+
+    /// <summary>Capability identifier for Linux-only modules.</summary>
+    public const string Linux = "linux";
+
+    /// <summary>Capability identifier for macOS-only modules.</summary>
+    public const string MacOS = "macos";
+
+    /// <summary>
+    /// Returns the operating-system capability an OS-only mandatory condition targets, or
+    /// <see langword="null"/> if the attribute is not an OS-only condition. Pattern matching
+    /// means subclasses of the OS-only attributes are classified by their base operating system.
+    /// </summary>
+#pragma warning disable CS0618 // MandatoryRunConditionAttribute is the legacy base type these OS conditions derive from.
+    public static string? GetTarget(MandatoryRunConditionAttribute attribute) => attribute switch
+#pragma warning restore CS0618
+    {
+        RunOnWindowsOnlyAttribute => Windows,
+        RunOnLinuxOnlyAttribute => Linux,
+        RunOnMacOSOnlyAttribute => MacOS,
+        _ => null,
+    };
+}

--- a/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
@@ -35,20 +35,16 @@ internal class DistributedWorkPublisher(
             .Select(a => a.Capability)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        // Auto-detect OS requirements from RunOn*Only mandatory conditions
-        if (moduleType.GetCustomAttribute<RunOnLinuxOnlyAttribute>(true) is not null)
+        // Auto-detect OS requirements from RunOn*Only mandatory conditions, sharing the same
+        // attribute-to-capability mapping the condition handler uses so the two cannot drift.
+#pragma warning disable CS0618 // MandatoryRunConditionAttribute is the legacy base type of the OS-only conditions.
+        foreach (var osCondition in moduleType.GetCustomAttributes<MandatoryRunConditionAttribute>(true))
+#pragma warning restore CS0618
         {
-            requiredCapabilities.Add("linux");
-        }
-
-        if (moduleType.GetCustomAttribute<RunOnWindowsOnlyAttribute>(true) is not null)
-        {
-            requiredCapabilities.Add("windows");
-        }
-
-        if (moduleType.GetCustomAttribute<RunOnMacOSOnlyAttribute>(true) is not null)
-        {
-            requiredCapabilities.Add("macos");
+            if (OperatingSystemConditions.GetTarget(osCondition) is { } osCapability)
+            {
+                requiredCapabilities.Add(osCapability);
+            }
         }
 
         var config = module.Configuration;

--- a/src/ModularPipelines/Engine/ModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/ModuleConditionHandler.cs
@@ -171,7 +171,7 @@ internal class ModuleConditionHandler : IModuleConditionHandler
         // otherwise the master would publish an assignment requiring multiple mutually
         // exclusive OS capabilities and wait forever for a result that never arrives.
         var targetsMultipleOperatingSystems = allMandatoryConditions
-            .Select(GetOperatingSystemConditionTarget)
+            .Select(OperatingSystemConditions.GetTarget)
             .Where(operatingSystem => operatingSystem is not null)
             .Distinct()
             .Count() > 1;
@@ -179,7 +179,7 @@ internal class ModuleConditionHandler : IModuleConditionHandler
         var deferOperatingSystemConditionsToWorker = isDistributedMaster && !targetsMultipleOperatingSystems;
 
         var mandatoryConditions = allMandatoryConditions
-            .Where(attribute => !deferOperatingSystemConditionsToWorker || !IsOperatingSystemCondition(attribute))
+            .Where(attribute => !deferOperatingSystemConditionsToWorker || OperatingSystemConditions.GetTarget(attribute) is null)
             .ToArray();
         var optionalConditions = moduleType
             .GetCustomAttributes<RunConditionAttribute>(inherit: true)
@@ -216,23 +216,4 @@ internal class ModuleConditionHandler : IModuleConditionHandler
         return (false, SkipDecision.Skip($"No run conditions were met: {string.Join(", ", names)}"));
     }
 #pragma warning restore CS0618
-
-    private static bool IsOperatingSystemCondition(MandatoryRunConditionAttribute attribute)
-    {
-        return GetOperatingSystemConditionTarget(attribute) is not null;
-    }
-
-    /// <summary>
-    /// Returns a stable identifier for the operating system an OS-only mandatory condition
-    /// targets, or <see langword="null"/> if the attribute is not an OS-only condition.
-    /// Pattern matching means subclasses of the OS-only attributes are classified by their
-    /// base operating system, so contradictory combinations are detected even via inheritance.
-    /// </summary>
-    private static string? GetOperatingSystemConditionTarget(MandatoryRunConditionAttribute attribute) => attribute switch
-    {
-        RunOnWindowsOnlyAttribute => "windows",
-        RunOnLinuxOnlyAttribute => "linux",
-        RunOnMacOSOnlyAttribute => "macos",
-        _ => null,
-    };
 }


### PR DESCRIPTION
Follow-up to #3117. Three related fixes so OS gating behaves consistently across standalone and distributed execution.

## Changes

### 1. `RunUnitTestModule`: add `[RunOnLinuxOnly]`
`[RequiresCapability("linux")]` only routes work **in distributed mode**. Without `[RunOnLinuxOnly]`, a plain local run or a non-distributed CI shard would attempt these Linux-only test modules (and their subclasses, which inherit the attribute) on Windows/macOS too — the same standalone-execution gap #3117 closed for the platform build modules. The auto-derived `linux` capability from `[RunOnLinuxOnly]` matches the existing `[RequiresCapability("linux")]`, so distributed routing is unchanged.

### 2. Docs: make the Mixed Pipeline example consistent
`docs/docs/distributed/capabilities.md` gated its Linux module with `[RunOnLinuxOnly]` but its Windows module with a bare `[RequiresCapability("windows")]` — teaching the unsafe pattern a contributor would copy. The Windows half now uses `[RunOnWindowsOnly]` (which auto-derives the `windows` capability), matching the Linux half and gating standalone execution too.

### 3. Deduplicate the `RunOn*Only` → OS-capability mapping
`ModuleConditionHandler` and `DistributedWorkPublisher` each mapped the OS-only attributes to `"windows"`/`"linux"`/`"macos"` independently and had to stay in lockstep as new operating systems were added. Both now use a single shared `OperatingSystemConditions.GetTarget` helper. Behaviour is unchanged — the publisher's three explicit `if` checks become one loop over the module's mandatory conditions using the same mapping.

## Notes
- Behaviour-preserving for the distributed path; the only functional change is that Linux-only unit-test modules are now correctly skipped in **standalone** execution on non-Linux hosts.
- These are the actionable items from #3186. The runtime OS detector (`OsCapabilityDetector`, which maps the *current* host OS) is a separate concern and left as-is.

Closes #3186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KayGZtGoXLVALeiPHXRWdx)_