### PR TITLE
Stabilize generated CLI enums

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/EnumDefinitionStabilizerTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/EnumDefinitionStabilizerTests.cs
@@ -1,0 +1,108 @@
+using ModularPipelines.OptionsGenerator.Generators;
+using ModularPipelines.OptionsGenerator.Models;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Generators;
+
+public class EnumDefinitionStabilizerTests
+{
+    [Test]
+    public async Task Stabilize_Preserves_Existing_Raw_Value_Order_And_Ordinals()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), "mp-enum-tests", Guid.NewGuid().ToString("N"));
+        var enumDirectory = Path.Combine(outputRoot, "src", "Fake", "Enums");
+        Directory.CreateDirectory(enumDirectory);
+        File.WriteAllText(
+            Path.Combine(enumDirectory, "FakeVisibility.Generated.cs"),
+            """
+            public enum FakeVisibility
+            {
+                [Description("private")]
+                Private,
+
+                [Description("public")]
+                Public,
+
+                [Description("internal")]
+                Internal
+            }
+            """);
+
+        try
+        {
+            var tool = Tool(
+                Value("public"),
+                Value("internal"),
+                Value("private"),
+                Value("enterprise"));
+
+            var stabilized = EnumDefinitionStabilizer.Stabilize(tool, outputRoot);
+            var values = stabilized.AllEnums.Single().Values;
+
+            await Assert.That(values[0].CliValue).IsEqualTo("private");
+            await Assert.That(values[1].CliValue).IsEqualTo("public");
+            await Assert.That(values[2].CliValue).IsEqualTo("internal");
+            await Assert.That(values[3].CliValue).IsEqualTo("enterprise");
+            await Assert.That(values[0].NumericValue).IsEqualTo(0);
+            await Assert.That(values[1].NumericValue).IsEqualTo(1);
+            await Assert.That(values[2].NumericValue).IsEqualTo(2);
+            await Assert.That(values[3].NumericValue).IsEqualTo(3);
+
+            var generated = (await new EnumGenerator().GenerateAsync(stabilized)).Single().Content;
+            await Assert.That(generated).Contains("Private = 0,");
+            await Assert.That(generated).Contains("Public = 1,");
+            await Assert.That(generated).Contains("Internal = 2,");
+            await Assert.That(generated).Contains("Enterprise = 3");
+        }
+        finally
+        {
+            Directory.Delete(outputRoot, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Stabilize_Rejects_Suspicious_Prose_Values()
+    {
+        var tool = Tool(Value("them"), Value("accepts"));
+        void Stabilize() => EnumDefinitionStabilizer.Stabilize(tool, Path.GetTempPath());
+
+        await Assert.That(Stabilize)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("suspicious prose value");
+    }
+
+    private static CliToolDefinition Tool(params CliEnumValue[] values)
+    {
+        var definition = new CliEnumDefinition
+        {
+            EnumName = "FakeVisibility",
+            Values = values,
+        };
+
+        return new CliToolDefinition
+        {
+            ToolName = "fake",
+            NamespacePrefix = "Fake",
+            TargetNamespace = "ModularPipelines.Fake",
+            OutputDirectory = Path.Combine("src", "Fake"),
+            Commands =
+            [
+                new CliCommandDefinition
+                {
+                    FullCommand = "fake",
+                    CommandParts = [],
+                    ClassName = "FakeOptions",
+                    ParentClassName = "FakeOptions",
+                    ToolNamespacePrefix = "Fake",
+                    Options = [],
+                    Enums = [definition],
+                },
+            ],
+        };
+    }
+
+    private static CliEnumValue Value(string cliValue) => new()
+    {
+        CliValue = cliValue,
+        MemberName = GeneratorUtils.ToEnumMemberName(cliValue),
+    };
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/EnumDefinitionStabilizerTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/EnumDefinitionStabilizerTests.cs
@@ -60,6 +60,47 @@ public class EnumDefinitionStabilizerTests
     }
 
     [Test]
+    public async Task Stabilize_RoundTrips_EnumGenerator_Output()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), "mp-enum-tests", Guid.NewGuid().ToString("N"));
+        var enumDirectory = Path.Combine(outputRoot, "src", "Fake", "Enums");
+        Directory.CreateDirectory(enumDirectory);
+        var enumPath = Path.Combine(enumDirectory, "FakeVisibility.Generated.cs");
+
+        try
+        {
+            var initial = EnumDefinitionStabilizer.Stabilize(
+                Tool(Value("public"), Value("private")),
+                outputRoot);
+            var initialGenerated = (await new EnumGenerator().GenerateAsync(initial)).Single().Content;
+            await File.WriteAllTextAsync(enumPath, initialGenerated);
+
+            var reordered = Tool(Value("private"), Value("public"), Value("enterprise"));
+            var stabilized = EnumDefinitionStabilizer.Stabilize(reordered, outputRoot);
+            var values = stabilized.AllEnums.Single().Values;
+
+            await Assert.That(values[0].CliValue).IsEqualTo("public");
+            await Assert.That(values[1].CliValue).IsEqualTo("private");
+            await Assert.That(values[2].CliValue).IsEqualTo("enterprise");
+            await Assert.That(values[0].NumericValue).IsEqualTo(0);
+            await Assert.That(values[1].NumericValue).IsEqualTo(1);
+            await Assert.That(values[2].NumericValue).IsEqualTo(2);
+
+            var generated = (await new EnumGenerator().GenerateAsync(stabilized)).Single().Content;
+            await File.WriteAllTextAsync(enumPath, generated);
+
+            var restabilized = EnumDefinitionStabilizer.Stabilize(reordered, outputRoot);
+            var regenerated = (await new EnumGenerator().GenerateAsync(restabilized)).Single().Content;
+
+            await Assert.That(regenerated).IsEqualTo(generated);
+        }
+        finally
+        {
+            Directory.Delete(outputRoot, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task Stabilize_Rejects_Suspicious_Prose_Values()
     {
         var tool = Tool(Value("them"), Value("accepts"));

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
@@ -51,6 +51,20 @@ public class GeneratorUtilsTests
     }
 
     [Test]
+    [Arguments("ChartRevision", "ChartRevision")]
+    [Arguments("IfNotPresent", "IfNotPresent")]
+    [Arguments("ConfigMap", "ConfigMap")]
+    [Arguments("OCIRepository", "OciRepository")]
+    public async Task ToEnumMemberName_Preserves_Existing_Word_Boundaries(
+        string input,
+        string expected)
+    {
+        var result = GeneratorUtils.ToEnumMemberName(input);
+
+        await Assert.That(result).IsEqualTo(expected);
+    }
+
+    [Test]
     public async Task ToPascalCase_Returns_Empty_For_Empty_Input()
     {
         var result = GeneratorUtils.ToPascalCase("");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KindCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KindCliScraperTests.cs
@@ -63,6 +63,26 @@ public class KindCliScraperTests
             .IsEquivalentTo(["url", "file", "release", "ci", "source"]);
     }
 
+    [Test]
+    public async Task Ordinary_One_Of_Prose_Does_Not_Create_An_Enum()
+    {
+        var command = await Parse(
+            ["kind", "create", "cluster"],
+            """
+            Create a cluster
+
+            Usage:
+              kind create cluster [flags]
+
+            Flags:
+                  --sparse-checkout strings   list of directories; the configured path must be one of them, accepts comma-separated values
+            """);
+
+        var option = command.Options.Single(option => option.SwitchName == "--sparse-checkout");
+        await Assert.That(option.EnumDefinition).IsNull();
+        await Assert.That(option.CSharpType).IsEqualTo("IEnumerable<string>?");
+    }
+
     private static async Task<CliCommandDefinition> Parse(string[] commandPath, string helpText) =>
         (await new TestKindCliScraper().Parse(commandPath, helpText))!;
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KindCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KindCliScraperTests.cs
@@ -98,10 +98,12 @@ public class KindCliScraperTests
         string expectedValues)
     {
         var command = await Parse(
-            [toolName],
+            [toolName, "run"],
             $"""
+             {toolName} production enum fixture
+
              Usage:
-               {toolName} [flags]
+               {toolName} run [flags]
 
              Flags:
                    --value string   {description}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KindCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KindCliScraperTests.cs
@@ -83,6 +83,36 @@ public class KindCliScraperTests
         await Assert.That(option.CSharpType).IsEqualTo("IEnumerable<string>?");
     }
 
+    [Test]
+    [Arguments(
+        "docker",
+        """Set the logging level ("debug", "info", "warn", "error", "fatal")""",
+        "debug,info,warn,error,fatal")]
+    [Arguments(
+        "kubectl",
+        """Must be "background", "orphan", or "foreground". Selects the deletion cascading strategy.""",
+        "background,orphan,foreground")]
+    public async Task Shared_Cobra_Parser_Preserves_Production_Enum_Phrases(
+        string toolName,
+        string description,
+        string expectedValues)
+    {
+        var command = await Parse(
+            [toolName],
+            $"""
+             Usage:
+               {toolName} [flags]
+
+             Flags:
+                   --value string   {description}
+             """);
+
+        var option = command.Options.Single(option => option.SwitchName == "--value");
+        await Assert.That(option.EnumDefinition).IsNotNull();
+        await Assert.That(option.EnumDefinition!.Values.Select(value => value.CliValue))
+            .IsEquivalentTo(expectedValues.Split(','));
+    }
+
     private static async Task<CliCommandDefinition> Parse(string[] commandPath, string helpText) =>
         (await new TestKindCliScraper().Parse(commandPath, helpText))!;
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
@@ -15,6 +15,7 @@ public class DescriptionEnumValueParserTests
     [Test]
     [Arguments("Output format (table, json, yaml)", "table,json,yaml")]
     [Arguments("Log types to enable (all, none, api, audit)", "all,none,api,audit")]
+    [Arguments("""Set the logging level ("debug", "info", "warn", "error", "fatal")""", "debug,info,warn,error,fatal")]
     public async Task TryParse_Accepts_Contextual_Parenthesized_Values(string description, string expectedValues)
     {
         var result = DescriptionEnumValueParser.TryParse(description);
@@ -56,6 +57,7 @@ public class DescriptionEnumValueParserTests
     [Test]
     [Arguments("One of: json or yaml", "json,yaml")]
     [Arguments("Optionally specify one of 'url', 'file', 'release' or 'source'", "url,file,release,source")]
+    [Arguments("""Must be "background", "orphan", or "foreground".""", "background,orphan,foreground")]
     public async Task TryParse_Accepts_Prose_Separated_Explicit_Values(
         string description,
         string expectedValues)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
@@ -55,7 +55,7 @@ public class DescriptionEnumValueParserTests
 
     [Test]
     [Arguments("One of: json or yaml", "json,yaml")]
-    [Arguments("Valid values are low and high", "low,high")]
+    [Arguments("Optionally specify one of 'url', 'file', 'release' or 'source'", "url,file,release,source")]
     public async Task TryParse_Accepts_Prose_Separated_Explicit_Values(
         string description,
         string expectedValues)
@@ -65,6 +65,16 @@ public class DescriptionEnumValueParserTests
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.Values).IsEquivalentTo(expectedValues.Split(','));
         await Assert.That(result.MatchKind).IsEqualTo(DescriptionEnumMatchKind.Explicit);
+    }
+
+    [Test]
+    [Arguments("Valid values are low and high")]
+    [Arguments("list of directories; the configured path must be one of them, accepts comma-separated values")]
+    public async Task TryParse_Rejects_Ordinary_Prose(string description)
+    {
+        var result = DescriptionEnumValueParser.TryParse(description);
+
+        await Assert.That(result).IsNull();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
@@ -423,6 +423,7 @@ public class CodeGeneratorOrchestrator
             GlobalOptions = globalOptions,
             SupplementalGlobalOptions = [],
         };
+        toolDefinition = EnumDefinitionStabilizer.Stabilize(toolDefinition, outputDirectory);
         var coverage = CommandCoverageGuard.Evaluate(
             toolDefinition,
             outputDirectory,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/EnumDefinitionStabilizer.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/EnumDefinitionStabilizer.cs
@@ -156,6 +156,8 @@ internal static partial class EnumDefinitionStabilizer
         return values;
     }
 
+    // Description was emitted by generators before EnumValue existed. Retaining this migration
+    // shape preserves established ordinals on the first regeneration of older enum files.
     [GeneratedRegex(
         """\[(?:EnumValue|Description)\("(?<cliValue>(?:\\.|[^"\\])*)"\)\]\s*(?<member>[\p{L}_][\p{L}\p{Nd}_]*)(?:\s*=\s*(?<number>-?\d+))?\s*(?:,|})""")]
     private static partial Regex ExistingEnumValuePattern();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/EnumDefinitionStabilizer.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/EnumDefinitionStabilizer.cs
