### PR TITLE
Complete recursive CLI command discovery

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AnsibleCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AnsibleCliScraperTests.cs
@@ -82,14 +82,30 @@ public class AnsibleCliScraperTests
         await Assert.That(GetOption(command, "--private-key").IsSecret).IsTrue();
     }
 
+    [Test]
+    public async Task ScrapeAsync_Validates_Only_The_Matching_Option_Entry()
+    {
+        var scraper = new TestAnsibleCliScraper(new StubExecutor(HelpText));
+        var commands = new List<CliCommandDefinition>();
+
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        var ansible = commands.Single();
+        await Assert.That(GetOption(ansible, "--become-password-file").AcceptsMultipleValues).IsFalse();
+        await Assert.That(GetOption(ansible, "--extra-vars").AcceptsMultipleValues).IsTrue();
+    }
+
     private static CliOptionDefinition GetOption(CliCommandDefinition command, string switchName) =>
         command.Options.Single(option => option.SwitchName == switchName);
 
     private sealed class TestAnsibleCliScraper : AnsibleCliScraper
     {
-        public TestAnsibleCliScraper()
+        public TestAnsibleCliScraper(ICliCommandExecutor? executor = null)
             : base(
-                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                executor ?? new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
                 new HelpTextCache(NullLogger<HelpTextCache>.Instance),
                 NullLogger<AnsibleCliScraper>.Instance)
         {
@@ -97,5 +113,25 @@ public class AnsibleCliScraperTests
 
         public Task<CliCommandDefinition?> Parse(string helpText) =>
             ParseCommandAsync(["ansible"], helpText, CancellationToken.None);
+    }
+
+    private sealed class StubExecutor(string helpText) : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null) =>
+            Task.FromResult(new CliCommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = helpText,
+                StandardError = string.Empty,
+            });
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -56,16 +56,16 @@ public class CliScraperTraversalTests
     }
 
     [Test]
-    public async Task SharedTraversal_Fails_When_Declared_Group_Has_No_Children()
+    public async Task SharedTraversal_Skips_Invalid_Group_And_Continues_With_Sibling()
     {
-        const string emptyGroupHelp = """
+        var emptyGroupHelp = """
             Manage parent resources.
 
             Usage:
               fake parent <command>
 
             Available Commands:
-            """;
+            """.ReplaceLineEndings("\r\n");
         var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["--help"] = """
@@ -76,19 +76,30 @@ public class CliScraperTraversalTests
 
                 Available Commands:
                   parent:  Manage parent resources
+                  sibling: Execute a sibling command
                 """,
             ["parent --help"] = emptyGroupHelp,
+            ["sibling --help"] = """
+                Execute a sibling command.
+
+                Usage:
+                  fake sibling [flags]
+
+                Flags:
+                  --value string   Supply a value
+                """,
         });
         var scraper = new TestCobraScraper(executor);
 
         await Assert.That(scraper.DeclaresCommandGroup(emptyGroupHelp)).IsTrue();
         await Assert.That(scraper.GetSubcommands(emptyGroupHelp)).IsEmpty();
