### PR TITLE
Strip ANSI formatting from CLI scraper help

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
@@ -26,6 +26,18 @@ public class ZeroOutputScraperTests
     }
 
     [Test]
+    public async Task Aws_Extracts_Service_List_With_Ansi_Formatting()
+    {
+        const string helpText = "\u001b[4mAVAILABLE SERVICES\u001b[24m\n\n"
+            + "       \u001b[1mo accessanalyzer\u001b[22m\n"
+            + "       \u001b[1mo cloudformation\u001b[22m\n"
+            + "       \u001b[1mo ec2\u001b[22m\n";
+
+        await Assert.That(new TestAwsCliScraper().ExtractNormalized(helpText))
+            .IsEquivalentTo(["accessanalyzer", "cloudformation", "ec2"]);
+    }
+
+    [Test]
     public async Task Gh_Parses_Uppercase_Usage_And_Flags_Sections()
     {
         const string helpText = """
@@ -192,6 +204,21 @@ public class ZeroOutputScraperTests
             .IsEquivalentTo(["add", "install", "workspace"]);
     }
 
+    [Test]
+    public async Task Yarn_Extracts_Berry_Commands_With_Ansi_Formatting()
+    {
+        const string helpText = "\u001b[1m━━━ General commands ━━━━━━━━━━━\u001b[0m\n\n"
+            + "  \u001b[1myarn add [--json]\u001b[22m\n"
+            + "    add dependencies to the project\n\n"
+            + "  \u001b[1myarn cache clean [--mirror]\u001b[22m\n"
+            + "    remove the shared cache files\n\n"
+            + "\u001b[1m━━━ Npm-related commands ━━━━━━━\u001b[0m\n\n"
+            + "  \u001b[1myarn npm info [--json]\u001b[22m\n";
+
+        await Assert.That(new TestYarnCliScraper().ExtractNormalized(helpText))
+            .IsEquivalentTo(["add", "cache", "cache clean", "npm", "npm info"]);
+    }
+
     private sealed class TestAwsCliScraper : AwsCliScraper
     {
         public TestAwsCliScraper()
@@ -203,6 +230,9 @@ public class ZeroOutputScraperTests
         }
 
         public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
+
+        public IReadOnlyList<string> ExtractNormalized(string helpText) =>
+            ExtractSubcommands(NormalizeHelpText(helpText)).ToList();
     }
 
     private sealed class TestGhCliScraper : GhCliScraper
@@ -232,5 +262,8 @@ public class ZeroOutputScraperTests
         }
 
         public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
+
+        public IReadOnlyList<string> ExtractNormalized(string helpText) =>
+            ExtractSubcommands(NormalizeHelpText(helpText)).ToList();
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
@@ -29,12 +29,15 @@ public class ZeroOutputScraperTests
     public async Task Aws_Extracts_Service_List_With_Ansi_Formatting()
     {
         const string helpText = "\u001b[4mAVAILABLE SERVICES\u001b[24m\n\n"
-            + "       \u001b[1mo accessanalyzer\u001b[22m\n"
+            + "       \u001b[1mo \u001b]8;;https://example.test\u001b\\accessanalyzer\u001b]8;;\u001b\\\u001b[22m\n"
             + "       \u001b[1mo cloudformation\u001b[22m\n"
             + "       \u001b[1mo ec2\u001b[22m\n";
+        const string commandHelp = "OPTIONS\n       --enabled (boolean)\n";
+        var scraper = new TestAwsCliScraper(new StubExecutor(arguments =>
+            arguments == "help" ? helpText : commandHelp));
 
-        await Assert.That(new TestAwsCliScraper().ExtractNormalized(helpText))
-            .IsEquivalentTo(["accessanalyzer", "cloudformation", "ec2"]);
+        await Assert.That((await ScrapeAsync(scraper)).Select(command => command.FullCommand))
+            .IsEquivalentTo(["aws accessanalyzer", "aws cloudformation", "aws ec2"]);
     }
 
     [Test]
@@ -208,31 +211,46 @@ public class ZeroOutputScraperTests
     public async Task Yarn_Extracts_Berry_Commands_With_Ansi_Formatting()
     {
         const string helpText = "\u001b[1m━━━ General commands ━━━━━━━━━━━\u001b[0m\n\n"
-            + "  \u001b[1myarn add [--json]\u001b[22m\n"
+            + "  \u001b[1myarn \u001b]8;;https://example.test\u001b\\add\u001b]8;;\u001b\\ [--json]\u001b[22m\n"
             + "    add dependencies to the project\n\n"
             + "  \u001b[1myarn cache clean [--mirror]\u001b[22m\n"
             + "    remove the shared cache files\n\n"
             + "\u001b[1m━━━ Npm-related commands ━━━━━━━\u001b[0m\n\n"
             + "  \u001b[1myarn npm info [--json]\u001b[22m\n";
+        const string commandHelp = "━━━ Details ━━━\nCommand details.\n\n"
+            + "━━━ Options ━━━\n  --json  Format output as JSON.\n";
+        var scraper = new TestYarnCliScraper(new StubExecutor(arguments => arguments switch
+        {
+            "--help" => helpText,
+            _ => commandHelp,
+        }));
 
-        await Assert.That(new TestYarnCliScraper().ExtractNormalized(helpText))
-            .IsEquivalentTo(["add", "cache", "cache clean", "npm", "npm info"]);
+        await Assert.That((await ScrapeAsync(scraper)).Select(command => command.FullCommand))
+            .IsEquivalentTo(["yarn add", "yarn cache", "yarn cache clean", "yarn npm", "yarn npm info"]);
+    }
+
+    private static async Task<IReadOnlyList<CliCommandDefinition>> ScrapeAsync(ICliScraper scraper)
+    {
+        var commands = new List<CliCommandDefinition>();
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        return commands;
     }
 
     private sealed class TestAwsCliScraper : AwsCliScraper
     {
-        public TestAwsCliScraper()
+        public TestAwsCliScraper(ICliCommandExecutor? executor = null)
             : base(
-                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                executor ?? new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
                 new HelpTextCache(NullLogger<HelpTextCache>.Instance),
                 NullLogger<AwsCliScraper>.Instance)
         {
         }
 
         public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
-
-        public IReadOnlyList<string> ExtractNormalized(string helpText) =>
-            ExtractSubcommands(NormalizeHelpText(helpText)).ToList();
     }
 
     private sealed class TestGhCliScraper : GhCliScraper
@@ -253,9 +271,9 @@ public class ZeroOutputScraperTests
 
     private sealed class TestYarnCliScraper : YarnCliScraper
     {
-        public TestYarnCliScraper()
+        public TestYarnCliScraper(ICliCommandExecutor? executor = null)
             : base(
-                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                executor ?? new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
                 new HelpTextCache(NullLogger<HelpTextCache>.Instance),
                 NullLogger<YarnCliScraper>.Instance)
         {
@@ -263,7 +281,35 @@ public class ZeroOutputScraperTests
 
         public IReadOnlyList<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
 
-        public IReadOnlyList<string> ExtractNormalized(string helpText) =>
-            ExtractSubcommands(NormalizeHelpText(helpText)).ToList();
+        protected override async Task<string?> GetHelpTextAsync(
+            string[] commandPath,
+            CancellationToken cancellationToken)
+        {
+            var arguments = commandPath.Length > 1
+                ? string.Join(" ", commandPath.Skip(1)) + " --help"
+                : "--help";
+            var result = await Executor.ExecuteAsync(ToolName, arguments, cancellationToken);
+            return result.StandardOutput;
+        }
+    }
+
+    private sealed class StubExecutor(Func<string, string> outputByArguments) : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null) =>
+            Task.FromResult(new CliCommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = outputByArguments(arguments),
+                StandardError = string.Empty,
+            });
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -814,7 +814,7 @@ public abstract partial class CliScraperBase : ICliScraper
         RegexOptions.IgnoreCase)]
     private static partial Regex RepeatableValuePattern();
 
-    [GeneratedRegex(@"\x1B(?:\][^\x07]*(?:\x07|\x1B\\)|\[[0-?]*[ -/]*[@-~])")]
+    [GeneratedRegex(@"\x1B(?:\][^\x07\x1B]*(?:\x07|\x1B\\)|\[[0-?]*[ -/]*[@-~])")]
     private static partial Regex AnsiEscapeSequencePattern();
 
     #endregion

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -326,6 +326,8 @@ public abstract partial class CliScraperBase : ICliScraper
             return;
         }
 
+        helpText = NormalizeHelpText(helpText);
+
         if (path.Length == 1)
         {
             GlobalOptions = ParseGlobalOptions(helpText);
@@ -541,6 +543,13 @@ public abstract partial class CliScraperBase : ICliScraper
     /// Each CLI has different formatting - must be implemented per CLI type.
     /// </summary>
     protected abstract IEnumerable<string> ExtractSubcommands(string helpText);
+
+    /// <summary>
+    /// Removes terminal formatting that changes the text shape consumed by scraper parsers.
+    /// Some CLIs emit ANSI sequences even when output is redirected and <c>NO_COLOR</c> is set.
+    /// </summary>
+    protected static string NormalizeHelpText(string helpText) =>
+        AnsiEscapeSequencePattern().Replace(helpText, string.Empty);
 
     /// <summary>
     /// Parses a command from its help text into a CliCommandDefinition.
@@ -804,6 +813,9 @@ public abstract partial class CliScraperBase : ICliScraper
         @"\b(?:one\s+or\s+more|zero\s+or\s+more|multiple\s+(?:times|values)|more\s+than\s+once|repeat(?:able|ed|edly)?)\b",
         RegexOptions.IgnoreCase)]
     private static partial Regex RepeatableValuePattern();
+
+    [GeneratedRegex(@"\x1B(?:\][^\x07]*(?:\x07|\x1B\\)|\[[0-?]*[ -/]*[@-~])")]
+    private static partial Regex AnsiEscapeSequencePattern();
 
     #endregion
 }


### PR DESCRIPTION
## Summary

- normalize CLI help text by removing ANSI CSI/OSC formatting before parser dispatch
- restore AWS service discovery when rendered headings contain underline sequences
- restore Yarn Berry command discovery when category headings and command rows are styled
- add regression fixtures matching the failed CI output shape

The other zero-output causes tracked by #3010 were addressed by the installation, executable pinning, logging, and tool-specific scraper changes already merged since the reported run. AWS and Yarn were the remaining current-main parser failures in run 30185753285: both returned non-empty help, but ANSI formatting hid parser boundaries.

## Validation

- OptionsGenerator tests: 572 passed, 0 failed
- `ModularPipelines.OptionsGenerator.sln` Release build: 0 errors (2 existing warnings)
- touched-file whitespace verification: clean
- reproduced live Yarn 4.17.1 ANSI help output locally

Closes #3010