### PR TITLE
Preserve executable parent commands in sub-domains

### DIFF
--- a/docs/docs/mp-packages/cli/kubectl.md
+++ b/docs/docs/mp-packages/cli/kubectl.md
@@ -30,8 +30,8 @@ public class RunCommandModule : Module<CommandResult>
         IModuleContext context,
         CancellationToken cancellationToken)
     {
-        return await context.Kubernetes().Autoscale(
-            new KubernetesAutoscaleOptions(),
+        return await context.Kubernetes().Annotate(
+            new KubernetesAnnotateOptions(),
             cancellationToken: cancellationToken);
     }
 }
@@ -42,17 +42,22 @@ public class RunCommandModule : Module<CommandResult>
 | CLI command | Options record |
 | --- | --- |
 | `kubectl annotate` | `KubernetesAnnotateOptions` |
+| `kubectl apply` | `KubernetesApplyOptions` |
 | `kubectl apply edit-last-applied` | `KubernetesApplyEditLastAppliedOptions` |
 | `kubectl apply set-last-applied` | `KubernetesApplySetLastAppliedOptions` |
 | `kubectl apply view-last-applied` | `KubernetesApplyViewLastAppliedOptions` |
 | `kubectl attach` | `KubernetesAttachOptions` |
+| `kubectl auth` | `KubernetesAuthOptions` |
 | `kubectl auth can-i` | `KubernetesAuthCanIOptions` |
 | `kubectl auth reconcile` | `KubernetesAuthReconcileOptions` |
 | `kubectl auth whoami` | `KubernetesAuthWhoamiOptions` |
 | `kubectl autoscale` | `KubernetesAutoscaleOptions` |
+| `kubectl certificate` | `KubernetesCertificateOptions` |
 | `kubectl certificate approve` | `KubernetesCertificateApproveOptions` |
 | `kubectl certificate deny` | `KubernetesCertificateDenyOptions` |
+| `kubectl cluster-info` | `KubernetesClusterInfoOptions` |
 | `kubectl cluster-info dump` | `KubernetesClusterInfoDumpOptions` |
+| `kubectl config` | `KubernetesConfigOptions` |
 | `kubectl config get-contexts` | `KubernetesConfigGetContextsOptions` |
 | `kubectl config set` | `KubernetesConfigSetOptions` |
 | `kubectl config set-cluster` | `KubernetesConfigSetClusterOptions` |
@@ -67,6 +72,7 @@ public class RunCommandModule : Module<CommandResult>
 | `kubectl drain` | `KubernetesDrainOptions` |
 | `kubectl events` | `KubernetesEventsOptions` |
 | `kubectl exec` | `KubernetesExecOptions` |
+| `kubectl kuberc` | `KubernetesKubercOptions` |
 | `kubectl kuberc set` | `KubernetesKubercSetOptions` |
 | `kubectl kuberc view` | `KubernetesKubercViewOptions` |
 | `kubectl label` | `KubernetesLabelOptions` |
@@ -75,6 +81,7 @@ public class RunCommandModule : Module<CommandResult>
 | `kubectl port-forward` | `KubernetesPortForwardOptions` |
 | `kubectl proxy` | `KubernetesProxyOptions` |
 | `kubectl replace` | `KubernetesReplaceOptions` |
+| `kubectl rollout` | `KubernetesRolloutOptions` |
 | `kubectl rollout history` | `KubernetesRolloutHistoryOptions` |
 | `kubectl rollout pause` | `KubernetesRolloutPauseOptions` |
 | `kubectl rollout restart` | `KubernetesRolloutRestartOptions` |
@@ -83,6 +90,7 @@ public class RunCommandModule : Module<CommandResult>
 | `kubectl rollout undo` | `KubernetesRolloutUndoOptions` |
 | `kubectl scale` | `KubernetesScaleOptions` |
 | `kubectl taint` | `KubernetesTaintOptions` |
+| `kubectl top` | `KubernetesTopOptions` |
 | `kubectl top node` | `KubernetesTopNodeOptions` |
 | `kubectl top pod` | `KubernetesTopPodOptions` |
 | `kubectl uncordon` | `KubernetesUncordonOptions` |