@@ -1,0 +1,164 @@
+using System.Text.RegularExpressions;
+using ModularPipelines.OptionsGenerator.Models;
+
+namespace ModularPipelines.OptionsGenerator.Generators;
+
+/// <summary>
+/// Preserves the public numeric contract of generated enums across regeneration.
+/// </summary>
+internal static partial class EnumDefinitionStabilizer
+{
+    private static readonly HashSet<string> SuspiciousProseValues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "accepts",
+        "them",
+    };
+
+    public static CliToolDefinition Stabilize(CliToolDefinition tool, string outputDirectory)
+    {
+        var stabilizedEnums = tool.AllEnums.ToDictionary(
+            definition => definition.EnumName,
+            definition => Stabilize(
+                definition,
+                Path.Combine(
+                    outputDirectory,
+                    tool.OutputDirectory,
+                    "Enums",
+                    $"{definition.EnumName}.Generated.cs")),
+            StringComparer.Ordinal);
+
+        var commands = tool.Commands
+            .Select(command => command with
+            {
+                Enums = command.Enums.Select(definition => stabilizedEnums[definition.EnumName]).ToList(),
+                Options = StabilizeOptions(command.Options, stabilizedEnums),
+            })
+            .ToList();
+
+        return tool with
+        {
+            Commands = commands,
+            GlobalOptions = StabilizeOptions(tool.GlobalOptions, stabilizedEnums),
+        };
+    }
+
+    private static IReadOnlyList<CliOptionDefinition> StabilizeOptions(
+        IReadOnlyList<CliOptionDefinition> options,
+        IReadOnlyDictionary<string, CliEnumDefinition> stabilizedEnums) =>
+        options.Select(option => option.EnumDefinition is null
+                ? option
+                : option with { EnumDefinition = stabilizedEnums[option.EnumDefinition.EnumName] })
+            .ToList();
+
+    private static CliEnumDefinition Stabilize(CliEnumDefinition definition, string existingFile)
+    {
+        ValidateValues(definition);
+
+        var existingValues = File.Exists(existingFile)
+            ? ParseExistingValues(File.ReadAllText(existingFile))
+            : [];
+
+        var existingByCliValue = existingValues.ToDictionary(value => value.CliValue, StringComparer.Ordinal);
+        var incomingByCliValue = definition.Values.ToDictionary(value => value.CliValue, StringComparer.Ordinal);
+        var stabilizedValues = new List<CliEnumValue>(definition.Values.Count);
+
+        foreach (var existingValue in existingValues)
+        {
+            if (incomingByCliValue.TryGetValue(existingValue.CliValue, out var incomingValue))
+            {
+                stabilizedValues.Add(incomingValue with { NumericValue = existingValue.NumericValue });
+            }
+        }
+
+        var usedNumericValues = existingValues
+            .Select(value => value.NumericValue)
+            .ToHashSet();
+        var newValues = definition.Values
+            .Where(value => !existingByCliValue.ContainsKey(value.CliValue))
+            .ToList();
+        var nextNumericValue = newValues.Count > 0 && usedNumericValues.Count > 0
+            ? checked(usedNumericValues.Max() + 1)
+            : 0;
+
+        for (var index = 0; index < newValues.Count; index++)
+        {
+            var incomingValue = newValues[index];
+            while (usedNumericValues.Contains(nextNumericValue))
+            {
+                nextNumericValue = checked(nextNumericValue + 1);
+            }
+
+            stabilizedValues.Add(incomingValue with { NumericValue = nextNumericValue });
+            usedNumericValues.Add(nextNumericValue);
+            if (index < newValues.Count - 1)
+            {
+                nextNumericValue = checked(nextNumericValue + 1);
+            }
+        }
+
+        return definition with { Values = stabilizedValues };
+    }
+
+    private static void ValidateValues(CliEnumDefinition definition)
+    {
+        var duplicateCliValue = definition.Values
+            .GroupBy(value => value.CliValue, StringComparer.Ordinal)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicateCliValue is not null)
+        {
+            throw new InvalidOperationException(
+                $"Enum '{definition.EnumName}' contains duplicate CLI value '{duplicateCliValue.Key}'.");
+        }
+
+        var suspiciousValue = definition.Values
+            .FirstOrDefault(value => SuspiciousProseValues.Contains(value.CliValue));
+        if (suspiciousValue is not null)
+        {
+            throw new InvalidOperationException(
+                $"Enum '{definition.EnumName}' contains suspicious prose value '{suspiciousValue.CliValue}'.");
+        }
+    }
+
+    private static IReadOnlyList<ExistingEnumValue> ParseExistingValues(string content)
+    {
+        var values = new List<ExistingEnumValue>();
+        var nextNumericValue = 0;
+
+        foreach (Match match in ExistingEnumValuePattern().Matches(content))
+        {
+            var numericValue = match.Groups["number"].Success
+                ? int.Parse(match.Groups["number"].Value, System.Globalization.CultureInfo.InvariantCulture)
+                : nextNumericValue;
+            var cliValue = Regex.Unescape(match.Groups["cliValue"].Value);
+
+            values.Add(new ExistingEnumValue(cliValue, numericValue));
+            nextNumericValue = checked(numericValue + 1);
+        }
+
+        var duplicateCliValue = values
+            .GroupBy(value => value.CliValue, StringComparer.Ordinal)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicateCliValue is not null)
+        {
+            throw new InvalidOperationException(
+                $"Existing generated enum contains duplicate CLI value '{duplicateCliValue.Key}'.");
+        }
+
+        var duplicateNumericValue = values
+            .GroupBy(value => value.NumericValue)
+            .FirstOrDefault(group => group.Count() > 1);
+        if (duplicateNumericValue is not null)
+        {
+            throw new InvalidOperationException(
+                $"Existing generated enum contains duplicate numeric value '{duplicateNumericValue.Key}'.");
+        }
+
+        return values;
+    }
+
+    [GeneratedRegex(
+        """\[(?:EnumValue|Description)\("(?<cliValue>(?:\\.|[^"\\])*)"\)\]\s*(?<member>[\p{L}_][\p{L}\p{Nd}_]*)(?:\s*=\s*(?<number>-?\d+))?\s*(?:,|})""")]
+    private static partial Regex ExistingEnumValuePattern();
+
+    private sealed record ExistingEnumValue(string CliValue, int NumericValue);
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/EnumGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/EnumGenerator.cs
@@ -71,7 +71,8 @@ public class EnumGenerator : ICodeGenerator
             // Escape special characters in the CLI value for use in string literal
             var escapedCliValue = EscapeStringLiteral(value.CliValue);
             sb.AppendLine($"    [EnumValue(\"{escapedCliValue}\")]");
