### PR TITLE
Use terminal-safe progress status glyphs

### DIFF
--- a/src/ModularPipelines/Console/ProgressDisplayStyle.cs
+++ b/src/ModularPipelines/Console/ProgressDisplayStyle.cs
@@ -1,0 +1,39 @@
+using Spectre.Console;
+
+namespace ModularPipelines.Console;
+
+internal static class ProgressDisplayStyle
+{
+    internal const string PendingMarker = ".";
+    internal const string RunningMarker = ">";
+    internal const string SucceededMarker = "+";
+    internal const string FailedMarker = "!";
+    internal const string SkippedMarker = "-";
+
+    internal static Spinner Spinner { get; } = Spinner.Known.Ascii;
+
+    internal static string FormatTask(string name, ProgressTaskStatus status, bool isSubModule = false)
+    {
+        var (style, marker) = status switch
+        {
+            ProgressTaskStatus.Pending => ("dim", PendingMarker),
+            ProgressTaskStatus.Running => ("cyan", RunningMarker),
+            ProgressTaskStatus.Succeeded => ("green", SucceededMarker),
+            ProgressTaskStatus.Failed => ("red", FailedMarker),
+            ProgressTaskStatus.Skipped => ("yellow", SkippedMarker),
+            _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
+        };
+
+        var indentation = isSubModule ? "  " : string.Empty;
+        return $"[{style}]{indentation}{marker} {name}[/]";
+    }
+}
+
+internal enum ProgressTaskStatus
+{
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+    Skipped,
+}

--- a/src/ModularPipelines/Console/ProgressDisplayStyle.cs
+++ b/src/ModularPipelines/Console/ProgressDisplayStyle.cs
@@ -9,6 +9,7 @@ internal static class ProgressDisplayStyle
     internal const string SucceededMarker = "+";
     internal const string FailedMarker = "!";
     internal const string SkippedMarker = "-";
+    internal const string CompletedSpinnerText = " ";
 
     internal static Spinner Spinner { get; } = Spinner.Known.Ascii;
 

--- a/src/ModularPipelines/Console/ProgressSession.cs
+++ b/src/ModularPipelines/Console/ProgressSession.cs
@@ -93,7 +93,7 @@ internal class ProgressSession : IProgressSession, IProgressController
                     new ElapsedTimeColumn(),
                     new SpinnerColumn(ProgressDisplayStyle.Spinner)
                     {
-                        CompletedText = ProgressDisplayStyle.SucceededMarker,
+                        CompletedText = ProgressDisplayStyle.CompletedSpinnerText,
                         PendingText = ProgressDisplayStyle.PendingMarker,
                     })
                 .StartAsync(async ctx =>

--- a/src/ModularPipelines/Console/ProgressSession.cs
+++ b/src/ModularPipelines/Console/ProgressSession.cs
@@ -91,7 +91,11 @@ internal class ProgressSession : IProgressSession, IProgressController
                     new TaskDescriptionColumn(),
                     new ProgressBarColumn(),
                     new ElapsedTimeColumn(),
-                    new SpinnerColumn())
+                    new SpinnerColumn(ProgressDisplayStyle.Spinner)
+                    {
+                        CompletedText = ProgressDisplayStyle.SucceededMarker,
+                        PendingText = ProgressDisplayStyle.PendingMarker,
+                    })
                 .StartAsync(async ctx =>
                 {
                     _progressContext = ctx;
@@ -194,7 +198,7 @@ internal class ProgressSession : IProgressSession, IProgressController
         foreach (var ignored in _modules.IgnoredModules)
         {
             var name = FormatModuleName(ignored.Module.GetType().Name);
-            ctx.AddTask($"[yellow]⊘ {name}[/]").StopTask();
+            ctx.AddTask(ProgressDisplayStyle.FormatTask(name, ProgressTaskStatus.Skipped)).StopTask();
         }
     }
 
@@ -208,7 +212,9 @@ internal class ProgressSession : IProgressSession, IProgressController
 
                 // Create task in paused state with dim waiting status
                 // autoStart: false means task is paused, NOT stopped (stopped tasks can't restart)
-                var task = ctx.AddTask($"[dim]○ {name}[/]", autoStart: false);
+                var task = ctx.AddTask(
+                    ProgressDisplayStyle.FormatTask(name, ProgressTaskStatus.Pending),
+                    autoStart: false);
 
                 // Store for lookup when module actually starts
                 _moduleTasks[runnableModule.Module] = task;
@@ -240,14 +246,16 @@ internal class ProgressSession : IProgressSession, IProgressController
                 }
 
                 // Update to running status with cyan color
-                task.Description = $"[cyan]◉ {name}[/]";
+                task.Description = ProgressDisplayStyle.FormatTask(name, ProgressTaskStatus.Running);
                 task.Value = 0;
                 task.StartTask();
             }
             else
             {
                 // Fallback: create new task if not pre-registered
-                task = _progressContext.AddTask($"[cyan]◉ {name}[/]", autoStart: true);
+                task = _progressContext.AddTask(
+                    ProgressDisplayStyle.FormatTask(name, ProgressTaskStatus.Running),
+                    autoStart: true);
                 _moduleTasks[state.Module] = task;
             }
 
@@ -275,8 +283,8 @@ internal class ProgressSession : IProgressSession, IProgressController
 
                     var name = FormatModuleName(state.ModuleType.Name);
                     task.Description = isSuccessful