--- a/src/ModularPipelines.Kubernetes/Services/KubernetesClusterinfo.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/KubernetesClusterinfo.Generated.cs
@@ -32,6 +32,21 @@ public class KubernetesClusterinfo
     #region Commands
 
     /// <summary>
+    /// Display addresses of the control plane and services with label kubernetes.io/cluster-service=true. To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public virtual async Task<CommandResult> Execute(
+        KubernetesClusterInfoOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineTool(options ?? new KubernetesClusterInfoOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <summary>
     /// Dump cluster information out suitable for debugging and diagnosing cluster problems.  By default, dumps everything to stdout. You can optionally specify a directory with --output-directory.  If you specify a directory, Kubernetes will build a set of files in that directory.  By default, only dumps things in the current namespace and 'kube-system' namespace, but you can switch to a different namespace with the --namespaces flag, or specify --all-namespaces to dump all namespaces.
     /// </summary>
     /// <param name="options">The command options.</param>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -672,12 +672,20 @@ public class GeneratorHardeningTests
     {
         var tool = Tool(
             Command("ToolNetworkCreateOptions", "ToolOptions", ["network", "create"], subDomainGroup: "network"),
-            Command("ToolNetworkOptions", "ToolOptions", ["network"]),
-            Command("ToolNetwork2Options", "ToolOptions", ["Network"]));
+            Command("ToolNetworkOptions", "ToolOptions", ["network"]) with
+            {
+                FullCommand = "tool network",
+            },
+            Command("ToolNetwork2Options", "ToolOptions", ["Network"]) with
+            {
+                FullCommand = "tool Network",
+            });
 
-        await Assert.That(() => new SubDomainClassGenerator().GenerateAsync(tool))
+        void Generate() => _ = new SubDomainClassGenerator().GenerateAsync(tool);
+
+        await Assert.That(Generate)
             .Throws<InvalidOperationException>()
-            .And.HasMessageContaining("network");
+            .And.HasMessageContaining("Network (tool network, tool Network)");
     }
 
     #endregion

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -210,6 +210,77 @@ public class GeneratorHardeningTests
         await Assert.That(repoService.Content).Contains("public virtual async Task<CommandResult> Execute(");
     }
 
