### PR TITLE
Generate module event metadata for trim safety

### DIFF
--- a/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
@@ -174,7 +174,7 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
             return null;
         }
 
-        var constructorArguments = FormatArguments(attribute.ConstructorArguments);
+        var constructorArguments = FormatArguments(attribute.ConstructorArguments, currentAssembly);
         var namedArguments = FormatNamedArguments(attribute, attributeType, currentAssembly);
         if (constructorArguments is null || namedArguments is null)
         {
@@ -202,12 +202,14 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
         return attributeType;
     }
 
-    private static List<string>? FormatArguments(ImmutableArray<TypedConstant> arguments)
+    private static List<string>? FormatArguments(
+        ImmutableArray<TypedConstant> arguments,
+        IAssemblySymbol currentAssembly)
     {
         var expressions = new List<string>();
         foreach (var argument in arguments)
         {
-            var expression = FormatTypedConstant(argument);
+            var expression = FormatTypedConstant(argument, currentAssembly);
             if (expression is null)
             {
                 return null;
@@ -228,7 +230,7 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
         foreach (var argument in attribute.NamedArguments)
         {
             var member = attributeType.GetMembers(argument.Key).FirstOrDefault();
-            var expression = FormatTypedConstant(argument.Value);
+            var expression = FormatTypedConstant(argument.Value, currentAssembly);
             if (member is null
                 || expression is null
                 || !IsAccessible(member.DeclaredAccessibility, member.ContainingAssembly, currentAssembly))
@@ -257,11 +259,19 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
         return result;
     }
 
-    private static string? FormatTypedConstant(TypedConstant constant)
+    private static string? FormatTypedConstant(
+        TypedConstant constant,
+        IAssemblySymbol currentAssembly)
     {
         if (constant.IsNull)
         {
             return "null";
+        }
+
+        if (constant.Type is not null
+            && !IsTypeReferenceAccessible(constant.Type, currentAssembly))
+        {
+            return null;
         }
 
         if (constant.Kind == TypedConstantKind.Array)
@@ -274,7 +284,7 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
             var values = new List<string>();
             foreach (var value in constant.Values)
             {
-                var expression = FormatTypedConstant(value);
+                var expression = FormatTypedConstant(value, currentAssembly);
                 if (expression is null)
                 {
                     return null;
@@ -289,6 +299,11 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
 
         if (constant.Kind == TypedConstantKind.Type && constant.Value is ITypeSymbol type)
         {
+            if (!IsTypeReferenceAccessible(type, currentAssembly))
+            {
+                return null;
+            }
+
             return $"typeof({type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})";
         }
 
@@ -299,6 +314,22 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
         }
 
         return FormatPrimitive(constant.Value);
+    }
+
+    private static bool IsTypeReferenceAccessible(
+        ITypeSymbol type,
+        IAssemblySymbol currentAssembly)
+    {
+        return type switch
+        {
+            IArrayTypeSymbol arrayType
+                => IsTypeReferenceAccessible(arrayType.ElementType, currentAssembly),
+            IPointerTypeSymbol pointerType
+                => IsTypeReferenceAccessible(pointerType.PointedAtType, currentAssembly),
+            INamedTypeSymbol namedType => IsTypeAccessible(namedType, currentAssembly),
+            ITypeParameterSymbol => false,
+            _ => true,
+        };
     }
 
     private static string? FormatPrimitive(object? value)

--- a/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
@@ -229,7 +229,7 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
         var namedArguments = new List<string>();
         foreach (var argument in attribute.NamedArguments)
         {
-            var member = attributeType.GetMembers(argument.Key).FirstOrDefault();
+            var member = FindNamedArgumentMember(attributeType, argument.Key);
             var expression = FormatTypedConstant(argument.Value, currentAssembly);
             if (member is null
                 || expression is null
@@ -242,6 +242,20 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
         }
 
         return namedArguments;
+    }
+
+    private static ISymbol? FindNamedArgumentMember(INamedTypeSymbol attributeType, string name)
+    {
+        for (var current = attributeType; current is not null; current = current.BaseType)
+        {
+            var member = current.GetMembers(name).FirstOrDefault();
+            if (member is not null)
+            {
+                return member;
+            }
+        }
+
+        return null;
     }
 
     private static string BuildAttributeExpression(
@@ -274,47 +288,46 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
             return null;
         }
 
-        if (constant.Kind == TypedConstantKind.Array)
+        return constant.Kind switch
         {
-            if (constant.Type is not IArrayTypeSymbol arrayType)
-            {
-                return null;
-            }
-
-            var values = new List<string>();
-            foreach (var value in constant.Values)
-            {
-                var expression = FormatTypedConstant(value, currentAssembly);
-                if (expression is null)
-                {
-                    return null;
-                }
-
-                values.Add(expression);
-            }
-
-            var elementType = arrayType.ElementType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            return $"new {elementType}[] {{ {string.Join(", ", values)} }}";
-        }
-
-        if (constant.Kind == TypedConstantKind.Type && constant.Value is ITypeSymbol type)
-        {
-            if (!IsTypeReferenceAccessible(type, currentAssembly))
-            {
-                return null;
-            }
-
-            return $"typeof({type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})";
-        }
-
-        if (constant.Type?.TypeKind == TypeKind.Enum)
-        {
-            var enumType = constant.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            return $"({enumType}){FormatEnumValue(constant.Value!)}";
-        }
-
-        return FormatPrimitive(constant.Value);
+            TypedConstantKind.Array => FormatArrayConstant(constant, currentAssembly),
+            TypedConstantKind.Type => FormatTypeConstant(constant, currentAssembly),
+            _ when constant.Type?.TypeKind == TypeKind.Enum
+                => FormatEnumConstant(constant),
+            _ => FormatPrimitive(constant.Value),
+        };
     }
+
+    private static string? FormatArrayConstant(
+        TypedConstant constant,
+        IAssemblySymbol currentAssembly)
+    {
+        if (constant.Type is not IArrayTypeSymbol arrayType)
+        {
+            return null;
+        }
+
+        var values = FormatArguments(constant.Values, currentAssembly);
+        if (values is null)
+        {
+            return null;
+        }
+
+        var elementType = arrayType.ElementType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        return $"new {elementType}[] {{ {string.Join(", ", values)} }}";
+    }
+
+    private static string? FormatTypeConstant(
+        TypedConstant constant,
+        IAssemblySymbol currentAssembly) =>
+        constant.Value is ITypeSymbol type
+        && IsTypeReferenceAccessible(type, currentAssembly)
+            ? $"typeof({type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})"
+            : null;
+
+    private static string FormatEnumConstant(TypedConstant constant) =>
+        $"({constant.Type!.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})"
+        + FormatEnumValue(constant.Value!);
 
     private static bool IsTypeReferenceAccessible(
         ITypeSymbol type,
@@ -407,7 +420,7 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
         }
 
         return type.TypeArguments.All(typeArgument =>
-            typeArgument is not INamedTypeSymbol namedType || IsTypeAccessible(namedType, currentAssembly));
+            IsTypeReferenceAccessible(typeArgument, currentAssembly));
     }
 
     private static bool IsAccessible(
@@ -418,7 +431,8 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
         return accessibility == Accessibility.Public
             || ((accessibility == Accessibility.Internal
                     || accessibility == Accessibility.ProtectedOrInternal)
-                && SymbolEqualityComparer.Default.Equals(containingAssembly, currentAssembly));
+                && (SymbolEqualityComparer.Default.Equals(containingAssembly, currentAssembly)
+                    || containingAssembly.GivesAccessTo(currentAssembly)));
     }
 
     private static string Generate(ImmutableArray<ModuleEventMetadata> items)

