### PR TITLE
Emit only safe runnable CLI examples

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -254,6 +254,88 @@ public class MarkdownDocumentationGeneratorTests
     }
 
     [Test]
+    public async Task GenerateAsync_RejectsMissingPreferredCommand()
+    {
+        var tool = Tool("fake", Command("fake run", "FakeRunOptions", ["run"])) with
+        {
+            PreferredDocumentationExampleCommand = "fake status",
+        };
+
+        void GenerateDocumentation() =>
+            _ = new MarkdownDocumentationGenerator().GenerateAsync(tool);
+
+        await Assert.That(GenerateDocumentation)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("'fake status' for 'fake' does not match an emitted command");
+    }
+
+    [Test]
+    public async Task Apply_RejectsCatalogCommandsMissingFromScraperOutput()
+    {
+        var tool = Tool(
+            "vault",
+            Command("vault state", "VaultStateOptions", ["state"]));
+
+        void ApplyCatalog() => DocumentationExampleCatalog.Apply(tool);
+
+        await Assert.That(ApplyCatalog)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining(
+                "catalog for 'vault' references missing command(s): vault delete, vault status");
+    }
+
+    [Test]
+    public async Task ValidateRegisteredTools_CoversEveryRegisteredCli()
+    {
+        var registeredTools = new[]
+        {
+            "ansible", "argocd", "aws", "az", "brew", "buildah", "cargo", "choco",
+            "cosign", "docker", "dotnet", "eksctl", "flux", "flyway", "gcloud", "gh",
+            "git", "go", "gradle", "grype", "hadolint", "helm", "jq", "kind", "kubectl",
+            "kustomize", "liquibase", "minikube", "mvn", "newman", "packer", "pip", "pnpm",
+            "podman", "pulumi", "shellcheck", "skopeo", "snyk", "sonar-scanner", "syft",
+            "terraform", "trivy", "vault", "winget", "yarn", "yq",
+        };
+
+        void ValidateCatalog() =>
+            DocumentationExampleCatalog.ValidateRegisteredTools(registeredTools);
+
+        await Assert.That(ValidateCatalog).ThrowsNothing();
+    }
+
+    [Test]
+    public async Task ValidateRegisteredTools_RejectsUnclassifiedCli()
+    {
+        void ValidateCatalog() =>
+            DocumentationExampleCatalog.ValidateRegisteredTools(["unclassified"]);
+
+        await Assert.That(ValidateCatalog)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("unclassified");
+    }
+
+    [Test]
+    public async Task GenerateAsync_EnforcesIntentionalCatalogOmission()
+    {
+        var tool = Tool(
+            "docker",
+            Command("docker version", "DockerVersionOptions", ["version"]) with
+            {
+                IsSafeForDocumentation = true,
+            }) with
+        {
+            PreferredDocumentationExampleCommand = "docker version",
+        };
+
+        var documentation = await new MarkdownDocumentationGenerator().GenerateAsync(tool);
+
+        await Assert.That(documentation[0].Content)
+            .Contains("A runnable example is omitted when no command has complete safety metadata");
+        await Assert.That(documentation[0].Content)
+            .DoesNotContain("context.Fake().Version(");
+    }
+
+    [Test]
     public async Task GenerateAsync_RejectsIncompleteExampleValues()
     {
         var command = Command("fake run", "FakeRunOptions", ["run"]) with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 
@@ -33,8 +35,14 @@ public class MarkdownDocumentationGeneratorTests
                             IsRequired = true,
                         },
                     ],
+                    IsSafeForDocumentation = true,
+                    DocumentationExampleValues = new Dictionary<string, string>
+                    {
+                        ["Project"] = "\"sample.csproj\"",
+                    },
                 },
             ],
+            PreferredDocumentationExampleCommand = "fake-cli run",
         };
 
         var files = await new MarkdownDocumentationGenerator().GenerateAsync(tool);
@@ -51,7 +59,7 @@ public class MarkdownDocumentationGeneratorTests
         await Assert.That(files[0].Content).Contains("Task<CommandResult?> ExecuteAsync");
         await Assert.That(files[0].Content).Contains("return await context.Fake()");
         await Assert.That(files[0].Content).Contains("| `fake-cli run` | `FakeRunOptions` |");
-        await Assert.That(files[0].Content).Contains("new FakeRunOptions(\"value\")");
+        await Assert.That(files[0].Content).Contains("new FakeRunOptions(\"sample.csproj\")");
     }
 
     [Test]
@@ -112,6 +120,12 @@ public class MarkdownDocumentationGeneratorTests
                     IsRequired = true,
                 },
             ],
