### PR TITLE
Revalidate the runnable dependency graph at run time

### DIFF
--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -7,6 +7,7 @@ using ModularPipelines.Distributed.Serialization;
 using ModularPipelines.Distributed.Worker;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -24,6 +25,9 @@ internal class DistributedModuleExecutor(
     ModuleTypeRegistry typeRegistry,
     ModuleResultSerializer serializer,
     IModuleResultRegistry resultRegistry,
+    IEnumerable<IModule> registeredModules,
+    IModuleDependencyRegistry dependencyRegistry,
+    IModuleMetadataRegistry metadataRegistry,
     IOptions<DistributedOptions> options,
     ArtifactLifecycleManager? artifactLifecycleManager,
     ILogger<DistributedModuleExecutor> logger) : IModuleExecutor
@@ -38,6 +42,9 @@ internal class DistributedModuleExecutor(
     private readonly ModuleTypeRegistry _typeRegistry = typeRegistry;
     private readonly ModuleResultSerializer _serializer = serializer;
     private readonly IModuleResultRegistry _resultRegistry = resultRegistry;
+    private readonly IEnumerable<IModule> _registeredModules = registeredModules;
+    private readonly IModuleDependencyRegistry _dependencyRegistry = dependencyRegistry;
+    private readonly IModuleMetadataRegistry _metadataRegistry = metadataRegistry;
     private readonly IOptions<DistributedOptions> _options = options;
     private readonly ArtifactLifecycleManager? _artifactLifecycleManager = artifactLifecycleManager;
     private readonly ILogger<DistributedModuleExecutor> _logger = logger;
@@ -60,6 +67,12 @@ internal class DistributedModuleExecutor(
 
         // Invoke registration events before dependency resolution
         await _registrationEventExecutor.InvokeRegistrationEventsAsync(modules).ConfigureAwait(false);
+
+        // Revalidate the runnable set now that registration-event dependencies are populated, so
+        // missing/self/cyclic dependencies (including ones added via AddDependency) fail fast here
+        // rather than the master hanging or failing late. The full registered set is the available
+        // universe, so depending on a registered-but-skipped module is not misreported as missing.
+        ModuleDependencyValidator.Validate(modules, _registeredModules, _dependencyRegistry, _metadataRegistry);
 
         // Wait for workers to register before distributing work
         await WaitForWorkersAsync(_lifetime.ApplicationStopping);

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -25,7 +25,6 @@ internal class DistributedModuleExecutor(
     ModuleTypeRegistry typeRegistry,
     ModuleResultSerializer serializer,
     IModuleResultRegistry resultRegistry,
-    IEnumerable<IModule> registeredModules,
     IModuleDependencyRegistry dependencyRegistry,
     IModuleMetadataRegistry metadataRegistry,
     IOptions<DistributedOptions> options,
@@ -42,7 +41,6 @@ internal class DistributedModuleExecutor(
     private readonly ModuleTypeRegistry _typeRegistry = typeRegistry;
     private readonly ModuleResultSerializer _serializer = serializer;
     private readonly IModuleResultRegistry _resultRegistry = resultRegistry;
-    private readonly IEnumerable<IModule> _registeredModules = registeredModules;
     private readonly IModuleDependencyRegistry _dependencyRegistry = dependencyRegistry;
     private readonly IModuleMetadataRegistry _metadataRegistry = metadataRegistry;
     private readonly IOptions<DistributedOptions> _options = options;
@@ -70,9 +68,8 @@ internal class DistributedModuleExecutor(
 
         // Revalidate the runnable set now that registration-event dependencies are populated, so
         // missing/self/cyclic dependencies (including ones added via AddDependency) fail fast here
-        // rather than the master hanging or failing late. The full registered set is the available
-        // universe, so depending on a registered-but-skipped module is not misreported as missing.
-        ModuleDependencyValidator.Validate(modules, _registeredModules, _dependencyRegistry, _metadataRegistry);
+        // rather than the master hanging or failing late. Mirrors the standalone ModuleExecutor.
+        ModuleDependencyValidator.Validate(modules, _dependencyRegistry, _metadataRegistry);
 
         // Wait for workers to register before distributing work
         await WaitForWorkersAsync(_lifetime.ApplicationStopping);

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -30,7 +30,6 @@ internal class ModuleExecutor : IModuleExecutor
     private readonly IParallelLimitProvider _parallelLimitProvider;
     private readonly IRegistrationEventExecutor _registrationEventExecutor;
     private readonly IMetricsCollector _metricsCollector;
-    private readonly IEnumerable<IModule> _registeredModules;
     private readonly IModuleDependencyRegistry _dependencyRegistry;
     private readonly IModuleMetadataRegistry _metadataRegistry;
     private readonly IOptions<PipelineOptions> _pipelineOptions;
@@ -44,7 +43,6 @@ internal class ModuleExecutor : IModuleExecutor
         IParallelLimitProvider parallelLimitProvider,
         IRegistrationEventExecutor registrationEventExecutor,
         IMetricsCollector metricsCollector,
-        IEnumerable<IModule> registeredModules,
         IModuleDependencyRegistry dependencyRegistry,
         IModuleMetadataRegistry metadataRegistry,
         IOptions<PipelineOptions> pipelineOptions,
@@ -57,7 +55,6 @@ internal class ModuleExecutor : IModuleExecutor
         _parallelLimitProvider = parallelLimitProvider;
         _registrationEventExecutor = registrationEventExecutor;
         _metricsCollector = metricsCollector;
-        _registeredModules = registeredModules;
         _dependencyRegistry = dependencyRegistry;
         _metadataRegistry = metadataRegistry;
         _pipelineOptions = pipelineOptions;
@@ -115,10 +112,11 @@ internal class ModuleExecutor : IModuleExecutor
         // Revalidate the runnable set now that registration-event dependencies are populated and
         // discovery has settled. Build-time validation only saw the statically registered graph;
         // dependencies added via IModuleRegistrationContext.AddDependency, and modules whose
-        // runnability depends on stateful run conditions, are only fully known here. The full
-        // registered set is the available universe, so a runnable module depending on a
-        // registered-but-skipped module is not misreported as missing.
-        ModuleDependencyValidator.Validate(modules, _registeredModules, _dependencyRegistry, _metadataRegistry);
+        // runnability depends on stateful run conditions, are only fully known here. Validating
+        // the runnable set against itself mirrors the DependencyWaiter check (a required
+        // dependency outside the runnable set throws), surfacing missing/cyclic dependencies
+        // eagerly with a clear message instead of failing later in the scheduler.
+        ModuleDependencyValidator.Validate(modules, _dependencyRegistry, _metadataRegistry);
 
         var scheduler = _schedulerFactory.Create();
         scheduler.InitializeModules(modules);

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Helpers;
 using ModularPipelines.Interfaces;
@@ -29,6 +30,9 @@ internal class ModuleExecutor : IModuleExecutor
     private readonly IParallelLimitProvider _parallelLimitProvider;
     private readonly IRegistrationEventExecutor _registrationEventExecutor;
     private readonly IMetricsCollector _metricsCollector;
+    private readonly IEnumerable<IModule> _registeredModules;
+    private readonly IModuleDependencyRegistry _dependencyRegistry;
+    private readonly IModuleMetadataRegistry _metadataRegistry;
     private readonly IOptions<PipelineOptions> _pipelineOptions;
     private readonly ILogger<ModuleExecutor> _logger;
 
@@ -40,6 +44,9 @@ internal class ModuleExecutor : IModuleExecutor
         IParallelLimitProvider parallelLimitProvider,
         IRegistrationEventExecutor registrationEventExecutor,
         IMetricsCollector metricsCollector,
+        IEnumerable<IModule> registeredModules,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
         IOptions<PipelineOptions> pipelineOptions,
         ILogger<ModuleExecutor> logger)
     {
@@ -50,6 +57,9 @@ internal class ModuleExecutor : IModuleExecutor
         _parallelLimitProvider = parallelLimitProvider;
         _registrationEventExecutor = registrationEventExecutor;
         _metricsCollector = metricsCollector;
+        _registeredModules = registeredModules;
+        _dependencyRegistry = dependencyRegistry;
+        _metadataRegistry = metadataRegistry;
         _pipelineOptions = pipelineOptions;
         _logger = logger;
     }
@@ -101,6 +111,14 @@ internal class ModuleExecutor : IModuleExecutor
 
         // Invoke registration events before dependency resolution
         await _registrationEventExecutor.InvokeRegistrationEventsAsync(modules).ConfigureAwait(false);
+
+        // Revalidate the runnable set now that registration-event dependencies are populated and
+        // discovery has settled. Build-time validation only saw the statically registered graph;
+        // dependencies added via IModuleRegistrationContext.AddDependency, and modules whose
+        // runnability depends on stateful run conditions, are only fully known here. The full
+        // registered set is the available universe, so a runnable module depending on a
+        // registered-but-skipped module is not misreported as missing.
+        ModuleDependencyValidator.Validate(modules, _registeredModules, _dependencyRegistry, _metadataRegistry);
 
         var scheduler = _schedulerFactory.Create();
         scheduler.InitializeModules(modules);

--- a/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
+++ b/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
@@ -24,14 +24,45 @@ public static class ModuleDependencyValidator
         IModuleDependencyRegistry? dynamicRegistry,
         IModuleMetadataRegistry? metadataRegistry)
     {
-        var modulesByType = registeredModules
+        // Whole-graph validation: the modules to validate ARE the full registered set.
+        var materialized = registeredModules as IReadOnlyCollection<IModule> ?? registeredModules.ToArray();
+        Validate(materialized, materialized, dynamicRegistry, metadataRegistry);
+    }
+
+    /// <summary>
+    /// Validates the dependencies of <paramref name="modulesToValidate"/> against the universe of
+    /// <paramref name="availableModules"/>. A required dependency is satisfiable when its target is
+    /// present in <paramref name="availableModules"/> (or is itself one of the modules being
+    /// validated), so a runnable module that depends on a <b>registered-but-skipped</b> module is
+    /// not falsely reported as missing.
+    /// </summary>
+    /// <remarks>
+    /// Used at run time to revalidate the runnable set once dynamic (registration-event)
+    /// dependencies have been populated: the runnable set is the modules-to-validate and the full
+    /// registered set is the available universe. This catches missing/self/cyclic dependencies —
+    /// including ones introduced by <c>IModuleRegistrationContext.AddDependency</c> — eagerly,
+    /// instead of letting them surface later in the scheduler/dependency waiter.
+    /// </remarks>
+    internal static void Validate(
+        IEnumerable<IModule> modulesToValidate,
+        IEnumerable<IModule> availableModules,
+        IModuleDependencyRegistry? dynamicRegistry,
+        IModuleMetadataRegistry? metadataRegistry)
+    {
+        var modulesByType = modulesToValidate
             .GroupBy(module => module.GetType())
             .ToDictionary(group => group.Key, group => group.First());
-        var moduleTypes = modulesByType.Keys.ToHashSet();
-        if (moduleTypes.Count == 0)
+        var moduleTypesToValidate = modulesByType.Keys.ToHashSet();
+        if (moduleTypesToValidate.Count == 0)
         {
             return;
         }
+
+        // The universe a dependency may resolve to: every available (registered) module, plus the
+        // modules being validated. Registered-but-skipped modules remain in this set, so depending
+        // on one is not a "missing dependency".
+        var availableTypes = availableModules.Select(module => module.GetType()).ToHashSet();
+        availableTypes.UnionWith(moduleTypesToValidate);
 
         foreach (var (moduleType, module) in modulesByType)
         {
@@ -40,7 +71,7 @@ public static class ModuleDependencyValidator
 
         var dependenciesByModule = modulesByType.ToDictionary(
             pair => pair.Key,
-            pair => GetAllDependencies(pair.Value, moduleTypes, dynamicRegistry, metadataRegistry));
+            pair => GetAllDependencies(pair.Value, availableTypes, dynamicRegistry, metadataRegistry));
 
         foreach (var (moduleType, dependencies) in dependenciesByModule)
         {
@@ -53,7 +84,7 @@ public static class ModuleDependencyValidator
                         "A module cannot depend on its own result.");
                 }
 
-                if (!optional && !moduleTypes.Contains(dependencyType))
+                if (!optional && !availableTypes.Contains(dependencyType))
                 {
                     throw new ModuleNotRegisteredException(
                         $"Module '{moduleType.Name}' requires '{dependencyType.Name}', " +
@@ -66,7 +97,7 @@ public static class ModuleDependencyValidator
         var dependencyGraph = dependenciesByModule.ToDictionary(
             pair => pair.Key,
             pair => pair.Value
-                .Where(dependency => moduleTypes.Contains(dependency.DependencyType))
+                .Where(dependency => moduleTypesToValidate.Contains(dependency.DependencyType))
                 .Select(dependency => dependency.DependencyType)
                 .ToHashSet());
         ValidateCircularDependencies(dependencyGraph);

--- a/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
+++ b/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
@@ -24,45 +24,14 @@ public static class ModuleDependencyValidator
         IModuleDependencyRegistry? dynamicRegistry,
         IModuleMetadataRegistry? metadataRegistry)
     {
-        // Whole-graph validation: the modules to validate ARE the full registered set.
-        var materialized = registeredModules as IReadOnlyCollection<IModule> ?? registeredModules.ToArray();
-        Validate(materialized, materialized, dynamicRegistry, metadataRegistry);
-    }
-
-    /// <summary>
-    /// Validates the dependencies of <paramref name="modulesToValidate"/> against the universe of
-    /// <paramref name="availableModules"/>. A required dependency is satisfiable when its target is
-    /// present in <paramref name="availableModules"/> (or is itself one of the modules being
-    /// validated), so a runnable module that depends on a <b>registered-but-skipped</b> module is
-    /// not falsely reported as missing.
-    /// </summary>
-    /// <remarks>
-    /// Used at run time to revalidate the runnable set once dynamic (registration-event)
-    /// dependencies have been populated: the runnable set is the modules-to-validate and the full
-    /// registered set is the available universe. This catches missing/self/cyclic dependencies —
-    /// including ones introduced by <c>IModuleRegistrationContext.AddDependency</c> — eagerly,
-    /// instead of letting them surface later in the scheduler/dependency waiter.
-    /// </remarks>
-    internal static void Validate(
-        IEnumerable<IModule> modulesToValidate,
-        IEnumerable<IModule> availableModules,
-        IModuleDependencyRegistry? dynamicRegistry,
-        IModuleMetadataRegistry? metadataRegistry)
-    {
-        var modulesByType = modulesToValidate
+        var modulesByType = registeredModules
             .GroupBy(module => module.GetType())
             .ToDictionary(group => group.Key, group => group.First());
-        var moduleTypesToValidate = modulesByType.Keys.ToHashSet();
-        if (moduleTypesToValidate.Count == 0)
+        var moduleTypes = modulesByType.Keys.ToHashSet();
+        if (moduleTypes.Count == 0)
         {
             return;
         }
-
-        // The universe a dependency may resolve to: every available (registered) module, plus the
-        // modules being validated. Registered-but-skipped modules remain in this set, so depending
-        // on one is not a "missing dependency".
-        var availableTypes = availableModules.Select(module => module.GetType()).ToHashSet();
-        availableTypes.UnionWith(moduleTypesToValidate);
 
         foreach (var (moduleType, module) in modulesByType)
         {
@@ -71,7 +40,7 @@ public static class ModuleDependencyValidator
 
         var dependenciesByModule = modulesByType.ToDictionary(
             pair => pair.Key,
-            pair => GetAllDependencies(pair.Value, availableTypes, dynamicRegistry, metadataRegistry));
+            pair => GetAllDependencies(pair.Value, moduleTypes, dynamicRegistry, metadataRegistry));
 
         foreach (var (moduleType, dependencies) in dependenciesByModule)
         {
@@ -84,7 +53,7 @@ public static class ModuleDependencyValidator
                         "A module cannot depend on its own result.");
                 }
 
-                if (!optional && !availableTypes.Contains(dependencyType))
+                if (!optional && !moduleTypes.Contains(dependencyType))
                 {
                     throw new ModuleNotRegisteredException(
                         $"Module '{moduleType.Name}' requires '{dependencyType.Name}', " +
@@ -97,7 +66,7 @@ public static class ModuleDependencyValidator
         var dependencyGraph = dependenciesByModule.ToDictionary(
             pair => pair.Key,
             pair => pair.Value
-                .Where(dependency => moduleTypesToValidate.Contains(dependency.DependencyType))
+                .Where(dependency => moduleTypes.Contains(dependency.DependencyType))
                 .Select(dependency => dependency.DependencyType)
                 .ToHashSet());
         ValidateCircularDependencies(dependencyGraph);

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -11,15 +11,24 @@ using ModularPipelines.Distributed.Serialization;
 using ModularPipelines.Distributed.Worker;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Enums;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 
 namespace ModularPipelines.Distributed.UnitTests.Master;
 
 public class DistributedModuleExecutorTests
 {
+    // Real, empty registries so the master's pre-distribution dependency validation is a no-op
+    // for these dependency-free test modules (matches the production DI singletons).
+    private static ModuleDependencyRegistry NewDependencyRegistry() => new();
+
+    private static ModuleMetadataRegistry NewMetadataRegistry() =>
+        new(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()));
+
     // --- Test module types ---
 
     private class SimpleResult
@@ -168,6 +177,9 @@ public class DistributedModuleExecutorTests
             typeRegistry,
             serializer,
             resultRegistry,
+            System.Array.Empty<IModule>(),
+            NewDependencyRegistry(),
+            NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(new DistributedOptions()),
             artifactManager,
             NullLogger<DistributedModuleExecutor>.Instance);
@@ -654,7 +666,8 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, Microsoft.Extensions.Options.Options.Create(new DistributedOptions()),
+            resultRegistry, System.Array.Empty<IModule>(), NewDependencyRegistry(), NewMetadataRegistry(),
+            Microsoft.Extensions.Options.Options.Create(new DistributedOptions()),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
         // Act
@@ -701,7 +714,8 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             noDequeue, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, Microsoft.Extensions.Options.Options.Create(distributedOptions),
+            resultRegistry, System.Array.Empty<IModule>(), NewDependencyRegistry(), NewMetadataRegistry(),
+            Microsoft.Extensions.Options.Options.Create(distributedOptions),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
         // Simulate a worker registering after a short delay
@@ -796,7 +810,8 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, Microsoft.Extensions.Options.Options.Create(distributedOptions),
+            resultRegistry, System.Array.Empty<IModule>(), NewDependencyRegistry(), NewMetadataRegistry(),
+            Microsoft.Extensions.Options.Options.Create(distributedOptions),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
         // Act — should proceed after 3 seconds timeout even though only 1/3 workers registered

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -177,7 +177,6 @@ public class DistributedModuleExecutorTests
             typeRegistry,
             serializer,
             resultRegistry,
-            System.Array.Empty<IModule>(),
             NewDependencyRegistry(),
             NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(new DistributedOptions()),
@@ -666,7 +665,7 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, System.Array.Empty<IModule>(), NewDependencyRegistry(), NewMetadataRegistry(),
+            resultRegistry, NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(new DistributedOptions()),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
@@ -714,7 +713,7 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             noDequeue, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, System.Array.Empty<IModule>(), NewDependencyRegistry(), NewMetadataRegistry(),
+            resultRegistry, NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
@@ -810,7 +809,7 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, System.Array.Empty<IModule>(), NewDependencyRegistry(), NewMetadataRegistry(),
+            resultRegistry, NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 

--- a/test/ModularPipelines.UnitTests/Attributes/DynamicDependencyIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/DynamicDependencyIntegrationTests.cs
@@ -1,5 +1,6 @@
 using ModularPipelines.Attributes.Events;
 using ModularPipelines.Context;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
 
@@ -47,6 +48,28 @@ public class DynamicDependencyIntegrationTests : TestBase
         }
     }
 
+    // Never registered — a dynamic dependency on this module cannot be satisfied.
+    public class UnregisteredModule : Module<string>
+    {
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            return "unregistered";
+        }
+    }
+
+    // The dependency is added at registration time (after build-time auto-registration has run),
+    // so nothing auto-registers UnregisteredModule and it must be caught by the run-time revalidation.
+    [AddDependency(typeof(UnregisteredModule))]
+    public class ModuleWithMissingDynamicDependency : Module<string>
+    {
+        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            return "never runs";
+        }
+    }
+
     [Before(Test)]
     public void ClearExecutionOrder()
     {
@@ -63,5 +86,18 @@ public class DynamicDependencyIntegrationTests : TestBase
 
         await Assert.That(result.Status).IsEqualTo(Enums.Status.Successful);
         await Assert.That(ExecutionOrder).IsEquivalentTo(new[] { "A", "B" });
+    }
+
+    [Test]
+    public async Task DynamicDependency_OnUnregisteredModule_FailsFast()
+    {
+        // A dependency added via a registration event on a module that is not registered
+        // (and cannot be auto-registered, because it is not declared via [DependsOn]) must be
+        // caught by the run-time revalidation of the canonical graph, before the scheduler runs,
+        // rather than surfacing late as a dependency-waiter failure.
+        await Assert.ThrowsAsync<ModuleNotRegisteredException>(() =>
+            TestPipelineHostBuilder.Create()
+                .AddModule<ModuleWithMissingDynamicDependency>()
+                .ExecutePipelineAsync());
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -1,8 +1,10 @@
 using System.Collections.Concurrent;
 using System.Text;
 using System.Threading.Channels;
+using ModularPipelines.Configuration;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Engine.Scheduling;
 using ModularPipelines.Helpers;
@@ -39,6 +41,9 @@ public class ModuleExecutorLoggingTests
         var parallelLimitProvider = new Mock<IParallelLimitProvider>();
         parallelLimitProvider.Setup(x => x.GetMaxDegreeOfParallelism()).Returns(1);
 
+        var module = new Mock<IModule>();
+        module.SetupGet(x => x.Configuration).Returns(ModuleConfiguration.Default);
+
         var executor = new ModuleExecutor(
             schedulerFactory.Object,
             Mock.Of<IModuleRunner>(),
@@ -47,10 +52,13 @@ public class ModuleExecutorLoggingTests
             parallelLimitProvider.Object,
             registrationEvents.Object,
             Mock.Of<IMetricsCollector>(),
+            new[] { module.Object },
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
             new StringLogger<ModuleExecutor>(logs));
 
-        await executor.ExecuteAsync([Mock.Of<IModule>()]);
+        await executor.ExecuteAsync([module.Object]);
 
         var logOutput = logs.ToString();
         await Assert.That(logOutput).DoesNotContain("Cancellation triggered");

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -52,7 +52,6 @@ public class ModuleExecutorLoggingTests
             parallelLimitProvider.Object,
             registrationEvents.Object,
             Mock.Of<IMetricsCollector>(),
-            new[] { module.Object },
             new ModuleDependencyRegistry(),
             new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),

--- a/test/ModularPipelines.UnitTests/Modules/ModuleDependencyValidatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/ModuleDependencyValidatorTests.cs
@@ -1,46 +1,47 @@
-using ModularPipelines.Attributes;
 using ModularPipelines.Context;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Modules;
 
 namespace ModularPipelines.UnitTests.Modules;
 
 /// <summary>
-/// Covers the run-time validation overload that separates the modules being validated from the
-/// universe of available modules, so the runnable set can be revalidated without misreporting a
-/// dependency on a registered-but-skipped module as missing.
+/// Covers dependency validation over the dynamic (registration-event) dependency registry, which
+/// the executors invoke against the runnable set once registration events have populated it.
 /// </summary>
 public class ModuleDependencyValidatorTests
 {
     [Test]
-    public async Task Runnable_Module_Depending_On_Registered_But_Skipped_Module_Does_Not_Throw()
+    public async Task Validate_Dynamic_Dependency_On_Module_Outside_The_Set_Throws()
+    {
+        var consumer = new ConsumerModule();
+
+        var dynamicRegistry = new ModuleDependencyRegistry();
+        dynamicRegistry.AddDynamicDependency(typeof(ConsumerModule), typeof(ProducerModule));
+
+        // The producer is not among the validated modules, so the required dynamic dependency is
+        // unsatisfiable and must be reported eagerly (mirrors the DependencyWaiter failure).
+        await Assert.That(() => ModuleDependencyValidator.Validate(
+                new IModule[] { consumer },
+                dynamicRegistry,
+                metadataRegistry: null))
+            .Throws<ModuleNotRegisteredException>();
+    }
+
+    [Test]
+    public async Task Validate_Dynamic_Dependency_On_Module_In_The_Set_Does_Not_Throw()
     {
         var consumer = new ConsumerModule();
         var producer = new ProducerModule();
 
-        // The consumer is the only runnable module; the producer is registered but skipped
-        // (e.g. an OS-only module on a foreign OS), so it is available but not in the runnable set.
+        var dynamicRegistry = new ModuleDependencyRegistry();
+        dynamicRegistry.AddDynamicDependency(typeof(ConsumerModule), typeof(ProducerModule));
+
         await Assert.That(() => ModuleDependencyValidator.Validate(
-                modulesToValidate: new IModule[] { consumer },
-                availableModules: new IModule[] { consumer, producer },
-                dynamicRegistry: null,
+                new IModule[] { consumer, producer },
+                dynamicRegistry,
                 metadataRegistry: null))
             .ThrowsNothing();
-    }
-
-    [Test]
-    public async Task Runnable_Module_Depending_On_Unavailable_Module_Throws()
-    {
-        var consumer = new ConsumerModule();
-
-        // The producer is neither runnable nor registered, so the required dependency is genuinely
-        // unsatisfiable and must be reported.
-        await Assert.That(() => ModuleDependencyValidator.Validate(
-                modulesToValidate: new IModule[] { consumer },
-                availableModules: new IModule[] { consumer },
-                dynamicRegistry: null,
-                metadataRegistry: null))
-            .Throws<ModuleNotRegisteredException>();
     }
 
     private sealed class ProducerModule : Module<string>
@@ -49,7 +50,6 @@ public class ModuleDependencyValidatorTests
             => Task.FromResult<string?>("produced");
     }
 
-    [DependsOn<ProducerModule>]
     private sealed class ConsumerModule : Module<string>
     {
         protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)

--- a/test/ModularPipelines.UnitTests/Modules/ModuleDependencyValidatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/ModuleDependencyValidatorTests.cs
@@ -1,0 +1,58 @@
+using ModularPipelines.Attributes;
+using ModularPipelines.Context;
+using ModularPipelines.Exceptions;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.UnitTests.Modules;
+
+/// <summary>
+/// Covers the run-time validation overload that separates the modules being validated from the
+/// universe of available modules, so the runnable set can be revalidated without misreporting a
+/// dependency on a registered-but-skipped module as missing.
+/// </summary>
+public class ModuleDependencyValidatorTests
+{
+    [Test]
+    public async Task Runnable_Module_Depending_On_Registered_But_Skipped_Module_Does_Not_Throw()
+    {
+        var consumer = new ConsumerModule();
+        var producer = new ProducerModule();
+
+        // The consumer is the only runnable module; the producer is registered but skipped
+        // (e.g. an OS-only module on a foreign OS), so it is available but not in the runnable set.
+        await Assert.That(() => ModuleDependencyValidator.Validate(
+                modulesToValidate: new IModule[] { consumer },
+                availableModules: new IModule[] { consumer, producer },
+                dynamicRegistry: null,
+                metadataRegistry: null))
+            .ThrowsNothing();
+    }
+
+    [Test]
+    public async Task Runnable_Module_Depending_On_Unavailable_Module_Throws()
+    {
+        var consumer = new ConsumerModule();
+
+        // The producer is neither runnable nor registered, so the required dependency is genuinely
+        // unsatisfiable and must be reported.
+        await Assert.That(() => ModuleDependencyValidator.Validate(
+                modulesToValidate: new IModule[] { consumer },
+                availableModules: new IModule[] { consumer },
+                dynamicRegistry: null,
+                metadataRegistry: null))
+            .Throws<ModuleNotRegisteredException>();
+    }
+
+    private sealed class ProducerModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult<string?>("produced");
+    }
+
+    [DependsOn<ProducerModule>]
+    private sealed class ConsumerModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult<string?>("consumed");
+    }
+}