--- a/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
@@ -1,0 +1,455 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ModularPipelines.SourceGenerator;
+
+/// <summary>
+/// Generates direct attribute factories for statically known module types.
+/// </summary>
+[Generator]
+public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
+{
+    internal const string ModuleBaseFullName = "ModularPipelines.Modules.Module`1";
+
+    private const string AttributeUsageFullName = "System.AttributeUsageAttribute";
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var modules = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                static (node, _) => node is TypeDeclarationSyntax
+                {
+                    BaseList.Types.Count: > 0,
+                },
+                static (generatorContext, _) => GetModuleMetadata(generatorContext))
+            .Where(static metadata => metadata is not null)
+            .Select(static (metadata, _) => metadata!);
+
+        context.RegisterSourceOutput(modules.Collect(), static (sourceContext, metadata) =>
+        {
+            if (!metadata.IsEmpty)
+            {
+                sourceContext.AddSource(
+                    "ModularPipelines.ModuleEventMetadata.g.cs",
+                    Generate(metadata));
+            }
+        });
+    }
+
+    private static ModuleEventMetadata? GetModuleMetadata(GeneratorSyntaxContext context)
+    {
+        var compilation = context.SemanticModel.Compilation;
+        var type = GetEligibleModuleType(context, compilation);
+        if (type is null)
+        {
+            return null;
+        }
+
+        var attributeMetadata = GetAttributeMetadata(type, compilation.Assembly);
+        return new ModuleEventMetadata(
+            type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            attributeMetadata.Expressions,
+            attributeMetadata.IsComplete);
+    }
+
+    private static INamedTypeSymbol? GetEligibleModuleType(
+        GeneratorSyntaxContext context,
+        Compilation compilation)
+    {
+        if (context.SemanticModel.GetDeclaredSymbol(context.Node) is not INamedTypeSymbol type
+            || type.IsAbstract
+            || type.IsGenericType
+            || !IsTypeAccessible(type, compilation.Assembly)
+            || !InheritsFromModule(type, compilation))
+        {
+            return null;
+        }
+
+        return type;
+    }
+
+    private static AttributeMetadata GetAttributeMetadata(
+        INamedTypeSymbol type,
+        IAssemblySymbol currentAssembly)
+    {
+        var attributes = ImmutableArray.CreateBuilder<string>();
+        var seenSingleUseAttributes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var isComplete = true;
+
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            foreach (var attribute in current.GetAttributes())
+            {
+                var candidate = GetAttributeCandidate(
+                    attribute,
+                    current,
+                    type,
+                    currentAssembly,
+                    seenSingleUseAttributes);
+                if (!candidate.IsComplete)
+                {
+                    isComplete = false;
+                }
+
+                if (candidate.Expression is not null)
+                {
+                    attributes.Add(candidate.Expression);
+                }
+            }
+        }
+
+        return new AttributeMetadata(attributes.ToImmutable(), isComplete);
+    }
+
+    private static AttributeCandidate GetAttributeCandidate(
+        AttributeData attribute,
+        INamedTypeSymbol declaringType,
+        INamedTypeSymbol moduleType,
+        IAssemblySymbol currentAssembly,
+        HashSet<INamedTypeSymbol> seenSingleUseAttributes)
+    {
+        if (attribute.AttributeClass is not { } attributeType)
+        {
+            return new AttributeCandidate(null, IsComplete: false);
+        }
+
+        var usage = GetAttributeUsage(attributeType);
+        if (!SymbolEqualityComparer.Default.Equals(declaringType, moduleType) && !usage.Inherited)
+        {
+            return new AttributeCandidate(null, IsComplete: true);
+        }
+
+        if (!usage.AllowMultiple && !seenSingleUseAttributes.Add(attributeType))
+        {
+            return new AttributeCandidate(null, IsComplete: true);
+        }
+
+        var expression = CreateAttributeExpression(attribute, currentAssembly);
+        return new AttributeCandidate(expression, IsComplete: expression is not null);
+    }
+
+    private static AttributeUsageMetadata GetAttributeUsage(INamedTypeSymbol attributeType)
+    {
+        AttributeData? usage = null;
+        for (var current = attributeType; current is not null && usage is null; current = current.BaseType)
+        {
+            usage = current.GetAttributes().FirstOrDefault(attribute =>
+                attribute.AttributeClass?.ToDisplayString() == AttributeUsageFullName);
+        }
+
+        if (usage is null)
+        {
+            return new AttributeUsageMetadata(AllowMultiple: false, Inherited: true);
+        }
+
+        var allowMultiple = GetNamedBoolean(usage, nameof(AttributeUsageAttribute.AllowMultiple), false);
+        var inherited = GetNamedBoolean(usage, nameof(AttributeUsageAttribute.Inherited), true);
+        return new AttributeUsageMetadata(allowMultiple, inherited);
+    }
+
+    private static bool GetNamedBoolean(AttributeData attribute, string name, bool defaultValue)
+    {
+        foreach (var argument in attribute.NamedArguments)
+        {
+            if (argument.Key == name && argument.Value.Value is bool value)
+            {
+                return value;
+            }
+        }
+
+        return defaultValue;
+    }
+
+    private static string? CreateAttributeExpression(
+        AttributeData attribute,
+        IAssemblySymbol currentAssembly)
+    {
+        var attributeType = GetAccessibleAttributeType(attribute, currentAssembly);
+        if (attributeType is null)
+        {
+            return null;
+        }
+
+        var constructorArguments = FormatArguments(attribute.ConstructorArguments);
+        var namedArguments = FormatNamedArguments(attribute, attributeType, currentAssembly);
+        if (constructorArguments is null || namedArguments is null)
+        {
+            return null;
+        }
+
+        return BuildAttributeExpression(attributeType, constructorArguments, namedArguments);
+    }
+
+    private static INamedTypeSymbol? GetAccessibleAttributeType(
+        AttributeData attribute,
+        IAssemblySymbol currentAssembly)
+    {
+        if (attribute.AttributeClass is not { } attributeType
+            || attribute.AttributeConstructor is not { } constructor
+            || !IsTypeAccessible(attributeType, currentAssembly)
+            || !IsAccessible(
+                constructor.DeclaredAccessibility,
+                constructor.ContainingAssembly,
+                currentAssembly))
+        {
+            return null;
+        }
+
+        return attributeType;
+    }
+
+    private static List<string>? FormatArguments(ImmutableArray<TypedConstant> arguments)
+    {
+        var expressions = new List<string>();
+        foreach (var argument in arguments)
+        {
+            var expression = FormatTypedConstant(argument);
+            if (expression is null)
+            {
+                return null;
+            }
+
+            expressions.Add(expression);
+        }
+
+        return expressions;
+    }
+
+    private static List<string>? FormatNamedArguments(
+        AttributeData attribute,
+        INamedTypeSymbol attributeType,
+        IAssemblySymbol currentAssembly)
+    {
+        var namedArguments = new List<string>();
+        foreach (var argument in attribute.NamedArguments)
+        {
+            var member = attributeType.GetMembers(argument.Key).FirstOrDefault();
+            var expression = FormatTypedConstant(argument.Value);
+            if (member is null
+                || expression is null
+                || !IsAccessible(member.DeclaredAccessibility, member.ContainingAssembly, currentAssembly))
+            {
+                return null;
+            }
+
+            namedArguments.Add($"@{argument.Key} = {expression}");
+        }
+
+        return namedArguments;
+    }
+
+    private static string BuildAttributeExpression(
+        INamedTypeSymbol attributeType,
+        List<string> constructorArguments,
+        List<string> namedArguments)
+    {
+        var typeName = attributeType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        var result = $"new {typeName}({string.Join(", ", constructorArguments)})";
+        if (namedArguments.Count > 0)
+        {
+            result += $" {{ {string.Join(", ", namedArguments)} }}";
+        }
+
+        return result;
+    }
+
+    private static string? FormatTypedConstant(TypedConstant constant)
+    {
+        if (constant.IsNull)
+        {
+            return "null";
+        }
+
+        if (constant.Kind == TypedConstantKind.Array)
+        {
+            if (constant.Type is not IArrayTypeSymbol arrayType)
+            {
+                return null;
+            }
+
+            var values = new List<string>();
+            foreach (var value in constant.Values)
+            {
+                var expression = FormatTypedConstant(value);
+                if (expression is null)
+                {
+                    return null;
+                }
+
+                values.Add(expression);
+            }
+
+            var elementType = arrayType.ElementType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return $"new {elementType}[] {{ {string.Join(", ", values)} }}";
+        }
+
+        if (constant.Kind == TypedConstantKind.Type && constant.Value is ITypeSymbol type)
+        {
+            return $"typeof({type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)})";
+        }
+
+        if (constant.Type?.TypeKind == TypeKind.Enum)
+        {
+            var enumType = constant.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            return $"({enumType}){FormatEnumValue(constant.Value!)}";
+        }
+
+        return FormatPrimitive(constant.Value);
+    }
+
+    private static string? FormatPrimitive(object? value)
+    {
+        return value switch
+        {
+            null => "null",
+            string text => SymbolDisplay.FormatLiteral(text, quote: true),
+            char character => SymbolDisplay.FormatLiteral(character, quote: true),
+            bool boolean => boolean ? "true" : "false",
+            byte number => $"(byte){number.ToString(CultureInfo.InvariantCulture)}",
+            sbyte number => $"(sbyte){number.ToString(CultureInfo.InvariantCulture)}",
+            short number => $"(short){number.ToString(CultureInfo.InvariantCulture)}",
+            ushort number => $"(ushort){number.ToString(CultureInfo.InvariantCulture)}",
+            int number => number.ToString(CultureInfo.InvariantCulture),
+            uint number => $"{number.ToString(CultureInfo.InvariantCulture)}U",
+            long number => $"{number.ToString(CultureInfo.InvariantCulture)}L",
+            ulong number => $"{number.ToString(CultureInfo.InvariantCulture)}UL",
+            float number when float.IsNaN(number) => "global::System.Single.NaN",
+            float number when float.IsPositiveInfinity(number) => "global::System.Single.PositiveInfinity",
+            float number when float.IsNegativeInfinity(number) => "global::System.Single.NegativeInfinity",
+            float number => $"{number.ToString("R", CultureInfo.InvariantCulture)}F",
+            double number when double.IsNaN(number) => "global::System.Double.NaN",
+            double number when double.IsPositiveInfinity(number) => "global::System.Double.PositiveInfinity",
+            double number when double.IsNegativeInfinity(number) => "global::System.Double.NegativeInfinity",
+            double number => number.ToString("R", CultureInfo.InvariantCulture),
+            _ => null,
+        };
+    }
+
+    private static string FormatEnumValue(object value)
+    {
+        return value switch
+        {
+            byte number => number.ToString(CultureInfo.InvariantCulture),
+            sbyte number => number.ToString(CultureInfo.InvariantCulture),
+            short number => number.ToString(CultureInfo.InvariantCulture),
+            ushort number => number.ToString(CultureInfo.InvariantCulture),
+            int number => number.ToString(CultureInfo.InvariantCulture),
+            uint number => $"{number.ToString(CultureInfo.InvariantCulture)}U",
+            long number => $"{number.ToString(CultureInfo.InvariantCulture)}L",
+            ulong number => $"{number.ToString(CultureInfo.InvariantCulture)}UL",
+            _ => throw new InvalidOperationException($"Unsupported enum value type {value.GetType()}."),
+        };
+    }
+
+    private static bool InheritsFromModule(INamedTypeSymbol type, Compilation compilation)
+    {
+        var moduleBaseType = compilation.GetTypeByMetadataName(ModuleBaseFullName);
+        if (moduleBaseType is null)
+        {
+            return false;
+        }
+
+        for (var current = type.BaseType; current is not null; current = current.BaseType)
+        {
+            if (current.IsGenericType
+                && SymbolEqualityComparer.Default.Equals(current.OriginalDefinition, moduleBaseType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsTypeAccessible(INamedTypeSymbol type, IAssemblySymbol currentAssembly)
+    {
+        for (var current = type; current is not null; current = current.ContainingType)
+        {
+            if (!IsAccessible(current.DeclaredAccessibility, current.ContainingAssembly, currentAssembly))
+            {
+                return false;
+            }
+        }
+
+        return type.TypeArguments.All(typeArgument =>
+            typeArgument is not INamedTypeSymbol namedType || IsTypeAccessible(namedType, currentAssembly));
+    }
+
+    private static bool IsAccessible(
+        Accessibility accessibility,
+        IAssemblySymbol containingAssembly,
+        IAssemblySymbol currentAssembly)
+    {
+        return accessibility == Accessibility.Public
+            || ((accessibility == Accessibility.Internal
+                    || accessibility == Accessibility.ProtectedOrInternal)
+                && SymbolEqualityComparer.Default.Equals(containingAssembly, currentAssembly));
+    }
+
+    private static string Generate(ImmutableArray<ModuleEventMetadata> items)
+    {
+        var modules = items
+            .GroupBy(item => item.TypeName, StringComparer.Ordinal)
+            .Select(group => group.First())
+            .OrderBy(item => item.TypeName, StringComparer.Ordinal);
+        var builder = new StringBuilder();
+
+        builder.AppendLine("// <auto-generated/>");
+        builder.AppendLine("#nullable enable");
+        builder.AppendLine("#pragma warning disable CS0618");
+        builder.AppendLine();
+        builder.AppendLine("namespace ModularPipelines.Generated;");
+        builder.AppendLine();
+        builder.AppendLine("internal static class ModuleEventMetadataRegistration");
+        builder.AppendLine("{");
+        builder.AppendLine("    [global::System.Runtime.CompilerServices.ModuleInitializer]");
+        builder.AppendLine("    internal static void Register()");
+        builder.AppendLine("    {");
+
+        foreach (var module in modules)
+        {
+            builder.AppendLine("        global::ModularPipelines.Engine.Attributes.GeneratedModuleEventMetadata.Register(");
+            builder.AppendLine($"            typeof({module.TypeName}),");
+            if (module.Attributes.IsEmpty)
+            {
+                builder.AppendLine("            static () => global::System.Array.Empty<global::System.Attribute>(),");
+            }
+            else
+            {
+                builder.AppendLine("            static () => new global::System.Attribute[]");
+                builder.AppendLine("            {");
+                foreach (var attribute in module.Attributes)
+                {
+                    builder.AppendLine($"                {attribute},");
+                }
+
+                builder.AppendLine("            },");
+            }
+
+            builder.AppendLine($"            isComplete: {(module.IsComplete ? "true" : "false")});");
+        }
+
+        builder.AppendLine("    }");
+        builder.AppendLine("}");
+        return builder.ToString();
+    }
+
+    private sealed record ModuleEventMetadata(
+        string TypeName,
+        ImmutableArray<string> Attributes,
+        bool IsComplete);
+
+    private sealed record AttributeMetadata(
+        ImmutableArray<string> Expressions,
+        bool IsComplete);
+
+    private sealed record AttributeCandidate(
+        string? Expression,
+        bool IsComplete);
+
+    private sealed record AttributeUsageMetadata(bool AllowMultiple, bool Inherited);
+}

--- a/src/ModularPipelines/Engine/Attributes/GeneratedModuleEventMetadata.cs
+++ b/src/ModularPipelines/Engine/Attributes/GeneratedModuleEventMetadata.cs
@@ -19,10 +19,7 @@ public static class GeneratedModuleEventMetadata
         Func<IReadOnlyList<Attribute>> attributeFactory,
         bool isComplete = true)
     {
-        if (!Factories.TryAdd(moduleType, new AttributeMetadata(attributeFactory, isComplete)))
-        {
-            throw new InvalidOperationException($"Module event metadata is already registered for {moduleType}.");
-        }
+        Factories.TryAdd(moduleType, new AttributeMetadata(attributeFactory, isComplete));
     }
 
     internal static bool TryCreateAttributes(

--- a/src/ModularPipelines/Engine/Attributes/GeneratedModuleEventMetadata.cs
+++ b/src/ModularPipelines/Engine/Attributes/GeneratedModuleEventMetadata.cs
@@ -1,0 +1,45 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+
+namespace ModularPipelines.Engine.Attributes;
+
+/// <summary>
+/// Stores module attribute factories emitted by ModularPipelines.SourceGenerator.
+/// </summary>
+public static class GeneratedModuleEventMetadata
+{
+    private static readonly ConcurrentDictionary<Type, AttributeMetadata> Factories = new();
+
+    /// <summary>
+    /// Registers a generated attribute factory for a module type.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void Register(
+        Type moduleType,
+        Func<IReadOnlyList<Attribute>> attributeFactory,
+        bool isComplete = true)
+    {
+        if (!Factories.TryAdd(moduleType, new AttributeMetadata(attributeFactory, isComplete)))
+        {
+            throw new InvalidOperationException($"Module event metadata is already registered for {moduleType}.");
+        }
+    }
+
+    internal static bool TryCreateAttributes(
+        Type moduleType,
+        out IReadOnlyList<Attribute> attributes)
+    {
+        if (Factories.TryGetValue(moduleType, out var metadata) && metadata.IsComplete)
+        {
+            attributes = metadata.AttributeFactory();
+            return true;
+        }
+
+        attributes = [];
+        return false;
+    }
+
+    private sealed record AttributeMetadata(
+        Func<IReadOnlyList<Attribute>> AttributeFactory,
+        bool IsComplete);
+}

--- a/src/ModularPipelines/Engine/Attributes/IModuleAttributeEventService.cs
+++ b/src/ModularPipelines/Engine/Attributes/IModuleAttributeEventService.cs
@@ -7,6 +7,8 @@ namespace ModularPipelines.Engine.Attributes;
 /// </summary>
 internal interface IModuleAttributeEventService
 {
+    IReadOnlyList<Attribute> GetAttributes(Type moduleType);
+
     IReadOnlyList<IModuleRegistrationEventReceiver> GetRegistrationReceivers(Type moduleType);
 
     IReadOnlyList<IModuleReadyHandler> GetReadyHandlers(Type moduleType);

--- a/src/ModularPipelines/Engine/Attributes/ModuleAttributeEventService.cs
+++ b/src/ModularPipelines/Engine/Attributes/ModuleAttributeEventService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using ModularPipelines.Attributes.Events;
 
@@ -13,6 +14,9 @@ namespace ModularPipelines.Engine.Attributes;
 internal class ModuleAttributeEventService : IModuleAttributeEventService
 {
     private readonly ConcurrentDictionary<Type, AttributeHandlerCache> _cache = new();
+
+    public IReadOnlyList<Attribute> GetAttributes(Type moduleType)
+        => CreateAttributes(moduleType);
 
     public IReadOnlyList<IModuleRegistrationEventReceiver> GetRegistrationReceivers(Type moduleType)
         => GetCache(moduleType).RegistrationReceivers;
@@ -37,9 +41,18 @@ internal class ModuleAttributeEventService : IModuleAttributeEventService
 
     private static AttributeHandlerCache DiscoverHandlers(Type moduleType)
     {
-        // Get attributes in declaration order
-        var attributes = moduleType.GetCustomAttributes(inherit: true);
+        return CreateHandlerCache(CreateAttributes(moduleType));
+    }
 
+    private static IReadOnlyList<Attribute> CreateAttributes(Type moduleType)
+    {
+        return GeneratedModuleEventMetadata.TryCreateAttributes(moduleType, out var generatedAttributes)
+            ? generatedAttributes
+            : GetAttributesWithReflection(moduleType);
+    }
+
+    private static AttributeHandlerCache CreateHandlerCache(IReadOnlyList<Attribute> attributes)
+    {
         var registrationReceivers = new List<IModuleRegistrationEventReceiver>();
         var readyHandlers = new List<IModuleReadyHandler>();
         var startHandlers = new List<IModuleStartHandler>();
@@ -91,6 +104,18 @@ internal class ModuleAttributeEventService : IModuleAttributeEventService
             SortByPriority(skippedHandlers));
     }
 
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "This fallback is used only for dynamic or plugin module types without generated metadata.")]
+    private static IReadOnlyList<Attribute> GetAttributesWithReflection(Type moduleType)
+        => DiscoverAttributesWithReflection(moduleType);
+
+    [RequiresUnreferencedCode(
+        "Reflection fallback requires module attribute constructors. Ensure ModularPipelines.SourceGenerator runs for trim-safe event invocation.")]
+    private static IReadOnlyList<Attribute> DiscoverAttributesWithReflection(Type moduleType)
+        => [.. moduleType.GetCustomAttributes(inherit: true).OfType<Attribute>()];
+
     private static IReadOnlyList<T> SortByPriority<T>(List<T> handlers)
     {
         if (handlers.Count <= 1)
@@ -99,9 +124,7 @@ internal class ModuleAttributeEventService : IModuleAttributeEventService
         }
 
         // Use stable sort to preserve declaration order for handlers with same priority
-        return handlers
-            .OrderBy(r => GetPriority(r))
-            .ToList();
+        return [.. handlers.OrderBy(GetPriority)];
     }
 
     private static int GetPriority<T>(T handler)

