### PR TITLE
Model optional-value and terminal CLI options

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,6 +45,9 @@ jobs:
       # the persistent nodes accumulate memory across those builds, which contributed to the
       # runner reclaim in #3179. Disabling reuse keeps peak memory bounded per build.
       MSBUILDDISABLENODEREUSE: "1"
+      # Workstation GC keeps the build/test footprint lower than server GC (which allocates a
+      # heap per core) on these multi-core runners.
+      DOTNET_gcServer: "0"
       # Single source of truth for the solutions CI restores and builds, so the Restore and
       # Build steps below can't drift apart. This mirrors BuildSolutionsModule.Solutions in
       # src/ModularPipelines.Build; keep the two in sync when adding a solution.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -70,6 +70,19 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Increase swap space
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          # Two consecutive builds exhausted the hosted runner while compiling
+          # ModularPipelines.Examples.sln after the full solution (MSB4166).
+          sudo swapoff -a || true
+          sudo rm -f /mnt/swapfile || true
+          sudo fallocate -l 10G /mnt/swapfile
+          sudo chmod 600 /mnt/swapfile
+          sudo mkswap /mnt/swapfile
+          sudo swapon /mnt/swapfile
+          free -h
       - name: Setup .NET
         uses: actions/setup-dotnet@v6.0.0
         with:

--- a/src/ModularPipelines.Jq/Options/JqExecuteOptions.Generated.cs
+++ b/src/ModularPipelines.Jq/Options/JqExecuteOptions.Generated.cs
@@ -178,6 +178,12 @@ public record JqExecuteOptions : JqOptions
     public bool? ExitStatus { get; set; }
 
     /// <summary>
+    /// Open input/output streams in binary mode
+    /// </summary>
+    [CliFlag("--binary", ShortForm = "-b", PreferShortForm = true)]
+    public bool? Binary { get; set; }
+
+    /// <summary>
     /// show the version
     /// </summary>
     [CliFlag("--version", ShortForm = "-V")]
@@ -196,27 +202,15 @@ public record JqExecuteOptions : JqOptions
     public bool? Help { get; set; }
 
     /// <summary>
-    /// Run jq tests from standard input
+    /// Run jq tests from standard input or the specified file
     /// </summary>
-    [CliFlag("--run-tests")]
-    public bool? RunTests { get; set; }
-
-    /// <summary>
-    /// Open input/output streams in binary mode
-    /// </summary>
-    [CliFlag("--binary", ShortForm = "-b", PreferShortForm = true)]
-    public bool? Binary { get; set; }
-
-    /// <summary>
-    /// Run jq tests from the specified file
-    /// </summary>
-    [CliOption("--run-tests")]
-    public string? RunTestsFile { get; set; }
+    [CliOption("--run-tests", ValueArity = CliOptionValueArity.Optional, Phase = CommandLinePhase.Terminal)]
+    public string? RunTests { get; set; }
 
     /// <summary>
     /// Stop processing options so filters beginning with a dash are treated as positional arguments
     /// </summary>
-    [CliFlag("--")]
+    [CliFlag("--", Phase = CommandLinePhase.EndOfOptions)]
     public bool? EndOfOptions { get; set; }
 
     /// <summary>

--- a/src/ModularPipelines.Jq/Options/JqOptions.Generated.cs
+++ b/src/ModularPipelines.Jq/Options/JqOptions.Generated.cs
@@ -19,6 +19,7 @@ namespace ModularPipelines.Jq.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliTool("jq")]
+[CliGlobalOptions]
 public abstract record JqOptions : CommandLineToolOptions
 {
 }

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -19,6 +19,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
     internal const string CliGlobalOptionsAttributeFullName = "ModularPipelines.Attributes.CliGlobalOptionsAttribute";
     internal const string SecretValueAttributeFullName = "ModularPipelines.Attributes.SecretValueAttribute";
 
+    private const int PassthroughCommandLinePhase = 3;
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var metadata = context.SyntaxProvider
@@ -145,6 +147,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     false,
                     0,
                     0,
+                    0,
+                    0,
                     null,
                     GetConstructorStrings(secretAttribute),
                     false));
@@ -184,6 +188,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 false,
                 GetConstructorInt(attribute),
                 GetNamedInt(attribute, "Placement"),
+                GetNamedInt(attribute, "Phase", defaultValue: PassthroughCommandLinePhase),
+                0,
                 null,
                 [],
                 isGlobalOption);
@@ -199,6 +205,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 GetNamedBool(attribute, "PreferShortForm"),
                 0,
                 0,
+                GetNamedInt(attribute, "Phase"),
+                0,
                 null,
                 [],
                 isGlobalOption);
@@ -212,6 +220,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             GetNamedBool(attribute, "PreferShortForm"),
             GetNamedInt(attribute, "Format"),
             GetNamedBool(attribute, "AllowMultiple") ? 1 : 0,
+            GetNamedInt(attribute, "Phase"),
+            GetNamedInt(attribute, "ValueArity"),
             GetNamedString(attribute, "CustomSeparator"),
             [],
             isGlobalOption);
@@ -287,6 +297,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     sb.AppendLine($"                    new global::ModularPipelines.Attributes.CliArgumentAttribute({property.FirstInt})");
                     sb.AppendLine("                    {");
                     sb.AppendLine($"                        Placement = (global::ModularPipelines.Attributes.ArgumentPlacement){property.SecondInt},");
+                    sb.AppendLine($"                        Phase = (global::ModularPipelines.Attributes.CommandLinePhase){property.Phase},");
                     sb.AppendLine($"                        Name = {NullableLiteral(property.PrimaryValue)},");
                     sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)} }},");
                     break;
@@ -297,6 +308,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     sb.AppendLine("                    {");
                     sb.AppendLine($"                        ShortForm = {NullableLiteral(property.ShortForm)},");
                     sb.AppendLine($"                        PreferShortForm = {BooleanLiteral(property.BooleanValue)},");
+                    sb.AppendLine($"                        Phase = (global::ModularPipelines.Attributes.CommandLinePhase){property.Phase},");
                     sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)} }},");
                     break;
                 case PropertyKind.Option:
@@ -308,6 +320,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     sb.AppendLine($"                        PreferShortForm = {BooleanLiteral(property.BooleanValue)},");
                     sb.AppendLine($"                        Format = (global::ModularPipelines.Attributes.OptionFormat){property.FirstInt},");
                     sb.AppendLine($"                        AllowMultiple = {BooleanLiteral(property.SecondInt == 1)},");
+                    sb.AppendLine($"                        ValueArity = (global::ModularPipelines.Attributes.CliOptionValueArity){property.ValueArity},");
+                    sb.AppendLine($"                        Phase = (global::ModularPipelines.Attributes.CommandLinePhase){property.Phase},");
                     sb.AppendLine($"                        CustomSeparator = {NullableLiteral(property.CustomSeparator)},");
                     sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)} }},");
                     break;
@@ -410,10 +424,10 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
     private static bool GetNamedBool(AttributeData attribute, string name) =>
         attribute.NamedArguments.FirstOrDefault(argument => argument.Key == name).Value.Value as bool? ?? false;
 
-    private static int GetNamedInt(AttributeData attribute, string name)
+    private static int GetNamedInt(AttributeData attribute, string name, int defaultValue = 0)
     {
         var value = attribute.NamedArguments.FirstOrDefault(argument => argument.Key == name).Value.Value;
-        return value is null ? 0 : Convert.ToInt32(value);
+        return value is null ? defaultValue : Convert.ToInt32(value);
     }
 
     private static string BooleanLiteral(bool value) => value ? "true" : "false";
@@ -450,6 +464,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         bool BooleanValue,
         int FirstInt,
         int SecondInt,
+        int Phase,
+        int ValueArity,
         string? CustomSeparator,
         ImmutableArray<string> SecretValueKeys,
         bool IsGlobalOption);

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -19,6 +19,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
     internal const string CliGlobalOptionsAttributeFullName = "ModularPipelines.Attributes.CliGlobalOptionsAttribute";
     internal const string SecretValueAttributeFullName = "ModularPipelines.Attributes.SecretValueAttribute";
 
+    // Keep synchronized with CommandLinePhase.Passthrough; GeneratedRuntimeMetadataTests guards the ordinal.
     private const int PassthroughCommandLinePhase = 3;
 
     public void Initialize(IncrementalGeneratorInitializationContext context)

--- a/src/ModularPipelines/Attributes/CliArgumentAttribute.cs
+++ b/src/ModularPipelines/Attributes/CliArgumentAttribute.cs
@@ -42,6 +42,12 @@ public sealed class CliArgumentAttribute : Attribute
     public string? Name { get; set; }
 
     /// <summary>
+    /// Gets or sets the semantic phase used to order this argument.
+    /// Positional arguments default to the pass-through phase after option parsing.
+    /// </summary>
+    public CommandLinePhase Phase { get; set; } = CommandLinePhase.Passthrough;
+
+    /// <summary>
     /// Initialises a new instance of the <see cref="CliArgumentAttribute"/> class.
     /// Initializes a new instance of the <see cref="CliArgumentAttribute"/> class with default position 0.
     /// </summary>

--- a/src/ModularPipelines/Attributes/CliFlagAttribute.cs
+++ b/src/ModularPipelines/Attributes/CliFlagAttribute.cs
@@ -40,6 +40,11 @@ public sealed class CliFlagAttribute : Attribute
     public bool PreferShortForm { get; set; }
 
     /// <summary>
+    /// Gets or sets the semantic phase used to order this flag.
+    /// </summary>
+    public CommandLinePhase Phase { get; set; } = CommandLinePhase.Normal;
+
+    /// <summary>
     /// Initialises a new instance of the <see cref="CliFlagAttribute"/> class.
     /// Initializes a new instance of the <see cref="CliFlagAttribute"/> class.
     /// </summary>

--- a/src/ModularPipelines/Attributes/CliOptionAttribute.cs
+++ b/src/ModularPipelines/Attributes/CliOptionAttribute.cs
@@ -55,6 +55,18 @@ public sealed class CliOptionAttribute : Attribute
     public bool AllowMultiple { get; set; }
 
     /// <summary>
+    /// Gets or sets whether this option requires a value.
+    /// For <see cref="CliOptionValueArity.Optional"/>, a null property omits the option,
+    /// an empty string renders the bare option, and a non-empty string renders its value.
+    /// </summary>
+    public CliOptionValueArity ValueArity { get; set; } = CliOptionValueArity.Required;
+
+    /// <summary>
+    /// Gets or sets the semantic phase used to order this option.
+    /// </summary>
+    public CommandLinePhase Phase { get; set; } = CommandLinePhase.Normal;
+
+    /// <summary>
     /// Gets or sets a custom separator string. When set, this overrides <see cref="Format"/>.
     /// Useful for non-standard separators.
     /// </summary>

--- a/src/ModularPipelines/Attributes/CliOptionValueArity.cs
+++ b/src/ModularPipelines/Attributes/CliOptionValueArity.cs
@@ -1,0 +1,23 @@
+namespace ModularPipelines.Attributes;
+
+/// <summary>
+/// Describes whether a CLI option requires a value.
+/// </summary>
+public enum CliOptionValueArity
+{
+    /// <summary>
+    /// The option requires a value.
+    /// </summary>
+    Required,
+
+    /// <summary>
+    /// The option can be rendered either bare or with a value.
+    /// A null property omits the option; an empty string renders it bare.
+    /// </summary>
+    Optional,
+
+    /// <summary>
+    /// The option does not accept a value.
+    /// </summary>
+    None,
+}

--- a/src/ModularPipelines/Attributes/CommandLinePhase.cs
+++ b/src/ModularPipelines/Attributes/CommandLinePhase.cs
@@ -1,0 +1,27 @@
+namespace ModularPipelines.Attributes;
+
+/// <summary>
+/// Defines the semantic rendering phase for a command-line part.
+/// </summary>
+public enum CommandLinePhase
+{
+    /// <summary>
+    /// Regular flags and options.
+    /// </summary>
+    Normal,
+
+    /// <summary>
+    /// An option that terminates normal option parsing and must follow regular options.
+    /// </summary>
+    Terminal,
+
+    /// <summary>
+    /// An explicit end-of-options marker such as <c>--</c>.
+    /// </summary>
+    EndOfOptions,
+
+    /// <summary>
+    /// Positional or pass-through values that must follow option parsing.
+    /// </summary>
+    Passthrough,
+}