-        await Assert.That(async () =>
-            {
-                await ScrapeAsync(scraper);
-            })
-            .Throws<InvalidOperationException>()
-            .And.HasMessageContaining("no child commands were extracted");
+
+        var commands = await ScrapeAsync(scraper);
+
+        await Assert.That(commands.Select(command => command.FullCommand))
+            .IsEquivalentTo(["fake sibling"]);
+        await Assert.That(executor.Arguments)
+            .IsEquivalentTo(["--help", "parent --help", "sibling --help"]);
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -1,0 +1,195 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers.Cli;
+
+public class CliScraperTraversalTests
+{
+    [Test]
+    public async Task SharedTraversal_Discovers_ExecutableParent_And_Children()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                A tool-neutral CLI.
+
+                Usage:
+                  fake <command> [flags]
+
+                Available Commands:
+                  parent:  Execute or manage parent resources
+                """,
+            ["parent --help"] = """
+                Execute or manage parent resources.
+
+                Usage:
+                  fake parent <command> [flags]
+
+                Available Commands:
+                  child:  Execute a child command
+
+                Flags:
+                  --scope string   Select a scope
+                """,
+            ["parent child --help"] = """
+                Execute a child command.
+
+                Usage:
+                  fake parent child [flags]
+
+                Flags:
+                  --value string   Supply a value
+                """,
+        });
+        var scraper = new TestCobraScraper(executor);
+
+        var commands = await ScrapeAsync(scraper);
+
+        await Assert.That(commands.Select(command => command.FullCommand))
+            .IsEquivalentTo(["fake parent", "fake parent child"]);
+        await Assert.That(commands.Single(command => command.FullCommand == "fake parent").Options)
+            .Contains(option => option.SwitchName == "--scope");
+        await Assert.That(executor.Arguments)
+            .IsEquivalentTo(["--help", "parent --help", "parent child --help"]);
+    }
+
+    [Test]
+    public async Task SharedTraversal_Fails_When_Declared_Group_Has_No_Children()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                A broken CLI.
+
+                Usage:
+                  fake <command>
+
+                Available Commands:
+                  parent:  Manage parent resources
+                """,
+            ["parent --help"] = """
+                Manage parent resources.
+
+                Usage:
+                  fake parent <command>
+
+                Available Commands:
+                """,
+        });
+        var scraper = new TestCobraScraper(executor);
+
+        await Assert.That(() => ScrapeForExceptionAssertionAsync(scraper))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("no child commands were extracted");
+    }
+
+    [Test]
+    public async Task SharedShapeInference_Models_Documented_Repeatability()
+    {
+        const string helpText = """
+            Execute a command.
+
+            Usage:
+              fake execute [flags]
+
+            Flags:
+              --tag string   May be specified multiple times
+            """;
+        var scraper = new TestCobraScraper(new StubExecutor(
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)));
+
+        var command = await scraper.Parse(["fake", "execute"], helpText);
+        var tag = command!.Options.Single();
+
+        await Assert.That(tag.AcceptsMultipleValues).IsTrue();
+        await Assert.That(tag.CSharpType).IsEqualTo("IEnumerable<string>?");
+    }
+
+    private static async Task<IReadOnlyList<CliCommandDefinition>?> ScrapeForExceptionAssertionAsync(
+        ICliScraper scraper) =>
+        await ScrapeAsync(scraper);
+
+    private static async Task<IReadOnlyList<CliCommandDefinition>> ScrapeAsync(ICliScraper scraper)
+    {
+        var commands = new List<CliCommandDefinition>();
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        return commands;
+    }
+
+    private sealed class TestCobraScraper : CobraCliScraper
+    {
+        public TestCobraScraper(ICliCommandExecutor executor)
+            : base(
+                executor,
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<TestCobraScraper>.Instance)
+        {
+        }
+
+        public override string ToolName => "fake";
+
+        public override string NamespacePrefix => "Fake";
+
+        public override string TargetNamespace => "ModularPipelines.Fake";
+
+        public override string OutputDirectory => "src/ModularPipelines.Fake";
+
+        protected override int MaxParallelism => 2;
+
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+    }
+
+    private sealed class StubExecutor(IReadOnlyDictionary<string, string> helpByArguments)
+        : ICliCommandExecutor
+    {
+        private readonly object _gate = new();
+        private readonly List<string> _arguments = [];
+
+        public IReadOnlyList<string> Arguments
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _arguments.ToArray();
+                }
+            }
+        }
+
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            lock (_gate)
+            {
+                _arguments.Add(arguments);
+            }
+
+            if (!helpByArguments.TryGetValue(arguments, out var helpText))
+            {
+                throw new InvalidOperationException($"Unexpected arguments: {arguments}");
+            }
+
+            return Task.FromResult(new CliCommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = helpText,
+                StandardError = string.Empty,
+            });
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -58,6 +58,14 @@ public class CliScraperTraversalTests
     [Test]
     public async Task SharedTraversal_Fails_When_Declared_Group_Has_No_Children()
     {
+        const string emptyGroupHelp = """
+            Manage parent resources.
+
+            Usage:
+              fake parent <command>
+
+            Available Commands:
+            """;
         var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["--help"] = """
@@ -69,18 +77,16 @@ public class CliScraperTraversalTests
                 Available Commands:
                   parent:  Manage parent resources
                 """,
-            ["parent --help"] = """
-                Manage parent resources.
-
-                Usage:
-                  fake parent <command>
-
-                Available Commands:
-                """,
+            ["parent --help"] = emptyGroupHelp,
         });
         var scraper = new TestCobraScraper(executor);
 
-        await Assert.That(() => ScrapeForExceptionAssertionAsync(scraper))
+        await Assert.That(scraper.DeclaresCommandGroup(emptyGroupHelp)).IsTrue();
+        await Assert.That(scraper.GetSubcommands(emptyGroupHelp)).IsEmpty();
+        await Assert.That(async () =>
+            {
+                await ScrapeAsync(scraper);
+            })
             .Throws<InvalidOperationException>()
             .And.HasMessageContaining("no child commands were extracted");
     }
@@ -107,9 +113,28 @@ public class CliScraperTraversalTests
         await Assert.That(tag.CSharpType).IsEqualTo("IEnumerable<string>?");
     }
 
