### PR TITLE
Single-source CI build solutions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -91,7 +91,7 @@ jobs:
           do
             [[ -z "$SOLUTION" || "$SOLUTION" == \#* ]] && continue
             dotnet restore "$SOLUTION"
-          done < BuildSolutions.txt
+          done < <(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' BuildSolutions.txt)
 
       - name: Build solutions
         shell: bash
@@ -111,7 +111,7 @@ jobs:
             echo "::group::Build $SOLUTION"
             dotnet build "$SOLUTION" -c Release --no-restore
             echo "::endgroup::"
-          done < BuildSolutions.txt
+          done < <(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' BuildSolutions.txt)
 
       - name: Run Pipeline
         run: dotnet run -c Release --framework net10.0

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -48,16 +48,6 @@ jobs:
       # Workstation GC keeps the build/test footprint lower than server GC (which allocates a
       # heap per core) on these multi-core runners.
       DOTNET_gcServer: "0"
-      # Single source of truth for the solutions CI restores and builds, so the Restore and
-      # Build steps below can't drift apart. This mirrors BuildSolutionsModule.Solutions in
-      # src/ModularPipelines.Build; keep the two in sync when adding a solution.
-      SOLUTIONS: >-
-        ModularPipelines.Analyzers.sln
-        ModularPipelines.All.sln
-        ModularPipelines.Examples.sln
-        src/ModularPipelines.Azure/ModularPipelines.Azure.sln
-        src/ModularPipelines.AmazonWebServices/ModularPipelines.AmazonWebServices.sln
-        src/ModularPipelines.Google/ModularPipelines.Google.sln
 
     steps:
       - name: Add mask
@@ -97,10 +87,11 @@ jobs:
       - name: Restore
         shell: bash
         run: |
-          for SOLUTION in $SOLUTIONS
+          while IFS= read -r SOLUTION || [[ -n "$SOLUTION" ]]
           do
+            [[ -z "$SOLUTION" || "$SOLUTION" == \#* ]] && continue
             dotnet restore "$SOLUTION"
-          done
+          done < BuildSolutions.txt
 
       - name: Build solutions
         shell: bash
@@ -114,12 +105,13 @@ jobs:
         # the huge AWS/Azure/Google SDK metadata into one compilation unit. That test was removed,
         # so each integration now compiles with only its own SDK and the parallel build fits.
         run: |
-          for SOLUTION in $SOLUTIONS
+          while IFS= read -r SOLUTION || [[ -n "$SOLUTION" ]]
           do
+            [[ -z "$SOLUTION" || "$SOLUTION" == \#* ]] && continue
             echo "::group::Build $SOLUTION"
             dotnet build "$SOLUTION" -c Release --no-restore
             echo "::endgroup::"
-          done
+          done < BuildSolutions.txt
 
       - name: Run Pipeline
         run: dotnet run -c Release --framework net10.0

--- a/BuildSolutions.txt
+++ b/BuildSolutions.txt
@@ -1,0 +1,7 @@
+# Solutions restored and built by CI and BuildSolutionsModule.
+ModularPipelines.Analyzers.sln
+ModularPipelines.All.sln
+ModularPipelines.Examples.sln
+src/ModularPipelines.Azure/ModularPipelines.Azure.sln
+src/ModularPipelines.AmazonWebServices/ModularPipelines.AmazonWebServices.sln
+src/ModularPipelines.Google/ModularPipelines.Google.sln

--- a/BuildSolutions.txt
+++ b/BuildSolutions.txt
@@ -1,4 +1,4 @@
-# Solutions restored and built by CI and BuildSolutionsModule.
+  # Solutions restored and built by CI and BuildSolutionsModule.
 ModularPipelines.Analyzers.sln
 ModularPipelines.All.sln
 ModularPipelines.Examples.sln

--- a/src/ModularPipelines.Build/Modules/BuildSolutionsModule.cs
+++ b/src/ModularPipelines.Build/Modules/BuildSolutionsModule.cs
@@ -13,26 +13,20 @@ namespace ModularPipelines.Build.Modules;
 [ProducesArtifact("build-output", "../../_build-staging")]
 public class BuildSolutionsModule : Module<CommandResult[]>
 {
-    private static readonly string[] Solutions =
-    [
-        "ModularPipelines.Analyzers.sln",
-        "ModularPipelines.All.sln",
-        "ModularPipelines.Examples.sln",
-        "src/ModularPipelines.Azure/ModularPipelines.Azure.sln",
-        "src/ModularPipelines.AmazonWebServices/ModularPipelines.AmazonWebServices.sln",
-        "src/ModularPipelines.Google/ModularPipelines.Google.sln",
-    ];
-
     protected override async Task<CommandResult[]?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
         var gitRoot = context.Git().RootDirectory.Path;
+        var solutions = File.ReadLines(Path.Combine(gitRoot, "BuildSolutions.txt"))
+            .Select(line => line.Trim())
+            .Where(line => !string.IsNullOrEmpty(line) && !line.StartsWith('#'))
+            .ToArray();
 
         // Build all solutions with --no-restore (the workflow already restored and, in CI,
         // natively built them, so this is a fast MSBuild-incremental pass). Default
         // parallelism: the runner reclaim in #3179 came from a single test project that
         // referenced every integration at once, pulling the huge AWS/Azure/Google SDK metadata
         // into one compilation unit; that test was removed, not MSBuild parallelism changed.
-        var results = await Solutions
+        var results = await solutions
             .ToAsyncProcessorBuilder()
             .SelectAsync(async solution => await context.DotNet().Build(new DotNetBuildOptions
             {


### PR DESCRIPTION
Closes #3213.

## Summary
- add `BuildSolutions.txt` as the shared solution manifest
- make workflow restore/build loops read the manifest
- make `BuildSolutionsModule` read the same manifest

## Validation
- verified all 6 manifest entries resolve to existing solution files
- exercised the Bash manifest loop against all entries
- scoped C# whitespace formatting passed
- `git diff --check` passed

The repository instructions prohibit building or running `ModularPipelines.Build` locally; CI performs that heavy validation.