--- a/src/ModularPipelines/Engine/Attributes/RegistrationEventExecutor.cs
+++ b/src/ModularPipelines/Engine/Attributes/RegistrationEventExecutor.cs
@@ -85,7 +85,7 @@ internal class RegistrationEventExecutor : IRegistrationEventExecutor
 
             var context = new ModuleRegistrationContext(
                 moduleType,
-                moduleType.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray(),
+                _attributeEventService.GetAttributes(moduleType),
                 _configuration,
                 _environment,
                 registeredModuleTypes,

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -1,10 +1,10 @@
 using System.Diagnostics;
-using System.Reflection;
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Context;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Events;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
@@ -32,6 +32,7 @@ internal class ModuleRunner : IModuleRunner
     private readonly IDependencyWaiter _dependencyWaiter;
     private readonly IParallelLimitHandler _parallelLimitHandler;
     private readonly IModuleLifecycleEventInvoker _lifecycleEventInvoker;
+    private readonly IModuleAttributeEventService _moduleAttributeEventService;
     private readonly IModuleResultRegistrar _resultRegistrar;
 
     public ModuleRunner(
@@ -47,6 +48,7 @@ internal class ModuleRunner : IModuleRunner
         IDependencyWaiter dependencyWaiter,
         IParallelLimitHandler parallelLimitHandler,
         IModuleLifecycleEventInvoker lifecycleEventInvoker,
+        IModuleAttributeEventService moduleAttributeEventService,
         IModuleResultRegistrar resultRegistrar)
     {
         _serviceProvider = serviceProvider;
@@ -61,6 +63,7 @@ internal class ModuleRunner : IModuleRunner
         _dependencyWaiter = dependencyWaiter;
         _parallelLimitHandler = parallelLimitHandler;
         _lifecycleEventInvoker = lifecycleEventInvoker;
+        _moduleAttributeEventService = moduleAttributeEventService;
         _resultRegistrar = resultRegistrar;
     }
 
@@ -204,8 +207,7 @@ internal class ModuleRunner : IModuleRunner
 
         // Track start time for lifecycle events
         var startTime = DateTimeOffset.UtcNow;
-        var moduleAttributes = moduleType.GetCustomAttributes(inherit: true).OfType<Attribute>().ToArray();
-
+        var moduleAttributes = _moduleAttributeEventService.GetAttributes(moduleType);
         var lifecycleContext = new ModuleLifecycleContext(
             module,
             moduleType,
@@ -215,7 +217,7 @@ internal class ModuleRunner : IModuleRunner
             scopedServiceProvider,
             cancellationToken)
         {
-            ReadyTime = moduleState.ReadyTime ?? startTime
+            ReadyTime = moduleState.ReadyTime ?? startTime,
         };
 
         try

--- a/test/ModularPipelines.UnitTests/Attributes/GeneratedAttributeEventMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/GeneratedAttributeEventMetadataTests.cs
@@ -46,6 +46,28 @@ public sealed class GeneratedNoEventModule : Module<string>
         => Task.FromResult<string?>("none");
 }
 
