### PR TITLE
Cascade-skip modules with skipped required dependencies

### DIFF
--- a/docs/docs/how-to/execution-and-dependencies.md
+++ b/docs/docs/how-to/execution-and-dependencies.md
@@ -25,6 +25,7 @@ By default, dependencies declared with `[DependsOn<T>]` are **required**. This m
 
 1. **Auto-registration**: If the dependency module is not explicitly registered, ModularPipelines will automatically register it for you
 2. **Validation**: The pipeline validates that all required dependencies can be resolved before execution
+3. **Cascade skipping**: If a required dependency is skipped by a run condition or category filter, the dependent module is skipped too
 
 ```csharp
 // Required dependency (default)
@@ -81,12 +82,12 @@ public class Module2 : Module<string>
 Optional dependencies are useful when:
 
 - A module can work with or without another module's output
-- You're using category filters and some dependencies may be excluded
+- A module should still run when a dependency is excluded by a category filter or run condition
 - You want conditional behavior based on what modules are registered
 
-### Category Filters and Optional Dependencies
+### Category Filters and Skipped Dependencies
 
-When using `RunOnlyCategories` to filter which modules run, dependencies in other categories may not execute. Mark such dependencies as optional:
+When a category filter skips a required dependency, ModularPipelines cascade-skips the dependent module and any modules that require it. Use an optional dependency when the dependent module should still execute:
 
 ```csharp
 [ModuleCategory("test")]
@@ -99,7 +100,7 @@ public class TestModule : Module<string>
 
         if (compile == null)
         {
-            // CompileModule was filtered out - handle gracefully
+            // Optional dependencies are not auto-registered
             return "Running tests without compile";
         }
 
