### PR TITLE
Document generated CLI prerequisites

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
@@ -34,6 +34,10 @@ public class CodeGeneratorOrchestratorTests
 
         public string? Version { get; init; } = "fake 1.0";
 
+        public CliExecutablePrerequisite? ExecutablePrerequisite { get; init; }
+
+        public string? ExecutablePrerequisiteMetadataExemption { get; init; }
+
         public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default) => Task.FromResult(Available);
 
         public Task<string?> GetVersionAsync(CancellationToken cancellationToken = default) =>
@@ -59,6 +63,8 @@ public class CodeGeneratorOrchestratorTests
             Commands = [],
             CommandCoverage = CommandCoverage,
             GlobalOptions = GlobalOptions,
+            ExecutablePrerequisite = ExecutablePrerequisite,
+            ExecutablePrerequisiteMetadataExemption = ExecutablePrerequisiteMetadataExemption,
         };
     }
 
@@ -86,6 +92,44 @@ public class CodeGeneratorOrchestratorTests
             htmlScrapers: [],
             generators,
             NullLogger<CodeGeneratorOrchestrator>.Instance);
+
+    [Test]
+    public async Task Cli_Metadata_Is_Preserved_For_Generators()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), "mp-orchestrator-tests", Guid.NewGuid().ToString("N"));
+        var prerequisite = new CliExecutablePrerequisite
+        {
+            CommandName = "fake-cli",
+            SupportedVersion = "1.2.3",
+        };
+        CliToolDefinition? generatedTool = null;
+        var scraper = new FakeCliScraper
+        {
+            Commands = [FakeCommand()],
+            ExecutablePrerequisite = prerequisite,
+        };
+        var generator = new FakeGenerator
+        {
+            OnGenerate = tool =>
+            {
+                generatedTool = tool;
+                return [];
+            },
+        };
+
+        try
+        {
+            var result = await Orchestrator(scraper, generator).GenerateAsync("fake", outputRoot);
+
+            await Assert.That(result.HasErrors).IsFalse();
+            await Assert.That(generatedTool).IsNotNull();
+            await Assert.That(generatedTool!.ExecutablePrerequisite).IsSameReferenceAs(prerequisite);
+        }
+        finally
+        {
+            Directory.Delete(outputRoot, recursive: true);
+        }
+    }
 
     /// <summary>
     /// Creates a temp output root containing one pre-existing generated file for the tool,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