+            IsSafeForDocumentation = true,
+            DocumentationExampleValues = new Dictionary<string, string>
+            {
+                ["Target"] = "42",
+                ["Files"] = "[\"input.txt\"]",
+            },
         };
         var tool = new CliToolDefinition
         {
@@ -120,12 +134,13 @@ public class MarkdownDocumentationGeneratorTests
             TargetNamespace = "ModularPipelines.Fake",
             OutputDirectory = "src/ModularPipelines.Fake",
             Commands = [command],
+            PreferredDocumentationExampleCommand = "fake run",
         };
 
         var documentation = await new MarkdownDocumentationGenerator().GenerateAsync(tool);
         var options = await new OptionsClassGenerator().GenerateAsync(tool);
 
-        await Assert.That(documentation[0].Content).Contains("new FakeRunOptions(1, [\"value\"])");
+        await Assert.That(documentation[0].Content).Contains("new FakeRunOptions(42, [\"input.txt\"])");
         await Assert.That(options[0].Content).Contains("int Target");
         await Assert.That(options[0].Content).Contains("IEnumerable<string> Files");
         await Assert.That(options[0].Content).DoesNotContain("string target");
@@ -142,14 +157,22 @@ public class MarkdownDocumentationGeneratorTests
             OutputDirectory = "src/ModularPipelines.Fake",
             Commands =
             [
-                Command("fake zeta", "FakeZetaOptions", ["zeta"]),
-                Command("fake alpha", "FakeAlphaOptions", ["alpha"]),
+                Command("fake zeta", "FakeZetaOptions", ["zeta"]) with
+                {
+                    IsSafeForDocumentation = true,
+                },
+                Command("fake alpha", "FakeAlphaOptions", ["alpha"]) with
+                {
+                    IsSafeForDocumentation = true,
+                },
             ],
+            PreferredDocumentationExampleCommand = "fake zeta",
         };
 
         var documentation = await new MarkdownDocumentationGenerator().GenerateAsync(tool);
 
-        await Assert.That(documentation[0].Content).Contains("context.Fake().Alpha(");
+        await Assert.That(documentation[0].Content).Contains("context.Fake().Zeta(");
+        await Assert.That(documentation[0].Content).DoesNotContain("context.Fake().Alpha(");
     }
 
     [Test]
@@ -217,6 +240,292 @@ public class MarkdownDocumentationGeneratorTests
         await Assert.That(documentation[0].Content)
             .Contains("| `fake enterprise` | Requires an enterprise license. |");
     }