@@ -110,6 +111,8 @@ public class TestModule : Module<string>
     }
 }
 ```
+
+If the dependency above were required (`[DependsOn<CompileModule>]`), `TestModule` would be skipped whenever the category filter skipped `CompileModule`.
 
 ## Accessing Dependency Results
 

--- a/src/ModularPipelines/Attributes/DependsOnAttribute.cs
+++ b/src/ModularPipelines/Attributes/DependsOnAttribute.cs
@@ -81,6 +81,7 @@ public class DependsOnAttribute : Attribute
     /// </para>
     /// <list type="bullet">
     /// <item>The dependency module will be <b>auto-registered</b> if not explicitly added to the pipeline</item>
+    /// <item>If the dependency is skipped, the dependent module is skipped too</item>
     /// <item>Use <c>GetModule&lt;T&gt;()</c> to access the dependency - it is guaranteed to be present</item>
     /// </list>
     /// <para>
@@ -89,7 +90,7 @@ public class DependsOnAttribute : Attribute
     /// <list type="bullet">
     /// <item>The dependency module will <b>not</b> be auto-registered</item>
     /// <item>Use <c>GetModuleIfRegistered&lt;T&gt;()</c> to safely check if the dependency exists</item>
-    /// <item>Useful when using category filters where dependencies may be excluded</item>
+    /// <item>Useful when the dependent module should still run after a category or condition skips the dependency</item>
     /// </list>
     /// </remarks>
     /// <value>

--- a/src/ModularPipelines/Context/PipelineContext.cs
+++ b/src/ModularPipelines/Context/PipelineContext.cs
@@ -106,11 +106,15 @@ internal class PipelineContext : IPipelineHookContext, IInternalPipelineContext
     public TModule? GetModule<TModule>()
         where TModule : class, IModule
     {
-        return _serviceProvider.GetServices<IModule>().OfType<TModule>().SingleOrDefault();
+        return GetDistinctModules().OfType<TModule>().SingleOrDefault();
     }
 
     public IModule? GetModule(Type type)
     {
-        return _serviceProvider.GetServices<IModule>().SingleOrDefault(module => module.GetType() == type);
+        return GetDistinctModules().SingleOrDefault(module => module.GetType() == type);
     }
+
+    private IEnumerable<IModule> GetDistinctModules() =>
+        _serviceProvider.GetServices<IModule>()
+            .Distinct<IModule>(ReferenceEqualityComparer.Instance);
 }

--- a/src/ModularPipelines/Distributed/DependencyResultApplicator.cs
+++ b/src/ModularPipelines/Distributed/DependencyResultApplicator.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Distributed.Master;
 using ModularPipelines.Distributed.Serialization;
+using ModularPipelines.Engine;
 using ModularPipelines.Modules;
 
 namespace ModularPipelines.Distributed;
@@ -30,7 +31,8 @@ internal static class DependencyResultApplicator
     }
 
     /// <summary>
-    /// Applies dependency results received in an assignment to local module instances.
+    /// Applies dependency results received in an assignment to local module instances
+    /// and the result registry.
     /// This enables <c>GetModule&lt;T&gt;()</c> to resolve cross-process dependencies.
     /// <c>TrySetResult</c> is idempotent — safe if CompletionSource was already set.
     /// </summary>
@@ -38,6 +40,7 @@ internal static class DependencyResultApplicator
         IReadOnlyList<SerializedModuleResult> dependencyResults,
         Dictionary<string, IModule> moduleLookup,
         ModuleResultSerializer serializer,
+        IModuleResultRegistry resultRegistry,
         ILogger logger)
     {
         foreach (var serializedDep in dependencyResults)
@@ -61,6 +64,7 @@ internal static class DependencyResultApplicator
                 var result = serializer.Deserialize(toDeserialize);
                 if (result is not null)
                 {
+                    resultRegistry.RegisterResult(depModule.GetType(), result);
                     ModuleCompletionSourceApplicator.TryApply(depModule, result);
                 }
             }

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -79,6 +79,10 @@ internal class DistributedModuleExecutor(
         {
             scheduler = _schedulerFactory.Create();
             scheduler.InitializeModules(modules);
+            UsedHistoryModuleSchedulerInitializer.Precomplete(
+                modules,
+                scheduler,
+                _resultRegistry);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_lifetime.ApplicationStopping);
             cts.Token.Register(() => scheduler.CancelPendingModules());
@@ -305,6 +309,11 @@ internal class DistributedModuleExecutor(
         }
 
         var moduleState = new ModuleState(module, module.GetType());
+        ModuleStateDependencyInitializer.Populate(
+            moduleState,
+            _typeRegistry.GetRegisteredModuleTypes(),
+            _dependencyRegistry,
+            _metadataRegistry);
         await _moduleRunner.ExecuteWithoutDependencyWaitAsync(moduleState, workerScheduler, cancellationToken);
 
         var result = await module.ResultTask;

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -283,7 +283,12 @@ internal class DistributedModuleExecutor(
         // Apply dependency results so that GetModule<T>() works
         if (assignment.DependencyResults is { Count: > 0 })
         {
-            DependencyResultApplicator.Apply(assignment.DependencyResults, moduleLookup, _serializer, _logger);
+            DependencyResultApplicator.Apply(
+                assignment.DependencyResults,
+                moduleLookup,
+                _serializer,
+                _resultRegistry,
+                _logger);
         }
 
         try

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -69,7 +69,11 @@ internal class DistributedModuleExecutor(
         // Revalidate the runnable set now that registration-event dependencies are populated, so
         // missing/self/cyclic dependencies (including ones added via AddDependency) fail fast here
         // rather than the master hanging or failing late. Mirrors the standalone ModuleExecutor.
-        ModuleDependencyValidator.Validate(modules, _dependencyRegistry, _metadataRegistry);
+        ModuleDependencyValidator.Validate(
+            modules,
+            _dependencyRegistry,
+            _metadataRegistry,
+            UsedHistoryModuleSchedulerInitializer.GetPrecompletedModuleTypes(modules, _resultRegistry));
 
         // Wait for workers to register before distributing work
         await WaitForWorkersAsync(_lifetime.ApplicationStopping);

--- a/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
@@ -16,9 +16,11 @@ namespace ModularPipelines.Distributed.Worker;
 internal class WorkerModuleExecutor(
     IHostApplicationLifetime lifetime,
     IDistributedCoordinator coordinator,
+    IEnumerable<IModule> registeredModules,
     ModuleTypeRegistry typeRegistry,
     ModuleResultSerializer serializer,
     IModuleRunner moduleRunner,
+    IModuleResultRegistry resultRegistry,
     IModuleDependencyRegistry dependencyRegistry,
     IModuleMetadataRegistry metadataRegistry,
     IOptions<DistributedOptions> options,
@@ -27,9 +29,14 @@ internal class WorkerModuleExecutor(
 {
     private readonly IHostApplicationLifetime _lifetime = lifetime;
     private readonly IDistributedCoordinator _coordinator = coordinator;
+    private readonly IReadOnlyList<IModule> _registeredModules = registeredModules
+        .Distinct<IModule>(ReferenceEqualityComparer.Instance)
+        .ToArray();
+
     private readonly ModuleTypeRegistry _typeRegistry = typeRegistry;
     private readonly ModuleResultSerializer _serializer = serializer;
     private readonly IModuleRunner _moduleRunner = moduleRunner;
+    private readonly IModuleResultRegistry _resultRegistry = resultRegistry;
     private readonly IModuleDependencyRegistry _dependencyRegistry = dependencyRegistry;
     private readonly IModuleMetadataRegistry _metadataRegistry = metadataRegistry;
     private readonly IOptions<DistributedOptions> _options = options;
@@ -40,13 +47,17 @@ internal class WorkerModuleExecutor(
     {
         var options = _options.Value;
         var cancellationToken = _lifetime.ApplicationStopping;
+        var availableModules = _registeredModules
+            .Concat(modules)
+            .Distinct<IModule>(ReferenceEqualityComparer.Instance)
+            .ToArray();
 
-        foreach (var module in modules)
+        foreach (var module in availableModules)
         {
             _typeRegistry.Register(module.GetType());
         }
 
-        var moduleLookup = DependencyResultApplicator.BuildModuleLookup(modules);
+        var moduleLookup = DependencyResultApplicator.BuildModuleLookup(availableModules);
         var capabilities = BuildCapabilities(options);
         await RegisterWorkerAsync(options.InstanceIndex, capabilities, cancellationToken);
 
@@ -135,7 +146,12 @@ internal class WorkerModuleExecutor(
 
         if (assignment.DependencyResults is { Count: > 0 })
         {
-            DependencyResultApplicator.Apply(assignment.DependencyResults, moduleLookup, _serializer, _logger);
+            DependencyResultApplicator.Apply(
+                assignment.DependencyResults,
+                moduleLookup,
+                _serializer,
+                _resultRegistry,
+                _logger);
         }
 
         try

--- a/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Worker/WorkerModuleExecutor.cs
@@ -5,6 +5,7 @@ using ModularPipelines.Distributed.Artifacts;
 using ModularPipelines.Distributed.Capabilities;
 using ModularPipelines.Distributed.Serialization;
 using ModularPipelines.Engine;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -18,6 +19,8 @@ internal class WorkerModuleExecutor(
     ModuleTypeRegistry typeRegistry,
     ModuleResultSerializer serializer,
     IModuleRunner moduleRunner,
+    IModuleDependencyRegistry dependencyRegistry,
+    IModuleMetadataRegistry metadataRegistry,
     IOptions<DistributedOptions> options,
     ArtifactLifecycleManager? artifactLifecycleManager,
     ILogger<WorkerModuleExecutor> logger) : IModuleExecutor
@@ -27,6 +30,8 @@ internal class WorkerModuleExecutor(
     private readonly ModuleTypeRegistry _typeRegistry = typeRegistry;
     private readonly ModuleResultSerializer _serializer = serializer;
     private readonly IModuleRunner _moduleRunner = moduleRunner;
+    private readonly IModuleDependencyRegistry _dependencyRegistry = dependencyRegistry;
+    private readonly IModuleMetadataRegistry _metadataRegistry = metadataRegistry;
     private readonly IOptions<DistributedOptions> _options = options;
     private readonly ArtifactLifecycleManager? _artifactLifecycleManager = artifactLifecycleManager;
     private readonly ILogger<WorkerModuleExecutor> _logger = logger;
@@ -159,6 +164,11 @@ internal class WorkerModuleExecutor(
         }
 
         var moduleState = new ModuleState(module, module.GetType());
+        ModuleStateDependencyInitializer.Populate(
+            moduleState,
+            _typeRegistry.GetRegisteredModuleTypes(),
+            _dependencyRegistry,
+            _metadataRegistry);
         await _moduleRunner.ExecuteWithoutDependencyWaitAsync(moduleState, workerScheduler, cancellationToken);
 
         var result = await module.ResultTask;

--- a/src/ModularPipelines/Engine/Attributes/RegistrationEventExecutor.cs
+++ b/src/ModularPipelines/Engine/Attributes/RegistrationEventExecutor.cs
@@ -19,6 +19,7 @@ internal class RegistrationEventExecutor : IRegistrationEventExecutor
     private readonly IConfiguration _configuration;
     private readonly IHostEnvironment _environment;
     private Task? _invocationTask;
+    private HashSet<Type>? _registeredModuleTypes;
 
     public RegistrationEventExecutor(
         IModuleAttributeEventService attributeEventService,
@@ -38,11 +39,33 @@ internal class RegistrationEventExecutor : IRegistrationEventExecutor
 
     public Task InvokeRegistrationEventsAsync(IEnumerable<IModule> modules)
     {
+        var moduleArray = modules.ToArray();
+
         lock (_lock)
         {
+            if (_invocationTask is not null)
+            {
+                var missingModuleTypes = moduleArray
+                    .Select(module => module.GetType())
+                    .Where(moduleType => !_registeredModuleTypes!.Contains(moduleType))
+                    .Distinct()
+                    .ToArray();
+                if (missingModuleTypes.Length > 0)
+                {
+                    throw new InvalidOperationException(
+                        "Registration events were initialized without these module types: "
+                        + string.Join(", ", missingModuleTypes.Select(moduleType => moduleType.Name)));
+                }
+
+                return _invocationTask;
+            }
+
             // Discovery invokes registration events early so dynamic dependencies can affect filtering.
             // Executors invoke this service again, so share the first invocation rather than running receivers twice.
-            return _invocationTask ??= InvokeRegistrationEventsInternalAsync(modules.ToArray());
+            _registeredModuleTypes = moduleArray
+                .Select(module => module.GetType())
+                .ToHashSet();
+            return _invocationTask = InvokeRegistrationEventsInternalAsync(moduleArray);
         }
     }
 

--- a/src/ModularPipelines/Engine/Attributes/RegistrationEventExecutor.cs
+++ b/src/ModularPipelines/Engine/Attributes/RegistrationEventExecutor.cs
@@ -11,12 +11,14 @@ namespace ModularPipelines.Engine.Attributes;
 /// </summary>
 internal class RegistrationEventExecutor : IRegistrationEventExecutor
 {
+    private readonly object _lock = new();
     private readonly IModuleAttributeEventService _attributeEventService;
     private readonly IAttributeEventInvoker _attributeEventInvoker;
     private readonly IModuleDependencyRegistry _dependencyRegistry;
     private readonly IModuleMetadataRegistry _metadataRegistry;
     private readonly IConfiguration _configuration;
     private readonly IHostEnvironment _environment;
+    private Task? _invocationTask;
 
     public RegistrationEventExecutor(
         IModuleAttributeEventService attributeEventService,
@@ -34,12 +36,21 @@ internal class RegistrationEventExecutor : IRegistrationEventExecutor
         _environment = environment;
     }
 
-    public async Task InvokeRegistrationEventsAsync(IEnumerable<IModule> modules)
+    public Task InvokeRegistrationEventsAsync(IEnumerable<IModule> modules)
     {
-        var moduleArray = modules.ToArray();
-        var registeredModuleTypes = moduleArray.Select(m => m.GetType()).ToArray();
+        lock (_lock)
+        {
+            // Discovery invokes registration events early so dynamic dependencies can affect filtering.
+            // Executors invoke this service again, so share the first invocation rather than running receivers twice.
+            return _invocationTask ??= InvokeRegistrationEventsInternalAsync(modules.ToArray());
+        }
+    }
 
-        foreach (var module in moduleArray)
+    private async Task InvokeRegistrationEventsInternalAsync(IReadOnlyList<IModule> modules)
+    {
+        var registeredModuleTypes = modules.Select(module => module.GetType()).ToArray();
+
+        foreach (var module in modules)
         {
             var moduleType = module.GetType();
             var receivers = _attributeEventService.GetRegistrationReceivers(moduleType);

--- a/src/ModularPipelines/Engine/Dependencies/DependencySkipCascade.cs
+++ b/src/ModularPipelines/Engine/Dependencies/DependencySkipCascade.cs
@@ -1,0 +1,120 @@
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine.Dependencies;
+
+internal static class DependencySkipCascade
+{
+    public static async Task<DependencySkipCascadeResult> ApplyAsync(
+        IReadOnlyCollection<IModule> allModules,
+        IEnumerable<IModule> runnableModules,
+        IEnumerable<IgnoredModule> ignoredModules,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
+        Func<IReadOnlyList<IgnoredModule>, Task> prepareIgnoredModules,
+        Func<Type, bool> isSkipped,
+        CancellationToken cancellationToken = default)
+    {
+        var availableModuleTypes = allModules
+            .Select(module => module.GetType())
+            .Distinct()
+            .ToArray();
+        var remainingModules = runnableModules.ToList();
+        var remainingModuleSet = remainingModules.ToHashSet<IModule>(ReferenceEqualityComparer.Instance);
+        var runnableModuleTypeCounts = remainingModules
+            .GroupBy(module => module.GetType())
+            .ToDictionary(group => group.Key, group => group.Count());
+        var allIgnoredModules = ignoredModules.ToList();
+        var pendingIgnoredModules = allIgnoredModules.ToList();
+        var requiredDependenciesByModule = remainingModules.ToDictionary<IModule, IModule, Type[]>(
+            module => module,
+            module => ModuleDependencyResolver
+                .GetAllDependencies(module, availableModuleTypes, dependencyRegistry, metadataRegistry)
+                .Where(dependency => !dependency.Optional)
+                .Select(dependency => dependency.DependencyType)
+                .Distinct()
+                .OrderBy(dependencyType => dependencyType.FullName, StringComparer.Ordinal)
+                .ToArray(),
+            ReferenceEqualityComparer.Instance);
+        var dependentsByType = requiredDependenciesByModule
+            .SelectMany(pair => pair.Value.Select(dependencyType => (DependencyType: dependencyType, Module: pair.Key)))
+            .GroupBy(pair => pair.DependencyType)
+            .ToDictionary(
+                group => group.Key,
+                group => group
+                    .Select(pair => pair.Module)
+                    .Distinct<IModule>(ReferenceEqualityComparer.Instance)
+                    .ToArray());
+        var skippedIgnoredModulesByType = new Dictionary<Type, IgnoredModule>();
+
+        while (pendingIgnoredModules.Count > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await prepareIgnoredModules(pendingIgnoredModules).ConfigureAwait(false);
+
+            var newlySkippedTypes = pendingIgnoredModules
+                .Where(ignoredModule => !runnableModuleTypeCounts.ContainsKey(ignoredModule.Module.GetType()))
+                .Where(ignoredModule => isSkipped(ignoredModule.Module.GetType()))
+                .GroupBy(ignoredModule => ignoredModule.Module.GetType())
+                .Where(group => !skippedIgnoredModulesByType.ContainsKey(group.Key))
+                .Select(group =>
+                {
+                    skippedIgnoredModulesByType[group.Key] = group.First();
+                    return group.Key;
+                })
+                .ToArray();
+            var candidateModules = newlySkippedTypes
+                .Where(dependentsByType.ContainsKey)
+                .SelectMany(moduleType => dependentsByType[moduleType])
+                .Where(remainingModuleSet.Contains)
+                .Distinct<IModule>(ReferenceEqualityComparer.Instance);
+            var newlyIgnoredModules = candidateModules
+                .Select(module => new
+                {
+                    Module = module,
+                    SkippedDependencies = requiredDependenciesByModule[module]
+                        .Where(skippedIgnoredModulesByType.ContainsKey)
+                        .ToArray(),
+                })
+                .Where(item => item.SkippedDependencies.Length > 0)
+                .Select(item => new IgnoredModule(
+                    item.Module,
+                    DependencySkipDecisionFactory.Create(
+                        item.SkippedDependencies
+                            .Select(dependencyType => (
+                                ModuleType: dependencyType,
+                                SkipDecision: (SkipDecision?) skippedIgnoredModulesByType[dependencyType].SkipDecision))
+                            .ToArray())))
+                .ToList();
+
+            if (newlyIgnoredModules.Count == 0)
+            {
+                break;
+            }
+
+            var newlyIgnoredModuleSet = newlyIgnoredModules
+                .Select(ignoredModule => ignoredModule.Module)
+                .ToHashSet<IModule>(ReferenceEqualityComparer.Instance);
+            remainingModules.RemoveAll(newlyIgnoredModuleSet.Contains);
+            remainingModuleSet.ExceptWith(newlyIgnoredModuleSet);
+
+            foreach (var ignoredModule in newlyIgnoredModules)
+            {
+                var moduleType = ignoredModule.Module.GetType();
+                if (--runnableModuleTypeCounts[moduleType] == 0)
+                {
+                    runnableModuleTypeCounts.Remove(moduleType);
+                }
+            }
+
+            allIgnoredModules.AddRange(newlyIgnoredModules);
+            pendingIgnoredModules = newlyIgnoredModules;
+        }
+
+        return new DependencySkipCascadeResult(remainingModules, allIgnoredModules);
+    }
+}
+
+internal sealed record DependencySkipCascadeResult(
+    IReadOnlyList<IModule> RunnableModules,
+    IReadOnlyList<IgnoredModule> IgnoredModules);

--- a/src/ModularPipelines/Engine/Dependencies/ModuleStateDependencyInitializer.cs
+++ b/src/ModularPipelines/Engine/Dependencies/ModuleStateDependencyInitializer.cs
@@ -1,0 +1,35 @@
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine.Dependencies;
+
+internal static class ModuleStateDependencyInitializer
+{
+    public static IReadOnlyList<(Type DependencyType, bool Optional)> Populate(
+        ModuleState state,
+        IReadOnlyList<Type> availableModuleTypes,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry)
+    {
+        var dependencies = ModuleDependencyResolver.GetAllDependencies(
+                state.Module,
+                availableModuleTypes,
+                dependencyRegistry,
+                metadataRegistry)
+            .ToArray();
+
+        foreach (var (dependencyType, optional) in dependencies)
+        {
+            Record(state, dependencyType, optional);
+        }
+
+        return dependencies;
+    }
+
+    public static void Record(ModuleState state, Type dependencyType, bool optional)
+    {
+        state.Dependencies[dependencyType] =
+            state.Dependencies.TryGetValue(dependencyType, out var existingOptional)
+                ? existingOptional && optional
+                : optional;
+    }
+}

--- a/src/ModularPipelines/Engine/DependencySkipDecisionFactory.cs
+++ b/src/ModularPipelines/Engine/DependencySkipDecisionFactory.cs
@@ -1,0 +1,26 @@
+using ModularPipelines.Models;
+
+namespace ModularPipelines.Engine;
+
+internal static class DependencySkipDecisionFactory
+{
+    public static SkipDecision Create(
+        IReadOnlyList<(Type ModuleType, SkipDecision? SkipDecision)> skippedDependencies)
+    {
+        if (skippedDependencies.Count == 1)
+        {
+            var dependency = skippedDependencies[0];
+            var dependencyReason = dependency.SkipDecision?.Reason;
+            var reasonSuffix = string.IsNullOrWhiteSpace(dependencyReason)
+                ? string.Empty
+                : $": {dependencyReason}";
+            return SkipDecision.Skip(
+                $"Required dependency '{dependency.ModuleType.Name}' was skipped{reasonSuffix}");
+        }
+
+        var dependencyNames = string.Join(
+            ", ",
+            skippedDependencies.Select(dependency => $"'{dependency.ModuleType.Name}'"));
+        return SkipDecision.Skip($"Required dependencies {dependencyNames} were skipped");
+    }
+}

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -143,8 +143,9 @@ internal class ModuleRunner : IModuleRunner
 
         // Create module-specific context
         var executionContext = CreateExecutionContext(module, moduleType);
+        ApplyDependencySkip(moduleState, executionContext);
         var loggerType = typeof(ModuleLogger<>).MakeGenericType(moduleType);
-        var logger = (IModuleLogger)scopedServiceProvider.GetRequiredService(loggerType);
+        var logger = (IModuleLogger) scopedServiceProvider.GetRequiredService(loggerType);
         var moduleContext = new ModuleContext(pipelineContext, module, executionContext, logger);
 
         // Start Activity for distributed tracing (Phase 1: alongside AsyncLocal for compatibility)
@@ -284,6 +285,30 @@ internal class ModuleRunner : IModuleRunner
     {
         // Use compiled delegate factory instead of Activator.CreateInstance
         return ExecutionContextFactory.Create(module, moduleType);
+    }
+
+    private void ApplyDependencySkip(ModuleState moduleState, ModuleExecutionContext executionContext)
+    {
+        var skippedDependencies = moduleState.Dependencies
+            .Where(dependency => !dependency.Value)
+            .Select(dependency => (
+                Type: dependency.Key,
+                Result: _resultRegistry.GetResult(dependency.Key)))
+            .Where(dependency => dependency.Result?.ModuleStatus == Enums.Status.Skipped)
+            .OrderBy(dependency => dependency.Type.FullName, StringComparer.Ordinal)
+            .ToArray();
+
+        if (skippedDependencies.Length == 0)
+        {
+            return;
+        }
+
+        executionContext.SkipResult = DependencySkipDecisionFactory.Create(
+            skippedDependencies
+                .Select(dependency => (
+                    ModuleType: dependency.Type,
+                    SkipDecision: dependency.Result!.SkipDecisionOrDefault))
+                .ToArray());
     }
 
     private async Task<IModuleResult> ExecuteTypedModule(

--- a/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
+++ b/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
@@ -33,6 +33,7 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
     private readonly IPipelineExecutor _pipelineExecutor;
     private readonly IPipelineOutputCoordinator _outputCoordinator;
     private readonly IIgnoredModuleResultRegistrar _ignoredModuleResultRegistrar;
+    private readonly IModuleResultRegistry _resultRegistry;
     private readonly IPipelineSummaryFactory _pipelineSummaryFactory;
     private readonly EngineCancellationToken _engineCancellationToken;
     private readonly IThreadPoolConfigurator _threadPoolConfigurator;
@@ -50,6 +51,7 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
         IPipelineExecutor pipelineExecutor,
         IPipelineOutputCoordinator outputCoordinator,
         IIgnoredModuleResultRegistrar ignoredModuleResultRegistrar,
+        IModuleResultRegistry resultRegistry,
         IPipelineSummaryFactory pipelineSummaryFactory,
         EngineCancellationToken engineCancellationToken,
         IThreadPoolConfigurator threadPoolConfigurator,
@@ -62,6 +64,7 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
         _pipelineExecutor = pipelineExecutor;
         _outputCoordinator = outputCoordinator;
         _ignoredModuleResultRegistrar = ignoredModuleResultRegistrar;
+        _resultRegistry = resultRegistry;
         _pipelineSummaryFactory = pipelineSummaryFactory;
         _engineCancellationToken = engineCancellationToken;
         _threadPoolConfigurator = threadPoolConfigurator;
@@ -108,10 +111,17 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
 
         var organizedModules = await _pipelineInitializer.Initialize(cancellationToken).ConfigureAwait(false);
 
-        // Register skipped results for ignored modules (via Category/RunCondition)
-        await _ignoredModuleResultRegistrar.RegisterIgnoredModuleResultsAsync(organizedModules.IgnoredModules).ConfigureAwait(false);
+        // Resolve ignored modules against history before cascading required dependencies.
+        organizedModules = await _ignoredModuleResultRegistrar
+            .RegisterIgnoredModuleResultsAsync(organizedModules)
+            .ConfigureAwait(false);
 
-        var runnableModules = organizedModules.RunnableModules.Select(x => (IModule) x.Module).ToList();
+        var runnableModules = organizedModules.RunnableModules
+            .Select(x => (IModule) x.Module)
+            .Concat(organizedModules.IgnoredModules
+                .Select(ignoredModule => ignoredModule.Module)
+                .Where(module => _resultRegistry.GetResult(module.GetType())?.ModuleStatus == Status.UsedHistory))
+            .ToList();
 
         var start = DateTimeOffset.UtcNow;
         var stopWatch = Stopwatch.StartNew();

--- a/src/ModularPipelines/Engine/Executors/IIgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IIgnoredModuleResultRegistrar.cs
@@ -10,7 +10,8 @@ namespace ModularPipelines.Engine.Executors;
 internal interface IIgnoredModuleResultRegistrar
 {
     /// <summary>
-    /// Registers results for all ignored modules.
+    /// Registers ignored results and cascades modules whose required dependencies
+    /// remain skipped after history restoration.
     /// </summary>
-    Task RegisterIgnoredModuleResultsAsync(IReadOnlyList<IgnoredModule> ignoredModules);
+    Task<OrganizedModules> RegisterIgnoredModuleResultsAsync(OrganizedModules organizedModules);
 }

--- a/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Context;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Enums;
 using ModularPipelines.Helpers;
@@ -20,65 +21,138 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
     private readonly IModuleResultRegistry _resultRegistry;
     private readonly IModuleResultRepository _resultRepository;
     private readonly IPipelineContextProvider _pipelineContextProvider;
+    private readonly IModuleDependencyRegistry _dependencyRegistry;
+    private readonly IModuleMetadataRegistry _metadataRegistry;
     private readonly ILogger<IgnoredModuleResultRegistrar> _logger;
 
     public IgnoredModuleResultRegistrar(
         IModuleResultRegistry resultRegistry,
         IModuleResultRepository resultRepository,
         IPipelineContextProvider pipelineContextProvider,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
         ILogger<IgnoredModuleResultRegistrar> logger)
     {
         _resultRegistry = resultRegistry;
         _resultRepository = resultRepository;
         _pipelineContextProvider = pipelineContextProvider;
+        _dependencyRegistry = dependencyRegistry;
+        _metadataRegistry = metadataRegistry;
         _logger = logger;
     }
 
     /// <inheritdoc />
-    public async Task RegisterIgnoredModuleResultsAsync(IReadOnlyList<IgnoredModule> ignoredModules)
+    public async Task<OrganizedModules> RegisterIgnoredModuleResultsAsync(OrganizedModules organizedModules)
     {
         var pipelineContext = _pipelineContextProvider.GetModuleContext();
+        var runnableModules = organizedModules.RunnableModules.ToList();
+        var ignoredModules = organizedModules.IgnoredModules.ToList();
+        var pendingIgnoredModules = ignoredModules.ToList();
+        var availableModuleTypes = organizedModules.AllModules
+            .Select(module => module.GetType())
+            .Distinct()
+            .ToArray();
 
-        foreach (var ignoredModule in ignoredModules)
+        while (pendingIgnoredModules.Count > 0)
         {
-            var module = ignoredModule.Module;
-            var moduleType = module.GetType();
-            var resultType = module.ResultType;
-
-            // For ignored modules, always check for historical data if a repository is configured
-            if (_resultRepository.GetType() != typeof(NoOpModuleResultRepository))
+            foreach (var ignoredModule in pendingIgnoredModules)
             {
-                var historicalResult = await TryGetHistoricalResultAsync(module, resultType, pipelineContext).ConfigureAwait(false);
-                if (historicalResult != null)
-                {
-                    // Update the status to UsedHistory using the factory method
-                    var usedHistoryResult = ModuleResultFactory.WithStatus(historicalResult, Status.UsedHistory);
-                    _logger.LogDebug("Using historical result for ignored module {ModuleName}",
-                        moduleType.Name);
-                    _resultRegistry.RegisterResult(moduleType, usedHistoryResult);
-
-                    // Set the completion source so awaiting the module returns immediately
-                    SetModuleCompletionSource(module, resultType, usedHistoryResult);
-                    continue;
-                }
+                await RegisterIgnoredModuleResultAsync(ignoredModule, pipelineContext).ConfigureAwait(false);
             }
 
-            _logger.LogDebug("Registering skipped result for ignored module {ModuleName}",
-                moduleType.Name);
+            var runnableModuleTypes = runnableModules
+                .Select(runnableModule => runnableModule.Module.GetType())
+                .ToHashSet();
+            var skippedIgnoredModulesByType = ignoredModules
+                .Where(ignoredModule => !runnableModuleTypes.Contains(ignoredModule.Module.GetType()))
+                .Where(ignoredModule =>
+                    _resultRegistry.GetResult(ignoredModule.Module.GetType())?.ModuleStatus == Status.Skipped)
+                .GroupBy(ignoredModule => ignoredModule.Module.GetType())
+                .ToDictionary(group => group.Key, group => group.First());
+            var newlyIgnoredModules = runnableModules
+                .Select(runnableModule => new
+                {
+                    RunnableModule = runnableModule,
+                    SkippedDependencies = ModuleDependencyResolver
+                        .GetAllDependencies(
+                            runnableModule.Module,
+                            availableModuleTypes,
+                            _dependencyRegistry,
+                            _metadataRegistry)
+                        .Where(dependency => !dependency.Optional)
+                        .Select(dependency => dependency.DependencyType)
+                        .Where(skippedIgnoredModulesByType.ContainsKey)
+                        .Distinct()
+                        .OrderBy(dependencyType => dependencyType.FullName, StringComparer.Ordinal)
+                        .ToArray(),
+                })
+                .Where(item => item.SkippedDependencies.Length > 0)
+                .Select(item => new IgnoredModule(
+                    item.RunnableModule.Module,
+                    ModuleRetriever.CreateDependencySkipDecision(
+                        item.SkippedDependencies,
+                        skippedIgnoredModulesByType)))
+                .ToList();
 
-            // Create execution context with Skipped status using compiled delegate factory
-            var executionContext = ExecutionContextFactory.Create(module, moduleType);
-            executionContext.Status = Status.Skipped;
-            executionContext.SkipResult = ignoredModule.SkipDecision;
+            if (newlyIgnoredModules.Count == 0)
+            {
+                break;
+            }
 
-            // Create ModuleResult<T> with the skipped status using compiled delegate factory
-            var result = ModuleResultFactory.CreateSkipped(resultType, executionContext);
+            foreach (var ignoredModule in newlyIgnoredModules)
+            {
+                runnableModules.RemoveAll(runnableModule =>
+                    ReferenceEquals(runnableModule.Module, ignoredModule.Module));
+                ignoredModules.Add(ignoredModule);
+            }
 
-            _resultRegistry.RegisterResult(moduleType, result);
-
-            // Set the completion source so awaiting the module returns immediately
-            SetModuleCompletionSource(module, resultType, result);
+            pendingIgnoredModules = newlyIgnoredModules;
         }
+
+        return new OrganizedModules(runnableModules, ignoredModules);
+    }
+
+    private async Task RegisterIgnoredModuleResultAsync(
+        IgnoredModule ignoredModule,
+        IPipelineHookContext pipelineContext)
+    {
+        var module = ignoredModule.Module;
+        var moduleType = module.GetType();
+        var resultType = module.ResultType;
+
+        // For ignored modules, always check for historical data if a repository is configured
+        if (_resultRepository.GetType() != typeof(NoOpModuleResultRepository))
+        {
+            var historicalResult = await TryGetHistoricalResultAsync(module, resultType, pipelineContext).ConfigureAwait(false);
+            if (historicalResult != null)
+            {
+                // Update the status to UsedHistory using the factory method
+                var usedHistoryResult = ModuleResultFactory.WithStatus(historicalResult, Status.UsedHistory);
+                _logger.LogDebug("Using historical result for ignored module {ModuleName}",
+                    moduleType.Name);
+                _resultRegistry.RegisterResult(moduleType, usedHistoryResult);
+
+                // Set the completion source so awaiting the module returns immediately
+                SetModuleCompletionSource(module, resultType, usedHistoryResult);
+                return;
+            }
+        }
+
+        _logger.LogDebug("Registering skipped result for ignored module {ModuleName}",
+            moduleType.Name);
+
+        // Create execution context with Skipped status using compiled delegate factory
+        var executionContext = ExecutionContextFactory.Create(module, moduleType);
+        executionContext.Status = Status.Skipped;
+        executionContext.SkipResult = ignoredModule.SkipDecision;
+
+        // Create ModuleResult<T> with the skipped status using compiled delegate factory
+        var result = ModuleResultFactory.CreateSkipped(resultType, executionContext);
+
+        _resultRegistry.RegisterResult(moduleType, result);
+
+        // Set the completion source so awaiting the module returns immediately
+        SetModuleCompletionSource(module, resultType, result);
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
@@ -53,6 +53,11 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
     /// <inheritdoc />
     public async Task<OrganizedModules> RegisterIgnoredModuleResultsAsync(OrganizedModules organizedModules)
     {
+        if (IsDistributedWorker())
+        {
+            return organizedModules;
+        }
+
         var pipelineContext = _pipelineContextProvider.GetModuleContext();
         var runnableModules = organizedModules.RunnableModules.ToList();
         var ignoredModules = organizedModules.IgnoredModules.ToList();
@@ -67,11 +72,6 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
             foreach (var ignoredModule in pendingIgnoredModules)
             {
                 await RegisterIgnoredModuleResultAsync(ignoredModule, pipelineContext).ConfigureAwait(false);
-            }
-
-            if (IsDistributedWorker())
-            {
-                break;
             }
 
             var runnableModuleTypes = runnableModules

--- a/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
@@ -1,7 +1,10 @@
 using System.Collections.Concurrent;
 using System.Linq.Expressions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModularPipelines.Context;
+using ModularPipelines.Distributed;
+using ModularPipelines.Distributed.Configuration;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Enums;
@@ -23,6 +26,8 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
     private readonly IPipelineContextProvider _pipelineContextProvider;
     private readonly IModuleDependencyRegistry _dependencyRegistry;
     private readonly IModuleMetadataRegistry _metadataRegistry;
+    private readonly IOptions<DistributedOptions> _distributedOptions;
+    private readonly RoleDetector _roleDetector;
     private readonly ILogger<IgnoredModuleResultRegistrar> _logger;
 
     public IgnoredModuleResultRegistrar(
@@ -31,6 +36,8 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
         IPipelineContextProvider pipelineContextProvider,
         IModuleDependencyRegistry dependencyRegistry,
         IModuleMetadataRegistry metadataRegistry,
+        IOptions<DistributedOptions> distributedOptions,
+        RoleDetector roleDetector,
         ILogger<IgnoredModuleResultRegistrar> logger)
     {
         _resultRegistry = resultRegistry;
@@ -38,6 +45,8 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
         _pipelineContextProvider = pipelineContextProvider;
         _dependencyRegistry = dependencyRegistry;
         _metadataRegistry = metadataRegistry;
+        _distributedOptions = distributedOptions;
+        _roleDetector = roleDetector;
         _logger = logger;
     }
 
@@ -58,6 +67,11 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
             foreach (var ignoredModule in pendingIgnoredModules)
             {
                 await RegisterIgnoredModuleResultAsync(ignoredModule, pipelineContext).ConfigureAwait(false);
+            }
+
+            if (IsDistributedWorker())
+            {
+                break;
             }
 
             var runnableModuleTypes = runnableModules
@@ -110,6 +124,14 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
         }
 
         return new OrganizedModules(runnableModules, ignoredModules);
+    }
+
+    private bool IsDistributedWorker()
+    {
+        var options = _distributedOptions.Value;
+        return options.Enabled
+               && options.TotalInstances > 1
+               && _roleDetector.DetectRole() == DistributedRole.Worker;
     }
 
     private async Task RegisterIgnoredModuleResultAsync(

--- a/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
@@ -61,69 +61,27 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
         var pipelineContext = _pipelineContextProvider.GetModuleContext();
         var runnableModules = organizedModules.RunnableModules.ToList();
         var ignoredModules = organizedModules.IgnoredModules.ToList();
-        var pendingIgnoredModules = ignoredModules.ToList();
-        var availableModuleTypes = organizedModules.AllModules
-            .Select(module => module.GetType())
-            .Distinct()
-            .ToArray();
-
-        while (pendingIgnoredModules.Count > 0)
-        {
-            foreach (var ignoredModule in pendingIgnoredModules)
+        var cascadeResult = await DependencySkipCascade.ApplyAsync(
+            organizedModules.AllModules.ToArray(),
+            runnableModules.Select(runnableModule => runnableModule.Module),
+            ignoredModules,
+            _dependencyRegistry,
+            _metadataRegistry,
+            async pendingIgnoredModules =>
             {
-                await RegisterIgnoredModuleResultAsync(ignoredModule, pipelineContext).ConfigureAwait(false);
-            }
-
-            var runnableModuleTypes = runnableModules
-                .Select(runnableModule => runnableModule.Module.GetType())
-                .ToHashSet();
-            var skippedIgnoredModulesByType = ignoredModules
-                .Where(ignoredModule => !runnableModuleTypes.Contains(ignoredModule.Module.GetType()))
-                .Where(ignoredModule =>
-                    _resultRegistry.GetResult(ignoredModule.Module.GetType())?.ModuleStatus == Status.Skipped)
-                .GroupBy(ignoredModule => ignoredModule.Module.GetType())
-                .ToDictionary(group => group.Key, group => group.First());
-            var newlyIgnoredModules = runnableModules
-                .Select(runnableModule => new
+                foreach (var ignoredModule in pendingIgnoredModules)
                 {
-                    RunnableModule = runnableModule,
-                    SkippedDependencies = ModuleDependencyResolver
-                        .GetAllDependencies(
-                            runnableModule.Module,
-                            availableModuleTypes,
-                            _dependencyRegistry,
-                            _metadataRegistry)
-                        .Where(dependency => !dependency.Optional)
-                        .Select(dependency => dependency.DependencyType)
-                        .Where(skippedIgnoredModulesByType.ContainsKey)
-                        .Distinct()
-                        .OrderBy(dependencyType => dependencyType.FullName, StringComparer.Ordinal)
-                        .ToArray(),
-                })
-                .Where(item => item.SkippedDependencies.Length > 0)
-                .Select(item => new IgnoredModule(
-                    item.RunnableModule.Module,
-                    ModuleRetriever.CreateDependencySkipDecision(
-                        item.SkippedDependencies,
-                        skippedIgnoredModulesByType)))
-                .ToList();
+                    await RegisterIgnoredModuleResultAsync(ignoredModule, pipelineContext).ConfigureAwait(false);
+                }
+            },
+            moduleType => _resultRegistry.GetResult(moduleType)?.ModuleStatus == Status.Skipped)
+            .ConfigureAwait(false);
+        var remainingModules = cascadeResult.RunnableModules.ToHashSet<IModule>(
+            ReferenceEqualityComparer.Instance);
 
-            if (newlyIgnoredModules.Count == 0)
-            {
-                break;
-            }
-
-            foreach (var ignoredModule in newlyIgnoredModules)
-            {
-                runnableModules.RemoveAll(runnableModule =>
-                    ReferenceEquals(runnableModule.Module, ignoredModule.Module));
-                ignoredModules.Add(ignoredModule);
-            }
-
-            pendingIgnoredModules = newlyIgnoredModules;
-        }
-
-        return new OrganizedModules(runnableModules, ignoredModules);
+        return new OrganizedModules(
+            runnableModules.Where(runnableModule => remainingModules.Contains(runnableModule.Module)).ToList(),
+            cascadeResult.IgnoredModules);
     }
 
     private bool IsDistributedWorker()

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -82,17 +82,19 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             // Setup cancellation based on AlwaysRun behavior
             SetupCancellation(config, executionContext, engineCancellationToken);
 
-            // Check for skip condition
-            if (config.SkipCondition != null)
+            // A required dependency can skip after discovery through a fluent condition.
+            var skipDecision = executionContext.SkipResult;
+            if (!skipDecision.ShouldSkip && config.SkipCondition != null)
             {
-                var skipDecision = await config.SkipCondition(moduleContext).ConfigureAwait(false);
-                if (skipDecision.ShouldSkip)
-                {
-                    // Call direct skip hook first
-                    await _directHookInvoker.InvokeSkippedAsync(module, moduleContext, skipDecision, executionContext.ModuleCancellationTokenSource.Token).ConfigureAwait(false);
+                skipDecision = await config.SkipCondition(moduleContext).ConfigureAwait(false);
+            }
 
-                    return await HandleSkipped(module, executionContext, moduleContext, skipDecision, logger).ConfigureAwait(false);
-                }
+            if (skipDecision.ShouldSkip)
+            {
+                // Call direct skip hook first
+                await _directHookInvoker.InvokeSkippedAsync(module, moduleContext, skipDecision, executionContext.ModuleCancellationTokenSource.Token).ConfigureAwait(false);
+
+                return await HandleSkipped(module, executionContext, moduleContext, skipDecision, logger).ConfigureAwait(false);
             }
 
             // Check for cancellation after skip check

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -119,7 +119,11 @@ internal class ModuleExecutor : IModuleExecutor
         // the runnable set against itself mirrors the DependencyWaiter check (a required
         // dependency outside the runnable set throws), surfacing missing/cyclic dependencies
         // eagerly with a clear message instead of failing later in the scheduler.
-        ModuleDependencyValidator.Validate(modules, _dependencyRegistry, _metadataRegistry);
+        ModuleDependencyValidator.Validate(
+            modules,
+            _dependencyRegistry,
+            _metadataRegistry,
+            UsedHistoryModuleSchedulerInitializer.GetPrecompletedModuleTypes(modules, _resultRegistry));
 
         var scheduler = _schedulerFactory.Create();
         scheduler.InitializeModules(modules);

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -27,6 +27,7 @@ internal class ModuleExecutor : IModuleExecutor
     private readonly IModuleRunner _moduleRunner;
     private readonly IAlwaysRunHandler _alwaysRunHandler;
     private readonly IModuleResultRegistrar _resultRegistrar;
+    private readonly IModuleResultRegistry _resultRegistry;
     private readonly IParallelLimitProvider _parallelLimitProvider;
     private readonly IRegistrationEventExecutor _registrationEventExecutor;
     private readonly IMetricsCollector _metricsCollector;
@@ -40,6 +41,7 @@ internal class ModuleExecutor : IModuleExecutor
         IModuleRunner moduleRunner,
         IAlwaysRunHandler alwaysRunHandler,
         IModuleResultRegistrar resultRegistrar,
+        IModuleResultRegistry resultRegistry,
         IParallelLimitProvider parallelLimitProvider,
         IRegistrationEventExecutor registrationEventExecutor,
         IMetricsCollector metricsCollector,
@@ -52,6 +54,7 @@ internal class ModuleExecutor : IModuleExecutor
         _moduleRunner = moduleRunner;
         _alwaysRunHandler = alwaysRunHandler;
         _resultRegistrar = resultRegistrar;
+        _resultRegistry = resultRegistry;
         _parallelLimitProvider = parallelLimitProvider;
         _registrationEventExecutor = registrationEventExecutor;
         _metricsCollector = metricsCollector;
@@ -120,6 +123,27 @@ internal class ModuleExecutor : IModuleExecutor
 
         var scheduler = _schedulerFactory.Create();
         scheduler.InitializeModules(modules);
+
+        foreach (var module in modules)
+        {
+            var moduleType = module.GetType();
+            var existingResult = _resultRegistry.GetResult(moduleType);
+            if (existingResult?.ModuleStatus != Enums.Status.UsedHistory)
+            {
+                continue;
+            }
+
+            var moduleState = scheduler.GetModuleState(moduleType);
+            if (moduleState != null)
+            {
+                moduleState.Result = existingResult;
+            }
+
+            scheduler.MarkModuleCompleted(
+                moduleType,
+                success: true,
+                statusOverride: Enums.Status.UsedHistory);
+        }
 
         return scheduler;
     }

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -123,27 +123,10 @@ internal class ModuleExecutor : IModuleExecutor
 
         var scheduler = _schedulerFactory.Create();
         scheduler.InitializeModules(modules);
-
-        foreach (var module in modules)
-        {
-            var moduleType = module.GetType();
-            var existingResult = _resultRegistry.GetResult(moduleType);
-            if (existingResult?.ModuleStatus != Enums.Status.UsedHistory)
-            {
-                continue;
-            }
-
-            var moduleState = scheduler.GetModuleState(moduleType);
-            if (moduleState != null)
-            {
-                moduleState.Result = existingResult;
-            }
-
-            scheduler.MarkModuleCompleted(
-                moduleType,
-                success: true,
-                statusOverride: Enums.Status.UsedHistory);
-        }
+        UsedHistoryModuleSchedulerInitializer.Precomplete(
+            modules,
+            scheduler,
+            _resultRegistry);
 
         return scheduler;
     }

--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -35,8 +35,8 @@ internal class ModuleRetriever
         _dependencyRegistry = dependencyRegistry;
         _metadataRegistry = metadataRegistry;
 
-        // Re-registering one pre-created module adds another service descriptor,
-        // but the module object still represents one execution.
+        // Defend against direct service registrations that repeat one module instance.
+        // The module object still represents one execution.
         _modules = modules
             .Distinct<IModule>(ReferenceEqualityComparer.Instance)
             .ToList();

--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using EnumerableAsyncProcessor.Extensions;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
 using ModularPipelines.Models;
@@ -12,17 +13,23 @@ internal class ModuleRetriever
 {
     private readonly IModuleConditionHandler _moduleConditionHandler;
     private readonly ISafeModuleEstimatedTimeProvider _estimatedTimeProvider;
+    private readonly IModuleDependencyRegistry _dependencyRegistry;
+    private readonly IModuleMetadataRegistry _metadataRegistry;
     private readonly List<IModule> _modules;
     private Task<OrganizedModules>? _cached;
 
     public ModuleRetriever(
         IModuleConditionHandler moduleConditionHandler,
         IEnumerable<IModule> modules,
-        ISafeModuleEstimatedTimeProvider estimatedTimeProvider
+        ISafeModuleEstimatedTimeProvider estimatedTimeProvider,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry
     )
     {
         _moduleConditionHandler = moduleConditionHandler;
         _estimatedTimeProvider = estimatedTimeProvider;
+        _dependencyRegistry = dependencyRegistry;
+        _metadataRegistry = metadataRegistry;
         _modules = modules.ToList();
     }
 
@@ -62,7 +69,86 @@ internal class ModuleRetriever
             }
         }
 
+        CascadeSkippedDependencies(modulesToProcess, modulesToIgnore, cancellationToken);
+
         return new DiscoveredModules(modulesToProcess, modulesToIgnore);
+    }
+
+    private void CascadeSkippedDependencies(
+        List<IModule> runnableModules,
+        List<IgnoredModule> ignoredModules,
+        CancellationToken cancellationToken)
+    {
+        var availableModuleTypes = _modules
+            .Select(module => module.GetType())
+            .Distinct()
+            .ToArray();
+        var ignoredModulesByType = ignoredModules.ToDictionary(
+            ignoredModule => ignoredModule.Module.GetType());
+        var requiredDependenciesByModule = runnableModules.ToDictionary(
+            module => module,
+            module => ModuleDependencyResolver
+                .GetAllDependencies(module, availableModuleTypes, _dependencyRegistry, _metadataRegistry)
+                .Where(dependency => !dependency.Optional)
+                .Select(dependency => dependency.DependencyType)
+                .Distinct()
+                .OrderBy(dependencyType => dependencyType.FullName, StringComparer.Ordinal)
+                .ToArray());
+
+        while (true)
+        {
+            var newlyIgnoredModules = new List<IgnoredModule>();
+
+            foreach (var module in runnableModules)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var skippedDependencies = requiredDependenciesByModule[module]
+                    .Where(ignoredModulesByType.ContainsKey)
+                    .ToArray();
+
+                if (skippedDependencies.Length == 0)
+                {
+                    continue;
+                }
+
+                newlyIgnoredModules.Add(new IgnoredModule(
+                    module,
+                    CreateDependencySkipDecision(skippedDependencies, ignoredModulesByType)));
+            }
+
+            if (newlyIgnoredModules.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var ignoredModule in newlyIgnoredModules)
+            {
+                runnableModules.Remove(ignoredModule.Module);
+                ignoredModules.Add(ignoredModule);
+                ignoredModulesByType.Add(ignoredModule.Module.GetType(), ignoredModule);
+            }
+        }
+    }
+
+    private static SkipDecision CreateDependencySkipDecision(
+        IReadOnlyList<Type> skippedDependencies,
+        IReadOnlyDictionary<Type, IgnoredModule> ignoredModulesByType)
+    {
+        if (skippedDependencies.Count == 1)
+        {
+            var dependencyType = skippedDependencies[0];
+            var dependencyReason = ignoredModulesByType[dependencyType].SkipDecision.Reason;
+            var reasonSuffix = string.IsNullOrWhiteSpace(dependencyReason)
+                ? string.Empty
+                : $": {dependencyReason}";
+            return SkipDecision.Skip($"Required dependency '{dependencyType.Name}' was skipped{reasonSuffix}");
+        }
+
+        var dependencyNames = string.Join(
+            ", ",
+            skippedDependencies.Select(dependencyType => $"'{dependencyType.Name}'"));
+        return SkipDecision.Skip($"Required dependencies {dependencyNames} were skipped");
     }
 
     private async Task<OrganizedModules> GetInternal(CancellationToken cancellationToken)

--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -51,10 +51,12 @@ internal class ModuleRetriever
     internal async Task<IReadOnlyList<IModule>> GetRunnableModulesForValidation(
         CancellationToken cancellationToken = default)
     {
-        return (await DiscoverModules(cancellationToken).ConfigureAwait(false)).RunnableModules;
+        return (await DiscoverModules(cancellationToken, cascadeSkippedDependencies: true).ConfigureAwait(false)).RunnableModules;
     }
 
-    private async Task<DiscoveredModules> DiscoverModules(CancellationToken cancellationToken)
+    private async Task<DiscoveredModules> DiscoverModules(
+        CancellationToken cancellationToken,
+        bool cascadeSkippedDependencies)
     {
         if (_modules.Count == 0)
         {
@@ -81,7 +83,10 @@ internal class ModuleRetriever
             }
         }
 
-        CascadeSkippedDependencies(modulesToProcess, modulesToIgnore, cancellationToken);
+        if (cascadeSkippedDependencies)
+        {
+            CascadeSkippedDependencies(modulesToProcess, modulesToIgnore, cancellationToken);
+        }
 
         return new DiscoveredModules(modulesToProcess, modulesToIgnore);
     }
@@ -102,7 +107,7 @@ internal class ModuleRetriever
             .Where(ignoredModule => !runnableModuleTypes.Contains(ignoredModule.Module.GetType()))
             .GroupBy(ignoredModule => ignoredModule.Module.GetType())
             .ToDictionary(group => group.Key, group => group.First());
-        var requiredDependenciesByModule = runnableModules.ToDictionary(
+        var requiredDependenciesByModule = runnableModules.ToDictionary<IModule, IModule, Type[]>(
             module => module,
             module => ModuleDependencyResolver
                 .GetAllDependencies(module, availableModuleTypes, _dependencyRegistry, _metadataRegistry)
@@ -110,7 +115,8 @@ internal class ModuleRetriever
                 .Select(dependency => dependency.DependencyType)
                 .Distinct()
                 .OrderBy(dependencyType => dependencyType.FullName, StringComparer.Ordinal)
-                .ToArray());
+                .ToArray(),
+            ReferenceEqualityComparer.Instance);
 
         while (true)
         {
@@ -157,29 +163,23 @@ internal class ModuleRetriever
         }
     }
 
-    private static SkipDecision CreateDependencySkipDecision(
+    internal static SkipDecision CreateDependencySkipDecision(
         IReadOnlyList<Type> skippedDependencies,
         IReadOnlyDictionary<Type, IgnoredModule> ignoredModulesByType)
     {
-        if (skippedDependencies.Count == 1)
-        {
-            var dependencyType = skippedDependencies[0];
-            var dependencyReason = ignoredModulesByType[dependencyType].SkipDecision.Reason;
-            var reasonSuffix = string.IsNullOrWhiteSpace(dependencyReason)
-                ? string.Empty
-                : $": {dependencyReason}";
-            return SkipDecision.Skip($"Required dependency '{dependencyType.Name}' was skipped{reasonSuffix}");
-        }
-
-        var dependencyNames = string.Join(
-            ", ",
-            skippedDependencies.Select(dependencyType => $"'{dependencyType.Name}'"));
-        return SkipDecision.Skip($"Required dependencies {dependencyNames} were skipped");
+        return DependencySkipDecisionFactory.Create(
+            skippedDependencies
+                .Select(dependencyType => (
+                    ModuleType: dependencyType,
+                    SkipDecision: (SkipDecision?) ignoredModulesByType[dependencyType].SkipDecision))
+                .ToArray());
     }
 
     private async Task<OrganizedModules> GetInternal(CancellationToken cancellationToken)
     {
-        var discoveredModules = await DiscoverModules(cancellationToken).ConfigureAwait(false);
+        var discoveredModules = await DiscoverModules(
+            cancellationToken,
+            cascadeSkippedDependencies: false).ConfigureAwait(false);
         var runnableModulesWithEstimatatedDuration = await discoveredModules.RunnableModules.ToAsyncProcessorBuilder()
             .SelectAsync(async module =>
             {

--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -85,94 +85,20 @@ internal class ModuleRetriever
 
         if (cascadeSkippedDependencies)
         {
-            CascadeSkippedDependencies(modulesToProcess, modulesToIgnore, cancellationToken);
+            var cascadeResult = await DependencySkipCascade.ApplyAsync(
+                _modules,
+                modulesToProcess,
+                modulesToIgnore,
+                _dependencyRegistry,
+                _metadataRegistry,
+                _ => Task.CompletedTask,
+                _ => true,
+                cancellationToken).ConfigureAwait(false);
+            modulesToProcess = cascadeResult.RunnableModules.ToList();
+            modulesToIgnore = cascadeResult.IgnoredModules.ToList();
         }
 
         return new DiscoveredModules(modulesToProcess, modulesToIgnore);
-    }
-
-    private void CascadeSkippedDependencies(
-        List<IModule> runnableModules,
-        List<IgnoredModule> ignoredModules,
-        CancellationToken cancellationToken)
-    {
-        var availableModuleTypes = _modules
-            .Select(module => module.GetType())
-            .Distinct()
-            .ToArray();
-        var runnableModuleTypes = runnableModules
-            .Select(module => module.GetType())
-            .ToHashSet();
-        var ignoredModulesByType = ignoredModules
-            .Where(ignoredModule => !runnableModuleTypes.Contains(ignoredModule.Module.GetType()))
-            .GroupBy(ignoredModule => ignoredModule.Module.GetType())
-            .ToDictionary(group => group.Key, group => group.First());
-        var requiredDependenciesByModule = runnableModules.ToDictionary<IModule, IModule, Type[]>(
-            module => module,
-            module => ModuleDependencyResolver
-                .GetAllDependencies(module, availableModuleTypes, _dependencyRegistry, _metadataRegistry)
-                .Where(dependency => !dependency.Optional)
-                .Select(dependency => dependency.DependencyType)
-                .Distinct()
-                .OrderBy(dependencyType => dependencyType.FullName, StringComparer.Ordinal)
-                .ToArray(),
-            ReferenceEqualityComparer.Instance);
-
-        while (true)
-        {
-            var newlyIgnoredModules = new List<IgnoredModule>();
-
-            foreach (var module in runnableModules)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var skippedDependencies = requiredDependenciesByModule[module]
-                    .Where(ignoredModulesByType.ContainsKey)
-                    .ToArray();
-
-                if (skippedDependencies.Length == 0)
-                {
-                    continue;
-                }
-
-                newlyIgnoredModules.Add(new IgnoredModule(
-                    module,
-                    CreateDependencySkipDecision(skippedDependencies, ignoredModulesByType)));
-            }
-
-            if (newlyIgnoredModules.Count == 0)
-            {
-                return;
-            }
-
-            foreach (var ignoredModule in newlyIgnoredModules)
-            {
-                runnableModules.Remove(ignoredModule.Module);
-                ignoredModules.Add(ignoredModule);
-            }
-
-            foreach (var ignoredModuleGroup in newlyIgnoredModules.GroupBy(
-                         ignoredModule => ignoredModule.Module.GetType()))
-            {
-                var moduleType = ignoredModuleGroup.Key;
-                if (runnableModules.All(module => module.GetType() != moduleType))
-                {
-                    ignoredModulesByType[moduleType] = ignoredModuleGroup.First();
-                }
-            }
-        }
-    }
-
-    internal static SkipDecision CreateDependencySkipDecision(
-        IReadOnlyList<Type> skippedDependencies,
-        IReadOnlyDictionary<Type, IgnoredModule> ignoredModulesByType)
-    {
-        return DependencySkipDecisionFactory.Create(
-            skippedDependencies
-                .Select(dependencyType => (
-                    ModuleType: dependencyType,
-                    SkipDecision: (SkipDecision?) ignoredModulesByType[dependencyType].SkipDecision))
-                .ToArray());
     }
 
     private async Task<OrganizedModules> GetInternal(CancellationToken cancellationToken)

--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -34,7 +34,12 @@ internal class ModuleRetriever
         _estimatedTimeProvider = estimatedTimeProvider;
         _dependencyRegistry = dependencyRegistry;
         _metadataRegistry = metadataRegistry;
-        _modules = modules.ToList();
+
+        // Re-registering one pre-created module adds another service descriptor,
+        // but the module object still represents one execution.
+        _modules = modules
+            .Distinct<IModule>(ReferenceEqualityComparer.Instance)
+            .ToList();
     }
 
     [MethodImpl(MethodImplOptions.Synchronized)]

--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using EnumerableAsyncProcessor.Extensions;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
@@ -12,6 +13,7 @@ namespace ModularPipelines.Engine;
 internal class ModuleRetriever
 {
     private readonly IModuleConditionHandler _moduleConditionHandler;
+    private readonly IRegistrationEventExecutor _registrationEventExecutor;
     private readonly ISafeModuleEstimatedTimeProvider _estimatedTimeProvider;
     private readonly IModuleDependencyRegistry _dependencyRegistry;
     private readonly IModuleMetadataRegistry _metadataRegistry;
@@ -20,6 +22,7 @@ internal class ModuleRetriever
 
     public ModuleRetriever(
         IModuleConditionHandler moduleConditionHandler,
+        IRegistrationEventExecutor registrationEventExecutor,
         IEnumerable<IModule> modules,
         ISafeModuleEstimatedTimeProvider estimatedTimeProvider,
         IModuleDependencyRegistry dependencyRegistry,
@@ -27,6 +30,7 @@ internal class ModuleRetriever
     )
     {
         _moduleConditionHandler = moduleConditionHandler;
+        _registrationEventExecutor = registrationEventExecutor;
         _estimatedTimeProvider = estimatedTimeProvider;
         _dependencyRegistry = dependencyRegistry;
         _metadataRegistry = metadataRegistry;
@@ -51,6 +55,9 @@ internal class ModuleRetriever
         {
             throw new PipelineException("No modules have been registered");
         }
+
+        // Dynamic dependencies and metadata must be registered before conditions and cascade skipping are evaluated.
+        await _registrationEventExecutor.InvokeRegistrationEventsAsync(_modules).ConfigureAwait(false);
 
         var modulesToIgnore = new List<IgnoredModule>();
         var modulesToProcess = new List<IModule>();
@@ -83,8 +90,13 @@ internal class ModuleRetriever
             .Select(module => module.GetType())
             .Distinct()
             .ToArray();
-        var ignoredModulesByType = ignoredModules.ToDictionary(
-            ignoredModule => ignoredModule.Module.GetType());
+        var runnableModuleTypes = runnableModules
+            .Select(module => module.GetType())
+            .ToHashSet();
+        var ignoredModulesByType = ignoredModules
+            .Where(ignoredModule => !runnableModuleTypes.Contains(ignoredModule.Module.GetType()))
+            .GroupBy(ignoredModule => ignoredModule.Module.GetType())
+            .ToDictionary(group => group.Key, group => group.First());
         var requiredDependenciesByModule = runnableModules.ToDictionary(
             module => module,
             module => ModuleDependencyResolver
@@ -126,7 +138,16 @@ internal class ModuleRetriever
             {
                 runnableModules.Remove(ignoredModule.Module);
                 ignoredModules.Add(ignoredModule);
-                ignoredModulesByType.Add(ignoredModule.Module.GetType(), ignoredModule);
+            }
+
+            foreach (var ignoredModuleGroup in newlyIgnoredModules.GroupBy(
+                         ignoredModule => ignoredModule.Module.GetType()))
+            {
+                var moduleType = ignoredModuleGroup.Key;
+                if (runnableModules.All(module => module.GetType() != moduleType))
+                {
+                    ignoredModulesByType[moduleType] = ignoredModuleGroup.First();
+                }
             }
         }
     }

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -194,13 +194,13 @@ internal class ModuleScheduler : IModuleScheduler
 
                 foreach (var (dependencyType, optional) in newlyResolvedDependencies)
                 {
-                    RecordDependency(existingState, dependencyType, optional);
+                    ModuleStateDependencyInitializer.Record(existingState, dependencyType, optional);
                 }
             }
 
             foreach (var (dependencyType, optional) in newModuleDependencies)
             {
-                RecordDependency(state, dependencyType, optional);
+                ModuleStateDependencyInitializer.Record(state, dependencyType, optional);
             }
 
             _moduleStates[moduleType] = state;
@@ -322,18 +322,17 @@ internal class ModuleScheduler : IModuleScheduler
         ModuleState state,
         IReadOnlyList<Type> availableModuleTypes)
     {
-        var dependencies = ModuleDependencyResolver.GetAllDependencies(
-            state.Module,
+        var dependencies = ModuleStateDependencyInitializer.Populate(
+            state,
             availableModuleTypes,
             _dependencyRegistry,
-            _metadataRegistry).ToArray();
+            _metadataRegistry);
         _dependencyGraph[state.ModuleType] = dependencies
             .Select(dependency => dependency.DependencyType)
             .ToHashSet();
 
         foreach (var (dependencyType, optional) in dependencies)
         {
-            RecordDependency(state, dependencyType, optional);
             LinkDependencyState(state, dependencyType, optional);
         }
     }
@@ -391,13 +390,6 @@ internal class ModuleScheduler : IModuleScheduler
                 dependencyState.DependentModules.Add(dependentState);
             }
         }
-    }
-
-    private static void RecordDependency(ModuleState state, Type dependencyType, bool optional)
-    {
-        state.Dependencies[dependencyType] = state.Dependencies.TryGetValue(dependencyType, out var existingOptional)
-            ? existingOptional && optional
-            : optional;
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/UsedHistoryModuleSchedulerInitializer.cs
+++ b/src/ModularPipelines/Engine/UsedHistoryModuleSchedulerInitializer.cs
@@ -1,0 +1,34 @@
+using ModularPipelines.Enums;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine;
+
+internal static class UsedHistoryModuleSchedulerInitializer
+{
+    public static void Precomplete(
+        IReadOnlyList<IModule> modules,
+        IModuleScheduler scheduler,
+        IModuleResultRegistry resultRegistry)
+    {
+        foreach (var module in modules)
+        {
+            var moduleType = module.GetType();
+            var existingResult = resultRegistry.GetResult(moduleType);
+            if (existingResult?.ModuleStatus != Status.UsedHistory)
+            {
+                continue;
+            }
+
+            var moduleState = scheduler.GetModuleState(moduleType);
+            if (moduleState is not null)
+            {
+                moduleState.Result = existingResult;
+            }
+
+            scheduler.MarkModuleCompleted(
+                moduleType,
+                success: true,
+                statusOverride: Status.UsedHistory);
+        }
+    }
+}

--- a/src/ModularPipelines/Engine/UsedHistoryModuleSchedulerInitializer.cs
+++ b/src/ModularPipelines/Engine/UsedHistoryModuleSchedulerInitializer.cs
@@ -5,6 +5,16 @@ namespace ModularPipelines.Engine;
 
 internal static class UsedHistoryModuleSchedulerInitializer
 {
+    public static HashSet<Type> GetPrecompletedModuleTypes(
+        IReadOnlyList<IModule> modules,
+        IModuleResultRegistry resultRegistry)
+    {
+        return modules
+            .Select(module => module.GetType())
+            .Where(moduleType => resultRegistry.GetResult(moduleType)?.ModuleStatus == Status.UsedHistory)
+            .ToHashSet();
+    }
+
     public static void Precomplete(
         IReadOnlyList<IModule> modules,
         IModuleScheduler scheduler,

--- a/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
@@ -98,10 +98,18 @@ public static class ServiceCollectionExtensions
     public static IModuleRegistrationBuilder AddModule<TModule>(this IServiceCollection services, TModule tModule)
         where TModule : class, IModule
     {
+        ArgumentNullException.ThrowIfNull(tModule);
+
         // Track module type for auto-registration and unused module detection
         GetOrCreateModuleTypesHolder(services).Add(typeof(TModule));
 
-        services.AddSingleton<IModule>(tModule);
+        if (!services.Any(descriptor =>
+                descriptor.ServiceType == typeof(IModule)
+                && ReferenceEquals(descriptor.ImplementationInstance, tModule)))
+        {
+            services.AddSingleton<IModule>(tModule);
+        }
+
         return new ModuleRegistrationBuilder(services, typeof(TModule));
     }
 

--- a/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
+++ b/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
@@ -22,7 +22,8 @@ public static class ModuleDependencyValidator
     internal static void Validate(
         IEnumerable<IModule> registeredModules,
         IModuleDependencyRegistry? dynamicRegistry,
-        IModuleMetadataRegistry? metadataRegistry)
+        IModuleMetadataRegistry? metadataRegistry,
+        IReadOnlySet<Type>? precompletedModuleTypes = null)
     {
         var modulesByType = registeredModules
             .GroupBy(module => module.GetType())
@@ -40,7 +41,9 @@ public static class ModuleDependencyValidator
 
         var dependenciesByModule = modulesByType.ToDictionary(
             pair => pair.Key,
-            pair => GetAllDependencies(pair.Value, moduleTypes, dynamicRegistry, metadataRegistry));
+            pair => precompletedModuleTypes?.Contains(pair.Key) == true
+                ? []
+                : GetAllDependencies(pair.Value, moduleTypes, dynamicRegistry, metadataRegistry));
 
         foreach (var (moduleType, dependencies) in dependenciesByModule)
         {

--- a/test/ModularPipelines.Distributed.UnitTests/DependencyResultPropagationTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/DependencyResultPropagationTests.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
 using ModularPipelines.Distributed;
 using ModularPipelines.Distributed.Serialization;
-using ModularPipelines.Distributed.Worker;
+using ModularPipelines.Engine;
 using ModularPipelines.Enums;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -84,25 +84,32 @@ public class DependencyResultPropagationTests
         var depModule = new DependencyModule();
         var consumerModule = new ConsumerModule();
         IReadOnlyList<IModule> modules = [depModule, consumerModule];
+        var resultRegistry = new ModuleResultRegistry();
+        var localSkip = new ModuleResult.Skipped(SkipDecision.Skip("Unavailable on this worker"))
+        {
+            ModuleName = nameof(DependencyModule),
+            ModuleTypeName = typeof(DependencyModule).FullName,
+            ModuleDuration = TimeSpan.Zero,
+            ModuleStart = DateTimeOffset.UtcNow,
+            ModuleEnd = DateTimeOffset.UtcNow,
+            ModuleStatus = Status.Skipped,
+        };
+        resultRegistry.RegisterResult(typeof(DependencyModule), localSkip);
 
         // Act — apply dependency results (simulating what WorkerModuleExecutor does)
-        foreach (var dep in assignment.DependencyResults!)
-        {
-            var localModule = modules.FirstOrDefault(m => m.GetType().FullName == dep.ModuleTypeName);
-            if (localModule is not null)
-            {
-                var result = serializer.Deserialize(dep);
-                if (result is not null)
-                {
-                    ModuleCompletionSourceApplicator.TryApply(localModule, result);
-                }
-            }
-        }
+        DependencyResultApplicator.Apply(
+            assignment.DependencyResults!,
+            DependencyResultApplicator.BuildModuleLookup(modules),
+            serializer,
+            resultRegistry,
+            NullLogger.Instance);
 
         // Assert — GetModule<DependencyModule> should now resolve (ResultTask completes)
         var moduleResult = await ((IModule) depModule).ResultTask;
         await Assert.That(moduleResult).IsNotNull();
         await Assert.That(moduleResult!.IsSuccess).IsTrue();
+        await Assert.That(resultRegistry.GetResult(typeof(DependencyModule))?.ModuleStatus)
+            .IsEqualTo(Status.Successful);
     }
 
     [Test]

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -58,6 +58,14 @@ public class DistributedModuleExecutorTests
             => Task.FromResult(42);
     }
 
+    [ModularPipelines.Attributes.DependsOn<DistributedModule>]
+    private class DependsOnDistributedModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            Context.IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult<string?>("dependent done");
+    }
+
     /// <summary>
     /// Wraps an <see cref="IDistributedCoordinator"/> so that <see cref="DequeueModuleAsync"/>
     /// returns null immediately. This prevents the master worker loop from competing with
@@ -89,7 +97,11 @@ public class DistributedModuleExecutorTests
 
     // --- Helpers ---
 
-    private static ModuleResult<T> CreateSuccessResult<T>(T value, string moduleName) where T : notnull
+    private static ModuleResult<T> CreateSuccessResult<T>(
+        T value,
+        string moduleName,
+        Status status = Status.Successful)
+        where T : notnull
     {
         var now = DateTimeOffset.UtcNow;
         return new ModuleResult<T>.Success(value)
@@ -99,7 +111,7 @@ public class DistributedModuleExecutorTests
             ModuleDuration = TimeSpan.FromMilliseconds(100),
             ModuleStart = now,
             ModuleEnd = now.AddMilliseconds(100),
-            ModuleStatus = Status.Successful,
+            ModuleStatus = status,
         };
     }
 
@@ -271,6 +283,33 @@ public class DistributedModuleExecutorTests
         var registeredResult = resultRegistry.GetResult(typeof(DistributedModule));
         await Assert.That(registeredResult).IsNotNull();
         await Assert.That(registeredResult!.IsFailure).IsTrue();
+    }
+
+    [Test]
+    public async Task History_Restored_Module_Is_Precompleted_Before_Distribution()
+    {
+        var module = new DistributedModule();
+        var moduleState = new ModuleState(module, typeof(DistributedModule));
+        var scheduler = CreateMockScheduler();
+        scheduler.Setup(instance => instance.GetModuleState(typeof(DistributedModule)))
+            .Returns(moduleState);
+        var resultRegistry = new ModuleResultRegistry();
+        var historyResult = CreateSuccessResult(
+            new SimpleResult { Message = "history" },
+            "DistributedModule",
+            Status.UsedHistory);
+        resultRegistry.RegisterResult(typeof(DistributedModule), historyResult);
+
+        var executor = CreateExecutor(scheduler, resultRegistry: resultRegistry);
+
+        await executor.ExecuteAsync([module]);
+
+        await Assert.That(moduleState.Result).IsSameReferenceAs(historyResult);
+        scheduler.Verify(instance => instance.MarkModuleCompleted(
+            typeof(DistributedModule),
+            true,
+            null,
+            Status.UsedHistory), Times.Once());
     }
 
     [Test]
@@ -449,6 +488,48 @@ public class DistributedModuleExecutorTests
         var registeredResult = resultRegistry.GetResult(typeof(DistributedModule));
         await Assert.That(registeredResult).IsNotNull();
         await Assert.That(registeredResult!.IsSuccess).IsTrue();
+    }
+
+    [Test]
+    public async Task Master_Worker_Populates_Required_Dependency_Metadata()
+    {
+        var dependency = new DistributedModule();
+        var dependent = new DependsOnDistributedModule();
+        var scheduler = CreateMockScheduler(
+            new ModuleState(dependent, typeof(DependsOnDistributedModule)));
+        var resultRegistry = new ModuleResultRegistry();
+        var coordinator = new InMemoryDistributedCoordinator();
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(DistributedModule));
+        typeRegistry.Register(typeof(DependsOnDistributedModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var resultCollector = new DistributedResultCollector(coordinator, serializer);
+        var moduleRunner = new Mock<IModuleRunner>();
+        ModuleState? capturedState = null;
+
+        moduleRunner.Setup(runner => runner.ExecuteWithoutDependencyWaitAsync(
+                It.IsAny<ModuleState>(),
+                It.IsAny<IModuleScheduler>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<ModuleState, IModuleScheduler, CancellationToken>((state, _, _) =>
+            {
+                capturedState = state;
+                var result = CreateSuccessResult("dependent done", "DependsOnDistributedModule");
+                ModuleCompletionSourceApplicator.TryApply(dependent, result);
+            })
+            .Returns(Task.CompletedTask);
+
+        var executor = CreateExecutor(
+            scheduler,
+            moduleRunner,
+            resultRegistry,
+            coordinator,
+            resultCollector);
+
+        await executor.ExecuteAsync([dependency, dependent]);
+
+        await Assert.That(capturedState).IsNotNull();
+        await Assert.That(capturedState!.Dependencies[typeof(DistributedModule)]).IsFalse();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Attributes/DynamicDependencyIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/DynamicDependencyIntegrationTests.cs
@@ -70,6 +70,25 @@ public class DynamicDependencyIntegrationTests : TestBase
         }
     }
 
+    [ModularPipelines.Attributes.ModuleCategory("compile")]
+    public class DynamicallySkippedDependency : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("A filtered dependency must not execute");
+    }
+
+    [ModularPipelines.Attributes.ModuleCategory("test")]
+    [AddDependency(typeof(DynamicallySkippedDependency))]
+    public class DynamicallySkippedDependent : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("A cascade-skipped dependent must not execute");
+    }
+
     [Before(Test)]
     public void ClearExecutionOrder()
     {
@@ -99,5 +118,24 @@ public class DynamicDependencyIntegrationTests : TestBase
             TestPipelineHostBuilder.Create()
                 .AddModule<ModuleWithMissingDynamicDependency>()
                 .ExecutePipelineAsync());
+    }
+
+    [Test]
+    public async Task DynamicDependency_OnFilteredModule_CascadeSkipsDependent()
+    {
+        var result = await TestPipelineHostBuilder.Create()
+            .AddModule<DynamicallySkippedDependency>()
+            .AddModule<DynamicallySkippedDependent>()
+            .ConfigurePipelineOptions(options => options.RunOnlyCategories = ["test"])
+            .ExecutePipelineAsync();
+
+        await Assert.That(result.Status).IsEqualTo(Enums.Status.Successful);
+
+        var dependentResult = await result.Modules
+            .OfType<DynamicallySkippedDependent>()
+            .Single();
+        await Assert.That(dependentResult.IsSkipped).IsTrue();
+        await Assert.That(dependentResult.SkipDecisionOrDefault.Reason)
+            .Contains(nameof(DynamicallySkippedDependency));
     }
 }

--- a/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
@@ -17,6 +17,19 @@ public class CategoryFilterDependencyTests : TestBase
         protected override string Result => "compiled";
     }
 
+    [ModuleCategory("compile")]
+    [ModularPipelines.Attributes.DependsOn<CompileModule>]
+    private class CompileResultConsumerModule : Module<string>
+    {
+        protected internal override async Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            var result = await context.GetModule<CompileModule>();
+            return result.ValueOrDefault;
+        }
+    }
+
     [ModuleCategory("test")]
     [ModularPipelines.Attributes.DependsOn<CompileModule>(Optional = true)]  // Optional - gracefully handle if dependency is filtered
     private class TestModuleWithOptionalDep : Module<string>
@@ -155,13 +168,14 @@ public class CategoryFilterDependencyTests : TestBase
     }
 
     [Test]
-    public async Task Repeated_Runnable_Module_Instance_Is_Discovered_Once()
+    public async Task Repeated_Runnable_Module_Instance_Is_Registered_Once_For_Dependents()
     {
         var compileModule = new CompileModule();
 
         var pipelineSummary = await TestPipelineHostBuilder.Create()
             .AddModule(compileModule)
             .AddModule(compileModule)
+            .AddModule<CompileResultConsumerModule>()
             .ConfigurePipelineOptions(opt => opt.RunOnlyCategories = ["compile"])
             .ExecutePipelineAsync();
 
@@ -169,6 +183,11 @@ public class CategoryFilterDependencyTests : TestBase
         await Assert.That(pipelineSummary.Modules.Count(module => ReferenceEquals(module, compileModule)))
             .IsEqualTo(1);
         await Assert.That((await compileModule).ValueOrDefault).IsEqualTo("compiled");
+
+        var consumerResult = await pipelineSummary.Modules
+            .OfType<CompileResultConsumerModule>()
+            .Single();
+        await Assert.That(consumerResult.ValueOrDefault).IsEqualTo("compiled");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
@@ -52,14 +52,14 @@ public class CategoryFilterDependencyTests : TestBase
     }
 
     [ModuleCategory("test")]
-    [DependsOn<CompileModule>]
+    [ModularPipelines.Attributes.DependsOn<CompileModule>]
     private class TestModuleWithRequiredDep : SimpleTestModule<string>
     {
         protected override string Result => throw new InvalidOperationException("A cascade-skipped module must not execute");
     }
 
     [ModuleCategory("test")]
-    [DependsOn<TestModuleWithRequiredDep>]
+    [ModularPipelines.Attributes.DependsOn<TestModuleWithRequiredDep>]
     private class TransitiveRequiredDepModule : SimpleTestModule<string>
     {
         protected override string Result => throw new InvalidOperationException("A transitively cascade-skipped module must not execute");
@@ -127,6 +127,31 @@ public class CategoryFilterDependencyTests : TestBase
         await Assert.That(transitiveResult.IsSkipped).IsTrue();
         await Assert.That(transitiveResult.SkipDecisionOrDefault.Reason)
             .Contains(nameof(TestModuleWithRequiredDep));
+    }
+
+    [Test]
+    public async Task Duplicate_Filtered_Module_Types_Cascade_Skip_Without_Crashing()
+    {
+        var firstCompileModule = new CompileModule();
+        var secondCompileModule = new CompileModule();
+
+        var pipelineSummary = await TestPipelineHostBuilder.Create()
+            .AddModule(firstCompileModule)
+            .AddModule(secondCompileModule)
+            .AddModule<TestModuleWithRequiredDep>()
+            .ConfigurePipelineOptions(opt => opt.RunOnlyCategories = ["test"])
+            .ExecutePipelineAsync();
+
+        await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
+        await Assert.That((await firstCompileModule).IsSkipped).IsTrue();
+        await Assert.That((await secondCompileModule).IsSkipped).IsTrue();
+
+        var requiredResult = await pipelineSummary.Modules
+            .OfType<TestModuleWithRequiredDep>()
+            .Single();
+        await Assert.That(requiredResult.IsSkipped).IsTrue();
+        await Assert.That(requiredResult.SkipDecisionOrDefault.Reason)
+            .Contains(nameof(CompileModule));
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
@@ -155,6 +155,23 @@ public class CategoryFilterDependencyTests : TestBase
     }
 
     [Test]
+    public async Task Repeated_Runnable_Module_Instance_Is_Discovered_Once()
+    {
+        var compileModule = new CompileModule();
+
+        var pipelineSummary = await TestPipelineHostBuilder.Create()
+            .AddModule(compileModule)
+            .AddModule(compileModule)
+            .ConfigurePipelineOptions(opt => opt.RunOnlyCategories = ["compile"])
+            .ExecutePipelineAsync();
+
+        await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
+        await Assert.That(pipelineSummary.Modules.Count(module => ReferenceEquals(module, compileModule)))
+            .IsEqualTo(1);
+        await Assert.That((await compileModule).ValueOrDefault).IsEqualTo("compiled");
+    }
+
+    [Test]
     public async Task Both_Categories_Run_Successfully()
     {
         var pipelineSummary = await TestPipelineHostBuilder.Create()

--- a/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
@@ -225,6 +225,28 @@ public class CategoryFilterDependencyTests : TestBase
     }
 
     [Test]
+    public async Task Repeated_Factory_Module_Instance_Is_Resolved_Once_For_Dependents()
+    {
+        var compileModule = new CompileModule();
+
+        var pipelineSummary = await TestPipelineHostBuilder.Create()
+            .AddModule<CompileModule>(_ => compileModule)
+            .AddModule<CompileModule>(_ => compileModule)
+            .AddModule<CompileResultConsumerModule>()
+            .ConfigurePipelineOptions(opt => opt.RunOnlyCategories = ["compile"])
+            .ExecutePipelineAsync();
+
+        await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
+        await Assert.That(pipelineSummary.Modules.Count(module => ReferenceEquals(module, compileModule)))
+            .IsEqualTo(1);
+
+        var consumerResult = await pipelineSummary.Modules
+            .OfType<CompileResultConsumerModule>()
+            .Single();
+        await Assert.That(consumerResult.ValueOrDefault).IsEqualTo("compiled");
+    }
+
+    [Test]
     public async Task Fluent_Skip_Cascade_Skips_Required_Dependent()
     {
         var pipelineSummary = await TestPipelineHostBuilder.Create()

--- a/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
@@ -1,5 +1,7 @@
 using ModularPipelines.Attributes;
+using ModularPipelines.Configuration;
 using ModularPipelines.Context;
+using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
 using Status = ModularPipelines.Enums.Status;
@@ -76,6 +78,38 @@ public class CategoryFilterDependencyTests : TestBase
     private class TransitiveRequiredDepModule : SimpleTestModule<string>
     {
         protected override string Result => throw new InvalidOperationException("A transitively cascade-skipped module must not execute");
+    }
+
+    private class FluentlySkippedModule : SimpleTestModule<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(() => SkipDecision.Skip("Fluent skip"))
+            .Build();
+
+        protected override string Result => throw new InvalidOperationException("A fluently skipped module must not execute");
+    }
+
+    [ModularPipelines.Attributes.DependsOn<FluentlySkippedModule>]
+    private class FluentSkipDependentModule : SimpleTestModule<string>
+    {
+        protected override string Result => throw new InvalidOperationException("A dependent of a skipped module must not execute");
+    }
+
+    private abstract class ValueEqualModule : SimpleTestModule<string>
+    {
+        public override bool Equals(object? obj) => obj is ValueEqualModule;
+
+        public override int GetHashCode() => 1;
+    }
+
+    private class FirstValueEqualModule : ValueEqualModule
+    {
+        protected override string Result => "first";
+    }
+
+    private class SecondValueEqualModule : ValueEqualModule
+    {
+        protected override string Result => "second";
     }
 
     [Test]
@@ -188,6 +222,37 @@ public class CategoryFilterDependencyTests : TestBase
             .OfType<CompileResultConsumerModule>()
             .Single();
         await Assert.That(consumerResult.ValueOrDefault).IsEqualTo("compiled");
+    }
+
+    [Test]
+    public async Task Fluent_Skip_Cascade_Skips_Required_Dependent()
+    {
+        var pipelineSummary = await TestPipelineHostBuilder.Create()
+            .AddModule<FluentlySkippedModule>()
+            .AddModule<FluentSkipDependentModule>()
+            .ExecutePipelineAsync();
+
+        var dependentResult = await pipelineSummary.Modules
+            .OfType<FluentSkipDependentModule>()
+            .Single();
+
+        await Assert.That(dependentResult.IsSkipped).IsTrue();
+        await Assert.That(dependentResult.SkipDecisionOrDefault.Reason)
+            .Contains(nameof(FluentlySkippedModule));
+    }
+
+    [Test]
+    public async Task Value_Equal_Module_Instances_Are_Discovered_Independently()
+    {
+        var pipelineSummary = await TestPipelineHostBuilder.Create()
+            .AddModule<FirstValueEqualModule>()
+            .AddModule<SecondValueEqualModule>()
+            .ExecutePipelineAsync();
+
+        await Assert.That((await pipelineSummary.Modules.OfType<FirstValueEqualModule>().Single()).ValueOrDefault)
+            .IsEqualTo("first");
+        await Assert.That((await pipelineSummary.Modules.OfType<SecondValueEqualModule>().Single()).ValueOrDefault)
+            .IsEqualTo("second");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/CategoryFilterDependencyTests.cs
@@ -51,6 +51,20 @@ public class CategoryFilterDependencyTests : TestBase
         }
     }
 
+    [ModuleCategory("test")]
+    [DependsOn<CompileModule>]
+    private class TestModuleWithRequiredDep : SimpleTestModule<string>
+    {
+        protected override string Result => throw new InvalidOperationException("A cascade-skipped module must not execute");
+    }
+
+    [ModuleCategory("test")]
+    [DependsOn<TestModuleWithRequiredDep>]
+    private class TransitiveRequiredDepModule : SimpleTestModule<string>
+    {
+        protected override string Result => throw new InvalidOperationException("A transitively cascade-skipped module must not execute");
+    }
+
     [Test]
     public async Task Optional_Dependency_Works_When_Filtered_By_Category()
     {
@@ -86,6 +100,33 @@ public class CategoryFilterDependencyTests : TestBase
         var result = await testModule;
         // CompileModule was skipped due to category filter
         await Assert.That(result.ValueOrDefault).IsEqualTo("test-compile-skipped");
+    }
+
+    [Test]
+    public async Task Required_Dependency_Filtered_By_Category_Cascade_Skips_Dependents()
+    {
+        var pipelineSummary = await TestPipelineHostBuilder.Create()
+            .AddModule<CompileModule>()
+            .AddModule<TestModuleWithRequiredDep>()
+            .AddModule<TransitiveRequiredDepModule>()
+            .ConfigurePipelineOptions(opt => opt.RunOnlyCategories = ["test"])
+            .ExecutePipelineAsync();
+
+        await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
+
+        var requiredResult = await pipelineSummary.Modules
+            .OfType<TestModuleWithRequiredDep>()
+            .Single();
+        var transitiveResult = await pipelineSummary.Modules
+            .OfType<TransitiveRequiredDepModule>()
+            .Single();
+
+        await Assert.That(requiredResult.IsSkipped).IsTrue();
+        await Assert.That(requiredResult.SkipDecisionOrDefault.Reason)
+            .Contains(nameof(CompileModule));
+        await Assert.That(transitiveResult.IsSkipped).IsTrue();
+        await Assert.That(transitiveResult.SkipDecisionOrDefault.Reason)
+            .Contains(nameof(TestModuleWithRequiredDep));
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/IgnoredModuleResultRegistrarTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/IgnoredModuleResultRegistrarTests.cs
@@ -38,8 +38,9 @@ public class IgnoredModuleResultRegistrarTests
             contextProvider
                 .Setup(provider => provider.GetModuleContext())
                 .Returns(Mock.Of<IPipelineHookContext>());
+            var resultRegistry = new ModuleResultRegistry();
             var registrar = new IgnoredModuleResultRegistrar(
-                new ModuleResultRegistry(),
+                resultRegistry,
                 new NoOpModuleResultRepository(),
                 contextProvider.Object,
                 new ModuleDependencyRegistry(),
@@ -54,6 +55,8 @@ public class IgnoredModuleResultRegistrarTests
                 .Contains(dependent);
             await Assert.That(result.IgnoredModules.Select(module => module.Module))
                 .DoesNotContain(dependent);
+            await Assert.That(resultRegistry.GetResult(dependency.GetType())).IsNull();
+            await Assert.That(((IModule) dependency).ResultTask.IsCompleted).IsFalse();
         }
         finally
         {

--- a/test/ModularPipelines.UnitTests/Engine/IgnoredModuleResultRegistrarTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/IgnoredModuleResultRegistrarTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes;
+using ModularPipelines.Context;
+using ModularPipelines.Distributed;
+using ModularPipelines.Distributed.Configuration;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Engine.Executors;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+[TUnit.Core.NotInParallel(nameof(IgnoredModuleResultRegistrarTests))]
+public class IgnoredModuleResultRegistrarTests
+{
+    [Test]
+    public async Task Distributed_Worker_Does_Not_Cascade_Local_Skip_To_Dependent()
+    {
+        var previousInstance = Environment.GetEnvironmentVariable("MODULAR_PIPELINES_INSTANCE");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("MODULAR_PIPELINES_INSTANCE", "1");
+            var options = Microsoft.Extensions.Options.Options.Create(new DistributedOptions
+            {
+                Enabled = true,
+                InstanceIndex = 1,
+                TotalInstances = 2,
+            });
+            var dependency = new ForeignOperatingSystemModule();
+            var dependent = new CrossPlatformDependentModule();
+            var organizedModules = new OrganizedModules(
+                [new RunnableModule(dependent, TimeSpan.Zero, [])],
+                [new IgnoredModule(dependency, SkipDecision.Skip("Unavailable on this worker"))]);
+            var contextProvider = new Mock<IPipelineContextProvider>();
+            contextProvider
+                .Setup(provider => provider.GetModuleContext())
+                .Returns(Mock.Of<IPipelineHookContext>());
+            var registrar = new IgnoredModuleResultRegistrar(
+                new ModuleResultRegistry(),
+                new NoOpModuleResultRepository(),
+                contextProvider.Object,
+                new ModuleDependencyRegistry(),
+                Mock.Of<IModuleMetadataRegistry>(),
+                options,
+                new RoleDetector(options),
+                NullLogger<IgnoredModuleResultRegistrar>.Instance);
+
+            var result = await registrar.RegisterIgnoredModuleResultsAsync(organizedModules);
+
+            await Assert.That(result.RunnableModules.Select(module => module.Module))
+                .Contains(dependent);
+            await Assert.That(result.IgnoredModules.Select(module => module.Module))
+                .DoesNotContain(dependent);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MODULAR_PIPELINES_INSTANCE", previousInstance);
+        }
+    }
+
+    [RunOnWindowsOnly]
+    private sealed class ForeignOperatingSystemModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>(null);
+    }
+
+    [ModularPipelines.Attributes.DependsOn<ForeignOperatingSystemModule>]
+    private sealed class CrossPlatformDependentModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>(null);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -49,6 +49,7 @@ public class ModuleExecutorLoggingTests
             Mock.Of<IModuleRunner>(),
             Mock.Of<IAlwaysRunHandler>(),
             Mock.Of<IModuleResultRegistrar>(),
+            Mock.Of<IModuleResultRegistry>(),
             parallelLimitProvider.Object,
             registrationEvents.Object,
             Mock.Of<IMetricsCollector>(),

--- a/test/ModularPipelines.UnitTests/Engine/RegistrationEventExecutorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RegistrationEventExecutorTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using ModularPipelines.Context;
+using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Modules;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class RegistrationEventExecutorTests
+{
+    [Test]
+    public async Task Later_Invocation_Cannot_Add_Module_Types()
+    {
+        var attributeEventService = new Mock<IModuleAttributeEventService>();
+        attributeEventService
+            .Setup(service => service.GetRegistrationReceivers(It.IsAny<Type>()))
+            .Returns([]);
+        var executor = new RegistrationEventExecutor(
+            attributeEventService.Object,
+            Mock.Of<IAttributeEventInvoker>(),
+            new ModuleDependencyRegistry(),
+            Mock.Of<IModuleMetadataRegistry>(),
+            Mock.Of<IConfiguration>(),
+            Mock.Of<IHostEnvironment>());
+
+        await executor.InvokeRegistrationEventsAsync([new FirstModule()]);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            executor.InvokeRegistrationEventsAsync([new FirstModule(), new LaterModule()]));
+
+        await Assert.That(exception!.Message).Contains(nameof(LaterModule));
+    }
+
+    private sealed class FirstModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+
+    private sealed class LaterModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Execution/ModuleHistoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleHistoryTests.cs
@@ -22,6 +22,17 @@ public class ModuleHistoryTests
         }
     }
 
+    [ModularPipelines.Attributes.DependsOn<SkipFromCategory>]
+    private class UsesCategoryDependency : Module<Status>
+    {
+        protected internal override async Task<Status> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return (await context.GetModule<SkipFromCategory>()).ModuleStatus;
+        }
+    }
+
     private class SkipRunConditionAttribute : RunConditionAttribute
     {
         public override Task<bool> Condition(IPipelineHookContext pipelineContext)
@@ -217,6 +228,26 @@ public class ModuleHistoryTests
         var resultRegistry = host.RootServices.GetRequiredService<IModuleResultRegistry>();
         var result = resultRegistry.GetResult(typeof(SkipFromCategory))!;
         await Assert.That(result.ModuleStatus).IsEqualTo(Status.UsedHistory);
+    }
+
+    [Test]
+    public async Task Required_Dependency_With_History_Does_Not_Skip_Dependent()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<SkipFromCategory>()
+            .AddModule<UsesCategoryDependency>()
+            .IgnoreCategories("1")
+            .AddResultsRepository<GoodModuleRepository>()
+            .BuildHostAsync();
+
+        var summary = await host.ExecutePipelineAsync();
+
+        var dependencyResult = await summary.Modules.OfType<SkipFromCategory>().Single();
+        var dependentResult = await summary.Modules.OfType<UsesCategoryDependency>().Single();
+
+        await Assert.That(dependencyResult.ModuleStatus).IsEqualTo(Status.UsedHistory);
+        await Assert.That(dependentResult.ModuleStatus).IsEqualTo(Status.Successful);
+        await Assert.That(dependentResult.ValueOrDefault).IsEqualTo(Status.UsedHistory);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/ModuleHistoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleHistoryTests.cs
@@ -94,6 +94,27 @@ public class ModuleHistoryTests
         }
     }
 
+    private class CascadeDependentHistoryRepository : IModuleResultRepository
+    {
+        public bool IsEnabled => true;
+
+        public Task SaveResultAsync<T>(Module<T> module, ModuleResult<T> moduleResult, IPipelineContext pipelineContext)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<ModuleResult<T>?> GetResultAsync<T>(Module<T> module, IPipelineContext pipelineContext)
+        {
+            if (module.GetType() != typeof(UsesCategoryDependency))
+            {
+                return Task.FromResult<ModuleResult<T>?>(null);
+            }
+
+            var executionContext = new ModuleExecutionContext(module, module.GetType());
+            return Task.FromResult<ModuleResult<T>?>(ModuleResult<T>.CreateSuccess(default!, executionContext));
+        }
+    }
+
     [Test]
     public async Task Ignore_Category_Without_History_Repository()
     {
@@ -248,6 +269,25 @@ public class ModuleHistoryTests
         await Assert.That(dependencyResult.ModuleStatus).IsEqualTo(Status.UsedHistory);
         await Assert.That(dependentResult.ModuleStatus).IsEqualTo(Status.Successful);
         await Assert.That(dependentResult.ValueOrDefault).IsEqualTo(Status.UsedHistory);
+    }
+
+    [Test]
+    public async Task Cascade_Skipped_Module_Uses_Its_Own_History()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<SkipFromCategory>()
+            .AddModule<UsesCategoryDependency>()
+            .IgnoreCategories("1")
+            .AddResultsRepository<CascadeDependentHistoryRepository>()
+            .BuildHostAsync();
+
+        var summary = await host.ExecutePipelineAsync();
+
+        var dependencyResult = await summary.Modules.OfType<SkipFromCategory>().Single();
+        var dependentResult = await summary.Modules.OfType<UsesCategoryDependency>().Single();
+
+        await Assert.That(dependencyResult.ModuleStatus).IsEqualTo(Status.Skipped);
+        await Assert.That(dependentResult.ModuleStatus).IsEqualTo(Status.UsedHistory);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- transitively cascade-skip runnable modules whose required dependencies were excluded by conditions or category filters
- preserve optional-dependency execution and route cascaded modules through normal ignored-result registration, summaries, histories, and skip reasons
- document required/optional skip behavior and add category-filter regression coverage

## Validation

- `dotnet build src/ModularPipelines/ModularPipelines.csproj -c Release --no-restore -m:1`
- dedicated real pipeline host check: required and transitive dependents skipped with chained reasons; optional dependent executed and observed the skipped dependency
- `npm run build` in `docs`
- `dotnet format whitespace` on changed C# files; `git diff --check`

The full `ModularPipelines.UnitTests` project build was attempted but stalled silently in this Windows runner and left an orphaned `dotnet build` process; the exact orphan was terminated. The focused pipeline behavior check and core build completed successfully, and CI will run the full project graph.

Closes #3194