### PR TITLE
Render verbose CI diagnostics as tables

### DIFF
--- a/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines;
 using ModularPipelines.Attributes;
@@ -61,6 +62,7 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
                     "--coverage-output-format", "cobertura",
                     "--hangdump",
                     "--hangdump-timeout", "20m",
+                    "--results-directory", trxFile.Folder!.Path,
                     "--report-trx",
                     "--report-trx-filename", TrxFileName,
                 ],
@@ -107,6 +109,21 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
 
     private static async Task PrintSkippedTests(IModuleContext context, File trxFile)
     {
+        try
+        {
+            await PrintSkippedTestsCore(context, trxFile);
+        }
+        catch (Exception exception)
+        {
+            context.Logger.LogWarning(
+                exception,
+                "Unable to render skipped test results from {TrxFile}",
+                trxFile.Path);
+        }
+    }
+
+    private static async Task PrintSkippedTestsCore(IModuleContext context, File trxFile)
+    {
         if (!trxFile.Exists)
         {
             return;
@@ -137,7 +154,7 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
                 Markup.Escape(GetSkipReason(skippedTest)));
         }
 
-        var consoleWriter = (IConsoleWriter) context.Logger;
+        var consoleWriter = context.GetService<IConsoleWriter>();
         consoleWriter.LogToConsole($"[dim]⏭ {skippedTests.Count} skipped[/]");
         consoleWriter.Write(table);
     }

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
@@ -1,30 +1,34 @@
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Options;
+using ModularPipelines;
 using ModularPipelines.Attributes;
 using ModularPipelines.Build.Settings;
+using ModularPipelines.Configuration;
 using ModularPipelines.Context;
+using ModularPipelines.DotNet.Enums;
 using ModularPipelines.DotNet.Extensions;
 using ModularPipelines.DotNet.Options;
+using ModularPipelines.DotNet.Parsers.Trx;
 using ModularPipelines.Git.Extensions;
 using ModularPipelines.Models;
-using ModularPipelines.Configuration;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using Polly;
+using Spectre.Console;
+using File = ModularPipelines.FileSystem.File;
 
 namespace ModularPipelines.Build.Modules.UnitTests;
 
+/// <summary>
+/// Runs a unit test project and renders its skipped tests as structured output.
+/// </summary>
 [DependsOn<BuildSolutionsModule>(Optional = true)]
 [ConsumesArtifact(typeof(BuildSolutionsModule), "build-output", RestorePath = "../../")]
 [RunOnLinuxOnly]
 [RequiresCapability("linux")]