+
+    [Test]
+    public async Task GenerateAsync_OmitsRunnableExampleWithoutQualifiedMetadata()
+    {
+        var tool = Tool("fake", Command("fake delete", "FakeDeleteOptions", ["delete"]));
+
+        var documentation = await new MarkdownDocumentationGenerator().GenerateAsync(tool);
+
+        await Assert.That(documentation[0].Content)
+            .Contains("A runnable example is omitted when no command has complete safety metadata");
+        await Assert.That(documentation[0].Content).DoesNotContain("context.Fake().Delete(");
+    }
+
+    [Test]
+    public async Task GenerateAsync_RejectsIncompleteExampleValues()
+    {
+        var command = Command("fake run", "FakeRunOptions", ["run"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--project",
+                    PropertyName = "Project",
+                    CSharpType = "string",
+                    IsRequired = true,
+                },
+            ],
+            IsSafeForDocumentation = true,
+        };
+        var tool = Tool("fake", command) with
+        {
+            PreferredDocumentationExampleCommand = "fake run",
+        };
+
+        void GenerateDocumentation() =>
+            _ = new MarkdownDocumentationGenerator().GenerateAsync(tool);
+
+        await Assert.That(GenerateDocumentation)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("required property 'Project' has no sample value");
+    }
+
+    [Test]
+    public async Task GenerateAsync_UsesCuratedSafeRegressionExamples()
+    {
+        var ansible = Tool(
+            "ansible",
+            Command("ansible", "AnsibleExecuteOptions", []) with
+            {
+                Options =
+                [
+                    Option("--list-hosts", "ListHosts", "bool?"),
+                ],
+                PositionalArguments =
+                [
+                    Positional("Pattern", "string", isRequired: true),
+                ],
+            });
+        var buildah = Tool(
+            "buildah",
+            Command("buildah add", "BuildahAddOptions", ["add"]),
+            Command("buildah containers", "BuildahContainersOptions", ["containers"]));
+        var jq = Tool(
+            "jq",
+            Command("jq", "JqExecuteOptions", []) with
+            {
+                PositionalArguments =
+                [
+                    Positional("Filter", "string?"),
+                    Positional("InputFiles", "IEnumerable<string>?"),
+                ],
+            });
+        var newman = Tool(
+            "newman",
+            Command("newman URL", "NewmanUrlOptions", ["URL"]),
+            Command("newman run", "NewmanRunOptions", ["run"]) with
+            {
+                PositionalArguments =
+                [
+                    Positional("Collection", "string", isRequired: true),
+                ],
+            });
+        var packer = Tool(
+            "packer",
+            Command("packer console", "PackerConsoleOptions", ["console"]));
+        var vault = Tool(
+            "vault",
+            Command("vault delete", "VaultDeleteOptions", ["delete"]),
+            Command("vault status", "VaultStatusOptions", ["status"]));
+
+        var generator = new MarkdownDocumentationGenerator();
+        var ansibleDocumentation = (await generator.GenerateAsync(ansible))[0].Content;
+        var buildahDocumentation = (await generator.GenerateAsync(buildah))[0].Content;
+        var jqDocumentation = (await generator.GenerateAsync(jq))[0].Content;
+        var newmanDocumentation = (await generator.GenerateAsync(newman))[0].Content;
+        var packerDocumentation = (await generator.GenerateAsync(packer))[0].Content;
+        var vaultDocumentation = (await generator.GenerateAsync(vault))[0].Content;
+
+        await Assert.That(ansibleDocumentation).Contains("new AnsibleExecuteOptions(\"localhost\")");
+        await Assert.That(ansibleDocumentation).Contains("ListHosts = true");
+        await Assert.That(buildahDocumentation).Contains("context.Fake().Containers(");
+        await Assert.That(buildahDocumentation).DoesNotContain("context.Fake().Add(");
+        await Assert.That(jqDocumentation).Contains("Filter = \".\"");
+        await Assert.That(jqDocumentation).Contains("InputFiles = [\"input.json\"]");
+        await Assert.That(newmanDocumentation)
+            .Contains("A runnable example is omitted when no command has complete safety metadata");
+        await Assert.That(newmanDocumentation).DoesNotContain("context.Fake().Run(");
+        await Assert.That(newmanDocumentation).DoesNotContain("context.Fake().Url(");
+        await Assert.That(packerDocumentation).DoesNotContain("context.Fake().Console(");
+        await Assert.That(vaultDocumentation).Contains("context.Fake().Status(");
+        await Assert.That(vaultDocumentation).DoesNotContain("context.Fake().Delete(");
+
+        foreach (var tool in new[] { ansible, buildah, jq, vault })
+        {
+            await AssertDocumentationExampleCompiles(tool);
+        }
+    }
+
+    private static async Task AssertDocumentationExampleCompiles(CliToolDefinition tool)
+    {
+        var preparedTool = DocumentationExampleCatalog.Apply(tool);
+        var command = preparedTool.Commands.Single(candidate => string.Equals(
+            candidate.FullCommand,
+            preparedTool.PreferredDocumentationExampleCommand,
+            StringComparison.OrdinalIgnoreCase));
+        var documentation = (await new MarkdownDocumentationGenerator().GenerateAsync(tool))[0].Content;
+        var example = ExtractCSharpExample(documentation);
+        var stubs = GenerateCompilationStubs(preparedTool, command);
+        var references = ((string) AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            $"{tool.ToolName}-documentation-example",
+            [
+                CSharpSyntaxTree.ParseText(
+                    "global using System;\n"
+                    + "global using System.Collections.Generic;\n"
+                    + "global using System.Threading;\n"
+                    + "global using System.Threading.Tasks;"),
+                CSharpSyntaxTree.ParseText(stubs),
+                CSharpSyntaxTree.ParseText(example),
+            ],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var errors = compilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .Select(diagnostic => diagnostic.ToString())
+            .ToArray();
+
+        await Assert.That(errors).IsEmpty();
+    }
+
+    private static string ExtractCSharpExample(string documentation)
+    {
+        const string openingFence = "```csharp\n";
+        const string closingFence = "```";
+        var normalizedDocumentation = documentation.ReplaceLineEndings("\n");
+        var start = normalizedDocumentation.IndexOf(openingFence, StringComparison.Ordinal);
+        if (start < 0)
+        {
+            throw new InvalidOperationException("Documentation has no C# example.");
+        }
+
+        start += openingFence.Length;
+        var end = normalizedDocumentation.IndexOf(closingFence, start, StringComparison.Ordinal);
+        if (end < 0)
+        {
+            throw new InvalidOperationException("Documentation example fence is not closed.");
+        }
+
+        return normalizedDocumentation[start..end];
+    }
+
+    private static string GenerateCompilationStubs(
+        CliToolDefinition tool,
+        CliCommandDefinition command)
+    {
+        var requiredParameters = GeneratorUtils.GetRequiredConstructorParameters(command);
+        var requiredNames = requiredParameters
+            .Select(parameter => parameter.PropertyName)
+            .ToHashSet(StringComparer.Ordinal);
+        var properties = command.Options
+            .Select(option => (option.PropertyName, option.CSharpType))
+            .Concat(CliPositionalArgument.MergeDuplicates(command.PositionalArguments)
+                .Select(argument => (argument.PropertyName, argument.CSharpType)))
+            .DistinctBy(property => property.PropertyName, StringComparer.Ordinal)
+            .Where(property => !requiredNames.Contains(property.PropertyName))
+            .ToArray();
+        var constructor = requiredParameters.Count == 0
+            ? string.Empty
+            : $"({string.Join(", ", requiredParameters.Select(parameter => $"{parameter.CSharpType} {parameter.PropertyName}"))})";
+        var propertyDeclarations = string.Join(
+            Environment.NewLine,
+            properties.Select(property =>
+                $"        public {property.CSharpType} {property.PropertyName} {{ get; set; }}"));
+        var methodName = GeneratorUtils.GenerateMethodNameFromCommandParts(command.CommandParts);
+
+        return $$"""
+            #nullable enable
+
+            namespace ModularPipelines.Context
+            {
+                public interface IModuleContext
+                {
+                }
+            }
+
+            namespace ModularPipelines.Models
+            {
+                public sealed class CommandResult
+                {
+                }
+            }
+
+            namespace ModularPipelines.Modules
+            {
+                public abstract class Module<T>
+                {
+                    protected abstract Task<T?> ExecuteAsync(
+                        ModularPipelines.Context.IModuleContext context,
+                        CancellationToken cancellationToken);
+                }
+            }
+
+            namespace {{tool.TargetNamespace}}.Options
+            {
+                public record {{command.ClassName}}{{constructor}}
+                {
+            {{propertyDeclarations}}
+                }
+            }
+
+            namespace {{tool.TargetNamespace}}.Extensions
+            {
+                using ModularPipelines.Context;
+                using ModularPipelines.Models;
+                using {{tool.TargetNamespace}}.Options;
+
+                public interface I{{tool.NamespacePrefix}}Service
+                {
+                    Task<CommandResult?> {{methodName}}(
+                        {{command.ClassName}} options,
+                        CancellationToken cancellationToken = default);
+                }
+
+                public static class {{tool.NamespacePrefix}}Extensions
+                {
+                    public static I{{tool.NamespacePrefix}}Service {{tool.NamespacePrefix}}(
+                        this IModuleContext context) =>
+                        throw new NotImplementedException();
+                }
+            }
+            """;
+    }
+
+    private static CliToolDefinition Tool(
+        string toolName,
+        params CliCommandDefinition[] commands) => new()
+        {
+            ToolName = toolName,
+            NamespacePrefix = "Fake",
+            TargetNamespace = "ModularPipelines.Fake",
+            OutputDirectory = "src/ModularPipelines.Fake",
+            Commands = commands,
+        };
+
+    private static CliOptionDefinition Option(
+        string switchName,
+        string propertyName,
+        string cSharpType) => new()
+        {
+            SwitchName = switchName,
+            PropertyName = propertyName,
+            CSharpType = cSharpType,
+        };
+
+    private static CliPositionalArgument Positional(
+        string propertyName,
+        string cSharpType,
+        bool isRequired = false) => new()
+        {
+            PropertyName = propertyName,
+            CSharpType = cSharpType,
+            IsRequired = isRequired,
+        };
 
     private static CliCommandDefinition Command(
         string fullCommand,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ModularPipelines.OptionsGenerator.Tests.csproj
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ModularPipelines.OptionsGenerator.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
@@ -381,6 +381,7 @@ public class CodeGeneratorOrchestrator
             CommandCoverage = toolDefinition.CommandCoverage,
             GlobalOptions = toolDefinition.GlobalOptions,
             SupplementalGlobalOptions = toolDefinition.SupplementalGlobalOptions,
+            PreferredDocumentationExampleCommand = toolDefinition.PreferredDocumentationExampleCommand,
             Errors = []
         };
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DocumentationExampleCatalog.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DocumentationExampleCatalog.cs
@@ -8,6 +8,53 @@ namespace ModularPipelines.OptionsGenerator.Generators;
 /// </summary>
 internal static class DocumentationExampleCatalog
 {
+    // These tools intentionally receive the non-runnable service-resolution example
+    // until a command and all required sample values have been explicitly reviewed.
+    private static readonly IReadOnlySet<string> ToolsWithoutCuratedExamples =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "argocd",
+            "aws",
+            "az",
+            "brew",
+            "cargo",
+            "choco",
+            "cosign",
+            "docker",
+            "dotnet",
+            "eksctl",
+            "flux",
+            "flyway",
+            "gcloud",
+            "gh",
+            "git",
+            "go",
+            "gradle",
+            "grype",
+            "hadolint",
+            "helm",
+            "kind",
+            "kubectl",
+            "kustomize",
+            "liquibase",
+            "minikube",
+            "mvn",
+            "pip",
+            "pnpm",
+            "podman",
+            "pulumi",
+            "shellcheck",
+            "skopeo",
+            "snyk",
+            "sonar-scanner",
+            "syft",
+            "terraform",
+            "trivy",
+            "winget",
+            "yarn",
+            "yq",
+        };
+
     private static readonly IReadOnlyDictionary<string, ToolMetadata> Tools =
         new Dictionary<string, ToolMetadata>(StringComparer.OrdinalIgnoreCase)
         {
@@ -52,12 +99,43 @@ internal static class DocumentationExampleCatalog
                 ]),
         };
 
