### PR TITLE
Support F# pipeline modules

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,6 +37,7 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="EnumerableAsyncProcessor" Version="4.0.0" />
     <PackageVersion Include="FluentFTP" Version="54.2.0" />
+    <PackageVersion Include="FSharp.Core" Version="10.1.302" />
     <PackageVersion Include="Initialization.Microsoft.Extensions.DependencyInjection" Version="1.1.44" />
     <PackageVersion Include="MailKit" Version="4.17.0" />
     <PackageVersion Include="Mediator.Abstractions" Version="3.0.2" />

--- a/ModularPipelines.All.sln
+++ b/ModularPipelines.All.sln
@@ -181,6 +181,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.NerdbankGi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.NerdbankGitVersioning.UnitTests", "test\ModularPipelines.NerdbankGitVersioning.UnitTests\ModularPipelines.NerdbankGitVersioning.UnitTests.csproj", "{6259C165-F4E7-4666-B245-859AB1A53721}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "ModularPipelines.FSharp.TestFixtures", "test\ModularPipelines.FSharp.TestFixtures\ModularPipelines.FSharp.TestFixtures.fsproj", "{C294970E-BDBD-413C-A431-3012ECA5FC1C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1199,6 +1201,18 @@ Global
 		{6259C165-F4E7-4666-B245-859AB1A53721}.Release|x64.Build.0 = Release|Any CPU
 		{6259C165-F4E7-4666-B245-859AB1A53721}.Release|x86.ActiveCfg = Release|Any CPU
 		{6259C165-F4E7-4666-B245-859AB1A53721}.Release|x86.Build.0 = Release|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Debug|x64.Build.0 = Debug|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Debug|x86.Build.0 = Debug|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Release|x64.ActiveCfg = Release|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Release|x64.Build.0 = Release|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Release|x86.ActiveCfg = Release|Any CPU
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1288,6 +1302,7 @@ Global
 		{B195308E-AA70-4D41-92F1-FABF910FE50D} = {F213898F-1E32-48F1-AB8C-83D2BD01A93B}
 		{639D67F3-3C80-4DBC-BD20-0D3475EC7948} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{6259C165-F4E7-4666-B245-859AB1A53721} = {F213898F-1E32-48F1-AB8C-83D2BD01A93B}
+		{C294970E-BDBD-413C-A431-3012ECA5FC1C} = {F213898F-1E32-48F1-AB8C-83D2BD01A93B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A5905A5D-B4E1-4A7A-9279-0283D86A9F7F}

--- a/docs/docs/how-to/execution-and-dependencies.md
+++ b/docs/docs/how-to/execution-and-dependencies.md
@@ -12,7 +12,7 @@ If you don't want a particular module to start until another one has finished, t
 These can chain together as appropriate. And it'll detect if two modules depend on each other.
 
 ```csharp
-[DependsOn<Module1>] // or [DependsOn(typeof(Module1))] for older language versions
+[DependsOn<Module1>] // F#: [<DependsOn(typeof<Module1>)>]
 public class Module2 : Module
 {
     ...

--- a/docs/docs/how-to/fsharp.md
+++ b/docs/docs/how-to/fsharp.md
@@ -1,0 +1,64 @@
+---
+title: Using F#
+sidebar_position: 10
+---
+
+# Using F#
+
+ModularPipelines modules can be authored and executed from an F# project. Inherit
+from `Module<'T>`, override `ExecuteAsync`, and open
+`ModularPipelines.Extensions` for pipeline-builder extension methods.
+
+```fsharp
+open System.Threading
+open System.Threading.Tasks
+open ModularPipelines
+open ModularPipelines.Attributes
+open ModularPipelines.Context
+open ModularPipelines.Extensions
+open ModularPipelines.Modules
+
+type BuildModule() =
+    inherit Module<string>()
+
+    override _.ExecuteAsync(
+        _context: IModuleContext,
+        _cancellationToken: CancellationToken
+    ) : Task<string> =
+        Task.FromResult("built")
+
+[<DependsOn(typeof<BuildModule>)>]
+type TestModule() =
+    inherit Module<string>()
+
+    override _.ExecuteAsync(
+        context: IModuleContext,
+        _cancellationToken: CancellationToken
+    ) : Task<string> =
+        task {
+            let! build = context.GetModule<BuildModule>()
+            return $"tested {build.ValueOrDefault}"
+        }
+
+let builder = Pipeline.CreateBuilder()
+
+builder
+    .AddModule<TestModule>()
+    .ExecutePipelineAsync()
+    .GetAwaiter()
+    .GetResult()
+|> ignore
+```
+
+F# does not support applying generic attribute types, so declare static module
+dependencies with `[<DependsOn(typeof<DependencyModule>)>]`. This overload is a
+supported API and has the same auto-registration, validation, optional-dependency,
+and cascade-skip behavior as C#'s `[DependsOn<DependencyModule>]`.
+
+For dynamic dependencies, override `DeclareDependencies` and use its generic
+methods:
+
+```fsharp
+override _.DeclareDependencies(dependencies) =
+    dependencies.DependsOn<BuildModule>()
+```

