### PR TITLE
Polish pipeline summary output

### DIFF
--- a/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
+++ b/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
@@ -120,12 +120,11 @@ internal class SpectreResultsPrinter : IResultsPrinter
         System.Console.WriteLine();
     }
 
-    private static Table CreateModulesTable(PipelineSummary pipelineSummary)
+    internal static Table CreateModulesTable(PipelineSummary pipelineSummary)
     {
         var table = new Table
         {
             Border = TableBorder.Rounded,
-            Expand = true,
         };
 
         // Add columns with alignment
@@ -174,8 +173,6 @@ internal class SpectreResultsPrinter : IResultsPrinter
             AddModuleRow(table, module, timelineLookup);
         }
 
-        // Add separator and total row
-        table.AddEmptyRow();
         AddTotalRow(table, pipelineSummary);
 
         return table;
@@ -248,7 +245,7 @@ internal class SpectreResultsPrinter : IResultsPrinter
             ModuleStatus.TimedOut => "[red]Timeout[/]",
             ModuleStatus.PipelineTerminated => "[red]Terminated[/]",
             ModuleStatus.IgnoredFailure => "[yellow]Ignored[/]",
-            ModuleStatus.Skipped => "[yellow]Skipped[/]",
+            ModuleStatus.Skipped => "[dim]⏭ skipped[/]",
             ModuleStatus.UsedHistory => "[green3]Cached[/]",
             ModuleStatus.Retried => "[yellow]Retried[/]",
             ModuleStatus.Processing => "[blue]Running[/]",
@@ -286,18 +283,20 @@ internal class SpectreResultsPrinter : IResultsPrinter
 
         System.Console.WriteLine();
 
-        // Create a compact metrics display
-        var metricsPanel = new Panel(
+        AnsiConsole.Write(CreateMetricsPanel(metrics));
+    }
+
+    internal static Panel CreateMetricsPanel(PipelineMetrics metrics)
+    {
+        return new Panel(
             new Markup(
-                $"[dim]Parallelism:[/] [bold]{metrics.ParallelismFactor:F1}x[/]  " +
+                $"[dim]Speedup:[/] [bold]{metrics.ParallelismFactor:F1}x[/]  " +
                 $"[dim]Peak:[/] [bold]{metrics.PeakConcurrency}[/]  " +
                 $"[dim]Saved:[/] [bold]{(metrics.TotalModuleExecutionTime - metrics.WallClockDuration).ToDisplayString()}[/]"))
         {
             Border = BoxBorder.None,
             Padding = new Padding(0, 0, 0, 0),
         };
-
-        AnsiConsole.Write(metricsPanel);
     }
 
     private static string FormatTime(DateTimeOffset dateTimeOffset, bool isSameDay)

--- a/src/ModularPipelines/Helpers/TimeSpanFormatter.cs
+++ b/src/ModularPipelines/Helpers/TimeSpanFormatter.cs
@@ -11,15 +11,15 @@ internal static class TimeSpanFormatter
 
         if (timeSpan.TotalMinutes < 1)
         {
-            return $"{Seconds(timeSpan)} & {Milliseconds(timeSpan)}";
+            return $"{Seconds(timeSpan)} {Milliseconds(timeSpan)}";
         }
 
         if (timeSpan.TotalHours < 1)
         {
-            return $"{Minutes(timeSpan)} & {Seconds(timeSpan)}";
+            return $"{Minutes(timeSpan)} {Seconds(timeSpan)}";
         }
 
-        return $"{Hours(timeSpan)} & {Minutes(timeSpan)}";
+        return $"{Hours(timeSpan)} {Minutes(timeSpan)}";
     }
 
     private static string Milliseconds(TimeSpan timeSpan)

--- a/test/ModularPipelines.UnitTests/Engine/ModuleCompletionLogStateTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleCompletionLogStateTests.cs
@@ -13,7 +13,7 @@ public class ModuleCompletionLogStateTests
         var properties = state.ToDictionary(x => x.Key, x => x.Value);
 
         await Assert.That(state.Message).IsEqualTo(
-            "Module ExampleModule completed after 23s & 737ms with lock keys: (none) (Active: Q=1, E=2)");
+            "Module ExampleModule completed after 23s 737ms with lock keys: (none) (Active: Q=1, E=2)");
         await Assert.That(properties["Duration"]).IsTypeOf<TimeSpan>();
         await Assert.That(properties["Duration"]).IsEqualTo(duration);
         await Assert.That(properties["ExecutionTime"]).IsTypeOf<double>();