-    private static async Task<IReadOnlyList<CliCommandDefinition>?> ScrapeForExceptionAssertionAsync(
-        ICliScraper scraper) =>
-        await ScrapeAsync(scraper);
+    [Test]
+    public async Task SharedTraversal_Skips_One_Invalid_Option_Shape()
+    {
+        const string helpText = """
+            Execute a command.
+
+            Usage:
+              fake [flags]
+
+            Flags:
+              --tag string   May be specified multiple times
+            """;
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = helpText,
+        });
+        var scraper = new ShapeMismatchScraper(executor);
+
+        var commands = await ScrapeAsync(scraper);
+
+        await Assert.That(commands).IsEmpty();
+    }
 
     private static async Task<IReadOnlyList<CliCommandDefinition>> ScrapeAsync(ICliScraper scraper)
     {
@@ -144,6 +169,54 @@ public class CliScraperTraversalTests
 
         public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
             ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+
+        public bool DeclaresCommandGroup(string helpText) => HelpDeclaresCommandGroup(helpText);
+
+        public IReadOnlyList<string> GetSubcommands(string helpText) => ExtractSubcommands(helpText).ToList();
+    }
+
+    private sealed class ShapeMismatchScraper : CliScraperBase
+    {
+        public ShapeMismatchScraper(ICliCommandExecutor executor)
+            : base(
+                executor,
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<ShapeMismatchScraper>.Instance)
+        {
+        }
+
+        public override string ToolName => "fake";
+
+        public override string NamespacePrefix => "Fake";
+
+        public override string TargetNamespace => "ModularPipelines.Fake";
+
+        public override string OutputDirectory => "src/ModularPipelines.Fake";
+
+        protected override IEnumerable<string> ExtractSubcommands(string helpText) => [];
+
+        protected override Task<CliCommandDefinition?> ParseCommandAsync(
+            string[] commandPath,
+            string helpText,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<CliCommandDefinition?>(new CliCommandDefinition
+            {
+                FullCommand = "fake",
+                CommandParts = [],
+                ClassName = "FakeOptions",
+                ParentClassName = "FakeOptions",
+                ToolNamespacePrefix = "Fake",
+                Options =
+                [
+                    new CliOptionDefinition
+                    {
+                        SwitchName = "--tag",
+                        PropertyName = "Tag",
+                        CSharpType = "string?",
+                        Description = "May be specified multiple times",
+                    },
+                ],
+            });
     }
 
     private sealed class StubExecutor(IReadOnlyDictionary<string, string> helpByArguments)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
@@ -86,6 +86,99 @@ public class ZeroOutputScraperTests
     }
 
     [Test]