--- a/src/ModularPipelines/Attributes/CommandLinePhase.cs
+++ b/src/ModularPipelines/Attributes/CommandLinePhase.cs
@@ -11,17 +11,17 @@ public enum CommandLinePhase
     Normal,
 
     /// <summary>
-    /// An option that terminates normal option parsing and must follow regular options.
+    /// A final option that must follow regular options and positional operands.
     /// </summary>
     Terminal,
 
     /// <summary>
-    /// An explicit end-of-options marker such as <c>--</c>.
+    /// An explicit end-of-options marker such as <c>--</c>, rendered before pass-through operands.
     /// </summary>
     EndOfOptions,
 
     /// <summary>
-    /// Positional or pass-through values that must follow option parsing.
+    /// Positional or pass-through values rendered after option parsing and before terminal options.
     /// </summary>
     Passthrough,
 }

--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -1,3 +1,4 @@
+using ModularPipelines.Attributes;
 using ModularPipelines.Helpers.Internal;
 using ModularPipelines.Models;
 using ModularPipelines.Options;
@@ -56,10 +57,17 @@ internal sealed class CommandLineBuilder : ICommandLineBuilder
         // on a [CliGlobalOptions] base belong before the subcommand; command-specific
         // properties retain their normal position after it.
         var commandModel = _commandModelProvider.GetCommandModel(options.GetType());
-        var globalCommandModel = commandModel.Where(part => part.IsGlobalOption).ToList();
-        var commandSpecificModel = commandModel.Where(part => !part.IsGlobalOption).ToList();
+        var terminalCommandModel = commandModel
+            .Where(part => part.Phase == CommandLinePhase.Terminal)
+            .ToList();
+        var nonTerminalCommandModel = commandModel
+            .Where(part => part.Phase != CommandLinePhase.Terminal)
+            .ToList();
+        var globalCommandModel = nonTerminalCommandModel.Where(part => part.IsGlobalOption).ToList();
+        var commandSpecificModel = nonTerminalCommandModel.Where(part => !part.IsGlobalOption).ToList();
         var globalArgs = _commandArgumentBuilder.BuildArguments(globalCommandModel, options);
         var propertyArgs = _commandArgumentBuilder.BuildArguments(commandSpecificModel, options);
+        var terminalArgs = _commandArgumentBuilder.BuildArguments(terminalCommandModel, options);
 
         // 4. Combine: global args + preceding args (subcommands) + property args
         var allArgs = new List<string>(globalArgs);
@@ -74,6 +82,22 @@ internal sealed class CommandLineBuilder : ICommandLineBuilder
             manualArgs = manualArgs.Skip(1).ToList();
         }
 
+        if (terminalArgs.Count > 0)
+        {
+            var endOfOptionsModel = commandModel
+                .Where(part => part.Phase == CommandLinePhase.EndOfOptions)
+                .ToList();
+            var hasPropertyEndOfOptions =
+                _commandArgumentBuilder.BuildArguments(endOfOptionsModel, options).Count > 0;
+            var hasManualEndOfOptions = manualArgs.Contains("--", StringComparer.Ordinal);
+
+            if (hasPropertyEndOfOptions || hasManualEndOfOptions || options.RunSettings is not null)
+            {
+                throw new InvalidOperationException(
+                    "Terminal options cannot be combined with an end-of-options marker.");
+            }
+        }
+
         allArgs.AddRange(manualArgs);
 
         // 6. Add RunSettings after "--" if present
@@ -82,6 +106,9 @@ internal sealed class CommandLineBuilder : ICommandLineBuilder
             allArgs.Add("--");
             allArgs.AddRange(options.RunSettings);
         }
+
+        // 7. Terminal options must follow every positional argument source.
+        allArgs.AddRange(terminalArgs);
 
         return new CommandLine(tool, allArgs);
     }

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -30,20 +30,65 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         var argumentsAfterOptions =
             argumentsByPlacement.GetValueOrDefault(ArgumentPlacement.AfterOptions) ?? [];
 
-        // Render semantic phases explicitly rather than relying on declaration order.
-        foreach (var phase in Enum.GetValues<CommandLinePhase>())
+        var normal = RenderPhase(
+            CommandLinePhase.Normal,
+            flagsAndOptions,
+            argumentsAfterOptions,
+            optionsObject);
+        var endOfOptions = RenderPhase(
+            CommandLinePhase.EndOfOptions,
+            flagsAndOptions,
+            argumentsAfterOptions,
+            optionsObject);
+        var passthrough = RenderPhase(
+            CommandLinePhase.Passthrough,
+            flagsAndOptions,
+            argumentsAfterOptions,
+            optionsObject);
+        var terminal = RenderPhase(
+            CommandLinePhase.Terminal,
+            flagsAndOptions,
+            argumentsAfterOptions,
+            optionsObject,
+            argumentsFirst: true);
+
+        if (endOfOptions.Count > 0 && terminal.Count > 0)
         {
-            AddFlagsAndOptions(
-                args,
-                flagsAndOptions.Where(part => part.Phase == phase),
-                optionsObject);
-            AddArguments(
-                args,
-                argumentsAfterOptions.Where(part => part.Phase == phase),
-                optionsObject);
+            throw new InvalidOperationException(
+                "Terminal options cannot be combined with an end-of-options marker.");
         }
 
+        args.AddRange(normal);
+        args.AddRange(endOfOptions);
+        args.AddRange(passthrough);
+        args.AddRange(terminal);
+
         return args;