+    public static void ValidateRegisteredTools(IEnumerable<string> toolNames)
+    {
+        ArgumentNullException.ThrowIfNull(toolNames);
+
+        var missingPolicies = toolNames
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(toolName =>
+                !Tools.ContainsKey(toolName)
+                && !ToolsWithoutCuratedExamples.Contains(toolName))
+            .OrderBy(toolName => toolName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (missingPolicies.Length > 0)
+        {
+            throw new InvalidOperationException(
+                "Documentation example policy is missing for registered tool(s): "
+                + string.Join(", ", missingPolicies)
+                + ". Add a curated example or explicitly omit the tool.");
+        }
+    }
+
     public static CliToolDefinition Apply(CliToolDefinition tool)
     {
         if (!Tools.TryGetValue(tool.ToolName, out var toolMetadata))
         {
+            if (ToolsWithoutCuratedExamples.Contains(tool.ToolName))
+            {
+                return tool with
+                {
+                    PreferredDocumentationExampleCommand = null,
+                };
+            }
+
             return tool;
         }
+
+        ValidateMetadata(tool, toolMetadata);
 
         var commands = tool.Commands
             .Select(command => Apply(command, toolMetadata))
@@ -70,6 +148,33 @@ internal static class DocumentationExampleCatalog
                 tool.PreferredDocumentationExampleCommand
                 ?? toolMetadata.PreferredCommand,
         };
+    }
+
+    private static void ValidateMetadata(CliToolDefinition tool, ToolMetadata toolMetadata)
+    {
+        var actualCommands = tool.Commands
+            .Select(command => command.FullCommand)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var missingCommands = toolMetadata.Commands
+            .Select(command => command.FullCommand)
+            .Where(command => !actualCommands.Contains(command))
+            .ToArray();
+
+        if (missingCommands.Length > 0)
+        {
+            throw new InvalidOperationException(
+                $"Documentation example catalog for '{tool.ToolName}' references missing command(s): "
+                + string.Join(", ", missingCommands)
+                + ". Update the catalog to match the scraper output.");
+        }
+
+        if (toolMetadata.PreferredCommand is not null
+            && !actualCommands.Contains(toolMetadata.PreferredCommand))
+        {
+            throw new InvalidOperationException(
+                $"Documentation example catalog for '{tool.ToolName}' prefers missing command "
+                + $"'{toolMetadata.PreferredCommand}'. Update the catalog to match the scraper output.");
+        }
     }
 
     private static CliCommandDefinition Apply(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DocumentationExampleCatalog.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/DocumentationExampleCatalog.cs
@@ -1,0 +1,129 @@
+using ModularPipelines.OptionsGenerator.Models;
+
+namespace ModularPipelines.OptionsGenerator.Generators;
+
+/// <summary>
+/// Curated runnable documentation examples. Scraped help can describe syntax, but it
+/// cannot establish whether a command is interactive, destructive, or safe to copy.
+/// </summary>
+internal static class DocumentationExampleCatalog
+{
+    private static readonly IReadOnlyDictionary<string, ToolMetadata> Tools =
+        new Dictionary<string, ToolMetadata>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["ansible"] = new(
+                "ansible",
+                [
+                    Safe(
+                        "ansible",
+                        ("Pattern", "\"localhost\""),
+                        ("ListHosts", "true")),
+                ]),
+            ["buildah"] = new(
+                "buildah containers",
+                [
+                    Unsafe("buildah add", isDestructive: true),
+                    Safe("buildah containers"),
+                ]),
+            ["jq"] = new(
+                "jq",
+                [
+                    Safe(
+                        "jq",
+                        ("Filter", "\".\""),
+                        ("InputFiles", "[\"input.json\"]")),
+                ]),
+            ["newman"] = new(
+                null,
+                [
+                    Unsafe("newman run", isDestructive: true),
+                    Unsafe("newman URL"),
+                ]),
+            ["packer"] = new(
+                null,
+                [
+                    Unsafe("packer console", isInteractive: true),
+                ]),
+            ["vault"] = new(
+                "vault status",
+                [
+                    Unsafe("vault delete", isDestructive: true),
+                    Safe("vault status"),
+                ]),
+        };
+
+    public static CliToolDefinition Apply(CliToolDefinition tool)
+    {
+        if (!Tools.TryGetValue(tool.ToolName, out var toolMetadata))
+        {
+            return tool;
+        }
+
+        var commands = tool.Commands
+            .Select(command => Apply(command, toolMetadata))
+            .ToArray();
+
+        return tool with
+        {
+            Commands = commands,
+            PreferredDocumentationExampleCommand =
+                tool.PreferredDocumentationExampleCommand
+                ?? toolMetadata.PreferredCommand,
+        };
+    }
+
+    private static CliCommandDefinition Apply(
+        CliCommandDefinition command,
+        ToolMetadata toolMetadata)
+    {
+        var commandMetadata = toolMetadata.Commands.FirstOrDefault(metadata =>
+            string.Equals(metadata.FullCommand, command.FullCommand, StringComparison.OrdinalIgnoreCase));
+        if (commandMetadata is null)
+        {
+            return command;
+        }
+
+        return command with
+        {
+            IsSafeForDocumentation = commandMetadata.IsSafeForDocumentation,
+            IsInteractive = commandMetadata.IsInteractive,
+            IsDestructive = commandMetadata.IsDestructive,
+            DocumentationExampleValues = commandMetadata.Values,
+        };
+    }
+
+    private static CommandMetadata Safe(
+        string fullCommand,
+        params (string PropertyName, string CSharpExpression)[] values) =>
+        new(
+            fullCommand,
+            IsSafeForDocumentation: true,
+            IsInteractive: false,
+            IsDestructive: false,
+            values.ToDictionary(
+                value => value.PropertyName,
+                value => value.CSharpExpression,
+                StringComparer.Ordinal));
+
+    private static CommandMetadata Unsafe(
+        string fullCommand,
+        bool isInteractive = false,
+        bool isDestructive = false) =>
+        new(
+            fullCommand,
+            IsSafeForDocumentation: false,
+            isInteractive,
+            isDestructive,
+            new Dictionary<string, string>(StringComparer.Ordinal));
+
+    private sealed record ToolMetadata(
+        string? PreferredCommand,
+        IReadOnlyList<CommandMetadata> Commands);
+
+    private sealed record CommandMetadata(
+        string FullCommand,
+        bool IsSafeForDocumentation,
+        bool IsInteractive,
+        bool IsDestructive,
+        IReadOnlyDictionary<string, string> Values);
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -16,6 +16,7 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         CliToolDefinition tool,
         CancellationToken cancellationToken = default)
     {
+        tool = DocumentationExampleCatalog.Apply(tool);
         var file = new GeneratedFile
         {
             RelativePath = Path.Combine(DocumentationDirectory, GetFileName(tool.ToolName)),
@@ -128,13 +129,12 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         sb.AppendLine("## Module example");
         sb.AppendLine();
 
-        var rootCommands = GeneratorUtils.GetNonCollidingRootCommands(tool);
-        var command = rootCommands
-            .OrderBy(candidate => candidate.FullCommand, StringComparer.OrdinalIgnoreCase)
-            .FirstOrDefault();
+        var command = SelectExampleCommand(tool);
         if (command is null)
         {
-            sb.AppendLine("Resolve the service in a module, then select a generated sub-domain and command from the table below:");
+            sb.AppendLine(
+                "Resolve the service in a module, then select a command from the table below. "
+                + "A runnable example is omitted when no command has complete safety metadata:");
             sb.AppendLine();
             sb.AppendLine("```csharp");
             sb.AppendLine($"using {tool.TargetNamespace}.Extensions;");
@@ -146,8 +146,7 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         }
 
         var methodName = GeneratorUtils.GenerateMethodNameFromCommandParts(command.CommandParts);
-        var constructorArguments = GeneratorUtils.GetRequiredConstructorParameters(command)
-            .Select(parameter => ExampleValue(parameter.CSharpType));
+        var optionsExpression = BuildOptionsExpression(command);
 
         sb.AppendLine("```csharp");
         sb.AppendLine("using ModularPipelines.Context;");
@@ -163,12 +162,127 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         sb.AppendLine("        CancellationToken cancellationToken)");
         sb.AppendLine("    {");
         sb.AppendLine($"        return await context.{tool.NamespacePrefix}().{methodName}(");
-        sb.AppendLine($"            new {command.ClassName}({string.Join(", ", constructorArguments)}),");
+        AppendIndentedExpression(sb, optionsExpression, "            ", appendComma: true);
         sb.AppendLine("            cancellationToken: cancellationToken);");
         sb.AppendLine("    }");
         sb.AppendLine("}");
         sb.AppendLine("```");
         sb.AppendLine();
+    }
+
+    private static CliCommandDefinition? SelectExampleCommand(CliToolDefinition tool)
+    {
+        if (string.IsNullOrWhiteSpace(tool.PreferredDocumentationExampleCommand))
+        {
+            return null;
+        }
+
+        var command = GeneratorUtils.GetNonCollidingRootCommands(tool)
+            .FirstOrDefault(candidate => string.Equals(
+                candidate.FullCommand,
+                tool.PreferredDocumentationExampleCommand,
+                StringComparison.OrdinalIgnoreCase));
+
+        return command is
+        {
+            IsSafeForDocumentation: true,
+            IsInteractive: false,
+            IsDestructive: false,
+        }
+            ? command
+            : null;
+    }
+
+    private static string BuildOptionsExpression(CliCommandDefinition command)
+    {
+        var values = command.DocumentationExampleValues;
+        var requiredParameters = GeneratorUtils.GetRequiredConstructorParameters(command);
+        var positionalArguments = CliPositionalArgument.MergeDuplicates(command.PositionalArguments);
+        var knownProperties = command.Options
+            .Select(option => option.PropertyName)
+            .Concat(positionalArguments.Select(argument => argument.PropertyName))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value.Value))
+            {
+                throw InvalidExample(command, $"sample value for '{value.Key}' is empty");
+            }
+
+            if (!knownProperties.Contains(value.Key, StringComparer.Ordinal))
+            {
+                throw InvalidExample(command, $"sample property '{value.Key}' is not generated");
+            }
+        }
+
+        foreach (var parameter in requiredParameters)
+        {
+            if (!values.ContainsKey(parameter.PropertyName))
+            {
+                throw InvalidExample(command, $"required property '{parameter.PropertyName}' has no sample value");
+            }
+        }
+
+        var constructorValues = requiredParameters
+            .Select(parameter => values[parameter.PropertyName])
+            .ToArray();
+        var expression = new StringBuilder()
+            .Append("new ")
+            .Append(command.ClassName)
+            .Append('(')
+            .AppendJoin(", ", constructorValues)
+            .Append(')');
+        var requiredPropertyNames = requiredParameters
+            .Select(parameter => parameter.PropertyName)
+            .ToHashSet(StringComparer.Ordinal);
+        var initializedProperties = knownProperties
+            .Where(values.ContainsKey)
+            .Where(property => !requiredPropertyNames.Contains(property))
+            .ToArray();
+
+        if (initializedProperties.Length == 0)
+        {
+            return expression.ToString();
+        }
+
+        expression.AppendLine()
+            .AppendLine("{");
+        foreach (var property in initializedProperties)
+        {
+            expression.Append("    ")
+                .Append(property)
+                .Append(" = ")
+                .Append(values[property])
+                .AppendLine(",");
+        }
+
+        return expression.Append('}').ToString();
+    }
+
+    private static InvalidOperationException InvalidExample(
+        CliCommandDefinition command,
+        string reason) =>
+        new($"Documentation example metadata for '{command.FullCommand}' is invalid: {reason}.");
+
+    private static void AppendIndentedExpression(
+        StringBuilder sb,
+        string expression,
+        string indentation,
+        bool appendComma)
+    {
+        var lines = expression.ReplaceLineEndings("\n").Split('\n');
+        for (var index = 0; index < lines.Length; index++)
+        {
+            sb.Append(indentation).Append(lines[index]);
+            if (appendComma && index == lines.Length - 1)
+            {
+                sb.Append(',');
+            }
+
+            sb.AppendLine();
+        }
     }
 
     private static IReadOnlyList<CliCommandDefinition> GetExposedCommands(CliToolDefinition tool)