+    public async Task Gh_Extracts_General_And_Targeted_Child_Commands()
+    {
+        const string helpText = """
+            Work with GitHub issues.
+
+            USAGE
+              gh issue <command> [flags]
+
+            GENERAL COMMANDS
+              create:        Create a new issue
+              list:          List issues in a repository
+              status:        Show status of relevant issues
+
+            TARGETED COMMANDS
+              close:         Close issue
+              view:          View an issue
+
+            FLAGS
+              -R, --repo [HOST/]OWNER/REPO   Select another repository
+            """;
+
+        await Assert.That(new TestGhCliScraper().Extract(helpText))
+            .IsEquivalentTo(["create", "list", "status", "close", "view"]);
+    }
+
+    [Test]
+    public async Task Gh_Extracts_Core_Pr_Child_Commands()
+    {
+        const string helpText = """
+            Work with GitHub pull requests.
+
+            USAGE
+              gh pr <command> [flags]
+
+            GENERAL COMMANDS
+              create:        Create a pull request
+              list:          List pull requests
+
+            TARGETED COMMANDS
+              checkout:      Check out a pull request
+              merge:         Merge a pull request
+              view:          View a pull request
+            """;
+
+        await Assert.That(new TestGhCliScraper().Extract(helpText))
+            .IsEquivalentTo(["create", "list", "checkout", "merge", "view"]);
+    }
+
+    [Test]
+    public async Task Gh_Api_Models_Field_And_Header_Options_As_Repeatable()
+    {
+        const string helpText = """
+            Makes an authenticated HTTP request.
+
+            USAGE
+              gh api <endpoint> [flags]
+
+            FLAGS
+              -F, --field key=value       Add a typed parameter
+              -H, --header key:value      Add a HTTP request header
+              -f, --raw-field key=value   Add a string parameter
+            """;
+
+        var command = await new TestGhCliScraper().Parse(["gh", "api"], helpText);
+
+        await Assert.That(command).IsNotNull();
+        await Assert.That(command!.Options.All(option => option.AcceptsMultipleValues)).IsTrue();
+        await Assert.That(command.Options.Select(option => option.CSharpType))
+            .IsEquivalentTo(Enumerable.Repeat("IEnumerable<string>?", 3));
+    }
+
+    [Test]
+    public async Task Gh_Search_Models_Explicit_Boolean_Filter_As_Value_Taking()
+    {
+        const string helpText = """
+            Search for issues on GitHub.
+
+            USAGE
+              gh search issues [<query>] [flags]
+
+            FLAGS
+                  --archived   Filter based on the repository archived state {true|false}
+            """;
+
+        var command = await new TestGhCliScraper().Parse(["gh", "search", "issues"], helpText);
+        var archived = command!.Options.Single();
+
+        await Assert.That(archived.IsFlag).IsFalse();
+        await Assert.That(archived.CSharpType).IsEqualTo("bool?");
+        await Assert.That(archived.ValueSeparator).IsEqualTo("=");
+    }
+
+    [Test]
     public async Task Yarn_Extracts_Classic_Bulleted_Command_List()
     {
         const string helpText = """
@@ -124,6 +217,8 @@ public class ZeroOutputScraperTests
 
         public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
             ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+
+        public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
     }
 
     private sealed class TestYarnCliScraper : YarnCliScraper

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -376,6 +376,10 @@ public abstract partial class CliScraperBase : ICliScraper
         try
         {
             command = await ParseCommandAsync(path, helpText, cancellationToken);
+            if (command is not null)
+            {
+                ValidateOptionShapes(command, helpText);
+            }
         }
         catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
         {
@@ -385,7 +389,6 @@ public abstract partial class CliScraperBase : ICliScraper
 
         if (command is not null)
         {
-            ValidateOptionShapes(command, helpText);
             await commandChannel.Writer.WriteAsync(command, cancellationToken);
         }
     }
@@ -692,11 +695,31 @@ public abstract partial class CliScraperBase : ICliScraper
         }
 
         var optionPattern = $@"(?<![\w-]){Regex.Escape(switchName)}(?![\w-])";
-        return helpText
-            .ReplaceLineEndings("\n")
-            .Split("\n\n", StringSplitOptions.RemoveEmptyEntries)
-            .Where(paragraph => Regex.IsMatch(paragraph, optionPattern, RegexOptions.IgnoreCase))
-            .Any(paragraph => RepeatableValuePattern().IsMatch(paragraph));
+        var lines = helpText.ReplaceLineEndings("\n").Split('\n');
+
+        for (var index = 0; index < lines.Length; index++)
+        {
+            if (!OptionLinePattern().IsMatch(lines[index])
+                || !Regex.IsMatch(lines[index], optionPattern, RegexOptions.IgnoreCase))
+            {
+                continue;
+            }
+
+            var end = index + 1;
+            while (end < lines.Length
+                   && !string.IsNullOrWhiteSpace(lines[end])
+                   && !OptionLinePattern().IsMatch(lines[end]))
+            {
+                end++;
+            }
+
+            if (RepeatableValuePattern().IsMatch(string.Join('\n', lines[index..end])))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static void ValidateOptionShapes(CliCommandDefinition command, string helpText)
@@ -724,7 +747,9 @@ public abstract partial class CliScraperBase : ICliScraper
     /// <summary>
     /// Pattern to match option lines (e.g., "-f, --flag" or "--option").
     /// </summary>
-    [GeneratedRegex(@"^\s*(?:-\w,\s*)?--[\w-]+", RegexOptions.Multiline)]
+    [GeneratedRegex(
+        @"^[ \t]*(?:-\w(?:[ \t]+[^,\s]+)?[ \t]*,[ \t]*)?--[\w-]+(?:[ \t]|,|$)",
+        RegexOptions.Multiline)]
     protected static partial Regex OptionLinePattern();
 
     [GeneratedRegex(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.RegularExpressions;
 using System.Threading.Channels;
 using Microsoft.Extensions.Logging;
@@ -148,7 +149,6 @@ public abstract partial class CliScraperBase : ICliScraper
     {
         private int _outstandingWork;
         private readonly Channel<string[]> _workChannel;
-        private readonly TaskCompletionSource _completionSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public WorkCoordinator(Channel<string[]> workChannel)
         {
@@ -175,19 +175,8 @@ public abstract partial class CliScraperBase : ICliScraper
             if (remaining == 0)
             {
                 _workChannel.Writer.TryComplete();
-                _completionSignal.TrySetResult();
             }
         }
-
-        /// <summary>
-        /// Gets a task that completes when all work is done.
-        /// </summary>
-        public Task CompletionTask => _completionSignal.Task;
-
-        /// <summary>
-        /// Current count of outstanding work items (for diagnostics).
-        /// </summary>
-        public int OutstandingWork => Volatile.Read(ref _outstandingWork);
     }
 
     /// <summary>
@@ -224,22 +213,26 @@ public abstract partial class CliScraperBase : ICliScraper
 
         // Coordinator handles completion signaling atomically
         var coordinator = new WorkCoordinator(workChannel);
+        var visitedPaths = new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
 
         // Start discovery with root path - increment BEFORE adding to channel
+        visitedPaths.TryAdd(ToolName, 0);
         coordinator.IncrementWork();
         await workChannel.Writer.WriteAsync([ToolName], cancellationToken);
 
         // Start worker tasks
         var workerTasks = Enumerable.Range(0, MaxParallelism)
-            .Select(_ => ProcessWorkQueueAsync(workChannel, commandChannel, coordinator, cancellationToken))
+            .Select(_ => ProcessWorkQueueAsync(
+                workChannel,
+                commandChannel,
+                coordinator,
+                visitedPaths,
+                cancellationToken))
             .ToList();
 
-        // Background task to complete command channel when all work is done
-        _ = Task.Run(async () =>
-        {
-            await Task.WhenAll(workerTasks);
-            commandChannel.Writer.Complete();
-        }, cancellationToken);
+        // Always complete the result channel, including when a worker faults. Without this,
+        // the consumer can wait forever after a malformed command group fails validation.
+        _ = CompleteCommandChannelAsync(workerTasks, commandChannel);
 
         // Yield commands as they're discovered
         var commandCount = 0;
@@ -261,6 +254,7 @@ public abstract partial class CliScraperBase : ICliScraper
         Channel<string[]> workChannel,
         Channel<CliCommandDefinition> commandChannel,
         WorkCoordinator coordinator,
+        ConcurrentDictionary<string, byte> visitedPaths,
         CancellationToken cancellationToken)
     {
         // ReadAllAsync handles channel completion cleanly - no polling needed
@@ -268,7 +262,13 @@ public abstract partial class CliScraperBase : ICliScraper
         {
             try
             {
-                await ProcessPathAsync(path, workChannel, commandChannel, coordinator, cancellationToken);
+                await ProcessPathAsync(
+                    path,
+                    workChannel,
+                    commandChannel,
+                    coordinator,
+                    visitedPaths,
+                    cancellationToken);
             }
             finally
             {
@@ -286,6 +286,7 @@ public abstract partial class CliScraperBase : ICliScraper
         Channel<string[]> workChannel,
         Channel<CliCommandDefinition> commandChannel,
         WorkCoordinator coordinator,
+        ConcurrentDictionary<string, byte> visitedPaths,
         CancellationToken cancellationToken)
     {
         if (ShouldSkipDeepPath(path))
@@ -310,9 +311,15 @@ public abstract partial class CliScraperBase : ICliScraper
         }
 
         var subcommands = ExtractSubcommands(helpText).ToList();
-        LogMissingRootSubcommands(path, helpText, subcommands);
+        ValidateSubcommandDiscovery(path, helpText, subcommands);
         await ParseAndWriteCommandAsync(path, helpText, subcommands, commandChannel, cancellationToken);
-        await EnqueueSubcommandsAsync(path, subcommands, workChannel, coordinator, cancellationToken);
+        await EnqueueSubcommandsAsync(
+            path,
+            subcommands,
+            workChannel,
+            coordinator,
+            visitedPaths,
+            cancellationToken);
     }
 
     private bool ShouldSkipDeepPath(string[] path)
@@ -338,21 +345,19 @@ public abstract partial class CliScraperBase : ICliScraper
         return true;
     }
 
-    private void LogMissingRootSubcommands(
+    private void ValidateSubcommandDiscovery(
         string[] path,
         string helpText,
         IReadOnlyCollection<string> subcommands)
     {
-        if (path.Length != 1 || subcommands.Count != 0)
+        if (subcommands.Count != 0 || !HelpDeclaresCommandGroup(helpText))
         {
             return;
         }
 
-        Logger.LogWarning(
-            "[{Tool}] No subcommands extracted from root help text. Help text length: {Length} chars. First 500 chars: {Preview}",
-            ToolName,
-            helpText.Length,
-            helpText.Length > 500 ? helpText[..500] : helpText);
+        throw new InvalidOperationException(
+            $"{string.Join(' ', path)} help declares a command group, but no child commands were extracted. "
+            + "Update the shared command-section parser or the tool adapter before generating partial output.");
     }
 
     private async Task ParseAndWriteCommandAsync(
@@ -367,17 +372,21 @@ public abstract partial class CliScraperBase : ICliScraper
             return;
         }
 
+        CliCommandDefinition? command;
         try
         {
-            var command = await ParseCommandAsync(path, helpText, cancellationToken);
-            if (command is not null)
-            {
-                await commandChannel.Writer.WriteAsync(command, cancellationToken);
-            }
+            command = await ParseCommandAsync(path, helpText, cancellationToken);
         }
         catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
         {
             Logger.LogWarning(ex, "Failed to parse command: {Command}", string.Join(" ", path));
+            return;
+        }
+
+        if (command is not null)
+        {
+            ValidateOptionShapes(command, helpText);
+            await commandChannel.Writer.WriteAsync(command, cancellationToken);
         }
     }
 
@@ -386,6 +395,7 @@ public abstract partial class CliScraperBase : ICliScraper
         IEnumerable<string> subcommands,
         Channel<string[]> workChannel,
         WorkCoordinator coordinator,
+        ConcurrentDictionary<string, byte> visitedPaths,
         CancellationToken cancellationToken)
     {
         foreach (var subcommand in subcommands)
@@ -396,10 +406,33 @@ public abstract partial class CliScraperBase : ICliScraper
             }
 
             var childPath = path.Append(subcommand).ToArray();
+            if (!visitedPaths.TryAdd(string.Join(' ', childPath), 0))
+            {
+                continue;
+            }
+
             // Increment before writing to avoid completing the work queue before the child is visible.
             coordinator.IncrementWork();
             await workChannel.Writer.WriteAsync(childPath, cancellationToken);
         }
+    }
+
+    private static async Task CompleteCommandChannelAsync(
+        IReadOnlyCollection<Task> workerTasks,
+        Channel<CliCommandDefinition> commandChannel)
+    {
+        Exception? failure = null;
+
+        try
+        {
+            await Task.WhenAll(workerTasks);
+        }
+        catch (Exception ex)
+        {
+            failure = ex;
+        }
+
+        commandChannel.Writer.TryComplete(failure);
     }
 
     /// <summary>
@@ -501,6 +534,15 @@ public abstract partial class CliScraperBase : ICliScraper
                helpText.Contains("Global Flags:") ||
                OptionLinePattern().IsMatch(helpText);
     }
+
+    /// <summary>
+    /// Returns whether help declares a parent command group that must have discoverable children.
+    /// Requiring both a usage placeholder and a command-section heading avoids confusing ordinary
+    /// positional operands named "command" with command-tree nodes.
+    /// </summary>
+    protected virtual bool HelpDeclaresCommandGroup(string helpText) =>
+        CommandGroupUsagePattern().IsMatch(helpText)
+        && CommandSectionHeadingPattern().IsMatch(helpText);
 
     /// <summary>
     /// Default subcommands to always skip.
@@ -631,10 +673,77 @@ public abstract partial class CliScraperBase : ICliScraper
     protected static string ToPascalCase(string input) => GeneratorUtils.ToPascalCase(input);
 
     /// <summary>
+    /// Returns whether an option description requires an explicit Boolean value.
+    /// </summary>
+    protected static bool HelpDeclaresExplicitBooleanValue(string description) =>
+        ExplicitBooleanValuePattern().IsMatch(description);
+
+    /// <summary>
+    /// Returns whether help describes an option as repeatable.
+    /// </summary>
+    protected static bool HelpDeclaresRepeatableOption(
+        string helpText,
+        string switchName,
+        string description)
+    {
+        if (RepeatableValuePattern().IsMatch(description))
+        {
+            return true;
+        }
+
+        var optionPattern = $@"(?<![\w-]){Regex.Escape(switchName)}(?![\w-])";
+        return helpText
+            .ReplaceLineEndings("\n")
+            .Split("\n\n", StringSplitOptions.RemoveEmptyEntries)
+            .Where(paragraph => Regex.IsMatch(paragraph, optionPattern, RegexOptions.IgnoreCase))
+            .Any(paragraph => RepeatableValuePattern().IsMatch(paragraph));
+    }
+
+    private static void ValidateOptionShapes(CliCommandDefinition command, string helpText)
+    {
+        foreach (var option in command.Options)
+        {
+            var description = option.Description ?? string.Empty;
+            if (HelpDeclaresExplicitBooleanValue(description) && option.IsFlag)
+            {
+                throw new InvalidOperationException(
+                    $"{command.FullCommand} {option.SwitchName} declares explicit true/false values, "
+                    + "but the parsed model marks it as a presence-only flag.");
+            }
+
+            if (HelpDeclaresRepeatableOption(helpText, option.SwitchName, description)
+                && !option.AcceptsMultipleValues)
+            {
+                throw new InvalidOperationException(
+                    $"{command.FullCommand} {option.SwitchName} is documented as repeatable, "
+                    + "but the parsed model is scalar.");
+            }
+        }
+    }
+
+    /// <summary>
     /// Pattern to match option lines (e.g., "-f, --flag" or "--option").
     /// </summary>
     [GeneratedRegex(@"^\s*(?:-\w,\s*)?--[\w-]+", RegexOptions.Multiline)]
     protected static partial Regex OptionLinePattern();
+
+    [GeneratedRegex(
+        @"^[ \t]*(?:Usage:?[ \t]*(?:\r?\n[ \t]*)?)?[^\r\n]*(?:<command>|\[command\])[^\r\n]*$",
+        RegexOptions.IgnoreCase | RegexOptions.Multiline)]
+    private static partial Regex CommandGroupUsagePattern();
+
+    [GeneratedRegex(@"^[ \t]*[A-Z][A-Z0-9 _/-]*COMMANDS?:?[ \t]*$", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
+    private static partial Regex CommandSectionHeadingPattern();
+
+    [GeneratedRegex(
+        @"(?:[\[{(<]\s*true\s*(?:\||/|or)\s*false\s*[\]})>]|(?:boolean|bool)\s+value|true\s+or\s+false)",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex ExplicitBooleanValuePattern();
+
+    [GeneratedRegex(
+        @"\b(?:one\s+or\s+more|zero\s+or\s+more|multiple\s+(?:times|values)|more\s+than\s+once|repeat(?:able|ed|edly)?)\b",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex RepeatableValuePattern();
 
     #endregion
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -231,7 +231,7 @@ public abstract partial class CliScraperBase : ICliScraper
             .ToList();
 
         // Always complete the result channel, including when a worker faults. Without this,
-        // the consumer can wait forever after a malformed command group fails validation.
+        // the consumer can wait forever after an unexpected traversal failure.
         _ = CompleteCommandChannelAsync(workerTasks, commandChannel);
 
         // Yield commands as they're discovered
@@ -311,7 +311,16 @@ public abstract partial class CliScraperBase : ICliScraper
         }
 
         var subcommands = ExtractSubcommands(helpText).ToList();
-        ValidateSubcommandDiscovery(path, helpText, subcommands);
+        try
+        {
+            ValidateSubcommandDiscovery(path, helpText, subcommands);
+        }
+        catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
+        {
+            Logger.LogWarning(ex, "Failed to validate subcommand discovery: {Command}", string.Join(" ", path));
+            return;
+        }
+
         await ParseAndWriteCommandAsync(path, helpText, subcommands, commandChannel, cancellationToken);
         await EnqueueSubcommandsAsync(
             path,
@@ -753,11 +762,11 @@ public abstract partial class CliScraperBase : ICliScraper
     protected static partial Regex OptionLinePattern();
 
     [GeneratedRegex(
-        @"^[ \t]*(?:Usage:?[ \t]*(?:\r?\n[ \t]*)?)?[^\r\n]*(?:<command>|\[command\])[^\r\n]*$",
+        @"^[ \t]*(?:Usage:?[ \t]*(?:\r?\n[ \t]*)?)?[^\r\n]*(?:<command>|\[command\])[^\r\n]*\r?$",
         RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex CommandGroupUsagePattern();
 
-    [GeneratedRegex(@"^[ \t]*[A-Z][A-Z0-9 _/-]*COMMANDS?:?[ \t]*$", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
+    [GeneratedRegex(@"^[ \t]*[A-Z][A-Z0-9 _/-]*COMMANDS?:?[ \t]*\r?$", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex CommandSectionHeadingPattern();
 
     [GeneratedRegex(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -309,7 +309,13 @@ public abstract partial class CobraCliScraper : CliScraperBase
                 var isInteger = IsKnownIntegerType(actualType);
                 var isFloat = IsKnownFloatType(actualType);
                 var isDuration = IsKnownDurationType(actualType);
-                var isArray = IsKnownArrayType(actualType);
+                var isArray = IsKnownArrayType(actualType)
+                              || IsRepeatableOption(
+                                  commandParts,
+                                  longForm,
+                                  actualType,
+                                  description,
+                                  helpText);
                 var isKeyValue = IsKnownKeyValueType(actualType);
 
                 // Try to detect enum values
@@ -397,6 +403,20 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// Applies tool-specific normalization before option descriptions are generated.
     /// </summary>
     protected virtual string NormalizeOptionDescription(string description) => description;
+
+    /// <summary>
+    /// Determines whether an option accepts repeated values when the source type is scalar.
+    /// Tool adapters may extend this for repeatability that their help format does not encode
+    /// directly; the resulting cardinality remains shared <see cref="CliOptionDefinition"/>
+    /// metadata.
+    /// </summary>
+    protected virtual bool IsRepeatableOption(
+        string[] commandParts,
+        string switchName,
+        string typeHint,
+        string description,
+        string helpText) =>
+        HelpDeclaresRepeatableOption(helpText, switchName, description);
 
     /// <summary>
     /// Extracts the Flags and Global Flags sections from help text.
@@ -804,7 +824,8 @@ public abstract partial class CobraCliScraper : CliScraperBase
         string[] commandParts,
         string switchName,
         string description) =>
-        description.Contains("(default true)", StringComparison.OrdinalIgnoreCase);
+        description.Contains("(default true)", StringComparison.OrdinalIgnoreCase)
+        || HelpDeclaresExplicitBooleanValue(description);
 
     #region Type Detection - HashSet-based for extensibility
 
@@ -942,13 +963,15 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// "Common Commands:", "Management Commands:", "Swarm Commands:", "Scanning Commands:",
     /// "Utility Commands:", etc. Uses a flexible pattern to match any word prefix.
     /// </summary>
-    [GeneratedRegex(@"^[A-Z][\w ]*Commands?:?\s*$", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^[A-Z][\w ]*Commands?:?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex CommandsSectionPattern();
 
     /// <summary>
     /// Matches section headers like "Flags:", "Usage:", etc.
     /// </summary>
-    [GeneratedRegex(@"^(?:[A-Z][\w\s]*:|[A-Z][\w ]*(?:Commands|Flags|Options|Usage|Examples))\s*$", RegexOptions.Multiline)]
+    [GeneratedRegex(
+        @"^(?:[A-Z][\w\s]*:|[A-Z][\w ]*(?:Commands|Flags|Options|Usage|Examples))\s*$",
+        RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex SectionHeaderPattern();
 
     /// <summary>
@@ -956,7 +979,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// or "command    description".
     /// Also handles Docker's asterisk markers for extensions: "  buildx*    description"
     /// </summary>
-    [GeneratedRegex(@"^\s*(?<name>[\w-]+)\*?\s+", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^\s*(?<name>[\w-]+)\*?:?\s+", RegexOptions.Multiline)]
     private static partial Regex SubcommandLinePattern();
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GhCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GhCliScraper.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -26,6 +25,13 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 /// </summary>
 public partial class GhCliScraper : CobraCliScraper
 {
+    private static readonly HashSet<string> RepeatableOptions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "--field",
+        "--raw-field",
+        "--header",
+    };
+
     public GhCliScraper(ICliCommandExecutor executor, IHelpTextCache helpCache, ILogger<GhCliScraper> logger)
         : base(executor, helpCache, logger)
     {
@@ -49,126 +55,13 @@ public partial class GhCliScraper : CobraCliScraper
         "accessibility", "actions", "environment", "exit-codes", "formatting", "mintty", "reference"
     };
 
-    /// <summary>
-    /// Extracts subcommand names from gh help text.
-    /// gh uses "command:" format (with colon after command name).
-    /// Only extracts from COMMANDS sections, not HELP TOPICS.
-    /// </summary>
-    protected override IEnumerable<string> ExtractSubcommands(string helpText)
-    {
-        var subcommands = new List<string>();
-        var seenCommands = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        // Normalize line endings for consistent parsing
-        var normalizedText = helpText.Replace("\r\n", "\n").Replace("\r", "\n");
-
-        // Collect all command section matches
-        var sectionMatches = new List<Match>();
-
-        // Try primary pattern for gh-specific sections (CORE COMMANDS, etc.)
-        var commandsSectionMatches = GhCommandsSectionPattern().Matches(normalizedText);
-        foreach (Match m in commandsSectionMatches)
-        {
-            sectionMatches.Add(m);
-        }
-
-        // Also try fallback pattern for standard Cobra "Commands:" sections
-        var fallbackMatches = FallbackCommandsSectionPattern().Matches(normalizedText);
-        foreach (Match m in fallbackMatches)
-        {
-            sectionMatches.Add(m);
-        }
-
-        if (sectionMatches.Count == 0)
-        {
-            Logger.LogWarning("[gh] No COMMANDS sections found in help text. Tried GhCommandsSectionPattern and FallbackCommandsSectionPattern");
-            return subcommands;
-        }
-
-        Logger.LogDebug("[gh] Found {Count} command sections in help text", sectionMatches.Count);
-
-        foreach (var sectionMatch in sectionMatches)
-        {
-            var sectionStart = sectionMatch.Index + sectionMatch.Length;
-
-            // Find where this section ends (next ALL-CAPS section header)
-            var sectionEnd = normalizedText.Length;
-            var nextSectionMatch = GhSectionHeaderPattern().Match(normalizedText, sectionStart);
-            if (nextSectionMatch.Success)
-            {
-                sectionEnd = nextSectionMatch.Index;
-            }
-
-            var section = normalizedText.Substring(sectionStart, sectionEnd - sectionStart);
-
-            // Parse command lines in this section only
-            var lines = section.Split('\n');
-            foreach (var line in lines)
-            {
-                // Try gh-specific pattern first (command: description)
-                var match = GhSubcommandLinePattern().Match(line);
-                if (!match.Success)
-                {
-                    // Try standard Cobra pattern (command    description)
-                    match = FallbackSubcommandLinePattern().Match(line);
-                }
-
-                if (match.Success)
-                {
-                    var commandName = match.Groups["name"].Value.Trim();
-                    if (!string.IsNullOrEmpty(commandName) &&
-                        !commandName.Contains(' ') &&
-                        commandName.Length > 1 &&
-                        seenCommands.Add(commandName))
-                    {
-                        subcommands.Add(commandName);
-                    }
-                }
-            }
-        }
-
-        Logger.LogInformation("Extracted {Count} subcommands from gh help", subcommands.Count);
-        return subcommands;
-    }
-
-    #region Regex Patterns
-
-    /// <summary>
-    /// Matches COMMANDS section headers (but NOT HELP TOPICS or other non-command sections).
-    /// Includes AVAILABLE COMMANDS which is used in newer gh versions and subcommand help.
-    /// </summary>
-    [GeneratedRegex(@"^(?:CORE|ADDITIONAL|GITHUB\s+ACTIONS|ALIAS|AVAILABLE)\s+COMMANDS\s*$", RegexOptions.Multiline | RegexOptions.IgnoreCase)]
-    private static partial Regex GhCommandsSectionPattern();
-
-    /// <summary>
-    /// Matches any ALL-CAPS section header (used to find section boundaries).
-    /// </summary>
-    [GeneratedRegex(@"^[A-Z][A-Z\s]+$", RegexOptions.Multiline)]
-    private static partial Regex GhSectionHeaderPattern();
-
-    /// <summary>
-    /// Matches FLAGS section header.
-    /// </summary>
-    [GeneratedRegex(@"^FLAGS\s*$", RegexOptions.Multiline | RegexOptions.IgnoreCase)]
-    private static partial Regex GhFlagsSectionPattern();
-
-    /// <summary>
-    /// Matches gh subcommand lines: "  command:    description"
-    /// </summary>
-    [GeneratedRegex(@"^\s{2}(?<name>[\w-]+):\s+\S", RegexOptions.Multiline)]
-    private static partial Regex GhSubcommandLinePattern();
-
-    /// <summary>
-    /// Fallback pattern for standard Cobra-style "Commands:" or "Available Commands:" sections.
-    /// </summary>
-    [GeneratedRegex(@"(?:\w+\s+)?[Cc]ommands?:\s*\n", RegexOptions.Multiline)]
-    private static partial Regex FallbackCommandsSectionPattern();
-
-    /// <summary>
-    /// Fallback pattern for standard Cobra subcommand lines: "  command    description"
-    /// </summary>
-    [GeneratedRegex(@"^\s{2,}(?<name>[\w-]+)\s{2,}", RegexOptions.Multiline)]
-    private static partial Regex FallbackSubcommandLinePattern();
-
-    #endregion
+    /// <inheritdoc />
+    protected override bool IsRepeatableOption(
+        string[] commandParts,
+        string switchName,
+        string typeHint,
+        string description,
+        string helpText) =>
+        RepeatableOptions.Contains(switchName)
+        || base.IsRepeatableOption(commandParts, switchName, typeHint, description, helpText);
 }


### PR DESCRIPTION
## Summary

- make shared Cobra discovery understand all command-section headings and colon-delimited rows, restoring gh issue/pr children
- harden recursive traversal with duplicate-path suppression, declared-empty-group validation, and fault propagation that cannot hang the result channel
- infer shared repeatable cardinality and explicit-value Boolean shapes, with gh API field/header metadata
- add gh issue/pr/api/search regressions plus tool-neutral tree and cardinality fixtures

This composes with #3202 (value arity), #3204 (executable parent exposure), and #3209 (persisted coverage baselines). Shared positional parsing remains tracked by #3161 as requested in this issue.

## Validation

- `ModularPipelines.OptionsGenerator.sln` builds with 0 errors
- `ModularPipelines.OptionsGenerator.Tests`: 505/505 passed

Closes #3162