### PR TITLE
Parse positional operands through shared CLI model

### DIFF
--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -186,7 +186,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 PropertyKind.Argument,
                 GetNamedString(attribute, "Name"),
                 null,
-                false,
+                GetNamedBool(attribute, "PrependOptionTerminator"),
                 GetConstructorInt(attribute),
                 GetNamedInt(attribute, "Placement"),
                 GetNamedInt(attribute, "Phase", defaultValue: PassthroughCommandLinePhase),
@@ -300,6 +300,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     sb.AppendLine($"                        Placement = (global::ModularPipelines.Attributes.ArgumentPlacement){property.SecondInt},");
                     sb.AppendLine($"                        Phase = (global::ModularPipelines.Attributes.CommandLinePhase){property.Phase},");
                     sb.AppendLine($"                        Name = {NullableLiteral(property.PrimaryValue)},");
+                    sb.AppendLine($"                        PrependOptionTerminator = {BooleanLiteral(property.BooleanValue)},");
                     sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)} }},");
                     break;
                 case PropertyKind.Flag:

--- a/src/ModularPipelines/Attributes/CliArgumentAttribute.cs
+++ b/src/ModularPipelines/Attributes/CliArgumentAttribute.cs
@@ -48,6 +48,12 @@ public sealed class CliArgumentAttribute : Attribute
     public CommandLinePhase Phase { get; set; } = CommandLinePhase.Passthrough;
 
     /// <summary>
+    /// Gets or sets a value indicating whether <c>--</c> is emitted immediately
+    /// before this argument when it has a value.
+    /// </summary>
+    public bool PrependOptionTerminator { get; set; }
+
+    /// <summary>
     /// Initialises a new instance of the <see cref="CliArgumentAttribute"/> class.
     /// Initializes a new instance of the <see cref="CliArgumentAttribute"/> class with default position 0.
     /// </summary>

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -117,6 +117,11 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
             }
 
             var values = GetValues(rawValue);
+            if (argumentPart.Attribute.PrependOptionTerminator && values.Count > 0)
+            {
+                args.Add("--");
+            }
+
             args.AddRange(values);
         }
     }

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -123,6 +123,19 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task Parser_Prepends_Option_Terminator_To_Passthrough_Arguments()
+    {
+        var options = new TestCliOptionsWithPassthroughArguments
+        {
+            Args = ["first", "second"],
+        };
+
+        var list = BuildArguments(options);
+
+        await Assert.That(string.Join(' ', list)).IsEqualTo("-- first second");
+    }
+
+    [Test]
     public async Task Parser_Handles_CliFlag()
     {
         var options = new TestCliOptionsWithFlag { Debug = true };
@@ -427,6 +440,12 @@ public class CliAttributeTests
 
         [CliArgument(1)]
         public string? ChartReference { get; set; }
+    }
+
+    private record TestCliOptionsWithPassthroughArguments
+    {
+        [CliArgument(0, PrependOptionTerminator = true)]
+        public IEnumerable<string>? Args { get; set; }
     }
 
     private record TestCliOptionsComplete

--- a/test/ModularPipelines.UnitTests/Attributes/GeneratedRuntimeMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/GeneratedRuntimeMetadataTests.cs
@@ -9,7 +9,11 @@ namespace ModularPipelines.UnitTests.Attributes;
 [CliTool("metadata-test")]
 internal sealed record GeneratedMetadataOptions : CommandLineToolOptions
 {
-    [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions, Name = "<FILE>")]
+    [CliArgument(
+        0,
+        Placement = ArgumentPlacement.BeforeOptions,
+        Name = "<FILE>",
+        PrependOptionTerminator = true)]
     public string? File { get; init; }
 
     [CliFlag("--verbose", ShortForm = "-v", PreferShortForm = true)]
@@ -129,6 +133,7 @@ public class GeneratedRuntimeMetadataTests
         await Assert.That(argument.Attribute.Placement).IsEqualTo(ArgumentPlacement.BeforeOptions);
         await Assert.That(argument.Attribute.Phase).IsEqualTo(CommandLinePhase.Passthrough);
         await Assert.That(argument.Attribute.Name).IsEqualTo("<FILE>");
+        await Assert.That(argument.Attribute.PrependOptionTerminator).IsTrue();
 
         var flag = model.OfType<FlagPart>().Single();
         await Assert.That((bool) flag.Getter(options)!).IsTrue();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ArgoCdCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ArgoCdCliScraperTests.cs
@@ -436,7 +436,10 @@ public class ArgoCdCliScraperTests
             IReadOnlyList<CliPositionalArgument> positionalArguments) =>
             ApplyPositionalArgumentFixes(commandParts, positionalArguments);
 
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = ParseUsageSynopsis(commandPath, helpText);
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ArgoCdCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ArgoCdCliScraperTests.cs
@@ -38,6 +38,7 @@ public class ArgoCdCliScraperTests
     {
         var scraper = new TestArgoCdCliScraper();
         var arguments = scraper.ParseArguments(
+            ["argocd", "app", "rollback"],
             "Usage:\n  argocd app rollback APPNAME [ID] [flags]");
 
         await Assert.That(arguments).Count().IsEqualTo(2);
@@ -48,13 +49,16 @@ public class ArgoCdCliScraperTests
     }
 
     [Test]