+    }
+
+    private static List<string> RenderPhase(
+        CommandLinePhase phase,
+        IEnumerable<PropertyCommandLinePart> flagsAndOptions,
+        IEnumerable<ArgumentPart> arguments,
+        object optionsObject,
+        bool argumentsFirst = false)
+    {
+        var rendered = new List<string>();
+        var phaseOptions = flagsAndOptions.Where(part => part.Phase == phase);
+        var phaseArguments = arguments.Where(part => part.Phase == phase);
+
+        if (argumentsFirst)
+        {
+            AddArguments(rendered, phaseArguments, optionsObject);
+            AddFlagsAndOptions(rendered, phaseOptions, optionsObject);
+        }
+        else
+        {
+            AddFlagsAndOptions(rendered, phaseOptions, optionsObject);
+            AddArguments(rendered, phaseArguments, optionsObject);
+        }
+
+        return rendered;
     }
 
     private static void AddArguments(

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -27,16 +27,29 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         // Add arguments before options
         AddArguments(args, argumentsByPlacement.GetValueOrDefault(ArgumentPlacement.BeforeOptions), optionsObject);
 
-        // Add flags and options
-        AddFlagsAndOptions(args, flagsAndOptions, optionsObject);
+        var argumentsAfterOptions =
+            argumentsByPlacement.GetValueOrDefault(ArgumentPlacement.AfterOptions) ?? [];
 
-        // Add arguments after options
-        AddArguments(args, argumentsByPlacement.GetValueOrDefault(ArgumentPlacement.AfterOptions), optionsObject);
+        // Render semantic phases explicitly rather than relying on declaration order.
+        foreach (var phase in Enum.GetValues<CommandLinePhase>())
+        {
+            AddFlagsAndOptions(
+                args,
+                flagsAndOptions.Where(part => part.Phase == phase),
+                optionsObject);
+            AddArguments(
+                args,
+                argumentsAfterOptions.Where(part => part.Phase == phase),
+                optionsObject);
+        }
 
         return args;
     }
 
-    private static void AddArguments(List<string> args, List<ArgumentPart>? argumentParts, object optionsObject)
+    private static void AddArguments(
+        List<string> args,
+        IEnumerable<ArgumentPart>? argumentParts,
+        object optionsObject)
     {
         if (argumentParts is null)
         {
@@ -63,7 +76,10 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         }
     }
 
-    private static void AddFlagsAndOptions(List<string> args, List<PropertyCommandLinePart> parts, object optionsObject)
+    private static void AddFlagsAndOptions(
+        List<string> args,
+        IEnumerable<PropertyCommandLinePart> parts,
+        object optionsObject)
     {
         foreach (var part in parts)
         {
@@ -100,6 +116,16 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
 
     private static void AddOption(List<string> args, OptionPart optionPart, object rawValue)
     {
+        if (optionPart.ValueArity == CliOptionValueArity.None)
+        {
+            if (rawValue is not bool value || value)
+            {
+                args.Add(optionPart.Attribute.GetEffectiveName());
+            }
+
+            return;
+        }
+
         if (TryAddOptionValuePairs(args, optionPart, rawValue))
         {
             return;
@@ -111,6 +137,11 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         {
             if (string.IsNullOrWhiteSpace(value))
             {
+                if (optionPart.ValueArity == CliOptionValueArity.Optional)
+                {
+                    args.Add(optionPart.Attribute.GetEffectiveName());
+                }
+
                 continue;
             }
 

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -14,12 +14,15 @@ internal sealed class CommandModelProvider : ICommandModelProvider
     [RequiresUnreferencedCode("Calls ModularPipelines.Helpers.Internal.CommandModelProvider.BuildModel(Type)")]
     public IReadOnlyList<PropertyCommandLinePart> GetCommandModel(Type optionsType)
     {
-        if (GeneratedCommandMetadata.TryGet(optionsType, out var generatedModel))
+        return _cache.GetOrAdd(optionsType, static type =>
         {
-            return generatedModel;
-        }
+            var model = GeneratedCommandMetadata.TryGet(type, out var generatedModel)
+                ? generatedModel
+                : BuildModel(type);
 
-        return _cache.GetOrAdd(optionsType, BuildModel);
+            ValidateUniqueSwitches(type, model);
+            return model;
+        });
     }
 
     [RequiresUnreferencedCode("Reflection fallback requires CLI-attributed properties. Ensure ModularPipelines.SourceGenerator runs for trim-safe command models.")]
@@ -79,5 +82,49 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         }
 
         return false;
+    }
+
+    private static void ValidateUniqueSwitches(
+        Type optionsType,
+        IReadOnlyList<PropertyCommandLinePart> parts)
+    {
+        var switches = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var part in parts)
+        {
+            foreach (var switchName in GetSwitchNames(part))
+            {
+                if (switches.TryGetValue(switchName, out var existingProperty))
+                {
+                    throw new InvalidOperationException(
+                        $"{optionsType.Name} defines CLI switch '{switchName}' more than once " +
+                        $"on properties '{existingProperty}' and '{part.PropertyName}'. " +
+                        "Model aliases with ShortForm on a single property.");
+                }
+
+                switches.Add(switchName, part.PropertyName);
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetSwitchNames(PropertyCommandLinePart part)
+    {
+        return part switch
+        {
+            FlagPart flag => GetNames(flag.Attribute.Name, flag.Attribute.ShortForm),
+            OptionPart option => GetNames(option.Attribute.Name, option.Attribute.ShortForm),
+            _ => [],
+        };
+    }
+
+    private static IEnumerable<string> GetNames(string name, string? shortForm)
+    {
+        yield return name;
+
+        if (!string.IsNullOrWhiteSpace(shortForm) &&
+            !string.Equals(name, shortForm, StringComparison.Ordinal))
+        {
+            yield return shortForm;
+        }
     }
 }

--- a/src/ModularPipelines/Helpers/Internal/PropertyCommandLinePart.cs
+++ b/src/ModularPipelines/Helpers/Internal/PropertyCommandLinePart.cs
@@ -11,6 +11,16 @@ public abstract record PropertyCommandLinePart(string PropertyName, Func<object,
     /// Gets a value indicating whether the property belongs before command parts.
     /// </summary>
     public bool IsGlobalOption { get; init; }
+
+    /// <summary>
+    /// Gets the semantic rendering phase.
+    /// </summary>
+    public abstract CommandLinePhase Phase { get; }
+
+    /// <summary>
+    /// Gets the number-of-values contract for this command-line part.
+    /// </summary>
+    public abstract CliOptionValueArity ValueArity { get; }
 }
 
 /// <summary>
@@ -19,7 +29,14 @@ public abstract record PropertyCommandLinePart(string PropertyName, Func<object,
 public sealed record ArgumentPart(
     string PropertyName,
     Func<object, object?> Getter,
-    CliArgumentAttribute Attribute) : PropertyCommandLinePart(PropertyName, Getter);
+    CliArgumentAttribute Attribute) : PropertyCommandLinePart(PropertyName, Getter)
+{
+    /// <inheritdoc />
+    public override CommandLinePhase Phase => Attribute.Phase;
+
+    /// <inheritdoc />
+    public override CliOptionValueArity ValueArity => CliOptionValueArity.Required;
+}
 
 /// <summary>
 /// Representation of a boolean flag.
@@ -27,7 +44,14 @@ public sealed record ArgumentPart(
 public sealed record FlagPart(
     string PropertyName,
     Func<object, object?> Getter,
-    CliFlagAttribute Attribute) : PropertyCommandLinePart(PropertyName, Getter);
+    CliFlagAttribute Attribute) : PropertyCommandLinePart(PropertyName, Getter)
+{
+    /// <inheritdoc />
+    public override CommandLinePhase Phase => Attribute.Phase;
+
+    /// <inheritdoc />
+    public override CliOptionValueArity ValueArity => CliOptionValueArity.None;
+}
 
 /// <summary>
 /// Representation of an option with a value.
@@ -35,4 +59,11 @@ public sealed record FlagPart(
 public sealed record OptionPart(
     string PropertyName,
     Func<object, object?> Getter,
-    CliOptionAttribute Attribute) : PropertyCommandLinePart(PropertyName, Getter);
+    CliOptionAttribute Attribute) : PropertyCommandLinePart(PropertyName, Getter)
+{
+    /// <inheritdoc />
+    public override CommandLinePhase Phase => Attribute.Phase;
+
+    /// <inheritdoc />
+    public override CliOptionValueArity ValueArity => Attribute.ValueArity;
+}

--- a/test/ModularPipelines.Jq.UnitTests/Attributes/JqOptionsTests.cs
+++ b/test/ModularPipelines.Jq.UnitTests/Attributes/JqOptionsTests.cs
@@ -65,7 +65,7 @@ public class JqOptionsTests
         {
             LibraryPath = ["modules"],
             Binary = true,
-            RunTestsFile = "tests.jq",
+            RunTests = "tests.jq",
             EndOfOptions = true,
             Filter = "-1",
         });
@@ -77,13 +77,14 @@ public class JqOptionsTests
             "--run-tests", "tests.jq",
             "--",
             "-1",
-        ]);
+        ],
+        TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
     public async Task Renders_Bare_RunTests_For_Standard_Input()
     {
-        var arguments = BuildArguments(new JqExecuteOptions { RunTests = true });
+        var arguments = BuildArguments(new JqExecuteOptions { RunTests = string.Empty });
 
         await Assert.That(arguments).IsEquivalentTo(["--run-tests"]);
     }