-            sb.AppendLine($"    {value.MemberName}{(isLast ? "" : ",")}");
+            var numericValue = value.NumericValue is { } number ? $" = {number}" : string.Empty;
+            sb.AppendLine($"    {value.MemberName}{numericValue}{(isLast ? "" : ",")}");
 
             if (!isLast)
             {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -139,7 +139,7 @@ public static partial class GeneratorUtils
         }
 
         var normalizedValue = InvalidIdentifierCharacterPattern().Replace(cliValue, " ");
-        var pascalCase = ToPascalCase(normalizedValue);
+        var pascalCase = ToPascalCasePreservingWordBoundaries(normalizedValue);
         if (string.IsNullOrEmpty(pascalCase))
         {
             return "Unknown";
@@ -197,8 +197,30 @@ public static partial class GeneratorUtils
         return result;
     }
 
+    private static string ToPascalCasePreservingWordBoundaries(string input)
+    {
+        var words = SeparatorPattern()
+            .Split(input)
+            .SelectMany(word => IdentifierWordPattern().Matches(word).Select(match => match.Value));
+        var sb = new StringBuilder();
+
+        foreach (var word in words)
+        {
+            sb.Append(char.ToUpperInvariant(word[0]));
+            if (word.Length > 1)
+            {
+                sb.Append(word[1..].ToLowerInvariant());
+            }
+        }
+
+        return sb.ToString();
+    }
+
     [GeneratedRegex(@"[-_\s]+")]
     private static partial Regex SeparatorPattern();