@@ -181,32 +295,6 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
             .Where(command => command.SubDomainGroup is not null || rootCommands.Contains(command.ClassName))
             .DistinctBy(command => command.ClassName)
             .ToList();
-    }
-
-    private static string ExampleValue(string cSharpType)
-    {
-        var type = cSharpType.TrimEnd('?');
-        if (type == "string")
-        {
-            return "\"value\"";
-        }
-
-        if (type.Contains("string", StringComparison.Ordinal)
-            && (type.EndsWith("[]", StringComparison.Ordinal)
-                || type.StartsWith("IEnumerable<", StringComparison.Ordinal)
-                || type.StartsWith("IReadOnly", StringComparison.Ordinal)
-                || type.StartsWith("List<", StringComparison.Ordinal)))
-        {
-            return "[\"value\"]";
-        }
-
-        return type switch
-        {
-            "bool" => "true",
-            "byte" or "short" or "int" or "long" or "float" or "double" or "decimal" => "1",
-            "TimeSpan" => "TimeSpan.FromSeconds(30)",
-            _ => "default!",
-        };
     }
 
     private static string EscapeTableCell(string value) => value.Replace("|", "\\|", StringComparison.Ordinal);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -183,14 +183,22 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
                 tool.PreferredDocumentationExampleCommand,
                 StringComparison.OrdinalIgnoreCase));
 
