### PR TITLE
Surface warnings and errors in Azure Pipelines

### DIFF
--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -319,6 +319,9 @@ internal static class DependencyInjectionSetup
             .AddSingleton<IBuildSystemSecretMasker, BuildSystemSecretMasker>()
             .AddSingleton<IBuildSystemDetector, BuildSystemDetector>()
             .AddSingleton<IBuildSystemFormatterProvider, BuildSystemFormatterProvider>();
+
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<ILoggerProvider, BuildSystemLogIssueLoggerProvider>());
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/BuildSystemFormatters/AzurePipelinesFormatter.cs
+++ b/src/ModularPipelines/Engine/BuildSystemFormatters/AzurePipelinesFormatter.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace ModularPipelines.Engine.BuildSystemFormatters;
 
 /// <summary>
@@ -25,4 +27,28 @@ internal class AzurePipelinesFormatter : IBuildSystemFormatter
     public string GetEndBlockCommand(string name) => "##[endgroup]";
 
     public string GetMaskSecretCommand(string secret) => $"##vso[task.setvariable variable=secret_{Guid.NewGuid():N};issecret=true]{secret}";
+
+    public string? GetLogIssueCommand(LogLevel logLevel, string message)
+    {
+        var issueType = logLevel switch
+        {
+            LogLevel.Critical or LogLevel.Error => "error",
+            LogLevel.Warning => "warning",
+            _ => null,
+        };
+
+        return issueType is null
+            ? null
+            : $"##vso[task.logissue type={issueType};]{EscapeLoggingCommandValue(message)}";
+    }
+
+    private static string EscapeLoggingCommandValue(string value)
+    {
+        return value
+            .Replace("%", "%AZP25", StringComparison.Ordinal)
+            .Replace(";", "%3B", StringComparison.Ordinal)
+            .Replace("\r", "%0D", StringComparison.Ordinal)
+            .Replace("\n", "%0A", StringComparison.Ordinal)
+            .Replace("]", "%5D", StringComparison.Ordinal);
+    }
 }

--- a/src/ModularPipelines/Engine/IBuildSystemFormatter.cs
+++ b/src/ModularPipelines/Engine/IBuildSystemFormatter.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace ModularPipelines.Engine;
 
 /// <summary>
@@ -46,4 +48,12 @@ internal interface IBuildSystemFormatter
     /// <param name="secret">The secret value to mask.</param>
     /// <returns>The formatted masking command, or null if not supported by this build system.</returns>
     string? GetMaskSecretCommand(string secret);
+
+    /// <summary>
+    /// Gets the command that surfaces a warning or error in the build system UI.
+    /// </summary>
+    /// <param name="logLevel">The severity of the log event.</param>
+    /// <param name="message">The rendered log message.</param>
+    /// <returns>The formatted issue command, or null if the event should not be surfaced separately.</returns>
+    string? GetLogIssueCommand(LogLevel logLevel, string message) => null;
 }

--- a/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
@@ -48,6 +48,11 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
             }
 
             var message = messageFormatter(state, exception);
+            if (exception is not null)
+            {
+                message = $"{message}{Environment.NewLine}{exception}";
+            }
+
             var command = formatter.GetLogIssueCommand(logLevel, message);
             if (command is not null)
             {

--- a/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Engine;
+
+namespace ModularPipelines.Logging;
+
+internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
+{
+    private readonly ILogger _logger;
+
+    public BuildSystemLogIssueLoggerProvider(IBuildSystemFormatterProvider formatterProvider)
+        : this(formatterProvider.GetFormatter(), () => System.Console.Out)
+    {
+    }
+
+    internal BuildSystemLogIssueLoggerProvider(
+        IBuildSystemFormatter formatter,
+        Func<TextWriter> writerProvider)
+    {
+        _logger = new BuildSystemLogIssueLogger(formatter, writerProvider);
+    }
+
+    public ILogger CreateLogger(string categoryName) => _logger;
+
+    public void Dispose()
+    {
+    }
+
+    private sealed class BuildSystemLogIssueLogger(
+        IBuildSystemFormatter formatter,
+        Func<TextWriter> writerProvider) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) =>
+            logLevel is LogLevel.Warning or LogLevel.Error or LogLevel.Critical;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> messageFormatter)
+        {
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            var message = messageFormatter(state, exception);
+            var command = formatter.GetLogIssueCommand(logLevel, message);
+            if (command is not null)
+            {
+                writerProvider().WriteLine(command);
+            }
+        }
+    }
+}