--- a/docs/docs/how-to/fsharp.md
+++ b/docs/docs/how-to/fsharp.md
@@ -60,5 +60,5 @@ methods:
 
 ```fsharp
 override _.DeclareDependencies(dependencies) =
-    dependencies.DependsOn<BuildModule>()
+    dependencies.DependsOn<BuildModule>() |> ignore
 ```

--- a/src/ModularPipelines/Attributes/DependsOnAttribute.cs
+++ b/src/ModularPipelines/Attributes/DependsOnAttribute.cs
@@ -47,8 +47,11 @@ public class DependsOnAttribute : Attribute
     /// Initializes a new instance of the <see cref="DependsOnAttribute"/> class.
     /// </summary>
     /// <param name="type">The type of module this module depends on.</param>
+    /// <remarks>
+    /// Use this overload from .NET languages that cannot apply generic attributes, such as F#.
+    /// C# callers should prefer <see cref="DependsOnAttribute{TModule}"/>.
+    /// </remarks>
     /// <exception cref="InvalidModuleTypeException">Thrown when the type does not implement <see cref="IModule"/>.</exception>
-    [Obsolete("Use the generic DependsOnAttribute<TModule> instead for compile-time type safety. This constructor will be removed in a future version.")]
     public DependsOnAttribute(Type type)
     {
         if (!type.IsAssignableTo(typeof(IModule)))

--- a/test/ModularPipelines.FSharp.TestFixtures/ModularPipelines.FSharp.TestFixtures.fsproj
+++ b/test/ModularPipelines.FSharp.TestFixtures/ModularPipelines.FSharp.TestFixtures.fsproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="PipelineModules.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ModularPipelines\ModularPipelines.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/ModularPipelines.FSharp.TestFixtures/PipelineModules.fs
+++ b/test/ModularPipelines.FSharp.TestFixtures/PipelineModules.fs
@@ -1,0 +1,38 @@
+namespace ModularPipelines.FSharp.TestFixtures
+
+open System.Threading
+open System.Threading.Tasks
+open ModularPipelines
+open ModularPipelines.Attributes
+open ModularPipelines.Context
+open ModularPipelines.Extensions
+open ModularPipelines.Modules
+
+type DependencyModule() =
+    inherit Module<string>()
+
+    override _.ExecuteAsync(
+        _context: IModuleContext,
+        _cancellationToken: CancellationToken
+    ) : Task<string> =
+        Task.FromResult("dependency")
+
+[<DependsOn(typeof<DependencyModule>)>]
+type DependentModule() =
+    inherit Module<string>()
+
+    override _.ExecuteAsync(
+        context: IModuleContext,
+        _cancellationToken: CancellationToken
+    ) : Task<string> =
+        task {
+            let! dependency = context.GetModule<DependencyModule>()
+            return $"{dependency.ValueOrDefault}-dependent"
+        }
+
+type PipelineRunner =
+    static member RunAsync() =
+        Pipeline
+            .CreateBuilder()
+            .AddModule<DependentModule>()
+            .ExecutePipelineAsync()

--- a/test/ModularPipelines.FSharp.TestFixtures/PipelineModules.fs
+++ b/test/ModularPipelines.FSharp.TestFixtures/PipelineModules.fs
@@ -30,9 +30,31 @@ type DependentModule() =
             return $"{dependency.ValueOrDefault}-dependent"
         }
 