-    public async Task Shared_Cobra_Parser_Does_Not_Parse_Bare_Kubectl_Qualifier_Tokens()
+    public async Task Shared_Usage_Parser_Keeps_Kubectl_Qualified_Name_As_One_Operand()
     {
         var scraper = new TestArgoCdCliScraper();
-        var arguments = scraper.ParseBaseArguments(
+        var arguments = scraper.ParseArguments(
+            ["kubectl", "get"],
             "Usage:\n  kubectl get TYPE[.VERSION][.GROUP]/NAME [flags]");
 
-        await Assert.That(arguments).IsEmpty();
+        await Assert.That(arguments).Count().IsEqualTo(1);
+        await Assert.That(arguments[0].PlaceholderName).IsEqualTo("TYPE[.VERSION][.GROUP]/NAME");
+        await Assert.That(arguments[0].IsRequired).IsTrue();
     }
 
     [Test]
@@ -107,6 +111,7 @@ public class ArgoCdCliScraperTests
     {
         var scraper = new TestArgoCdCliScraper();
         var parsedArguments = scraper.ParseArguments(
+            ["argocd", "app", "rollback"],
             "Usage:\n  argocd app rollback APPNAME [ID] [flags]");
 
         var arguments = scraper.ApplyFix(["app", "rollback"], parsedArguments);
@@ -120,6 +125,7 @@ public class ArgoCdCliScraperTests
     {
         var scraper = new TestArgoCdCliScraper();
         var parsedArguments = scraper.ParseArguments(
+            ["argocd", "admin", "settings", "rbac", "can"],
             "Usage:\n  argocd admin settings rbac can ROLE/SUBJECT ACTION RESOURCE [SUB-RESOURCE] [flags]");
         var arguments = scraper.ApplyFix(["admin", "settings", "rbac", "can"], parsedArguments);
 
@@ -137,6 +143,7 @@ public class ArgoCdCliScraperTests
     {
         var scraper = new TestArgoCdCliScraper();
         var parsedArguments = scraper.ParseArguments(
+            ["argocd", "app", command],
             $"Usage:\n  argocd app {command} [APPNAME... | -l selector] [flags]");
 
         var arguments = scraper.ApplyFix(["app", command], parsedArguments);
@@ -152,6 +159,7 @@ public class ArgoCdCliScraperTests
     {
         var scraper = new TestArgoCdCliScraper();
         var parsedArguments = scraper.ParseArguments(
+            ["argocd", "repo", "rm"],
             "Usage:\n  argocd repo rm REPO ... [flags]");
 
         var arguments = scraper.ApplyFix(["repo", "rm"], parsedArguments);
@@ -245,6 +253,7 @@ public class ArgoCdCliScraperTests
     {
         var scraper = new TestArgoCdCliScraper();
         var parsedArguments = scraper.ParseArguments(
+            ["argocd", "context"],
             "Usage:\n  argocd context [CONTEXT] [flags]");
 
         var arguments = scraper.ApplyFix(["context"], parsedArguments);
@@ -260,6 +269,7 @@ public class ArgoCdCliScraperTests
     {
         var scraper = new TestArgoCdCliScraper();
         var parsedArguments = scraper.ParseArguments(
+            ["argocd", "admin", "cluster", "kubeconfig"],
             "Usage:\n  argocd admin cluster kubeconfig CLUSTER_URL OUTPUT_PATH [flags]");
 
         var arguments = scraper.ApplyFix(["admin", "cluster", "kubeconfig"], parsedArguments);
@@ -283,7 +293,7 @@ public class ArgoCdCliScraperTests
         string? lastProperty)
     {
         var scraper = new TestArgoCdCliScraper();
-        var parsedArguments = scraper.ParseArguments(helpText);
+        var parsedArguments = scraper.ParseArguments(["argocd", parentCommand, command], helpText);
 
         var arguments = scraper.ApplyFix([parentCommand, command], parsedArguments);
 
@@ -308,6 +318,7 @@ public class ArgoCdCliScraperTests
     {
         var scraper = new TestArgoCdCliScraper();
         var parsedArguments = scraper.ParseArguments(
+            ["argocd", "proj", command],
             $"Usage:\n  argocd proj {command} PROJECT SERVER {trailingOperands} [flags]");
 
         var arguments = scraper.ApplyFix(["proj", command], parsedArguments);
@@ -327,6 +338,7 @@ public class ArgoCdCliScraperTests
     {
         var scraper = new TestArgoCdCliScraper();
         var parsedArguments = scraper.ParseArguments(
+            ["argocd", parentCommand, command],
             $"Usage:\n  argocd {parentCommand} {command} {placeholder} [flags]");
 
         var arguments = scraper.ApplyFix([parentCommand, command], parsedArguments);
@@ -414,11 +426,10 @@ public class ArgoCdCliScraperTests
         public IReadOnlyList<string> ExtractCommands(string helpText) =>
             ExtractSubcommands(helpText).ToList();
 
-        public IReadOnlyList<CliPositionalArgument> ParseArguments(string helpText) =>
-            ParsePositionalArguments(helpText);
-
-        public IReadOnlyList<CliPositionalArgument> ParseBaseArguments(string helpText) =>
-            base.ParsePositionalArguments(helpText);
+        public IReadOnlyList<CliPositionalArgument> ParseArguments(
+            string[] commandPath,
+            string helpText) =>
+            ParseUsageSynopsis(commandPath, helpText).PositionalArguments;
 
         public IReadOnlyList<CliPositionalArgument> ApplyFix(
             string[] commandParts,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -148,6 +148,27 @@ public class CliScraperTraversalTests
     }
 
     [Test]
+    public async Task SharedTraversal_Propagates_Invalid_Operand_Coverage()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Execute a command.
+
+                Usage:
+                  fake <TARGET>
+                """,
+        });
+        var scraper = new OperandCoverageMismatchScraper(executor);
+
+        async Task Scrape() => await ScrapeAsync(scraper);
+
+        await Assert.That(Scrape)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("no CliPositionalArgument");
+    }
+
+    [Test]
     public async Task Shared_Skip_Filter_Preserves_Uppercase_Subcommands()
     {
         var scraper = new ShapeMismatchScraper(new StubExecutor(
@@ -241,6 +262,42 @@ public class CliScraperTraversalTests
                         Description = "May be specified multiple times",
                     },
                 ],
+            });
+    }
+
+    private sealed class OperandCoverageMismatchScraper : CliScraperBase
+    {
+        public OperandCoverageMismatchScraper(ICliCommandExecutor executor)
+            : base(
+                executor,
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<OperandCoverageMismatchScraper>.Instance)
+        {
+        }
+
+        public override string ToolName => "fake";
+
+        public override string NamespacePrefix => "Fake";
+
+        public override string TargetNamespace => "ModularPipelines.Fake";
+
+        public override string OutputDirectory => "src/ModularPipelines.Fake";
+
+        protected override IEnumerable<string> ExtractSubcommands(string helpText) => [];
+
+        protected override Task<CliCommandDefinition?> ParseCommandAsync(
+            string[] commandPath,
+            string helpText,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<CliCommandDefinition?>(new CliCommandDefinition
+            {
+                FullCommand = "fake",
+                CommandParts = [],
+                ClassName = "FakeOptions",
+                ParentClassName = "FakeOptions",
+                ToolNamespacePrefix = "Fake",
+                HasOperandTakingUsage = true,
+                Options = [],
             });
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -296,7 +296,6 @@ public class CliScraperTraversalTests
                 ClassName = "FakeOptions",
                 ParentClassName = "FakeOptions",
                 ToolNamespacePrefix = "Fake",
-                HasOperandTakingUsage = true,
                 Options = [],
             });
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -147,6 +147,15 @@ public class CliScraperTraversalTests
         await Assert.That(commands).IsEmpty();
     }
 
+    [Test]
+    public async Task Shared_Skip_Filter_Preserves_Uppercase_Subcommands()
+    {
+        var scraper = new ShapeMismatchScraper(new StubExecutor(
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)));
+
+        await Assert.That(scraper.Skips("SSH")).IsFalse();
+    }
+
     private static async Task<IReadOnlyList<CliCommandDefinition>> ScrapeAsync(ICliScraper scraper)
     {
         var commands = new List<CliCommandDefinition>();
@@ -208,6 +217,8 @@ public class CliScraperTraversalTests
         public override string OutputDirectory => "src/ModularPipelines.Fake";
 
         protected override IEnumerable<string> ExtractSubcommands(string helpText) => [];
+
+        public bool Skips(string subcommand) => IsSkippableSubcommand(subcommand);
 
         protected override Task<CliCommandDefinition?> ParseCommandAsync(
             string[] commandPath,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -178,8 +178,11 @@ public class CliScraperTraversalTests
 
         protected override int MaxParallelism => 2;
 
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = ParseUsageSynopsis(commandPath, helpText);
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
 
         public bool DeclaresCommandGroup(string helpText) => HelpDeclaresCommandGroup(helpText);
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CosignCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CosignCliScraperTests.cs
@@ -135,8 +135,11 @@ public class CosignCliScraperTests
 
         public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
 
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = ParseUsageSynopsis(commandPath, helpText);
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
 
         public IReadOnlyList<CliPositionalArgument> ApplyFix(
             string[] commandParts,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/EksctlCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/EksctlCliScraperTests.cs
@@ -174,7 +174,10 @@ public class EksctlCliScraperTests
 
         public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
 
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = ParseUsageSynopsis(commandPath, helpText);
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KindCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KindCliScraperTests.cs
@@ -128,7 +128,10 @@ public class KindCliScraperTests
         {
         }
 
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = ParseUsageSynopsis(commandPath, helpText);
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/TrivyCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/TrivyCliScraperTests.cs
@@ -200,7 +200,10 @@ public class TrivyCliScraperTests
 
         public string NormalizeDescription(string description) => NormalizeOptionDescription(description);
 
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = ParseUsageSynopsis(commandPath, helpText);
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -144,6 +144,40 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Parses_Inline_Usage_Continuation_Lines()
+    {
+        const string helpText = """
+            Usage: tool upload [OPTIONS]
+                   <SOURCE> <DESTINATION>
+
+            Options:
+              --force
+            """;
+
+        var result = UsageSynopsisParser.Parse(helpText, ["tool", "upload"]);
+
+        await Assert.That(result.PositionalArguments.Select(argument => argument.PropertyName))
+            .IsEquivalentTo(["Source", "Destination"]);
+        await Assert.That(result.PositionalArguments.All(argument =>
+                argument.Placement == PositionalArgumentPosition.AfterOptions))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task Carries_Standalone_Option_Terminator_To_Following_Operand()
+    {
+        var required = UsageSynopsisParser.Parse(
+            "Usage: tool run [OPTIONS] -- <ARGS>",
+            ["tool", "run"]);
+        var optional = UsageSynopsisParser.Parse(
+            "Usage: tool run [OPTIONS] [--] [ARGS...]",
+            ["tool", "run"]);
+
+        await Assert.That(required.PositionalArguments.Single().PrependOptionTerminator).IsTrue();
+        await Assert.That(optional.PositionalArguments.Single().PrependOptionTerminator).IsTrue();
+    }
+
+    [Test]
     public async Task Relaxes_Operands_Absent_From_Alternate_Invocation_Forms()
     {
         const string helpText = """
@@ -159,6 +193,22 @@ public class UsageSynopsisParserTests
         await Assert.That(result.MatchedSynopsisCount).IsEqualTo(3);
         await Assert.That(dependency.IsRequired).IsFalse();
         await Assert.That(dependency.CSharpType).IsEqualTo("string?");
+    }
+
+    [Test]
+    public async Task Relaxes_Operands_When_An_Alternate_Form_Is_Operandless()
+    {
+        const string helpText = """
+            Usage:
+              tool run <FILE>
+              tool run
+            """;
+
+        var result = UsageSynopsisParser.Parse(helpText, ["tool", "run"]);
+        var file = result.PositionalArguments.Single();
+
+        await Assert.That(file.IsRequired).IsFalse();
+        await Assert.That(file.CSharpType).IsEqualTo("string?");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -1,0 +1,244 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Generators;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class UsageSynopsisParserTests
+{
+    [Test]
+    public async Task Parses_Regression_Operand_Syntax_Through_One_Model()
+    {
+        var fixtures = new[]
+        {
+            Fixture(
+                "vault",
+                "Usage: vault delete [options] PATH",
+                ["vault", "delete"],
+                Required("Path")),
+            Fixture(
+                "terraform",
+                "Usage: terraform [global options] import [options] ADDRESS ID",
+                ["terraform", "import"],
+                Required("Address"),
+                Required("Id")),
+            Fixture(
+                "cargo",
+                "Usage: cargo new [OPTIONS] <PATH>",
+                ["cargo", "new"],
+                Required("Path")),
+            Fixture(
+                "packer",
+                "Usage: packer build [options] TEMPLATE",
+                ["packer", "build"],
+                Required("Template")),
+            Fixture(
+                "gh",
+                "USAGE\n  gh api <endpoint> [flags]",
+                ["gh", "api"],
+                Required("Endpoint")),
+            Fixture(
+                "podman",
+                "Usage:\n  podman attach [options] CONTAINER",
+                ["podman", "attach"],
+                Required("Container")),
+            Fixture(
+                "buildah",
+                "Usage: buildah add [options] container source [source ...] destination",
+                ["buildah", "add"],
+                Required("Container"),
+                Required("Source", isVariadic: true),
+                Required("Destination")),
+            Fixture(
+                "newman",
+                "Usage: newman run [options] <collection|URL>",
+                ["newman", "run"],
+                Required("Collection")),
+        };
+
+        foreach (var fixture in fixtures)
+        {
+            var result = UsageSynopsisParser.Parse(fixture.HelpText, fixture.CommandPath);
+
+            await Assert.That(result.HasOperandTokens)
+                .IsTrue()
+                .Because(fixture.Tool);
+            await Assert.That(result.PositionalArguments.Count)
+                .IsEqualTo(fixture.ExpectedArguments.Count)
+                .Because(fixture.Tool);
+
+            for (var index = 0; index < fixture.ExpectedArguments.Count; index++)
+            {
+                var actual = result.PositionalArguments[index];
+                var expected = fixture.ExpectedArguments[index];
+                await Assert.That(actual.PropertyName).IsEqualTo(expected.PropertyName).Because(fixture.Tool);
+                await Assert.That(actual.IsRequired).IsEqualTo(expected.IsRequired).Because(fixture.Tool);
+                await Assert.That(actual.IsVariadic).IsEqualTo(expected.IsVariadic).Because(fixture.Tool);
+                await Assert.That(actual.PositionIndex).IsEqualTo(index).Because(fixture.Tool);
+            }
+        }
+    }
+
+    [Test]
+    public async Task Parses_Required_Optional_And_Repeat_Markers()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool deploy TARGET [environment] [FILE...]",
+            ["tool", "deploy"]);
+
+        await Assert.That(result.PositionalArguments.Count).IsEqualTo(3);
+        await Assert.That(result.PositionalArguments[0].CSharpType).IsEqualTo("string");
+        await Assert.That(result.PositionalArguments[1].CSharpType).IsEqualTo("string?");
+        await Assert.That(result.PositionalArguments[2].CSharpType).IsEqualTo("IEnumerable<string>?");
+        await Assert.That(result.PositionalArguments[2].IsVariadic).IsTrue();
+    }
+
+    [Test]
+    public async Task Kustomize_Adapter_Supplies_Omitted_Buildmetadata_Operand()
+    {
+        const string helpText = """
+            Adds build metadata.
+
+            Usage:
+              kustomize edit add buildmetadata [flags]
+
+            Flags:
+              -h, --help   help for buildmetadata
+            """;
+
+        var command = await new TestKustomizeCliScraper().Parse(
+            ["kustomize", "edit", "add", "buildmetadata"],
+            helpText);
+
+        var metadata = command!.PositionalArguments.Single();
+        await Assert.That(metadata.PropertyName).IsEqualTo("Metadata");
+        await Assert.That(metadata.IsRequired).IsTrue();
+    }
+
+    [Test]
+    public async Task Newman_Does_Not_Promote_Wrapped_Alternate_To_Subcommand()
+    {
+        const string helpText = """
+            Commands:
+              run [options] <collection|URL>  Run a collection
+                  URL                       Wrapped description continuation
+            """;
+
+        var commands = new TestNewmanCliScraper().Extract(helpText);
+
+        await Assert.That(commands).IsEquivalentTo(["run"]);
+    }
+
+    [Test]
+    public async Task Generator_Renders_Required_Operands_As_Constructor_Parameters_And_Optional_As_Properties()
+    {
+        var usage = UsageSynopsisParser.Parse(
+            "Usage: tool upload <SOURCE> [DESTINATION...]",
+            ["tool", "upload"]);
+        var command = new CliCommandDefinition
+        {
+            FullCommand = "tool upload",
+            CommandParts = ["upload"],
+            ClassName = "ToolUploadOptions",
+            ParentClassName = "ToolOptions",
+            ToolNamespacePrefix = "Tool",
+            Options = [],
+            PositionalArguments = usage.PositionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
+        };
+        var tool = new CliToolDefinition
+        {
+            ToolName = "tool",
+            NamespacePrefix = "Tool",
+            TargetNamespace = "ModularPipelines.Tool",
+            OutputDirectory = "src/ModularPipelines.Tool",
+            Commands = [command],
+        };
+
+        var generated = (await new OptionsClassGenerator().GenerateAsync(tool)).Single().Content;
+
+        await Assert.That(generated).Contains(
+            "[property: CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)] string Source");
+        await Assert.That(generated).Contains(
+            "[CliArgument(1, Placement = ArgumentPlacement.BeforeOptions)]");
+        await Assert.That(generated).Contains(
+            "public IEnumerable<string>? Destination { get; set; }");
+    }
+
+    [Test]
+    public async Task Model_Rejects_OperandTaking_Usage_With_No_Positionals()
+    {
+        var command = new CliCommandDefinition
+        {
+            FullCommand = "tool broken",
+            CommandParts = ["broken"],
+            ClassName = "ToolBrokenOptions",
+            ParentClassName = "ToolOptions",
+            ToolNamespacePrefix = "Tool",
+            Options = [],
+            UsageSynopsis = "tool broken <TARGET>",
+            HasOperandTakingUsage = true,
+        };
+
+        await Assert.That(command.ValidateOperandCoverage)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("no CliPositionalArgument");
+    }
+
+    private static OperandFixture Fixture(
+        string tool,
+        string helpText,
+        string[] commandPath,
+        params ExpectedArgument[] expectedArguments) =>
+        new(tool, helpText, commandPath, expectedArguments);
+
+    private static ExpectedArgument Required(string propertyName, bool isVariadic = false) =>
+        new(propertyName, IsRequired: true, IsVariadic: isVariadic);
+
+    private sealed record OperandFixture(
+        string Tool,
+        string HelpText,
+        string[] CommandPath,
+        IReadOnlyList<ExpectedArgument> ExpectedArguments);
+
+    private sealed record ExpectedArgument(
+        string PropertyName,
+        bool IsRequired,
+        bool IsVariadic);
+
+    private sealed class TestKustomizeCliScraper : KustomizeCliScraper
+    {
+        public TestKustomizeCliScraper()
+            : base(
+                Executor(),
+                Cache(),
+                NullLogger<KustomizeCliScraper>.Instance)
+        {
+        }
+
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+    }
+
+    private sealed class TestNewmanCliScraper : NewmanCliScraper
+    {
+        public TestNewmanCliScraper()
+            : base(
+                Executor(),
+                Cache(),
+                NullLogger<NewmanCliScraper>.Instance)
+        {
+        }
+
+        public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
+    }
+
+    private static ProcessCliCommandExecutor Executor() =>
+        new(NullLogger<ProcessCliCommandExecutor>.Instance);
+
+    private static HelpTextCache Cache() =>
+        new(NullLogger<HelpTextCache>.Instance);
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -56,6 +56,13 @@ public class UsageSynopsisParserTests
                 "Usage: newman run [options] <collection|URL>",
                 ["newman", "run"],
                 Required("Collection", placement: PositionalArgumentPosition.AfterOptions)),
+            Fixture(
+                "docker",
+                "Usage: docker exec [OPTIONS] CONTAINER COMMAND [ARG...]",
+                ["docker", "exec"],
+                Required("Container", placement: PositionalArgumentPosition.AfterOptions),
+                Required("Command", placement: PositionalArgumentPosition.AfterOptions),
+                Optional("Arg", isVariadic: true, placement: PositionalArgumentPosition.AfterOptions)),
         };
 
         foreach (var fixture in fixtures)
@@ -133,6 +140,25 @@ public class UsageSynopsisParserTests
         await Assert.That(argument.CSharpType).IsEqualTo("IEnumerable<string>?");
         await Assert.That(argument.IsVariadic).IsTrue();
         await Assert.That(argument.Placement).IsEqualTo(PositionalArgumentPosition.AfterOptions);
+        await Assert.That(argument.PrependOptionTerminator).IsTrue();
+    }
+
+    [Test]
+    public async Task Relaxes_Operands_Absent_From_Alternate_Invocation_Forms()
+    {
+        const string helpText = """
+            Usage:
+              cargo add <DEP>[@<VERSION>]
+              cargo add --path <PATH>
+              cargo add --git <URL>
+            """;
+
+        var result = UsageSynopsisParser.Parse(helpText, ["cargo", "add"]);
+        var dependency = result.PositionalArguments.Single();
+
+        await Assert.That(result.MatchedSynopsisCount).IsEqualTo(3);
+        await Assert.That(dependency.IsRequired).IsFalse();
+        await Assert.That(dependency.CSharpType).IsEqualTo("string?");
     }
 
     [Test]
@@ -265,6 +291,39 @@ public class UsageSynopsisParserTests
             "[CliArgument(1, Placement = ArgumentPlacement.BeforeOptions)]");
         await Assert.That(generated).Contains(
             "public IEnumerable<string>? Destination { get; set; }");
+    }
+
+    [Test]
+    public async Task Generator_Emits_Option_Terminator_Metadata()
+    {
+        var usage = UsageSynopsisParser.Parse(
+            "Usage: cargo test [OPTIONS] [-- [ARGS]...]",
+            ["cargo", "test"]);
+        var command = new CliCommandDefinition
+        {
+            FullCommand = "cargo test",
+            CommandParts = ["test"],
+            ClassName = "CargoTestOptions",
+            ParentClassName = "CargoOptions",
+            ToolNamespacePrefix = "Cargo",
+            Options = [],
+            PositionalArguments = usage.PositionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
+        };
+        var tool = new CliToolDefinition
+        {
+            ToolName = "cargo",
+            NamespacePrefix = "Cargo",
+            TargetNamespace = "ModularPipelines.Cargo",
+            OutputDirectory = "src/ModularPipelines.Cargo",
+            Commands = [command],
+        };
+
+        var generated = (await new OptionsClassGenerator().GenerateAsync(tool)).Single().Content;
+
+        await Assert.That(generated).Contains(
+            "PrependOptionTerminator = true");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -167,6 +167,16 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Migrated_Scraper_Rejects_Missing_Shared_Usage_Result()
+    {
+        var scraper = new TestKustomizeCliScraper();
+
+        await Assert.That(() => scraper.ParseWithoutUsage(["kustomize", "build"], "Usage: kustomize build"))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("Shared traversal must pass its parsed synopsis");
+    }
+
+    [Test]
     public async Task Newman_Does_Not_Promote_Wrapped_Alternate_To_Subcommand()
     {
         const string helpText = """
@@ -268,7 +278,13 @@ public class UsageSynopsisParserTests
         {
         }
 
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = ParseUsageSynopsis(commandPath, helpText);
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
+
+        public Task<CliCommandDefinition?> ParseWithoutUsage(string[] commandPath, string helpText) =>
             ParseCommandAsync(commandPath, helpText, CancellationToken.None);
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -120,6 +120,22 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Preserves_Operands_Grouped_Behind_Option_Terminator()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: cargo login [OPTIONS] [-- [args]...]",
+            ["cargo", "login"]);
+
+        var argument = result.PositionalArguments.Single();
+
+        await Assert.That(result.HasOperandTokens).IsTrue();
+        await Assert.That(argument.PropertyName).IsEqualTo("Args");
+        await Assert.That(argument.CSharpType).IsEqualTo("IEnumerable<string>?");
+        await Assert.That(argument.IsVariadic).IsTrue();
+        await Assert.That(argument.Placement).IsEqualTo(PositionalArgumentPosition.AfterOptions);
+    }
+
+    [Test]
     public async Task Prefers_Full_Command_Path_Over_Suffix_With_More_Operands()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -96,6 +96,55 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
+    public async Task Prefers_Full_Command_Path_Over_Suffix_With_More_Operands()
+    {
+        const string helpText = """
+            Usage:
+              tool config get <TARGET>
+              get <WRONG> <EXTRA>
+            """;
+
+        var result = UsageSynopsisParser.Parse(
+            helpText,
+            ["tool", "config", "get"]);
+
+        await Assert.That(result.Synopsis).IsEqualTo("tool config get <TARGET>");
+        await Assert.That(result.PositionalArguments.Select(argument => argument.PropertyName))
+            .IsEquivalentTo(["Target"]);
+    }
+
+    [Test]
+    public async Task Reports_Equally_Ranked_Synopses_As_Ambiguous()
+    {
+        const string helpText = """
+            Usage:
+              tool run <FILE>
+              tool run <TARGET>
+            """;
+
+        var result = UsageSynopsisParser.Parse(helpText, ["tool", "run"]);
+
+        await Assert.That(result.MatchedSynopsisCount).IsEqualTo(2);
+        await Assert.That(result.HasAmbiguousMatch).IsTrue();
+    }
+
+    [Test]
+    public async Task Shared_Traversal_Parses_Usage_Once()
+    {
+        var scraper = new CountingUsageScraper();
+        var commands = new List<CliCommandDefinition>();
+
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        await Assert.That(scraper.UsageParseCount).IsEqualTo(1);
+        await Assert.That(commands.Single().PositionalArguments.Single().PropertyName)
+            .IsEqualTo("Target");
+    }
+
+    [Test]
     public async Task Kustomize_Adapter_Supplies_Omitted_Buildmetadata_Operand()
     {
         const string helpText = """
@@ -234,6 +283,81 @@ public class UsageSynopsisParserTests
         }
 
         public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
+    }
+
+    private sealed class CountingUsageScraper : CliScraperBase
+    {
+        public CountingUsageScraper()
+            : base(
+                new StubExecutor(),
+                Cache(),
+                NullLogger<CountingUsageScraper>.Instance)
+        {
+        }
+
+        public int UsageParseCount { get; private set; }
+
+        public override string ToolName => "tool";
+
+        public override string NamespacePrefix => "Tool";
+
+        public override string TargetNamespace => "ModularPipelines.Tool";
+
+        public override string OutputDirectory => "src/ModularPipelines.Tool";
+
+        protected override IEnumerable<string> ExtractSubcommands(string helpText) => [];
+
+        protected override IEnumerable<string> GetAdditionalUsageSynopses(
+            string[] commandPath,
+            string helpText)
+        {
+            UsageParseCount++;
+            return [];
+        }
+
+        protected override Task<CliCommandDefinition?> ParseCommandAsync(
+            string[] commandPath,
+            string helpText,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Shared traversal should pass its parsed synopsis.");
+
+        protected override Task<CliCommandDefinition?> ParseCommandAsync(
+            string[] commandPath,
+            string helpText,
+            UsageSynopsisParseResult usage,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<CliCommandDefinition?>(new CliCommandDefinition
+            {
+                FullCommand = "tool",
+                CommandParts = [],
+                ClassName = "ToolOptions",
+                ParentClassName = "ToolOptions",
+                ToolNamespacePrefix = "Tool",
+                Options = [],
+                PositionalArguments = usage.PositionalArguments,
+                UsageSynopsis = usage.Synopsis,
+                HasOperandTakingUsage = usage.HasOperandTokens,
+            });
+    }
+
+    private sealed class StubExecutor : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null) =>
+            Task.FromResult(new CliCommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = "Usage: tool <TARGET>",
+                StandardError = string.Empty,
+            });
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
     }
 
     private static ProcessCliCommandExecutor Executor() =>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -17,23 +17,23 @@ public class UsageSynopsisParserTests
                 "vault",
                 "Usage: vault delete [options] PATH",
                 ["vault", "delete"],
-                Required("Path")),
+                Required("Path", placement: PositionalArgumentPosition.AfterOptions)),
             Fixture(
                 "terraform",
                 "Usage: terraform [global options] import [options] ADDRESS ID",
                 ["terraform", "import"],
-                Required("Address"),
-                Required("Id")),
+                Required("Address", placement: PositionalArgumentPosition.AfterOptions),
+                Required("Id", placement: PositionalArgumentPosition.AfterOptions)),
             Fixture(
                 "cargo",
-                "Usage: cargo new [OPTIONS] <PATH>",
-                ["cargo", "new"],
-                Required("Path")),
+                "Usage: cargo run [OPTIONS] [ARGS]...",
+                ["cargo", "run"],
+                Optional("Args", isVariadic: true, placement: PositionalArgumentPosition.AfterOptions)),
             Fixture(
                 "packer",
                 "Usage: packer build [options] TEMPLATE",
                 ["packer", "build"],
-                Required("Template")),
+                Required("Template", placement: PositionalArgumentPosition.AfterOptions)),
             Fixture(
                 "gh",
                 "USAGE\n  gh api <endpoint> [flags]",
@@ -43,19 +43,19 @@ public class UsageSynopsisParserTests
                 "podman",
                 "Usage:\n  podman attach [options] CONTAINER",
                 ["podman", "attach"],
-                Required("Container")),
+                Required("Container", placement: PositionalArgumentPosition.AfterOptions)),
             Fixture(
                 "buildah",
                 "Usage: buildah add [options] container source [source ...] destination",
                 ["buildah", "add"],
-                Required("Container"),
-                Required("Source", isVariadic: true),
-                Required("Destination")),
+                Required("Container", placement: PositionalArgumentPosition.AfterOptions),
+                Required("Source", isVariadic: true, placement: PositionalArgumentPosition.AfterOptions),
+                Required("Destination", placement: PositionalArgumentPosition.AfterOptions)),
             Fixture(
                 "newman",
                 "Usage: newman run [options] <collection|URL>",
                 ["newman", "run"],
-                Required("Collection")),
+                Required("Collection", placement: PositionalArgumentPosition.AfterOptions)),
         };
 
         foreach (var fixture in fixtures)
