### PR TITLE
Revalidate canonical dependency graph at runtime

### DIFF
--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -7,6 +7,7 @@ using ModularPipelines.Distributed.Serialization;
 using ModularPipelines.Distributed.Worker;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -18,6 +19,8 @@ internal class DistributedModuleExecutor(
     IModuleSchedulerFactory schedulerFactory,
     IModuleRunner moduleRunner,
     IRegistrationEventExecutor registrationEventExecutor,
+    IModuleDependencyRegistry dependencyRegistry,
+    IModuleMetadataRegistry metadataRegistry,
     IDistributedCoordinator coordinator,
     DistributedWorkPublisher publisher,
     DistributedResultCollector resultCollector,
@@ -32,6 +35,8 @@ internal class DistributedModuleExecutor(
     private readonly IModuleSchedulerFactory _schedulerFactory = schedulerFactory;
     private readonly IModuleRunner _moduleRunner = moduleRunner;
     private readonly IRegistrationEventExecutor _registrationEventExecutor = registrationEventExecutor;
+    private readonly IModuleDependencyRegistry _dependencyRegistry = dependencyRegistry;
+    private readonly IModuleMetadataRegistry _metadataRegistry = metadataRegistry;
     private readonly IDistributedCoordinator _coordinator = coordinator;
     private readonly DistributedWorkPublisher _publisher = publisher;
     private readonly DistributedResultCollector _resultCollector = resultCollector;
@@ -42,7 +47,9 @@ internal class DistributedModuleExecutor(
     private readonly ArtifactLifecycleManager? _artifactLifecycleManager = artifactLifecycleManager;
     private readonly ILogger<DistributedModuleExecutor> _logger = logger;
 
-    public async Task<IEnumerable<IModule>> ExecuteAsync(IReadOnlyList<IModule> modules)
+    public async Task<IEnumerable<IModule>> ExecuteAsync(
+        IReadOnlyList<IModule> modules,
+        IReadOnlyList<IModule> availableModules)
     {
         if (modules.Count == 0)
         {
@@ -58,15 +65,21 @@ internal class DistributedModuleExecutor(
         // Build O(1) lookup for module resolution
         var moduleLookup = DependencyResultApplicator.BuildModuleLookup(modules);
 
-        // Invoke registration events before dependency resolution
-        await _registrationEventExecutor.InvokeRegistrationEventsAsync(modules).ConfigureAwait(false);
-
-        // Wait for workers to register before distributing work
-        await WaitForWorkersAsync(_lifetime.ApplicationStopping);
-
         IModuleScheduler? scheduler = null;
         try
         {
+            // Invoke registration events before dependency resolution
+            await _registrationEventExecutor.InvokeRegistrationEventsAsync(modules).ConfigureAwait(false);
+
+            ModuleDependencyValidator.Validate(
+                modules,
+                availableModules,
+                _dependencyRegistry,
+                _metadataRegistry);
+
+            // Wait for workers to register before distributing work
+            await WaitForWorkersAsync(_lifetime.ApplicationStopping);
+
             scheduler = _schedulerFactory.Create();
             scheduler.InitializeModules(modules);
 

--- a/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
@@ -31,7 +31,9 @@ internal class WorkerModuleExecutor(
     private readonly ArtifactLifecycleManager? _artifactLifecycleManager = artifactLifecycleManager;
     private readonly ILogger<WorkerModuleExecutor> _logger = logger;
 
-    public async Task<IEnumerable<IModule>> ExecuteAsync(IReadOnlyList<IModule> modules)
+    public async Task<IEnumerable<IModule>> ExecuteAsync(
+        IReadOnlyList<IModule> modules,
+        IReadOnlyList<IModule> _)
     {
         var options = _options.Value;
         var cancellationToken = _lifetime.ApplicationStopping;

--- a/src/ModularPipelines/Engine/Executors/PipelineExecutor.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineExecutor.cs
@@ -53,7 +53,9 @@ internal class PipelineExecutor : IPipelineExecutor
         try
         {
             // ModuleExecutor handles waiting for AlwaysRun modules internally
-            await _moduleExecutor.ExecuteAsync(runnableModules).ConfigureAwait(false);
+            await _moduleExecutor
+                .ExecuteAsync(runnableModules, organizedModules.AllModules)
+                .ConfigureAwait(false);
         }
         finally
         {

--- a/src/ModularPipelines/Engine/IModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/IModuleExecutor.cs
@@ -4,5 +4,7 @@ namespace ModularPipelines.Engine;
 
 internal interface IModuleExecutor
 {
-    Task<IEnumerable<IModule>> ExecuteAsync(IReadOnlyList<IModule> modules);
+    Task<IEnumerable<IModule>> ExecuteAsync(
+        IReadOnlyList<IModule> modules,
+        IReadOnlyList<IModule> availableModules);
 }

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Helpers;
 using ModularPipelines.Interfaces;
@@ -28,6 +29,8 @@ internal class ModuleExecutor : IModuleExecutor
     private readonly IModuleResultRegistrar _resultRegistrar;
     private readonly IParallelLimitProvider _parallelLimitProvider;
     private readonly IRegistrationEventExecutor _registrationEventExecutor;
+    private readonly IModuleDependencyRegistry _dependencyRegistry;
+    private readonly IModuleMetadataRegistry _metadataRegistry;
     private readonly IMetricsCollector _metricsCollector;
     private readonly IOptions<PipelineOptions> _pipelineOptions;
     private readonly ILogger<ModuleExecutor> _logger;
@@ -39,6 +42,8 @@ internal class ModuleExecutor : IModuleExecutor
         IModuleResultRegistrar resultRegistrar,
         IParallelLimitProvider parallelLimitProvider,
         IRegistrationEventExecutor registrationEventExecutor,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
         IMetricsCollector metricsCollector,
         IOptions<PipelineOptions> pipelineOptions,
         ILogger<ModuleExecutor> logger)
@@ -49,6 +54,8 @@ internal class ModuleExecutor : IModuleExecutor
         _resultRegistrar = resultRegistrar;
         _parallelLimitProvider = parallelLimitProvider;
         _registrationEventExecutor = registrationEventExecutor;
+        _dependencyRegistry = dependencyRegistry;
+        _metadataRegistry = metadataRegistry;
         _metricsCollector = metricsCollector;
         _pipelineOptions = pipelineOptions;
         _logger = logger;
@@ -57,9 +64,12 @@ internal class ModuleExecutor : IModuleExecutor
     /// <summary>
     /// Executes a collection of modules using eager parallel scheduling.
     /// </summary>
-    public async Task<IEnumerable<IModule>> ExecuteAsync(IReadOnlyList<IModule> modules)
+    public async Task<IEnumerable<IModule>> ExecuteAsync(
+        IReadOnlyList<IModule> modules,
+        IReadOnlyList<IModule> availableModules)
     {
         ArgumentNullException.ThrowIfNull(modules);
+        ArgumentNullException.ThrowIfNull(availableModules);
 
         if (modules.Count == 0)
         {
@@ -71,7 +81,7 @@ internal class ModuleExecutor : IModuleExecutor
 
         try
         {
-            scheduler = await InitializeSchedulerAsync(modules).ConfigureAwait(false);
+            scheduler = await InitializeSchedulerAsync(modules, availableModules).ConfigureAwait(false);
             return await ExecuteWithSchedulerAsync(modules, scheduler).ConfigureAwait(false);
         }
         catch (Exception outerEx)
@@ -92,7 +102,9 @@ internal class ModuleExecutor : IModuleExecutor
         }
     }
 
-    private async Task<IModuleScheduler> InitializeSchedulerAsync(IReadOnlyList<IModule> modules)
+    private async Task<IModuleScheduler> InitializeSchedulerAsync(
+        IReadOnlyList<IModule> modules,
+        IReadOnlyList<IModule> availableModules)
     {
         _logger.LogDebug("Initializing unified scheduler for {Count} modules", modules.Count);
 
@@ -101,6 +113,12 @@ internal class ModuleExecutor : IModuleExecutor
 
         // Invoke registration events before dependency resolution
         await _registrationEventExecutor.InvokeRegistrationEventsAsync(modules).ConfigureAwait(false);
+
+        ModuleDependencyValidator.Validate(
+            modules,
+            availableModules,
+            _dependencyRegistry,
+            _metadataRegistry);
 
         var scheduler = _schedulerFactory.Create();
         scheduler.InitializeModules(modules);

--- a/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
+++ b/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
@@ -24,14 +24,28 @@ public static class ModuleDependencyValidator
         IModuleDependencyRegistry? dynamicRegistry,
         IModuleMetadataRegistry? metadataRegistry)
     {
-        var modulesByType = registeredModules
+        var modules = registeredModules.ToArray();
+        Validate(modules, modules, dynamicRegistry, metadataRegistry);
+    }
+
+    internal static void Validate(
+        IEnumerable<IModule> modulesToValidate,
+        IEnumerable<IModule> availableModules,
+        IModuleDependencyRegistry? dynamicRegistry,
+        IModuleMetadataRegistry? metadataRegistry)
+    {
+        var modulesByType = modulesToValidate
             .GroupBy(module => module.GetType())
             .ToDictionary(group => group.Key, group => group.First());
-        var moduleTypes = modulesByType.Keys.ToHashSet();
-        if (moduleTypes.Count == 0)
+        var validatedModuleTypes = modulesByType.Keys.ToHashSet();
+        if (validatedModuleTypes.Count == 0)
         {
             return;
         }
+
+        var availableModuleTypes = availableModules
+            .Select(module => module.GetType())
+            .ToHashSet();
 
         foreach (var (moduleType, module) in modulesByType)
         {
@@ -40,7 +54,7 @@ public static class ModuleDependencyValidator
 
         var dependenciesByModule = modulesByType.ToDictionary(
             pair => pair.Key,
-            pair => GetAllDependencies(pair.Value, moduleTypes, dynamicRegistry, metadataRegistry));
+            pair => GetAllDependencies(pair.Value, availableModuleTypes, dynamicRegistry, metadataRegistry));
 
         foreach (var (moduleType, dependencies) in dependenciesByModule)
         {
@@ -53,7 +67,7 @@ public static class ModuleDependencyValidator
                         "A module cannot depend on its own result.");
                 }
 
-                if (!optional && !moduleTypes.Contains(dependencyType))
+                if (!optional && !availableModuleTypes.Contains(dependencyType))
                 {
                     throw new ModuleNotRegisteredException(
                         $"Module '{moduleType.Name}' requires '{dependencyType.Name}', " +
@@ -66,7 +80,7 @@ public static class ModuleDependencyValidator
         var dependencyGraph = dependenciesByModule.ToDictionary(
             pair => pair.Key,
             pair => pair.Value
-                .Where(dependency => moduleTypes.Contains(dependency.DependencyType))
+                .Where(dependency => validatedModuleTypes.Contains(dependency.DependencyType))
                 .Select(dependency => dependency.DependencyType)
                 .ToHashSet());
         ValidateCircularDependencies(dependencyGraph);

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -11,10 +11,13 @@ using ModularPipelines.Distributed.Serialization;
 using ModularPipelines.Distributed.Worker;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Enums;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 
 namespace ModularPipelines.Distributed.UnitTests.Master;
 
@@ -47,6 +50,13 @@ public class DistributedModuleExecutorTests
         protected internal override Task<int> ExecuteAsync(
             Context.IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult(42);
+    }
+
+    private class MissingDistributedDependency : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            Context.IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(null);
     }
 
     /// <summary>
@@ -137,7 +147,10 @@ public class DistributedModuleExecutorTests
         IModuleResultRegistry? resultRegistry = null,
         IDistributedCoordinator? coordinator = null,
         DistributedResultCollector? resultCollector = null,
-        ArtifactLifecycleManager? artifactManager = null)
+        ArtifactLifecycleManager? artifactManager = null,
+        IRegistrationEventExecutor? registrationEventExecutor = null,
+        IModuleDependencyRegistry? dependencyRegistry = null,
+        IModuleMetadataRegistry? metadataRegistry = null)
     {
         var lifetime = new Mock<IHostApplicationLifetime>();
         lifetime.Setup(l => l.ApplicationStopping).Returns(CancellationToken.None);
@@ -145,11 +158,18 @@ public class DistributedModuleExecutorTests
         var factory = new Mock<IModuleSchedulerFactory>();
         factory.Setup(f => f.Create()).Returns(scheduler.Object);
 
-        var regEventExecutor = new Mock<IRegistrationEventExecutor>();
-        regEventExecutor.Setup(r => r.InvokeRegistrationEventsAsync(It.IsAny<IEnumerable<IModule>>()))
-            .Returns(Task.CompletedTask);
+        if (registrationEventExecutor is null)
+        {
+            var regEventExecutor = new Mock<IRegistrationEventExecutor>();
+            regEventExecutor.Setup(r => r.InvokeRegistrationEventsAsync(It.IsAny<IEnumerable<IModule>>()))
+                .Returns(Task.CompletedTask);
+            registrationEventExecutor = regEventExecutor.Object;
+        }
 
         coordinator ??= new InMemoryDistributedCoordinator();
+        dependencyRegistry ??= new ModuleDependencyRegistry();
+        metadataRegistry ??= new ModuleMetadataRegistry(
+            Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()));
         var typeRegistry = new ModuleTypeRegistry();
         var serializer = new ModuleResultSerializer(typeRegistry);
         resultRegistry ??= new ModuleResultRegistry();
@@ -161,7 +181,9 @@ public class DistributedModuleExecutorTests
             lifetime.Object,
             factory.Object,
             moduleRunner.Object,
-            regEventExecutor.Object,
+            registrationEventExecutor,
+            dependencyRegistry,
+            metadataRegistry,
             coordinator,
             publisher,
             resultCollector,
@@ -176,6 +198,37 @@ public class DistributedModuleExecutorTests
     // =================================================================
     // Result Registration Tests
     // =================================================================
+
+    [Test]
+    public async Task RegistrationEventDependency_IsValidatedBeforeMasterScheduling()
+    {
+        var module = new DistributedModule();
+        var scheduler = CreateMockScheduler();
+        var coordinator = new Mock<IDistributedCoordinator>();
+        coordinator.Setup(c => c.SignalCompletionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var dependencyRegistry = new ModuleDependencyRegistry();
+        var registrationEventExecutor = new Mock<IRegistrationEventExecutor>();
+        registrationEventExecutor
+            .Setup(r => r.InvokeRegistrationEventsAsync(It.IsAny<IEnumerable<IModule>>()))
+            .Callback(() => dependencyRegistry.AddDynamicDependency(
+                typeof(DistributedModule),
+                typeof(MissingDistributedDependency)))
+            .Returns(Task.CompletedTask);
+
+        var executor = CreateExecutor(
+            scheduler,
+            coordinator: coordinator.Object,
+            registrationEventExecutor: registrationEventExecutor.Object,
+            dependencyRegistry: dependencyRegistry);
+
+        await Assert.ThrowsAsync<ModuleNotRegisteredException>(
+            () => executor.ExecuteAsync([module], [module]));
+        coordinator.Verify(
+            c => c.SignalCompletionAsync(CancellationToken.None),
+            Times.Once);
+    }
 
     [Test]
     public async Task Distributed_Module_Success_Registers_Result_In_Registry()
@@ -211,7 +264,7 @@ public class DistributedModuleExecutorTests
         });
 
         // Act
-        await executor.ExecuteAsync([module]);
+        await executor.ExecuteAsync([module], [module]);
 
         // Assert
         var registeredResult = resultRegistry.GetResult(typeof(DistributedModule));
@@ -254,7 +307,7 @@ public class DistributedModuleExecutorTests
         });
 
         // Act
-        await executor.ExecuteAsync([module]);
+        await executor.ExecuteAsync([module], [module]);
 
         // Assert
         var registeredResult = resultRegistry.GetResult(typeof(DistributedModule));
@@ -290,7 +343,7 @@ public class DistributedModuleExecutorTests
             resultCollector: resultCollector);
 
         // Act
-        await executor.ExecuteAsync([module]);
+        await executor.ExecuteAsync([module], [module]);
 
         // Assert — cancellation should register a failure result
         var registeredResult = resultRegistry.GetResult(typeof(DistributedModule));
@@ -326,7 +379,7 @@ public class DistributedModuleExecutorTests
             resultCollector: resultCollector);
 
         // Act
-        await executor.ExecuteAsync([module]);
+        await executor.ExecuteAsync([module], [module]);
 
         // Assert
         var registeredResult = resultRegistry.GetResult(typeof(DistributedModule));
@@ -377,7 +430,7 @@ public class DistributedModuleExecutorTests
         });
 
         // Act
-        await executor.ExecuteAsync([moduleA, moduleB]);
+        await executor.ExecuteAsync([moduleA, moduleB], [moduleA, moduleB]);
 
         // Assert — module A has failure, module B also gets a failure (cancelled)
         var resultA = resultRegistry.GetResult(typeof(DistributedModule));
@@ -428,7 +481,7 @@ public class DistributedModuleExecutorTests
             resultCollector: resultCollector);
 
         // Act