--- a/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
@@ -1,39 +1,59 @@
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
+using Spectre.Console;
 
 namespace ModularPipelines.Logging;
 
 internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
 {
-    private readonly ILogger _logger;
+    private static readonly string[] ExcludedCategoryPrefixes =
+    [
+        "Microsoft",
+        "System",
+    ];
+
+    private readonly IBuildSystemFormatter _formatter;
+    private readonly IAnsiConsole _console;
 
     public BuildSystemLogIssueLoggerProvider(IBuildSystemFormatterProvider formatterProvider)
-        : this(formatterProvider.GetFormatter(), () => System.Console.Out)
+        : this(formatterProvider.GetFormatter(), ModularPipelines.Console.DelegatingAnsiConsole.Instance)
     {
     }
 
     internal BuildSystemLogIssueLoggerProvider(
         IBuildSystemFormatter formatter,
-        Func<TextWriter> writerProvider)
+        IAnsiConsole console)
     {
-        _logger = new BuildSystemLogIssueLogger(formatter, writerProvider);
+        _formatter = formatter;
+        _console = console;
     }
 
-    public ILogger CreateLogger(string categoryName) => _logger;
+    public ILogger CreateLogger(string categoryName) =>
+        new BuildSystemLogIssueLogger(
+            _formatter,
+            _console,
+            IsIssueCategory(categoryName));
 
     public void Dispose()
     {
     }
 
+    private static bool IsIssueCategory(string categoryName) =>
+        !ExcludedCategoryPrefixes.Any(prefix =>
+            categoryName.Equals(prefix, StringComparison.Ordinal)
+            || categoryName.StartsWith($"{prefix}.", StringComparison.Ordinal));
+
     private sealed class BuildSystemLogIssueLogger(
         IBuildSystemFormatter formatter,
-        Func<TextWriter> writerProvider) : ILogger
+        IAnsiConsole console,
+        bool isIssueCategory) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state)
             where TState : notnull => null;
 
         public bool IsEnabled(LogLevel logLevel) =>
-            logLevel is LogLevel.Warning or LogLevel.Error or LogLevel.Critical;
+            isIssueCategory
+            && logLevel is LogLevel.Warning or LogLevel.Error or LogLevel.Critical;
 
         public void Log<TState>(
             LogLevel logLevel,
@@ -56,7 +76,7 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
             var command = formatter.GetLogIssueCommand(logLevel, message);
             if (command is not null)
             {
-                writerProvider().WriteLine(command);
+                console.Profile.Out.Writer.WriteLine(command);
             }
         }
     }

--- a/test/ModularPipelines.UnitTests/Engine/AzurePipelinesFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/AzurePipelinesFormatterTests.cs
@@ -1,0 +1,40 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Engine.BuildSystemFormatters;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class AzurePipelinesFormatterTests
+{
+    [Test]
+    [Arguments(LogLevel.Warning, "warning")]
+    [Arguments(LogLevel.Error, "error")]
+    [Arguments(LogLevel.Critical, "error")]
+    public async Task GetLogIssueCommand_MapsIssueSeverities(LogLevel logLevel, string issueType)
+    {
+        var command = new AzurePipelinesFormatter().GetLogIssueCommand(logLevel, "message");
+
+        await Assert.That(command).IsEqualTo($"##vso[task.logissue type={issueType};]message");
+    }
+
+    [Test]
+    [Arguments(LogLevel.Trace)]
+    [Arguments(LogLevel.Debug)]
+    [Arguments(LogLevel.Information)]
+    [Arguments(LogLevel.None)]
+    public async Task GetLogIssueCommand_IgnoresNonIssueSeverities(LogLevel logLevel)
+    {
+        var command = new AzurePipelinesFormatter().GetLogIssueCommand(logLevel, "message");
+
+        await Assert.That(command).IsNull();
+    }
+
+    [Test]
+    public async Task GetLogIssueCommand_EscapesReservedCharacters()
+    {
+        var command = new AzurePipelinesFormatter()
+            .GetLogIssueCommand(LogLevel.Warning, "50%;]\r\nnext");
+
+        await Assert.That(command)
+            .IsEqualTo("##vso[task.logissue type=warning;]50%AZP25%3B%5D%0D%0Anext");
+    }
+}

--- a/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
@@ -36,6 +36,24 @@ public class BuildSystemLogIssueLoggerProviderTests
     }
 
     [Test]