@@ -76,9 +76,33 @@ public class UsageSynopsisParserTests
                 await Assert.That(actual.PropertyName).IsEqualTo(expected.PropertyName).Because(fixture.Tool);
                 await Assert.That(actual.IsRequired).IsEqualTo(expected.IsRequired).Because(fixture.Tool);
                 await Assert.That(actual.IsVariadic).IsEqualTo(expected.IsVariadic).Because(fixture.Tool);
+                await Assert.That(actual.Placement).IsEqualTo(expected.Placement).Because(fixture.Tool);
                 await Assert.That(actual.PositionIndex).IsEqualTo(index).Because(fixture.Tool);
             }
         }
+    }
+
+    [Test]
+    public async Task Preserves_Operand_Order_Around_Options()
+    {
+        var result = UsageSynopsisParser.Parse(
+            "Usage: tool copy <SOURCE> [OPTIONS] <DESTINATION>",
+            ["tool", "copy"]);
+
+        var source = result.PositionalArguments.Single(argument => argument.PropertyName == "Source");
+        var destination = result.PositionalArguments.Single(argument => argument.PropertyName == "Destination");
+
+        await Assert.That(source.Placement).IsEqualTo(PositionalArgumentPosition.BeforeOptions);
+        await Assert.That(source.PositionIndex).IsEqualTo(0);
+        await Assert.That(destination.Placement).IsEqualTo(PositionalArgumentPosition.AfterOptions);
+        await Assert.That(destination.PositionIndex).IsEqualTo(0);
+
+        var globalOptions = UsageSynopsisParser.Parse(
+            "Usage: tool [GLOBAL OPTIONS] copy <SOURCE>",
+            ["tool", "copy"]);
+
+        await Assert.That(globalOptions.PositionalArguments.Single().Placement)
+            .IsEqualTo(PositionalArgumentPosition.AfterOptions);
     }
 
     [Test]