-        await executor.ExecuteAsync([module]);
+        await executor.ExecuteAsync([module], [module]);
 
         // Assert — the master worker loop used a WorkerModuleScheduler (no-op)
         await Assert.That(capturedScheduler).IsNotNull();
@@ -489,7 +542,7 @@ public class DistributedModuleExecutorTests
             resultCollector: resultCollector);
 
         // Act
-        await executor.ExecuteAsync([module]);
+        await executor.ExecuteAsync([module], [module]);
 
         // Assert
         coordinator.Verify(c => c.SignalCompletionAsync(CancellationToken.None), Times.Once());
@@ -520,7 +573,7 @@ public class DistributedModuleExecutorTests
             resultCollector: resultCollector);
 
         // Act
-        await executor.ExecuteAsync([module]);
+        await executor.ExecuteAsync([module], [module]);
 
         // Assert — always signals completion, even on failure
         coordinator.Verify(c => c.SignalCompletionAsync(CancellationToken.None), Times.Once());
@@ -536,7 +589,7 @@ public class DistributedModuleExecutorTests
         var scheduler = CreateMockScheduler();
         var executor = CreateExecutor(scheduler);
 
-        var result = await executor.ExecuteAsync([]);
+        var result = await executor.ExecuteAsync([], []);
 
         await Assert.That(result.Count()).IsEqualTo(0);
     }