-public abstract class RunUnitTestModule : Module<CommandResult>
+public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipelineSettings) : Module<CommandResult>
 {
-    private readonly IOptions<PipelineSettings> _pipelineSettings;
-
-    protected RunUnitTestModule(IOptions<PipelineSettings> pipelineSettings)
-    {
-        _pipelineSettings = pipelineSettings;
-    }
+    private const string TrxFileName = "test-results.trx";
 
     protected abstract string TestProjectFileName { get; }
 
@@ -37,37 +41,123 @@ public abstract class RunUnitTestModule : Module<CommandResult>
         var testProject = context.Git().RootDirectory
             .GetFiles(file => file.Name.Equals(TestProjectFileName, StringComparison.OrdinalIgnoreCase))
             .Single();
+        var trxFile = GetTrxFile(testProject);
 
-        return await context.DotNet().Run(new DotNetRunOptions
+        if (trxFile.Exists)
         {
-            Project = testProject.Path,
-            NoBuild = true,
-            Framework = _pipelineSettings.Value.TestFramework,
-            Arguments = ["--coverage", "--coverage-output-format", "cobertura", "--hangdump", "--hangdump-timeout", "20m"],
-            Configuration = "Release",
-            Properties =
-            [
-                new("RunAnalyzersDuringBuild", "false"),
-                new("RunAnalyzers", "false")
-            ],
-        },
-        new CommandExecutionOptions
+            await trxFile.DeleteAsync(cancellationToken);
+        }
+
+        try
         {
-            EnvironmentVariables = new Dictionary<string, string?>
+            return await context.DotNet().Run(new DotNetRunOptions
             {
-                ["GITHUB_ACTIONS"] = null,
-                ["GITHUB_STEP_SUMMARY"] = null,
-                // Clear distributed mode env vars to prevent test subprocesses
-                // from inheriting coordinator/artifact store connections
-                ["INSTANCE_INDEX"] = null,
-                ["TOTAL_INSTANCES"] = null,
-                ["UPSTASH_REDIS_REST_URL"] = null,
-                ["UPSTASH_REDIS_REST_TOKEN"] = null,
-                ["R2_ENDPOINT_URL"] = null,
-                ["R2_ACCESS_KEY"] = null,
-                ["R2_SECRET_KEY"] = null,
+                Project = testProject.Path,
+                NoBuild = true,
+                Framework = pipelineSettings.Value.TestFramework,
+                Arguments =
+                [
+                    "--coverage",
+                    "--coverage-output-format", "cobertura",
+                    "--hangdump",
+                    "--hangdump-timeout", "20m",
+                    "--report-trx",
+                    "--report-trx-filename", TrxFileName,
+                ],
+                Configuration = "Release",
+                Properties =
+                [
+                    new("RunAnalyzersDuringBuild", "false"),
+                    new("RunAnalyzers", "false"),
+                ],
             },
-        },
-        cancellationToken);
+            new CommandExecutionOptions
+            {
+                EnvironmentVariables = new Dictionary<string, string?>
+                {
+                    ["GITHUB_ACTIONS"] = null,
+                    ["GITHUB_STEP_SUMMARY"] = null,
+
+                    // Clear distributed mode env vars to prevent test subprocesses
+                    // from inheriting coordinator/artifact store connections
+                    ["INSTANCE_INDEX"] = null,
+                    ["TOTAL_INSTANCES"] = null,
+                    ["UPSTASH_REDIS_REST_URL"] = null,
+                    ["UPSTASH_REDIS_REST_TOKEN"] = null,
+                    ["R2_ENDPOINT_URL"] = null,
+                    ["R2_ACCESS_KEY"] = null,
+                    ["R2_SECRET_KEY"] = null,
+                },
+                OutputLoggingManipulator = RemoveSkippedTestOutput,
+            },
+            cancellationToken);
+        }
+        finally
+        {
+            await PrintSkippedTests(context, trxFile);
+        }
     }
+
+    private File GetTrxFile(File testProject)
+    {
+        return testProject.Folder!
+            .GetFolder($"bin/Release/{pipelineSettings.Value.TestFramework}/TestResults")
+            .GetFile(TrxFileName);
+    }
+
+    private static async Task PrintSkippedTests(IModuleContext context, File trxFile)
+    {
+        if (!trxFile.Exists)
+        {
+            return;
+        }
+
+        var testResults = await context.Trx().ParseTrxFile(trxFile);
+        var skippedTests = testResults.UnitTestResults
+            .Where(result => result.Outcome == TestOutcome.NotExecuted)
+            .ToList();
+
+        if (skippedTests.Count == 0)
+        {
+            return;
+        }
+
+        var table = new Table
+        {
+            Border = TableBorder.Rounded,
+        };
+
+        table.AddColumn(new TableColumn("[bold]Test[/]").LeftAligned());
+        table.AddColumn(new TableColumn("[bold]Reason[/]").LeftAligned());
+
+        foreach (var skippedTest in skippedTests)
+        {
+            table.AddRow(
+                Markup.Escape(skippedTest.TestName ?? string.Empty),
+                Markup.Escape(GetSkipReason(skippedTest)));
+        }
+
+        var consoleWriter = (IConsoleWriter) context.Logger;
+        consoleWriter.LogToConsole($"[dim]⏭ {skippedTests.Count} skipped[/]");
+        consoleWriter.Write(table);
+    }
+
+    private static string GetSkipReason(UnitTestResult testResult)
+    {
+        const string skippedPrefix = "Skipped:";
+        var debugTrace = testResult.Output?.DebugTrace?.Trim();
+
+        return debugTrace?.StartsWith(skippedPrefix, StringComparison.OrdinalIgnoreCase) == true
+            ? debugTrace[skippedPrefix.Length..].Trim()
+            : debugTrace ?? string.Empty;
+    }
+
+    private static string RemoveSkippedTestOutput(string output)
+    {
+        return SkippedTestOutputRegex().Replace(output, string.Empty).TrimStart();
+    }
+
+    [GeneratedRegex(
+        @"(?m)^skipped .+ \([^)]+\)\r?\n(?:  .*(?:\r?\n|$))?\r?\n?")]
+    private static partial Regex SkippedTestOutputRegex();
 }