@@ -16,7 +16,7 @@ public class CodeGeneratorOrchestratorTests
 
     private sealed class FakeCliScraper : ICliScraper
     {
-        public string ToolName => "fake";
+        public string ToolName { get; init; } = "fake";
 
         public string NamespacePrefix => "Fake";
 
@@ -34,7 +34,10 @@ public class CodeGeneratorOrchestratorTests
 
         public string? Version { get; init; } = "fake 1.0";
 
-        public CliExecutablePrerequisite? ExecutablePrerequisite { get; init; }
+        public CliExecutablePrerequisite? ExecutablePrerequisite { get; init; } = new()
+        {
+            CommandName = "fake",
+        };
 
         public string? ExecutablePrerequisiteMetadataExemption { get; init; }
 
@@ -128,6 +131,120 @@ public class CodeGeneratorOrchestratorTests
         finally
         {
             Directory.Delete(outputRoot, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Catalog_Metadata_Is_Applied_Before_Every_Generator()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), "mp-orchestrator-tests", Guid.NewGuid().ToString("N"));
+        var generatedTools = new List<CliToolDefinition>();
+        var scraper = new FakeCliScraper
+        {
+            ToolName = "terraform",
+            Commands = [FakeCommand()],
+            ExecutablePrerequisite = null,
+        };
+        var firstGenerator = new FakeGenerator
+        {
+            OnGenerate = tool =>
+            {
+                generatedTools.Add(tool);
+                return [];
+            },
+        };
+        var secondGenerator = new FakeGenerator
+        {
+            OnGenerate = tool =>
+            {
+                generatedTools.Add(tool);
+                return [];
+            },
+        };
+
+        try
+        {
+            var result = await Orchestrator(scraper, firstGenerator, secondGenerator)
+                .GenerateAsync("terraform", outputRoot);
+
+            await Assert.That(result.HasErrors).IsFalse();
+            await Assert.That(generatedTools).Count().IsEqualTo(2);
+            await Assert.That(generatedTools.All(
+                    tool => tool.ExecutablePrerequisite?.CommandName == "terraform"))
+                .IsTrue();
+            await Assert.That(generatedTools.All(
+                    tool => tool.ExecutablePrerequisite?.InstallationUrl ==
+                            "https://developer.hashicorp.com/terraform/install"))
+                .IsTrue();
+        }
+        finally
+        {
+            Directory.Delete(outputRoot, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Missing_Metadata_Is_Rejected_Before_Generators_Run()
+    {
+        await AssertMetadataFailureBeforeGeneratorsRun(
+            "unregistered-cli",
+            prerequisite: null,
+            expectedMessage: "no executable prerequisite metadata or explicit exemption");
+    }
+
+    [Test]
+    public async Task Invalid_Metadata_Is_Rejected_Before_Generators_Run()
+    {
+        await AssertMetadataFailureBeforeGeneratorsRun(
+            "fake",
+            new CliExecutablePrerequisite
+            {
+                CommandName = "fake",
+                InstallationUrl = "http://insecure.example.test/install",
+            },
+            "invalid HTTPS installation URL");
+    }
+
+    private static async Task AssertMetadataFailureBeforeGeneratorsRun(
+        string toolName,
+        CliExecutablePrerequisite? prerequisite,
+        string expectedMessage)
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), "mp-orchestrator-tests", Guid.NewGuid().ToString("N"));
+        var generatorCalled = false;
+        var scraper = new FakeCliScraper
+        {
+            ToolName = toolName,
+            Commands = [FakeCommand()],
+            ExecutablePrerequisite = prerequisite,
+        };
+        var generator = new FakeGenerator
+        {
+            OnGenerate = _ =>
+            {
+                generatorCalled = true;
+                return [];
+            },
+        };
+
+        try
+        {
+            var result = await Orchestrator(scraper, generator).GenerateAsync(toolName, outputRoot);
+
+            await Assert.That(result.HasErrors).IsTrue();
+            await Assert.That(result.Errors.Any(
+                    error => error.Message.Contains(
+                        expectedMessage,
+                        StringComparison.Ordinal)))
+                .IsTrue();
+            await Assert.That(generatorCalled).IsFalse();
+        }
+        finally
+        {
+            if (Directory.Exists(outputRoot))
+            {
+                Directory.Delete(outputRoot, recursive: true);
+            }
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -127,25 +127,6 @@ public class MarkdownDocumentationGeneratorTests
     }
 
     [Test]
-    public async Task GenerateAsync_RejectsInvalidPrerequisiteMetadata()
-    {
-        var tool = ToolDefinition("broken") with
-        {
-            ExecutablePrerequisite = new CliExecutablePrerequisite
-            {
-                CommandName = "broken",
-                InstallationUrl = "http://insecure.example.test/install",
-            },
-        };
-        void GenerateDocumentation() =>
-            _ = new MarkdownDocumentationGenerator().GenerateAsync(tool);
-
-        await Assert.That(GenerateDocumentation)
-            .Throws<InvalidOperationException>()
-            .And.HasMessageContaining("invalid HTTPS installation URL");
-    }
-
-    [Test]
     public async Task GenerateAsync_AcceptsExplicitMetadataExemption()
     {
         var tool = ToolDefinition("embedded") with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -51,6 +51,9 @@ public class MarkdownDocumentationGeneratorTests
         await Assert.That(files[0].RelativePath.Replace('\\', '/'))
             .IsEqualTo("docs/docs/mp-packages/cli/fake-cli.md");
         await Assert.That(files[0].Content).Contains("dotnet add package ModularPipelines.Fake");
+        await Assert.That(files[0].Content)
+            .Contains("This package does not install the `fake-cli` executable");
+        await Assert.That(files[0].Content).Contains("`fake-cli` is available on `PATH`");
         await Assert.That(files[0].Content).Contains("context.Fake()");
         await Assert.That(files[0].Content).Contains("using ModularPipelines.Context;");
         await Assert.That(files[0].Content).Contains("using ModularPipelines.Models;");
@@ -60,6 +63,102 @@ public class MarkdownDocumentationGeneratorTests
         await Assert.That(files[0].Content).Contains("return await context.Fake()");
         await Assert.That(files[0].Content).Contains("| `fake-cli run` | `FakeRunOptions` |");
         await Assert.That(files[0].Content).Contains("new FakeRunOptions(\"sample.csproj\")");
+    }
+
+    [Test]
+    [Arguments(
+        "syft",
+        "https://oss.anchore.com/docs/installation/syft/")]
+    [Arguments(
+        "sonar-scanner",
+        "https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner")]
+    [Arguments(
+        "terraform",
+        "https://developer.hashicorp.com/terraform/install")]
+    public async Task GenerateAsync_EmitsToolSpecificExecutablePrerequisites(
+        string toolName,
+        string installationUrl)
+    {
+        var documentation = await GenerateDocumentation(ToolDefinition(toolName));
+
+        await Assert.That(documentation).Contains($"does not install the `{toolName}` executable");
+        await Assert.That(documentation).Contains($"[{toolName} installation guide]({installationUrl})");
+    }
+
+    [Test]
+    public async Task GenerateAsync_EmitsPinnedGeneratorVersion()
+    {
+        var documentation = await GenerateDocumentation(ToolDefinition("sonar-scanner"));
+
+        await Assert.That(documentation)
+            .Contains("generation workflow is pinned to `sonar-scanner` version `8.0.1.6346`");
+    }
+
+    [Test]
+    public async Task GenerateAsync_UsesSafeGenericExecutableFallback()
+    {
+        var documentation = await GenerateDocumentation(ToolDefinition("future-cli"));
+
+        await Assert.That(documentation).Contains("does not install the `future-cli` executable");
+        await Assert.That(documentation)
+            .Contains("Follow the executable's official documentation for installation instructions.");
+    }
+
+    [Test]
+    public async Task GenerateAsync_UsesExplicitPrerequisiteMetadata()
+    {
+        var tool = ToolDefinition("custom-cli") with
+        {
+            ExecutablePrerequisite = new CliExecutablePrerequisite
+            {
+                CommandName = "custom",
+                SupportedVersion = "2.4.1",
+                InstallationUrl = "https://example.test/custom/install",
+                InstallationNotes = "Install the platform-specific archive.",
+            },
+        };
+
+        var documentation = await GenerateDocumentation(tool);
+
+        await Assert.That(documentation).Contains("does not install the `custom` executable");
+        await Assert.That(documentation).Contains("version `2.4.1`");
+        await Assert.That(documentation).Contains("https://example.test/custom/install");
+        await Assert.That(documentation).Contains("Install the platform-specific archive.");
+    }
+
+    [Test]
+    public async Task GenerateAsync_RejectsInvalidPrerequisiteMetadata()
+    {
+        var tool = ToolDefinition("broken") with
+        {
+            ExecutablePrerequisite = new CliExecutablePrerequisite
+            {
+                CommandName = "broken",
+                InstallationUrl = "http://insecure.example.test/install",
+            },
+        };
+        void GenerateDocumentation() =>
+            _ = new MarkdownDocumentationGenerator().GenerateAsync(tool);
+
+        await Assert.That(GenerateDocumentation)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("invalid HTTPS installation URL");
+    }
+
+    [Test]
+    public async Task GenerateAsync_AcceptsExplicitMetadataExemption()
+    {
+        var tool = ToolDefinition("embedded") with
+        {
+            ExecutablePrerequisiteMetadataExemption =
+                "This integration is supplied by the host environment.",
+        };
+
+        var documentation = await GenerateDocumentation(tool);
+
+        await Assert.That(documentation).Contains("does not install the `embedded` executable");
+        await Assert.That(documentation)
+            .Contains("This integration is supplied by the host environment.");
     }
 
     [Test]
@@ -623,4 +722,16 @@ public class MarkdownDocumentationGeneratorTests
             Options = [],
             SubDomainGroup = subDomainGroup,
         };