+    [Test]
+    public async Task SubDomain_Generators_Expose_Executable_Parent_And_Child()
+    {
+        var tool = Tool(
+            Command("ToolGroupOptions", "ToolOptions", ["group"]),
+            Command(
+                "ToolGroupChildOptions",
+                "ToolOptions",
+                ["group", "child"],
+                subDomainGroup: "group"));
+
+        var optionFiles = await new OptionsClassGenerator().GenerateAsync(tool);
+        var subDomainFiles = await new SubDomainClassGenerator().GenerateAsync(tool);
+        var interfaceFiles = await new ServiceInterfaceGenerator().GenerateAsync(tool);
+        var groupService = subDomainFiles.Single();
+
+        await Assert.That(groupService.Content).Contains("ToolGroupOptions? options = null");
+        await Assert.That(groupService.Content)
+            .Contains("public virtual async Task<CommandResult> Execute(");
+        await Assert.That(groupService.Content)
+            .Contains("public virtual async Task<CommandResult> Child(");
+        await Assert.That(interfaceFiles.Single().Content).Contains("ToolGroup Group { get; }");
+        await Assert.That(optionFiles.Single(file =>
+                file.RelativePath.EndsWith("ToolGroupOptions.Generated.cs")).Content)
+            .Contains("[CliSubCommand(\"group\")]");
+        await Assert.That(optionFiles.Single(file =>
+                file.RelativePath.EndsWith("ToolGroupChildOptions.Generated.cs")).Content)
+            .Contains("[CliSubCommand(\"group\", \"child\")]");
+    }
+
+    [Test]
+    public async Task SubDomain_Generators_Expose_Kubectl_ClusterInfo_Parent()
+    {
+        var tool = Tool(
+            Command(
+                "KubernetesClusterInfoOptions",
+                "KubernetesOptions",
+                ["cluster-info"]),
+            Command(
+                "KubernetesClusterInfoDumpOptions",
+                "KubernetesOptions",
+                ["cluster-info", "dump"],
+                subDomainGroup: "ClusterInfo")) with
+        {
+            ToolName = "kubectl",
+            NamespacePrefix = "Kubernetes",
+            TargetNamespace = "ModularPipelines.Kubernetes",
+            OutputDirectory = "src/ModularPipelines.Kubernetes",
+        };
+
+        var subDomainFiles = await new SubDomainClassGenerator().GenerateAsync(tool);
+        var interfaceFiles = await new ServiceInterfaceGenerator().GenerateAsync(tool);
+        var implementationFiles = await new ServiceImplementationGenerator().GenerateAsync(tool);
+        var registrationFiles = await new DependencyRegistrationGenerator().GenerateAsync(tool);
+        var clusterInfoService = subDomainFiles.Single(file =>
+            file.RelativePath.EndsWith("KubernetesClusterinfo.Generated.cs"));
+
+        await Assert.That(clusterInfoService.Content)
+            .Contains("KubernetesClusterInfoOptions? options = null");
+        await Assert.That(clusterInfoService.Content)
+            .Contains("public virtual async Task<CommandResult> Execute(");
+        await Assert.That(clusterInfoService.Content)
+            .Contains("public virtual async Task<CommandResult> Dump(");
+        await Assert.That(interfaceFiles.Single().Content)
+            .Contains("KubernetesClusterinfo Clusterinfo { get; }");
+        await Assert.That(implementationFiles.Single().Content)
+            .Contains("KubernetesClusterinfo Clusterinfo { get; }");
+        await Assert.That(registrationFiles.Single().Content)
+            .Contains("TryAddScoped<KubernetesClusterinfo>()");
+    }
+
     #endregion
 
     #region Positional argument deduplication

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -63,7 +63,7 @@ public class MarkdownDocumentationGeneratorTests
     }
 
     [Test]
-    public async Task GenerateAsync_ExcludesRootCommandsHiddenBySubDomainProperties()
+    public async Task GenerateAsync_IncludesRootCommandsExposedBySubDomainExecute()
     {
         var tool = new CliToolDefinition
         {
@@ -80,7 +80,7 @@ public class MarkdownDocumentationGeneratorTests
 
         var files = await new MarkdownDocumentationGenerator().GenerateAsync(tool);
 
-        await Assert.That(files[0].Content).DoesNotContain("| `fake app` | `FakeAppOptions` |");
+        await Assert.That(files[0].Content).Contains("| `fake app` | `FakeAppOptions` |");
         await Assert.That(files[0].Content).Contains("| `fake app get` | `FakeAppGetOptions` |");
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -668,9 +668,7 @@ public static partial class GeneratorUtils
     {
         ArgumentNullException.ThrowIfNull(tool);
 
-        var subDomainNames = new HashSet<string>(
-            tool.SubDomainGroups.Select(group => GetSubDomainIdentifier(tool, group)),
-            StringComparer.OrdinalIgnoreCase);
+        var subDomainNames = GetSubDomainIdentifiers(tool);
 
         var rootCommands = tool.Commands
             .Where(c => c.SubDomainGroup is null)
@@ -694,6 +692,37 @@ public static partial class GeneratorUtils
         }
 
         return rootCommands;
+    }
+
+    /// <summary>
+    /// Returns executable root commands that own a generated sub-domain. These commands
+    /// are exposed as <c>Execute</c> on the matching sub-domain class.
+    /// </summary>
+    internal static IReadOnlyList<CliCommandDefinition> GetSubDomainParentCommands(CliToolDefinition tool)
+    {
+        ArgumentNullException.ThrowIfNull(tool);
+
+        var subDomainNames = GetSubDomainIdentifiers(tool);
+        var parentCommands = tool.Commands
+            .Where(command => command.SubDomainGroup is null)
+            .Where(command => command.CommandParts.Length == 1)
+            .Where(command => subDomainNames.Contains(GetCommandGroupIdentifier(command)))
+            .ToList();
+
+        var duplicateParentNames = parentCommands
+            .GroupBy(GetCommandGroupIdentifier, StringComparer.OrdinalIgnoreCase)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.First().CommandParts[0])
+            .ToList();
+
+        if (duplicateParentNames.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"The {tool.ToolName} scraper produced multiple definitions for the same root command(s): " +
+                $"{string.Join(", ", duplicateParentNames)}. Fix the scraper to emit each command once.");
+        }
+
+        return parentCommands;
     }
 
     /// <summary>
