### PR TITLE
Give the CI pipeline build memory headroom to stop the runner OOM-kill

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -66,6 +66,26 @@ jobs:
         uses: samypr100/setup-dev-drive@v4
         with:
           drive-size: 5GB
+      # The distributed master (and other Linux instances) builds the full
+      # ModularPipelines.All.sln, whose peak memory can exceed the 7 GB RAM of a
+      # standard ubuntu-latest runner. When it does, the host OOM-kills the runner
+      # agent, which surfaces as "The runner has received a shutdown signal" mid-build
+      # (see #3179). Add a large swapfile so the build has headroom to complete instead
+      # of being reclaimed.
+      - name: Increase swap space
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          # Replace the default 4 GB swapfile with a larger one on /mnt (the ephemeral
+          # disk), leaving the root filesystem free for the NuGet restore and build output.
+          sudo swapoff -a || true
+          sudo rm -f /mnt/swapfile || true
+          sudo fallocate -l 10G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+          echo "Memory and swap after reconfiguration:"
+          free -h
       - name: Setup .NET
         uses: actions/setup-dotnet@v6.0.0
         with:
@@ -108,6 +128,11 @@ jobs:
         run: dotnet run -c Release --framework net10.0
         working-directory: "src/ModularPipelines.Build"
         env:
+          # Use workstation GC for the pipeline and the dotnet build/test child processes
+          # it spawns. Server GC allocates a heap per core, inflating peak memory on the
+          # multi-core runners during the full-solution build; workstation GC keeps the
+          # footprint far lower, complementing the swap headroom above (see #3179).
+          DOTNET_gcServer: 0
           GITHUB_TOKEN: ${{ github.token }}
           DOTNET_ENVIRONMENT: ${{ github.ref == 'refs/heads/main' && 'Production' || 'Development' }}
           NuGet__ApiKey: ${{ github.ref == 'refs/heads/main' && secrets.NuGet__ApiKey || null }}


### PR DESCRIPTION
## Problem (#3179)

The `pipeline (ubuntu-latest)` (instance 0 / master) check fails on essentially every PR — it's the sole red check that's forced an admin override on the last several merges (#3117, #3190, #3192). The signature is always the same:

```
Executing modules: BuildSolutionsModule
##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
##[error]The operation was canceled.
```

It happens **partway through `BuildSolutionsModule`** (which builds the full 60+ project `ModularPipelines.All.sln`), at **variable times** (~2 → ~7 → ~19 → ~50 min across runs), while every other check — worker shards, `Analyze`, reviews — is green. That signature + a memory-heavy full-solution build on a 7 GB `ubuntu-latest` runner is the classic profile of the host **OOM-killing the runner agent**.

## Fix

Two low-risk, workflow-only levers that address the out-of-memory reclaim at its root:

1. **Increase swap** — replace the default 4 GB swapfile with a 10 GB one on `/mnt` (the ephemeral disk, so the root filesystem stays free for restore/build output). 7 GB RAM + 10 GB swap gives the full-solution build room to complete rather than being killed. The step logs `free -h` so the active swap is visible.
2. **`DOTNET_gcServer=0`** — run the pipeline and the `dotnet build`/`test` child processes it spawns under workstation GC. Server GC allocates a heap per core, inflating peak memory on the multi-core runners during the full-solution build; workstation GC keeps the footprint far lower.

No product code changes — only `.github/workflows/dotnet.yml`.

## Why not just cap parallelism

#3182 tried `-maxcpucount:2` on its own and still overshot RAM, because halving concurrency without adding headroom still peaked above 7 GB. Swap provides that headroom, and workstation GC lowers the peak. If this proves insufficient, reducing build parallelism (or a larger runner for `instance: 0`) remains available as a follow-up lever.

## Validation note

This targets the runner environment, so it can only really be proven by CI itself — if instance 0 gets through `BuildSolutionsModule` to completion, the fix holds. The `free -h` output in the new step will confirm the swap is active.

Toward #3179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KayGZtGoXLVALeiPHXRWdx)_