+public static class GeneratedInaccessibleTypeArgument
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class MarkerAttribute(Type type) : Attribute
+    {
+        public Type Type { get; } = type;
+    }
+
+    [Marker(typeof(InaccessibleType))]
+    public sealed class TestModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult<string?>("fallback");
+    }
+
+    private sealed class InaccessibleType
+    {
+    }
+}
+
 public class GeneratedAttributeEventMetadataTests
 {
     [Test]
@@ -114,6 +136,23 @@ public class GeneratedAttributeEventMetadataTests
         await Assert.That(generated).IsFalse();
         await Assert.That(handlers).HasSingleItem();
         await Assert.That(handlers[0]).IsTypeOf<ReflectionFallbackStartAttribute>();
+    }
+
+    [Test]
+    public async Task Generator_FallsBackForInaccessibleTypeArgument()
+    {
+        var generated = GeneratedModuleEventMetadata.TryCreateAttributes(
+            typeof(GeneratedInaccessibleTypeArgument.TestModule),
+            out _);
+        var service = new ModuleAttributeEventService();
+
+        var attributes = service.GetAttributes(typeof(GeneratedInaccessibleTypeArgument.TestModule));
+        var marker = attributes
+            .OfType<GeneratedInaccessibleTypeArgument.MarkerAttribute>()
+            .Single();
+
+        await Assert.That(generated).IsFalse();
+        await Assert.That(marker.Type.Name).IsEqualTo("InaccessibleType");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Attributes/GeneratedAttributeEventMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/GeneratedAttributeEventMetadataTests.cs
@@ -1,0 +1,149 @@
+using ModularPipelines.Attributes.Events;
+using ModularPipelines.Context;
+using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.UnitTests.Attributes;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+internal sealed class GeneratedStartAttribute(string name) : Attribute, IModuleStartHandler, IEventHandlerPriority
+{
+    public string Name { get; } = name;
+
+    public int Priority { get; set; }
+
+    public Task OnModuleStartAsync(IModuleHookContext context) => Task.CompletedTask;
+}
+
+[AttributeUsage(AttributeTargets.Class, Inherited = true)]
+internal sealed class GeneratedMarkerAttribute(string value) : Attribute
+{
+    public string Value { get; } = value;
+}
+
+[GeneratedStart("base", Priority = 20)]
+[GeneratedMarker("base-marker")]
+public class GeneratedEventBaseModule : Module<string>
+{
+    protected internal override Task<string?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+        => Task.FromResult<string?>("base");
+}
+
+[GeneratedStart("derived", Priority = 10)]
+[GeneratedStart("repeated", Priority = 30)]
+[GeneratedMarker("marker")]
+public sealed class GeneratedEventDerivedModule : GeneratedEventBaseModule
+{
+}
+
+public sealed class GeneratedNoEventModule : Module<string>
+{
+    protected internal override Task<string?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+        => Task.FromResult<string?>("none");
+}
+
+public class GeneratedAttributeEventMetadataTests
+{
+    [Test]
+    public async Task Generator_RegistersInheritedRepeatedAndNamedAttributeValues()
+    {
+        var found = GeneratedModuleEventMetadata.TryCreateAttributes(
+            typeof(GeneratedEventDerivedModule),
+            out var attributes);
+
+        await Assert.That(found).IsTrue();
+        var handlers = attributes.OfType<GeneratedStartAttribute>().ToArray();
+        await Assert.That(handlers.Length).IsEqualTo(3);
+        await Assert.That(handlers[0].Name).IsEqualTo("derived");
+        await Assert.That(handlers[0].Priority).IsEqualTo(10);
+        await Assert.That(handlers[1].Name).IsEqualTo("repeated");
+        await Assert.That(handlers[1].Priority).IsEqualTo(30);
+        await Assert.That(handlers[2].Name).IsEqualTo("base");
+        await Assert.That(handlers[2].Priority).IsEqualTo(20);
+        await Assert.That(attributes.OfType<GeneratedMarkerAttribute>().Single().Value)
+            .IsEqualTo("marker");
+    }
+
+    [Test]
+    public async Task Generator_RegistersModuleWithoutHooks()
+    {
+        var found = GeneratedModuleEventMetadata.TryCreateAttributes(
+            typeof(GeneratedNoEventModule),
+            out var attributes);
+
+        await Assert.That(found).IsTrue();
+        await Assert.That(attributes).IsEmpty();
+    }
+
+    [Test]
+    public async Task Runtime_UsesGeneratedHandlersInPriorityOrder()
+    {
+        var service = new ModuleAttributeEventService();
+
+        var handlers = service.GetStartHandlers(typeof(GeneratedEventDerivedModule));
+        var contextAttributes = service.GetAttributes(typeof(GeneratedEventDerivedModule));
+
+        await Assert.That(((GeneratedStartAttribute) handlers[0]).Name).IsEqualTo("derived");
+        await Assert.That(((GeneratedStartAttribute) handlers[1]).Name).IsEqualTo("base");
+        await Assert.That(((GeneratedStartAttribute) handlers[2]).Name).IsEqualTo("repeated");
+        await Assert.That(ReferenceEquals(
+                handlers[0],
+                contextAttributes.OfType<GeneratedStartAttribute>().First()))
+            .IsFalse();
+        await Assert.That(contextAttributes
+            .OfType<GeneratedMarkerAttribute>()
+            .Single()
+            .Value)
+            .IsEqualTo("marker");
+    }
+
+    [Test]
+    public async Task Runtime_ReflectsForInaccessibleDynamicModuleType()
+    {
+        var generated = GeneratedModuleEventMetadata.TryCreateAttributes(
+            typeof(ReflectionFallbackModule),
+            out _);
+        var service = new ModuleAttributeEventService();
+
+        var handlers = service.GetStartHandlers(typeof(ReflectionFallbackModule));
+
+        await Assert.That(generated).IsFalse();
+        await Assert.That(handlers).HasSingleItem();
+        await Assert.That(handlers[0]).IsTypeOf<ReflectionFallbackStartAttribute>();
+    }
+
+    [Test]
+    public async Task Registry_RejectsDuplicateRegistration()
+    {
+        GeneratedModuleEventMetadata.Register(
+            typeof(DuplicateRegistrationType),
+            static () => Array.Empty<Attribute>());
+
+        await Assert.That(() => GeneratedModuleEventMetadata.Register(
+                typeof(DuplicateRegistrationType),
+                static () => Array.Empty<Attribute>()))
+            .Throws<InvalidOperationException>();
+    }
+
+    private sealed class ReflectionFallbackStartAttribute : Attribute, IModuleStartHandler
+    {
+        public Task OnModuleStartAsync(IModuleHookContext context) => Task.CompletedTask;
+    }
+
+    [ReflectionFallbackStart]
+    private sealed class ReflectionFallbackModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult<string?>("fallback");
+    }
+
+    private sealed class DuplicateRegistrationType
+    {
+    }
+}