@@ -725,9 +754,14 @@ public static partial class GeneratorUtils
         };
     }
 
-    private static string GetCommandGroupIdentifier(CliCommandDefinition command) =>
+    internal static string GetCommandGroupIdentifier(CliCommandDefinition command) =>
         command.CommandGroupIdentifierOverride
         ?? GenerateMethodNameFromCommandParts(command.CommandParts);
+
+    private static HashSet<string> GetSubDomainIdentifiers(CliToolDefinition tool) =>
+        new(
+            tool.SubDomainGroups.Select(group => GetSubDomainIdentifier(tool, group)),
+            StringComparer.OrdinalIgnoreCase);
 
     private static bool NeedsClassNameNormalization(CliCommandDefinition command) =>
         string.Equals(command.ClassName, command.ParentClassName, StringComparison.OrdinalIgnoreCase);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -678,9 +678,9 @@ public static partial class GeneratorUtils
         // Distinct commands can normalize to the same method name (e.g. "build-server"
         // and "build_server" both become BuildServer). Emitting both would produce
         // duplicate members the duplicate-path check cannot see, so fail loudly here.
-        var duplicateMethodNames = rootCommands
-            .GroupBy(c => GenerateMethodNameFromCommandParts(c.CommandParts), StringComparer.OrdinalIgnoreCase)
-            .Where(g => g.Count() > 1)
+        var duplicateMethodNames = GetDuplicateCommandGroups(
+                rootCommands,
+                command => GenerateMethodNameFromCommandParts(command.CommandParts))
             .Select(g => $"{g.Key} ({string.Join(", ", g.Select(c => c.FullCommand))})")
             .ToList();
 
@@ -709,9 +709,9 @@ public static partial class GeneratorUtils
             .Where(command => subDomainNames.Contains(GetCommandGroupIdentifier(command)))
             .ToList();
 
-        var duplicateParentNames = parentCommands
-            .GroupBy(GetCommandGroupIdentifier, StringComparer.OrdinalIgnoreCase)
-            .Where(group => group.Count() > 1)
+        var duplicateParentNames = GetDuplicateCommandGroups(
+                parentCommands,
+                GetCommandGroupIdentifier)
             .Select(group => group.First().CommandParts[0])
             .ToList();
 
@@ -762,6 +762,13 @@ public static partial class GeneratorUtils
         new(
             tool.SubDomainGroups.Select(group => GetSubDomainIdentifier(tool, group)),
             StringComparer.OrdinalIgnoreCase);
+
+    private static IEnumerable<IGrouping<string, CliCommandDefinition>> GetDuplicateCommandGroups(
+        IEnumerable<CliCommandDefinition> commands,
+        Func<CliCommandDefinition, string> identifierSelector) =>
+        commands
+            .GroupBy(identifierSelector, StringComparer.OrdinalIgnoreCase)
+            .Where(group => group.Skip(1).Any());
 
     private static bool NeedsClassNameNormalization(CliCommandDefinition command) =>
         string.Equals(command.ClassName, command.ParentClassName, StringComparison.OrdinalIgnoreCase);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -709,17 +709,18 @@ public static partial class GeneratorUtils
             .Where(command => subDomainNames.Contains(GetCommandGroupIdentifier(command)))
             .ToList();
 