+
+    private static CliToolDefinition ToolDefinition(string toolName) => new()
+    {
+        ToolName = toolName,
+        NamespacePrefix = "Fake",
+        TargetNamespace = "ModularPipelines.Fake",
+        OutputDirectory = "src/ModularPipelines.Fake",
+        Commands = [Command($"{toolName} status", "FakeStatusOptions", ["status"])],
+    };
+
+    private static async Task<string> GenerateDocumentation(CliToolDefinition tool) =>
+        (await new MarkdownDocumentationGenerator().GenerateAsync(tool))[0].Content;
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
@@ -382,6 +382,8 @@ public class CodeGeneratorOrchestrator
             GlobalOptions = toolDefinition.GlobalOptions,
             SupplementalGlobalOptions = toolDefinition.SupplementalGlobalOptions,
             PreferredDocumentationExampleCommand = toolDefinition.PreferredDocumentationExampleCommand,
+            ExecutablePrerequisite = toolDefinition.ExecutablePrerequisite,
+            ExecutablePrerequisiteMetadataExemption = toolDefinition.ExecutablePrerequisiteMetadataExemption,
             Errors = []
         };
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
@@ -419,12 +419,13 @@ public class CodeGeneratorOrchestrator
     {
         var globalOptions = tool.GetGlobalOptions();
         var normalizedCommands = GeneratorUtils.NormalizeCommandClassNames(tool.Commands);
-        var toolDefinition = tool with
+        var toolDefinition = ExecutablePrerequisiteCatalog.PrepareForGeneration(tool with
         {
             Commands = normalizedCommands,
             GlobalOptions = globalOptions,
             SupplementalGlobalOptions = [],
-        };
+        });
+
         toolDefinition = EnumDefinitionStabilizer.Stabilize(toolDefinition, outputDirectory);
         var coverage = CommandCoverageGuard.Evaluate(
             toolDefinition,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ExecutablePrerequisiteCatalog.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ExecutablePrerequisiteCatalog.cs
@@ -3,13 +3,56 @@ using ModularPipelines.OptionsGenerator.Models;
 namespace ModularPipelines.OptionsGenerator.Generators;
 
 /// <summary>
-/// Tool-specific executable prerequisites layered over a safe generic fallback.
+/// Declared executable prerequisites for every registered CLI integration.
+/// A missing entry is intentional validation failure, so adding a scraper requires
+/// either catalog metadata or an explicit exemption on its tool definition.
 /// </summary>
 internal static class ExecutablePrerequisiteCatalog
 {
+    internal const string GenericInstallationNotes =
+        "Follow the executable's official documentation for installation instructions.";
+
     private static readonly IReadOnlyDictionary<string, CliExecutablePrerequisite> Prerequisites =
         new Dictionary<string, CliExecutablePrerequisite>(StringComparer.OrdinalIgnoreCase)
         {
+            ["ansible"] = Declared("ansible"),
+            ["argocd"] = Declared("argocd"),
+            ["aws"] = Declared("aws"),
+            ["az"] = Declared("az"),
+            ["brew"] = Declared("brew"),
+            ["buildah"] = Declared("buildah"),
+            ["cargo"] = Declared("cargo"),
+            ["choco"] = Declared("choco"),
+            ["cosign"] = Declared("cosign"),
+            ["docker"] = Declared("docker"),
+            ["dotnet"] = Declared("dotnet"),
+            ["eksctl"] = Declared("eksctl"),
+            ["flyway"] = Declared("flyway"),
+            ["flux"] = Declared("flux"),
+            ["gcloud"] = Declared("gcloud"),
+            ["gh"] = Declared("gh"),
+            ["git"] = Declared("git"),
+            ["go"] = Declared("go"),
+            ["gradle"] = Declared("gradle"),
+            ["grype"] = Declared("grype"),
+            ["hadolint"] = Declared("hadolint"),
+            ["helm"] = Declared("helm"),
+            ["jq"] = Declared("jq"),
+            ["kind"] = Declared("kind"),
+            ["kubectl"] = Declared("kubectl"),
+            ["kustomize"] = Declared("kustomize"),
+            ["liquibase"] = Declared("liquibase"),
+            ["minikube"] = Declared("minikube"),
+            ["mvn"] = Declared("mvn"),
+            ["newman"] = Declared("newman"),
+            ["packer"] = Declared("packer"),
+            ["pip"] = Declared("pip"),
+            ["pnpm"] = Declared("pnpm"),
+            ["podman"] = Declared("podman"),
+            ["pulumi"] = Declared("pulumi"),
+            ["shellcheck"] = Declared("shellcheck"),
+            ["skopeo"] = Declared("skopeo"),
+            ["snyk"] = Declared("snyk"),
             ["sonar-scanner"] = new()
             {
                 CommandName = "sonar-scanner",
@@ -29,6 +72,11 @@ internal static class ExecutablePrerequisiteCatalog
                 CommandName = "terraform",
                 InstallationUrl = "https://developer.hashicorp.com/terraform/install",
             },
+            ["trivy"] = Declared("trivy"),
+            ["vault"] = Declared("vault"),
+            ["winget"] = Declared("winget"),
+            ["yarn"] = Declared("yarn"),
+            ["yq"] = Declared("yq"),
         };
 
     public static CliToolDefinition Apply(CliToolDefinition tool)
@@ -39,14 +87,52 @@ internal static class ExecutablePrerequisiteCatalog
             return tool;
         }
 
-        var prerequisite = Prerequisites.GetValueOrDefault(tool.ToolName)
-                           ?? new CliExecutablePrerequisite
-                           {
-                               CommandName = tool.ToolName,
-                               InstallationNotes =
-                                   "Follow the executable's official documentation for installation instructions.",
-                           };
-
-        return tool with { ExecutablePrerequisite = prerequisite };
+        return Prerequisites.TryGetValue(tool.ToolName, out var prerequisite)
+            ? tool with { ExecutablePrerequisite = prerequisite }
+            : tool;
     }