--- a/test/ModularPipelines.UnitTests/Attributes/GeneratedAttributeEventMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/GeneratedAttributeEventMetadataTests.cs
@@ -1,3 +1,4 @@
+using ModularPipelines.Attributes;
 using ModularPipelines.Attributes.Events;
 using ModularPipelines.Context;
 using ModularPipelines.Engine.Attributes;
@@ -66,6 +67,54 @@ public static class GeneratedInaccessibleTypeArgument
     private sealed class InaccessibleType
     {
     }
+}
+
+public static class GeneratedNestedInaccessibleTypeArgument
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class MarkerAttribute(Type type) : Attribute
+    {
+        public Type Type { get; } = type;
+    }
+
+    public sealed class Wrapper<T>;
+
+    [Marker(typeof(Wrapper<InaccessibleType[]>))]
+    public sealed class TestModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult<string?>("fallback");
+    }
+
+    private sealed class InaccessibleType;
+}
+
+public abstract class GeneratedNamedArgumentBaseAttribute : Attribute
+{
+    public string? InheritedValue { get; set; }
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class GeneratedInheritedNamedArgumentAttribute : GeneratedNamedArgumentBaseAttribute;
+
+[GeneratedInheritedNamedArgument(InheritedValue = "inherited")]
+public sealed class GeneratedInheritedNamedArgumentModule : Module<string>
+{
+    protected internal override Task<string?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+        => Task.FromResult<string?>("generated");
+}
+
+[MatrixTarget("friend")]
+public sealed class GeneratedFriendAttributeModule : Module<string>
+{
+    protected internal override Task<string?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+        => Task.FromResult<string?>("generated");
 }
 
 public class GeneratedAttributeEventMetadataTests
@@ -156,16 +205,70 @@ public class GeneratedAttributeEventMetadataTests
     }
 
     [Test]