+    public async Task Logger_IncludesExceptionDetailsInIssueCommand()
+    {
+        using var writer = new StringWriter();
+        using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
+        var logger = provider.CreateLogger("test");
+        var exception = new InvalidOperationException("failure");
+
+        logger.LogError(exception, "message");
+
+        var escapedNewLine = Environment.NewLine
+            .Replace("\r", "%0D", StringComparison.Ordinal)
+            .Replace("\n", "%0A", StringComparison.Ordinal);
+        await Assert.That(writer.ToString())
+            .IsEqualTo(
+                $"##vso[task.logissue type=error;]message{escapedNewLine}{exception}{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task Logger_WritesNothingWhenBuildSystemHasNoIssueCommand()
     {
         using var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.BuildSystemFormatters;
+using ModularPipelines.Logging;
+
+namespace ModularPipelines.UnitTests.Logging;
+
+public class BuildSystemLogIssueLoggerProviderTests
+{
+    [Test]
+    [Arguments(LogLevel.Warning, "warning")]
+    [Arguments(LogLevel.Error, "error")]
+    [Arguments(LogLevel.Critical, "error")]
+    public async Task Logger_WritesAzureIssueCommands(LogLevel logLevel, string issueType)
+    {
+        using var writer = new StringWriter();
+        using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
+        var logger = provider.CreateLogger("test");
+
+        logger.Log(logLevel, "message");
+
+        await Assert.That(writer.ToString())
+            .IsEqualTo($"##vso[task.logissue type={issueType};]message{Environment.NewLine}");
+    }
+
+    [Test]
+    public async Task Logger_IgnoresNonIssueLevels()
+    {
+        using var writer = new StringWriter();
+        using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
+        var logger = provider.CreateLogger("test");
+
+        logger.LogInformation("message");
+
+        await Assert.That(writer.ToString()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Logger_WritesNothingWhenBuildSystemHasNoIssueCommand()
+    {
+        using var writer = new StringWriter();
+        using var provider = CreateProvider(new DefaultFormatter(), writer);
+        var logger = provider.CreateLogger("test");
+
+        logger.LogWarning("message");
+
+        await Assert.That(writer.ToString()).IsEmpty();
+    }
+
+    private static BuildSystemLogIssueLoggerProvider CreateProvider(
+        IBuildSystemFormatter formatter,
+        TextWriter writer)
+    {
+        return new BuildSystemLogIssueLoggerProvider(formatter, () => writer);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.BuildSystemFormatters;
 using ModularPipelines.Logging;
+using Spectre.Console;
 
 namespace ModularPipelines.UnitTests.Logging;
 
@@ -15,7 +16,7 @@ public class BuildSystemLogIssueLoggerProviderTests
     {
         using var writer = new StringWriter();
         using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
-        var logger = provider.CreateLogger("test");
+        var logger = provider.CreateLogger("Example.Pipeline");
 
         logger.Log(logLevel, "message");
 
@@ -28,7 +29,7 @@ public class BuildSystemLogIssueLoggerProviderTests
     {
         using var writer = new StringWriter();
         using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
-        var logger = provider.CreateLogger("test");
+        var logger = provider.CreateLogger("Example.Pipeline");
 
         logger.LogInformation("message");
 
@@ -40,7 +41,7 @@ public class BuildSystemLogIssueLoggerProviderTests
     {
         using var writer = new StringWriter();
         using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
-        var logger = provider.CreateLogger("test");
+        var logger = provider.CreateLogger("Example.Pipeline");
         var exception = new InvalidOperationException("failure");
 
         logger.LogError(exception, "message");
@@ -58,7 +59,23 @@ public class BuildSystemLogIssueLoggerProviderTests
     {
         using var writer = new StringWriter();
         using var provider = CreateProvider(new DefaultFormatter(), writer);
-        var logger = provider.CreateLogger("test");
+        var logger = provider.CreateLogger("Example.Pipeline");
+
+        logger.LogWarning("message");
+
+        await Assert.That(writer.ToString()).IsEmpty();
+    }
+
+    [Test]
+    [Arguments("Microsoft")]
+    [Arguments("Microsoft.Extensions.Http")]
+    [Arguments("System")]
+    [Arguments("System.Net.Http")]
+    public async Task Logger_IgnoresInfrastructureCategories(string category)
+    {
+        using var writer = new StringWriter();
+        using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
+        var logger = provider.CreateLogger(category);
 
         logger.LogWarning("message");
 
@@ -69,6 +86,11 @@ public class BuildSystemLogIssueLoggerProviderTests
         IBuildSystemFormatter formatter,
         TextWriter writer)
     {
-        return new BuildSystemLogIssueLoggerProvider(formatter, () => writer);
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(writer),
+        });
+
+        return new BuildSystemLogIssueLoggerProvider(formatter, console);
     }
 }


### PR DESCRIPTION
## Summary
- emit Azure Pipelines `task.logissue` commands for warning, error, and critical `ILogger` events
- escape Azure logging-command reserved characters without changing normal console logging
- register the provider for pipeline-wide logs and keep other build systems as no-ops

## Validation
- focused Azure formatter, logger-provider, and dependency-injection tests: 15 passed
- core Release build: 0 errors (existing repository warnings remain)
- scoped formatting verification and `git diff --check`: passed

Closes #2540