+
+    [GeneratedRegex(@"\p{Lu}+(?=\p{Lu}\p{Ll}|\p{Nd}|$)|\p{Lu}?\p{Ll}+|\p{Nd}+|\p{Lu}+")]
+    private static partial Regex IdentifierWordPattern();
 
     [GeneratedRegex(@"[^\p{L}\p{Nd}_]")]
     private static partial Regex InvalidIdentifierCharacterPattern();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliEnumDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliEnumDefinition.cs
@@ -40,4 +40,9 @@ public record CliEnumValue
     /// Description for XML documentation.
     /// </summary>
     public string? Description { get; init; }
+
+    /// <summary>
+    /// Stable numeric value preserved from an existing generated enum.
+    /// </summary>
+    public int? NumericValue { get; init; }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -563,20 +563,6 @@ public abstract partial class CobraCliScraper : CliScraperBase
                    minimumValues: 2,
                    maximumValues: 20,
                    validateValues: true)
-               ?? TryCreateEnumDefinition(
-                   propertyName,
-                   className,
-                   OneOfPattern().Match(description),
-                   minimumValues: 1,
-                   maximumValues: int.MaxValue,
-                   validateValues: false)
-               ?? TryCreateEnumDefinition(
-                   propertyName,
-                   className,
-                   ParenthesizedValuesPattern().Match(description),
-                   minimumValues: 2,
-                   maximumValues: 10,
-                   validateValues: true)
                ?? TryCreateEnumDefinitionFromTypeHint(propertyName, className, typeHint);
     }
 
