### PR TITLE
Parse nested CLI argument groups

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
@@ -1,0 +1,367 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers.Cli;
+
+public partial class NestedArgumentGroupParsingTests
+{
+    [Test]
+    public async Task SharedParser_Recovers_Nested_Alternatives_And_Documentation()
+    {
+        const string section = """
+              --mode=MODE
+                 Select the operating mode.
+
+                 Shorthand Example:
+                   --example-only=literal
+
+              At most one of these can be specified:
+                --token=TOKEN
+                   Authenticate with a token.
+
+                Or at least one of these can be specified:
+                  --profile=PROFILE
+                     Select a saved profile.
+                  --[no-]interactive
+                     Enable or disable prompts.
+            """;
+
+        var group = TestArgumentGroupScraper.ParseGroups(section);
+        var arguments = group.FlattenArguments().ToArray();
+
+        await Assert.That(string.Join(" ", arguments.Select(argument => argument.SwitchName)))
+            .IsEqualTo("--mode --token --profile --interactive");
+        await Assert.That(group.Groups.Single().Kind)
+            .IsEqualTo(CliArgumentGroupKind.AtMostOne);
+        await Assert.That(group.Groups.Single().Groups.Single().Kind)
+            .IsEqualTo(CliArgumentGroupKind.Alternative | CliArgumentGroupKind.AtLeastOne);
+        await Assert.That(arguments.Single(argument => argument.SwitchName == "--profile").Documentation)
+            .Contains("At most one of these can be specified")
+            .And.Contains("Or at least one of these can be specified")
+            .And.Contains("Select a saved profile");
+        await Assert.That(arguments.Single(argument => argument.SwitchName == "--interactive").IsNegatable)
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task SharedValidation_Rejects_Grouped_Declaration_Not_Emitted_As_Option()
+    {
+        const string helpText = """
+            Fake help.
+
+            FLAGS
+              --parent=PARENT
+                 Parent value.
+
+              At most one of these can be specified:
+                --nested=NESTED
+                   Nested value.
+            """;
+        var scraper = new OmittingArgumentScraper(helpText);
+        var commands = new List<CliCommandDefinition>();
+
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        await Assert.That(commands).IsEmpty();
+    }
+
+    [Test]
+    public async Task GcloudAgentIdentityUpdate_Emits_Nested_Scope_Credential_And_Negatable_Flags()
+    {
+        const string helpText = """
+            NAME
+                gcloud agent-identity auth-providers update - update an auth provider
+
+            SYNOPSIS
+                gcloud agent-identity auth-providers update
+
+            FLAGS
+                 --request-id=REQUEST_ID
+                    An optional request ID.
+
+                 Update allowed_scopes.
+
+                 At most one of these can be specified:
+                   --allowed-scopes=[ALLOWED_SCOPES,...]
+                      Set allowed_scopes to a new value.
+
+                   Or at least one of these can be specified:
+                     --add-allowed-scopes=[ADD_ALLOWED_SCOPES,...]
+                        Add values to allowed_scopes.
+
+                     At most one of these can be specified:
+                       --clear-allowed-scopes
+                          Clear allowed_scopes.
+                       --remove-allowed-scopes=[REMOVE_ALLOWED_SCOPES,...]
+                          Remove values from allowed_scopes.
+
+                 AuthProvider type specific parameters.
+
+                   --clear-auth-provider-type-params
+                      Reset type parameters.
+
+                   At most one of these can be specified:
+                     --api-key=API_KEY
+                        The API key for this auth provider.
+                     --three-legged-oauth-client-secret=THREE_LEGGED_OAUTH_CLIENT_SECRET
+                        The OAuth client secret.
+                     --[no-]three-legged-oauth-enable-pkce
+                        Enable or disable PKCE.
+
+            GCLOUD WIDE FLAGS
+                 --project=PROJECT_ID
+            """;
+        var command = await CreateGcloudScraper().Parse(
+            ["gcloud", "agent-identity", "auth-providers", "update"],
+            helpText);
+        var switches = command!.Options.Select(option => option.SwitchName).ToArray();
+
+        await Assert.That(switches).Contains("--allowed-scopes");
+        await Assert.That(switches).Contains("--add-allowed-scopes");
+        await Assert.That(switches).Contains("--clear-allowed-scopes");
+        await Assert.That(switches).Contains("--remove-allowed-scopes");
+        await Assert.That(switches).Contains("--api-key");
+        await Assert.That(switches).Contains("--three-legged-oauth-client-secret");
+        await Assert.That(switches).Contains("--three-legged-oauth-enable-pkce");
+        await Assert.That(command.Options.Single(option => option.SwitchName == "--request-id").Description!)
+            .DoesNotContain("--allowed-scopes");
+        await Assert.That(command.Options.Single(option => option.SwitchName == "--three-legged-oauth-client-secret").IsSecret)
+            .IsTrue();
+        await Assert.That(command.Options.Single(option => option.SwitchName == "--three-legged-oauth-enable-pkce").IsFlag)
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task GcloudDeveloperConnectCreate_Emits_Nested_Resource_And_Secret_Flags()
+    {
+        const string helpText = """
+            NAME
+                gcloud developer-connect connections create - create a connection resource
+
+            SYNOPSIS
+                gcloud developer-connect connections create CONNECTION
+
+            FLAGS
+                 --validate-only
+                    If set, validate the request without posting it.
+
+                 The crypto key configuration. The arguments in this resource group
+                 can specify its attributes.
+
+                   --crypto-key-config-reference=CRYPTO_KEY_CONFIG_REFERENCE
+                      ID of the cryptoKey.
+                   --key-ring=KEY_RING
+                      The keyRing ID.
+
+                 Arguments for the connection config.
+
+                 At most one of these can be specified:
+                   Configuration for Bitbucket Cloud.
+
+                     --bitbucket-cloud-config-authorizer-credential-user-token-secret-version=BITBUCKET_SECRET_VERSION
+                        SecretManager version containing the user token.
+                     --bitbucket-cloud-config-workspace=BITBUCKET_WORKSPACE
+                        The workspace ID.
+
+                   Configuration for an HTTP provider.
+
+                     Arguments for the authentication.
+
+                     At most one of these can be specified:
+                       --http-config-bearer-token-authentication-secret-version=HTTP_BEARER_SECRET_VERSION
+                          SecretManager version containing the bearer token.
+                       --http-config-basic-authentication-password-secret-version=HTTP_PASSWORD_SECRET_VERSION
+                          SecretManager version containing the password.
+
+            GCLOUD WIDE FLAGS
+                 --project=PROJECT_ID
+            """;
+        var command = await CreateGcloudScraper().Parse(
+            ["gcloud", "developer-connect", "connections", "create"],
+            helpText);
+        var switches = command!.Options.Select(option => option.SwitchName).ToArray();
+
+        await Assert.That(switches).Contains("--crypto-key-config-reference");
+        await Assert.That(switches).Contains("--key-ring");
+        await Assert.That(switches)
+            .Contains("--bitbucket-cloud-config-authorizer-credential-user-token-secret-version");
+        await Assert.That(switches)
+            .Contains("--http-config-bearer-token-authentication-secret-version");
+        await Assert.That(switches)
+            .Contains("--http-config-basic-authentication-password-secret-version");
+        await Assert.That(command.Options.Single(option => option.SwitchName == "--validate-only").Description!)
+            .DoesNotContain("--crypto-key-config-reference");
+        await Assert.That(command.Options
+                .Single(option => option.SwitchName == "--http-config-basic-authentication-password-secret-version")
+                .IsSecret)
+            .IsTrue();
+        await Assert.That(command.ArgumentGroups.Single().Groups)
+            .Contains(group => group.Kind.HasFlag(CliArgumentGroupKind.Resource));
+    }
+
+    private static TestGcloudScraper CreateGcloudScraper() =>
+        new(new EmptyExecutor());
+
+    private sealed class TestGcloudScraper(ICliCommandExecutor executor)
+        : GcloudCliScraper(
+            executor,
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<GcloudCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+    }
+
+    private sealed class TestArgumentGroupScraper : CliScraperBase
+    {
+        private TestArgumentGroupScraper()
+            : base(
+                new EmptyExecutor(),
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<TestArgumentGroupScraper>.Instance)
+        {
+        }
+
+        public override string ToolName => "fake";
+
+        public override string NamespacePrefix => "Fake";
+
+        public override string TargetNamespace => "ModularPipelines.Fake";
+
+        public override string OutputDirectory => "src/ModularPipelines.Fake";
+
+        public static CliArgumentGroup ParseGroups(string section) =>
+            ParseArgumentGroups(section, ParseArgument);
+
+        protected override IEnumerable<string> ExtractSubcommands(string helpText) => [];
+
+        protected override Task<CliCommandDefinition?> ParseCommandAsync(
+            string[] commandPath,
+            string helpText,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<CliCommandDefinition?>(null);
+
+        private static CliArgumentDefinition? ParseArgument(string line)
+        {
+            var match = ArgumentPattern().Match(line);
+            if (!match.Success)
+            {
+                return null;
+            }
+
+            var negatable = match.Groups["negatable"].Success;
+            return new CliArgumentDefinition
+            {
+                SwitchName = negatable
+                    ? $"--{match.Groups["negatableName"].Value}"
+                    : match.Groups["long"].Value,
+                ValueHint = match.Groups["value"].Value,
+                IsNegatable = negatable,
+                Indentation = match.Groups["indent"].Value.Length,
+            };
+        }
+    }
+
+    private sealed class OmittingArgumentScraper(string helpText) : TestArgumentGroupScraperBase(helpText)
+    {
+        protected override Task<CliCommandDefinition?> ParseCommandAsync(
+            string[] commandPath,
+            string commandHelpText,
+            CancellationToken cancellationToken)
+        {
+            var group = ParseArgumentGroups(
+                commandHelpText[(commandHelpText.IndexOf("FLAGS", StringComparison.Ordinal) + "FLAGS".Length)..],
+                ParseNeutralArgument);
+            var parent = group.FlattenArguments().Single(argument => argument.SwitchName == "--parent");
+
+            return Task.FromResult<CliCommandDefinition?>(new CliCommandDefinition
+            {
+                FullCommand = "fake",
+                CommandParts = [],
+                ClassName = "FakeOptions",
+                ParentClassName = "FakeOptions",
+                ToolNamespacePrefix = "Fake",
+                Options =
+                [
+                    new CliOptionDefinition
+                    {
+                        SwitchName = parent.SwitchName,
+                        PropertyName = "Parent",
+                        CSharpType = "string?",
+                        Description = parent.Documentation,
+                    },
+                ],
+                ArgumentGroups = [group],
+            });
+        }
+    }
+
+    private abstract class TestArgumentGroupScraperBase(string helpText) : CliScraperBase(
+        new SingleHelpExecutor(helpText),
+        new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+        NullLogger<TestArgumentGroupScraperBase>.Instance)
+    {
+        public override string ToolName => "fake";
+
+        public override string NamespacePrefix => "Fake";
+
+        public override string TargetNamespace => "ModularPipelines.Fake";
+
+        public override string OutputDirectory => "src/ModularPipelines.Fake";
+
+        protected override IEnumerable<string> ExtractSubcommands(string commandHelpText) => [];
+
+        protected static CliArgumentDefinition? ParseNeutralArgument(string line)
+        {
+            var match = ArgumentPattern().Match(line);
+            return !match.Success
+                ? null
+                : new CliArgumentDefinition
+                {
+                    SwitchName = match.Groups["long"].Value,
+                    ValueHint = match.Groups["value"].Value,
+                    Indentation = match.Groups["indent"].Value.Length,
+                };
+        }
+    }
+
+    private sealed class SingleHelpExecutor(string helpText) : EmptyExecutor
+    {
+        public override Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null) =>
+            Task.FromResult(new CliCommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = helpText,
+                StandardError = string.Empty,
+            });
+    }
+
+    private class EmptyExecutor : ICliCommandExecutor
+    {
+        public virtual Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null) =>
+            throw new InvalidOperationException("Execution was not expected.");
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+
+    [GeneratedRegex(
+        @"^(?<indent>\s+)(?:(?<negatable>--\[no-\])(?<negatableName>[\w-]+)|(?<long>--[\w-]+))(?:=(?<value>\S+))?$")]
+    private static partial Regex ArgumentPattern();
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
@@ -72,6 +72,55 @@ public partial class NestedArgumentGroupParsingTests
     }
 
     [Test]
+    public async Task SharedParser_Preserves_Undocumented_Sibling_And_Final_Declarations()
+    {
+        const string section = """
+              --quiet
+              --verbosity=VERBOSITY
+                 Override the default verbosity.
+              --recursive
+            """;
+
+        var arguments = TestArgumentGroupScraper.ParseGroups(section)
+            .FlattenArguments()
+            .ToArray();
+
+        await Assert.That(arguments.Select(argument => argument.SwitchName))
+            .IsEquivalentTo(["--quiet", "--verbosity", "--recursive"]);
+        await Assert.That(arguments.Single(argument => argument.SwitchName == "--quiet").Description)
+            .IsNull();
+        await Assert.That(arguments.Single(argument => argument.SwitchName == "--recursive").Description)
+            .IsNull();
+    }
+
+    [Test]
+    public async Task Gcloud_Emits_Long_Options_With_Short_Aliases()
+    {
+        const string helpText = """
+            NAME
+                gcloud compute instances list - list instances
+
+            SYNOPSIS
+                gcloud compute instances list
+
+            FLAGS
+                 --zone=ZONE, -z ZONE
+                    Zone to list.
+                 --tag=TAG, -t TAG
+
+            GCLOUD WIDE FLAGS
+                 --project=PROJECT_ID
+            """;
+
+        var command = await CreateGcloudScraper().Parse(
+            ["gcloud", "compute", "instances", "list"],
+            helpText);
+
+        await Assert.That(command!.Options.Select(option => option.SwitchName))
+            .IsEquivalentTo(["--zone", "--tag"]);
+    }
+
+    [Test]
     public async Task GcloudAgentIdentityUpdate_Emits_Nested_Scope_Credential_And_Negatable_Flags()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliArgumentGroup.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliArgumentGroup.cs
@@ -1,0 +1,128 @@
+namespace ModularPipelines.OptionsGenerator.Models;
+
+/// <summary>
+/// Describes a nested group of CLI arguments declared by help output.
+/// </summary>
+public record CliArgumentGroup
+{
+    /// <summary>
+    /// Prose introducing the group, including any cardinality constraint.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Semantics inferred from the group prose.
+    /// </summary>
+    public CliArgumentGroupKind Kind { get; init; }
+
+    /// <summary>
+    /// Arguments declared directly in this group.
+    /// </summary>
+    public IReadOnlyList<CliArgumentDefinition> Arguments { get; init; } = [];
+
+    /// <summary>
+    /// Nested argument groups.
+    /// </summary>
+    public IReadOnlyList<CliArgumentGroup> Groups { get; init; } = [];
+
+    /// <summary>
+    /// Traverses all nested groups and carries their prose into each argument's documentation.
+    /// </summary>
+    public IEnumerable<CliArgumentDefinition> FlattenArguments() =>
+        FlattenArguments([])
+            .OrderBy(argument => argument.SourceOrder);
+
+    private IEnumerable<CliArgumentDefinition> FlattenArguments(IReadOnlyList<string> parentDescriptions)
+    {
+        var descriptions = string.IsNullOrWhiteSpace(Description)
+            ? parentDescriptions
+            : [.. parentDescriptions, Description];
+        var groupDescription = descriptions.Count == 0
+            ? null
+            : string.Join(" ", descriptions);
+
+        foreach (var argument in Arguments)
+        {
+            yield return argument with { GroupDescription = groupDescription };
+        }
+
+        foreach (var group in Groups)
+        {
+            foreach (var argument in group.FlattenArguments(descriptions))
+            {
+                yield return argument;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// A CLI argument declaration before tool-specific type inference.
+/// </summary>
+public record CliArgumentDefinition
+{
+    /// <summary>
+    /// Normalized switch name, including its leading dashes.
+    /// </summary>
+    public required string SwitchName { get; init; }
+
+    /// <summary>
+    /// Value placeholder shown by help output.
+    /// </summary>
+    public string? ValueHint { get; init; }
+
+    /// <summary>
+    /// Documentation directly beneath the declaration.
+    /// </summary>
+    public string? Description { get; init; }
+
+    /// <summary>
+    /// Documentation inherited from containing argument groups.
+    /// </summary>
+    public string? GroupDescription { get; init; }
+
+    /// <summary>
+    /// Whether the source syntax represents both positive and negative forms.
+    /// </summary>
+    public bool IsNegatable { get; init; }
+
+    /// <summary>
+    /// Source indentation used to recover nesting.
+    /// </summary>
+    public int Indentation { get; init; }
+
+    /// <summary>
+    /// Source line order retained while nested groups are flattened.
+    /// </summary>
+    public int SourceOrder { get; init; }
+
+    /// <summary>
+    /// Complete documentation retained for generated output.
+    /// </summary>
+    public string? Documentation => JoinDocumentation(GroupDescription, Description);
+
+    private static string? JoinDocumentation(string? groupDescription, string? description)
+    {
+        if (string.IsNullOrWhiteSpace(groupDescription))
+        {
+            return string.IsNullOrWhiteSpace(description) ? null : description;
+        }
+
+        return string.IsNullOrWhiteSpace(description)
+            ? groupDescription
+            : $"{groupDescription} {description}";
+    }
+}
+
+/// <summary>
+/// Semantics commonly used by nested CLI argument groups.
+/// </summary>
+[Flags]
+public enum CliArgumentGroupKind
+{
+    None = 0,
+    Alternative = 1,
+    AtMostOne = 2,
+    AtLeastOne = 4,
+    Resource = 8,
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -46,6 +46,11 @@ public record CliCommandDefinition
     public required IReadOnlyList<CliOptionDefinition> Options { get; init; }
 
     /// <summary>
+    /// Nested argument-group declarations retained from CLI help.
+    /// </summary>
+    public IReadOnlyList<CliArgumentGroup> ArgumentGroups { get; init; } = [];
+
+    /// <summary>
     /// Positional arguments for this command.
     /// </summary>
     public IReadOnlyList<CliPositionalArgument> PositionalArguments { get; init; } = [];

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliArgumentGroupParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliArgumentGroupParser.cs
@@ -75,32 +75,40 @@ internal static partial class CliArgumentGroupParser
         var declarations = new List<ParsedArgumentLine>();
         for (var index = 0; index < lines.Length; index++)
         {
-            if (parseArgument(lines[index]) is { } argument
-                && HasDocumentationBlock(lines, index, argument.Indentation))
+            if (parseArgument(lines[index]) is not { } argument)
             {
-                declarations.Add(new ParsedArgumentLine(index, argument));
+                continue;
             }
+
+            if (declarations.Count > 0
+                && IsInsideDocumentationBlock(lines, declarations[^1], index, argument.Indentation))
+            {
+                continue;
+            }
+
+            declarations.Add(new ParsedArgumentLine(index, argument));
         }
 
         return declarations;
     }
 
-    private static bool HasDocumentationBlock(
+    private static bool IsInsideDocumentationBlock(
         IReadOnlyList<string> lines,
-        int declarationIndex,
-        int declarationIndentation)
+        ParsedArgumentLine previousDeclaration,
+        int candidateIndex,
+        int candidateIndentation)
     {
-        for (var index = declarationIndex + 1; index < lines.Count; index++)
+        var declarationIndentation = previousDeclaration.Argument.Indentation;
+        if (candidateIndentation <= declarationIndentation)
         {
-            if (string.IsNullOrWhiteSpace(lines[index]))
-            {
-                continue;
-            }
-
-            return GetIndentation(lines[index]) > declarationIndentation;
+            return false;
         }
 
-        return false;
+        return lines
+            .Skip(previousDeclaration.LineIndex + 1)
+            .Take(candidateIndex - previousDeclaration.LineIndex - 1)
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .All(line => GetIndentation(line) > declarationIndentation);
     }
 
     private static void MoveToContainingGroup(
@@ -217,6 +225,8 @@ internal static partial class CliArgumentGroupParser
             return CliArgumentGroupKind.None;
         }
 
+        // Help headings are free-form prose, so classification is deliberately best-effort.
+        // Tool adapters can retain the group tree even when their phrasing maps to None.
         var kind = CliArgumentGroupKind.None;
         if (AtMostOnePattern().IsMatch(description))
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliArgumentGroupParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliArgumentGroupParser.cs
@@ -1,0 +1,288 @@
+using System.Text.RegularExpressions;
+using ModularPipelines.OptionsGenerator.Models;
+
+namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
+
+/// <summary>
+/// Recovers nested argument groups from indentation-based CLI help.
+/// </summary>
+internal static partial class CliArgumentGroupParser
+{
+    public static CliArgumentGroup Parse(
+        string section,
+        Func<string, CliArgumentDefinition?> parseArgument)
+    {
+        ArgumentNullException.ThrowIfNull(section);
+        ArgumentNullException.ThrowIfNull(parseArgument);
+
+        var lines = section.ReplaceLineEndings("\n").Split('\n');
+        var declarations = ParseDeclarations(lines, parseArgument);
+        if (declarations.Count == 0)
+        {
+            return new CliArgumentGroup
+            {
+                Description = NormalizeDocumentation(section),
+            };
+        }
+
+        var root = new ArgumentGroupBuilder(
+            declarations.Min(declaration => declaration.Argument.Indentation),
+            NormalizeDocumentation(lines[..declarations[0].LineIndex]));
+        var stack = new Stack<ArgumentGroupBuilder>();
+        stack.Push(root);
+        var previousDescriptionEnd = 0;
+
+        for (var index = 0; index < declarations.Count; index++)
+        {
+            var declaration = declarations[index];
+            var nextLineIndex = index + 1 < declarations.Count
+                ? declarations[index + 1].LineIndex
+                : lines.Length;
+            var descriptionEnd = FindDescriptionEnd(
+                lines,
+                declaration.LineIndex + 1,
+                nextLineIndex,
+                declaration.Argument.Indentation);
+            var description = NormalizeDocumentation(
+                lines[(declaration.LineIndex + 1)..descriptionEnd]);
+            var preludeStart = index == 0 ? 0 : previousDescriptionEnd;
+            var preludeLines = lines[preludeStart..declaration.LineIndex];
+            var prelude = NormalizeDocumentation(preludeLines);
+            var preludeIndentation = GetMinimumContentIndentation(preludeLines);
+            previousDescriptionEnd = descriptionEnd;
+
+            MoveToContainingGroup(
+                stack,
+                declaration.Argument.Indentation,
+                preludeIndentation);
+            AddArgument(
+                stack,
+                declaration.Argument with
+                {
+                    Description = description,
+                    SourceOrder = declaration.LineIndex,
+                },
+                prelude);
+        }
+
+        return root.Build();
+    }
+
+    private static List<ParsedArgumentLine> ParseDeclarations(
+        string[] lines,
+        Func<string, CliArgumentDefinition?> parseArgument)
+    {
+        var declarations = new List<ParsedArgumentLine>();
+        for (var index = 0; index < lines.Length; index++)
+        {
+            if (parseArgument(lines[index]) is { } argument
+                && HasDocumentationBlock(lines, index, argument.Indentation))
+            {
+                declarations.Add(new ParsedArgumentLine(index, argument));
+            }
+        }
+
+        return declarations;
+    }
+
+    private static bool HasDocumentationBlock(
+        IReadOnlyList<string> lines,
+        int declarationIndex,
+        int declarationIndentation)
+    {
+        for (var index = declarationIndex + 1; index < lines.Count; index++)
+        {
+            if (string.IsNullOrWhiteSpace(lines[index]))
+            {
+                continue;
+            }
+
+            return GetIndentation(lines[index]) > declarationIndentation;
+        }
+
+        return false;
+    }
+
+    private static void MoveToContainingGroup(
+        Stack<ArgumentGroupBuilder> stack,
+        int argumentIndentation,
+        int preludeIndentation)
+    {
+        while (stack.Count > 1
+               && (argumentIndentation < stack.Peek().Indentation
+                   || preludeIndentation < stack.Peek().Indentation))
+        {
+            stack.Pop();
+        }
+    }
+
+    private static void AddArgument(
+        Stack<ArgumentGroupBuilder> stack,
+        CliArgumentDefinition argument,
+        string? prelude)
+    {
+        var current = stack.Peek();
+        if (argument.Indentation > current.Indentation)
+        {
+            var child = new ArgumentGroupBuilder(argument.Indentation, prelude);
+            current.Groups.Add(child);
+            stack.Push(child);
+        }
+        else if (stack.Count > 1
+                 && !string.IsNullOrWhiteSpace(prelude)
+                 && Classify(prelude) != CliArgumentGroupKind.None)
+        {
+            stack.Pop();
+            var sibling = new ArgumentGroupBuilder(argument.Indentation, prelude);
+            stack.Peek().Groups.Add(sibling);
+            stack.Push(sibling);
+        }
+        else if (!string.IsNullOrWhiteSpace(prelude))
+        {
+            current.AppendDescription(prelude);
+        }
+
+        stack.Peek().Arguments.Add(argument);
+    }
+
+    private static int FindDescriptionEnd(
+        string[] lines,
+        int start,
+        int end,
+        int declarationIndentation)
+    {
+        for (var index = start; index < end; index++)
+        {
+            if (!string.IsNullOrWhiteSpace(lines[index])
+                && GetIndentation(lines[index]) <= declarationIndentation)
+            {
+                return index;
+            }
+        }
+
+        return end;
+    }
+
+    private static int GetIndentation(string line)
+    {
+        var indentation = 0;
+        foreach (var character in line)
+        {
+            switch (character)
+            {
+                case ' ':
+                    indentation++;
+                    break;
+                case '\t':
+                    indentation += 4;
+                    break;
+                default:
+                    return indentation;
+            }
+        }
+
+        return indentation;
+    }
+
+    private static int GetMinimumContentIndentation(IEnumerable<string> lines)
+    {
+        var indentations = lines
+            .Where(line => !string.IsNullOrWhiteSpace(line))
+            .Select(GetIndentation)
+            .ToArray();
+
+        return indentations.Length == 0 ? int.MaxValue : indentations.Min();
+    }
+
+    private static string? NormalizeDocumentation(IEnumerable<string> lines)
+    {
+        var text = string.Join(
+            " ",
+            lines
+                .Select(line => line.Trim())
+                .Where(line => !string.IsNullOrWhiteSpace(line)));
+
+        return string.IsNullOrWhiteSpace(text)
+            ? null
+            : WhitespacePattern().Replace(text, " ").Trim();
+    }
+
+    private static string? NormalizeDocumentation(string text) =>
+        NormalizeDocumentation(text.ReplaceLineEndings("\n").Split('\n'));
+
+    private static CliArgumentGroupKind Classify(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return CliArgumentGroupKind.None;
+        }
+
+        var kind = CliArgumentGroupKind.None;
+        if (AtMostOnePattern().IsMatch(description))
+        {
+            kind |= CliArgumentGroupKind.AtMostOne;
+        }
+
+        if (AtLeastOnePattern().IsMatch(description))
+        {
+            kind |= CliArgumentGroupKind.AtLeastOne;
+        }
+
+        if (AlternativePattern().IsMatch(description))
+        {
+            kind |= CliArgumentGroupKind.Alternative;
+        }
+
+        if (ResourcePattern().IsMatch(description))
+        {
+            kind |= CliArgumentGroupKind.Resource;
+        }
+
+        return kind;
+    }
+
+    private sealed class ArgumentGroupBuilder(int indentation, string? description)
+    {
+        public int Indentation { get; } = indentation;
+
+        public string? Description { get; private set; } = description;
+
+        public List<CliArgumentDefinition> Arguments { get; } = [];
+
+        public List<ArgumentGroupBuilder> Groups { get; } = [];
+
+        public void AppendDescription(string additionalDescription)
+        {
+            Description = string.IsNullOrWhiteSpace(Description)
+                ? additionalDescription
+                : $"{Description} {additionalDescription}";
+        }
+
+        public CliArgumentGroup Build() => new()
+        {
+            Description = Description,
+            Kind = Classify(Description),
+            Arguments = Arguments,
+            Groups = Groups.Select(group => group.Build()).ToArray(),
+        };
+    }
+
+    private sealed record ParsedArgumentLine(
+        int LineIndex,
+        CliArgumentDefinition Argument);
+
+    [GeneratedRegex(@"\s+", RegexOptions.CultureInvariant)]
+    private static partial Regex WhitespacePattern();
+
+    [GeneratedRegex(@"\bat most one\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex AtMostOnePattern();
+
+    [GeneratedRegex(@"\bat least one\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex AtLeastOnePattern();
+
+    [GeneratedRegex(@"(?:^|[.!?]\s+)or\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex AlternativePattern();
+
+    [GeneratedRegex(@"\b(?:resource|arguments? for)\b", RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex ResourcePattern();
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -414,6 +414,7 @@ public abstract partial class CliScraperBase : ICliScraper
             if (command is not null)
             {
                 ValidateOptionShapes(command, helpText);
+                ValidateArgumentGroups(command);
             }
         }
         catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
@@ -757,6 +758,16 @@ public abstract partial class CliScraperBase : ICliScraper
         return false;
     }
 
+    /// <summary>
+    /// Parses indentation-based argument declarations into a reusable nested group model.
+    /// The adapter only recognizes one tool-specific declaration line; traversal,
+    /// documentation boundaries, group classification, and flattening stay shared.
+    /// </summary>
+    protected static CliArgumentGroup ParseArgumentGroups(
+        string section,
+        Func<string, CliArgumentDefinition?> parseArgument) =>
+        CliArgumentGroupParser.Parse(section, parseArgument);
+
     private static void ValidateOptionShapes(CliCommandDefinition command, string helpText)
     {
         foreach (var option in command.Options)
@@ -776,6 +787,31 @@ public abstract partial class CliScraperBase : ICliScraper
                     $"{command.FullCommand} {option.SwitchName} is documented as repeatable, "
                     + "but the parsed model is scalar.");
             }
+        }
+    }
+
+    private static void ValidateArgumentGroups(CliCommandDefinition command)
+    {
+        if (command.ArgumentGroups.Count == 0)
+        {
+            return;
+        }
+
+        var emittedSwitches = command.Options
+            .Select(option => option.SwitchName)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var missingSwitches = command.ArgumentGroups
+            .SelectMany(group => group.FlattenArguments())
+            .Select(argument => argument.SwitchName)
+            .Where(switchName => !emittedSwitches.Contains(switchName))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (missingSwitches.Length != 0)
+        {
+            throw new InvalidOperationException(
+                $"{command.FullCommand} declares grouped arguments that were swallowed or omitted: "
+                + string.Join(", ", missingSwitches));
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -427,7 +427,7 @@ public partial class GcloudCliScraper : CliScraperBase
     /// --option=VALUE
     /// </summary>
     [GeneratedRegex(
-        @"^(?<indent>[ \t]+)(?:(?<negatable>--\[no-\])(?<negatableName>[\w-]+)|(?<long>--[\w-]+))(?:=(?<value>[^\s]+))?$")]
+        @"^(?<indent>[ \t]+)(?:(?<negatable>--\[no-\])(?<negatableName>[\w-]+)|(?<long>--[\w-]+))(?:=(?<value>[^\s]+))?(?:,\s*-[\w-]+(?:[ =]\S+)?)?$")]
     private static partial Regex GcloudFlagPattern();
 
     #endregion

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -99,7 +99,8 @@ public partial class GcloudCliScraper : CliScraperBase
 
         var subDomain = commandParts.Length > 1 ? ToPascalCase(commandParts[0]) : null;
         var description = ExtractDescription(helpText);
-        var options = ParseOptions(helpText, commandParts);
+        var parsedOptions = ParseOptions(helpText, commandParts);
+        var options = parsedOptions.Options;
         var positionalArgs = ParsePositionalArguments(helpText);
 
         var enums = options
@@ -119,6 +120,7 @@ public partial class GcloudCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = $"https://cloud.google.com/sdk/gcloud/reference/{string.Join("/", commandParts)}",
             Options = options,
+            ArgumentGroups = parsedOptions.ArgumentGroups,
             PositionalArguments = positionalArgs,
             SubDomainGroup = subDomain,
             Enums = enums
@@ -200,7 +202,9 @@ public partial class GcloudCliScraper : CliScraperBase
         return null;
     }
 
-    private List<CliOptionDefinition> ParseOptions(string helpText, string[] commandParts)
+    private (List<CliOptionDefinition> Options, IReadOnlyList<CliArgumentGroup> ArgumentGroups) ParseOptions(
+        string helpText,
+        string[] commandParts)
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -210,7 +214,7 @@ public partial class GcloudCliScraper : CliScraperBase
         var flagsMatch = Regex.Match(helpText, @"^FLAGS\s*$", RegexOptions.Multiline);
         if (!flagsMatch.Success)
         {
-            return options;
+            return (options, []);
         }
 
         var sectionStart = flagsMatch.Index + flagsMatch.Length;
@@ -220,15 +224,13 @@ public partial class GcloudCliScraper : CliScraperBase
         var sectionEnd = nextSectionMatch.Success ? sectionStart + nextSectionMatch.Index : helpText.Length;
 
         var flagsSection = helpText[sectionStart..sectionEnd];
+        var argumentGroup = ParseArgumentGroups(flagsSection, ParseGcloudArgument);
 
-        // Parse each flag: "     --flag" or "     --option=VALUE"
-        var flagMatches = GcloudFlagPattern().Matches(flagsSection);
-
-        foreach (Match match in flagMatches)
+        foreach (var argument in argumentGroup.FlattenArguments())
         {
-            var negatable = !string.IsNullOrEmpty(match.Groups["negatable"].Value);
-            var longForm = match.Groups["long"].Value;
-            var valueHint = match.Groups["value"].Value;
+            var negatable = argument.IsNegatable;
+            var longForm = argument.SwitchName;
+            var valueHint = argument.ValueHint ?? string.Empty;
 
             if (string.IsNullOrEmpty(longForm) || seenOptions.Contains(longForm))
             {
@@ -243,10 +245,7 @@ public partial class GcloudCliScraper : CliScraperBase
                 continue;
             }
 
-            // Get description (lines following the flag with more indentation)
-            var flagEnd = match.Index + match.Length;
-            var descMatch = Regex.Match(flagsSection[flagEnd..], @"^\s{8,}(.+?)(?=\n\s{5}--|\n\n\s{5}--|\z)", RegexOptions.Singleline);
-            var description = descMatch.Success ? descMatch.Groups[1].Value.Trim().Replace("\n", " ").Replace("  ", " ") : null;
+            var description = argument.Documentation;
 
             var isFlag = string.IsNullOrEmpty(valueHint) || negatable;
             var isArray = valueHint.Contains("...") || (description?.Contains("may be repeated") ?? false);
@@ -273,7 +272,29 @@ public partial class GcloudCliScraper : CliScraperBase
             });
         }
 
-        return options;
+        return (options, [argumentGroup]);
+    }
+
+    private static CliArgumentDefinition? ParseGcloudArgument(string line)
+    {
+        var match = GcloudFlagPattern().Match(line);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        var negatable = match.Groups["negatable"].Success;
+        var name = negatable
+            ? $"--{match.Groups["negatableName"].Value}"
+            : match.Groups["long"].Value;
+
+        return new CliArgumentDefinition
+        {
+            SwitchName = name,
+            ValueHint = match.Groups["value"].Value,
+            IsNegatable = negatable,
+            Indentation = match.Groups["indent"].Value.Length,
+        };
     }
 
     private static List<CliPositionalArgument> ParsePositionalArguments(string helpText)
@@ -405,7 +426,8 @@ public partial class GcloudCliScraper : CliScraperBase
     /// --[no-]flag
     /// --option=VALUE
     /// </summary>
-    [GeneratedRegex(@"^\s{5}(?<negatable>--\[no-\])?(?<long>--?[\w-]+)(?:=(?<value>[^\s\n]+))?", RegexOptions.Multiline)]
+    [GeneratedRegex(
+        @"^(?<indent>[ \t]+)(?:(?<negatable>--\[no-\])(?<negatableName>[\w-]+)|(?<long>--[\w-]+))(?:=(?<value>[^\s]+))?$")]
     private static partial Regex GcloudFlagPattern();
 
     #endregion


### PR DESCRIPTION
## Summary
- add a shared indentation-based `CliArgumentGroup` model and parser for nested alternatives, cardinality constraints, resource groups, and negatable flags
- validate that every grouped help declaration becomes a `CliOptionDefinition`
- adapt gcloud parsing so nested flags are no longer swallowed into preceding documentation while help examples remain documentation
- cover both reported gcloud commands and a tool-neutral nested-group fixture

## Validation
- `ModularPipelines.OptionsGenerator.Tests`: 574 passed with Cobertura coverage
- `ModularPipelines.OptionsGenerator.sln` Release build: 0 errors
- touched-file whitespace verification: clean

Closes #3160