@@ -573,7 +626,7 @@ public class DistributedModuleExecutorTests
         });
 
         // Act
-        await executor.ExecuteAsync([module]);
+        await executor.ExecuteAsync([module], [module]);
 
         // Assert
         scheduler.Verify(s => s.MarkModuleStarted(typeof(DistributedModule)), Times.Once());
@@ -608,7 +661,7 @@ public class DistributedModuleExecutorTests
         });
 
         // Act
-        await executor.ExecuteAsync([module]);
+        await executor.ExecuteAsync([module], [module]);
 
         // Assert
         scheduler.Verify(s => s.MarkModuleCompleted(typeof(DistributedModule), false, null, null), Times.Once());
@@ -653,12 +706,14 @@ public class DistributedModuleExecutorTests
 
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
             resultRegistry, Microsoft.Extensions.Options.Options.Create(new DistributedOptions()),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
         // Act
-        await executor.ExecuteAsync([moduleA, moduleB]);
+        await executor.ExecuteAsync([moduleA, moduleB], [moduleA, moduleB]);
 
         // Assert — both types are registered and resolvable
         var resolvedA = typeRegistry.Resolve(typeof(DistributedModule).FullName!);
@@ -700,6 +755,8 @@ public class DistributedModuleExecutorTests
 
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
             noDequeue, publisher, resultCollector, typeRegistry, serializer,
             resultRegistry, Microsoft.Extensions.Options.Options.Create(distributedOptions),
             null, NullLogger<DistributedModuleExecutor>.Instance);