@@ -734,26 +720,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
             return "Unknown";
         }
 
-        var cleaned = sanitized.Replace("-", "_").Replace(".", "_");
-        var parts = cleaned.Split('_', StringSplitOptions.RemoveEmptyEntries);
-        var result = string.Join("", parts.Select(ToPascalCase));
-
-        // Remove any remaining non-identifier characters
-        result = new string(result.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
-
-        if (string.IsNullOrEmpty(result))
-        {
-            return "Unknown";
-        }
-
-        // Ensure the enum member name starts with a letter or underscore (C# identifier requirement)
-        // Handles cases like "82540EM" (VirtualBox NIC type) or "9p" (filesystem protocol)
-        if (!char.IsLetter(result[0]))
-        {
-            result = "_" + result;
-        }
-
-        return result;
+        return GeneratorUtils.ToEnumMemberName(sanitized);
     }
 
     /// <summary>
@@ -1013,14 +980,8 @@ public abstract partial class CobraCliScraper : CliScraperBase
     [GeneratedRegex(@"^\s*(?:(?<short>-\w),\s*)?(?<long>--[\w-]+)(?:(?<default>=)(?<type>[^:\s]*))?:\s*(?<desc>.*)?$", RegexOptions.Multiline)]
     private static partial Regex KubectlOptionPattern();
 