-    public async Task Registry_RejectsDuplicateRegistration()
+    public async Task Generator_FallsBackForNestedInaccessibleTypeArgument()
+    {
+        var generated = GeneratedModuleEventMetadata.TryCreateAttributes(
+            typeof(GeneratedNestedInaccessibleTypeArgument.TestModule),
+            out _);
+        var service = new ModuleAttributeEventService();
+
+        var attributes = service.GetAttributes(typeof(GeneratedNestedInaccessibleTypeArgument.TestModule));
+        var marker = attributes
+            .OfType<GeneratedNestedInaccessibleTypeArgument.MarkerAttribute>()
+            .Single();
+
+        await Assert.That(generated).IsFalse();
+        await Assert.That(marker.Type.Name).IsEqualTo("Wrapper`1");
+    }
+
+    [Test]
+    public async Task Generator_ResolvesInheritedNamedArgumentMembers()
+    {
+        var generated = GeneratedModuleEventMetadata.TryCreateAttributes(
+            typeof(GeneratedInheritedNamedArgumentModule),
+            out var attributes);
+
+        await Assert.That(generated).IsTrue();
+        await Assert.That(attributes
+                .OfType<GeneratedInheritedNamedArgumentAttribute>()
+                .Single()
+                .InheritedValue)
+            .IsEqualTo("inherited");
+    }
+
+    [Test]
+    public async Task Generator_UsesInternalsVisibleToForFriendAssemblyAttributes()
+    {
+        var generated = GeneratedModuleEventMetadata.TryCreateAttributes(
+            typeof(GeneratedFriendAttributeModule),
+            out var attributes);
+
+        await Assert.That(generated).IsTrue();
+        await Assert.That(attributes
+                .OfType<MatrixTargetAttribute>()
+                .Single()
+                .Targets)
+            .IsEquivalentTo(["friend"]);
+    }
+
+    [Test]
+    public async Task Registry_KeepsFirstDuplicateRegistration()
     {
         GeneratedModuleEventMetadata.Register(
             typeof(DuplicateRegistrationType),
-            static () => Array.Empty<Attribute>());
+            static () => [new GeneratedMarkerAttribute("first")]);
 