+type DynamicDependentModule() =
+    inherit Module<string>()
+
+    override _.DeclareDependencies(dependencies) =
+        dependencies.DependsOn<DependencyModule>() |> ignore
+
+    override _.ExecuteAsync(
+        context: IModuleContext,
+        _cancellationToken: CancellationToken
+    ) : Task<string> =
+        task {
+            let! dependency = context.GetModule<DependencyModule>()
+            return $"{dependency.ValueOrDefault}-dynamic"
+        }
+
 type PipelineRunner =
     static member RunAsync() =
         Pipeline
             .CreateBuilder()
             .AddModule<DependentModule>()
+            .ExecutePipelineAsync()
+
+    static member RunDynamicAsync() =
+        Pipeline
+            .CreateBuilder()
+            .AddModule<DependencyModule>()
+            .AddModule<DynamicDependentModule>()
             .ExecutePipelineAsync()

--- a/test/ModularPipelines.UnitTests/Compatibility/FSharpCompatibilityTests.cs
+++ b/test/ModularPipelines.UnitTests/Compatibility/FSharpCompatibilityTests.cs
@@ -20,4 +20,20 @@ public class FSharpCompatibilityTests
             await Assert.That(dependentResult.ValueOrDefault).IsEqualTo("dependency-dependent");
         }
     }
+
+    [Test]
+    public async Task FSharp_Modules_Execute_With_Dynamic_Dependency()
+    {
+        var summary = await PipelineRunner.RunDynamicAsync();
+
+        var dependencyResult = await summary.GetModule<DependencyModule>();
+        var dependentResult = await summary.GetModule<DynamicDependentModule>();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(summary.Status).IsEqualTo(Status.Successful);
+            await Assert.That(dependencyResult.ValueOrDefault).IsEqualTo("dependency");
+            await Assert.That(dependentResult.ValueOrDefault).IsEqualTo("dependency-dynamic");
+        }
+    }
 }

--- a/test/ModularPipelines.UnitTests/Compatibility/FSharpCompatibilityTests.cs
+++ b/test/ModularPipelines.UnitTests/Compatibility/FSharpCompatibilityTests.cs
@@ -1,0 +1,23 @@
+using ModularPipelines.Enums;
+using ModularPipelines.FSharp.TestFixtures;
+
+namespace ModularPipelines.UnitTests.Compatibility;
+
+public class FSharpCompatibilityTests
+{
+    [Test]
+    public async Task FSharp_Modules_Execute_With_Type_Based_Dependency()
+    {
+        var summary = await PipelineRunner.RunAsync();
+
+        var dependencyResult = await summary.GetModule<DependencyModule>();
+        var dependentResult = await summary.GetModule<DependentModule>();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(summary.Status).IsEqualTo(Status.Successful);
+            await Assert.That(dependencyResult.ValueOrDefault).IsEqualTo("dependency");
+            await Assert.That(dependentResult.ValueOrDefault).IsEqualTo("dependency-dependent");
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
+++ b/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="..\..\src\ModularPipelines.DotNet\ModularPipelines.DotNet.csproj" />
     <ProjectReference Include="..\..\src\ModularPipelines.Git\ModularPipelines.Git.csproj" />
     <ProjectReference Include="..\..\src\ModularPipelines\ModularPipelines.csproj" />
+    <ProjectReference Include="..\ModularPipelines.FSharp.TestFixtures\ModularPipelines.FSharp.TestFixtures.fsproj" />
     <ProjectReference Include="..\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- keep the type-based `DependsOnAttribute` overload supported for languages that cannot apply generic attributes
- add compiled F# modules and an F#-owned pipeline runner with runtime dependency auto-registration coverage
- document F# module authoring and dependency syntax

## Validation
- focused F# compatibility test, Debug and Release: 1 passed
- F# fixture Release build: succeeded (existing warnings only)
- core `ModularPipelines.sln` Release build: succeeded, 0 warnings, 0 errors
- Docusaurus production build: succeeded
- scoped C# formatting: clean; core formatter reports pre-existing diagnostics in `DependsOnAttribute.cs`

Closes #2616