-    [GeneratedRegex(@"[Oo]ne of[:\s]+(?<values>[\w\-|,\s""'`]+?)(?:\s*\(|$|\.|;)", RegexOptions.IgnoreCase)]
-    private static partial Regex OneOfPattern();
-
     [GeneratedRegex(@"allowed values:\s*(?<values>[\w-]+(?:\s*,\s*[\w-]+)+|(?:-\s*[\w-]+\s*){2,})", RegexOptions.IgnoreCase)]
     private static partial Regex AllowedValuesPattern();
-
-    [GeneratedRegex(@"\((?<values>[\w\-]+(?:\s*[|,]\s*[\w\-]+)+)\)")]
-    private static partial Regex ParenthesizedValuesPattern();
 
     /// <summary>
     /// Matches values in Cobra's multi-line "Allowed values" bullet list.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
@@ -78,10 +78,10 @@ internal static partial class DescriptionEnumValueParser
     [GeneratedRegex("""\b(?:must be one of|one of|valid values|allowed values|possible values|accepted values)\b\s*:\s*[\[(]?(?<values>[^\s,|)\]]+(?:(?:\s*(?:\||,)\s*(?:(?:or|and)\s+)?|\s+(?:or|and)\s+)[^\s,|)\]]+)+)""", RegexOptions.IgnoreCase)]
     private static partial Regex ExplicitValuesPattern();
 