+
+    public static CliToolDefinition PrepareForGeneration(CliToolDefinition tool)
+    {
+        var preparedTool = Apply(tool);
+        Validate(preparedTool);
+        return preparedTool;
+    }
+
+    private static void Validate(CliToolDefinition tool)
+    {
+        if (tool.ExecutablePrerequisite is null)
+        {
+            if (!string.IsNullOrWhiteSpace(tool.ExecutablePrerequisiteMetadataExemption))
+            {
+                return;
+            }
+
+            throw new InvalidOperationException(
+                $"CLI tool '{tool.ToolName}' has no executable prerequisite metadata or explicit exemption.");
+        }
+
+        if (string.IsNullOrWhiteSpace(tool.ExecutablePrerequisite.CommandName))
+        {
+            throw new InvalidOperationException(
+                $"CLI tool '{tool.ToolName}' has executable prerequisite metadata with no command name.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(tool.ExecutablePrerequisite.InstallationUrl)
+            && (!Uri.TryCreate(
+                    tool.ExecutablePrerequisite.InstallationUrl,
+                    UriKind.Absolute,
+                    out var installationUri)
+                || installationUri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new InvalidOperationException(
+                $"CLI tool '{tool.ToolName}' has an invalid HTTPS installation URL.");
+        }
+    }
+
+    private static CliExecutablePrerequisite Declared(string commandName) => new()
+    {
+        CommandName = commandName,
+        InstallationNotes = GenericInstallationNotes,
+    };
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ExecutablePrerequisiteCatalog.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/ExecutablePrerequisiteCatalog.cs
@@ -1,0 +1,52 @@
+using ModularPipelines.OptionsGenerator.Models;
+
+namespace ModularPipelines.OptionsGenerator.Generators;
+
+/// <summary>
+/// Tool-specific executable prerequisites layered over a safe generic fallback.
+/// </summary>
+internal static class ExecutablePrerequisiteCatalog
+{
+    private static readonly IReadOnlyDictionary<string, CliExecutablePrerequisite> Prerequisites =
+        new Dictionary<string, CliExecutablePrerequisite>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["sonar-scanner"] = new()
+            {
+                CommandName = "sonar-scanner",
+                SupportedVersion = "8.0.1.6346",
+                InstallationUrl =
+                    "https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner",
+                InstallationNotes =
+                    "The generator workflow downloads the Linux x64 SonarScanner CLI distribution.",
+            },
+            ["syft"] = new()
+            {
+                CommandName = "syft",
+                InstallationUrl = "https://oss.anchore.com/docs/installation/syft/",
+            },
+            ["terraform"] = new()
+            {
+                CommandName = "terraform",
+                InstallationUrl = "https://developer.hashicorp.com/terraform/install",
+            },
+        };
+
+    public static CliToolDefinition Apply(CliToolDefinition tool)
+    {
+        if (tool.ExecutablePrerequisite is not null
+            || !string.IsNullOrWhiteSpace(tool.ExecutablePrerequisiteMetadataExemption))
+        {
+            return tool;
+        }
+
+        var prerequisite = Prerequisites.GetValueOrDefault(tool.ToolName)
+                           ?? new CliExecutablePrerequisite
+                           {
+                               CommandName = tool.ToolName,
+                               InstallationNotes =
+                                   "Follow the executable's official documentation for installation instructions.",
+                           };
+
+        return tool with { ExecutablePrerequisite = prerequisite };
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -17,6 +17,8 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         CancellationToken cancellationToken = default)
     {
         tool = DocumentationExampleCatalog.Apply(tool);
+        tool = ExecutablePrerequisiteCatalog.Apply(tool);
+        ValidateExecutablePrerequisite(tool);
         var file = new GeneratedFile
         {
             RelativePath = Path.Combine(DocumentationDirectory, GetFileName(tool.ToolName)),
@@ -51,7 +53,8 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         sb.AppendLine();
         sb.AppendLine($"`{tool.TargetNamespace}` provides strongly typed access to the `{tool.ToolName}` CLI.");
         sb.AppendLine();
-        sb.AppendLine("## Installation");
+        AppendExecutablePrerequisite(sb, tool);
+        sb.AppendLine("## Package installation");
         sb.AppendLine();
         sb.AppendLine("```shell");
         sb.AppendLine($"dotnet add package {tool.TargetNamespace}");
@@ -122,6 +125,76 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         }
 
         sb.AppendLine();
+    }
+
+    private static void AppendExecutablePrerequisite(StringBuilder sb, CliToolDefinition tool)
+    {
+        var prerequisite = tool.ExecutablePrerequisite;
+        var commandName = prerequisite?.CommandName ?? tool.ToolName;
+
+        sb.AppendLine("## Executable prerequisite");
+        sb.AppendLine();
+        sb.AppendLine(
+            $"This package does not install the `{commandName}` executable. "
+            + $"Install it separately and ensure `{commandName}` is available on `PATH`.");
+        sb.AppendLine();
+
+        if (!string.IsNullOrWhiteSpace(prerequisite?.SupportedVersion))
+        {
+            sb.AppendLine(
+                $"The generation workflow is pinned to `{commandName}` version "
+                + $"`{prerequisite.SupportedVersion}`.");
+            sb.AppendLine();
+        }
+
+        if (!string.IsNullOrWhiteSpace(prerequisite?.InstallationUrl))
+        {
+            sb.AppendLine($"See the [{commandName} installation guide]({prerequisite.InstallationUrl}).");
+            sb.AppendLine();
+        }
+
+        if (!string.IsNullOrWhiteSpace(prerequisite?.InstallationNotes))
+        {
+            sb.AppendLine(prerequisite.InstallationNotes);
+            sb.AppendLine();
+        }
+
+        if (!string.IsNullOrWhiteSpace(tool.ExecutablePrerequisiteMetadataExemption))
+        {
+            sb.AppendLine(tool.ExecutablePrerequisiteMetadataExemption);
+            sb.AppendLine();
+        }
+    }
+
+    private static void ValidateExecutablePrerequisite(CliToolDefinition tool)
+    {
+        if (tool.ExecutablePrerequisite is null)
+        {
+            if (!string.IsNullOrWhiteSpace(tool.ExecutablePrerequisiteMetadataExemption))
+            {
+                return;
+            }
+
+            throw new InvalidOperationException(
+                $"CLI tool '{tool.ToolName}' has no executable prerequisite metadata or explicit exemption.");
+        }
+
+        if (string.IsNullOrWhiteSpace(tool.ExecutablePrerequisite.CommandName))
+        {
+            throw new InvalidOperationException(
+                $"CLI tool '{tool.ToolName}' has executable prerequisite metadata with no command name.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(tool.ExecutablePrerequisite.InstallationUrl)
+            && (!Uri.TryCreate(
+                    tool.ExecutablePrerequisite.InstallationUrl,
+                    UriKind.Absolute,
+                    out var installationUri)
+                || installationUri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new InvalidOperationException(
+                $"CLI tool '{tool.ToolName}' has an invalid HTTPS installation URL.");
+        }
     }
 
     private static void AppendExample(StringBuilder sb, CliToolDefinition tool)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -18,7 +18,6 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
     {
         tool = DocumentationExampleCatalog.Apply(tool);
         tool = ExecutablePrerequisiteCatalog.Apply(tool);
-        ValidateExecutablePrerequisite(tool);
         var file = new GeneratedFile
         {
             RelativePath = Path.Combine(DocumentationDirectory, GetFileName(tool.ToolName)),
@@ -158,42 +157,17 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
             sb.AppendLine(prerequisite.InstallationNotes);
             sb.AppendLine();
         }
+        else if (prerequisite is null
+                 && string.IsNullOrWhiteSpace(tool.ExecutablePrerequisiteMetadataExemption))
+        {
+            sb.AppendLine(ExecutablePrerequisiteCatalog.GenericInstallationNotes);
+            sb.AppendLine();
+        }
 
         if (!string.IsNullOrWhiteSpace(tool.ExecutablePrerequisiteMetadataExemption))
         {
             sb.AppendLine(tool.ExecutablePrerequisiteMetadataExemption);
             sb.AppendLine();
-        }
-    }
-
-    private static void ValidateExecutablePrerequisite(CliToolDefinition tool)
-    {
-        if (tool.ExecutablePrerequisite is null)
-        {
-            if (!string.IsNullOrWhiteSpace(tool.ExecutablePrerequisiteMetadataExemption))
-            {
-                return;
-            }
-
-            throw new InvalidOperationException(
-                $"CLI tool '{tool.ToolName}' has no executable prerequisite metadata or explicit exemption.");
-        }
-
-        if (string.IsNullOrWhiteSpace(tool.ExecutablePrerequisite.CommandName))
-        {
-            throw new InvalidOperationException(
-                $"CLI tool '{tool.ToolName}' has executable prerequisite metadata with no command name.");
-        }
-
-        if (!string.IsNullOrWhiteSpace(tool.ExecutablePrerequisite.InstallationUrl)
-            && (!Uri.TryCreate(
-                    tool.ExecutablePrerequisite.InstallationUrl,
-                    UriKind.Absolute,
-                    out var installationUri)
-                || installationUri.Scheme != Uri.UriSchemeHttps))
-        {
-            throw new InvalidOperationException(
-                $"CLI tool '{tool.ToolName}' has an invalid HTTPS installation URL.");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliToolDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliToolDefinition.cs
@@ -57,10 +57,22 @@ public record CliToolDefinition
     public IReadOnlyList<CliOptionDefinition> GetGlobalOptions() =>
         CliGlobalOptionMerger.Merge(GlobalOptions, SupplementalGlobalOptions);
 
+    /// <summary>
     /// Full command name selected for the runnable documentation example.
     /// A missing value deliberately omits the runnable example.
     /// </summary>
     public string? PreferredDocumentationExampleCommand { get; init; }
+
+    /// <summary>
+    /// Installation metadata for the external executable used by this integration.
+    /// </summary>
+    public CliExecutablePrerequisite? ExecutablePrerequisite { get; init; }
+
+    /// <summary>
+    /// Explicit reason this tool uses generic prerequisite guidance instead of
+    /// tool-specific installation metadata.
+    /// </summary>
+    public string? ExecutablePrerequisiteMetadataExemption { get; init; }
 
     /// <summary>
     /// Sub-domain groups for organizing commands (e.g., "Container", "Image" for Docker).
@@ -129,6 +141,32 @@ public record CliCommandCoverageExclusion
     /// Human-readable reason, such as edition, licensing, or unsupported syntax.
     /// </summary>
     public required string Reason { get; init; }
+}
+
+/// <summary>
+/// Describes the external executable required by a generated CLI integration.
+/// </summary>
+public record CliExecutablePrerequisite
+{
+    /// <summary>
+    /// Executable command that must resolve through PATH.
+    /// </summary>
+    public required string CommandName { get; init; }
+
+    /// <summary>
+    /// Supported or workflow-pinned executable version, when generation uses one.
+    /// </summary>
+    public string? SupportedVersion { get; init; }
+
+    /// <summary>
+    /// Official installation documentation URL.
+    /// </summary>
+    public string? InstallationUrl { get; init; }
+
+    /// <summary>
+    /// Optional installation or compatibility notes.
+    /// </summary>
+    public string? InstallationNotes { get; init; }
 }
 
 /// <summary>


### PR DESCRIPTION
Closes #3166.

## Summary
- add reusable executable prerequisite metadata to `CliToolDefinition`
- emit shared install, `PATH`, pinned-version, URL, and notes guidance in generated CLI docs
- provide safe fallback metadata plus Syft, SonarScanner, and Terraform regressions
- preserve CLI scraper metadata through orchestration and validate malformed definitions

## Validation
- `dotnet build tools/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.sln -c Release --no-restore -m:1`
- OptionsGenerator tests: 507 passed
- `dotnet format tools/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.sln --no-restore --include <changed files>`