-                        ? $"[green]✓ {name}[/]"
-                        : $"[red]✗ {name}[/]";
+                        ? ProgressDisplayStyle.FormatTask(name, ProgressTaskStatus.Succeeded)
+                        : ProgressDisplayStyle.FormatTask(name, ProgressTaskStatus.Failed);
 
                     task.StopTask();
                 }
@@ -309,7 +317,7 @@ internal class ProgressSession : IProgressSession, IProgressController
 
             if (_moduleTasks.TryGetValue(state.Module, out var task))
             {
-                task.Description = $"[yellow]⊘ {name}[/]";
+                task.Description = ProgressDisplayStyle.FormatTask(name, ProgressTaskStatus.Skipped);
                 if (!task.IsFinished)
                 {
                     task.StopTask();
@@ -317,7 +325,8 @@ internal class ProgressSession : IProgressSession, IProgressController
             }
             else
             {
-                var newTask = _progressContext.AddTask($"[yellow]⊘ {name}[/]");
+                var newTask = _progressContext.AddTask(
+                    ProgressDisplayStyle.FormatTask(name, ProgressTaskStatus.Skipped));
                 newTask.StopTask();
             }
 
@@ -349,7 +358,10 @@ internal class ProgressSession : IProgressSession, IProgressController
 
             var subModuleName = SpectreMarkupEscaper.Escape(subModule.Name);
             var task = _progressContext.AddTaskAfter(
-                $"[cyan]  ◉ {subModuleName}[/]",
+                ProgressDisplayStyle.FormatTask(
+                    subModuleName,
+                    ProgressTaskStatus.Running,
+                    isSubModule: true),
                 new ProgressTaskSettings { AutoStart = true },
                 parentTask);
 
@@ -381,8 +393,14 @@ internal class ProgressSession : IProgressSession, IProgressController
 
                     var subModuleName = SpectreMarkupEscaper.Escape(subModule.Name);
                     task.Description = isSuccessful
-                        ? $"[green]  ✓ {subModuleName}[/]"
-                        : $"[red]  ✗ {subModuleName}[/]";
+                        ? ProgressDisplayStyle.FormatTask(
+                            subModuleName,
+                            ProgressTaskStatus.Succeeded,
+                            isSubModule: true)
+                        : ProgressDisplayStyle.FormatTask(
+                            subModuleName,
+                            ProgressTaskStatus.Failed,
+                            isSubModule: true);
 
                     task.StopTask();
                 }

--- a/test/ModularPipelines.UnitTests/Console/ProgressDisplayStyleTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ProgressDisplayStyleTests.cs
@@ -45,4 +45,11 @@ public class ProgressDisplayStyleTests
         await Assert.That(ProgressDisplayStyle.Spinner.Frames)
             .All(frame => frame.All(character => character <= sbyte.MaxValue));
     }
+
+    [Test]
+    public async Task Completed_Spinner_Is_Status_Neutral()
+    {
+        await Assert.That(ProgressDisplayStyle.CompletedSpinnerText)
+            .IsEqualTo(" ");
+    }
 }

--- a/test/ModularPipelines.UnitTests/Console/ProgressDisplayStyleTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ProgressDisplayStyleTests.cs
@@ -1,0 +1,48 @@
+using ModularPipelines.Console;
+
+namespace ModularPipelines.UnitTests.Console;
+
+public class ProgressDisplayStyleTests
+{
+    [Test]
+    public async Task Format_Uses_Single_Cell_Ascii_Status_Markers()
+    {
+        var testCases = new[]
+        {
+            (ProgressTaskStatus.Pending, "[dim]. Build[/]"),
+            (ProgressTaskStatus.Running, "[cyan]> Build[/]"),
+            (ProgressTaskStatus.Succeeded, "[green]+ Build[/]"),
+            (ProgressTaskStatus.Failed, "[red]! Build[/]"),
+            (ProgressTaskStatus.Skipped, "[yellow]- Build[/]"),
+        };
+
+        foreach (var (status, expected) in testCases)
+        {
+            var result = ProgressDisplayStyle.FormatTask("Build", status);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result).IsEqualTo(expected);
+                await Assert.That(result.All(character => character <= sbyte.MaxValue)).IsTrue();
+            }
+        }
+    }
+
+    [Test]
+    public async Task Format_Indents_Submodules_Without_Changing_Marker()
+    {
+        var result = ProgressDisplayStyle.FormatTask(
+            "Compile",
+            ProgressTaskStatus.Running,
+            isSubModule: true);
+
+        await Assert.That(result).IsEqualTo("[cyan]  > Compile[/]");
+    }
+
+    [Test]
+    public async Task Spinner_Uses_Only_Ascii_Frames()
+    {
+        await Assert.That(ProgressDisplayStyle.Spinner.Frames)
+            .All(frame => frame.All(character => character <= sbyte.MaxValue));
+    }
+}


### PR DESCRIPTION
## Summary
- replace Unicode progress-state glyphs with fixed-width, single-cell ASCII markers
- configure `SpinnerColumn` with ASCII frames and explicit ASCII pending/completed states
- add regression coverage for module, submodule, and spinner formatting

## Why
Rider's run-console pseudoterminal can substitute unsupported Unicode glyphs and corrupt progress-table alignment. JetBrains also documents that this run-console path may omit `TERMINAL_EMULATOR`, so environment-name detection is not reliable: https://youtrack.jetbrains.com/issue/GO-20196

## Validation
- focused display-style tests: 3/3 passed
- console unit tests: 38/38 passed
- `ModularPipelines.sln` Release build: 0 errors (248 pre-existing warnings)
- scoped whitespace and analyzer format checks passed for new files

Closes #2162