-    [GeneratedRegex("""\b(?:must be one of|one of)\b\s+(?<values>["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`](?:(?:\s*(?:,|\bor\b|\band\b)\s*)["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`])+)""", RegexOptions.IgnoreCase)]
+    [GeneratedRegex("""\b(?:must be(?:\s+one of)?|one of)\b\s+(?<values>["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`](?:(?:\s*(?:,|\bor\b|\band\b)\s*)["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`])+)""", RegexOptions.IgnoreCase)]
     private static partial Regex QuotedOneOfValuesPattern();
 
-    [GeneratedRegex("""\b(?:format|types?|mode)\b[^()\r\n]{0,40}\((?<values>[^\s,|)]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|)]+)+)\)""", RegexOptions.IgnoreCase)]
+    [GeneratedRegex("""\b(?:formats?|types?|modes?|levels?)\b[^()\r\n]{0,40}\((?<values>[^\s,|)]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|)]+)+)\)""", RegexOptions.IgnoreCase)]
     private static partial Regex ContextualParenthesizedValuesPattern();
 
     [GeneratedRegex(@"\s*(?:\||,|\b(?:or|and)\b)\s*", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
@@ -78,13 +78,13 @@ internal static partial class DescriptionEnumValueParser
     [GeneratedRegex("""\b(?:must be one of|one of|valid values|allowed values|possible values|accepted values)\b\s*:\s*[\[(]?(?<values>[^\s,|)\]]+(?:(?:\s*(?:\||,)\s*(?:(?:or|and)\s+)?|\s+(?:or|and)\s+)[^\s,|)\]]+)+)""", RegexOptions.IgnoreCase)]
     private static partial Regex ExplicitValuesPattern();
 
-    [GeneratedRegex("""\b(?:must be(?:\s+one of)?|one of)\b\s+(?<values>["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`](?:(?:\s*(?:,|\bor\b|\band\b)\s*)["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`])+)""", RegexOptions.IgnoreCase)]
+    [GeneratedRegex("""\b(?:must be(?:\s+one of)?|one of)\b\s+(?<values>["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`](?:(?:\s*,\s*(?:(?:or|and)\s+)?|\s+(?:or|and)\s+)["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`])+)""", RegexOptions.IgnoreCase)]
     private static partial Regex QuotedOneOfValuesPattern();
 
     [GeneratedRegex("""\b(?:formats?|types?|modes?|levels?)\b[^()\r\n]{0,40}\((?<values>[^\s,|)]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|)]+)+)\)""", RegexOptions.IgnoreCase)]
     private static partial Regex ContextualParenthesizedValuesPattern();
 
-    [GeneratedRegex(@"\s*(?:\||,|\b(?:or|and)\b)\s*", RegexOptions.IgnoreCase)]
+    [GeneratedRegex(@"(?:\s*(?:\||,)\s*(?:(?:or|and)\s+)?|\s+(?:or|and)\s+)", RegexOptions.IgnoreCase)]
     private static partial Regex EnumValueSeparatorPattern();
 
     [GeneratedRegex(@"^(?:or|and)\s+", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
@@ -25,6 +25,12 @@ internal static partial class DescriptionEnumValueParser
             return CreateMatch(explicitMatch, DescriptionEnumMatchKind.Explicit);
         }
 
+        var quotedMatch = QuotedOneOfValuesPattern().Match(description);
+        if (quotedMatch.Success)
+        {
+            return CreateMatch(quotedMatch, DescriptionEnumMatchKind.Explicit);
+        }
+
         var parenthesizedMatch = ContextualParenthesizedValuesPattern().Match(description);
         return parenthesizedMatch.Success
             ? CreateMatch(parenthesizedMatch, DescriptionEnumMatchKind.ContextualParenthesized)
@@ -69,8 +75,11 @@ internal static partial class DescriptionEnumValueParser
         return values is null ? null : new DescriptionEnumMatch(values, matchKind);
     }
 
-    [GeneratedRegex("""\b(?:must be one of|one of|valid values|allowed values|possible values|accepted values)\b(?:\s+are)?\s*:?\s*[\[(]?(?<values>[^\s,|)\]]+(?:(?:\s*(?:\||,)\s*(?:(?:or|and)\s+)?|\s+(?:or|and)\s+)[^\s,|)\]]+)+)""", RegexOptions.IgnoreCase)]
+    [GeneratedRegex("""\b(?:must be one of|one of|valid values|allowed values|possible values|accepted values)\b\s*:\s*[\[(]?(?<values>[^\s,|)\]]+(?:(?:\s*(?:\||,)\s*(?:(?:or|and)\s+)?|\s+(?:or|and)\s+)[^\s,|)\]]+)+)""", RegexOptions.IgnoreCase)]
     private static partial Regex ExplicitValuesPattern();
+
+    [GeneratedRegex("""\b(?:must be one of|one of)\b\s+(?<values>["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`](?:(?:\s*(?:,|\bor\b|\band\b)\s*)["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`])+)""", RegexOptions.IgnoreCase)]
+    private static partial Regex QuotedOneOfValuesPattern();
 
     [GeneratedRegex("""\b(?:format|types?|mode)\b[^()\r\n]{0,40}\((?<values>[^\s,|)]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|)]+)+)\)""", RegexOptions.IgnoreCase)]
     private static partial Regex ContextualParenthesizedValuesPattern();


### PR DESCRIPTION
Closes #3164.

## Summary
- reject ordinary prose while retaining explicit colon, quoted, parenthesized, and type-hint enum metadata
- preserve PascalCase word boundaries and acronyms in shared enum-member naming
- reconcile generated enums by raw CLI value against existing output
- preserve prior order/ordinals, reserve removed ordinals, and emit explicit numeric values
- reject suspicious prose values and duplicate raw/numeric values before output

## Validation
- `dotnet build tools/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.sln -c Release --no-restore -m:1`
- OptionsGenerator tests: 507 passed
- `dotnet format tools/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.sln --no-restore --include <changed files>`