@@ -723,7 +780,7 @@ public class DistributedModuleExecutorTests
         });
 
         // Act
-        await executor.ExecuteAsync([module]);
+        await executor.ExecuteAsync([module], [module]);
 
         // Assert — work was distributed and result collected (if barrier didn't work, result would be lost)
         var registeredResult = resultRegistry.GetResult(typeof(DistributedModule));
@@ -745,7 +802,7 @@ public class DistributedModuleExecutorTests
         var executor = CreateExecutor(scheduler, coordinator: coordinator.Object);
 
         // Act — should return quickly without calling GetRegisteredWorkersAsync
-        await executor.ExecuteAsync([]);
+        await executor.ExecuteAsync([], []);
 
         // Assert — GetRegisteredWorkersAsync should never be called
         coordinator.Verify(c => c.GetRegisteredWorkersAsync(It.IsAny<CancellationToken>()), Times.Never());
@@ -795,13 +852,15 @@ public class DistributedModuleExecutorTests
 
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
             resultRegistry, Microsoft.Extensions.Options.Options.Create(distributedOptions),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
         // Act — should proceed after 3 seconds timeout even though only 1/3 workers registered
         var sw = System.Diagnostics.Stopwatch.StartNew();
-        await executor.ExecuteAsync([module]);
+        await executor.ExecuteAsync([module], [module]);
         sw.Stop();
 
         // Assert — waited roughly 3 seconds (the timeout), not the full test timeout