@@ -254,8 +278,17 @@ public class UsageSynopsisParserTests
         params ExpectedArgument[] expectedArguments) =>
         new(tool, helpText, commandPath, expectedArguments);
 
-    private static ExpectedArgument Required(string propertyName, bool isVariadic = false) =>
-        new(propertyName, IsRequired: true, IsVariadic: isVariadic);
+    private static ExpectedArgument Required(
+        string propertyName,
+        bool isVariadic = false,
+        PositionalArgumentPosition placement = PositionalArgumentPosition.BeforeOptions) =>
+        new(propertyName, IsRequired: true, IsVariadic: isVariadic, Placement: placement);
+
+    private static ExpectedArgument Optional(
+        string propertyName,
+        bool isVariadic = false,
+        PositionalArgumentPosition placement = PositionalArgumentPosition.BeforeOptions) =>
+        new(propertyName, IsRequired: false, IsVariadic: isVariadic, Placement: placement);
 
     private sealed record OperandFixture(
         string Tool,
@@ -266,7 +299,8 @@ public class UsageSynopsisParserTests
     private sealed record ExpectedArgument(
         string PropertyName,
         bool IsRequired,
-        bool IsVariadic);
+        bool IsVariadic,
+        PositionalArgumentPosition Placement);
 
     private sealed class TestKustomizeCliScraper : KustomizeCliScraper
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
@@ -263,8 +263,11 @@ public class ZeroOutputScraperTests
         {
         }
 
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = ParseUsageSynopsis(commandPath, helpText);
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
 
         public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
@@ -354,6 +354,7 @@ public class CodeGeneratorOrchestrator
 
         await foreach (var command in cliScraper.ScrapeAsync(cancellationToken))
         {
+            command.ValidateOperandCoverage();
             allCommands.Add(command);
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/OptionsClassGenerator.cs
@@ -282,6 +282,11 @@ public class OptionsClassGenerator : ICodeGenerator
             parts.Add($"Placement = {placement}");
         }
 
+        if (positional.PrependOptionTerminator)
+        {
+            parts.Add("PrependOptionTerminator = true");
+        }
+
         // Note: We intentionally do NOT add the Name property here.
         // The Name property is only for documentation/help text and causes
         // CommandArgumentBuilder to skip the argument (it assumes Name means

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -56,6 +56,16 @@ public record CliCommandDefinition
     public IReadOnlyList<CliPositionalArgument> PositionalArguments { get; init; } = [];
 
     /// <summary>
+    /// Usage synopsis from which positional arguments were parsed.
+    /// </summary>
+    public string? UsageSynopsis { get; init; }
+
+    /// <summary>
+    /// Whether the usage synopsis declares one or more positional operands.
+    /// </summary>
+    public bool HasOperandTakingUsage { get; init; }
+
+    /// <summary>
     /// Required options that should be constructor parameters.
     /// </summary>
     public IReadOnlyList<CliOptionDefinition> RequiredOptions =>
@@ -108,6 +118,21 @@ public record CliCommandDefinition
     /// </summary>
     public IReadOnlyDictionary<string, string> DocumentationExampleValues { get; init; } =
         new Dictionary<string, string>(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Verifies that operand-taking usage cannot silently generate an unusable API.
+    /// </summary>
+    public void ValidateOperandCoverage()
+    {
+        if (!HasOperandTakingUsage || PositionalArguments.Count > 0)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"{FullCommand} declares positional operands in usage '{UsageSynopsis}', " +
+            "but no CliPositionalArgument values were generated.");
+    }
 }
 
 /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -122,15 +122,25 @@ public record CliCommandDefinition
     /// <summary>
     /// Verifies that operand-taking usage cannot silently generate an unusable API.
     /// </summary>
-    public void ValidateOperandCoverage()
+    public void ValidateOperandCoverage() =>
+        ValidateOperandCoverage(HasOperandTakingUsage, UsageSynopsis);
+
+    /// <summary>
+    /// Verifies operand coverage against usage parsed by the shared traversal.
+    /// </summary>
+    /// <param name="hasOperandTakingUsage">Whether the shared usage parser found operands.</param>
+    /// <param name="usageSynopsis">The usage synopsis inspected by the shared parser.</param>
+    public void ValidateOperandCoverage(
+        bool hasOperandTakingUsage,
+        string? usageSynopsis)
     {
-        if (!HasOperandTakingUsage || PositionalArguments.Count > 0)
+        if (!hasOperandTakingUsage || PositionalArguments.Count > 0)
         {
             return;
         }
 
         throw new InvalidOperationException(
-            $"{FullCommand} declares positional operands in usage '{UsageSynopsis}', " +
+            $"{FullCommand} declares positional operands in usage '{usageSynopsis}', " +
             "but no CliPositionalArgument values were generated.");
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliPositionalArgument.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliPositionalArgument.cs
@@ -6,8 +6,9 @@ namespace ModularPipelines.OptionsGenerator.Models;
 public record CliPositionalArgument
 {
     public static IReadOnlyList<CliPositionalArgument> MergeDuplicates(
-        IEnumerable<CliPositionalArgument> positionalArguments) =>
-        positionalArguments
+        IEnumerable<CliPositionalArgument> positionalArguments)
+    {
+        var merged = positionalArguments
             .GroupBy(argument => argument.PropertyName, StringComparer.OrdinalIgnoreCase)
             .Select(group =>
             {
@@ -21,10 +22,23 @@ public record CliPositionalArgument
                 {
                     CSharpType = required ? type : $"{type}?",
                     IsRequired = required,
+                    IsVariadic = group.Any(argument => argument.IsVariadic)
+                                 || collection is not null,
                 };
             })
             .OrderBy(argument => argument.PositionIndex)
             .ToList();
+
+        var nextPositions = new Dictionary<PositionalArgumentPosition, int>();
+        return merged
+            .Select(argument =>
+            {
+                var position = nextPositions.GetValueOrDefault(argument.Placement);
+                nextPositions[argument.Placement] = position + 1;
+                return argument with { PositionIndex = position };
+            })
+            .ToList();
+    }
 
     /// <summary>
     /// Placeholder name in documentation (e.g., "[<PROJECT>]").
@@ -61,6 +75,11 @@ public record CliPositionalArgument
     /// Whether this positional argument is required.
     /// </summary>
     public bool IsRequired { get; init; }
+
+    /// <summary>
+    /// Whether this positional argument accepts repeated values.
+    /// </summary>
+    public bool IsVariadic { get; init; }
 
     /// <summary>
     /// Whether this positional argument contains a secret value that should be obfuscated in logs.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliPositionalArgument.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliPositionalArgument.cs
@@ -24,6 +24,8 @@ public record CliPositionalArgument
                     IsRequired = required,
                     IsVariadic = group.Any(argument => argument.IsVariadic)
                                  || collection is not null,
+                    PrependOptionTerminator = group.Any(argument =>
+                        argument.PrependOptionTerminator),
                 };
             })
             .OrderBy(argument => argument.PositionIndex)
@@ -80,6 +82,11 @@ public record CliPositionalArgument
     /// Whether this positional argument accepts repeated values.
     /// </summary>
     public bool IsVariadic { get; init; }
+
+    /// <summary>
+    /// Whether the generated CLI argument must be preceded by the <c>--</c> option terminator.
+    /// </summary>
+    public bool PrependOptionTerminator { get; init; }
 
     /// <summary>
     /// Whether this positional argument contains a secret value that should be obfuscated in logs.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ArgoCdCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ArgoCdCliScraper.cs
@@ -47,50 +47,6 @@ public partial class ArgoCdCliScraper : CobraCliScraper
             : base.NormalizeCommandIdentifier(commandPart);
 
     /// <summary>
-    /// Argo CD renders required operands as bare uppercase names. Keep that parsing
-    /// local so other Cobra tools retain the conservative bracketed-operand parser.
-    /// </summary>
-    protected override List<CliPositionalArgument> ParsePositionalArguments(string helpText)
-    {
-        var usageLine = helpText
-            .Split('\n')
-            .Select(line => line.Trim())
-            .FirstOrDefault(line => line.StartsWith("argocd ", StringComparison.Ordinal));
-
-        if (usageLine is null)
-        {
-            return [];
-        }
-
-        var arguments = new List<CliPositionalArgument>();
-        foreach (Match match in ArgoCdPositionalArgumentPattern().Matches(usageLine))
-        {
-            var argumentName = match.Groups["name"].Value;
-            var propertyName = NormalizePropertyName(argumentName);
-            if (propertyName is null)
-            {
-                continue;
-            }
-
-            var isRequired = !match.Value.StartsWith('[');
-            var isMultiple = match.Groups["multiple"].Success;
-            var csharpType = isMultiple ? "IEnumerable<string>?" : "string?";
-
-            arguments.Add(new CliPositionalArgument
-            {
-                PropertyName = propertyName,
-                PlaceholderName = argumentName,
-                CSharpType = isRequired ? csharpType.TrimEnd('?') : csharpType,
-                IsRequired = isRequired,
-                PositionIndex = arguments.Count,
-                Description = null,
-            });
-        }
-
-        return arguments;
-    }
-
-    /// <summary>
     /// The appset create usage line omits its required file arguments even though the
     /// command accepts one or more filenames or URLs.
     /// </summary>
@@ -289,9 +245,6 @@ public partial class ArgoCdCliScraper : CobraCliScraper
     {
         "--help", "-h", "--version", "help", "completion", "version"
     };
-
-    [GeneratedRegex(@"(?<![\w<\[])(?:<(?<name>[A-Z][A-Z0-9_-]*)(?<multiple>\.\.\.)?>|\[(?<name>[A-Z][A-Z0-9_-]*)(?<multiple>\.\.\.)?\]|(?<name>[A-Z][A-Z0-9_-]*)(?<multiple>\.\.\.)?)(?![\w>\]])")]
-    private static partial Regex ArgoCdPositionalArgumentPattern();
 
     [GeneratedRegex(@"(?i)[A-Z]:[\\/]+Users[\\/]+[^\\/\s\""')]+(?=[\\/]\.config[\\/]argocd[\\/]config)")]
     private static partial Regex WindowsHomeDirectoryPattern();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
@@ -112,6 +112,17 @@ public partial class CargoCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray();
@@ -123,7 +134,6 @@ public partial class CargoCliScraper : CliScraperBase
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
-        var usage = ParseUsageSynopsis(commandPath, helpText);
         var enums = options
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
@@ -123,6 +123,7 @@ public partial class CargoCliScraper : CliScraperBase
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
+        var usage = ParseUsageSynopsis(commandPath, helpText);
         var enums = options
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)
@@ -140,7 +141,9 @@ public partial class CargoCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = "https://doc.rust-lang.org/cargo/commands/",
             Options = options,
-            PositionalArguments = [],
+            PositionalArguments = usage.PositionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = null,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CargoCliScraper.cs
@@ -113,11 +113,7 @@ public partial class CargoCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -417,6 +417,7 @@ public abstract partial class CliScraperBase : ICliScraper
             return;
         }
 
+        command.ValidateOperandCoverage();
         await commandChannel.Writer.WriteAsync(command, cancellationToken);
     }
 