-        var duplicateParentNames = GetDuplicateCommandGroups(
+        var duplicateParentGroups = GetDuplicateCommandGroups(
                 parentCommands,
                 GetCommandGroupIdentifier)
-            .Select(group => group.First().CommandParts[0])
+            .Select(group =>
+                $"{group.Key} ({string.Join(", ", group.Select(command => command.FullCommand))})")
             .ToList();
 
-        if (duplicateParentNames.Count > 0)
+        if (duplicateParentGroups.Count > 0)
         {
             throw new InvalidOperationException(
                 $"The {tool.ToolName} scraper produced multiple definitions for the same root command(s): " +
-                $"{string.Join(", ", duplicateParentNames)}. Fix the scraper to emit each command once.");
+                $"{string.Join("; ", duplicateParentGroups)}. Fix the scraper to emit each command once.");
         }
 
         return parentCommands;

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -295,12 +295,15 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
 
     private static IReadOnlyList<CliCommandDefinition> GetExposedCommands(CliToolDefinition tool)
     {
-        var rootCommands = GeneratorUtils.GetNonCollidingRootCommands(tool)
+        var exposedRootCommands = GeneratorUtils.GetNonCollidingRootCommands(tool)
+            .Concat(GeneratorUtils.GetSubDomainParentCommands(tool))
             .Select(command => command.ClassName)
             .ToHashSet(StringComparer.Ordinal);
 
         return tool.Commands
-            .Where(command => command.SubDomainGroup is not null || rootCommands.Contains(command.ClassName))
+            .Where(command =>
+                command.SubDomainGroup is not null ||
+                exposedRootCommands.Contains(command.ClassName))
             .DistinctBy(command => command.ClassName)
             .ToList();
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
@@ -38,32 +38,11 @@ public class SubDomainClassGenerator : ICodeGenerator
     {
         var files = new List<GeneratedFile>();
 
-        // Find root commands that match sub-domain names (e.g., "helm completion")
-        // These will be added as Execute() methods on the sub-domain class
-        var singlePartRootCommands = tool.Commands
-            .Where(c => c.SubDomainGroup is null && c.CommandParts.Length == 1)
-            .ToList();
-
-        // Duplicate definitions of the same command are a scraper bug; picking an
-        // arbitrary survivor would silently generate Execute() from the wrong options.
-        var duplicateParentNames = singlePartRootCommands
-            .GroupBy(
-                c => c.CommandGroupIdentifierOverride ?? c.CommandParts[0],
-                StringComparer.OrdinalIgnoreCase)
-            .Where(g => g.Count() > 1)
-            .Select(g => g.Key)
-            .ToList();
-
-        if (duplicateParentNames.Count > 0)
-        {
-            throw new InvalidOperationException(
-                $"The {tool.ToolName} scraper produced multiple definitions for the same root command(s): " +
-                $"{string.Join(", ", duplicateParentNames)}. Fix the scraper to emit each command once.");
-        }
-
-        var parentCommands = singlePartRootCommands
+        // Root commands that own subcommands are exposed as Execute() on the
+        // corresponding sub-domain class.
+        var parentCommands = GeneratorUtils.GetSubDomainParentCommands(tool)
             .ToDictionary(
-                c => c.CommandGroupIdentifierOverride ?? c.CommandParts[0],
+                GeneratorUtils.GetCommandGroupIdentifier,
                 StringComparer.OrdinalIgnoreCase);
 
         foreach (var subDomainGroup in tool.SubDomainGroups)


### PR DESCRIPTION
## Summary

- match executable parent commands to sub-domains through their normalized generated identifiers
- expose parent commands through `SubDomain.Execute(...)` while keeping child methods and DI construction intact
- include executable parents in generated command documentation
- regenerate Kubernetes so `Clusterinfo.Execute(...)` invokes `kubectl cluster-info`

## Testing

- `dotnet build tools/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.sln -c Release -m:1 --no-restore`
- OptionsGenerator tests: 500/500 passed
- `dotnet build src/ModularPipelines.Kubernetes/ModularPipelines.Kubernetes.sln -c Release -m:1 --no-restore`
- scoped `dotnet format whitespace --verify-no-changes`

Closes #3169
## Documentation regeneration note

The kubectl module example changed from `Autoscale` to `Annotate` because regeneration reconciled pre-existing checked-in documentation drift; parent-command selection does not cause that example change.