### PR DESCRIPTION
Addresses the two open **P2** review comments from #3086 (both on `PipelineImpl.cs`).

## Problem

Dependency validation runs at build time (`BuildAsync`/`ValidateAsync` → `PipelineImpl.CreateAsync`), but two kinds of edges are only known at **run time**:

1. **Dynamic dependencies** added via `IModuleRegistrationContext.AddDependency` — the registration-event receivers that add them are only invoked during `RunAsync` (`ModuleExecutor.InitializeSchedulerAsync`), so build-time validation sees an empty dependency registry.
2. **Condition-dependent runnability** — `PipelineInitializer` re-evaluates discovery during `RunAsync` after pipeline-start hooks, so a stateful/time-varying run condition can make a module runnable whose dependencies were never validated.

The successful path never revalidated afterward, so a registration-time missing/cyclic dependency passed validation and only failed late in the scheduler's `DependencyWaiter`.

## Fix

After registration events populate dynamic dependencies (and discovery has settled), the standalone `ModuleExecutor` and the master `DistributedModuleExecutor` revalidate the **runnable set** — `ModuleDependencyValidator.Validate(modules, dynamicRegistry, metadataRegistry)` — before scheduling.

This is an **eager mirror of the existing `DependencyWaiter` check**: the validator throws for a required dependency that is not in the runnable set, which is the identical condition under which `DependencyWaiter` throws `ModuleNotRegisteredException` (a required dependency whose `GetModuleCompletionTask` is null because it isn't a scheduled/runnable module). So validation and runtime agree — the check simply runs earlier, before scheduling, with a clearer message — and dynamic missing/cyclic dependencies are caught eagerly instead of surfacing late.

## Changes

- `ModuleExecutor` / `DistributedModuleExecutor`: inject the dependency + metadata registries; validate the runnable set immediately after registration events, before scheduling. (`WorkerModuleExecutor` is intentionally untouched — workers execute individually-assigned modules and don't build the graph.)
- `ModuleDependencyValidator`: **unchanged** — the fix reuses the existing overload. (An earlier revision added a separate available-universe overload; that was dropped after review, since it made the validator accept a dependency the runtime rejects.)
- Tests:
  - End-to-end: a registration-event dependency on an unregistered module now fails fast with `ModuleNotRegisteredException` during `RunAsync` instead of surfacing late.
  - Unit: validation over the dynamic dependency registry throws for a dynamic dependency outside the validated set and passes when it's present.

## Notes
- This is run-time revalidation (the reviewers' explicitly-accepted remedy: *"revalidate the canonical graph immediately after those events run"*). `BuildAsync`/`ValidateAsync` still can't see dynamic/condition-dependent edges, since those genuinely don't exist until run time.
- Behaviour change: a dynamic missing/cyclic dependency that previously failed late now fails eagerly during `RunAsync` — the intended fix. Whether a module depending on a *skipped* module should cascade-skip rather than error is a separate, pre-existing `DependencyWaiter` behaviour and out of scope here.

Closes #3189

🤖 Generated with [Claude Code](https://claude.com/claude-code)