--- a/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
@@ -1,0 +1,89 @@
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Helpers;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using Moq;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using ModuleStatus = ModularPipelines.Enums.Status;
+
+namespace ModularPipelines.UnitTests.Helpers;
+
+public class SpectreResultsPrinterTests
+{
+    private class SkippedModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+
+    [Test]
+    public async Task ModulesTable_IsCompactWithoutBlankSeparator_AndLabelsSkippedModules()
+    {
+        var start = new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero);
+        var end = start.AddSeconds(5);
+        var module = new SkippedModule();
+        var metricsCollector = new Mock<IMetricsCollector>();
+        metricsCollector
+            .Setup(x => x.GetTimelines())
+            .Returns(
+            [
+                new ModuleTimeline
+                {
+                    ModuleName = nameof(SkippedModule),
+                    Status = ModuleStatus.Skipped,
+                    WasSkipped = true,
+                },
+            ]);
+
+        var summary = new PipelineSummary(
+            [module],
+            end - start,
+            start,
+            end,
+            new Mock<IModuleResultRegistry>().Object,
+            metricsCollector.Object,
+            maxParallelism: 1);
+
+        var table = SpectreResultsPrinter.CreateModulesTable(summary);
+        var output = RenderToString(table);
+
+        await Assert.That(table.Expand).IsFalse();
+        await Assert.That(table.Rows.Count).IsEqualTo(2);
+        await Assert.That(output).Contains("⏭ skipped");
+    }
+
+    [Test]
+    public async Task MetricsPanel_LabelsParallelismFactorAsSpeedup()
+    {
+        var panel = SpectreResultsPrinter.CreateMetricsPanel(new PipelineMetrics
+        {
+            ParallelismFactor = 2.5,
+            PeakConcurrency = 4,
+            TotalModuleExecutionTime = TimeSpan.FromSeconds(10),
+            WallClockDuration = TimeSpan.FromSeconds(4),
+        });
+
+        var output = RenderToString(panel);
+
+        await Assert.That(output).Contains("Speedup:");
+        await Assert.That(output).DoesNotContain("Parallelism:");
+        await Assert.That(output).Contains("2.5x");
+    }
+
+    private static string RenderToString(IRenderable renderable)
+    {
+        using var writer = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(writer),
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+        });
+
+        console.Write(renderable);
+        return writer.ToString();
+    }
+}

--- a/test/ModularPipelines.UnitTests/Helpers/TimeSpanFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/TimeSpanFormatterTests.cs
@@ -6,9 +6,9 @@ public class TimeSpanFormatterTests
 {
     [Test]
     [Arguments(0, 0, 0, 849, "849ms")]
-    [Arguments(0, 0, 23, 737, "23s & 737ms")]
-    [Arguments(0, 9, 42, 0, "9m & 42s")]
-    [Arguments(2, 3, 0, 0, "2h & 3m")]
+    [Arguments(0, 0, 23, 737, "23s 737ms")]
+    [Arguments(0, 9, 42, 0, "9m 42s")]
+    [Arguments(2, 3, 0, 0, "2h 3m")]
     public async Task ToDisplayString_UsesOneReadableFormat(
         int hours,
         int minutes,
@@ -26,6 +26,6 @@ public class TimeSpanFormatterTests
     {
         var duration = TimeSpan.FromHours(25.5);
 
-        await Assert.That(duration.ToDisplayString()).IsEqualTo("25h & 30m");
+        await Assert.That(duration.ToDisplayString()).IsEqualTo("25h 30m");
     }
 }


### PR DESCRIPTION
## Summary

- compact the pipeline results table and remove the blank separator row
- render skipped modules as a dim `⏭ skipped` state
- rename the computed parallelism factor to `Speedup`
- format compound durations without ampersands
- add focused renderer and duration regression tests

## Validation

- focused helper tests: 7/7 passed with coverage
- `ModularPipelines.sln` Release build: 0 errors (254 existing warnings)
- scoped whitespace verification: clean
- `git diff --check`: clean

Closes #2621