-        return command is
+        if (command is null)
         {
-            IsSafeForDocumentation: true,
-            IsInteractive: false,
-            IsDestructive: false,
+            throw new InvalidOperationException(
+                $"Preferred documentation example command "
+                + $"'{tool.PreferredDocumentationExampleCommand}' for '{tool.ToolName}' "
+                + "does not match an emitted command.");
         }
-            ? command
-            : null;
+
+        if (!command.IsSafeForDocumentation || command.IsInteractive || command.IsDestructive)
+        {
+            throw new InvalidOperationException(
+                $"Preferred documentation example command '{command.FullCommand}' for "
+                + $"'{tool.ToolName}' does not have complete safe-example metadata.");
+        }
+
+        return command;
     }
 
     private static string BuildOptionsExpression(CliCommandDefinition command)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -81,6 +81,28 @@ public record CliCommandDefinition
     /// Public methods retained as obsolete forwarding aliases for compatibility.
     /// </summary>
     public IReadOnlyList<CliCompatibilityMethod> CompatibilityMethods { get; init; } = [];
+
+    /// <summary>
+    /// Whether this command has been explicitly reviewed as safe for a runnable documentation example.
+    /// Commands are unsafe by default; scraped names and descriptions are not enough to establish safety.
+    /// </summary>
+    public bool IsSafeForDocumentation { get; init; }
+
+    /// <summary>
+    /// Whether executing this command can wait for interactive input.
+    /// </summary>
+    public bool IsInteractive { get; init; }
+
+    /// <summary>
+    /// Whether executing this command can modify or delete external state.
+    /// </summary>
+    public bool IsDestructive { get; init; }
+
+    /// <summary>
+    /// C# expressions keyed by generated property name for a complete documentation example.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> DocumentationExampleValues { get; init; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
 }
 
 /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliToolDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliToolDefinition.cs
