### PR TITLE
Flush output from running modules

### DIFF
--- a/docs/docs/how-to/console-progress.md
+++ b/docs/docs/how-to/console-progress.md
@@ -8,3 +8,16 @@ If you are using an interactive terminal, then a progress dialog will be display
 
 ![image](https://github.com/thomhurst/ModularPipelines/assets/30480171/7d85af1e-abfd-40c4-8ef6-5df06baa88d6)
 
+## Long-running module output
+
+Buffered output from modules that are still running is flushed once per minute by default.
+This preserves recent diagnostic output if the process is killed before normal pipeline
+teardown. Incremental sections use an ellipsis (`…`) because the module has not completed.
+
+Configure the interval globally, or set it to zero to keep all output buffered until each
+module completes:
+
+```csharp
+builder.Options.ModuleOutputFlushInterval = TimeSpan.FromSeconds(30);
+```
+

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -302,10 +302,10 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     /// <inheritdoc />
     public Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync()
     {
-        return FlushPendingWritesAsync(isFinal: true);
+        return FlushPendingWritesAsync(OutputFlushKind.Complete);
     }
 
-    private async Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync(bool isFinal)
+    private async Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync(OutputFlushKind flushKind)
     {
         var populatedBeforeFlush = _moduleBuffers.Values
             .Where(buffer => buffer.HasOutput)
@@ -321,12 +321,12 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
 
         if (output is not null)
         {
-            await FlushWriterAsync(output, isFinal).ConfigureAwait(false);
+            await FlushWriterAsync(output, flushKind).ConfigureAwait(false);
         }
 
         if (error is not null && !ReferenceEquals(error, output))
         {
-            await FlushWriterAsync(error, isFinal).ConfigureAwait(false);
+            await FlushWriterAsync(error, flushKind).ConfigureAwait(false);
         }
 
         return _moduleBuffers.Values
@@ -338,7 +338,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     /// <inheritdoc />
     public async Task FlushInProgressModuleOutputAsync(CancellationToken cancellationToken = default)
     {
-        var newlyPopulatedBuffers = await FlushPendingWritesAsync(isFinal: false).ConfigureAwait(false);
+        var newlyPopulatedBuffers = await FlushPendingWritesAsync(OutputFlushKind.Incremental).ConfigureAwait(false);
 
         foreach (var buffer in newlyPopulatedBuffers.Where(buffer => buffer.IsComplete))
         {
@@ -357,14 +357,14 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         {
             cancellationToken.ThrowIfCancellationRequested();
             await _outputCoordinator
-                .EnqueueAndFlushIncrementalAsync(buffer, cancellationToken)
+                .EnqueueAndFlushAsync(buffer, OutputFlushKind.Incremental, cancellationToken)
                 .ConfigureAwait(false);
         }
     }
 
-    private static Task FlushWriterAsync(CoordinatedTextWriter writer, bool isFinal)
+    private static Task FlushWriterAsync(CoordinatedTextWriter writer, OutputFlushKind flushKind)
     {
-        return isFinal
+        return flushKind is OutputFlushKind.Complete
             ? writer.FlushAsync()
             : writer.FlushAvailableAsync();
     }
@@ -387,7 +387,12 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         {
             var unattributedLogger = _outputLogger ?? _loggerFactory.CreateLogger("ModularPipelines.Output");
             await _unattributedBuffer
-                .FlushToAsync(_originalConsoleOut, formatter, unattributedLogger, _loggerControl)
+                .FlushToAsync(
+                    _originalConsoleOut,
+                    formatter,
+                    unattributedLogger,
+                    _loggerControl,
+                    OutputFlushKind.Complete)
                 .ConfigureAwait(false);
         }
     }

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -300,7 +300,12 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     public IModuleOutputBuffer GetUnattributedBuffer() => _unattributedBuffer;
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync()
+    public Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync()
+    {
+        return FlushPendingWritesAsync(isFinal: true);
+    }
+
+    private async Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync(bool isFinal)
     {
         var populatedBeforeFlush = _moduleBuffers.Values
             .Where(buffer => buffer.HasOutput)
@@ -316,12 +321,12 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
 
         if (output is not null)
         {
-            await output.FlushAsync().ConfigureAwait(false);
+            await FlushWriterAsync(output, isFinal).ConfigureAwait(false);
         }
 
         if (error is not null && !ReferenceEquals(error, output))
         {
-            await error.FlushAsync().ConfigureAwait(false);
+            await FlushWriterAsync(error, isFinal).ConfigureAwait(false);
         }
 
         return _moduleBuffers.Values
@@ -333,7 +338,15 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     /// <inheritdoc />
     public async Task FlushInProgressModuleOutputAsync(CancellationToken cancellationToken = default)
     {
-        await FlushPendingWritesAsync().ConfigureAwait(false);
+        var newlyPopulatedBuffers = await FlushPendingWritesAsync(isFinal: false).ConfigureAwait(false);
+
+        foreach (var buffer in newlyPopulatedBuffers.Where(buffer => buffer.IsComplete))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await _outputCoordinator
+                .OnModuleCompletedAsync(buffer, buffer.ModuleType, cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         var buffers = _moduleBuffers.Values
             .Where(buffer => !buffer.IsComplete && buffer.HasOutput)
@@ -347,6 +360,13 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                 .EnqueueAndFlushIncrementalAsync(buffer, cancellationToken)
                 .ConfigureAwait(false);
         }
+    }
+
+    private static Task FlushWriterAsync(CoordinatedTextWriter writer, bool isFinal)
+    {
+        return isFinal
+            ? writer.FlushAsync()
+            : writer.FlushAvailableAsync();
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -342,9 +342,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
 
         foreach (var buffer in newlyPopulatedBuffers.Where(buffer => buffer.IsComplete))
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            await _outputCoordinator
-                .OnModuleCompletedAsync(buffer, buffer.ModuleType, cancellationToken)
+            await FlushBufferSafelyAsync(buffer, OutputFlushKind.Complete, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -355,10 +353,68 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
 
         foreach (var buffer in buffers)
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            await _outputCoordinator
-                .EnqueueAndFlushAsync(buffer, OutputFlushKind.Incremental, cancellationToken)
+            await FlushBufferSafelyAsync(buffer, OutputFlushKind.Incremental, cancellationToken)
                 .ConfigureAwait(false);
+        }
+
+        if (_unattributedBuffer.HasOutput)
+        {
+            await FlushBufferSafelyAsync(
+                    _unattributedBuffer,
+                    OutputFlushKind.Incremental,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private async Task FlushBufferSafelyAsync(
+        IModuleOutputBuffer buffer,
+        OutputFlushKind flushKind,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            if (flushKind is OutputFlushKind.Complete)
+            {
+                await _outputCoordinator
+                    .OnModuleCompletedAsync(buffer, buffer.ModuleType, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await _outputCoordinator
+                    .EnqueueAndFlushAsync(buffer, flushKind, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            ReportFlushFailure(buffer, exception);
+        }
+    }
+
+    private void ReportFlushFailure(IModuleOutputBuffer buffer, Exception exception)
+    {
+        try
+        {
+            var logger = _outputLogger ?? _loggerFactory.CreateLogger<ConsoleCoordinator>();
+            logger.LogWarning(
+                exception,
+                "Failed to flush output for {ModuleType}",
+                buffer.ModuleType);
+        }
+        catch
+        {
+            // The output provider itself may be the failing sink. Preserve a fallback
+            // diagnostic without preventing unrelated buffers from being flushed.
+            _deferredExceptions.Enqueue(
+                $"Failed to flush output for {buffer.ModuleType}: {exception}");
         }
     }
 

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -331,6 +331,25 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     }
 
     /// <inheritdoc />
+    public async Task FlushInProgressModuleOutputAsync(CancellationToken cancellationToken = default)
+    {
+        await FlushPendingWritesAsync().ConfigureAwait(false);
+
+        var buffers = _moduleBuffers.Values
+            .Where(buffer => !buffer.IsComplete && buffer.HasOutput)
+            .Cast<IModuleOutputBuffer>()
+            .ToArray();
+
+        foreach (var buffer in buffers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await _outputCoordinator
+                .EnqueueAndFlushIncrementalAsync(buffer, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
     public async Task FlushModuleOutputAsync()
     {
         // Output is now flushed immediately when modules complete.

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -373,15 +373,11 @@ internal class CoordinatedTextWriter : TextWriter
             {
                 var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
                 ObfuscateCompletePatterns(state, patterns);
-
-                var retainedLength = patterns.Length == 0
-                    ? 0
-                    : GetPotentialPatternPrefixLength(state.Buffer.ToString(), patterns);
-                FlushSafePrefix(state, state.Buffer.Length - retainedLength, shouldBuffer);
+                FlushSafeOutput(state, patterns, shouldBuffer);
 
                 if (shouldBuffer)
                 {
-                    retainedLength = patterns.Length == 0
+                    var retainedLength = patterns.Length == 0
                         ? 0
                         : GetPotentialPatternPrefixLength(state.Buffer.ToString(), patterns);
                     FlushPartialPrefix(state, state.Buffer.Length - retainedLength, shouldBuffer);

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -169,7 +169,10 @@ internal class CoordinatedTextWriter : TextWriter
             .OrderByDescending(pattern => pattern.Length)
             .ToArray();
 
-    private void ObfuscateCompletePatterns(LineBufferState state, IReadOnlyList<string> patterns)
+    private void ObfuscateCompletePatterns(
+        LineBufferState state,
+        IReadOnlyList<string> patterns,
+        bool preservePotentialLongerMatch = true)
     {
         if (state.Buffer.Length == 0 || patterns.Count == 0)
         {
@@ -192,7 +195,8 @@ internal class CoordinatedTextWriter : TextWriter
                 break;
             }
 
-            if (retainedPrefixLength > 0
+            if (preservePotentialLongerMatch
+                && retainedPrefixLength > 0
                 && match.Index + match.Length > retainedPrefixStart)
             {
                 output.Append(pending, searchIndex, pending.Length - searchIndex);
@@ -372,7 +376,7 @@ internal class CoordinatedTextWriter : TextWriter
             foreach (var state in _lineBuffers.Values.Where(state => state.Buffer.Length > 0))
             {
                 var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
-                ObfuscateCompletePatterns(state, patterns);
+                ObfuscateCompletePatterns(state, patterns, preservePotentialLongerMatch: false);
                 FlushSafeOutput(state, patterns, shouldBuffer);
 
                 if (shouldBuffer)

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -316,13 +316,18 @@ internal class CoordinatedTextWriter : TextWriter
 
     private void FlushPartialLine(LineBufferState state, bool shouldBuffer)
     {
-        if (state.Buffer.Length == 0)
+        FlushPartialPrefix(state, state.Buffer.Length, shouldBuffer);
+    }
+
+    private void FlushPartialPrefix(LineBufferState state, int length, bool shouldBuffer)
+    {
+        if (length <= 0)
         {
             return;
         }
 
-        var pending = state.Buffer.ToString();
-        state.Buffer.Clear();
+        var pending = state.Buffer.ToString(0, length);
+        state.Buffer.Remove(0, length);
         var obfuscated = _secretObfuscator.Obfuscate(pending, null);
 
         if (shouldBuffer)
@@ -353,6 +358,43 @@ internal class CoordinatedTextWriter : TextWriter
 
         // Always flush real console (needed for Spectre.Console internals)
         _realConsole.Flush();
+    }
+
+    /// <summary>
+    /// Flushes output that cannot be a prefix of a registered secret while retaining
+    /// incomplete secret prefixes for subsequent writes.
+    /// </summary>
+    internal Task FlushAvailableAsync()
+    {
+        lock (_lineBufferLock)
+        {
+            var patterns = GetSecretPatterns();
+            foreach (var state in _lineBuffers.Values.Where(state => state.Buffer.Length > 0))
+            {
+                var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
+                ObfuscateCompletePatterns(state, patterns);
+
+                var retainedLength = patterns.Length == 0
+                    ? 0
+                    : GetPotentialPatternPrefixLength(state.Buffer.ToString(), patterns);
+                FlushSafePrefix(state, state.Buffer.Length - retainedLength, shouldBuffer);
+
+                if (shouldBuffer)
+                {
+                    retainedLength = patterns.Length == 0
+                        ? 0
+                        : GetPotentialPatternPrefixLength(state.Buffer.ToString(), patterns);
+                    FlushPartialPrefix(state, state.Buffer.Length - retainedLength, shouldBuffer);
+                }
+
+                if (state.Buffer.Length == 0)
+                {
+                    state.ShouldBuffer = null;
+                }
+            }
+        }
+
+        return _realConsole.FlushAsync();
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/IConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/IConsoleCoordinator.cs
@@ -78,6 +78,12 @@ internal interface IConsoleCoordinator : IAsyncDisposable
     Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync();
 
     /// <summary>
+    /// Flushes output accumulated by modules that may still be running.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task FlushInProgressModuleOutputAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Flushes any remaining unattributed output.
     /// Module output is flushed immediately when modules complete.
     /// </summary>

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -58,48 +58,41 @@ internal interface IModuleOutputBuffer
     void SetException(Exception exception);
 
     /// <summary>
-    /// Gets whether there is any output to flush.
+    /// Gets a value indicating whether there is any output to flush.
     /// </summary>
     bool HasOutput { get; }
 
     /// <summary>
-    /// Gets whether the owning module has completed.
+    /// Gets a value indicating whether the owning module has completed.
     /// </summary>
-    bool IsComplete => false;
+    bool IsComplete { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether completing the module requires a final flush.
+    /// This remains true while an incremental flush owns output and until its final status is rendered.
+    /// </summary>
+    bool NeedsCompletionFlush { get; }
 
     /// <summary>
     /// Marks the owning module as complete so periodic flushing no longer selects it.
     /// </summary>
-    void MarkComplete()
-    {
-    }
+    void MarkComplete();
 
     /// <summary>
-    /// Flushes all buffered output to the console with CI formatting.
+    /// Flushes buffered output to the console with CI formatting.
     /// </summary>
     /// <param name="console">The console to write to.</param>
     /// <param name="formatter">The CI-specific formatter for log groups.</param>
     /// <param name="logger">The logger for structured log output.</param>
     /// <param name="loggerControl">Coordinates log rendering with direct console writes.</param>
+    /// <param name="flushKind">Whether this is an incremental or complete flush.</param>
     /// <param name="cancellationToken">Cancellation token for the flush operation.</param>
+    /// <returns>A task that completes when buffered output has been rendered.</returns>
     Task FlushToAsync(
         TextWriter console,
         IBuildSystemFormatter formatter,
         ILogger logger,
         ISpectreConsoleLoggerControl loggerControl,
+        OutputFlushKind flushKind,
         CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Flushes output accumulated so far while the module is still running.
-    /// </summary>
-    /// <remarks>
-    /// The default implementation preserves compatibility for alternate buffer implementations.
-    /// </remarks>
-    Task FlushIncrementallyToAsync(
-        TextWriter console,
-        IBuildSystemFormatter formatter,
-        ILogger logger,
-        ISpectreConsoleLoggerControl loggerControl,
-        CancellationToken cancellationToken = default)
-        => FlushToAsync(console, formatter, logger, loggerControl, cancellationToken);
 }

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -63,6 +63,18 @@ internal interface IModuleOutputBuffer
     bool HasOutput { get; }
 
     /// <summary>
+    /// Gets whether the owning module has completed.
+    /// </summary>
+    bool IsComplete => false;
+
+    /// <summary>
+    /// Marks the owning module as complete so periodic flushing no longer selects it.
+    /// </summary>
+    void MarkComplete()
+    {
+    }
+
+    /// <summary>
     /// Flushes all buffered output to the console with CI formatting.
     /// </summary>
     /// <param name="console">The console to write to.</param>
@@ -76,4 +88,18 @@ internal interface IModuleOutputBuffer
         ILogger logger,
         ISpectreConsoleLoggerControl loggerControl,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Flushes output accumulated so far while the module is still running.
+    /// </summary>
+    /// <remarks>
+    /// The default implementation preserves compatibility for alternate buffer implementations.
+    /// </remarks>
+    Task FlushIncrementallyToAsync(
+        TextWriter console,
+        IBuildSystemFormatter formatter,
+        ILogger logger,
+        ISpectreConsoleLoggerControl loggerControl,
+        CancellationToken cancellationToken = default)
+        => FlushToAsync(console, formatter, logger, loggerControl, cancellationToken);
 }

--- a/src/ModularPipelines/Console/IOutputCoordinator.cs
+++ b/src/ModularPipelines/Console/IOutputCoordinator.cs
@@ -18,17 +18,12 @@ internal interface IOutputCoordinator
     /// Called when a module's logger is disposed.
     /// </summary>
     /// <param name="buffer">The buffer to flush.</param>
+    /// <param name="flushKind">Whether this is an incremental or complete flush.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task that completes when the buffer has been flushed.</returns>
-    Task EnqueueAndFlushAsync(IModuleOutputBuffer buffer, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Enqueues output accumulated by a still-running module and waits until it is flushed.
-    /// </summary>
-    /// <param name="buffer">The buffer to flush.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    Task EnqueueAndFlushIncrementalAsync(
+    Task EnqueueAndFlushAsync(
         IModuleOutputBuffer buffer,
+        OutputFlushKind flushKind,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/ModularPipelines/Console/IOutputCoordinator.cs
+++ b/src/ModularPipelines/Console/IOutputCoordinator.cs
@@ -23,6 +23,15 @@ internal interface IOutputCoordinator
     Task EnqueueAndFlushAsync(IModuleOutputBuffer buffer, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Enqueues output accumulated by a still-running module and waits until it is flushed.
+    /// </summary>
+    /// <param name="buffer">The buffer to flush.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task EnqueueAndFlushIncrementalAsync(
+        IModuleOutputBuffer buffer,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Sets whether live progress is currently active.
     /// When active, module output is deferred until pipeline end.
     /// </summary>

--- a/src/ModularPipelines/Console/IOutputCoordinator.cs
+++ b/src/ModularPipelines/Console/IOutputCoordinator.cs
@@ -27,6 +27,12 @@ internal interface IOutputCoordinator
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Waits until every queued or active immediate flush has released its buffer.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task WaitForPendingFlushesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Sets whether live progress is currently active.
     /// When active, module output is deferred until pipeline end.
     /// </summary>

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -30,6 +30,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly DateTime _startTimeUtc;
     private Exception? _exception;
     private bool _isComplete;
+    private bool _hasRenderedIncrementalOutput;
 
     /// <inheritdoc />
     public Type ModuleType { get; }
@@ -174,7 +175,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 return Task.CompletedTask;
             }
 
-            if (_outputs.Count == 0)
+            if (_outputs.Count == 0 && (!isComplete || !_hasRenderedIncrementalOutput))
             {
                 return Task.CompletedTask;
             }
@@ -256,11 +257,32 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
         catch
         {
+            if (!isComplete)
+            {
+                RecordRenderedOutput(isComplete: false, renderedCount);
+            }
+
             RestoreUnrenderedOutputs(outputs, renderedCount);
             throw;
         }
 
+        RecordRenderedOutput(isComplete, renderedCount);
         return Task.CompletedTask;
+    }
+
+    private void RecordRenderedOutput(bool isComplete, int renderedCount)
+    {
+        lock (_lock)
+        {
+            if (isComplete)
+            {
+                _hasRenderedIncrementalOutput = false;
+            }
+            else if (renderedCount > 0)
+            {
+                _hasRenderedIncrementalOutput = true;
+            }
+        }
     }
 
     private static void EnterSynchronizationLock(

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -329,6 +329,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            // Output sinks are not transactional: they can accept this item and then
+            // throw. Count it as attempted before delivery so only untouched later
+            // items are restored and an accepted item is never duplicated.
+            renderedCount++;
+
             if (output.IsString)
             {
                 WriteDirect(directConsole, console, output.StringValue);
@@ -342,8 +347,6 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 logger.Log(logEvent.Level, logEvent.EventId, logEvent.State, logEvent.Exception,
                     (state, ex) => logEvent.Formatter(state, ex));
             }
-
-            renderedCount++;
         }
     }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -30,6 +30,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly DateTime _startTimeUtc;
     private Exception? _exception;
     private bool _isComplete;
+    private bool _isIncrementalFlushInProgress;
     private bool _hasRenderedIncrementalOutput;
 
     /// <inheritdoc />
@@ -115,6 +116,20 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     /// <inheritdoc />
+    public bool NeedsCompletionFlush
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _outputs.Count > 0
+                       || _isIncrementalFlushInProgress
+                       || _hasRenderedIncrementalOutput;
+            }
+        }
+    }
+
+    /// <inheritdoc />
     public void MarkComplete()
     {
         lock (_lock)
@@ -129,43 +144,10 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         IBuildSystemFormatter formatter,
         ILogger logger,
         ISpectreConsoleLoggerControl loggerControl,
+        OutputFlushKind flushKind,
         CancellationToken cancellationToken = default)
     {
-        return FlushToAsync(
-            console,
-            formatter,
-            logger,
-            loggerControl,
-            isComplete: true,
-            cancellationToken);
-    }
-
-    /// <inheritdoc />
-    public Task FlushIncrementallyToAsync(
-        TextWriter console,
-        IBuildSystemFormatter formatter,
-        ILogger logger,
-        ISpectreConsoleLoggerControl loggerControl,
-        CancellationToken cancellationToken = default)
-    {
-        return FlushToAsync(
-            console,
-            formatter,
-            logger,
-            loggerControl,
-            isComplete: false,
-            cancellationToken);
-    }
-
-    private Task FlushToAsync(
-        TextWriter console,
-        IBuildSystemFormatter formatter,
-        ILogger logger,
-        ISpectreConsoleLoggerControl loggerControl,
-        bool isComplete,
-        CancellationToken cancellationToken)
-    {
-        if (!TryTakeOutputs(isComplete, out var outputs, out var exception))
+        if (!TryTakeOutputs(flushKind, out var outputs, out var exception))
         {
             return Task.CompletedTask;
         }
@@ -182,41 +164,42 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 logger,
                 loggerControl.SynchronizationLock,
                 exception,
-                isComplete,
+                flushKind,
                 outputs,
                 ref renderedCount,
                 cancellationToken);
         }
         catch
         {
-            if (!isComplete)
+            if (flushKind is OutputFlushKind.Incremental)
             {
-                RecordRenderedOutput(isComplete: false, renderedCount);
+                RecordRenderedOutput(OutputFlushKind.Incremental, renderedCount);
             }
 
             RestoreUnrenderedOutputs(outputs, renderedCount);
             throw;
         }
 
-        RecordRenderedOutput(isComplete, renderedCount);
+        RecordRenderedOutput(flushKind, renderedCount);
         return Task.CompletedTask;
     }
 
     private bool TryTakeOutputs(
-        bool isComplete,
+        OutputFlushKind flushKind,
         out List<BufferedOutput> outputs,
         out Exception? exception)
     {
         lock (_lock)
         {
-            if (!isComplete && _isComplete)
+            if (flushKind is OutputFlushKind.Incremental && _isComplete)
             {
                 outputs = null!;
                 exception = null;
                 return false;
             }
 
-            if (_outputs.Count == 0 && (!isComplete || !_hasRenderedIncrementalOutput))
+            if (_outputs.Count == 0
+                && (flushKind is OutputFlushKind.Incremental || !_hasRenderedIncrementalOutput))
             {
                 outputs = null!;
                 exception = null;
@@ -225,6 +208,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
             outputs = new List<BufferedOutput>(_outputs);
             _outputs.Clear();
+            _isIncrementalFlushInProgress = flushKind is OutputFlushKind.Incremental;
             exception = _exception;
             return true;
         }
@@ -237,7 +221,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         ILogger logger,
         object synchronizationLock,
         Exception? exception,
-        bool isComplete,
+        OutputFlushKind flushKind,
         List<BufferedOutput> outputs,
         ref int renderedCount,
         CancellationToken cancellationToken)
@@ -251,7 +235,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 formatter,
                 logger,
                 exception,
-                isComplete,
+                flushKind,
                 outputs,
                 ref renderedCount,
                 cancellationToken);
@@ -268,12 +252,12 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         IBuildSystemFormatter formatter,
         ILogger logger,
         Exception? exception,
-        bool isComplete,
+        OutputFlushKind flushKind,
         List<BufferedOutput> outputs,
         ref int renderedCount,
         CancellationToken cancellationToken)
     {
-        var header = FormatHeader(exception, isComplete);
+        var header = FormatHeader(exception, flushKind);
         var startCommand = formatter.GetStartBlockCommand(header);
         var endCommand = formatter.GetEndBlockCommand(header);
         var groupStarted = false;
@@ -350,17 +334,21 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
     }
 
-    private void RecordRenderedOutput(bool isComplete, int renderedCount)
+    private void RecordRenderedOutput(OutputFlushKind flushKind, int renderedCount)
     {
         lock (_lock)
         {
-            if (isComplete)
+            if (flushKind is OutputFlushKind.Complete)
             {
                 _hasRenderedIncrementalOutput = false;
             }
-            else if (renderedCount > 0)
+            else
             {
-                _hasRenderedIncrementalOutput = true;
+                _isIncrementalFlushInProgress = false;
+                if (renderedCount > 0)
+                {
+                    _hasRenderedIncrementalOutput = true;
+                }
             }
         }
     }
@@ -389,7 +377,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
     }
 
-    private string FormatHeader(Exception? exception, bool isComplete)
+    private string FormatHeader(Exception? exception, OutputFlushKind flushKind)
     {
         var duration = DateTime.UtcNow - _startTimeUtc;
         var durationText = duration.ToDisplayString();
@@ -399,7 +387,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             return $"{_moduleName} \u2717 ({durationText}) - {exception.GetType().Name}";
         }
 
-        return isComplete
+        return flushKind is OutputFlushKind.Complete
             ? $"{_moduleName} \u2713 ({durationText})"
             : $"{_moduleName} \u2026 ({durationText})";
     }

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -313,11 +313,6 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Output sinks are not transactional: they can accept this item and then
-            // throw. Count it as attempted before delivery so only untouched later
-            // items are restored and an accepted item is never duplicated.
-            renderedCount++;
-
             if (output.IsString)
             {
                 WriteDirect(directConsole, console, output.StringValue);
@@ -331,6 +326,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 logger.Log(logEvent.Level, logEvent.EventId, logEvent.State, logEvent.Exception,
                     (state, ex) => logEvent.Formatter(state, ex));
             }
+
+            // Advance only after the sink returns successfully. A sink that accepts
+            // output and then throws may cause a duplicate on retry, but retaining
+            // the item avoids guaranteed data loss when delivery never happened.
+            renderedCount++;
         }
     }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -29,6 +29,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly string _moduleName;
     private readonly DateTime _startTimeUtc;
     private Exception? _exception;
+    private bool _isComplete;
 
     /// <inheritdoc />
     public Type ModuleType { get; }
@@ -101,6 +102,27 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     /// <inheritdoc />
+    public bool IsComplete
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _isComplete;
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void MarkComplete()
+    {
+        lock (_lock)
+        {
+            _isComplete = true;
+        }
+    }
+
+    /// <inheritdoc />
     public Task FlushToAsync(
         TextWriter console,
         IBuildSystemFormatter formatter,
@@ -108,11 +130,50 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         ISpectreConsoleLoggerControl loggerControl,
         CancellationToken cancellationToken = default)
     {
+        return FlushToAsync(
+            console,
+            formatter,
+            logger,
+            loggerControl,
+            isComplete: true,
+            cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public Task FlushIncrementallyToAsync(
+        TextWriter console,
+        IBuildSystemFormatter formatter,
+        ILogger logger,
+        ISpectreConsoleLoggerControl loggerControl,
+        CancellationToken cancellationToken = default)
+    {
+        return FlushToAsync(
+            console,
+            formatter,
+            logger,
+            loggerControl,
+            isComplete: false,
+            cancellationToken);
+    }
+
+    private Task FlushToAsync(
+        TextWriter console,
+        IBuildSystemFormatter formatter,
+        ILogger logger,
+        ISpectreConsoleLoggerControl loggerControl,
+        bool isComplete,
+        CancellationToken cancellationToken)
+    {
         List<BufferedOutput> outputs;
         Exception? exception;
 
         lock (_lock)
         {
+            if (!isComplete && _isComplete)
+            {
+                return Task.CompletedTask;
+            }
+
             if (_outputs.Count == 0)
             {
                 return Task.CompletedTask;
@@ -132,7 +193,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             EnterSynchronizationLock(synchronizationLock, cancellationToken);
             try
             {
-                var header = FormatHeader(exception);
+                var header = FormatHeader(exception, isComplete);
                 var startCommand = formatter.GetStartBlockCommand(header);
                 var endCommand = formatter.GetEndBlockCommand(header);
                 var groupStarted = false;
@@ -226,7 +287,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
     }
 
-    private string FormatHeader(Exception? exception)
+    private string FormatHeader(Exception? exception, bool isComplete)
     {
         var duration = DateTime.UtcNow - _startTimeUtc;
         var durationText = duration.ToDisplayString();
@@ -236,7 +297,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             return $"{_moduleName} \u2717 ({durationText}) - {exception.GetType().Name}";
         }
 
-        return $"{_moduleName} \u2713 ({durationText})";
+        return isComplete
+            ? $"{_moduleName} \u2713 ({durationText})"
+            : $"{_moduleName} \u2026 ({durationText})";
     }
 
     private static IAnsiConsole CreateDirectConsole(TextWriter writer)

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -165,24 +165,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         bool isComplete,
         CancellationToken cancellationToken)
     {
-        List<BufferedOutput> outputs;
-        Exception? exception;
-
-        lock (_lock)
+        if (!TryTakeOutputs(isComplete, out var outputs, out var exception))
         {
-            if (!isComplete && _isComplete)
-            {
-                return Task.CompletedTask;
-            }
-
-            if (_outputs.Count == 0 && (!isComplete || !_hasRenderedIncrementalOutput))
-            {
-                return Task.CompletedTask;
-            }
-
-            outputs = new List<BufferedOutput>(_outputs);
-            _outputs.Clear();
-            exception = _exception;
+            return Task.CompletedTask;
         }
 
         var directConsole = CreateDirectConsole(console);
@@ -190,70 +175,17 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         try
         {
-            var synchronizationLock = loggerControl.SynchronizationLock;
-            EnterSynchronizationLock(synchronizationLock, cancellationToken);
-            try
-            {
-                var header = FormatHeader(exception, isComplete);
-                var startCommand = formatter.GetStartBlockCommand(header);
-                var endCommand = formatter.GetEndBlockCommand(header);
-                var groupStarted = false;
-                var flushCompleted = false;
-
-                try
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    // Keep the synchronization gate for the complete group. MEL.Spectre uses
-                    // synchronous rendering, so unrelated logger calls cannot enter this group.
-                    if (startCommand != null)
-                    {
-                        WriteDirect(directConsole, console, startCommand);
-                        groupStarted = true;
-                    }
-
-                    foreach (var output in outputs)
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        if (output.IsString)
-                        {
-                            WriteDirect(directConsole, console, output.StringValue);
-                        }
-                        else if (output.LogEvent.HasValue)
-                        {
-                            var logEvent = output.LogEvent.Value;
-
-                            // Synchronous MEL.Spectre rendering preserves this buffer's position
-                            // while other providers (for example file logging) still receive the event.
-                            logger.Log(logEvent.Level, logEvent.EventId, logEvent.State, logEvent.Exception,
-                                (state, ex) => logEvent.Formatter(state, ex));
-                        }
-
-                        renderedCount++;
-                    }
-
-                    cancellationToken.ThrowIfCancellationRequested();
-                    flushCompleted = true;
-                }
-                finally
-                {
-                    if (groupStarted && endCommand != null)
-                    {
-                        console.WriteLine(endCommand);
-                    }
-
-                    if (groupStarted || flushCompleted)
-                    {
-                        // Add blank line between module sections for visual separation.
-                        console.WriteLine();
-                    }
-                }
-            }
-            finally
-            {
-                Monitor.Exit(synchronizationLock);
-            }
+            RenderOutputs(
+                console,
+                directConsole,
+                formatter,
+                logger,
+                loggerControl.SynchronizationLock,
+                exception,
+                isComplete,
+                outputs,
+                ref renderedCount,
+                cancellationToken);
         }
         catch
         {
@@ -268,6 +200,151 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         RecordRenderedOutput(isComplete, renderedCount);
         return Task.CompletedTask;
+    }
+
+    private bool TryTakeOutputs(
+        bool isComplete,
+        out List<BufferedOutput> outputs,
+        out Exception? exception)
+    {
+        lock (_lock)
+        {
+            if (!isComplete && _isComplete)
+            {
+                outputs = null!;
+                exception = null;
+                return false;
+            }
+
+            if (_outputs.Count == 0 && (!isComplete || !_hasRenderedIncrementalOutput))
+            {
+                outputs = null!;
+                exception = null;
+                return false;
+            }
+
+            outputs = new List<BufferedOutput>(_outputs);
+            _outputs.Clear();
+            exception = _exception;
+            return true;
+        }
+    }
+
+    private void RenderOutputs(
+        TextWriter console,
+        IAnsiConsole directConsole,
+        IBuildSystemFormatter formatter,
+        ILogger logger,
+        object synchronizationLock,
+        Exception? exception,
+        bool isComplete,
+        List<BufferedOutput> outputs,
+        ref int renderedCount,
+        CancellationToken cancellationToken)
+    {
+        EnterSynchronizationLock(synchronizationLock, cancellationToken);
+        try
+        {
+            RenderOutputGroup(
+                console,
+                directConsole,
+                formatter,
+                logger,
+                exception,
+                isComplete,
+                outputs,
+                ref renderedCount,
+                cancellationToken);
+        }
+        finally
+        {
+            Monitor.Exit(synchronizationLock);
+        }
+    }
+
+    private void RenderOutputGroup(
+        TextWriter console,
+        IAnsiConsole directConsole,
+        IBuildSystemFormatter formatter,
+        ILogger logger,
+        Exception? exception,
+        bool isComplete,
+        List<BufferedOutput> outputs,
+        ref int renderedCount,
+        CancellationToken cancellationToken)
+    {
+        var header = FormatHeader(exception, isComplete);
+        var startCommand = formatter.GetStartBlockCommand(header);
+        var endCommand = formatter.GetEndBlockCommand(header);
+        var groupStarted = false;
+        var flushCompleted = false;
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Keep the synchronization gate for the complete group. MEL.Spectre uses
+            // synchronous rendering, so unrelated logger calls cannot enter this group.
+            if (startCommand != null)
+            {
+                WriteDirect(directConsole, console, startCommand);
+                groupStarted = true;
+            }
+
+            RenderBufferedOutputs(
+                console,
+                directConsole,
+                logger,
+                outputs,
+                ref renderedCount,
+                cancellationToken);
+
+            cancellationToken.ThrowIfCancellationRequested();
+            flushCompleted = true;
+        }
+        finally
+        {
+            if (groupStarted && endCommand != null)
+            {
+                console.WriteLine(endCommand);
+            }
+
+            if (groupStarted || flushCompleted)
+            {
+                // Add blank line between module sections for visual separation.
+                console.WriteLine();
+            }
+        }
+    }
+
+    private static void RenderBufferedOutputs(
+        TextWriter console,
+        IAnsiConsole directConsole,
+        ILogger logger,
+        List<BufferedOutput> outputs,
+        ref int renderedCount,
+        CancellationToken cancellationToken)
+    {
+        foreach (var output in outputs)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (output.IsString)
+            {
+                WriteDirect(directConsole, console, output.StringValue);
+            }
+            else if (output.LogEvent.HasValue)
+            {
+                var logEvent = output.LogEvent.Value;
+
+                // Synchronous MEL.Spectre rendering preserves this buffer's position
+                // while other providers (for example file logging) still receive the event.
+                logger.Log(logEvent.Level, logEvent.EventId, logEvent.State, logEvent.Exception,
+                    (state, ex) => logEvent.Formatter(state, ex));
+            }
+
+            renderedCount++;
+        }
     }
 
     private void RecordRenderedOutput(bool isComplete, int renderedCount)

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -147,6 +147,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                 await FlushBufferAsync(
                         toFlush[nextOutputIndex].Buffer,
                         formatter,
+                        isComplete: true,
                         cancellationToken)
                     .ConfigureAwait(false);
             }
@@ -178,12 +179,33 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     /// <inheritdoc />
     public async Task EnqueueAndFlushAsync(IModuleOutputBuffer buffer, CancellationToken cancellationToken = default)
     {
+        await EnqueueAndFlushAsync(buffer, isComplete: true, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task EnqueueAndFlushIncrementalAsync(
+        IModuleOutputBuffer buffer,
+        CancellationToken cancellationToken = default)
+    {
+        if (buffer.IsComplete)
+        {
+            return;
+        }
+
+        await EnqueueAndFlushAsync(buffer, isComplete: false, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task EnqueueAndFlushAsync(
+        IModuleOutputBuffer buffer,
+        bool isComplete,
+        CancellationToken cancellationToken)
+    {
         if (!buffer.HasOutput)
         {
             return;
         }
 
-        var pending = new PendingFlush(buffer, cancellationToken);
+        var pending = new PendingFlush(buffer, isComplete, cancellationToken);
         bool shouldProcess;
 
         lock (_queueLock)
@@ -255,6 +277,12 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     {
         try
         {
+            if (!pending.IsComplete && pending.Buffer.IsComplete)
+            {
+                pending.CompletionSource.TrySetResult();
+                return;
+            }
+
             // Output sinks are not transactional. A provider can deliver an event and
             // then throw, so retrying here could duplicate output already accepted by
             // that provider. Preserve the buffer's unrendered tail and surface failure
@@ -284,7 +312,12 @@ internal sealed class OutputCoordinator : IOutputCoordinator
             await _progressController.PauseAsync().ConfigureAwait(false);
             try
             {
-                await FlushBufferAsync(pending.Buffer, formatter, cancellationToken).ConfigureAwait(false);
+                await FlushBufferAsync(
+                        pending.Buffer,
+                        formatter,
+                        pending.IsComplete,
+                        cancellationToken)
+                    .ConfigureAwait(false);
             }
             finally
             {
@@ -333,6 +366,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     private async Task FlushBufferAsync(
         IModuleOutputBuffer buffer,
         IBuildSystemFormatter formatter,
+        bool isComplete,
         CancellationToken cancellationToken)
     {
         var loggerType = typeof(ILogger<>).MakeGenericType(buffer.ModuleType);
@@ -340,9 +374,18 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                            ?? _loggerFactory.CreateLogger(buffer.ModuleType);
 
         using var directWrite = CoordinatedTextWriter.BeginDirectWrite();
-        await buffer
-            .FlushToAsync(_console, formatter, moduleLogger, _loggerControl, cancellationToken)
-            .ConfigureAwait(false);
+        if (isComplete)
+        {
+            await buffer
+                .FlushToAsync(_console, formatter, moduleLogger, _loggerControl, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        else
+        {
+            await buffer
+                .FlushIncrementallyToAsync(_console, formatter, moduleLogger, _loggerControl, cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 
     private sealed class PendingFlush
@@ -351,11 +394,17 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
         public CancellationToken CancellationToken { get; }
 
+        public bool IsComplete { get; }
+
         public TaskCompletionSource CompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public PendingFlush(IModuleOutputBuffer buffer, CancellationToken cancellationToken)
+        public PendingFlush(
+            IModuleOutputBuffer buffer,
+            bool isComplete,
+            CancellationToken cancellationToken)
         {
             Buffer = buffer;
+            IsComplete = isComplete;
             CancellationToken = cancellationToken;
         }
     }

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -88,6 +88,11 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     /// <inheritdoc />
     public async Task OnModuleCompletedAsync(IModuleOutputBuffer buffer, Type moduleType, CancellationToken cancellationToken = default)
     {
+        if (!buffer.NeedsCompletionFlush)
+        {
+            return;
+        }
+
         if (_isProgressActive)
         {
             // Progress is active - defer output until pipeline end
@@ -104,7 +109,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         else
         {
             // No progress - flush immediately (existing behavior)
-            await EnqueueAndFlushAsync(buffer, cancellationToken).ConfigureAwait(false);
+            await EnqueueAndFlushAsync(buffer, OutputFlushKind.Complete, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -142,7 +147,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                 await FlushBufferAsync(
                         toFlush[nextOutputIndex].Buffer,
                         formatter,
-                        isComplete: true,
+                        OutputFlushKind.Complete,
                         cancellationToken)
                     .ConfigureAwait(false);
             }
@@ -172,35 +177,22 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     }
 
     /// <inheritdoc />
-    public async Task EnqueueAndFlushAsync(IModuleOutputBuffer buffer, CancellationToken cancellationToken = default)
-    {
-        await EnqueueAndFlushAsync(buffer, isComplete: true, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <inheritdoc />
-    public async Task EnqueueAndFlushIncrementalAsync(
+    public async Task EnqueueAndFlushAsync(
         IModuleOutputBuffer buffer,
+        OutputFlushKind flushKind,
         CancellationToken cancellationToken = default)
     {
-        if (buffer.IsComplete)
+        if (flushKind is OutputFlushKind.Incremental && buffer.IsComplete)
         {
             return;
         }
 
-        await EnqueueAndFlushAsync(buffer, isComplete: false, cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task EnqueueAndFlushAsync(
-        IModuleOutputBuffer buffer,
-        bool isComplete,
-        CancellationToken cancellationToken)
-    {
-        if (!isComplete && !buffer.HasOutput)
+        if (flushKind is OutputFlushKind.Incremental && !buffer.HasOutput)
         {
             return;
         }
 
-        var pending = new PendingFlush(buffer, isComplete, cancellationToken);
+        var pending = new PendingFlush(buffer, flushKind, cancellationToken);
         bool shouldProcess;
 
         lock (_queueLock)
@@ -272,7 +264,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     {
         try
         {
-            if (!pending.IsComplete && pending.Buffer.IsComplete)
+            if (pending.FlushKind is OutputFlushKind.Incremental && pending.Buffer.IsComplete)
             {
                 pending.CompletionSource.TrySetResult();
                 return;
@@ -310,7 +302,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                 await FlushBufferAsync(
                         pending.Buffer,
                         formatter,
-                        pending.IsComplete,
+                        pending.FlushKind,
                         cancellationToken)
                     .ConfigureAwait(false);
             }
@@ -361,7 +353,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     private async Task FlushBufferAsync(
         IModuleOutputBuffer buffer,
         IBuildSystemFormatter formatter,
-        bool isComplete,
+        OutputFlushKind flushKind,
         CancellationToken cancellationToken)
     {
         var loggerType = typeof(ILogger<>).MakeGenericType(buffer.ModuleType);
@@ -369,18 +361,9 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                            ?? _loggerFactory.CreateLogger(buffer.ModuleType);
 
         using var directWrite = CoordinatedTextWriter.BeginDirectWrite();
-        if (isComplete)
-        {
-            await buffer
-                .FlushToAsync(_console, formatter, moduleLogger, _loggerControl, cancellationToken)
-                .ConfigureAwait(false);
-        }
-        else
-        {
-            await buffer
-                .FlushIncrementallyToAsync(_console, formatter, moduleLogger, _loggerControl, cancellationToken)
-                .ConfigureAwait(false);
-        }
+        await buffer
+            .FlushToAsync(_console, formatter, moduleLogger, _loggerControl, flushKind, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private sealed class PendingFlush
@@ -389,17 +372,17 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
         public CancellationToken CancellationToken { get; }
 
-        public bool IsComplete { get; }
+        public OutputFlushKind FlushKind { get; }
 
         public TaskCompletionSource CompletionSource { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public PendingFlush(
             IModuleOutputBuffer buffer,
-            bool isComplete,
+            OutputFlushKind flushKind,
             CancellationToken cancellationToken)
         {
             Buffer = buffer;
-            IsComplete = isComplete;
+            FlushKind = flushKind;
             CancellationToken = cancellationToken;
         }
     }

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -269,10 +269,9 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                 return;
             }
 
-            // Output sinks are not transactional. A provider can deliver an event and
-            // then throw, so retrying here could duplicate output already accepted by
-            // that provider. Preserve the buffer's unrendered tail and surface failure
-            // to the caller instead.
+            // Output sinks are not transactional. The buffer retains a failed item,
+            // preferring a possible duplicate on a later retry over guaranteed data loss.
+            // Surface this attempt's failure so the caller controls when to retry.
             await FlushPendingOnceAsync(pending, formatter).ConfigureAwait(false);
             pending.CompletionSource.TrySetResult();
         }
@@ -355,14 +354,24 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         OutputFlushKind flushKind,
         CancellationToken cancellationToken)
     {
-        var loggerType = typeof(ILogger<>).MakeGenericType(buffer.ModuleType);
-        var moduleLogger = _serviceProvider.GetService(loggerType) as ILogger
-                           ?? _loggerFactory.CreateLogger(buffer.ModuleType);
+        var moduleLogger = GetModuleLogger(buffer.ModuleType);
 
         using var directWrite = CoordinatedTextWriter.BeginDirectWrite();
         await buffer
             .FlushToAsync(_console, formatter, moduleLogger, _loggerControl, flushKind, cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    private ILogger GetModuleLogger(Type moduleType)
+    {
+        if (moduleType == typeof(void))
+        {
+            return _loggerFactory.CreateLogger(moduleType);
+        }
+
+        var loggerType = typeof(ILogger<>).MakeGenericType(moduleType);
+        return _serviceProvider.GetService(loggerType) as ILogger
+               ?? _loggerFactory.CreateLogger(moduleType);
     }
 
     private sealed class PendingFlush

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -160,10 +160,9 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         }
         catch
         {
-            // A sink may have accepted part of the current buffer before throwing.
-            // Retrying that buffer could duplicate delivered output, so only retain
-            // buffers that have not started rendering.
-            RequeueDeferredOutputs(toFlush.Skip(nextOutputIndex + 1));
+            // Preserve the current buffer too. Its own render cursor retains the
+            // failed item, preferring a possible duplicate over lost diagnostics.
+            RequeueDeferredOutputs(toFlush.Skip(nextOutputIndex));
 
             throw;
         }

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -25,11 +25,12 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     // Separate lock for deferred output operations to reduce contention
     // with immediate flush operations that use _queueLock
     private readonly object _deferredLock = new();
+    private readonly List<DeferredModuleOutput> _deferredOutputs = new();
 
     private IProgressController _progressController = NoOpProgressController.Instance;
     private bool _isProcessingQueue;
+    private TaskCompletionSource _queueIdle = CreateCompletedQueueIdleSource();
     private volatile bool _isProgressActive;
-    private readonly List<DeferredModuleOutput> _deferredOutputs = new();
 
     private readonly record struct DeferredModuleOutput(
         IModuleOutputBuffer Buffer,
@@ -201,6 +202,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
             if (shouldProcess)
             {
                 _isProcessingQueue = true;
+                _queueIdle = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             }
         }
 
@@ -214,6 +216,15 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         using var cancellationRegistration = cancellationToken.Register(
             () => pending.CompletionSource.TrySetCanceled(cancellationToken));
         await pending.CompletionSource.Task.ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public Task WaitForPendingFlushesAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_queueLock)
+        {
+            return _queueIdle.Task.WaitAsync(cancellationToken);
+        }
     }
 
     private async Task ProcessQueueAsync()
@@ -340,12 +351,20 @@ internal sealed class OutputCoordinator : IOutputCoordinator
             _isProcessingQueue = false;
             if (_pendingQueue.Count == 0)
             {
+                _queueIdle.TrySetResult();
                 return false;
             }
 
             _isProcessingQueue = true;
             return true;
         }
+    }
+
+    private static TaskCompletionSource CreateCompletedQueueIdleSource()
+    {
+        var completionSource = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        completionSource.SetResult();
+        return completionSource;
     }
 
     private async Task FlushBufferAsync(

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -88,11 +88,6 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     /// <inheritdoc />
     public async Task OnModuleCompletedAsync(IModuleOutputBuffer buffer, Type moduleType, CancellationToken cancellationToken = default)
     {
-        if (!buffer.HasOutput)
-        {
-            return;
-        }
-
         if (_isProgressActive)
         {
             // Progress is active - defer output until pipeline end
@@ -200,7 +195,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         bool isComplete,
         CancellationToken cancellationToken)
     {
-        if (!buffer.HasOutput)
+        if (!isComplete && !buffer.HasOutput)
         {
             return;
         }

--- a/src/ModularPipelines/Console/OutputFlushKind.cs
+++ b/src/ModularPipelines/Console/OutputFlushKind.cs
@@ -1,0 +1,17 @@
+namespace ModularPipelines.Console;
+
+/// <summary>
+/// Specifies whether buffered module output is being rendered during execution or at completion.
+/// </summary>
+internal enum OutputFlushKind
+{
+    /// <summary>
+    /// Renders output accumulated by a module that is still running.
+    /// </summary>
+    Incremental,
+
+    /// <summary>
+    /// Renders the final output and completion status for a module.
+    /// </summary>
+    Complete,
+}

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -56,6 +56,9 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
     /// <inheritdoc />
     public async Task<IPipelineOutputScope> InitializeAsync()
     {
+        var liveFlushInterval = _options.Value.ModuleOutputFlushInterval;
+        ValidateLiveFlushInterval(liveFlushInterval);
+
         // Install console coordination before starting progress
         _consoleCoordinator.Install();
 
@@ -71,7 +74,7 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
             printProgressExecutor,
             _consoleCoordinator,
             _outputCoordinator,
-            _options.Value.ModuleOutputFlushInterval,
+            liveFlushInterval,
             _logger);
     }
 
@@ -97,6 +100,19 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
         _summaryLogger.WriteLogs();
     }
 
+    private static void ValidateLiveFlushInterval(TimeSpan liveFlushInterval)
+    {
+        if (liveFlushInterval < TimeSpan.Zero
+            || liveFlushInterval > PipelineOptions.MaximumModuleOutputFlushInterval)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(liveFlushInterval),
+                liveFlushInterval,
+                $"The interval must be between {TimeSpan.Zero} and " +
+                $"{PipelineOptions.MaximumModuleOutputFlushInterval}.");
+        }
+    }
+
     private sealed class PipelineOutputScope : IPipelineOutputScope
     {
         private readonly IPrintProgressExecutor _printProgressExecutor;
@@ -117,16 +133,6 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
             _consoleCoordinator = consoleCoordinator;
             _outputCoordinator = outputCoordinator;
             _logger = logger;
-
-            if (liveFlushInterval < TimeSpan.Zero
-                || liveFlushInterval > PipelineOptions.MaximumModuleOutputFlushInterval)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(liveFlushInterval),
-                    liveFlushInterval,
-                    $"The interval must be between {TimeSpan.Zero} and " +
-                    $"{PipelineOptions.MaximumModuleOutputFlushInterval}.");
-            }
 
             _liveFlushTask = liveFlushInterval > TimeSpan.Zero
                 ? FlushPeriodicallyAsync(liveFlushInterval)

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -117,6 +117,17 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
             _consoleCoordinator = consoleCoordinator;
             _outputCoordinator = outputCoordinator;
             _logger = logger;
+
+            if (liveFlushInterval < TimeSpan.Zero
+                || liveFlushInterval > PipelineOptions.MaximumModuleOutputFlushInterval)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(liveFlushInterval),
+                    liveFlushInterval,
+                    $"The interval must be between {TimeSpan.Zero} and " +
+                    $"{PipelineOptions.MaximumModuleOutputFlushInterval}.");
+            }
+
             _liveFlushTask = liveFlushInterval > TimeSpan.Zero
                 ? FlushPeriodicallyAsync(liveFlushInterval)
                 : Task.CompletedTask;

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -1,7 +1,10 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModularPipelines.Console;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
+using ModularPipelines.Options;
 
 namespace ModularPipelines.Engine.Executors;
 
@@ -27,6 +30,8 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
     private readonly IExceptionBuffer _exceptionBuffer;
     private readonly IConsoleCoordinator _consoleCoordinator;
     private readonly IOutputCoordinator _outputCoordinator;
+    private readonly IOptions<PipelineOptions> _options;
+    private readonly ILogger<PipelineOutputCoordinator> _logger;
 
     public PipelineOutputCoordinator(
         IPrintProgressExecutor printProgressExecutor,
@@ -34,7 +39,9 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
         IInternalSummaryLogger summaryLogger,
         IExceptionBuffer exceptionBuffer,
         IConsoleCoordinator consoleCoordinator,
-        IOutputCoordinator outputCoordinator)
+        IOutputCoordinator outputCoordinator,
+        IOptions<PipelineOptions> options,
+        ILogger<PipelineOutputCoordinator> logger)
     {
         _printProgressExecutor = printProgressExecutor;
         _consolePrinter = consolePrinter;
@@ -42,6 +49,8 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
         _exceptionBuffer = exceptionBuffer;
         _consoleCoordinator = consoleCoordinator;
         _outputCoordinator = outputCoordinator;
+        _options = options;
+        _logger = logger;
     }
 
     /// <inheritdoc />
@@ -58,7 +67,12 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
         _consoleCoordinator.EnableOutputBuffering();
 
         var printProgressExecutor = await _printProgressExecutor.InitializeAsync().ConfigureAwait(false);
-        return new PipelineOutputScope(printProgressExecutor, _consoleCoordinator, _outputCoordinator);
+        return new PipelineOutputScope(
+            printProgressExecutor,
+            _consoleCoordinator,
+            _outputCoordinator,
+            _options.Value.ModuleOutputFlushInterval,
+            _logger);
     }
 
     /// <inheritdoc />
@@ -88,19 +102,32 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
         private readonly IPrintProgressExecutor _printProgressExecutor;
         private readonly IConsoleCoordinator _consoleCoordinator;
         private readonly IOutputCoordinator _outputCoordinator;
+        private readonly ILogger _logger;
+        private readonly CancellationTokenSource _liveFlushCancellation = new();
+        private readonly Task _liveFlushTask;
 
         public PipelineOutputScope(
             IPrintProgressExecutor printProgressExecutor,
             IConsoleCoordinator consoleCoordinator,
-            IOutputCoordinator outputCoordinator)
+            IOutputCoordinator outputCoordinator,
+            TimeSpan liveFlushInterval,
+            ILogger logger)
         {
             _printProgressExecutor = printProgressExecutor;
             _consoleCoordinator = consoleCoordinator;
             _outputCoordinator = outputCoordinator;
+            _logger = logger;
+            _liveFlushTask = liveFlushInterval > TimeSpan.Zero
+                ? FlushPeriodicallyAsync(liveFlushInterval)
+                : Task.CompletedTask;
         }
 
         public async ValueTask DisposeAsync()
         {
+            await _liveFlushCancellation.CancelAsync().ConfigureAwait(false);
+            await _liveFlushTask.ConfigureAwait(false);
+            _liveFlushCancellation.Dispose();
+
             // CRITICAL: Order matters!
             // 1. Flush retained console fragments while progress deferral is still active.
             var newlyPopulatedBuffers = await _consoleCoordinator
@@ -123,6 +150,38 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
 
             // 5. Flush any unattributed output from coordinator.
             await _consoleCoordinator.FlushModuleOutputAsync().ConfigureAwait(false);
+        }
+
+        private async Task FlushPeriodicallyAsync(TimeSpan interval)
+        {
+            using var timer = new PeriodicTimer(interval);
+
+            try
+            {
+                while (await timer
+                           .WaitForNextTickAsync(_liveFlushCancellation.Token)
+                           .ConfigureAwait(false))
+                {
+                    try
+                    {
+                        await _consoleCoordinator
+                            .FlushInProgressModuleOutputAsync(_liveFlushCancellation.Token)
+                            .ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (_liveFlushCancellation.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                    catch (Exception exception)
+                    {
+                        _logger.LogWarning(exception, "Failed to flush in-progress module output");
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (_liveFlushCancellation.IsCancellationRequested)
+            {
+                // Normal scope teardown.
+            }
         }
     }
 }

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -137,6 +137,10 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
         {
             await _liveFlushCancellation.CancelAsync().ConfigureAwait(false);
             await _liveFlushTask.ConfigureAwait(false);
+
+            // A canceled caller can finish before its queue processor releases the buffer.
+            // Final drains must not start until that processor has quiesced.
+            await _outputCoordinator.WaitForPendingFlushesAsync().ConfigureAwait(false);
             _liveFlushCancellation.Dispose();
 
             // CRITICAL: Order matters!

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -140,6 +140,8 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
             {
                 _buffer.SetException(_exception);
             }
+
+            _buffer.MarkComplete();
         }
 
         GC.SuppressFinalize(this);
@@ -163,6 +165,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
                 _buffer.SetException(_exception);
             }
 
+            _buffer.MarkComplete();
             shouldFlush = true;
         }
 

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -200,6 +200,16 @@ public record PipelineOptions
     public int? ConsoleWidth { get; set; }
 
     /// <summary>
+    /// Gets or sets how often buffered output from still-running modules is written to the console.
+    /// Set to <see cref="TimeSpan.Zero"/> to retain all module output until the module completes.
+    /// </summary>
+    /// <remarks>
+    /// Periodic flushing preserves diagnostic output when a process is killed before pipeline
+    /// teardown can run. The default is one minute.
+    /// </remarks>
+    public TimeSpan ModuleOutputFlushInterval { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
     /// Gets or sets the default execution options for all commands.
     /// When set, these options apply to all command executions unless overridden per-call.
     /// </summary>

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -238,4 +238,7 @@ public record PipelineOptions
     /// </para>
     /// </remarks>
     public bool ThrowOnPipelineFailure { get; set; } = true;
+
+    internal static TimeSpan MaximumModuleOutputFlushInterval { get; } =
+        TimeSpan.FromMilliseconds(uint.MaxValue - 1);
 }

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -297,6 +297,7 @@ public sealed class PipelineBuilder
                 opts.ConsoleWidth = _options.ConsoleWidth;
                 opts.DefaultExecutionOptions = _options.DefaultExecutionOptions;
                 opts.ThrowOnPipelineFailure = _options.ThrowOnPipelineFailure;
+                opts.ModuleOutputFlushInterval = _options.ModuleOutputFlushInterval;
             });
 
             // Auto-register any missing required dependencies

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -9,9 +9,6 @@ namespace ModularPipelines.Validation;
 /// </summary>
 internal class OptionsValidator : IOptionsValidator
 {
-    private static readonly TimeSpan MaximumPeriodicTimerInterval =
-        TimeSpan.FromMilliseconds(uint.MaxValue - 1);
-
     /// <inheritdoc />
     public int Order => 100;
 
@@ -53,11 +50,11 @@ internal class OptionsValidator : IOptionsValidator
                 ValidationErrorCategory.Options,
                 $"ModuleOutputFlushInterval cannot be negative. Current value: {options.ModuleOutputFlushInterval}"));
         }
-        else if (options.ModuleOutputFlushInterval > MaximumPeriodicTimerInterval)
+        else if (options.ModuleOutputFlushInterval > PipelineOptions.MaximumModuleOutputFlushInterval)
         {
             result.AddError(new ValidationError(
                 ValidationErrorCategory.Options,
-                $"ModuleOutputFlushInterval cannot exceed {MaximumPeriodicTimerInterval}. " +
+                $"ModuleOutputFlushInterval cannot exceed {PipelineOptions.MaximumModuleOutputFlushInterval}. " +
                 $"Current value: {options.ModuleOutputFlushInterval}"));
         }
 

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -9,6 +9,9 @@ namespace ModularPipelines.Validation;
 /// </summary>
 internal class OptionsValidator : IOptionsValidator
 {
+    private static readonly TimeSpan MaximumPeriodicTimerInterval =
+        TimeSpan.FromMilliseconds(uint.MaxValue - 1);
+
     /// <inheritdoc />
     public int Order => 100;
 
@@ -49,6 +52,13 @@ internal class OptionsValidator : IOptionsValidator
             result.AddError(new ValidationError(
                 ValidationErrorCategory.Options,
                 $"ModuleOutputFlushInterval cannot be negative. Current value: {options.ModuleOutputFlushInterval}"));
+        }
+        else if (options.ModuleOutputFlushInterval > MaximumPeriodicTimerInterval)
+        {
+            result.AddError(new ValidationError(
+                ValidationErrorCategory.Options,
+                $"ModuleOutputFlushInterval cannot exceed {MaximumPeriodicTimerInterval}. " +
+                $"Current value: {options.ModuleOutputFlushInterval}"));
         }
 
         // Validate concurrency options

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -44,6 +44,13 @@ internal class OptionsValidator : IOptionsValidator
                 $"DefaultModuleTimeout cannot be negative. Current value: {options.DefaultModuleTimeout}"));
         }
 
+        if (options.ModuleOutputFlushInterval < TimeSpan.Zero)
+        {
+            result.AddError(new ValidationError(
+                ValidationErrorCategory.Options,
+                $"ModuleOutputFlushInterval cannot be negative. Current value: {options.ModuleOutputFlushInterval}"));
+        }
+
         // Validate concurrency options
         if (options.Concurrency.MaxParallelism < 1)
         {

--- a/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
@@ -22,23 +22,7 @@ public class ConsoleCoordinatorTests
                 It.IsAny<Type>(),
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-        var secretProvider = new Mock<ISecretProvider>();
-        secretProvider.SetupGet(provider => provider.Secrets).Returns([]);
-        var secretObfuscator = new Mock<ISecretObfuscator>();
-        secretObfuscator
-            .Setup(obfuscator => obfuscator.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
-            .Returns((string? value, object? _) => value ?? string.Empty);
-        var coordinator = new ConsoleCoordinator(
-            Mock.Of<IBuildSystemFormatterProvider>(),
-            Mock.Of<IResultsPrinter>(),
-            secretObfuscator.Object,
-            secretProvider.Object,
-            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
-            NullLoggerFactory.Instance,
-            Mock.Of<IBuildSystemDetector>(),
-            Mock.Of<IServiceProvider>(),
-            outputCoordinator.Object,
-            Mock.Of<ISpectreConsoleLoggerControl>());
+        var coordinator = CreateCoordinator(outputCoordinator.Object);
         var previousModule = ModuleLogger.CurrentModuleType.Value;
 
         try
@@ -64,5 +48,89 @@ public class ConsoleCoordinatorTests
             ModuleLogger.CurrentModuleType.Value = previousModule;
             await coordinator.DisposeAsync();
         }
+    }
+
+    [Test]
+    public async Task PeriodicFlush_ContinuesAfterOneBufferFails()
+    {
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        var coordinator = CreateCoordinator(outputCoordinator.Object);
+        var failingBuffer = coordinator.GetModuleBuffer(typeof(string));
+        var succeedingBuffer = coordinator.GetModuleBuffer(typeof(int));
+        failingBuffer.WriteLine("fails");
+        succeedingBuffer.WriteLine("succeeds");
+        outputCoordinator
+            .Setup(output => output.EnqueueAndFlushAsync(
+                failingBuffer,
+                OutputFlushKind.Incremental,
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("sink failed"));
+        outputCoordinator
+            .Setup(output => output.EnqueueAndFlushAsync(
+                succeedingBuffer,
+                OutputFlushKind.Incremental,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        await coordinator.FlushInProgressModuleOutputAsync();
+
+        outputCoordinator.Verify(
+            output => output.EnqueueAndFlushAsync(
+                failingBuffer,
+                OutputFlushKind.Incremental,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        outputCoordinator.Verify(
+            output => output.EnqueueAndFlushAsync(
+                succeedingBuffer,
+                OutputFlushKind.Incremental,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task PeriodicFlush_IncludesUnattributedOutput()
+    {
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(output => output.EnqueueAndFlushAsync(
+                It.IsAny<IModuleOutputBuffer>(),
+                OutputFlushKind.Incremental,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var coordinator = CreateCoordinator(outputCoordinator.Object);
+        var unattributedBuffer = coordinator.GetUnattributedBuffer();
+        unattributedBuffer.WriteLine("pipeline output");
+
+        await coordinator.FlushInProgressModuleOutputAsync();
+
+        outputCoordinator.Verify(
+            output => output.EnqueueAndFlushAsync(
+                unattributedBuffer,
+                OutputFlushKind.Incremental,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static ConsoleCoordinator CreateCoordinator(IOutputCoordinator outputCoordinator)
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Secrets).Returns([]);
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(obfuscator => obfuscator.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? value, object? _) => value ?? string.Empty);
+
+        return new ConsoleCoordinator(
+            Mock.Of<IBuildSystemFormatterProvider>(),
+            Mock.Of<IResultsPrinter>(),
+            secretObfuscator.Object,
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
+            NullLoggerFactory.Instance,
+            Mock.Of<IBuildSystemDetector>(),
+            Mock.Of<IServiceProvider>(),
+            outputCoordinator,
+            Mock.Of<ISpectreConsoleLoggerControl>());
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
@@ -1,0 +1,69 @@
+using MEL.Spectre;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ModularPipelines.Console;
+using ModularPipelines.Engine;
+using ModularPipelines.Helpers;
+using ModularPipelines.Logging;
+using ModularPipelines.Options;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Console;
+
+[TUnit.Core.NotInParallel]
+public class ConsoleCoordinatorTests
+{
+    [Test]
+    public async Task PeriodicFlush_SchedulesCompletedBufferPopulatedByRetainedWrite()
+    {
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(output => output.OnModuleCompletedAsync(
+                It.IsAny<IModuleOutputBuffer>(),
+                It.IsAny<Type>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Secrets).Returns([]);
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(obfuscator => obfuscator.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? value, object? _) => value ?? string.Empty);
+        var coordinator = new ConsoleCoordinator(
+            Mock.Of<IBuildSystemFormatterProvider>(),
+            Mock.Of<IResultsPrinter>(),
+            secretObfuscator.Object,
+            secretProvider.Object,
+            Options.Create(new PipelineOptions()),
+            NullLoggerFactory.Instance,
+            Mock.Of<IBuildSystemDetector>(),
+            Mock.Of<IServiceProvider>(),
+            outputCoordinator.Object,
+            Mock.Of<ISpectreConsoleLoggerControl>());
+        var previousModule = ModuleLogger.CurrentModuleType.Value;
+
+        try
+        {
+            coordinator.Install();
+            coordinator.EnableOutputBuffering();
+            ModuleLogger.CurrentModuleType.Value = typeof(ConsoleCoordinatorTests);
+            System.Console.Write("retained fragment");
+            var buffer = coordinator.GetModuleBuffer(typeof(ConsoleCoordinatorTests));
+            buffer.MarkComplete();
+
+            await coordinator.FlushInProgressModuleOutputAsync();
+
+            outputCoordinator.Verify(
+                output => output.OnModuleCompletedAsync(
+                    buffer,
+                    typeof(ConsoleCoordinatorTests),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+        finally
+        {
+            ModuleLogger.CurrentModuleType.Value = previousModule;
+            await coordinator.DisposeAsync();
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
@@ -1,6 +1,5 @@
 using MEL.Spectre;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
 using ModularPipelines.Helpers;
@@ -34,7 +33,7 @@ public class ConsoleCoordinatorTests
             Mock.Of<IResultsPrinter>(),
             secretObfuscator.Object,
             secretProvider.Object,
-            Options.Create(new PipelineOptions()),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
             NullLoggerFactory.Instance,
             Mock.Of<IBuildSystemDetector>(),
             Mock.Of<IServiceProvider>(),

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -105,6 +105,32 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task CompleteFlush_WritesFinalHeaderAfterIncrementalDrain()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        buffer.WriteLine("partial output");
+
+        await buffer.FlushIncrementallyToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl);
+        buffer.MarkComplete();
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("ModuleOutputBufferTests …");
+        await Assert.That(output).Contains("ModuleOutputBufferTests ✓");
+        await Assert.That(output).Contains("partial output");
+    }
+
+    [Test]
     public async Task Flush_Keeps_Concurrent_Logs_Outside_Module_Group()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -299,7 +299,7 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
-    public async Task Flush_RenderingFailure_Retains_Only_Unattempted_Output()
+    public async Task Flush_RenderingFailure_Retains_Failed_Output()
     {
         var writer = new StringWriter();
         var loggerControl = new SynchronousLoggerControl(writer)
@@ -327,13 +327,13 @@ public class ModuleOutputBufferTests
             loggerControl,
             OutputFlushKind.Complete);
 
-        await Assert.That(writer.ToString()).DoesNotContain("structured log");
+        await Assert.That(writer.ToString()).Contains("structured log");
         await Assert.That(writer.ToString()).Contains("remaining output");
         await Assert.That(buffer.HasOutput).IsFalse();
     }
 
     [Test]
-    public async Task IncrementalFlush_DoesNotRetry_LogAcceptedBeforeProviderFailure()
+    public async Task IncrementalFlush_Retries_LogAcceptedBeforeProviderFailure()
     {
         var writer = new StringWriter();
         var loggerControl = new SynchronousLoggerControl(writer)
@@ -359,7 +359,7 @@ public class ModuleOutputBufferTests
             loggerControl,
             OutputFlushKind.Incremental);
 
-        await Assert.That(CountOccurrences(writer.ToString(), "structured log")).IsEqualTo(1);
+        await Assert.That(CountOccurrences(writer.ToString(), "structured log")).IsEqualTo(2);
         await Assert.That(writer.ToString()).Contains("remaining output");
         await Assert.That(buffer.HasOutput).IsFalse();
     }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -216,7 +216,7 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
-    public async Task Flush_RenderingFailure_Retains_Unrendered_Output()
+    public async Task Flush_RenderingFailure_Retains_Only_Unattempted_Output()
     {
         var writer = new StringWriter();
         var loggerControl = new SynchronousLoggerControl(writer)
@@ -234,7 +234,37 @@ public class ModuleOutputBufferTests
         loggerControl.LogException = null;
         await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
 
-        await Assert.That(writer.ToString()).Contains("structured log");
+        await Assert.That(writer.ToString()).DoesNotContain("structured log");
+        await Assert.That(writer.ToString()).Contains("remaining output");
+        await Assert.That(buffer.HasOutput).IsFalse();
+    }
+
+    [Test]
+    public async Task IncrementalFlush_DoesNotRetry_LogAcceptedBeforeProviderFailure()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer)
+        {
+            LogExceptionAfterWrite = new InvalidOperationException("provider failed after delivery"),
+        };
+        var buffer = CreateBufferWithStructuredLog();
+        buffer.WriteLine("remaining output");
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await buffer.FlushIncrementallyToAsync(
+                writer,
+                new GitHubActionsFormatter(),
+                loggerControl,
+                loggerControl));
+
+        loggerControl.LogExceptionAfterWrite = null;
+        await buffer.FlushIncrementallyToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl);
+
+        await Assert.That(CountOccurrences(writer.ToString(), "structured log")).IsEqualTo(1);
         await Assert.That(writer.ToString()).Contains("remaining output");
         await Assert.That(buffer.HasOutput).IsFalse();
     }
@@ -289,6 +319,11 @@ public class ModuleOutputBufferTests
         return buffer;
     }
 
+    private static int CountOccurrences(string value, string search)
+    {
+        return value.Split(search, StringSplitOptions.None).Length - 1;
+    }
+
     private sealed class SynchronousLoggerControl(TextWriter writer) : ILogger, ISpectreConsoleLoggerControl
     {
         public object SynchronizationLock { get; } = new();
@@ -296,6 +331,8 @@ public class ModuleOutputBufferTests
         public Action? AfterLog { get; set; }
 
         public Exception? LogException { get; set; }
+
+        public Exception? LogExceptionAfterWrite { get; set; }
 
         public IDisposable? BeginScope<TState>(TState state)
             where TState : notnull
@@ -317,6 +354,11 @@ public class ModuleOutputBufferTests
 
             Write(formatter(state, exception));
             AfterLog?.Invoke();
+
+            if (LogExceptionAfterWrite is not null)
+            {
+                throw LogExceptionAfterWrite;
+            }
         }
 
         public void Write(string message)

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -62,6 +62,49 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task IncrementalFlush_Marks_Module_As_InProgress()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        buffer.WriteLine("partial output");
+
+        await buffer.FlushIncrementallyToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("ModuleOutputBufferTests …");
+        await Assert.That(output).Contains("partial output");
+        await Assert.That(output).DoesNotContain("ModuleOutputBufferTests ✓");
+        await Assert.That(buffer.HasOutput).IsFalse();
+    }
+
+    [Test]
+    public async Task IncrementalFlush_DoesNotDrainCompletedModule()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        buffer.WriteLine("completed output");
+        buffer.MarkComplete();
+
+        await buffer.FlushIncrementallyToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl);
+
+        await Assert.That(writer.ToString()).IsEmpty();
+        await Assert.That(buffer.HasOutput).IsTrue();
+
+        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+        await Assert.That(writer.ToString()).Contains("completed output");
+    }
+
+    [Test]
     public async Task Flush_Keeps_Concurrent_Logs_Outside_Module_Group()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -14,7 +14,12 @@ public class ModuleOutputBufferTests
         var loggerControl = new SynchronousLoggerControl(writer);
         var buffer = CreateBufferWithStructuredLog();
 
-        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
 
         var output = writer.ToString();
         var structuredLog = output.IndexOf("structured log", StringComparison.Ordinal);
@@ -32,7 +37,12 @@ public class ModuleOutputBufferTests
         var buffer = CreateBufferWithStructuredLog();
         buffer.WriteLine("direct output");
 
-        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
 
         var output = writer.ToString();
         var groupStart = output.IndexOf("::group::", StringComparison.Ordinal);
@@ -54,7 +64,12 @@ public class ModuleOutputBufferTests
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
         buffer.WriteLine("[green]direct output[/]");
 
-        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
 
         var output = writer.ToString();
         await Assert.That(output).Contains("direct output");
@@ -69,17 +84,19 @@ public class ModuleOutputBufferTests
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
         buffer.WriteLine("partial output");
 
-        await buffer.FlushIncrementallyToAsync(
+        await buffer.FlushToAsync(
             writer,
             new GitHubActionsFormatter(),
             loggerControl,
-            loggerControl);
+            loggerControl,
+            OutputFlushKind.Incremental);
 
         var output = writer.ToString();
         await Assert.That(output).Contains("ModuleOutputBufferTests …");
         await Assert.That(output).Contains("partial output");
         await Assert.That(output).DoesNotContain("ModuleOutputBufferTests ✓");
         await Assert.That(buffer.HasOutput).IsFalse();
+        await Assert.That(buffer.NeedsCompletionFlush).IsTrue();
     }
 
     [Test]
@@ -91,16 +108,22 @@ public class ModuleOutputBufferTests
         buffer.WriteLine("completed output");
         buffer.MarkComplete();
 
-        await buffer.FlushIncrementallyToAsync(
+        await buffer.FlushToAsync(
             writer,
             new GitHubActionsFormatter(),
             loggerControl,
-            loggerControl);
+            loggerControl,
+            OutputFlushKind.Incremental);
 
         await Assert.That(writer.ToString()).IsEmpty();
         await Assert.That(buffer.HasOutput).IsTrue();
 
-        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
         await Assert.That(writer.ToString()).Contains("completed output");
     }
 
@@ -112,22 +135,70 @@ public class ModuleOutputBufferTests
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
         buffer.WriteLine("partial output");
 
-        await buffer.FlushIncrementallyToAsync(
+        await buffer.FlushToAsync(
             writer,
             new GitHubActionsFormatter(),
             loggerControl,
-            loggerControl);
+            loggerControl,
+            OutputFlushKind.Incremental);
         buffer.MarkComplete();
         await buffer.FlushToAsync(
             writer,
             new GitHubActionsFormatter(),
             loggerControl,
-            loggerControl);
+            loggerControl,
+            OutputFlushKind.Complete);
 
         var output = writer.ToString();
         await Assert.That(output).Contains("ModuleOutputBufferTests …");
         await Assert.That(output).Contains("ModuleOutputBufferTests ✓");
         await Assert.That(output).Contains("partial output");
+        await Assert.That(buffer.NeedsCompletionFlush).IsFalse();
+    }
+
+    [Test]
+    public async Task CompletionNeed_Remains_While_IncrementalFlush_Owns_Output()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = CreateBufferWithStructuredLog();
+        var renderingStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRendering = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        loggerControl.AfterLog = () =>
+        {
+            renderingStarted.TrySetResult();
+            releaseRendering.Task.GetAwaiter().GetResult();
+        };
+
+        var incrementalFlush = Task.Run(() => buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Incremental));
+        await renderingStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        try
+        {
+            await Assert.That(buffer.HasOutput).IsFalse();
+            await Assert.That(buffer.NeedsCompletionFlush).IsTrue();
+            buffer.MarkComplete();
+        }
+        finally
+        {
+            releaseRendering.TrySetResult();
+        }
+
+        await incrementalFlush;
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        await Assert.That(writer.ToString()).Contains("ModuleOutputBufferTests ✓");
+        await Assert.That(buffer.NeedsCompletionFlush).IsFalse();
     }
 
     [Test]
@@ -155,7 +226,12 @@ public class ModuleOutputBufferTests
             gateAttemptCompleted.Wait();
         };
 
-        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
         await outsideLog!;
 
         var output = writer.ToString();
@@ -181,6 +257,7 @@ public class ModuleOutputBufferTests
                 new GitHubActionsFormatter(),
                 loggerControl,
                 loggerControl,
+                OutputFlushKind.Complete,
                 cancellationTokenSource.Token));
 
         await Assert.That(buffer.HasOutput).IsTrue();
@@ -202,6 +279,7 @@ public class ModuleOutputBufferTests
                 new GitHubActionsFormatter(),
                 loggerControl,
                 loggerControl,
+                OutputFlushKind.Complete,
                 cancellationTokenSource.Token));
 
         var cancelledOutput = writer.ToString();
@@ -209,7 +287,12 @@ public class ModuleOutputBufferTests
             .IsGreaterThan(cancelledOutput.IndexOf("structured log", StringComparison.Ordinal));
         await Assert.That(buffer.HasOutput).IsTrue();
 
-        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
 
         await Assert.That(writer.ToString()).Contains("remaining output");
         await Assert.That(buffer.HasOutput).IsFalse();
@@ -227,12 +310,22 @@ public class ModuleOutputBufferTests
         buffer.WriteLine("remaining output");
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl));
+            await buffer.FlushToAsync(
+                writer,
+                new GitHubActionsFormatter(),
+                loggerControl,
+                loggerControl,
+                OutputFlushKind.Complete));
 
         await Assert.That(buffer.HasOutput).IsTrue();
 
         loggerControl.LogException = null;
-        await buffer.FlushToAsync(writer, new GitHubActionsFormatter(), loggerControl, loggerControl);
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
 
         await Assert.That(writer.ToString()).DoesNotContain("structured log");
         await Assert.That(writer.ToString()).Contains("remaining output");
@@ -251,18 +344,20 @@ public class ModuleOutputBufferTests
         buffer.WriteLine("remaining output");
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await buffer.FlushIncrementallyToAsync(
+            await buffer.FlushToAsync(
                 writer,
                 new GitHubActionsFormatter(),
                 loggerControl,
-                loggerControl));
+                loggerControl,
+                OutputFlushKind.Incremental));
 
         loggerControl.LogExceptionAfterWrite = null;
-        await buffer.FlushIncrementallyToAsync(
+        await buffer.FlushToAsync(
             writer,
             new GitHubActionsFormatter(),
             loggerControl,
-            loggerControl);
+            loggerControl,
+            OutputFlushKind.Incremental);
 
         await Assert.That(CountOccurrences(writer.ToString(), "structured log")).IsEqualTo(1);
         await Assert.That(writer.ToString()).Contains("remaining output");
@@ -296,6 +391,7 @@ public class ModuleOutputBufferTests
                     new GitHubActionsFormatter(),
                     loggerControl,
                     loggerControl,
+                    OutputFlushKind.Complete,
                     cancellationTokenSource.Token));
         }
         finally

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -121,6 +121,38 @@ public class OutputCoordinatorTests
     }
 
     [Test]