--- a/test/ModularPipelines.UnitTests/Attributes/DynamicDependencyIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/DynamicDependencyIntegrationTests.cs
@@ -1,5 +1,8 @@
 using ModularPipelines.Attributes.Events;
+using ModularPipelines.Conditions;
+using ModularPipelines.Configuration;
 using ModularPipelines.Context;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
 
@@ -47,6 +50,74 @@ public class DynamicDependencyIntegrationTests : TestBase
         }
     }
 
+    public class MissingDynamicDependency : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+    }
+
+    [AddDependency(typeof(MissingDynamicDependency))]
+    public class ModuleWithMissingDynamicDependency : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+    }
+
+    [AddDependency(typeof(DynamicCycleModuleB))]
+    public class DynamicCycleModuleA : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+    }
+
+    [AddDependency(typeof(DynamicCycleModuleA))]
+    public class DynamicCycleModuleB : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+    }
+
+    public class AvailableDependency : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+    }
+
+    [ModularPipelines.Attributes.DependsOn<AvailableDependency>]
+    public class RunnableModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+    }
+
+    public class RunOnSecondEvaluation : IRunCondition
+    {
+        private static int _evaluationCount;
+
+        public static void Reset() => _evaluationCount = 0;
+
+        public Task<bool> EvaluateAsync(IPipelineHookContext context)
+            => Task.FromResult(Interlocked.Increment(ref _evaluationCount) > 1);
+    }
+
+    [ModularPipelines.Attributes.RunIfAll<RunOnSecondEvaluation>]
+    public class StatefulRunnableModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .DependsOn<MissingDynamicDependency>()
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+    }
+
     [Before(Test)]
     public void ClearExecutionOrder()
     {
@@ -63,5 +134,50 @@ public class DynamicDependencyIntegrationTests : TestBase
 
         await Assert.That(result.Status).IsEqualTo(Enums.Status.Successful);
         await Assert.That(ExecutionOrder).IsEquivalentTo(new[] { "A", "B" });
+    }
+
+    [Test]
+    public async Task DynamicDependency_MissingModuleFailsBeforeScheduling()
+    {
+        await Assert.ThrowsAsync<ModuleNotRegisteredException>(() =>
+            TestPipelineHostBuilder.Create()
+                .AddModule<ModuleWithMissingDynamicDependency>()
+                .ExecutePipelineAsync());
+    }
+
+    [Test]
+    public async Task DynamicDependency_CycleFailsBeforeScheduling()
+    {
+        await Assert.ThrowsAsync<DependencyCollisionException>(() =>
+            TestPipelineHostBuilder.Create()
+                .AddModule<DynamicCycleModuleA>()
+                .AddModule<DynamicCycleModuleB>()
+                .ExecutePipelineAsync());
+    }
+
+    [Test]
+    public async Task RuntimeValidation_UsesModulesOutsideValidationTargetAsAvailableDependencies()
+    {
+        var runnableModule = new RunnableModule();
+        var availableDependency = new AvailableDependency();
+
+        await Assert.That(() => ModuleDependencyValidator.Validate(
+                [runnableModule],
+                [runnableModule, availableDependency],
+                dynamicRegistry: null,
+                metadataRegistry: null))
+            .ThrowsNothing();
+    }
+
+    [Test]
+    public async Task RuntimeValidation_CatchesDependencyAfterRunConditionChanges()
+    {
+        RunOnSecondEvaluation.Reset();
+
+        await using var pipeline = TestPipelineHostBuilder.Create()
+            .AddModule<StatefulRunnableModule>()
+            .Build();
+
+        await Assert.ThrowsAsync<ModuleNotRegisteredException>(() => pipeline.RunAsync());
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Threading.Channels;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Engine.Scheduling;
 using ModularPipelines.Helpers;
@@ -46,11 +47,14 @@ public class ModuleExecutorLoggingTests
             Mock.Of<IModuleResultRegistrar>(),
             parallelLimitProvider.Object,
             registrationEvents.Object,
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
             Mock.Of<IMetricsCollector>(),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
             new StringLogger<ModuleExecutor>(logs));
 
-        await executor.ExecuteAsync([Mock.Of<IModule>()]);
+        var module = Mock.Of<IModule>();
+        await executor.ExecuteAsync([module], [module]);
 
         var logOutput = logs.ToString();
         await Assert.That(logOutput).DoesNotContain("Cancellation triggered");


### PR DESCRIPTION
## Summary
- revalidate runnable modules after registration receivers populate dynamic dependencies
- validate against the full discovered module universe while detecting cycles only in the runnable graph
- apply the same eager validation on distributed masters; workers remain unchanged
- cover missing dynamic edges, dynamic cycles, changing run conditions, target/universe separation, and master shutdown signaling

## Validation
- core project build: 0 errors
- DynamicDependencyIntegrationTests: 5/5 passed via minimal focused harness
- DistributedModuleExecutorTests: 17/17 passed
- changed-file whitespace verification passed

Closes #3189