@@ -57,6 +57,11 @@ public record CliToolDefinition
     public IReadOnlyList<CliOptionDefinition> GetGlobalOptions() =>
         CliGlobalOptionMerger.Merge(GlobalOptions, SupplementalGlobalOptions);
 
+    /// Full command name selected for the runnable documentation example.
+    /// A missing value deliberately omits the runnable example.
+    /// </summary>
+    public string? PreferredDocumentationExampleCommand { get; init; }
+
     /// <summary>
     /// Sub-domain groups for organizing commands (e.g., "Container", "Image" for Docker).
     /// </summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Program.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Program.cs
@@ -183,6 +183,12 @@ rootCommand.SetAction(async (parseResult, cancellationToken) =>
 
     var host = builder.Build();
 
+    DocumentationExampleCatalog.ValidateRegisteredTools(
+        host.Services.GetServices<ICliScraper>()
+            .Select(scraper => scraper.ToolName)
+            .Concat(host.Services.GetServices<ICliDocumentationScraper>()
+                .Select(scraper => scraper.ToolName)));
+
     var orchestrator = host.Services.GetRequiredService<CodeGeneratorOrchestrator>();
     var logger = host.Services.GetRequiredService<ILogger<Program>>();
 


### PR DESCRIPTION
## Summary
- make runnable CLI documentation examples opt-in through shared command/tool safety metadata
- require preferred commands to be safe, non-interactive, non-destructive, and supplied with model-valid sample values
- omit runnable snippets when no qualified command exists instead of inventing generic placeholders
- curate safe Ansible, Buildah, jq, and Vault examples; explicitly reject the Packer/Newman and destructive regression cases
- compile every curated snippet against stubs generated from the same command model

## Validation
- guarded OptionsGenerator solution build (2 GB cap)
- guarded OptionsGenerator tests: 501 passed
- scoped `dotnet format whitespace`

Closes #3167