-        await Assert.That(() => GeneratedModuleEventMetadata.Register(
-                typeof(DuplicateRegistrationType),
-                static () => Array.Empty<Attribute>()))
-            .Throws<InvalidOperationException>();
+        GeneratedModuleEventMetadata.Register(
+            typeof(DuplicateRegistrationType),
+            static () => [new GeneratedMarkerAttribute("second")]);
+
+        var found = GeneratedModuleEventMetadata.TryCreateAttributes(
+            typeof(DuplicateRegistrationType),
+            out var attributes);
+
+        await Assert.That(found).IsTrue();
+        await Assert.That(attributes.OfType<GeneratedMarkerAttribute>().Single().Value)
+            .IsEqualTo("first");
     }
 
     private sealed class ReflectionFallbackStartAttribute : Attribute, IModuleStartHandler


### PR DESCRIPTION
## Summary
- generate direct attribute factories for statically known module types
- route registration and lifecycle contexts through generated metadata while retaining fresh attribute instances
- isolate reflection behind a trim-annotated fallback for dynamic and plugin module types
- preserve inherited/repeated attribute semantics and handler priority ordering

## Test plan
- [x] pwsh scripts/Invoke-AgentDotNet.ps1 -DotNetArguments @('build', 'ModularPipelines.sln', '-c', 'Release', '--no-restore')
- [x] pwsh scripts/Invoke-AgentDotNet.ps1 -DotNetArguments @('run', '--project', 'test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj', '--framework', 'net10.0', '--', '--treenode-filter', '/*/ModularPipelines.UnitTests.Attributes/*/*', '--minimum-expected-tests', '100', '--zero-tests-policy', 'strict') (103 passed)
- [x] scoped whitespace format verification

Closes #3227