--- a/src/ModularPipelines.DotNet/Parsers/Trx/TestOutput.cs
+++ b/src/ModularPipelines.DotNet/Parsers/Trx/TestOutput.cs
@@ -10,6 +10,9 @@ public record TestOutput
     [XmlElement("StdOut")]
     public string? StdOut { get; init; }
 
+    [XmlElement("DebugTrace")]
+    public string? DebugTrace { get; init; }
+
     [XmlElement("ErrorInfo")]
     public ErrorInfo? ErrorInfo { get; init; }
 }

--- a/src/ModularPipelines.DotNet/Parsers/Trx/TrxParser.cs
+++ b/src/ModularPipelines.DotNet/Parsers/Trx/TrxParser.cs
@@ -77,6 +77,7 @@ public class TrxParser : ITrxParser
             Output = new TestOutput
             {
                 StdOut = element.Descendants().FirstOrDefault(x => x.Name.LocalName == "StdOut")?.Value,
+                DebugTrace = element.Descendants().FirstOrDefault(x => x.Name.LocalName == "DebugTrace")?.Value,
                 ErrorInfo = errorInfo == null ? null : new ErrorInfo
                 {
                     Message = errorInfo.Descendants().FirstOrDefault(x => x.Name.LocalName == "Message")?.Value,

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -141,8 +141,8 @@ internal sealed class Command : ICommand, ICommandContext
                     .WithValidation(CommandResultValidation.None)
                     .ExecuteAsync(forcefulCancellationToken.Token, linkedCancellationToken.Token).ConfigureAwait(false);
 
-                standardOutput = execOpts.OutputLoggingManipulator == null ? standardOutputStringBuilder.ToString() : execOpts.OutputLoggingManipulator(standardOutputStringBuilder.ToString());
-                standardError = execOpts.OutputLoggingManipulator == null ? standardErrorStringBuilder.ToString() : execOpts.OutputLoggingManipulator(standardErrorStringBuilder.ToString());
+                standardOutput = standardOutputStringBuilder.ToString();
+                standardError = standardErrorStringBuilder.ToString();
 
                 _commandLogger.Log(
                     options: options,
@@ -165,8 +165,8 @@ internal sealed class Command : ICommand, ICommandContext
             }
             catch (CommandExecutionException e)
             {
-                standardOutput = execOpts.OutputLoggingManipulator == null ? standardOutputStringBuilder.ToString() : execOpts.OutputLoggingManipulator(standardOutputStringBuilder.ToString());
-                standardError = execOpts.OutputLoggingManipulator == null ? standardErrorStringBuilder.ToString() : execOpts.OutputLoggingManipulator(standardErrorStringBuilder.ToString());
+                standardOutput = standardOutputStringBuilder.ToString();
+                standardError = standardErrorStringBuilder.ToString();
 
                 _commandLogger.Log(
                     options: options,
@@ -183,8 +183,8 @@ internal sealed class Command : ICommand, ICommandContext
             }
             catch (Exception e) when (e is not CommandExecutionException and not CommandException)
             {
-                standardOutput = execOpts.OutputLoggingManipulator == null ? standardOutputStringBuilder.ToString() : execOpts.OutputLoggingManipulator(standardOutputStringBuilder.ToString());
-                standardError = execOpts.OutputLoggingManipulator == null ? standardErrorStringBuilder.ToString() : execOpts.OutputLoggingManipulator(standardErrorStringBuilder.ToString());
+                standardOutput = standardOutputStringBuilder.ToString();
+                standardError = standardErrorStringBuilder.ToString();
 
                 _commandLogger.Log(
                     options: options,

--- a/src/ModularPipelines/Engine/Executors/PipelineInitializer.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineInitializer.cs
@@ -1,8 +1,8 @@
 using System.Collections;
-using System.Text;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Helpers;
 using ModularPipelines.Models;
+using Spectre.Console;
 
 namespace ModularPipelines.Engine.Executors;
 
@@ -17,6 +17,8 @@ internal class PipelineInitializer : IPipelineInitializer
     private readonly IBuildSystemDetector _buildSystemDetector;
     private readonly IPipelineFileWriter _pipelineFileWriter;
     private readonly ILogger<PipelineInitializer> _logger;
+    private readonly IConsoleWriter _consoleWriter;
+    private readonly ISecretObfuscator _secretObfuscator;
     private OrganizedModules? _organizedModules;
 
     public PipelineInitializer(IConsolePrinter consolePrinter,
@@ -27,7 +29,9 @@ internal class PipelineInitializer : IPipelineInitializer
         IPipelineSetupExecutor pipelineSetupExecutor,
         IBuildSystemDetector buildSystemDetector,
         IPipelineFileWriter pipelineFileWriter,
-        ILogger<PipelineInitializer> logger)
+        ILogger<PipelineInitializer> logger,
+        IConsoleWriter consoleWriter,
+        ISecretObfuscator secretObfuscator)
     {
         _consolePrinter = consolePrinter;
         _moduleRetriever = moduleRetriever;
@@ -38,6 +42,8 @@ internal class PipelineInitializer : IPipelineInitializer
         _buildSystemDetector = buildSystemDetector;
         _pipelineFileWriter = pipelineFileWriter;
         _logger = logger;
+        _consoleWriter = consoleWriter;
+        _secretObfuscator = secretObfuscator;
     }
 
     public async Task<OrganizedModules> Initialize(CancellationToken cancellationToken = default)
@@ -69,20 +75,39 @@ internal class PipelineInitializer : IPipelineInitializer
 
     private void PrintEnvironmentVariables()
     {
-        _logger.LogTrace(
-            "Environment variables:\r\n{EnvironmentVariables}",
-            FormatEnvironmentVariables(Environment.GetEnvironmentVariables()));
-    }
-
-    internal static string FormatEnvironmentVariables(IDictionary variables)
-    {
-        var environmentVariables = new StringBuilder();
-
-        foreach (DictionaryEntry environmentVariable in variables)
+        if (!_logger.IsEnabled(LogLevel.Trace))
         {
-            environmentVariables.AppendLine($"{environmentVariable.Key}: {environmentVariable.Value}");
+            return;
         }
 
-        return environmentVariables.ToString();
+        _consoleWriter.Write(CreateEnvironmentVariablesTable(
+            Environment.GetEnvironmentVariables(),
+            value => _secretObfuscator.Obfuscate(value, null)));
+    }
+
+    internal static Table CreateEnvironmentVariablesTable(
+        IDictionary variables,
+        Func<string, string> obfuscate)
+    {
+        var table = new Table
+        {
+            Border = TableBorder.Rounded,
+            Expand = true,
+            Title = new TableTitle("[bold]Environment variables[/]"),
+        };
+
+        table.AddColumn(new TableColumn("[bold]Name[/]").LeftAligned());
+        table.AddColumn(new TableColumn("[bold]Value[/]").LeftAligned());
+
+        foreach (var environmentVariable in variables
+                     .Cast<DictionaryEntry>()
+                     .OrderBy(entry => entry.Key?.ToString(), StringComparer.OrdinalIgnoreCase))
+        {
+            table.AddRow(
+                Markup.Escape(environmentVariable.Key?.ToString() ?? string.Empty),
+                Markup.Escape(obfuscate(environmentVariable.Value?.ToString() ?? string.Empty)));
+        }
+
+        return table;
     }
 }

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -97,8 +97,15 @@ internal class CommandLogger : ICommandLogger
         commandMessage.Append("> ");
         commandMessage.Append(obfuscatedInput);
 
+        var standardOutputToLog = execOpts?.OutputLoggingManipulator is not null
+            ? execOpts.OutputLoggingManipulator(standardOutput)
+            : standardOutput;
+        var standardErrorToLog = execOpts?.OutputLoggingManipulator is not null
+            ? execOpts.OutputLoggingManipulator(standardError)
+            : standardError;
+
         // Add inline output for short, single-line output on successful commands
-        var trimmedOutput = standardOutput.Trim();
+        var trimmedOutput = standardOutputToLog.Trim();
         var hasShortOutput = !string.IsNullOrEmpty(trimmedOutput)
             && !trimmedOutput.Contains('\n')
             && trimmedOutput.Length <= 100
@@ -157,22 +164,16 @@ internal class CommandLogger : ICommandLogger
             && options.Verbosity >= CommandLogVerbosity.Normal
             && options.ShowStandardOutput)
         {
-            var outputToLog = execOpts?.OutputLoggingManipulator is not null
-                ? execOpts.OutputLoggingManipulator(trimmedOutput)
-                : trimmedOutput;
-            Logger.LogInformation("  ↳ {CommandOutput}", _secretObfuscator.Obfuscate(outputToLog, execOpts));
+            Logger.LogInformation("  ↳ {CommandOutput}", _secretObfuscator.Obfuscate(trimmedOutput, execOpts));
         }
 
         // Log errors on separate line
-        if (!string.IsNullOrWhiteSpace(standardError)
+        if (!string.IsNullOrWhiteSpace(standardErrorToLog)
             && options.Verbosity >= CommandLogVerbosity.Normal
             && options.ShowStandardError
             && exitCode != 0)
         {
-            var errorToLog = execOpts?.OutputLoggingManipulator is not null
-                ? execOpts.OutputLoggingManipulator(standardError)
-                : standardError;
-            Logger.LogWarning("  ✗ {CommandError}", _secretObfuscator.Obfuscate(errorToLog, execOpts));
+            Logger.LogWarning("  ✗ {CommandError}", _secretObfuscator.Obfuscate(standardErrorToLog, execOpts));
         }
 
         // Log working directory only at Diagnostic level (separate line, indented)

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -34,6 +34,38 @@ public class CommandLoggerTests : TestBase
     }
 
     [Test]
+    public async Task OutputLoggingManipulator_Does_Not_Change_Command_Result()
+    {
+        const string rawOutput = "raw-output";
+        const string displayedOutput = "displayed-output";
+        var file = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".txt");
+        var result = await GetService<ICommand>((_, collection) =>
+        {
+            collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
+            collection.AddLogging(builder => builder.AddFile(file));
+        });
+
+        var commandResult = await result.T.ExecuteCommandLineTool(
+            new PowershellScriptOptions($"Write-Output '{rawOutput}'"),
+            new CommandExecutionOptions
+            {
+                LogSettings = new CommandLoggingOptions
+                {
+                    ShowCommandArguments = false,
+                },
+                OutputLoggingManipulator = _ => displayedOutput,
+            });
+        await result.Host.DisposeAsync();
+
+        await Assert.That(commandResult.StandardOutput).Contains(rawOutput);
+        await Assert.That(commandResult.StandardOutput).DoesNotContain(displayedOutput);
+
+        var logFile = await File.ReadAllTextAsync(file);
+        await Assert.That(logFile).Contains(displayedOutput);
+        await Assert.That(logFile).DoesNotContain(rawOutput);
+    }
+
+    [Test]
     [MatrixDataSource]
     public async Task Logs_As_Expected_With_Options(
         [Matrix(true, false)] bool logInput,

--- a/test/ModularPipelines.UnitTests/Engine/Executors/PipelineInitializerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Executors/PipelineInitializerTests.cs
@@ -1,22 +1,37 @@
 using System.Collections.Specialized;
 using ModularPipelines.Engine.Executors;
+using Spectre.Console;
 
 namespace ModularPipelines.UnitTests.Engine.Executors;
 
 public class PipelineInitializerTests
 {
     [Test]
-    public async Task FormatEnvironmentVariables_DoesNotAddBlankLines()
+    public async Task EnvironmentVariables_AreRenderedAsMaskedSortedTable()
     {
         var variables = new OrderedDictionary
         {
-            ["FIRST"] = "one",
             ["SECOND"] = "two",
+            ["FIRST"] = "secret",
         };
 
-        var result = PipelineInitializer.FormatEnvironmentVariables(variables);
+        var table = PipelineInitializer.CreateEnvironmentVariablesTable(
+            variables,
+            value => value == "secret" ? "***" : value);
+        using var writer = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(writer),
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+        });
 
-        await Assert.That(result).IsEqualTo(
-            $"FIRST: one{Environment.NewLine}SECOND: two{Environment.NewLine}");
+        console.Write(table);
+        var output = writer.ToString();
+
+        await Assert.That(output).Contains("Environment variables");
+        await Assert.That(output).Contains("***");
+        await Assert.That(output.IndexOf("FIRST", StringComparison.Ordinal))
+            .IsLessThan(output.IndexOf("SECOND", StringComparison.Ordinal));
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/PipelineInitializerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineInitializerTests.cs
@@ -6,7 +6,7 @@ namespace ModularPipelines.UnitTests.Engine;
 public class PipelineInitializerTests
 {
     [Test]
-    public async Task FormatEnvironmentVariables_Does_Not_Add_Blank_Lines()
+    public async Task EnvironmentVariablesTable_Does_Not_Add_Blank_Rows()
     {
         var variables = new Hashtable
         {
@@ -14,9 +14,10 @@ public class PipelineInitializerTests
             ["SECOND"] = "two",
         };
 
-        var output = PipelineInitializer.FormatEnvironmentVariables(variables);
+        var table = PipelineInitializer.CreateEnvironmentVariablesTable(
+            variables,
+            value => value);
 
-        await Assert.That(output).DoesNotContain($"{Environment.NewLine}{Environment.NewLine}");
-        await Assert.That(output.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)).Count().IsEqualTo(2);
+        await Assert.That(table.Rows).Count().IsEqualTo(2);
     }
 }

--- a/test/ModularPipelines.UnitTests/Models/TrxParsingTests.cs
+++ b/test/ModularPipelines.UnitTests/Models/TrxParsingTests.cs
@@ -17,6 +17,36 @@ namespace ModularPipelines.UnitTests.Models;
 
 public class TrxParsingTests : TestBase
 {
+    [Test]
+    public async Task ParsesSkippedTestReason()
+    {
+        const string trx = """
+                           <TestRun>
+                             <Results>
+                               <UnitTestResult executionId="execution" testId="test" testName="Skipped_Test"
+                                 computerName="agent" duration="00:00:00" startTime="2026-07-27T12:00:00Z"
+                                 endTime="2026-07-27T12:00:00Z" testType="type" outcome="NotExecuted"
+                                 testListId="list" relativeResultsDirectory="results">
+                                 <Output>
+                                   <DebugTrace>Skipped: Linux only test</DebugTrace>
+                                 </Output>
+                               </UnitTestResult>
+                             </Results>
+                             <ResultSummary outcome="Completed">
+                               <Counters total="1" executed="0" passed="0" failed="0" error="0"
+                                 timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0"
+                                 notRunnable="0" notExecuted="1" disconnected="0" warning="0"
+                                 completed="0" inProgress="0" pending="0" />
+                             </ResultSummary>
+                           </TestRun>
+                           """;
+
+        var result = new TrxParser().ParseTrxContents(trx);
+
+        await Assert.That(result.UnitTestResults.Single().Output?.DebugTrace)
+            .IsEqualTo("Skipped: Linux only test");
+    }
+
     public class NUnitModule : Module<DotNetTestResult>
     {
         public DotNetTestResult? LastResult { get; private set; }


### PR DESCRIPTION
## Summary
- render trace-level environment variables as a sorted, masked Spectre table
- replace TUnit's flat skipped-test blocks with a count and Test/Reason table
- parse TRX `DebugTrace` so skip reasons remain authoritative

## Validation
- focused PipelineInitializer tests (2 passed)
- focused TRX parser test (1 passed)
- `ModularPipelines.Build.csproj` Release build (0 errors)
- scoped format verification

Closes #2622