### PR TITLE
Close remaining guard containment gaps

### DIFF
--- a/scripts/Invoke-AgentDotNet.ps1
+++ b/scripts/Invoke-AgentDotNet.ps1
@@ -34,26 +34,159 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+if ($IsWindows) {
+    Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+public static class AgentDotNetWindowsJob
+{
+    private const int JobObjectExtendedLimitInformation = 9;
+    private const uint JobObjectLimitKillOnJobClose = 0x00002000;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct BasicLimitInformation
+    {
+        public long PerProcessUserTimeLimit;
+        public long PerJobUserTimeLimit;
+        public uint LimitFlags;
+        public UIntPtr MinimumWorkingSetSize;
+        public UIntPtr MaximumWorkingSetSize;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass;
+        public uint SchedulingClass;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IoCounters
+    {
+        public ulong ReadOperationCount;
+        public ulong WriteOperationCount;
+        public ulong OtherOperationCount;
+        public ulong ReadTransferCount;
+        public ulong WriteTransferCount;
+        public ulong OtherTransferCount;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ExtendedLimitInformation
+    {
+        public BasicLimitInformation BasicLimitInformation;
+        public IoCounters IoInfo;
+        public UIntPtr ProcessMemoryLimit;
+        public UIntPtr JobMemoryLimit;
+        public UIntPtr PeakProcessMemoryUsed;
+        public UIntPtr PeakJobMemoryUsed;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    private static extern IntPtr CreateJobObject(IntPtr securityAttributes, string name);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool SetInformationJobObject(
+        IntPtr job,
+        int informationClass,
+        IntPtr information,
+        uint informationLength);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool CloseHandle(IntPtr handle);
+
+    public static IntPtr CreateKillOnClose()
+    {
+        IntPtr job = CreateJobObject(IntPtr.Zero, null);
+        if (job == IntPtr.Zero)
+        {
+            throw new Win32Exception();
+        }
+
+        int size = Marshal.SizeOf<ExtendedLimitInformation>();
+        IntPtr information = Marshal.AllocHGlobal(size);
+        try
+        {
+            var limits = new ExtendedLimitInformation();
+            limits.BasicLimitInformation.LimitFlags = JobObjectLimitKillOnJobClose;
+            Marshal.StructureToPtr(limits, information, false);
+            if (!SetInformationJobObject(
+                    job,
+                    JobObjectExtendedLimitInformation,
+                    information,
+                    (uint)size))
+            {
+                throw new Win32Exception();
+            }
+
+            return job;
+        }
+        catch
+        {
+            CloseHandle(job);
+            throw;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(information);
+        }
+    }
+
+    public static void Assign(IntPtr job, IntPtr process)
+    {
+        if (!AssignProcessToJobObject(job, process))
+        {
+            throw new Win32Exception();
+        }
+    }
+
+    public static void Close(IntPtr job)
+    {
+        if (job != IntPtr.Zero)
+        {
+            CloseHandle(job);
+        }
+    }
+}
+'@
+}
+else {
+    Add-Type -TypeDefinition @'
+using System.Runtime.InteropServices;
+
+public static class AgentDotNetUnixNative
+{
+    [DllImport("libc", SetLastError = true)]
+    public static extern int kill(int processId, int signal);
+}
+'@
+}
+
 function Get-ProcessSnapshot {
     if ($IsWindows) {
-        return Get-CimInstance Win32_Process -Property ProcessId, ParentProcessId, WorkingSetSize |
+        return Get-CimInstance Win32_Process `
+            -Property ProcessId, ParentProcessId, WorkingSetSize, CreationDate |
             ForEach-Object {
                 [pscustomobject]@{
                     ProcessId = [int]$_.ProcessId
                     ParentProcessId = [int]$_.ParentProcessId
                     WorkingSetBytes = [long]$_.WorkingSetSize
+                    StartIdentity = $_.CreationDate.ToUniversalTime().Ticks.ToString(
+                        [Globalization.CultureInfo]::InvariantCulture)
                 }
             }
     }
 
-    return & ps -eo pid=,ppid=,rss= |
+    return & ps -eo pid=,ppid=,rss=,lstart= |
         ForEach-Object {
-            $columns = $_.Trim() -split '\s+'
-            if ($columns.Count -eq 3) {
+            if ($_ -match '^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.+?)\s*$') {
                 [pscustomobject]@{
-                    ProcessId = [int]$columns[0]
-                    ParentProcessId = [int]$columns[1]
-                    WorkingSetBytes = [long]$columns[2] * 1KB
+                    ProcessId = [int]$Matches[1]
+                    ParentProcessId = [int]$Matches[2]
+                    WorkingSetBytes = [long]$Matches[3] * 1KB
+                    StartIdentity = $Matches[4]
                 }
             }
         }
@@ -74,66 +207,70 @@ function Get-ProcessTreeState([int]$RootProcessId) {
     }
     while ($added)
 
-    $workingSetBytes = ($snapshot |
-        Where-Object { $processIds.Contains($_.ProcessId) } |
-        Measure-Object -Property WorkingSetBytes -Sum).Sum
-
+    $treeProcesses = @($snapshot | Where-Object { $processIds.Contains($_.ProcessId) })
     return [pscustomobject]@{
-        ProcessIds = $processIds
-        WorkingSetBytes = [long]($workingSetBytes ?? 0)
-    }
-}
-
-function Get-ProcessStartTimeUtcTicks([int]$ProcessId) {
-    try {
-        $candidate = [System.Diagnostics.Process]::GetProcessById($ProcessId)
-        try {
-            return $candidate.StartTime.ToUniversalTime().Ticks
-        }
-        finally {
-            $candidate.Dispose()
-        }
-    }
-    catch [System.ArgumentException] {
-        Write-Verbose "Process $ProcessId exited before its identity could be read."
-        return $null
-    }
-    catch [System.InvalidOperationException] {
-        Write-Verbose "Process $ProcessId became unavailable before its identity could be read."
-        return $null
-    }
-    catch [System.ComponentModel.Win32Exception] {
-        Write-Verbose "Process $ProcessId identity could not be read: $_"
-        return $null
+        Snapshot = $snapshot
+        Processes = $treeProcesses
     }
 }
 
 function Sync-TrackedProcesses(
-    [System.Collections.Generic.Dictionary[int, long]]$TrackedProcesses,
-    [System.Collections.Generic.HashSet[int]]$CurrentProcessIds) {
+    [System.Collections.Generic.Dictionary[int, string]]$TrackedProcesses,
+    [object[]]$Snapshot,
+    [object[]]$TreeProcesses) {
+    $currentProcesses = @{}
+    foreach ($process in $Snapshot) {
+        $currentProcesses[$process.ProcessId] = $process
+    }
+
     foreach ($processId in @($TrackedProcesses.Keys)) {
-        $currentStartTimeUtcTicks = Get-ProcessStartTimeUtcTicks $processId
-        if (($null -eq $currentStartTimeUtcTicks) -or
-            ($currentStartTimeUtcTicks -ne $TrackedProcesses[$processId])) {
+        $currentProcess = $currentProcesses[$processId]
+        if (($null -eq $currentProcess) -or
+            ($currentProcess.StartIdentity -ne $TrackedProcesses[$processId])) {
             $null = $TrackedProcesses.Remove($processId)
         }
     }
 
-    foreach ($processId in $CurrentProcessIds) {
-        if ($TrackedProcesses.ContainsKey($processId)) {
-            continue
-        }
-
-        $startTimeUtcTicks = Get-ProcessStartTimeUtcTicks $processId
-        if ($null -ne $startTimeUtcTicks) {
-            $TrackedProcesses[$processId] = $startTimeUtcTicks
-        }
+    foreach ($process in $TreeProcesses) {
+        $TrackedProcesses[$process.ProcessId] = $process.StartIdentity
     }
+}
+
+function Get-TrackedWorkingSetBytes(
+    [System.Collections.Generic.Dictionary[int, string]]$TrackedProcesses,
+    [object[]]$Snapshot) {
+    $workingSetBytes = ($Snapshot |
+        Where-Object {
+            $TrackedProcesses.ContainsKey($_.ProcessId) -and
+            $TrackedProcesses[$_.ProcessId] -eq $_.StartIdentity
+        } |
+        Measure-Object -Property WorkingSetBytes -Sum).Sum
+
+    return [long]($workingSetBytes ?? 0)
 }
 
 function Stop-ProcessTree(
     [System.Diagnostics.Process]$RootProcess,
-    [System.Collections.Generic.Dictionary[int, long]]$TrackedProcesses) {
+    [System.Collections.Generic.Dictionary[int, string]]$TrackedProcesses,
+    [IntPtr]$WindowsJobHandle,
+    [int]$UnixProcessGroupId) {
+    if ($IsWindows -and $WindowsJobHandle -ne [IntPtr]::Zero) {
+        # Closing a kill-on-close Job Object catches descendants that exited the
+        # parent-PID tree before the final snapshot.
+        [AgentDotNetWindowsJob]::Close($WindowsJobHandle)
+    }
+    elseif ((-not $IsWindows) -and $UnixProcessGroupId -gt 0) {
+        # Signal the process group from the guard so timeout and memory-limit paths
+        # have the same containment as normal exit.
+        $killResult = [AgentDotNetUnixNative]::kill(-$UnixProcessGroupId, 9)
+        if ($killResult -ne 0) {
+            $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+            if ($errorCode -ne 3) {
+                Write-Verbose "Unix process group $UnixProcessGroupId could not be stopped (errno $errorCode)."
+            }
+        }
+    }
+
     try {
         if (-not $RootProcess.HasExited) {
             $RootProcess.Kill($true)
@@ -146,18 +283,37 @@ function Stop-ProcessTree(
         Write-Verbose "Root process-tree cleanup was unavailable: $_"
     }
 
+    try {
+        $currentSnapshot = @(Get-ProcessSnapshot)
+    }
+    catch {
+        Write-Verbose "Final process snapshot was unavailable: $_"
+        return
+    }
+
+    $currentProcesses = @{}
+    foreach ($process in $currentSnapshot) {
+        $currentProcesses[$process.ProcessId] = $process
+    }
+
+    # The Job Object/process group is the containment boundary. Identity-checked
+    # tracked cleanup is defense in depth for processes seen before reparenting.
     foreach ($trackedProcess in $TrackedProcesses.GetEnumerator()) {
         $processId = $trackedProcess.Key
         if ($processId -eq $PID) {
             continue
         }
 
+        $currentProcess = $currentProcesses[$processId]
+        if (($null -eq $currentProcess) -or
+            ($currentProcess.StartIdentity -ne $trackedProcess.Value)) {
+            continue
+        }
+
         try {
             $candidate = [System.Diagnostics.Process]::GetProcessById($processId)
             try {
-                if ($candidate.StartTime.ToUniversalTime().Ticks -eq $trackedProcess.Value) {
-                    $candidate.Kill($true)
-                }
+                $candidate.Kill($true)
             }
             finally {
                 $candidate.Dispose()
@@ -202,40 +358,107 @@ function Add-SingleNodeArgument([string[]]$Arguments) {
 $effectiveArguments = Add-SingleNodeArgument $DotNetArguments
 $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
 $startInfo.UseShellExecute = $false
-$startInfo.Environment['BuildInParallel'] = 'false'
 $startInfo.Environment['DOTNET_CLI_TELEMETRY_OPTOUT'] = '1'
 $startInfo.Environment['DOTNET_CLI_USE_MSBUILD_SERVER'] = '0'
 $startInfo.Environment['MSBUILDDISABLENODEREUSE'] = '1'
 $startInfo.Environment['UseSharedCompilation'] = 'false'
+$pwshPath = (Get-Process -Id $PID).Path
 
 if ($IsWindows) {
-    $startInfo.FileName = $DotNetPath
+    # The wrapper waits on a gate, allowing the guard to assign it to the Job Object
+    # and lower its priority before it can launch dotnet or any descendants.
+    $windowsWrapper = @'
+$startGate = [Threading.EventWaitHandle]::OpenExisting($args[0])
+try {
+    if (-not $startGate.WaitOne([TimeSpan]::FromSeconds(30))) {
+        [Console]::Error.WriteLine('Agent dotnet guard launch gate timed out.')
+        exit 126
+    }
+}
+finally {
+    $startGate.Dispose()
+}
+
+$startInfo = [Diagnostics.ProcessStartInfo]::new()
+$startInfo.UseShellExecute = $false
+$startInfo.FileName = $args[1]
+foreach ($argument in $args[2..($args.Count - 1)]) {
+    $startInfo.ArgumentList.Add($argument)
+}
+
+$child = [Diagnostics.Process]::Start($startInfo)
+try {
+    $child.WaitForExit()
+    $exitCode = $child.ExitCode
+}
+finally {
+    $child.Dispose()
+}
+
+exit $exitCode
+'@
+    $startInfo.FileName = $pwshPath
+    $startInfo.ArgumentList.Add('-NoProfile')
+    $startInfo.ArgumentList.Add('-NonInteractive')
+    $startInfo.ArgumentList.Add('-CommandWithArgs')
+    $startInfo.ArgumentList.Add($windowsWrapper)
+    $startInfo.ArgumentList.Add('{WINDOWS_START_GATE}')
+    $startInfo.ArgumentList.Add($DotNetPath)
     foreach ($argument in $effectiveArguments) {
         $startInfo.ArgumentList.Add($argument)
     }
 }
 else {
-    # A separate process group lets the wrapper kill descendants even if the command
-    # exits before the guard's first snapshot and Unix reparents its children.
+    # PowerShell is already a guard prerequisite, so libc calls provide portable
+    # process-group containment without requiring setsid(1) or Python on macOS.
     $unixWrapper = @'
-if command -v setsid >/dev/null 2>&1; then
-    setsid "$@" &
-elif command -v python3 >/dev/null 2>&1; then
-    python3 -c 'import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])' "$@" &
-else
-    echo "Agent dotnet guard requires setsid or python3 for Unix process containment." >&2
+Add-Type -TypeDefinition @"
+using System.Runtime.InteropServices;
+
+public static class AgentDotNetUnixChildNative
+{
+    [DllImport("libc", SetLastError = true)]
+    public static extern int setsid();
+
+    [DllImport("libc", SetLastError = true)]
+    public static extern int setpriority(int which, int who, int priority);
+}
+"@
+
+if ([AgentDotNetUnixChildNative]::setsid() -lt 0) {
+    $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    [Console]::Error.WriteLine("Agent dotnet guard could not create a Unix session (errno $errorCode).")
     exit 126
-fi
-child=$!
-wait "$child"
-status=$?
-kill -KILL -- "-$child" 2>/dev/null || :
-exit "$status"
+}
+
+if ([AgentDotNetUnixChildNative]::setpriority(0, 0, 10) -ne 0) {
+    $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    [Console]::Error.WriteLine("Agent dotnet guard could not lower Unix priority (errno $errorCode).")
+}
+
+$startInfo = [Diagnostics.ProcessStartInfo]::new()
+$startInfo.UseShellExecute = $false
+$startInfo.FileName = $args[0]
+foreach ($argument in $args[1..($args.Count - 1)]) {
+    $startInfo.ArgumentList.Add($argument)
+}
+
+$child = [Diagnostics.Process]::Start($startInfo)
+try {
+    $child.WaitForExit()
+    $exitCode = $child.ExitCode
+}
+finally {
+    $child.Dispose()
+}
+
+exit $exitCode
 '@
-    $startInfo.FileName = '/bin/sh'
-    $startInfo.ArgumentList.Add('-c')
+    $startInfo.FileName = $pwshPath
+    $startInfo.ArgumentList.Add('-NoProfile')
+    $startInfo.ArgumentList.Add('-NonInteractive')
+    $startInfo.ArgumentList.Add('-CommandWithArgs')
     $startInfo.ArgumentList.Add($unixWrapper)
-    $startInfo.ArgumentList.Add('agent-dotnet-guard')
     $startInfo.ArgumentList.Add($DotNetPath)
     foreach ($argument in $effectiveArguments) {
         $startInfo.ArgumentList.Add($argument)
@@ -245,19 +468,38 @@ exit "$status"
 $process = [System.Diagnostics.Process]::new()
 $process.StartInfo = $startInfo
 $processStarted = $false
-$trackedProcesses = [System.Collections.Generic.Dictionary[int, long]]::new()
+$trackedProcesses = [System.Collections.Generic.Dictionary[int, string]]::new()
 $deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
 $memoryLimitBytes = [long]$MemoryLimitMb * 1MB
 $guardExitCode = $null
 $finalExitCode = 1
+$windowsJobHandle = [IntPtr]::Zero
+$windowsStartGate = $null
+$unixProcessGroupId = 0
 
 try {
+    if ($IsWindows) {
+        $windowsJobHandle = [AgentDotNetWindowsJob]::CreateKillOnClose()
+        $windowsStartGateName = "agent-dotnet-guard-$([guid]::NewGuid())"
+        $windowsStartGate = [Threading.EventWaitHandle]::new(
+            $false,
+            [Threading.EventResetMode]::ManualReset,
+            $windowsStartGateName)
+        $gateArgumentIndex = $startInfo.ArgumentList.IndexOf('{WINDOWS_START_GATE}')
+        $startInfo.ArgumentList[$gateArgumentIndex] = $windowsStartGateName
+    }
+
     if (-not $process.Start()) {
         throw "Failed to start '$DotNetPath'."
     }
 
     $processStarted = $true
-    $trackedProcesses[$process.Id] = $process.StartTime.ToUniversalTime().Ticks
+    if ($IsWindows) {
+        [AgentDotNetWindowsJob]::Assign($windowsJobHandle, $process.Handle)
+    }
+    else {
+        $unixProcessGroupId = $process.Id
+    }
 
     try {
         $process.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::BelowNormal
@@ -266,12 +508,17 @@ try {
         Write-Verbose "Could not lower process priority: $_"
     }
 
+    if ($IsWindows) {
+        $null = $windowsStartGate.Set()
+    }
+
     while ($true) {
         $treeState = Get-ProcessTreeState $process.Id
-        Sync-TrackedProcesses $trackedProcesses $treeState.ProcessIds
+        Sync-TrackedProcesses $trackedProcesses @($treeState.Snapshot) @($treeState.Processes)
+        $workingSetBytes = Get-TrackedWorkingSetBytes $trackedProcesses @($treeState.Snapshot)
 
-        if ($treeState.WorkingSetBytes -gt $memoryLimitBytes) {
-            $workingSetMb = [math]::Round($treeState.WorkingSetBytes / 1MB)
+        if ($workingSetBytes -gt $memoryLimitBytes) {
+            $workingSetMb = [math]::Round($workingSetBytes / 1MB)
             [Console]::Error.WriteLine(
                 "Agent dotnet command exceeded ${MemoryLimitMb} MB process-tree limit (${workingSetMb} MB).")
             $guardExitCode = 137
@@ -291,7 +538,7 @@ try {
             [math]::Max(1, [math]::Ceiling($remaining.TotalMilliseconds)))
         if ($process.WaitForExit([int]$waitMilliseconds)) {
             $treeState = Get-ProcessTreeState $process.Id
-            Sync-TrackedProcesses $trackedProcesses $treeState.ProcessIds
+            Sync-TrackedProcesses $trackedProcesses @($treeState.Snapshot) @($treeState.Processes)
 
             if ([DateTimeOffset]::UtcNow -gt $deadline) {
                 [Console]::Error.WriteLine(
@@ -313,7 +560,19 @@ try {
 }
 finally {
     if ($processStarted) {
-        Stop-ProcessTree $process $trackedProcesses
+        Stop-ProcessTree `
+            -RootProcess $process `
+            -TrackedProcesses $trackedProcesses `
+            -WindowsJobHandle $windowsJobHandle `
+            -UnixProcessGroupId $unixProcessGroupId
+        $windowsJobHandle = [IntPtr]::Zero
+    }
+    elseif ($windowsJobHandle -ne [IntPtr]::Zero) {
+        [AgentDotNetWindowsJob]::Close($windowsJobHandle)
+    }
+
+    if ($null -ne $windowsStartGate) {
+        $windowsStartGate.Dispose()
     }
 
     $process.Dispose()

--- a/scripts/Invoke-AgentDotNet.ps1
+++ b/scripts/Invoke-AgentDotNet.ps1
@@ -591,16 +591,21 @@ function Add-SingleNodeArgument([string[]]$Arguments) {
 $effectiveArguments = Add-SingleNodeArgument $DotNetArguments
 $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
 $startInfo.UseShellExecute = $false
+$startInfo.Environment['BuildInParallel'] = 'false'
 $startInfo.Environment['DOTNET_CLI_TELEMETRY_OPTOUT'] = '1'
 $startInfo.Environment['DOTNET_CLI_USE_MSBUILD_SERVER'] = '0'
 $startInfo.Environment['MSBUILDDISABLENODEREUSE'] = '1'
 $startInfo.Environment['UseSharedCompilation'] = 'false'
 $pwshPath = (Get-Process -Id $PID).Path
+$wrapperPath = [System.IO.Path]::Combine(
+    [System.IO.Path]::GetTempPath(),
+    "agent-dotnet-wrapper-$([guid]::NewGuid()).ps1"
+)
 
 if ($IsWindows) {
     # The wrapper waits on a gate, allowing the guard to assign it to the Job Object
     # and lower its priority before it can launch dotnet or any descendants.
-    $windowsWrapper = @'
+    $wrapperScript = @'
 $startGate = [Threading.EventWaitHandle]::OpenExisting($args[0])
 try {
     if (-not $startGate.WaitOne([TimeSpan]::FromSeconds(30))) {
@@ -633,8 +638,8 @@ exit $exitCode
     $startInfo.FileName = $pwshPath
     $startInfo.ArgumentList.Add('-NoProfile')
     $startInfo.ArgumentList.Add('-NonInteractive')
-    $startInfo.ArgumentList.Add('-CommandWithArgs')
-    $startInfo.ArgumentList.Add($windowsWrapper)
+    $startInfo.ArgumentList.Add('-File')
+    $startInfo.ArgumentList.Add($wrapperPath)
     $startInfo.ArgumentList.Add('{WINDOWS_START_GATE}')
     $startInfo.ArgumentList.Add($DotNetPath)
     foreach ($argument in $effectiveArguments) {
@@ -644,7 +649,7 @@ exit $exitCode
 else {
     # PowerShell is already a guard prerequisite, so libc calls provide portable
     # process-group containment without requiring setsid(1) or Python on macOS.
-    $unixWrapper = @'
+    $wrapperScript = @'
 Add-Type -TypeDefinition @"
 using System.Runtime.InteropServices;
 
@@ -690,8 +695,8 @@ exit $exitCode
     $startInfo.FileName = $pwshPath
     $startInfo.ArgumentList.Add('-NoProfile')
     $startInfo.ArgumentList.Add('-NonInteractive')
-    $startInfo.ArgumentList.Add('-CommandWithArgs')
-    $startInfo.ArgumentList.Add($unixWrapper)
+    $startInfo.ArgumentList.Add('-File')
+    $startInfo.ArgumentList.Add($wrapperPath)
     $startInfo.ArgumentList.Add($DotNetPath)
     foreach ($argument in $effectiveArguments) {
         $startInfo.ArgumentList.Add($argument)
@@ -711,6 +716,13 @@ $windowsStartGate = $null
 $unixProcessGroupId = 0
 
 try {
+    # -File works on supported PowerShell versions; -CommandWithArgs was
+    # experimental before PowerShell 7.5.
+    [System.IO.File]::WriteAllText(
+        $wrapperPath,
+        $wrapperScript,
+        [System.Text.UTF8Encoding]::new($false))
+
     if ($IsWindows) {
         $windowsJobHandle = [AgentDotNetWindowsJob]::CreateKillOnClose()
         $windowsStartGateName = "agent-dotnet-guard-$([guid]::NewGuid())"
@@ -809,6 +821,10 @@ finally {
     }
 
     $process.Dispose()
+
+    if (Test-Path -LiteralPath $wrapperPath) {
+        Remove-Item -LiteralPath $wrapperPath -Force -ErrorAction SilentlyContinue
+    }
 }
 
 exit $finalExitCode

--- a/scripts/Invoke-AgentDotNet.ps1
+++ b/scripts/Invoke-AgentDotNet.ps1
@@ -154,12 +154,207 @@ public static class AgentDotNetWindowsJob
 }
 else {
     Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
 using System.Runtime.InteropServices;
 
 public static class AgentDotNetUnixNative
 {
     [DllImport("libc", SetLastError = true)]
     public static extern int kill(int processId, int signal);
+}
+
+public sealed class AgentDotNetUnixProcessInfo
+{
+    public int ProcessId { get; set; }
+    public int ParentProcessId { get; set; }
+    public long WorkingSetBytes { get; set; }
+    public string StartIdentity { get; set; }
+}
+
+public static class AgentDotNetLinuxProcessSnapshot
+{
+    public static AgentDotNetUnixProcessInfo[] Capture()
+    {
+        var processes = new List<AgentDotNetUnixProcessInfo>();
+        foreach (string directory in Directory.EnumerateDirectories("/proc"))
+        {
+            string name = Path.GetFileName(directory);
+            if (!int.TryParse(name, NumberStyles.None, CultureInfo.InvariantCulture, out int processId))
+            {
+                continue;
+            }
+
+            try
+            {
+                string stat = File.ReadAllText(Path.Combine(directory, "stat"));
+                int commandEnd = stat.LastIndexOf(") ", StringComparison.Ordinal);
+                if (commandEnd < 0)
+                {
+                    continue;
+                }
+
+                string[] fields = stat.Substring(commandEnd + 2)
+                    .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (fields.Length < 22)
+                {
+                    continue;
+                }
+
+                processes.Add(new AgentDotNetUnixProcessInfo
+                {
+                    ProcessId = processId,
+                    ParentProcessId = int.Parse(fields[1], CultureInfo.InvariantCulture),
+                    StartIdentity = fields[19],
+                    WorkingSetBytes =
+                        long.Parse(fields[21], CultureInfo.InvariantCulture) * Environment.SystemPageSize,
+                });
+            }
+            catch (IOException)
+            {
+                // The process exited while its snapshot was being read.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // The process cannot be inspected by this user.
+            }
+        }
+
+        return processes.ToArray();
+    }
+}
+
+public static class AgentDotNetMacProcessSnapshot
+{
+    private const int ProcPidTBsdInfo = 3;
+    private const int ProcPidTaskInfo = 4;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ProcBsdInfo
+    {
+        public uint Flags;
+        public uint Status;
+        public uint ExitStatus;
+        public uint ProcessId;
+        public uint ParentProcessId;
+        public uint UserId;
+        public uint GroupId;
+        public uint RealUserId;
+        public uint RealGroupId;
+        public uint SavedUserId;
+        public uint SavedGroupId;
+        public uint Reserved;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public byte[] Command;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+        public byte[] Name;
+        public uint OpenFileCount;
+        public uint ProcessGroupId;
+        public uint JobControlCount;
+        public uint ControllingTerminalDevice;
+        public uint TerminalProcessGroupId;
+        public int Nice;
+        public ulong StartTimeSeconds;
+        public ulong StartTimeMicroseconds;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ProcTaskInfo
+    {
+        public ulong VirtualSize;
+        public ulong ResidentSize;
+        public ulong TotalUserTime;
+        public ulong TotalSystemTime;
+        public ulong ThreadsUserTime;
+        public ulong ThreadsSystemTime;
+        public int Policy;
+        public int Faults;
+        public int PageIns;
+        public int CopyOnWriteFaults;
+        public int MessagesSent;
+        public int MessagesReceived;
+        public int MachSystemCalls;
+        public int UnixSystemCalls;
+        public int ContextSwitches;
+        public int ThreadCount;
+        public int RunningThreadCount;
+        public int Priority;
+    }
+
+    [DllImport("/usr/lib/libproc.dylib")]
+    private static extern int proc_listallpids([Out] int[] buffer, int bufferSize);
+
+    [DllImport("/usr/lib/libproc.dylib")]
+    private static extern int proc_pidinfo(
+        int processId,
+        int flavor,
+        ulong argument,
+        IntPtr buffer,
+        int bufferSize);
+
+    public static AgentDotNetUnixProcessInfo[] Capture()
+    {
+        var processIds = new int[131072];
+        int processCount = proc_listallpids(processIds, processIds.Length * sizeof(int));
+        var processes = new List<AgentDotNetUnixProcessInfo>(Math.Max(processCount, 0));
+
+        for (int index = 0; index < processCount && index < processIds.Length; index++)
+        {
+            int processId = processIds[index];
+            if (processId <= 0 ||
+                !TryRead(processId, ProcPidTBsdInfo, out ProcBsdInfo before))
+            {
+                continue;
+            }
+
+            TryRead(processId, ProcPidTaskInfo, out ProcTaskInfo task);
+            if (!TryRead(processId, ProcPidTBsdInfo, out ProcBsdInfo after) ||
+                before.ProcessId != after.ProcessId ||
+                before.ParentProcessId != after.ParentProcessId ||
+                before.StartTimeSeconds != after.StartTimeSeconds ||
+                before.StartTimeMicroseconds != after.StartTimeMicroseconds)
+            {
+                continue;
+            }
+
+            processes.Add(new AgentDotNetUnixProcessInfo
+            {
+                ProcessId = processId,
+                ParentProcessId = (int)after.ParentProcessId,
+                WorkingSetBytes = checked((long)task.ResidentSize),
+                StartIdentity = string.Concat(
+                    after.StartTimeSeconds.ToString(CultureInfo.InvariantCulture),
+                    ":",
+                    after.StartTimeMicroseconds.ToString(CultureInfo.InvariantCulture)),
+            });
+        }
+
+        return processes.ToArray();
+    }
+
+    private static bool TryRead<T>(int processId, int flavor, out T value)
+        where T : struct
+    {
+        int size = Marshal.SizeOf<T>();
+        IntPtr buffer = Marshal.AllocHGlobal(size);
+        try
+        {
+            if (proc_pidinfo(processId, flavor, 0, buffer, size) != size)
+            {
+                value = default(T);
+                return false;
+            }
+
+            value = Marshal.PtrToStructure<T>(buffer);
+            return true;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
 }
 '@
 }
@@ -179,17 +374,11 @@ function Get-ProcessSnapshot {
             }
     }
 
-    return & ps -eo pid=,ppid=,rss=,lstart= |
-        ForEach-Object {
-            if ($_ -match '^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.+?)\s*$') {
-                [pscustomobject]@{
-                    ProcessId = [int]$Matches[1]
-                    ParentProcessId = [int]$Matches[2]
-                    WorkingSetBytes = [long]$Matches[3] * 1KB
-                    StartIdentity = $Matches[4]
-                }
-            }
-        }
+    if ($IsMacOS) {
+        return [AgentDotNetMacProcessSnapshot]::Capture()
+    }
+
+    return [AgentDotNetLinuxProcessSnapshot]::Capture()
 }
 
 function Get-ProcessTreeState([int]$RootProcessId) {

--- a/scripts/Invoke-AgentDotNet.ps1
+++ b/scripts/Invoke-AgentDotNet.ps1
@@ -187,42 +187,54 @@ public static class AgentDotNetLinuxProcessSnapshot
                 continue;
             }
 
-            try
+            AgentDotNetUnixProcessInfo process = CaptureProcess(processId);
+            if (process != null)
             {
-                string stat = File.ReadAllText(Path.Combine(directory, "stat"));
-                int commandEnd = stat.LastIndexOf(") ", StringComparison.Ordinal);
-                if (commandEnd < 0)
-                {
-                    continue;
-                }
-
-                string[] fields = stat.Substring(commandEnd + 2)
-                    .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-                if (fields.Length < 22)
-                {
-                    continue;
-                }
-
-                processes.Add(new AgentDotNetUnixProcessInfo
-                {
-                    ProcessId = processId,
-                    ParentProcessId = int.Parse(fields[1], CultureInfo.InvariantCulture),
-                    StartIdentity = fields[19],
-                    WorkingSetBytes =
-                        long.Parse(fields[21], CultureInfo.InvariantCulture) * Environment.SystemPageSize,
-                });
-            }
-            catch (IOException)
-            {
-                // The process exited while its snapshot was being read.
-            }
-            catch (UnauthorizedAccessException)
-            {
-                // The process cannot be inspected by this user.
+                processes.Add(process);
             }
         }
 
         return processes.ToArray();
+    }
+
+    public static AgentDotNetUnixProcessInfo CaptureProcess(int processId)
+    {
+        try
+        {
+            string stat = File.ReadAllText(
+                Path.Combine("/proc", processId.ToString(CultureInfo.InvariantCulture), "stat"));
+            int commandEnd = stat.LastIndexOf(") ", StringComparison.Ordinal);
+            if (commandEnd < 0)
+            {
+                return null;
+            }
+
+            string[] fields = stat.Substring(commandEnd + 2)
+                .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (fields.Length < 22)
+            {
+                return null;
+            }
+
+            return new AgentDotNetUnixProcessInfo
+            {
+                ProcessId = processId,
+                ParentProcessId = int.Parse(fields[1], CultureInfo.InvariantCulture),
+                StartIdentity = fields[19],
+                WorkingSetBytes =
+                    long.Parse(fields[21], CultureInfo.InvariantCulture) * Environment.SystemPageSize,
+            };
+        }
+        catch (IOException)
+        {
+            // The process exited while its snapshot was being read.
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // The process cannot be inspected by this user.
+            return null;
+        }
     }
 }
 
@@ -302,36 +314,44 @@ public static class AgentDotNetMacProcessSnapshot
 
         for (int index = 0; index < processCount && index < processIds.Length; index++)
         {
-            int processId = processIds[index];
-            if (processId <= 0 ||
-                !TryRead(processId, ProcPidTBsdInfo, out ProcBsdInfo before))
+            AgentDotNetUnixProcessInfo process = CaptureProcess(processIds[index]);
+            if (process != null)
             {
-                continue;
+                processes.Add(process);
             }
-
-            TryRead(processId, ProcPidTaskInfo, out ProcTaskInfo task);
-            if (!TryRead(processId, ProcPidTBsdInfo, out ProcBsdInfo after) ||
-                before.ProcessId != after.ProcessId ||
-                before.ParentProcessId != after.ParentProcessId ||
-                before.StartTimeSeconds != after.StartTimeSeconds ||
-                before.StartTimeMicroseconds != after.StartTimeMicroseconds)
-            {
-                continue;
-            }
-
-            processes.Add(new AgentDotNetUnixProcessInfo
-            {
-                ProcessId = processId,
-                ParentProcessId = (int)after.ParentProcessId,
-                WorkingSetBytes = checked((long)task.ResidentSize),
-                StartIdentity = string.Concat(
-                    after.StartTimeSeconds.ToString(CultureInfo.InvariantCulture),
-                    ":",
-                    after.StartTimeMicroseconds.ToString(CultureInfo.InvariantCulture)),
-            });
         }
 
         return processes.ToArray();
+    }
+
+    public static AgentDotNetUnixProcessInfo CaptureProcess(int processId)
+    {
+        if (processId <= 0 ||
+            !TryRead(processId, ProcPidTBsdInfo, out ProcBsdInfo before))
+        {
+            return null;
+        }
+
+        TryRead(processId, ProcPidTaskInfo, out ProcTaskInfo task);
+        if (!TryRead(processId, ProcPidTBsdInfo, out ProcBsdInfo after) ||
+            before.ProcessId != after.ProcessId ||
+            before.ParentProcessId != after.ParentProcessId ||
+            before.StartTimeSeconds != after.StartTimeSeconds ||
+            before.StartTimeMicroseconds != after.StartTimeMicroseconds)
+        {
+            return null;
+        }
+
+        return new AgentDotNetUnixProcessInfo
+        {
+            ProcessId = processId,
+            ParentProcessId = (int)after.ParentProcessId,
+            WorkingSetBytes = checked((long)task.ResidentSize),
+            StartIdentity = string.Concat(
+                after.StartTimeSeconds.ToString(CultureInfo.InvariantCulture),
+                ":",
+                after.StartTimeMicroseconds.ToString(CultureInfo.InvariantCulture)),
+        };
     }
 
     private static bool TryRead<T>(int processId, int flavor, out T value)
@@ -379,6 +399,35 @@ function Get-ProcessSnapshot {
     }
 
     return [AgentDotNetLinuxProcessSnapshot]::Capture()
+}
+
+function Get-LiveProcessIdentity([int]$ProcessId) {
+    try {
+        if ($IsWindows) {
+            $process = Get-CimInstance Win32_Process `
+                -Filter "ProcessId = $ProcessId" `
+                -Property CreationDate
+            if ($null -eq $process) {
+                return $null
+            }
+
+            return $process.CreationDate.ToUniversalTime().Ticks.ToString(
+                [Globalization.CultureInfo]::InvariantCulture)
+        }
+
+        $process = if ($IsMacOS) {
+            [AgentDotNetMacProcessSnapshot]::CaptureProcess($ProcessId)
+        }
+        else {
+            [AgentDotNetLinuxProcessSnapshot]::CaptureProcess($ProcessId)
+        }
+
+        return $process?.StartIdentity
+    }
+    catch {
+        Write-Verbose "Live identity for process $ProcessId was unavailable: $_"
+        return $null
+    }
 }
 
 function Get-ProcessTreeState([int]$RootProcessId) {
@@ -472,19 +521,6 @@ function Stop-ProcessTree(
         Write-Verbose "Root process-tree cleanup was unavailable: $_"
     }
 
-    try {
-        $currentSnapshot = @(Get-ProcessSnapshot)
-    }
-    catch {
-        Write-Verbose "Final process snapshot was unavailable: $_"
-        return
-    }
-
-    $currentProcesses = @{}
-    foreach ($process in $currentSnapshot) {
-        $currentProcesses[$process.ProcessId] = $process
-    }
-
     # The Job Object/process group is the containment boundary. Identity-checked
     # tracked cleanup is defense in depth for processes seen before reparenting.
     foreach ($trackedProcess in $TrackedProcesses.GetEnumerator()) {
@@ -493,16 +529,24 @@ function Stop-ProcessTree(
             continue
         }
 
-        $currentProcess = $currentProcesses[$processId]
-        if (($null -eq $currentProcess) -or
-            ($currentProcess.StartIdentity -ne $trackedProcess.Value)) {
-            continue
-        }
-
         try {
             $candidate = [System.Diagnostics.Process]::GetProcessById($processId)
             try {
-                $candidate.Kill($true)
+                # Pin the native process handle before checking identity so Windows
+                # cleanup cannot reopen a recycled PID between verification and kill.
+                $null = $candidate.SafeHandle
+
+                # Re-read this PID immediately before acting. A bulk snapshot taken
+                # before the loop can become stale and target a recycled PID.
+                $liveIdentity = Get-LiveProcessIdentity -ProcessId $processId
+                if (($null -eq $liveIdentity) -or
+                    ($liveIdentity -ne $trackedProcess.Value)) {
+                    continue
+                }
+
+                # Primary containment already handled descendants. Kill only this
+                # identity-verified fallback process through the pinned handle.
+                $candidate.Kill()
             }
             finally {
                 $candidate.Dispose()

--- a/scripts/Test-InvokeAgentDotNet.ps1
+++ b/scripts/Test-InvokeAgentDotNet.ps1
@@ -91,6 +91,7 @@ param(
 
 [pscustomobject]@{
     Arguments = $ForwardedArguments
+    BuildInParallel = $env:BuildInParallel
     MsBuildDisableNodeReuse = $env:MSBUILDDISABLENODEREUSE
     UseSharedCompilation = $env:UseSharedCompilation
     Priority = if ($IsWindows) {
@@ -117,7 +118,8 @@ param(
         throw "Arguments were not forwarded exactly: $($capture.Arguments -join '|')"
     }
 
-    if (($capture.MsBuildDisableNodeReuse -ne '1') -or
+    if (($capture.BuildInParallel -ne 'false') -or
+        ($capture.MsBuildDisableNodeReuse -ne '1') -or
         ($capture.UseSharedCompilation -ne 'false')) {
         throw 'Guarded build environment was not applied to the child process.'
     }

--- a/scripts/Test-InvokeAgentDotNet.ps1
+++ b/scripts/Test-InvokeAgentDotNet.ps1
@@ -4,9 +4,13 @@ $guardScript = Join-Path $PSScriptRoot 'Invoke-AgentDotNet.ps1'
 $testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("agent-dotnet-guard-{0}" -f [guid]::NewGuid())
 $captureScript = Join-Path $testRoot 'Capture-Invocation.ps1'
 $timeoutScript = Join-Path $testRoot 'Spawn-Child.ps1'
+$orphanParentScript = Join-Path $testRoot 'Spawn-OrphanParent.ps1'
+$orphanIntermediateScript = Join-Path $testRoot 'Spawn-OrphanIntermediate.ps1'
+$orphanGrandchildScript = Join-Path $testRoot 'OrphanGrandchild.ps1'
 $capturePath = Join-Path $testRoot 'capture.json'
 $childPidPath = Join-Path $testRoot 'child.pid'
 $normalExitChildPidPath = Join-Path $testRoot 'normal-exit-child.pid'
+$orphanPidPath = Join-Path $testRoot 'orphan.pid'
 $pwshPath = (Get-Process -Id $PID).Path
 
 $resolvedTempRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
@@ -27,7 +31,8 @@ function Test-SavedProcessIsRunning($Identity) {
     try {
         $candidate = [System.Diagnostics.Process]::GetProcessById($Identity.ProcessId)
         try {
-            return $candidate.StartTime.ToUniversalTime().Ticks -eq $Identity.StartTimeUtcTicks
+            return (-not $candidate.HasExited) -and
+                $candidate.StartTime.ToUniversalTime().Ticks -eq $Identity.StartTimeUtcTicks
         }
         finally {
             $candidate.Dispose()
@@ -86,9 +91,14 @@ param(
 
 [pscustomobject]@{
     Arguments = $ForwardedArguments
-    BuildInParallel = $env:BuildInParallel
     MsBuildDisableNodeReuse = $env:MSBUILDDISABLENODEREUSE
     UseSharedCompilation = $env:UseSharedCompilation
+    Priority = if ($IsWindows) {
+        (Get-Process -Id $PID).PriorityClass.ToString()
+    }
+    else {
+        (& ps -o ni= -p $PID).Trim()
+    }
 } | ConvertTo-Json | Set-Content -LiteralPath $OutputPath
 '@ | Set-Content -LiteralPath $captureScript
 
@@ -107,10 +117,14 @@ param(
         throw "Arguments were not forwarded exactly: $($capture.Arguments -join '|')"
     }
 
-    if (($capture.BuildInParallel -ne 'false') -or
-        ($capture.MsBuildDisableNodeReuse -ne '1') -or
+    if (($capture.MsBuildDisableNodeReuse -ne '1') -or
         ($capture.UseSharedCompilation -ne 'false')) {
         throw 'Guarded build environment was not applied to the child process.'
+    }
+
+    if (($IsWindows -and $capture.Priority -ne 'BelowNormal') -or
+        ((-not $IsWindows) -and [int]$capture.Priority -le 0)) {
+        throw "Guarded child priority was not lowered: $($capture.Priority)"
     }
 
     @'
@@ -166,6 +180,77 @@ Start-Sleep -Milliseconds $ParentDelayMilliseconds
         throw "Timed-out descendant process $($timedOutChild.ProcessId) is still running."
     }
 
+    if (-not $IsWindows) {
+        @'
+param([string]$PidPath)
+
+[pscustomobject]@{
+    ProcessId = $PID
+    StartTimeUtcTicks = (Get-Process -Id $PID).StartTime.ToUniversalTime().Ticks
+} | ConvertTo-Json | Set-Content -LiteralPath $PidPath
+Start-Sleep -Seconds 60
+'@ | Set-Content -LiteralPath $orphanGrandchildScript
+
+        @'
+param(
+    [string]$GrandchildScript,
+    [string]$PidPath
+)
+
+$child = Start-Process `
+    -FilePath (Get-Process -Id $PID).Path `
+    -ArgumentList @('-NoProfile', '-File', $GrandchildScript, $PidPath) `
+    -PassThru
+
+$deadline = [DateTimeOffset]::UtcNow.AddSeconds(10)
+while ((-not (Test-Path -LiteralPath $PidPath)) -and
+    [DateTimeOffset]::UtcNow -lt $deadline) {
+    Start-Sleep -Milliseconds 50
+}
+'@ | Set-Content -LiteralPath $orphanIntermediateScript
+
+        @'
+param(
+    [string]$IntermediateScript,
+    [string]$GrandchildScript,
+    [string]$PidPath
+)
+
+$intermediate = Start-Process `
+    -FilePath (Get-Process -Id $PID).Path `
+    -ArgumentList @(
+        '-NoProfile',
+        '-File',
+        $IntermediateScript,
+        $GrandchildScript,
+        $PidPath) `
+    -PassThru
+$intermediate.WaitForExit()
+Start-Sleep -Seconds 60
+'@ | Set-Content -LiteralPath $orphanParentScript
+
+        $guardExitCode = Invoke-Guard `
+            -TimeoutSeconds 4 `
+            -MemoryLimitMb 512 `
+            -PollIntervalMilliseconds 10000 `
+            -Arguments @(
+                '-NoProfile',
+                '-File',
+                $orphanParentScript,
+                $orphanIntermediateScript,
+                $orphanGrandchildScript,
+                $orphanPidPath)
+
+        if ($guardExitCode -ne 124) {
+            throw "Unix orphan timeout returned $guardExitCode instead of 124."
+        }
+
+        $orphan = Get-SavedProcessIdentity $orphanPidPath
+        if (Test-SavedProcessIsRunning $orphan) {
+            throw "Reparented Unix descendant process $($orphan.ProcessId) is still running."
+        }
+    }
+
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     $guardExitCode = Invoke-Guard `
         -TimeoutSeconds 1 `
@@ -195,7 +280,7 @@ Start-Sleep -Milliseconds $ParentDelayMilliseconds
     Write-Output 'OK forwarding, normal-exit cleanup, bounded timeout, timeout cleanup, and memory limit passed.'
 }
 finally {
-    foreach ($pidPath in @($childPidPath, $normalExitChildPidPath)) {
+    foreach ($pidPath in @($childPidPath, $normalExitChildPidPath, $orphanPidPath)) {
         if (Test-Path -LiteralPath $pidPath) {
             Stop-SavedProcess (Get-SavedProcessIdentity $pidPath)
         }


### PR DESCRIPTION
## Summary
- contain Windows commands in a pre-launch-gated kill-on-close Job Object
- use libc-backed Unix sessions/process groups without external `setsid` or Python dependencies
- lower Unix priority before launching dotnet and kill the process group from every cleanup path
- capture process identity in the same snapshot as ancestry and retain identity-checked fallback cleanup

## Validation
- Windows: `pwsh -NoProfile scripts/Test-InvokeAgentDotNet.ps1`
- Linux container: `docker run --rm -v "${PWD}:/repo" -w /repo mcr.microsoft.com/powershell:latest pwsh -NoProfile scripts/Test-InvokeAgentDotNet.ps1`
- guarded real command: `scripts/Invoke-AgentDotNet.ps1 ... --version` -> `10.0.302`
- PowerShell parser: zero errors in both scripts
- post-test process audit: no guard descendants remain

Follow-up to late review feedback on #3200.

Closes #3199