--- a/test/ModularPipelines.Jq.UnitTests/Attributes/JqOptionsTests.cs
+++ b/test/ModularPipelines.Jq.UnitTests/Attributes/JqOptionsTests.cs
@@ -59,14 +59,13 @@ public class JqOptionsTests
     }
 
     [Test]
-    public async Task Renders_Portable_Library_Path_And_Documented_Trailing_Options()
+    public async Task Renders_RunTests_After_Positionals()
     {
         var arguments = BuildArguments(new JqExecuteOptions
         {
             LibraryPath = ["modules"],
             Binary = true,
             RunTests = "tests.jq",
-            EndOfOptions = true,
             Filter = "-1",
         });
 
@@ -74,11 +73,24 @@ public class JqOptionsTests
         [
             "-L", "modules",
             "-b",
-            "--run-tests", "tests.jq",
-            "--",
             "-1",
+            "--run-tests", "tests.jq",
         ],
         TUnit.Assertions.Enums.CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Renders_EndOfOptions_Before_DashPrefixed_Filter()
+    {
+        var arguments = BuildArguments(new JqExecuteOptions
+        {
+            EndOfOptions = true,
+            Filter = "-1",
+        });
+
+        await Assert.That(arguments).IsEquivalentTo(
+            ["--", "-1"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -192,14 +192,13 @@ public class CliAttributeTests
         {
             Normal = true,
             Terminal = string.Empty,
-            EndOfOptions = true,
             Passthrough = "input.txt",
         };
 
         var list = BuildArguments(options);
 
         await Assert.That(list).IsEquivalentTo(
-            ["--normal", "--terminal", "--", "input.txt"],
+            ["--normal", "input.txt", "--terminal"],
             TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
@@ -210,15 +209,39 @@ public class CliAttributeTests
         {
             Normal = true,
             Terminal = "tests.txt",
-            EndOfOptions = true,
             Passthrough = "input.txt",
         };
 
         var list = BuildArguments(options);
 
         await Assert.That(list).IsEquivalentTo(
-            ["--normal", "--terminal", "tests.txt", "--", "input.txt"],
+            ["--normal", "input.txt", "--terminal", "tests.txt"],
             TUnit.Assertions.Enums.CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Parser_Renders_EndOfOptions_Before_Passthrough()
+    {
+        var list = BuildArguments(new TestCliOptionsWithSemanticPhases
+        {
+            Normal = true,
+            EndOfOptions = true,
+            Passthrough = "-input.txt",
+        });
+
+        await Assert.That(list).IsEquivalentTo(
+            ["--normal", "--", "-input.txt"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Parser_Rejects_Terminal_Option_After_EndOfOptions()
+    {
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithSemanticPhases
+        {
+            Terminal = "tests.txt",
+            EndOfOptions = true,
+        })).Throws<InvalidOperationException>();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -111,6 +111,7 @@ public class CliAttributeTests
         var attribute = new CliArgumentAttribute(0);
 
         await Assert.That(attribute.Placement).IsEqualTo(ArgumentPlacement.AfterOptions);
+        await Assert.That(attribute.Phase).IsEqualTo(CommandLinePhase.Passthrough);
     }
 
     [Test]
@@ -182,6 +183,60 @@ public class CliAttributeTests
         var list = BuildArguments(options);
 
         await Assert.That(list).IsEquivalentTo(new[] { "--values", "file1.yaml", "--values", "file2.yaml" });
+    }
+
+    [Test]
+    public async Task Parser_Renders_Bare_OptionalValue_Option()
+    {
+        var options = new TestCliOptionsWithSemanticPhases
+        {
+            Normal = true,
+            Terminal = string.Empty,
+            EndOfOptions = true,
+            Passthrough = "input.txt",
+        };
+
+        var list = BuildArguments(options);
+
+        await Assert.That(list).IsEquivalentTo(
+            ["--normal", "--terminal", "--", "input.txt"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Parser_Renders_OptionalValue_And_Orders_By_Semantic_Phase()
+    {
+        var options = new TestCliOptionsWithSemanticPhases
+        {
+            Normal = true,
+            Terminal = "tests.txt",
+            EndOfOptions = true,
+            Passthrough = "input.txt",
+        };
+
+        var list = BuildArguments(options);
+
+        await Assert.That(list).IsEquivalentTo(
+            ["--normal", "--terminal", "tests.txt", "--", "input.txt"],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Parser_Renders_None_Arity_Option_Without_Value()
+    {
+        var list = BuildArguments(new TestCliOptionsWithSemanticPhases
+        {
+            Valueless = true,
+        });
+
+        await Assert.That(list).IsEquivalentTo(["--valueless"]);
+    }
+
+    [Test]
+    public async Task CommandModel_Rejects_Duplicate_Switches()
+    {
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithDuplicateSwitch()))
+            .Throws<InvalidOperationException>();
     }
 
     [Test]
@@ -283,6 +338,36 @@ public class CliAttributeTests
     {
         [CliOption("--values", AllowMultiple = true)]
         public string[]? Values { get; set; }
+    }
+
+    private record TestCliOptionsWithSemanticPhases
+    {
+        [CliFlag("--", Phase = CommandLinePhase.EndOfOptions)]
+        public bool? EndOfOptions { get; set; }
+
+        [CliOption(
+            "--terminal",
+            ValueArity = CliOptionValueArity.Optional,
+            Phase = CommandLinePhase.Terminal)]
+        public string? Terminal { get; set; }
+
+        [CliArgument(0)]
+        public string? Passthrough { get; set; }
+
+        [CliFlag("--normal")]
+        public bool? Normal { get; set; }
+
+        [CliOption("--valueless", ValueArity = CliOptionValueArity.None)]
+        public bool? Valueless { get; set; }
+    }
+
+    private record TestCliOptionsWithDuplicateSwitch
+    {
+        [CliFlag("--duplicate")]
+        public bool? First { get; set; }
+
+        [CliOption("--duplicate")]
+        public string? Second { get; set; }
     }
 
     private record TestCliOptionsWithArgumentAfterOptions

--- a/test/ModularPipelines.UnitTests/Attributes/GeneratedRuntimeMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/GeneratedRuntimeMetadataTests.cs
@@ -15,7 +15,12 @@ internal sealed record GeneratedMetadataOptions : CommandLineToolOptions
     [CliFlag("--verbose", ShortForm = "-v", PreferShortForm = true)]
     public bool? Verbose { get; init; }
 
-    [CliOption("--output", Format = OptionFormat.EqualsSeparated, AllowMultiple = true)]
+    [CliOption(
+        "--output",
+        Format = OptionFormat.EqualsSeparated,
+        AllowMultiple = true,
+        ValueArity = CliOptionValueArity.Optional,
+        Phase = CommandLinePhase.Terminal)]
     public string[]? Output { get; init; }
 
     [SecretValue]
@@ -122,16 +127,22 @@ public class GeneratedRuntimeMetadataTests
         await Assert.That(argument.Getter(options)).IsEqualTo("pipeline.yml");
         await Assert.That(argument.Attribute.Position).IsEqualTo(0);
         await Assert.That(argument.Attribute.Placement).IsEqualTo(ArgumentPlacement.BeforeOptions);
+        await Assert.That(argument.Attribute.Phase).IsEqualTo(CommandLinePhase.Passthrough);
         await Assert.That(argument.Attribute.Name).IsEqualTo("<FILE>");
 
         var flag = model.OfType<FlagPart>().Single();
         await Assert.That((bool) flag.Getter(options)!).IsTrue();
         await Assert.That(flag.Attribute.GetEffectiveName()).IsEqualTo("-v");
+        await Assert.That(flag.Attribute.Phase).IsEqualTo(CommandLinePhase.Normal);
+        await Assert.That(flag.ValueArity).IsEqualTo(CliOptionValueArity.None);
 
         var option = model.OfType<OptionPart>().Single();
         await Assert.That(option.Getter(options)).IsEqualTo(options.Output);
         await Assert.That(option.Attribute.GetSeparator()).IsEqualTo("=");
         await Assert.That(option.Attribute.AllowMultiple).IsTrue();
+        await Assert.That(option.Attribute.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+        await Assert.That(option.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+        await Assert.That(option.Attribute.Phase).IsEqualTo(CommandLinePhase.Terminal);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -43,6 +43,36 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
+    public async Task Build_Places_Terminal_Options_After_Manual_Arguments()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var result = builder.Build(new TestTerminalOptions
+        {
+            Arguments = ["."],
+            RunTests = "tests.jq",
+        });
+
+        await Assert.That(result.ToString()).IsEqualTo("jq . --run-tests tests.jq");
+    }
+
+    [Test]
+    public async Task Build_Rejects_Terminal_Options_With_RunSettings()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        CommandLine Build() => builder.Build(new TestTerminalOptions
+        {
+            RunTests = "tests.jq",
+            RunSettings = ["--filter", "Category=Unit"],
+        });
+
+        await Assert.That(Build)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("end-of-options marker");
+    }
+
+    [Test]
     public async Task Build_FromAttributeBasedOptions_ResolvesToolAndSubcommands()
     {
         var builder = await GetService<ICommandLineBuilder>();
@@ -178,6 +208,17 @@ public class CommandLineBuilderTests : TestBase
 
         [CliArgument(1, Placement = ArgumentPlacement.AfterOptions)]
         public string? ConfigPath { get; set; }
+    }
+
+    [CliTool("jq")]
+    [CliCommand("jq")]
+    private record TestTerminalOptions : CommandLineToolOptions
+    {
+        [CliOption(
+            "--run-tests",
+            ValueArity = CliOptionValueArity.Optional,
+            Phase = CommandLinePhase.Terminal)]
+        public string? RunTests { get; set; }
     }
 
     [CliTool("liquibase")]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
@@ -375,6 +375,43 @@ public class GeneratorUtilsTests
         await Assert.That(result).Contains("AllowMultiple = true");
     }
 
+    [Test]
+    public async Task GenerateCliAttributeString_Includes_OptionalArity_And_TerminalPhase()
+    {
+        var option = new CliOptionDefinition
+        {
+            SwitchName = "--run-tests",
+            PropertyName = "RunTests",
+            CSharpType = "string?",
+            ValueArity = CliOptionValueArity.Optional,
+            Phase = CommandLinePhase.Terminal,
+        };
+
+        var result = GeneratorUtils.GenerateCliAttributeString(option);
+
+        await Assert.That(result).IsEqualTo(
+            "CliOption(\"--run-tests\", ValueArity = CliOptionValueArity.Optional, " +
+            "Phase = CommandLinePhase.Terminal)");
+    }
+
+    [Test]
+    public async Task GenerateCliAttributeString_Includes_EndOfOptions_Phase_For_Flag()
+    {
+        var option = new CliOptionDefinition
+        {
+            SwitchName = "--",
+            PropertyName = "EndOfOptions",
+            CSharpType = "bool?",
+            IsFlag = true,
+            Phase = CommandLinePhase.EndOfOptions,
+        };
+
+        var result = GeneratorUtils.GenerateCliAttributeString(option);
+
+        await Assert.That(result).IsEqualTo(
+            "CliFlag(\"--\", Phase = CommandLinePhase.EndOfOptions)");
+    }
+
     #endregion
 
     #region GenerateMethodNameFromCommandParts Tests

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 
@@ -392,6 +393,23 @@ public class GeneratorUtilsTests
         await Assert.That(result).IsEqualTo(
             "CliOption(\"--run-tests\", ValueArity = CliOptionValueArity.Optional, " +
             "Phase = CommandLinePhase.Terminal)");
+    }
+
+    [Test]
+    public async Task GenerateCliAttributeString_Includes_NoneArity_For_Option()
+    {
+        var option = new CliOptionDefinition
+        {
+            SwitchName = "--valueless",
+            PropertyName = "Valueless",
+            CSharpType = "string?",
+            ValueArity = CliOptionValueArity.None,
+        };
+
+        var result = GeneratorUtils.GenerateCliAttributeString(option);
+
+        await Assert.That(result).IsEqualTo(
+            "CliOption(\"--valueless\", ValueArity = CliOptionValueArity.None)");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/JqCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/JqCliScraperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/JqCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/JqCliScraperTests.cs
@@ -28,7 +28,7 @@ public class JqCliScraperTests
     {
         var command = await new TestJqCliScraper().Parse(HelpText);
 
-        await Assert.That(command.Options).Count().IsEqualTo(11);
+        await Assert.That(command.Options).Count().IsEqualTo(10);
 
         var nullInput = command.Options.Single(x => x.PropertyName == "NullInput");
         await Assert.That(nullInput.ShortForm).IsEqualTo("-n");
@@ -57,16 +57,15 @@ public class JqCliScraperTests
         await Assert.That(binary.PreferShortForm).IsTrue();
 
         var runTests = command.Options.Single(x => x.PropertyName == "RunTests");
-        await Assert.That(runTests.CSharpType).IsEqualTo("bool?");
-        await Assert.That(runTests.IsFlag).IsTrue();
-
-        var runTestsFile = command.Options.Single(x => x.PropertyName == "RunTestsFile");
-        await Assert.That(runTestsFile.CSharpType).IsEqualTo("string?");
-        await Assert.That(runTestsFile.IsFlag).IsFalse();
+        await Assert.That(runTests.CSharpType).IsEqualTo("string?");
+        await Assert.That(runTests.IsFlag).IsFalse();
+        await Assert.That(runTests.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+        await Assert.That(runTests.Phase).IsEqualTo(CommandLinePhase.Terminal);
 
         var endOfOptions = command.Options.Single(x => x.PropertyName == "EndOfOptions");
         await Assert.That(endOfOptions.SwitchName).IsEqualTo("--");
         await Assert.That(endOfOptions.IsFlag).IsTrue();
+        await Assert.That(endOfOptions.Phase).IsEqualTo(CommandLinePhase.EndOfOptions);
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -265,30 +265,35 @@ public static partial class GeneratorUtils
     /// <returns>The attribute string (e.g., "CliFlag(\"--verbose\")" or "CliOption(\"--output\")").</returns>
     public static string GenerateCliAttributeString(CliOptionDefinition option)
     {
-        if (option.IsFlag)
+        return option.IsFlag
+            ? GenerateCliFlagAttributeString(option)
+            : GenerateCliOptionAttributeString(option);
+    }
+
+    private static string GenerateCliFlagAttributeString(CliOptionDefinition option)
+    {
+        var parts = new List<string> { $"\"{option.SwitchName}\"" };
+
+        if (!string.IsNullOrEmpty(option.ShortForm))
         {
-            // Use CliFlag for boolean flags
-            var parts = new List<string> { $"\"{option.SwitchName}\"" };
-
-            if (!string.IsNullOrEmpty(option.ShortForm))
-            {
-                parts.Add($"ShortForm = \"{option.ShortForm}\"");
-            }
-
-            if (option.PreferShortForm)
-            {
-                parts.Add("PreferShortForm = true");
-            }
-
-            if (option.Phase != CommandLinePhase.Normal)
-            {
-                parts.Add($"Phase = CommandLinePhase.{option.Phase}");
-            }
-
-            return $"CliFlag({string.Join(", ", parts)})";
+            parts.Add($"ShortForm = \"{option.ShortForm}\"");
         }
 
-        // Use CliOption for value options
+        if (option.PreferShortForm)
+        {
+            parts.Add("PreferShortForm = true");
+        }
+
+        if (option.Phase != CommandLinePhase.Normal)
+        {
+            parts.Add($"Phase = CommandLinePhase.{option.Phase}");
+        }
+
+        return $"CliFlag({string.Join(", ", parts)})";
+    }
+
+    private static string GenerateCliOptionAttributeString(CliOptionDefinition option)
+    {
         var optionParts = new List<string> { $"\"{option.SwitchName}\"" };
 
         if (!string.IsNullOrEmpty(option.ShortForm))

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Models;
 
 namespace ModularPipelines.OptionsGenerator.Generators;
@@ -328,9 +329,9 @@ public static partial class GeneratorUtils
             optionParts.Add("AllowMultiple = true");
         }
 
-        if (option.ValueArity == CliOptionValueArity.Optional)
+        if (option.ValueArity != CliOptionValueArity.Required)
         {
-            optionParts.Add("ValueArity = CliOptionValueArity.Optional");
+            optionParts.Add($"ValueArity = CliOptionValueArity.{option.ValueArity}");
         }
 
         if (option.Phase != CommandLinePhase.Normal)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -280,6 +280,11 @@ public static partial class GeneratorUtils
                 parts.Add("PreferShortForm = true");
             }
 
+            if (option.Phase != CommandLinePhase.Normal)
+            {
+                parts.Add($"Phase = CommandLinePhase.{option.Phase}");
+            }
+
             return $"CliFlag({string.Join(", ", parts)})";
         }
 
@@ -316,6 +321,16 @@ public static partial class GeneratorUtils
         if (option.AcceptsMultipleValues)
         {
             optionParts.Add("AllowMultiple = true");
+        }
+
+        if (option.ValueArity == CliOptionValueArity.Optional)
+        {
+            optionParts.Add("ValueArity = CliOptionValueArity.Optional");
+        }
+
+        if (option.Phase != CommandLinePhase.Normal)
+        {
+            optionParts.Add($"Phase = CommandLinePhase.{option.Phase}");
         }
 
         return $"CliOption({string.Join(", ", optionParts)})";

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
@@ -51,6 +51,16 @@ public record CliOptionDefinition
     public bool IsFlag { get; init; }
 
     /// <summary>
+    /// Whether a value is required, optional, or absent.
+    /// </summary>
+    public CliOptionValueArity ValueArity { get; init; } = CliOptionValueArity.Required;
+
+    /// <summary>
+    /// Semantic rendering phase for this option.
+    /// </summary>
+    public CommandLinePhase Phase { get; init; } = CommandLinePhase.Normal;
+
+    /// <summary>
     /// Whether the option is required.
     /// </summary>
     public bool IsRequired { get; init; }
@@ -120,6 +130,27 @@ public enum OptionAttributeType
     CommandSwitch,
     BooleanCommandSwitch,
     CommandEqualsSeparatorSwitch
+}
+
+/// <summary>
+/// Value arity for a generated CLI option.
+/// </summary>
+public enum CliOptionValueArity
+{
+    Required,
+    Optional,
+    None,
+}
+
+/// <summary>
+/// Semantic command-line rendering phases.
+/// </summary>
+public enum CommandLinePhase
+{
+    Normal,
+    Terminal,
+    EndOfOptions,
+    Passthrough,
 }
 
 /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliOptionDefinition.cs
@@ -1,3 +1,5 @@
+using ModularPipelines.Attributes;
+
 namespace ModularPipelines.OptionsGenerator.Models;
 
 /// <summary>
@@ -130,27 +132,6 @@ public enum OptionAttributeType
     CommandSwitch,
     BooleanCommandSwitch,
     CommandEqualsSeparatorSwitch
-}
-
-/// <summary>
-/// Value arity for a generated CLI option.
-/// </summary>
-public enum CliOptionValueArity
-{
-    Required,
-    Optional,
-    None,
-}
-
-/// <summary>
-/// Semantic command-line rendering phases.
-/// </summary>
-public enum CommandLinePhase
-{
-    Normal,
-    Terminal,
-    EndOfOptions,
-    Passthrough,
 }
 
 /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.csproj
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.csproj
@@ -26,6 +26,8 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="ModularPipelines.OptionsGenerator.Tests" />
+    <Compile Include="..\..\..\..\src\ModularPipelines\Attributes\CliOptionValueArity.cs" Link="Shared\CliOptionValueArity.cs" />
+    <Compile Include="..\..\..\..\src\ModularPipelines\Attributes\CommandLinePhase.cs" Link="Shared\CommandLinePhase.cs" />
     <Compile Include="..\..\..\..\src\ModularPipelines\Helpers\Internal\WindowsCommandResolver.cs" Link="Shared\WindowsCommandResolver.cs" />
   </ItemGroup>
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/JqCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/JqCliScraper.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/JqCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/JqCliScraper.cs
@@ -223,9 +223,11 @@ public partial class JqCliScraper : CliScraperBase
         {
             SwitchName = "--run-tests",
             PropertyName = "RunTests",
-            CSharpType = "bool?",
-            Description = "Run jq tests from standard input",
-            IsFlag = true
+            CSharpType = "string?",
+            Description = "Run jq tests from standard input or the specified file",
+            IsFlag = false,
+            ValueArity = CliOptionValueArity.Optional,
+            Phase = CommandLinePhase.Terminal
         });
 
         // jq's Linux help omits this Windows-supported option.
@@ -240,15 +242,6 @@ public partial class JqCliScraper : CliScraperBase
             IsFlag = true
         });
 
-        options.Add(new CliOptionDefinition
-        {
-            SwitchName = "--run-tests",
-            PropertyName = "RunTestsFile",
-            CSharpType = "string?",
-            Description = "Run jq tests from the specified file",
-            IsFlag = false
-        });
-
         // jq -h omits the POSIX end-of-options marker documented by its manual.
         options.Add(new CliOptionDefinition
         {
@@ -256,7 +249,9 @@ public partial class JqCliScraper : CliScraperBase
             PropertyName = "EndOfOptions",
             CSharpType = "bool?",
             Description = "Stop processing options so filters beginning with a dash are treated as positional arguments",
-            IsFlag = true
+            IsFlag = true,
+            ValueArity = CliOptionValueArity.None,
+            Phase = CommandLinePhase.EndOfOptions
         });
     }
 


### PR DESCRIPTION
## Summary
- add explicit CLI value arity and semantic rendering phases to generator/runtime metadata
- render normal, terminal, end-of-options, and passthrough parts in semantic order and reject duplicate switches
- model jq `--run-tests [filename]` as one optional-value API and preserve `--` ordering

## Validation
- `dotnet run --project tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ModularPipelines.OptionsGenerator.Tests.csproj -c Release --no-build --` (500 passed)
- `dotnet build src/ModularPipelines/ModularPipelines.csproj -c Release -f net10.0 -m:1`
- `dotnet build src/ModularPipelines.Jq/ModularPipelines.Jq.sln -c Release -m:1`

Closes #3170