@@ -444,7 +445,6 @@ public abstract partial class CliScraperBase : ICliScraper
 
             ValidateOptionShapes(command, helpText);
             ValidateArgumentGroups(command);
-            command.ValidateOperandCoverage();
             return command;
         }
         catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -417,7 +417,9 @@ public abstract partial class CliScraperBase : ICliScraper
             return;
         }
 
-        command.ValidateOperandCoverage();
+        command.ValidateOperandCoverage(
+            usage.HasOperandTokens,
+            usage.Synopsis);
         await commandChannel.Writer.WriteAsync(command, cancellationToken);
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -405,6 +405,7 @@ public abstract partial class CliScraperBase : ICliScraper
         CancellationToken cancellationToken)
     {
         var usage = ParseUsageSynopsis(path, helpText);
+        LogUsageSynopsisSelection(path, usage);
         if ((!HasOptions(helpText) && !usage.HasOperandTokens)
             || (path.Length == 1 && subcommands.Count > 0))
         {
@@ -414,7 +415,7 @@ public abstract partial class CliScraperBase : ICliScraper
         CliCommandDefinition? command;
         try
         {
-            command = await ParseCommandAsync(path, helpText, cancellationToken);
+            command = await ParseCommandAsync(path, helpText, usage, cancellationToken);
             if (command is not null)
             {
                 ValidateOptionShapes(command, helpText);
@@ -432,6 +433,31 @@ public abstract partial class CliScraperBase : ICliScraper
         {
             await commandChannel.Writer.WriteAsync(command, cancellationToken);
         }
+    }
+
+    private void LogUsageSynopsisSelection(
+        string[] commandPath,
+        UsageSynopsisParseResult usage)
+    {
+        if (usage.MatchedSynopsisCount <= 1)
+        {
+            return;
+        }
+
+        if (usage.HasAmbiguousMatch)
+        {
+            Logger.LogWarning(
+                "Multiple equally ranked usage synopses matched {Command}; selected: {Synopsis}",
+                string.Join(" ", commandPath),
+                usage.Synopsis);
+            return;
+        }
+
+        Logger.LogDebug(
+            "Selected usage synopsis for {Command} from {Count} matching candidates: {Synopsis}",
+            string.Join(" ", commandPath),
+            usage.MatchedSynopsisCount,
+            usage.Synopsis);
     }
 
     private async Task EnqueueSubcommandsAsync(
@@ -563,6 +589,17 @@ public abstract partial class CliScraperBase : ICliScraper
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Parses a command using the synopsis result already computed by shared traversal.
+    /// Override when a scraper consumes positional operands.
+    /// </summary>
+    protected virtual Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(commandPath, helpText, cancellationToken);
 
     #endregion
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -404,7 +404,9 @@ public abstract partial class CliScraperBase : ICliScraper
         Channel<CliCommandDefinition> commandChannel,
         CancellationToken cancellationToken)
     {
-        if (!HasOptions(helpText) || (path.Length == 1 && subcommands.Count > 0))
+        var usage = ParseUsageSynopsis(path, helpText);
+        if ((!HasOptions(helpText) && !usage.HasOperandTokens)
+            || (path.Length == 1 && subcommands.Count > 0))
         {
             return;
         }
@@ -417,6 +419,7 @@ public abstract partial class CliScraperBase : ICliScraper
             {
                 ValidateOptionShapes(command, helpText);
                 ValidateArgumentGroups(command);
+                command.ValidateOperandCoverage();
             }
         }
         catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
@@ -571,6 +574,24 @@ public abstract partial class CliScraperBase : ICliScraper
     protected virtual IReadOnlyList<CliOptionDefinition> ParseGlobalOptions(string helpText) => [];
 
     /// <summary>
+    /// Supplies extra usage synopses when a CLI omits operands from its primary usage text.
+    /// </summary>
+    protected virtual IEnumerable<string> GetAdditionalUsageSynopses(
+        string[] commandPath,
+        string helpText) => [];
+
+    /// <summary>
+    /// Parses positional operands through the shared usage/synopsis model.
+    /// </summary>
+    protected UsageSynopsisParseResult ParseUsageSynopsis(
+        string[] commandPath,
+        string helpText) =>
+        UsageSynopsisParser.Parse(
+            helpText,
+            commandPath,
+            GetAdditionalUsageSynopses(commandPath, helpText));
+
+    /// <summary>
     /// Checks if help text indicates the command has options/flags.
     /// Override if the CLI has a different pattern for leaf commands.
     /// </summary>
@@ -608,7 +629,7 @@ public abstract partial class CliScraperBase : ICliScraper
     {
         // Skip flag-like names (e.g., "--tls", "--tlsverify", "-h")
         // These are CLI flags that sometimes appear in help output sections
-        if (subcommand.StartsWith('-'))
+        if (subcommand.StartsWith('-') || UsageSynopsisParser.IsPlaceholderToken(subcommand))
         {
             return true;
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -406,32 +406,51 @@ public abstract partial class CliScraperBase : ICliScraper
     {
         var usage = ParseUsageSynopsis(path, helpText);
         LogUsageSynopsisSelection(path, usage);
-        if ((!HasOptions(helpText) && !usage.HasOperandTokens)
-            || (path.Length == 1 && subcommands.Count > 0))
+        if (ShouldSkipCommand(path, helpText, subcommands, usage))
         {
             return;
         }
 
-        CliCommandDefinition? command;
+        var command = await TryParseCommandAsync(path, helpText, usage, cancellationToken);
+        if (command is null)
+        {
+            return;
+        }
+
+        await commandChannel.Writer.WriteAsync(command, cancellationToken);
+    }
+
+    private bool ShouldSkipCommand(
+        string[] path,
+        string helpText,
+        IReadOnlyCollection<string> subcommands,
+        UsageSynopsisParseResult usage) =>
+        (!HasOptions(helpText) && !usage.HasOperandTokens)
+        || (path.Length == 1 && subcommands.Count > 0);
+
+    private async Task<CliCommandDefinition?> TryParseCommandAsync(
+        string[] path,
+        string helpText,
+        UsageSynopsisParseResult usage,
+        CancellationToken cancellationToken)
+    {
         try
         {
-            command = await ParseCommandAsync(path, helpText, usage, cancellationToken);
-            if (command is not null)
+            var command = await ParseCommandAsync(path, helpText, usage, cancellationToken);
+            if (command is null)
             {
-                ValidateOptionShapes(command, helpText);
-                ValidateArgumentGroups(command);
-                command.ValidateOperandCoverage();
+                return null;
             }
+
+            ValidateOptionShapes(command, helpText);
+            ValidateArgumentGroups(command);
+            command.ValidateOperandCoverage();
+            return command;
         }
         catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
         {
             Logger.LogWarning(ex, "Failed to parse command: {Command}", string.Join(" ", path));
-            return;
-        }
-
-        if (command is not null)
-        {
-            await commandChannel.Writer.WriteAsync(command, cancellationToken);
+            return null;
         }
     }
 
@@ -666,7 +685,7 @@ public abstract partial class CliScraperBase : ICliScraper
     {
         // Skip flag-like names (e.g., "--tls", "--tlsverify", "-h")
         // These are CLI flags that sometimes appear in help output sections
-        if (subcommand.StartsWith('-') || UsageSynopsisParser.IsPlaceholderToken(subcommand))
+        if (subcommand.StartsWith('-'))
         {
             return true;
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -110,6 +110,17 @@ public abstract partial class CobraCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray(); // Skip tool name
@@ -151,7 +162,6 @@ public abstract partial class CobraCliScraper : CliScraperBase
         var options = ParseOptions(helpText, commandParts);
 
         // Parse positional arguments from usage/synopsis text
-        var usage = ParseUsageSynopsis(commandPath, helpText);
         var positionalArgs = ApplyPositionalArgumentFixes(commandParts, usage.PositionalArguments);
 
         // Extract enums from options

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -150,8 +150,9 @@ public abstract partial class CobraCliScraper : CliScraperBase
         // Parse options from the help text
         var options = ParseOptions(helpText, commandParts);
 
-        // Parse positional arguments from usage line
-        var positionalArgs = ApplyPositionalArgumentFixes(commandParts, ParsePositionalArguments(helpText));
+        // Parse positional arguments from usage/synopsis text
+        var usage = ParseUsageSynopsis(commandPath, helpText);
+        var positionalArgs = ApplyPositionalArgumentFixes(commandParts, usage.PositionalArguments);
 
         // Extract enums from options
         var enums = options
@@ -172,6 +173,8 @@ public abstract partial class CobraCliScraper : CliScraperBase
             DocumentationUrl = null, // CLI-first, no URL
             Options = options,
             PositionalArguments = positionalArgs,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = subDomain,
             CommandGroupIdentifierOverride = commandGroupIdentifierOverride,
             Enums = enums
@@ -724,58 +727,6 @@ public abstract partial class CobraCliScraper : CliScraperBase
     }
 
     /// <summary>
-    /// Parses positional arguments from usage line.
-    /// </summary>
-    protected virtual List<CliPositionalArgument> ParsePositionalArguments(string helpText)
-    {
-        var args = new List<CliPositionalArgument>();
-
-        // Find usage line
-        var usageMatch = UsageLinePattern().Match(helpText);
-        if (!usageMatch.Success)
-        {
-            return args;
-        }
-
-        var usageLine = usageMatch.Groups["usage"].Value;
-
-        // Find positional arguments in brackets: [RELEASE] [CHART] <NAME>
-        var argMatches = PositionalArgPattern().Matches(usageLine);
-        var position = 0;
-
-        foreach (Match match in argMatches)
-        {
-            var argName = match.Groups["name"].Value;
-            var isRequired = match.Value.StartsWith('<'); // <NAME> is required, [NAME] is optional
-            var isMultiple = match.Groups["multiple"].Success;
-
-            var propertyName = NormalizePropertyName(argName.Replace('.', '-'));
-            if (propertyName is null)
-            {
-                continue;
-            }
-
-            var csharpType = isMultiple ? "IEnumerable<string>?" : "string?";
-            if (isRequired)
-            {
-                csharpType = csharpType.TrimEnd('?');
-            }
-
-            args.Add(new CliPositionalArgument
-            {
-                PropertyName = propertyName,
-                PlaceholderName = argName,
-                CSharpType = csharpType,
-                IsRequired = isRequired,
-                PositionIndex = position++,
-                Description = null
-            });
-        }
-
-        return CliPositionalArgument.MergeDuplicates(args).ToList();
-    }
-
-    /// <summary>
     /// Applies tool-specific corrections when Cobra's usage line omits or misrepresents
     /// positional arguments.
     /// </summary>
@@ -994,12 +945,6 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// </summary>
     [GeneratedRegex(@"^[ \t]*Usage:?[ \t]*(?:\r?\n[ \t]*)?(?<usage>[^\r\n]+)", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex UsageLinePattern();
-
-    /// <summary>
-    /// Matches positional arguments in usage: [NAME], &lt;NAME&gt;, or [NAME...].
-    /// </summary>
-    [GeneratedRegex(@"[\[<](?<name>[A-Z][A-Za-z0-9_.-]*?)(?<multiple>\.\.\.)?[\]>]")]
-    private static partial Regex PositionalArgPattern();
 
     /// <summary>
     /// Validates that a command part looks like a real CLI command/subcommand.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -111,11 +111,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
@@ -55,6 +55,16 @@ public partial class KustomizeCliScraper : CobraCliScraper
     public override string OutputDirectory => "src/ModularPipelines.Kubernetes";
 
     /// <summary>
+    /// Kustomize validates buildmetadata operands but omits them from Cobra's Use value.
+    /// </summary>
+    protected override IEnumerable<string> GetAdditionalUsageSynopses(
+        string[] commandPath,
+        string helpText) =>
+        commandPath.Skip(1).ToArray() is [.., "buildmetadata"]
+            ? [$"{string.Join(" ", commandPath)} <metadata>"]
+            : base.GetAdditionalUsageSynopses(commandPath, helpText);
+
+    /// <summary>
     /// Skip utility commands.
     /// </summary>
     protected override IReadOnlySet<string> AdditionalSkipSubcommands => new HashSet<string>(StringComparer.OrdinalIgnoreCase)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/NewmanCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/NewmanCliScraper.cs
@@ -94,6 +94,17 @@ public partial class NewmanCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray();
@@ -105,7 +116,6 @@ public partial class NewmanCliScraper : CliScraperBase
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
-        var usage = ParseUsageSynopsis(commandPath, helpText);
 
         var className = GenerateClassName(commandPath);
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/NewmanCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/NewmanCliScraper.cs
@@ -95,11 +95,7 @@ public partial class NewmanCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/NewmanCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/NewmanCliScraper.cs
@@ -76,6 +76,7 @@ public partial class NewmanCliScraper : CliScraperBase
                 {
                     var commandName = match.Groups["name"].Value.Trim();
                     if (!string.IsNullOrEmpty(commandName) &&
+                        !UsageSynopsisParser.IsPlaceholderToken(commandName) &&
                         seenCommands.Add(commandName))
                     {
                         subcommands.Add(commandName);
@@ -104,6 +105,7 @@ public partial class NewmanCliScraper : CliScraperBase
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
+        var usage = ParseUsageSynopsis(commandPath, helpText);
 
         var className = GenerateClassName(commandPath);
 
@@ -117,20 +119,9 @@ public partial class NewmanCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = "https://www.npmjs.com/package/newman",
             Options = options,
-            PositionalArguments = commandParts.Contains("run")
-                ?
-                [
-                    new CliPositionalArgument
-                    {
-                        PropertyName = "Collection",
-                        PlaceholderName = "collection",
-                        CSharpType = "string?",
-                        IsRequired = true,
-                        PositionIndex = 0,
-                        Description = "Postman collection file or URL"
-                    }
-                ]
-                : [],
+            PositionalArguments = usage.PositionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = null,
             Enums = []
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
@@ -83,6 +83,17 @@ public partial class PackerCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray();
@@ -94,7 +105,6 @@ public partial class PackerCliScraper : CliScraperBase
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
-        var usage = ParseUsageSynopsis(commandPath, helpText);
 
         var className = GenerateClassName(commandPath);
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
@@ -84,11 +84,7 @@ public partial class PackerCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
@@ -94,6 +94,7 @@ public partial class PackerCliScraper : CliScraperBase
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
+        var usage = ParseUsageSynopsis(commandPath, helpText);
 
         var className = GenerateClassName(commandPath);
 
@@ -107,7 +108,9 @@ public partial class PackerCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = "https://developer.hashicorp.com/packer/docs/commands",
             Options = options,
-            PositionalArguments = [],
+            PositionalArguments = usage.PositionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = null,
             Enums = []
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
@@ -141,6 +141,17 @@ public partial class TerraformCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray(); // Skip tool name
@@ -159,7 +170,6 @@ public partial class TerraformCliScraper : CliScraperBase
 
         // Parse options from the help text
         var options = ParseOptions(helpText, commandParts);
-        var usage = ParseUsageSynopsis(commandPath, helpText);
 
         // Extract enums from options
         var enums = options

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
@@ -159,6 +159,7 @@ public partial class TerraformCliScraper : CliScraperBase
 
         // Parse options from the help text
         var options = ParseOptions(helpText, commandParts);
+        var usage = ParseUsageSynopsis(commandPath, helpText);
 
         // Extract enums from options
         var enums = options
@@ -178,7 +179,9 @@ public partial class TerraformCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = null,
             Options = options,
-            PositionalArguments = [],
+            PositionalArguments = usage.PositionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = subDomain,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
@@ -142,11 +142,7 @@ public partial class TerraformCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TrivyCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TrivyCliScraper.cs
@@ -111,7 +111,11 @@ public partial class TrivyCliScraper : CobraCliScraper
         IReadOnlyList<CliPositionalArgument> positionalArguments)
     {
         var sourceArgument = positionalArguments.Count > 0
-            ? positionalArguments[0]
+            ? positionalArguments[0] with
+            {
+                PropertyName = "Source",
+                PlaceholderName = "NAME | URL | FILE_PATH",
+            }
             : RequiredArgument("Source", "NAME | URL | FILE_PATH");
 
         return

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -1,0 +1,430 @@
+using ModularPipelines.OptionsGenerator.Generators;
+using ModularPipelines.OptionsGenerator.Models;
+
+namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
+
+/// <summary>
+/// Parses positional operands from CLI usage and synopsis text.
+/// </summary>
+public static class UsageSynopsisParser
+{
+    private static readonly HashSet<string> ControlTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "arg",
+        "args",
+        "argument",
+        "arguments",
+        "command",
+        "commands",
+        "flag",
+        "flags",
+        "global option",
+        "global options",
+        "help",
+        "option",
+        "options",
+        "subcommand",
+        "subcommands",
+    };
+
+    /// <summary>
+    /// Parses the best matching synopsis for a command.
+    /// </summary>
+    public static UsageSynopsisParseResult Parse(
+        string helpText,
+        IReadOnlyList<string> commandPath,
+        IEnumerable<string>? additionalSynopses = null)
+    {
+        ArgumentNullException.ThrowIfNull(helpText);
+        ArgumentNullException.ThrowIfNull(commandPath);
+
+        var synopses = ExtractSynopses(helpText)
+            .Concat(additionalSynopses ?? [])
+            .Where(synopsis => !string.IsNullOrWhiteSpace(synopsis))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        return synopses
+            .Select(synopsis => ParseSynopsis(synopsis, commandPath))
+            .Where(result => result.CommandMatched)
+            .OrderByDescending(result => result.PositionalArguments.Count)
+            .ThenBy(result => result.UnparsedOperandTokens.Count)
+            .FirstOrDefault()
+            ?? UsageSynopsisParseResult.Empty;
+    }
+
+    /// <summary>
+    /// Returns true when a discovered token is placeholder syntax, not a command name.
+    /// </summary>
+    public static bool IsPlaceholderToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        var trimmed = token.Trim();
+        return IsWrapped(trimmed)
+               || trimmed.Contains('|')
+               || trimmed.EndsWith("...", StringComparison.Ordinal)
+               || (trimmed.Length > 1 && trimmed.All(character =>
+                   !char.IsLetter(character) || char.IsUpper(character)));
+    }
+
+    private static UsageSynopsisParseResult ParseSynopsis(
+        string synopsis,
+        IReadOnlyList<string> commandPath)
+    {
+        var tokens = Tokenize(synopsis);
+        var commandEnd = FindCommandEnd(tokens, commandPath);
+        if (commandEnd < 0)
+        {
+            return UsageSynopsisParseResult.Unmatched(synopsis);
+        }
+
+        var arguments = new List<CliPositionalArgument>();
+        var unparsedTokens = new List<string>();
+        foreach (var token in CollapseAlternatives(tokens.Skip(commandEnd + 1)))
+        {
+            if (TryApplyStandaloneRepeat(token, arguments) || IsControlToken(token))
+            {
+                continue;
+            }
+
+            var argument = ParseOperand(token, arguments.Count);
+            if (argument is null)
+            {
+                unparsedTokens.Add(token);
+                continue;
+            }
+
+            arguments.Add(argument);
+        }
+
+        return new UsageSynopsisParseResult
+        {
+            Synopsis = synopsis,
+            CommandMatched = true,
+            HasOperandTokens = arguments.Count > 0 || unparsedTokens.Count > 0,
+            PositionalArguments = CliPositionalArgument.MergeDuplicates(arguments),
+            UnparsedOperandTokens = unparsedTokens,
+        };
+    }
+
+    private static IReadOnlyList<string> ExtractSynopses(string helpText)
+    {
+        var lines = helpText
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Replace('\r', '\n')
+            .Split('\n');
+        var synopses = new List<string>();
+
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var trimmed = lines[index].Trim();
+            if (!TryReadUsageHeading(trimmed, out var inlineSynopsis))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(inlineSynopsis))
+            {
+                synopses.Add(inlineSynopsis);
+                continue;
+            }
+
+            index = ReadIndentedSynopses(lines, index + 1, synopses);
+        }
+
+        return synopses;
+    }
+
+    private static bool TryReadUsageHeading(string line, out string synopsis)
+    {
+        synopsis = "";
+        if (!line.StartsWith("usage", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var remainder = line["usage".Length..];
+        if (remainder.Length > 0 && remainder[0] != ':' && !char.IsWhiteSpace(remainder[0]))
+        {
+            return false;
+        }
+
+        synopsis = remainder.TrimStart(':', ' ', '\t');
+        return true;
+    }
+
+    private static int ReadIndentedSynopses(string[] lines, int startIndex, List<string> synopses)
+    {
+        var index = startIndex;
+        for (; index < lines.Length; index++)
+        {
+            var line = lines[index];
+            var trimmed = line.Trim();
+            if (string.IsNullOrWhiteSpace(trimmed))
+            {
+                break;
+            }
+
+            if (LooksLikeSectionHeading(trimmed))
+            {
+                break;
+            }
+
+            synopses.Add(trimmed);
+        }
+
+        return index;
+    }
+
+    private static bool LooksLikeSectionHeading(string line) =>
+        line.EndsWith(':')
+        || (line.Length < 50
+            && line.Any(char.IsLetter)
+            && line.Where(char.IsLetter).All(char.IsUpper));
+
+    private static IReadOnlyList<string> Tokenize(string synopsis)
+    {
+        var tokens = new List<string>();
+        var index = 0;
+        while (index < synopsis.Length)
+        {
+            while (index < synopsis.Length && char.IsWhiteSpace(synopsis[index]))
+            {
+                index++;
+            }
+
+            if (index >= synopsis.Length)
+            {
+                break;
+            }
+
+            var start = index;
+            if (TryGetClosingDelimiter(synopsis[index], out var closingDelimiter))
+            {
+                index++;
+                while (index < synopsis.Length && synopsis[index] != closingDelimiter)
+                {
+                    index++;
+                }
+
+                if (index < synopsis.Length)
+                {
+                    index++;
+                }
+
+                while (index < synopsis.Length && !char.IsWhiteSpace(synopsis[index]))
+                {
+                    index++;
+                }
+            }
+            else
+            {
+                while (index < synopsis.Length && !char.IsWhiteSpace(synopsis[index]))
+                {
+                    index++;
+                }
+            }
+
+            tokens.Add(synopsis[start..index]);
+        }
+
+        return tokens;
+    }
+
+    private static int FindCommandEnd(IReadOnlyList<string> tokens, IReadOnlyList<string> commandPath)
+    {
+        for (var pathStart = 0; pathStart < commandPath.Count; pathStart++)
+        {
+            var pathIndex = pathStart;
+            for (var tokenIndex = 0; tokenIndex < tokens.Count; tokenIndex++)
+            {
+                if (IsControlToken(tokens[tokenIndex]))
+                {
+                    continue;
+                }
+
+                if (!NormalizeLiteral(tokens[tokenIndex]).Equals(
+                        commandPath[pathIndex],
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                pathIndex++;
+                if (pathIndex == commandPath.Count)
+                {
+                    return tokenIndex;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    private static CliPositionalArgument? ParseOperand(string token, int positionIndex)
+    {
+        var trimmed = token.Trim().TrimEnd(',', ';');
+        var isRequired = !trimmed.StartsWith('[');
+        var content = TrimWrapper(trimmed).Trim();
+        var canonicalName = SelectCanonicalAlternative(content);
+        var isVariadic = canonicalName.EndsWith("...", StringComparison.Ordinal)
+                         || canonicalName.EndsWith("…", StringComparison.Ordinal)
+                         || canonicalName.EndsWith(" ...", StringComparison.Ordinal);
+        canonicalName = canonicalName.TrimEnd('.', '…').Trim();
+
+        if (canonicalName.StartsWith('-') || ControlTokens.Contains(canonicalName))
+        {
+            return null;
+        }
+
+        var propertyName = NormalizeOperandName(canonicalName);
+        if (string.IsNullOrWhiteSpace(propertyName))
+        {
+            return null;
+        }
+
+        return new CliPositionalArgument
+        {
+            PropertyName = propertyName,
+            PlaceholderName = content,
+            CSharpType = GetCSharpType(isRequired, isVariadic),
+            IsRequired = isRequired,
+            IsVariadic = isVariadic,
+            PositionIndex = positionIndex,
+            Description = $"The {canonicalName} operand.",
+        };
+    }
+
+    private static string SelectCanonicalAlternative(string content)
+    {
+        var pipeIndex = content.IndexOf('|');
+        if (pipeIndex >= 0)
+        {
+            return content[..pipeIndex].Trim();
+        }
+
+        return content
+            .Replace("/", " Or ", StringComparison.Ordinal)
+            .Replace("\\", " Or ", StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyList<string> CollapseAlternatives(IEnumerable<string> sourceTokens)
+    {
+        var tokens = sourceTokens.ToList();
+        var collapsed = new List<string>();
+        for (var index = 0; index < tokens.Count; index++)
+        {
+            var token = tokens[index];
+            while (index + 2 < tokens.Count && tokens[index + 1] == "|")
+            {
+                token = $"{token}|{tokens[index + 2]}";
+                index += 2;
+            }
+
+            collapsed.Add(token);
+        }
+
+        return collapsed;
+    }
+
+    private static string? NormalizeOperandName(string content)
+    {
+        var cleaned = new string(content
+            .Select(character => char.IsLetterOrDigit(character) ? character : ' ')
+            .ToArray());
+        var words = cleaned.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return words.Length == 0
+            ? null
+            : string.Concat(words.Select(GeneratorUtils.ToPascalCase));
+    }
+
+    private static bool TryApplyStandaloneRepeat(
+        string token,
+        List<CliPositionalArgument> arguments)
+    {
+        if (token is not ("..." or "…") || arguments.Count == 0)
+        {
+            return false;
+        }
+
+        arguments[^1] = arguments[^1] with
+        {
+            CSharpType = GetCSharpType(arguments[^1].IsRequired, isVariadic: true),
+            IsVariadic = true,
+        };
+        return true;
+    }
+
+    private static bool IsControlToken(string token)
+    {
+        var content = TrimWrapper(token).Trim();
+        return string.IsNullOrWhiteSpace(content)
+               || content.StartsWith('-')
+               || ControlTokens.Contains(content)
+               || content.All(character => !char.IsLetterOrDigit(character));
+    }
+
+    private static string NormalizeLiteral(string token) =>
+        TrimWrapper(token).Trim().TrimEnd(',', ':');
+
+    private static string TrimWrapper(string token)
+    {
+        if (!IsWrapped(token))
+        {
+            return token;
+        }
+
+        return token[1..^1];
+    }
+
+    private static bool IsWrapped(string token) =>
+        token.Length >= 2
+        && TryGetClosingDelimiter(token[0], out var closingDelimiter)
+        && token[^1] == closingDelimiter;
+
+    private static bool TryGetClosingDelimiter(char openingDelimiter, out char closingDelimiter)
+    {
+        closingDelimiter = openingDelimiter switch
+        {
+            '[' => ']',
+            '<' => '>',
+            '{' => '}',
+            '(' => ')',
+            _ => '\0',
+        };
+        return closingDelimiter != '\0';
+    }
+
+    private static string GetCSharpType(bool isRequired, bool isVariadic)
+    {
+        var type = isVariadic ? "IEnumerable<string>" : "string";
+        return isRequired ? type : $"{type}?";
+    }
+}
+
+/// <summary>
+/// Result of parsing a CLI usage synopsis.
+/// </summary>
+public sealed record UsageSynopsisParseResult
+{
+    internal static UsageSynopsisParseResult Empty { get; } = new();
+
+    internal static UsageSynopsisParseResult Unmatched(string synopsis) => new()
+    {
+        Synopsis = synopsis,
+    };
+
+    public string? Synopsis { get; init; }
+
+    public bool CommandMatched { get; init; }
+
+    public bool HasOperandTokens { get; init; }
+
+    public IReadOnlyList<CliPositionalArgument> PositionalArguments { get; init; } = [];
+
+    public IReadOnlyList<string> UnparsedOperandTokens { get; init; } = [];
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -44,13 +44,29 @@ public static class UsageSynopsisParser
             .Distinct(StringComparer.Ordinal)
             .ToList();
 
-        return synopses
+        var candidates = synopses
             .Select(synopsis => ParseSynopsis(synopsis, commandPath))
             .Where(result => result.CommandMatched)
-            .OrderByDescending(result => result.PositionalArguments.Count)
+            .ToList();
+        if (candidates.Count == 0)
+        {
+            return UsageSynopsisParseResult.Empty;
+        }
+
+        var rankedCandidates = candidates
+            .OrderByDescending(result => result.MatchedCommandPartCount)
+            .ThenByDescending(result => result.PositionalArguments.Count)
             .ThenBy(result => result.UnparsedOperandTokens.Count)
-            .FirstOrDefault()
-            ?? UsageSynopsisParseResult.Empty;
+            .ToList();
+        var selected = rankedCandidates[0];
+
+        return selected with
+        {
+            MatchedSynopsisCount = candidates.Count,
+            HasAmbiguousMatch = rankedCandidates
+                .Skip(1)
+                .Any(candidate => HasSameScore(selected, candidate)),
+        };
     }
 
     /// <summary>
@@ -76,15 +92,15 @@ public static class UsageSynopsisParser
         IReadOnlyList<string> commandPath)
     {
         var tokens = Tokenize(synopsis);
-        var commandEnd = FindCommandEnd(tokens, commandPath);
-        if (commandEnd < 0)
+        var commandMatch = FindCommand(tokens, commandPath);
+        if (commandMatch is null)
         {
             return UsageSynopsisParseResult.Unmatched(synopsis);
         }
 
         var arguments = new List<CliPositionalArgument>();
         var unparsedTokens = new List<string>();
-        foreach (var token in CollapseAlternatives(tokens.Skip(commandEnd + 1)))
+        foreach (var token in CollapseAlternatives(tokens.Skip(commandMatch.EndIndex + 1)))
         {
             if (TryApplyStandaloneRepeat(token, arguments) || IsControlToken(token))
             {
@@ -105,11 +121,19 @@ public static class UsageSynopsisParser
         {
             Synopsis = synopsis,
             CommandMatched = true,
+            MatchedCommandPartCount = commandMatch.PartCount,
             HasOperandTokens = arguments.Count > 0 || unparsedTokens.Count > 0,
             PositionalArguments = CliPositionalArgument.MergeDuplicates(arguments),
             UnparsedOperandTokens = unparsedTokens,
         };
     }
+
+    private static bool HasSameScore(
+        UsageSynopsisParseResult left,
+        UsageSynopsisParseResult right) =>
+        left.MatchedCommandPartCount == right.MatchedCommandPartCount
+        && left.PositionalArguments.Count == right.PositionalArguments.Count
+        && left.UnparsedOperandTokens.Count == right.UnparsedOperandTokens.Count;
 
     private static IReadOnlyList<string> ExtractSynopses(string helpText)
     {
@@ -235,7 +259,9 @@ public static class UsageSynopsisParser
         return tokens;
     }
 
-    private static int FindCommandEnd(IReadOnlyList<string> tokens, IReadOnlyList<string> commandPath)
+    private static CommandMatch? FindCommand(
+        IReadOnlyList<string> tokens,
+        IReadOnlyList<string> commandPath)
     {
         for (var pathStart = 0; pathStart < commandPath.Count; pathStart++)
         {
@@ -257,12 +283,14 @@ public static class UsageSynopsisParser
                 pathIndex++;
                 if (pathIndex == commandPath.Count)
                 {
-                    return tokenIndex;
+                    return new CommandMatch(
+                        tokenIndex,
+                        commandPath.Count - pathStart);
                 }
             }
         }
 
-        return -1;
+        return null;
     }
 
     private static CliPositionalArgument? ParseOperand(string token, int positionIndex)
@@ -272,7 +300,7 @@ public static class UsageSynopsisParser
         var content = TrimWrapper(trimmed).Trim();
         var canonicalName = SelectCanonicalAlternative(content);
         var isVariadic = canonicalName.EndsWith("...", StringComparison.Ordinal)
-                         || canonicalName.EndsWith("…", StringComparison.Ordinal)
+                         || canonicalName.EndsWith('…')
                          || canonicalName.EndsWith(" ...", StringComparison.Ordinal);
         canonicalName = canonicalName.TrimEnd('.', '…').Trim();
 
@@ -404,6 +432,8 @@ public static class UsageSynopsisParser
         var type = isVariadic ? "IEnumerable<string>" : "string";
         return isRequired ? type : $"{type}?";
     }
+
+    private sealed record CommandMatch(int EndIndex, int PartCount);
 }
 
 /// <summary>
@@ -421,6 +451,12 @@ public sealed record UsageSynopsisParseResult
     public string? Synopsis { get; init; }
 
     public bool CommandMatched { get; init; }
+
+    public int MatchedCommandPartCount { get; init; }
+
+    public int MatchedSynopsisCount { get; init; }
+
+    public bool HasAmbiguousMatch { get; init; }
 
     public bool HasOperandTokens { get; init; }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -69,6 +69,10 @@ public static class UsageSynopsisParser
             .ThenBy(result => result.UnparsedOperandTokens.Count)
             .ToList();
         var selected = rankedCandidates[0];
+        var sameCommandCandidates = candidates
+            .Where(candidate =>
+                candidate.MatchedCommandPartCount == selected.MatchedCommandPartCount)
+            .ToList();
 
         return selected with
         {
@@ -76,6 +80,9 @@ public static class UsageSynopsisParser
             HasAmbiguousMatch = rankedCandidates
                 .Skip(1)
                 .Any(candidate => HasSameScore(selected, candidate)),
+            PositionalArguments = RelaxArgumentsMissingFromAlternatives(
+                selected.PositionalArguments,
+                sameCommandCandidates),
         };
     }
 
@@ -122,10 +129,11 @@ public static class UsageSynopsisParser
                 placement = PositionalArgumentPosition.AfterOptions;
             }
 
-            var operandToken = TryUnwrapOptionTerminatedOperand(token, out var unwrappedOperand)
-                ? unwrappedOperand
-                : token;
-            if (TryApplyStandaloneRepeat(operandToken, arguments) || IsControlToken(operandToken))
+            var prependOptionTerminator =
+                TryUnwrapOptionTerminatedOperand(token, out var unwrappedOperand);
+            var operandToken = prependOptionTerminator ? unwrappedOperand : token;
+            if (TryApplyStandaloneRepeat(operandToken, arguments)
+                || IsNonOperandSyntax(operandToken))
             {
                 continue;
             }
@@ -135,6 +143,11 @@ public static class UsageSynopsisParser
             {
                 unparsedTokens.Add(operandToken);
                 continue;
+            }
+
+            if (prependOptionTerminator)
+            {
+                argument = argument with { PrependOptionTerminator = true };
             }
 
             arguments.Add(argument);
@@ -157,6 +170,34 @@ public static class UsageSynopsisParser
         left.MatchedCommandPartCount == right.MatchedCommandPartCount
         && left.PositionalArguments.Count == right.PositionalArguments.Count
         && left.UnparsedOperandTokens.Count == right.UnparsedOperandTokens.Count;
+
+    private static IReadOnlyList<CliPositionalArgument> RelaxArgumentsMissingFromAlternatives(
+        IReadOnlyList<CliPositionalArgument> selectedArguments,
+        IReadOnlyList<UsageSynopsisParseResult> alternatives)
+    {
+        var operandAlternatives = alternatives
+            .Where(alternative => alternative.PositionalArguments.Count > 0)
+            .ToList();
+        if (operandAlternatives.Count <= 1)
+        {
+            return selectedArguments;
+        }
+
+        return selectedArguments
+            .Select(argument => operandAlternatives.All(alternative =>
+                alternative.PositionalArguments.Any(candidate =>
+                    candidate.IsRequired
+                    && candidate.PropertyName.Equals(
+                        argument.PropertyName,
+                        StringComparison.OrdinalIgnoreCase)))
+                    ? argument
+                    : argument with
+                    {
+                        CSharpType = $"{argument.CSharpType.TrimEnd('?')}?",
+                        IsRequired = false,
+                    })
+            .ToList();
+    }
 
     private static IReadOnlyList<string> ExtractSynopses(string helpText)
     {
@@ -330,7 +371,7 @@ public static class UsageSynopsisParser
                          || canonicalName.EndsWith(" ...", StringComparison.Ordinal);
         canonicalName = canonicalName.TrimEnd('.', '…').Trim();
 
-        if (canonicalName.StartsWith('-') || ControlTokens.Contains(canonicalName))
+        if (canonicalName.StartsWith('-'))
         {
             return null;
         }
@@ -437,6 +478,15 @@ public static class UsageSynopsisParser
         return string.IsNullOrWhiteSpace(content)
                || content.StartsWith('-')
                || ControlTokens.Contains(content)
+               || content.All(character => !char.IsLetterOrDigit(character));
+    }
+
+    private static bool IsNonOperandSyntax(string token)
+    {
+        var content = TrimWrapper(token).Trim();
+        return string.IsNullOrWhiteSpace(content)
+               || content.StartsWith('-')
+               || OptionControlTokens.Contains(content)
                || content.All(character => !char.IsLetterOrDigit(character));
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -122,15 +122,18 @@ public static class UsageSynopsisParser
                 placement = PositionalArgumentPosition.AfterOptions;
             }
 
-            if (TryApplyStandaloneRepeat(token, arguments) || IsControlToken(token))
+            var operandToken = TryUnwrapOptionTerminatedOperand(token, out var unwrappedOperand)
+                ? unwrappedOperand
+                : token;
+            if (TryApplyStandaloneRepeat(operandToken, arguments) || IsControlToken(operandToken))
             {
                 continue;
             }
 
-            var argument = ParseOperand(token, arguments.Count, placement);
+            var argument = ParseOperand(operandToken, arguments.Count, placement);
             if (argument is null)
             {
-                unparsedTokens.Add(token);
+                unparsedTokens.Add(operandToken);
                 continue;
             }
 
@@ -409,6 +412,23 @@ public static class UsageSynopsisParser
             IsVariadic = true,
         };
         return true;
+    }
+
+    private static bool TryUnwrapOptionTerminatedOperand(
+        string token,
+        out string operand)
+    {
+        var content = TrimWrapper(token).Trim();
+        if (!content.StartsWith("--", StringComparison.Ordinal)
+            || content.Length == 2
+            || !char.IsWhiteSpace(content[2]))
+        {
+            operand = "";
+            return false;
+        }
+
+        operand = content[2..].Trim();
+        return !string.IsNullOrWhiteSpace(operand);
     }
 
     private static bool IsControlToken(string token)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -27,6 +27,16 @@ public static class UsageSynopsisParser
         "subcommands",
     };
 
+    private static readonly HashSet<string> OptionControlTokens = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "flag",
+        "flags",
+        "global option",
+        "global options",
+        "option",
+        "options",
+    };
+
     /// <summary>
     /// Parses the best matching synopsis for a command.
     /// </summary>
@@ -100,14 +110,24 @@ public static class UsageSynopsisParser
 
         var arguments = new List<CliPositionalArgument>();
         var unparsedTokens = new List<string>();
+        var placement = tokens
+            .Take(commandMatch.EndIndex + 1)
+            .Any(IsOptionControlToken)
+                ? PositionalArgumentPosition.AfterOptions
+                : PositionalArgumentPosition.BeforeOptions;
         foreach (var token in CollapseAlternatives(tokens.Skip(commandMatch.EndIndex + 1)))
         {
+            if (IsOptionControlToken(token))
+            {
+                placement = PositionalArgumentPosition.AfterOptions;
+            }
+
             if (TryApplyStandaloneRepeat(token, arguments) || IsControlToken(token))
             {
                 continue;
             }
 
-            var argument = ParseOperand(token, arguments.Count);
+            var argument = ParseOperand(token, arguments.Count, placement);
             if (argument is null)
             {
                 unparsedTokens.Add(token);
@@ -293,7 +313,10 @@ public static class UsageSynopsisParser
         return null;
     }
 
-    private static CliPositionalArgument? ParseOperand(string token, int positionIndex)
+    private static CliPositionalArgument? ParseOperand(
+        string token,
+        int positionIndex,
+        PositionalArgumentPosition placement)
     {
         var trimmed = token.Trim().TrimEnd(',', ';');
         var isRequired = !trimmed.StartsWith('[');
@@ -323,6 +346,7 @@ public static class UsageSynopsisParser
             IsRequired = isRequired,
             IsVariadic = isVariadic,
             PositionIndex = positionIndex,
+            Placement = placement,
             Description = $"The {canonicalName} operand.",
         };
     }
@@ -394,6 +418,13 @@ public static class UsageSynopsisParser
                || content.StartsWith('-')
                || ControlTokens.Contains(content)
                || content.All(character => !char.IsLetterOrDigit(character));
+    }
+
+    private static bool IsOptionControlToken(string token)
+    {
+        var content = TrimWrapper(token).Trim();
+        return content.StartsWith('-')
+               || OptionControlTokens.Contains(content);
     }
 
     private static string NormalizeLiteral(string token) =>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -48,8 +48,13 @@ public static class UsageSynopsisParser
         ArgumentNullException.ThrowIfNull(helpText);
         ArgumentNullException.ThrowIfNull(commandPath);
 
+        var suppliedSynopses = (additionalSynopses ?? [])
+            .Where(synopsis => !string.IsNullOrWhiteSpace(synopsis))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        var suppliedSynopsisSet = suppliedSynopses.ToHashSet(StringComparer.Ordinal);
         var synopses = ExtractSynopses(helpText)
-            .Concat(additionalSynopses ?? [])
+            .Concat(suppliedSynopses)
             .Where(synopsis => !string.IsNullOrWhiteSpace(synopsis))
             .Distinct(StringComparer.Ordinal)
             .ToList();
@@ -73,6 +78,11 @@ public static class UsageSynopsisParser
             .Where(candidate =>
                 candidate.MatchedCommandPartCount == selected.MatchedCommandPartCount)
             .ToList();
+        List<UsageSynopsisParseResult> requirednessCandidates =
+            suppliedSynopsisSet.Contains(selected.Synopsis ?? "")
+            ? [.. sameCommandCandidates
+                .Where(candidate => suppliedSynopsisSet.Contains(candidate.Synopsis ?? ""))]
+            : sameCommandCandidates;
 
         return selected with
         {
@@ -82,7 +92,7 @@ public static class UsageSynopsisParser
                 .Any(candidate => HasSameScore(selected, candidate)),
             PositionalArguments = RelaxArgumentsMissingFromAlternatives(
                 selected.PositionalArguments,
-                sameCommandCandidates),
+                requirednessCandidates),
         };
     }
 
@@ -117,6 +127,7 @@ public static class UsageSynopsisParser
 
         var arguments = new List<CliPositionalArgument>();
         var unparsedTokens = new List<string>();
+        var prependOptionTerminatorToNextOperand = false;
         var placement = tokens
             .Take(commandMatch.EndIndex + 1)
             .Any(IsOptionControlToken)
@@ -129,9 +140,15 @@ public static class UsageSynopsisParser
                 placement = PositionalArgumentPosition.AfterOptions;
             }
 
-            var prependOptionTerminator =
+            if (IsStandaloneOptionTerminator(token))
+            {
+                prependOptionTerminatorToNextOperand = true;
+                continue;
+            }
+
+            var groupedBehindOptionTerminator =
                 TryUnwrapOptionTerminatedOperand(token, out var unwrappedOperand);
-            var operandToken = prependOptionTerminator ? unwrappedOperand : token;
+            var operandToken = groupedBehindOptionTerminator ? unwrappedOperand : token;
             if (TryApplyStandaloneRepeat(operandToken, arguments)
                 || IsNonOperandSyntax(operandToken))
             {
@@ -145,12 +162,13 @@ public static class UsageSynopsisParser
                 continue;
             }
 
-            if (prependOptionTerminator)
+            if (groupedBehindOptionTerminator || prependOptionTerminatorToNextOperand)
             {
                 argument = argument with { PrependOptionTerminator = true };
             }
 
             arguments.Add(argument);
+            prependOptionTerminatorToNextOperand = false;
         }
 
         return new UsageSynopsisParseResult
@@ -173,18 +191,15 @@ public static class UsageSynopsisParser
 
     private static IReadOnlyList<CliPositionalArgument> RelaxArgumentsMissingFromAlternatives(
         IReadOnlyList<CliPositionalArgument> selectedArguments,
-        IReadOnlyList<UsageSynopsisParseResult> alternatives)
+        List<UsageSynopsisParseResult> alternatives)
     {
-        var operandAlternatives = alternatives
-            .Where(alternative => alternative.PositionalArguments.Count > 0)
-            .ToList();
-        if (operandAlternatives.Count <= 1)
+        if (alternatives.Count <= 1)
         {
             return selectedArguments;
         }
 
         return selectedArguments
-            .Select(argument => operandAlternatives.All(alternative =>
+            .Select(argument => alternatives.All(alternative =>
                 alternative.PositionalArguments.Any(candidate =>
                     candidate.IsRequired
                     && candidate.PropertyName.Equals(
@@ -217,7 +232,11 @@ public static class UsageSynopsisParser
 
             if (!string.IsNullOrWhiteSpace(inlineSynopsis))
             {
-                synopses.Add(inlineSynopsis);
+                index = ReadInlineSynopsis(
+                    lines,
+                    index + 1,
+                    inlineSynopsis,
+                    synopses);
                 continue;
             }
 
@@ -225,6 +244,53 @@ public static class UsageSynopsisParser
         }
 
         return synopses;
+    }
+
+    private static int ReadInlineSynopsis(
+        string[] lines,
+        int startIndex,
+        string inlineSynopsis,
+        List<string> synopses)
+    {
+        var parts = new List<string> { inlineSynopsis };
+        var index = startIndex;
+        for (; index < lines.Length; index++)
+        {
+            var line = lines[index];
+            var trimmed = line.Trim();
+            if (!IsSynopsisContinuation(line, trimmed))
+            {
+                break;
+            }
+
+            parts.Add(trimmed);
+        }
+
+        synopses.Add(string.Join(' ', parts));
+        return index - 1;
+    }
+
+    private static bool IsSynopsisContinuation(string line, string trimmed)
+    {
+        if (string.IsNullOrWhiteSpace(trimmed)
+            || line.Length == trimmed.Length)
+        {
+            return false;
+        }
+
+        var firstToken = trimmed.Split(' ', 2)[0];
+        if (LooksLikeSectionHeading(trimmed) && !IsWrapped(firstToken))
+        {
+            return false;
+        }
+
+        if (IsPlaceholderToken(firstToken))
+        {
+            return true;
+        }
+
+        return firstToken.StartsWith('-')
+               || firstToken is "|" or "...";
     }
 
     private static bool TryReadUsageHeading(string line, out string synopsis)
@@ -471,6 +537,9 @@ public static class UsageSynopsisParser
         operand = content[2..].Trim();
         return !string.IsNullOrWhiteSpace(operand);
     }
+
+    private static bool IsStandaloneOptionTerminator(string token) =>
+        TrimWrapper(token).Trim() == "--";
 
     private static bool IsControlToken(string token)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/VaultCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/VaultCliScraper.cs
@@ -82,6 +82,17 @@ public partial class VaultCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray();
@@ -93,7 +104,6 @@ public partial class VaultCliScraper : CliScraperBase
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
-        var usage = ParseUsageSynopsis(commandPath, helpText);
 
         var className = GenerateClassName(commandPath);
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/VaultCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/VaultCliScraper.cs
@@ -83,11 +83,7 @@ public partial class VaultCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/VaultCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/VaultCliScraper.cs
@@ -93,6 +93,7 @@ public partial class VaultCliScraper : CliScraperBase
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
+        var usage = ParseUsageSynopsis(commandPath, helpText);
 
         var className = GenerateClassName(commandPath);
 
@@ -106,7 +107,9 @@ public partial class VaultCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = "https://developer.hashicorp.com/vault/docs/commands",
             Options = options,
-            PositionalArguments = [],
+            PositionalArguments = usage.PositionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = null,
             Enums = []
         };


### PR DESCRIPTION
## Summary
- parse required, optional, variadic, alternate, and lowercase CLI operands through one shared usage synopsis parser
- validate operand-taking commands and render typed `CliArgument` metadata consistently
- migrate affected Cobra, Vault, Terraform, Cargo, Packer, Newman, Trivy, and Kustomize adapters

## Validation
- 504/504 `ModularPipelines.OptionsGenerator.Tests` passed with coverage under the 2 GB agent guard
- targeted formatter check reached only existing `info` analyzer diagnostics

Closes #3161