+    public async Task IncrementalFlush_UsesInProgressRendering()
+    {
+        var buffer = new Mock<IModuleOutputBuffer>();
+        buffer.SetupGet(x => x.ModuleType).Returns(typeof(OutputCoordinatorTests));
+        buffer.SetupGet(x => x.HasOutput).Returns(true);
+        buffer
+            .Setup(x => x.FlushIncrementallyToAsync(
+                It.IsAny<TextWriter>(),
+                It.IsAny<IBuildSystemFormatter>(),
+                It.IsAny<ILogger>(),
+                It.IsAny<ISpectreConsoleLoggerControl>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        await coordinator.EnqueueAndFlushIncrementalAsync(buffer.Object);
+
+        buffer.Verify(x => x.FlushIncrementallyToAsync(
+            It.IsAny<TextWriter>(),
+            It.IsAny<IBuildSystemFormatter>(),
+            It.IsAny<ILogger>(),
+            It.IsAny<ISpectreConsoleLoggerControl>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        buffer.Verify(x => x.FlushToAsync(
+            It.IsAny<TextWriter>(),
+            It.IsAny<IBuildSystemFormatter>(),
+            It.IsAny<ILogger>(),
+            It.IsAny<ISpectreConsoleLoggerControl>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
     public async Task ImmediateFlush_DoesNotApplyOwnerCancellationToLaterBuffers()
     {
         using var ownerCancellation = new CancellationTokenSource();

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -275,6 +275,33 @@ public class OutputCoordinatorTests
     }
 
     [Test]
+    public async Task WaitForPendingFlushes_WaitsForCanceledActiveFlushToReleaseBuffer()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var buffer = new BlockingOutputBuffer();
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        var flush = coordinator.EnqueueAndFlushAsync(
+            buffer,
+            OutputFlushKind.Incremental,
+            cancellationTokenSource.Token);
+        await buffer.FlushStarted.Task;
+
+        await cancellationTokenSource.CancelAsync();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await flush);
+
+        var waitForPendingFlushes = coordinator.WaitForPendingFlushesAsync();
+        var completedBeforeRelease = ReferenceEquals(
+            await Task.WhenAny(waitForPendingFlushes, Task.Delay(TimeSpan.FromMilliseconds(50))),
+            waitForPendingFlushes);
+
+        buffer.ReleaseFlush.TrySetResult();
+        await waitForPendingFlushes;
+
+        await Assert.That(completedBeforeRelease).IsFalse();
+    }
+
+    [Test]
     public async Task ImmediateFlush_OwnerReturnsBeforeLaterBufferCompletes()
     {
         var firstBuffer = new BlockingOutputBuffer();

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -153,6 +153,25 @@ public class OutputCoordinatorTests
     }
 
     [Test]
+    public async Task Completion_IsQueuedWhileIncrementalFlushOwnsOutput()
+    {
+        var buffer = new BlockingIncrementalOutputBuffer();
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        var incrementalFlush = coordinator.EnqueueAndFlushIncrementalAsync(buffer);
+        await buffer.IncrementalFlushStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        buffer.MarkComplete();
+        var completionFlush = coordinator.OnModuleCompletedAsync(buffer, buffer.ModuleType);
+
+        buffer.ReleaseIncrementalFlush.TrySetResult();
+        await incrementalFlush;
+        await completionFlush;
+
+        await Assert.That(buffer.CompleteFlushCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task ImmediateFlush_DoesNotApplyOwnerCancellationToLaterBuffers()
     {
         using var ownerCancellation = new CancellationTokenSource();
@@ -453,6 +472,68 @@ public class OutputCoordinatorTests
         {
             FlushStarted.TrySetResult();
             await ReleaseFlush.Task;
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+
+    private sealed class BlockingIncrementalOutputBuffer : IModuleOutputBuffer
+    {
+        private volatile bool _hasOutput = true;
+
+        public Type ModuleType => typeof(BlockingIncrementalOutputBuffer);
+
+        public bool HasOutput => _hasOutput;
+
+        public bool IsComplete { get; private set; }
+
+        public int CompleteFlushCount { get; private set; }
+
+        public TaskCompletionSource IncrementalFlushStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReleaseIncrementalFlush { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void MarkComplete() => IsComplete = true;
+
+        public void WriteLine(string message)
+        {
+        }
+
+        public void AddLogEvent(
+            LogLevel level,
+            EventId eventId,
+            object state,
+            Exception? exception,
+            Func<object, Exception?, string> formatter)
+        {
+        }
+
+        public void SetException(Exception exception)
+        {
+        }
+
+        public Task FlushToAsync(
+            TextWriter console,
+            IBuildSystemFormatter formatter,
+            ILogger logger,
+            ISpectreConsoleLoggerControl loggerControl,
+            CancellationToken cancellationToken = default)
+        {
+            CompleteFlushCount++;
+            return Task.CompletedTask;
+        }
+
+        public async Task FlushIncrementallyToAsync(
+            TextWriter console,
+            IBuildSystemFormatter formatter,
+            ILogger logger,
+            ISpectreConsoleLoggerControl loggerControl,
+            CancellationToken cancellationToken = default)
+        {
+            _hasOutput = false;
+            IncrementalFlushStarted.TrySetResult();
+            await ReleaseIncrementalFlush.Task;
             cancellationToken.ThrowIfCancellationRequested();
         }
     }

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -38,7 +38,7 @@ public class OutputCoordinatorTests
             null,
             static (state, _) => state.ToString()!);
 
-        await coordinator.EnqueueAndFlushAsync(moduleBuffer);
+        await coordinator.EnqueueAndFlushAsync(moduleBuffer, OutputFlushKind.Complete);
         await coordinatedWriter.FlushAsync();
 
         await Assert.That(directOutput.ToString()).Contains("replayed log");
@@ -108,6 +108,26 @@ public class OutputCoordinatorTests
     }
 
     [Test]
+    public async Task Completion_Skips_Buffer_That_Has_Never_Produced_Output()
+    {
+        var buffer = new Mock<IModuleOutputBuffer>();
+        buffer.SetupGet(x => x.ModuleType).Returns(typeof(OutputCoordinatorTests));
+        buffer.SetupGet(x => x.NeedsCompletionFlush).Returns(false);
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        await coordinator.OnModuleCompletedAsync(buffer.Object, buffer.Object.ModuleType);
+        await coordinator.FlushDeferredAsync();
+
+        buffer.Verify(x => x.FlushToAsync(
+            It.IsAny<TextWriter>(),
+            It.IsAny<IBuildSystemFormatter>(),
+            It.IsAny<ILogger>(),
+            It.IsAny<ISpectreConsoleLoggerControl>(),
+            It.IsAny<OutputFlushKind>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Test]
     public async Task ImmediateFlush_PropagatesCancellationToQueueOwner()
     {
         using var cancellationTokenSource = new CancellationTokenSource();
@@ -115,7 +135,10 @@ public class OutputCoordinatorTests
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
 
         await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-            await coordinator.EnqueueAndFlushAsync(buffer, cancellationTokenSource.Token));
+            await coordinator.EnqueueAndFlushAsync(
+                buffer,
+                OutputFlushKind.Complete,
+                cancellationTokenSource.Token));
 
         await Assert.That(buffer.FlushCount).IsEqualTo(1);
     }
@@ -127,28 +150,31 @@ public class OutputCoordinatorTests
         buffer.SetupGet(x => x.ModuleType).Returns(typeof(OutputCoordinatorTests));
         buffer.SetupGet(x => x.HasOutput).Returns(true);
         buffer
-            .Setup(x => x.FlushIncrementallyToAsync(
+            .Setup(x => x.FlushToAsync(
                 It.IsAny<TextWriter>(),
                 It.IsAny<IBuildSystemFormatter>(),
                 It.IsAny<ILogger>(),
                 It.IsAny<ISpectreConsoleLoggerControl>(),
+                OutputFlushKind.Incremental,
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
 
-        await coordinator.EnqueueAndFlushIncrementalAsync(buffer.Object);
+        await coordinator.EnqueueAndFlushAsync(buffer.Object, OutputFlushKind.Incremental);
 
-        buffer.Verify(x => x.FlushIncrementallyToAsync(
+        buffer.Verify(x => x.FlushToAsync(
             It.IsAny<TextWriter>(),
             It.IsAny<IBuildSystemFormatter>(),
             It.IsAny<ILogger>(),
             It.IsAny<ISpectreConsoleLoggerControl>(),
+            OutputFlushKind.Incremental,
             It.IsAny<CancellationToken>()), Times.Once);
         buffer.Verify(x => x.FlushToAsync(
             It.IsAny<TextWriter>(),
             It.IsAny<IBuildSystemFormatter>(),
             It.IsAny<ILogger>(),
             It.IsAny<ISpectreConsoleLoggerControl>(),
+            OutputFlushKind.Complete,
             It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -158,7 +184,7 @@ public class OutputCoordinatorTests
         var buffer = new BlockingIncrementalOutputBuffer();
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
 
-        var incrementalFlush = coordinator.EnqueueAndFlushIncrementalAsync(buffer);
+        var incrementalFlush = coordinator.EnqueueAndFlushAsync(buffer, OutputFlushKind.Incremental);
         await buffer.IncrementalFlushStarted.Task.WaitAsync(TimeSpan.FromSeconds(1));
 
         buffer.MarkComplete();
@@ -179,9 +205,12 @@ public class OutputCoordinatorTests
         var secondBuffer = new CancellingOutputBuffer();
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
 
-        var ownerFlush = coordinator.EnqueueAndFlushAsync(firstBuffer, ownerCancellation.Token);
+        var ownerFlush = coordinator.EnqueueAndFlushAsync(
+            firstBuffer,
+            OutputFlushKind.Complete,
+            ownerCancellation.Token);
         await firstBuffer.FlushStarted.Task;
-        var secondFlush = coordinator.EnqueueAndFlushAsync(secondBuffer);
+        var secondFlush = coordinator.EnqueueAndFlushAsync(secondBuffer, OutputFlushKind.Complete);
 
         await ownerCancellation.CancelAsync();
         firstBuffer.ReleaseFlush.TrySetResult();
@@ -199,9 +228,12 @@ public class OutputCoordinatorTests
         var queuedBuffer = new CancellingOutputBuffer();
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
 
-        var firstFlush = coordinator.EnqueueAndFlushAsync(firstBuffer);
+        var firstFlush = coordinator.EnqueueAndFlushAsync(firstBuffer, OutputFlushKind.Complete);
         await firstBuffer.FlushStarted.Task;
-        var queuedFlush = coordinator.EnqueueAndFlushAsync(queuedBuffer, queuedCancellation.Token);
+        var queuedFlush = coordinator.EnqueueAndFlushAsync(
+            queuedBuffer,
+            OutputFlushKind.Complete,
+            queuedCancellation.Token);
 
         await queuedCancellation.CancelAsync();
         var completedTask = await Task.WhenAny(queuedFlush, Task.Delay(TimeSpan.FromSeconds(1)));
@@ -221,9 +253,9 @@ public class OutputCoordinatorTests
         var secondBuffer = new BlockingOutputBuffer();
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
 
-        var ownerFlush = coordinator.EnqueueAndFlushAsync(firstBuffer);
+        var ownerFlush = coordinator.EnqueueAndFlushAsync(firstBuffer, OutputFlushKind.Complete);
         await firstBuffer.FlushStarted.Task;
-        var secondFlush = coordinator.EnqueueAndFlushAsync(secondBuffer);
+        var secondFlush = coordinator.EnqueueAndFlushAsync(secondBuffer, OutputFlushKind.Complete);
 
         firstBuffer.ReleaseFlush.TrySetResult();
         await secondBuffer.FlushStarted.Task;
@@ -241,7 +273,7 @@ public class OutputCoordinatorTests
         var buffer = new SynchronouslyBlockingOutputBuffer();
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
         var invocation = Task.Factory.StartNew(
-            () => coordinator.EnqueueAndFlushAsync(buffer),
+            () => coordinator.EnqueueAndFlushAsync(buffer, OutputFlushKind.Complete),
             CancellationToken.None,
             TaskCreationOptions.DenyChildAttach,
             TaskScheduler.Default);
@@ -276,8 +308,12 @@ public class OutputCoordinatorTests
         var abandonedBuffer = new CancellingOutputBuffer();
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await coordinator.EnqueueAndFlushAsync(abandonedBuffer).WaitAsync(TimeSpan.FromSeconds(1)));
-        await coordinator.EnqueueAndFlushAsync(abandonedBuffer).WaitAsync(TimeSpan.FromSeconds(1));
+            await coordinator
+                .EnqueueAndFlushAsync(abandonedBuffer, OutputFlushKind.Complete)
+                .WaitAsync(TimeSpan.FromSeconds(1)));
+        await coordinator
+            .EnqueueAndFlushAsync(abandonedBuffer, OutputFlushKind.Complete)
+            .WaitAsync(TimeSpan.FromSeconds(1));
 
         await Assert.That(abandonedBuffer.FlushCount).IsEqualTo(1);
     }
@@ -289,7 +325,7 @@ public class OutputCoordinatorTests
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
 
         await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await coordinator.EnqueueAndFlushAsync(buffer));
+            await coordinator.EnqueueAndFlushAsync(buffer, OutputFlushKind.Complete));
 
         await Assert.That(buffer.DeliveryCount).IsEqualTo(1);
     }
@@ -359,6 +395,12 @@ public class OutputCoordinatorTests
 
         public bool HasOutput => true;
 
+        public bool IsComplete { get; private set; }
+
+        public bool NeedsCompletionFlush => true;
+
+        public void MarkComplete() => IsComplete = true;
+
         public void WriteLine(string message)
         {
         }
@@ -381,6 +423,7 @@ public class OutputCoordinatorTests
             IBuildSystemFormatter formatter,
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
+            OutputFlushKind flushKind,
             CancellationToken cancellationToken = default)
         {
             FlushCount++;
@@ -402,6 +445,12 @@ public class OutputCoordinatorTests
 
         public bool HasOutput => true;
 
+        public bool IsComplete { get; private set; }
+
+        public bool NeedsCompletionFlush => true;
+
+        public void MarkComplete() => IsComplete = true;
+
         public void WriteLine(string message)
         {
         }
@@ -424,6 +473,7 @@ public class OutputCoordinatorTests
             IBuildSystemFormatter formatter,
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
+            OutputFlushKind flushKind,
             CancellationToken cancellationToken = default)
         {
             FlushCount++;
@@ -441,6 +491,12 @@ public class OutputCoordinatorTests
         public Type ModuleType => typeof(BlockingOutputBuffer);
 
         public bool HasOutput => true;
+
+        public bool IsComplete { get; private set; }
+
+        public bool NeedsCompletionFlush => true;
+
+        public void MarkComplete() => IsComplete = true;
 
         public TaskCompletionSource FlushStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -468,6 +524,7 @@ public class OutputCoordinatorTests
             IBuildSystemFormatter formatter,
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
+            OutputFlushKind flushKind,
             CancellationToken cancellationToken = default)
         {
             FlushStarted.TrySetResult();
@@ -485,6 +542,8 @@ public class OutputCoordinatorTests
         public bool HasOutput => _hasOutput;
 
         public bool IsComplete { get; private set; }
+
+        public bool NeedsCompletionFlush => true;
 
         public int CompleteFlushCount { get; private set; }
 
@@ -518,18 +577,19 @@ public class OutputCoordinatorTests
             IBuildSystemFormatter formatter,
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
+            OutputFlushKind flushKind,
             CancellationToken cancellationToken = default)
         {
-            CompleteFlushCount++;
-            return Task.CompletedTask;
+            if (flushKind is OutputFlushKind.Complete)
+            {
+                CompleteFlushCount++;
+                return Task.CompletedTask;
+            }
+
+            return FlushIncrementallyAsync(cancellationToken);
         }
 
-        public async Task FlushIncrementallyToAsync(
-            TextWriter console,
-            IBuildSystemFormatter formatter,
-            ILogger logger,
-            ISpectreConsoleLoggerControl loggerControl,
-            CancellationToken cancellationToken = default)
+        private async Task FlushIncrementallyAsync(CancellationToken cancellationToken)
         {
             _hasOutput = false;
             IncrementalFlushStarted.TrySetResult();
@@ -543,6 +603,12 @@ public class OutputCoordinatorTests
         public Type ModuleType => typeof(SynchronouslyBlockingOutputBuffer);
 
         public bool HasOutput => true;
+
+        public bool IsComplete { get; private set; }
+
+        public bool NeedsCompletionFlush => true;
+
+        public void MarkComplete() => IsComplete = true;
 
         public TaskCompletionSource FlushStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -570,6 +636,7 @@ public class OutputCoordinatorTests
             IBuildSystemFormatter formatter,
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
+            OutputFlushKind flushKind,
             CancellationToken cancellationToken = default)
         {
             FlushStarted.TrySetResult();
@@ -583,6 +650,12 @@ public class OutputCoordinatorTests
         public Type ModuleType => typeof(PartiallyDeliveringOutputBuffer);
 
         public bool HasOutput => true;
+
+        public bool IsComplete { get; private set; }
+
+        public bool NeedsCompletionFlush => true;
+
+        public void MarkComplete() => IsComplete = true;
 
         public int DeliveryCount { get; private set; }
 
@@ -608,6 +681,7 @@ public class OutputCoordinatorTests
             IBuildSystemFormatter formatter,
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
+            OutputFlushKind flushKind,
             CancellationToken cancellationToken = default)
         {
             DeliveryCount++;

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -68,7 +68,7 @@ public class OutputCoordinatorTests
     }
 
     [Test]
-    public async Task DeferredFlush_FailureOnlyRequeuesUnstartedOutputs()
+    public async Task DeferredFlush_FailureRequeuesCurrentAndUnstartedOutputs()
     {
         var firstBuffer = new FailingOnceOutputBuffer();
         var secondBuffer = new CancellingOutputBuffer();
@@ -83,12 +83,12 @@ public class OutputCoordinatorTests
 
         await coordinator.FlushDeferredAsync();
 
-        await Assert.That(firstBuffer.FlushCount).IsEqualTo(1);
+        await Assert.That(firstBuffer.FlushCount).IsEqualTo(2);
         await Assert.That(secondBuffer.FlushCount).IsEqualTo(1);
     }
 
     [Test]
-    public async Task DeferredFlush_ProviderCancellationOnlyRequeuesUnstartedOutputs()
+    public async Task DeferredFlush_ProviderCancellationRequeuesCurrentAndUnstartedOutputs()
     {
         var firstBuffer = new FailingOnceOutputBuffer(new OperationCanceledException("provider cancelled"));
         var secondBuffer = new CancellingOutputBuffer();
@@ -103,7 +103,7 @@ public class OutputCoordinatorTests
 
         await coordinator.FlushDeferredAsync();
 
-        await Assert.That(firstBuffer.FlushCount).IsEqualTo(1);
+        await Assert.That(firstBuffer.FlushCount).IsEqualTo(2);
         await Assert.That(secondBuffer.FlushCount).IsEqualTo(1);
     }
 

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -179,6 +179,34 @@ public class OutputCoordinatorTests
     }
 
     [Test]
+    public async Task IncrementalFlush_UsesNonGenericLoggerForUnattributedOutput()
+    {
+        var buffer = new Mock<IModuleOutputBuffer>();
+        buffer.SetupGet(x => x.ModuleType).Returns(typeof(void));
+        buffer.SetupGet(x => x.HasOutput).Returns(true);
+        buffer
+            .Setup(x => x.FlushToAsync(
+                It.IsAny<TextWriter>(),
+                It.IsAny<IBuildSystemFormatter>(),
+                It.IsAny<ILogger>(),
+                It.IsAny<ISpectreConsoleLoggerControl>(),
+                OutputFlushKind.Incremental,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        await coordinator.EnqueueAndFlushAsync(buffer.Object, OutputFlushKind.Incremental);
+
+        buffer.Verify(x => x.FlushToAsync(
+            It.IsAny<TextWriter>(),
+            It.IsAny<IBuildSystemFormatter>(),
+            It.IsAny<ILogger>(),
+            It.IsAny<ISpectreConsoleLoggerControl>(),
+            OutputFlushKind.Incremental,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
     public async Task Completion_IsQueuedWhileIncrementalFlushOwnsOutput()
     {
         var buffer = new BlockingIncrementalOutputBuffer();

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -125,6 +125,28 @@ public class PipelineOutputCoordinatorTests
             Times.AtLeastOnce);
     }
 
+    [Test]
+    [Arguments(-1L)]
+    [Arguments((long) uint.MaxValue)]
+    public async Task Initialize_InvalidLiveFlushIntervalThrowsImmediately(long milliseconds)
+    {
+        var coordinator = new PipelineOutputCoordinator(
+            new RecordingProgressExecutor([]),
+            Mock.Of<IConsolePrinter>(),
+            Mock.Of<IInternalSummaryLogger>(),
+            Mock.Of<IExceptionBuffer>(),
+            Mock.Of<IConsoleCoordinator>(),
+            Mock.Of<IOutputCoordinator>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                ModuleOutputFlushInterval = TimeSpan.FromMilliseconds(milliseconds),
+            }),
+            Mock.Of<ILogger<PipelineOutputCoordinator>>());
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            await coordinator.InitializeAsync());
+    }
+
     private sealed class RecordingProgressExecutor(List<string> events) : IPrintProgressExecutor
     {
         public Task<IPrintProgressExecutor> InitializeAsync() => Task.FromResult<IPrintProgressExecutor>(this);

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -62,6 +62,9 @@ public class PipelineOutputCoordinatorTests
         outputCoordinator.Setup(x => x.FlushDeferredAsync(It.IsAny<CancellationToken>()))
             .Callback(() => events.Add("deferred"))
             .Returns(Task.CompletedTask);
+        outputCoordinator.Setup(x => x.WaitForPendingFlushesAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => events.Add("quiesced"))
+            .Returns(Task.CompletedTask);
 
         var coordinator = new PipelineOutputCoordinator(
             new RecordingProgressExecutor(events),
@@ -80,7 +83,7 @@ public class PipelineOutputCoordinatorTests
         await scope.DisposeAsync();
 
         await Assert.That(string.Join(",", events))
-            .IsEqualTo("retained,scheduled,progress,deferred,unattributed");
+            .IsEqualTo("quiesced,retained,scheduled,progress,deferred,unattributed");
         outputCoordinator.VerifyAll();
     }
 
@@ -102,6 +105,9 @@ public class PipelineOutputCoordinatorTests
         var outputCoordinator = new Mock<IOutputCoordinator>();
         outputCoordinator
             .Setup(x => x.FlushDeferredAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        outputCoordinator
+            .Setup(x => x.WaitForPendingFlushesAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         var coordinator = new PipelineOutputCoordinator(
             new RecordingProgressExecutor([]),

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -1,15 +1,42 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Console;
+using ModularPipelines.Context;
 using ModularPipelines.Engine.Executors;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
+using ModularPipelines.Modules;
 using ModularPipelines.Options;
+using ModularPipelines.TestHelpers;
 using Moq;
 
 namespace ModularPipelines.UnitTests.Engine;
 
 public class PipelineOutputCoordinatorTests
 {
+    private sealed class OptionsTestModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+    }
+
+    [Test]
+    public async Task PipelineBuilder_CopiesModuleOutputFlushInterval()
+    {
+        var builder = TestPipelineHostBuilder.Create()
+            .AddModule<OptionsTestModule>();
+        var expectedInterval = TimeSpan.FromSeconds(17);
+        builder.Options.ModuleOutputFlushInterval = expectedInterval;
+
+        await using var pipeline = builder.Build();
+        var runtimeOptions = pipeline.Services
+            .GetRequiredService<Microsoft.Extensions.Options.IOptions<PipelineOptions>>()
+            .Value;
+
+        await Assert.That(runtimeOptions.ModuleOutputFlushInterval).IsEqualTo(expectedInterval);
+    }
+
     [Test]
     public async Task Dispose_SchedulesBuffersCreatedByRetainedWriteFlush()
     {

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -1,7 +1,9 @@
+using Microsoft.Extensions.Logging;
 using ModularPipelines.Console;
 using ModularPipelines.Engine.Executors;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
+using ModularPipelines.Options;
 using Moq;
 
 namespace ModularPipelines.UnitTests.Engine;
@@ -40,7 +42,12 @@ public class PipelineOutputCoordinatorTests
             Mock.Of<IInternalSummaryLogger>(),
             Mock.Of<IExceptionBuffer>(),
             consoleCoordinator.Object,
-            outputCoordinator.Object);
+            outputCoordinator.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                ModuleOutputFlushInterval = TimeSpan.Zero,
+            }),
+            Mock.Of<ILogger<PipelineOutputCoordinator>>());
         var scope = await coordinator.InitializeAsync();
 
         await scope.DisposeAsync();
@@ -48,6 +55,47 @@ public class PipelineOutputCoordinatorTests
         await Assert.That(string.Join(",", events))
             .IsEqualTo("retained,scheduled,progress,deferred,unattributed");
         outputCoordinator.VerifyAll();
+    }
+
+    [Test]
+    public async Task RunningScope_PeriodicallyFlushesInProgressOutput()
+    {
+        var flushObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.FlushInProgressModuleOutputAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => flushObserved.TrySetResult())
+            .Returns(Task.CompletedTask);
+        consoleCoordinator
+            .Setup(x => x.FlushPendingWritesAsync())
+            .ReturnsAsync([]);
+        consoleCoordinator
+            .Setup(x => x.FlushModuleOutputAsync())
+            .Returns(Task.CompletedTask);
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(x => x.FlushDeferredAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var coordinator = new PipelineOutputCoordinator(
+            new RecordingProgressExecutor([]),
+            Mock.Of<IConsolePrinter>(),
+            Mock.Of<IInternalSummaryLogger>(),
+            Mock.Of<IExceptionBuffer>(),
+            consoleCoordinator.Object,
+            outputCoordinator.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                ModuleOutputFlushInterval = TimeSpan.FromMilliseconds(10),
+            }),
+            Mock.Of<ILogger<PipelineOutputCoordinator>>());
+
+        var scope = await coordinator.InitializeAsync();
+        await flushObserved.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await scope.DisposeAsync();
+
+        consoleCoordinator.Verify(
+            x => x.FlushInProgressModuleOutputAsync(It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce);
     }
 
     private sealed class RecordingProgressExecutor(List<string> events) : IPrintProgressExecutor

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -136,12 +136,25 @@ public class PipelineOutputCoordinatorTests
     [Arguments((long) uint.MaxValue)]
     public async Task Initialize_InvalidLiveFlushIntervalThrowsImmediately(long milliseconds)
     {
+        var events = new List<string>();
+        var progressExecutor = new Mock<IPrintProgressExecutor>();
+        progressExecutor
+            .Setup(x => x.InitializeAsync())
+            .Callback(() => events.Add("progress"))
+            .ReturnsAsync(progressExecutor.Object);
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.Install())
+            .Callback(() => events.Add("install"));
+        consoleCoordinator
+            .Setup(x => x.EnableOutputBuffering())
+            .Callback(() => events.Add("buffer"));
         var coordinator = new PipelineOutputCoordinator(
-            new RecordingProgressExecutor([]),
+            progressExecutor.Object,
             Mock.Of<IConsolePrinter>(),
             Mock.Of<IInternalSummaryLogger>(),
             Mock.Of<IExceptionBuffer>(),
-            Mock.Of<IConsoleCoordinator>(),
+            consoleCoordinator.Object,
             Mock.Of<IOutputCoordinator>(),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
@@ -151,6 +164,7 @@ public class PipelineOutputCoordinatorTests
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
             await coordinator.InitializeAsync());
+        await Assert.That(events).IsEmpty();
     }
 
     private sealed class RecordingProgressExecutor(List<string> events) : IPrintProgressExecutor

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -103,6 +103,33 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task AvailableFlush_RetainsPotentialSecretPrefix()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("split-secret");
+        var outputBuffer = new Mock<IModuleOutputBuffer>();
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetUnattributedBuffer()).Returns(outputBuffer.Object);
+
+        using var writer = new CoordinatedTextWriter(
+            coordinator.Object,
+            new StringWriter(),
+            () => true,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("split-");
+        await writer.FlushAvailableAsync();
+
+        outputBuffer.Verify(x => x.WriteLine(It.IsAny<string>()), Times.Never);
+
+        writer.WriteLine("secret");
+
+        outputBuffer.Verify(x => x.WriteLine("**********"), Times.Once);
+        outputBuffer.Verify(x => x.WriteLine(It.Is<string>(value => value.Contains("split-secret"))), Times.Never);
+    }
+
+    [Test]
     public async Task DirectConsoleWrites_MaskSecretSplitAcrossChunks()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -130,6 +130,31 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task AvailableFlush_MasksCompleteSecretOverlappingRetainedPrefix()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("abc");
+        provider.AddSecret("bcx");
+        var outputBuffer = new Mock<IModuleOutputBuffer>();
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetUnattributedBuffer()).Returns(outputBuffer.Object);
+
+        using var writer = new CoordinatedTextWriter(
+            coordinator.Object,
+            new StringWriter(),
+            () => true,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("abc");
+        await writer.FlushAvailableAsync();
+        writer.WriteLine("y");
+
+        outputBuffer.Verify(x => x.WriteLine(It.Is<string>(value => value.Contains("abc"))), Times.Never);
+        outputBuffer.Verify(x => x.WriteLine(It.Is<string>(value => value.Contains("**********"))), Times.Once);
+    }
+
+    [Test]
     public async Task DirectConsoleWrites_MaskSecretSplitAcrossChunks()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -465,6 +465,21 @@ public class ValidationTests
     }
 
     [Test]
+    public async Task ValidateAsync_WithNegativeModuleOutputFlushInterval_ReturnsError()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.Services.AddModule<SimpleModule>();
+        builder.Options.ModuleOutputFlushInterval = TimeSpan.FromSeconds(-1);
+
+        var result = await builder.ValidateAsync();
+
+        await Assert.That(result.HasErrors).IsTrue();
+        await Assert.That(result.Errors.Any(e =>
+            e.Category == ValidationErrorCategory.Options &&
+            e.Message.Contains("ModuleOutputFlushInterval"))).IsTrue();
+    }
+
+    [Test]
     public async Task ValidateAsync_WithConflictingCategories_ReturnsError()
     {
         // Arrange

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -480,6 +480,21 @@ public class ValidationTests
     }
 
     [Test]
+    public async Task ValidateAsync_WithTooLargeModuleOutputFlushInterval_ReturnsError()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.Services.AddModule<SimpleModule>();
+        builder.Options.ModuleOutputFlushInterval = TimeSpan.FromMilliseconds(uint.MaxValue);
+
+        var result = await builder.ValidateAsync();
+
+        await Assert.That(result.HasErrors).IsTrue();
+        await Assert.That(result.Errors.Any(e =>
+            e.Category == ValidationErrorCategory.Options &&
+            e.Message.Contains("ModuleOutputFlushInterval"))).IsTrue();
+    }
+
+    [Test]
     public async Task ValidateAsync_WithConflictingCategories_ReturnsError()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- periodically flush buffered output from modules that are still running, preserving diagnostics across hard process termination
- route live chunks through the existing serialized, secret-masked output path and label them as in progress
- fence completed buffers so final ordered output is not drained by the live timer
- expose `PipelineOptions.ModuleOutputFlushInterval` (one minute by default; zero disables) and document it

## Validation
- focused output coordinator/buffer suite: 24/24 passed using a minimal harness against the production assembly
- `dotnet build src/ModularPipelines/ModularPipelines.csproj -c Release --no-restore -maxcpucount:1 --verbosity:minimal -nodeReuse:false -p:UseSharedCompilation=false` (255 existing warnings, 0 errors after rebase)
- touched-file whitespace verification and `git diff --check` pass
- the monolithic unit-test project compiler was attempted twice but stalled without diagnostics on this host; both exact orphaned build/compiler processes were stopped

Closes #3184