### PR TITLE
Generate minimal build server pipeline files

### DIFF
--- a/docs/docs/how-to/build-server-files.md
+++ b/docs/docs/how-to/build-server-files.md
@@ -55,6 +55,10 @@ The following optional properties customize the generated file:
 | `ModularPipelinesBuildBranch` | `main` |
 | `ModularPipelinesDotNetVersion` | `10.0.x` |
 | `ModularPipelinesDotNetSdkImage` | `mcr.microsoft.com/dotnet/sdk:10.0` |
+| `ModularPipelinesTargetFramework` | `TargetFramework`, or the first `TargetFrameworks` entry |
+
+For a multi-target pipeline project, set `ModularPipelinesTargetFramework` to
+choose which target framework the generated job runs.
 
 Existing YAML is preserved. To intentionally regenerate and replace it, build
 once with:

--- a/docs/docs/how-to/build-server-files.md
+++ b/docs/docs/how-to/build-server-files.md
@@ -35,7 +35,7 @@ project is in a subdirectory, set the repository root:
 ```xml
 <PropertyGroup>
   <ModularPipelinesBuildSystem>GitHubActions</ModularPipelinesBuildSystem>
-  <ModularPipelinesRepositoryRoot>$(MSBuildProjectDirectory)\..\..</ModularPipelinesRepositoryRoot>
+  <ModularPipelinesRepositoryRoot>$(MSBuildProjectDirectory)/../..</ModularPipelinesRepositoryRoot>
 </PropertyGroup>
 ```
 

--- a/docs/docs/how-to/build-server-files.md
+++ b/docs/docs/how-to/build-server-files.md
@@ -1,0 +1,67 @@
+---
+title: Generate build server files
+sidebar_position: 11
+---
+
+# Generate build server files
+
+The `ModularPipelines` package can create the minimal YAML needed to run a
+pipeline project in GitHub Actions, GitLab CI, or Azure Pipelines.
+
+Add the build system to the pipeline project's `.csproj`:
+
+```xml
+<PropertyGroup>
+  <ModularPipelinesBuildSystem>GitHubActions</ModularPipelinesBuildSystem>
+</PropertyGroup>
+```
+
+The next build creates the provider's conventional file:
+
+| Value | Generated file |
+| --- | --- |
+| `GitHubActions` | `.github/workflows/modular-pipelines.yml` |
+| `GitLab` | `.gitlab-ci.yml` |
+| `AzurePipelines` | `azure-pipelines.yml` |
+
+The generated job installs .NET and runs the pipeline project in Release
+configuration. Commit the generated YAML to the repository.
+
+## Pipeline projects below the repository root
+
+Generation defaults to the directory containing the pipeline project. If that
+project is in a subdirectory, set the repository root:
+
+```xml
+<PropertyGroup>
+  <ModularPipelinesBuildSystem>GitHubActions</ModularPipelinesBuildSystem>
+  <ModularPipelinesRepositoryRoot>$(MSBuildProjectDirectory)\..\..</ModularPipelinesRepositoryRoot>
+</PropertyGroup>
+```
+
+The project path in the generated command is calculated relative to this root.
+Override it explicitly when needed:
+
+```xml
+<ModularPipelinesPipelineProject>build/MyPipeline/MyPipeline.csproj</ModularPipelinesPipelineProject>
+```
+
+## Customization and overwrite safety
+
+The following optional properties customize the generated file:
+
+| Property | Default |
+| --- | --- |
+| `ModularPipelinesBuildBranch` | `main` |
+| `ModularPipelinesDotNetVersion` | `10.0.x` |
+| `ModularPipelinesDotNetSdkImage` | `mcr.microsoft.com/dotnet/sdk:10.0` |
+
+Existing YAML is preserved. To intentionally regenerate and replace it, build
+once with:
+
+```console
+dotnet build -p:ModularPipelinesOverwriteBuildServerFiles=true
+```
+
+Remove `ModularPipelinesBuildSystem` after committing the generated file if no
+further regeneration is wanted.

--- a/docs/docs/how-to/build-server-files.md
+++ b/docs/docs/how-to/build-server-files.md
@@ -27,6 +27,14 @@ The next build creates the provider's conventional file:
 The generated job installs .NET and runs the pipeline project in Release
 configuration. Commit the generated YAML to the repository.
 
+## Azure Repos pull request validation
+
+Azure Repos Git does not support YAML `pr` triggers. After creating the Azure
+Pipeline, configure it as an automatic **Build validation** branch policy for
+the target branch. The generated `pr` block applies only when Azure Pipelines
+builds a GitHub or Bitbucket Cloud repository. See
+[Set build validation](https://learn.microsoft.com/azure/devops/repos/git/branch-policies?view=azure-devops#set-build-validation).
+
 ## Pipeline projects below the repository root
 
 Generation defaults to the directory containing the pipeline project. If that

--- a/src/ModularPipelines/ModularPipelines.csproj
+++ b/src/ModularPipelines/ModularPipelines.csproj
@@ -130,6 +130,9 @@
     <ProjectReference Include="..\ModularPipelines.Analyzers\ModularPipelines.Analyzers\ModularPipelines.Analyzers.csproj" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
     <ProjectReference Include="..\ModularPipelines.Analyzers\ModularPipelines.Analyzers.CodeFixes\ModularPipelines.Analyzers.CodeFixes.csproj" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="buildTransitive\ModularPipelines.targets" Pack="true" PackagePath="buildTransitive\ModularPipelines.targets" />
+  </ItemGroup>
   <!-- Include source generator and analyzers in NuGet package for consumers -->
   <PropertyGroup>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddSourceGeneratorToPackage</TargetsForTfmSpecificContentInPackage>

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -52,8 +52,8 @@
       <_ModularPipelinesPipelineProject Condition="'$(_ModularPipelinesPipelineProjectSpecified)' == 'false'">@(_ModularPipelinesAssignedProject->'%(TargetPath)')</_ModularPipelinesPipelineProject>
       <_ModularPipelinesPipelineProject Condition="'$(_ModularPipelinesPipelineProjectSpecified)' == 'true'">$(ModularPipelinesPipelineProject)</_ModularPipelinesPipelineProject>
       <_ModularPipelinesPipelineProject Condition="'$(_ModularPipelinesIsWindows)' == 'true'">$(_ModularPipelinesPipelineProject.Replace('\', '/'))</_ModularPipelinesPipelineProject>
-      <_ModularPipelinesPipelineProjectEncoded>$([System.Uri]::EscapeDataString($(_ModularPipelinesPipelineProject)))</_ModularPipelinesPipelineProjectEncoded>
-      <_ModularPipelinesTargetFrameworkEncoded>$([System.Uri]::EscapeDataString($(ModularPipelinesTargetFramework)))</_ModularPipelinesTargetFrameworkEncoded>
+      <_ModularPipelinesPipelineProjectBase64>$([MSBuild]::ConvertToBase64($(_ModularPipelinesPipelineProject)))</_ModularPipelinesPipelineProjectBase64>
+      <_ModularPipelinesTargetFrameworkBase64>$([MSBuild]::ConvertToBase64($(ModularPipelinesTargetFramework)))</_ModularPipelinesTargetFrameworkBase64>
 
       <_ModularPipelinesGitHubDirectory>$(_ModularPipelinesRepositoryRoot)/.github/workflows</_ModularPipelinesGitHubDirectory>
       <_ModularPipelinesGitHubFile>$(_ModularPipelinesGitHubDirectory)/modular-pipelines.yml</_ModularPipelinesGitHubFile>
@@ -83,14 +83,12 @@ jobs:
         with:
           dotnet-version: "$(_ModularPipelinesYamlDotNetVersion)"
       - run: |
-          PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\x/g'`
-          PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
-          PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\x/g'`
-          PIPELINE_FRAMEWORK=`printf '%b' "$PIPELINE_FRAMEWORK"`
+          PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_BASE64" | base64 -d`
+          PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_BASE64" | base64 -d`
           dotnet run --project "$PIPELINE_PROJECT" --configuration Release --framework "$PIPELINE_FRAMEWORK"
         env:
-          PIPELINE_PROJECT_ENCODED: "$(_ModularPipelinesPipelineProjectEncoded)"
-          PIPELINE_FRAMEWORK_ENCODED: "$(_ModularPipelinesTargetFrameworkEncoded)"
+          PIPELINE_PROJECT_BASE64: "$(_ModularPipelinesPipelineProjectBase64)"
+          PIPELINE_FRAMEWORK_BASE64: "$(_ModularPipelinesTargetFrameworkBase64)"
 ]]></_ModularPipelinesGitHubWorkflow>
 
       <_ModularPipelinesGitLabPipeline><![CDATA[variables:
@@ -108,17 +106,15 @@ modular-pipelines:
     - if: '$CI_COMMIT_BRANCH == $MODULAR_PIPELINES_BUILD_BRANCH'
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == $MODULAR_PIPELINES_BUILD_BRANCH'
   variables:
-    PIPELINE_PROJECT_ENCODED:
-      value: "$(_ModularPipelinesPipelineProjectEncoded)"
+    PIPELINE_PROJECT_BASE64:
+      value: "$(_ModularPipelinesPipelineProjectBase64)"
       expand: false
-    PIPELINE_FRAMEWORK_ENCODED:
-      value: "$(_ModularPipelinesTargetFrameworkEncoded)"
+    PIPELINE_FRAMEWORK_BASE64:
+      value: "$(_ModularPipelinesTargetFrameworkBase64)"
       expand: false
   script:
-    - PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\x/g'`
-    - PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
-    - PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\x/g'`
-    - PIPELINE_FRAMEWORK=`printf '%b' "$PIPELINE_FRAMEWORK"`
+    - PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_BASE64" | base64 -d`
+    - PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_BASE64" | base64 -d`
     - dotnet run --project "$PIPELINE_PROJECT" --configuration Release --framework "$PIPELINE_FRAMEWORK"
 ]]></_ModularPipelinesGitLabPipeline>
 
@@ -137,15 +133,13 @@ steps:
       packageType: sdk
       version: "$(_ModularPipelinesYamlDotNetVersion)"
   - script: |
-      PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\x/g'`
-      PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
-      PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\x/g'`
-      PIPELINE_FRAMEWORK=`printf '%b' "$PIPELINE_FRAMEWORK"`
+      PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_BASE64" | base64 -d`
+      PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_BASE64" | base64 -d`
       dotnet run --project "$PIPELINE_PROJECT" --configuration Release --framework "$PIPELINE_FRAMEWORK"
     displayName: Run ModularPipelines
     env:
-      PIPELINE_PROJECT_ENCODED: "$(_ModularPipelinesPipelineProjectEncoded)"
-      PIPELINE_FRAMEWORK_ENCODED: "$(_ModularPipelinesTargetFrameworkEncoded)"
+      PIPELINE_PROJECT_BASE64: "$(_ModularPipelinesPipelineProjectBase64)"
+      PIPELINE_FRAMEWORK_BASE64: "$(_ModularPipelinesTargetFrameworkBase64)"
 ]]></_ModularPipelinesAzurePipeline>
 
       <_ModularPipelinesOutputFile Condition="'$(ModularPipelinesBuildSystem)' == 'GitHubActions'">$(_ModularPipelinesGitHubFile)</_ModularPipelinesOutputFile>

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -83,9 +83,9 @@ jobs:
         with:
           dotnet-version: "$(_ModularPipelinesYamlDotNetVersion)"
       - run: |
-          PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\\\x/g'`
+          PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\x/g'`
           PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
-          PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\\\x/g'`
+          PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\x/g'`
           PIPELINE_FRAMEWORK=`printf '%b' "$PIPELINE_FRAMEWORK"`
           dotnet run --project "$PIPELINE_PROJECT" --configuration Release --framework "$PIPELINE_FRAMEWORK"
         env:
@@ -115,9 +115,9 @@ modular-pipelines:
       value: "$(_ModularPipelinesTargetFrameworkEncoded)"
       expand: false
   script:
-    - PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\\\x/g'`
+    - PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\x/g'`
     - PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
-    - PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\\\x/g'`
+    - PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\x/g'`
     - PIPELINE_FRAMEWORK=`printf '%b' "$PIPELINE_FRAMEWORK"`
     - dotnet run --project "$PIPELINE_PROJECT" --configuration Release --framework "$PIPELINE_FRAMEWORK"
 ]]></_ModularPipelinesGitLabPipeline>
@@ -137,9 +137,9 @@ steps:
       packageType: sdk
       version: "$(_ModularPipelinesYamlDotNetVersion)"
   - script: |
-      PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\\\x/g'`
+      PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\x/g'`
       PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
-      PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\\\x/g'`
+      PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\x/g'`
       PIPELINE_FRAMEWORK=`printf '%b' "$PIPELINE_FRAMEWORK"`
       dotnet run --project "$PIPELINE_PROJECT" --configuration Release --framework "$PIPELINE_FRAMEWORK"
     displayName: Run ModularPipelines

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -1,33 +1,55 @@
 <Project>
   <PropertyGroup>
-    <ModularPipelinesRepositoryRoot Condition="'$(ModularPipelinesRepositoryRoot)' == ''">$(MSBuildProjectDirectory)</ModularPipelinesRepositoryRoot>
-    <ModularPipelinesBuildBranch Condition="'$(ModularPipelinesBuildBranch)' == ''">main</ModularPipelinesBuildBranch>
-    <ModularPipelinesDotNetVersion Condition="'$(ModularPipelinesDotNetVersion)' == ''">10.0.x</ModularPipelinesDotNetVersion>
-    <ModularPipelinesDotNetSdkImage Condition="'$(ModularPipelinesDotNetSdkImage)' == ''">mcr.microsoft.com/dotnet/sdk:10.0</ModularPipelinesDotNetSdkImage>
-    <ModularPipelinesOverwriteBuildServerFiles Condition="'$(ModularPipelinesOverwriteBuildServerFiles)' == ''">false</ModularPipelinesOverwriteBuildServerFiles>
+    <_ModularPipelinesPipelineProjectSpecified Condition="'$(ModularPipelinesPipelineProject.Length)' == '0'">false</_ModularPipelinesPipelineProjectSpecified>
+    <_ModularPipelinesPipelineProjectSpecified Condition="'$(ModularPipelinesPipelineProject.Length)' != '0'">true</_ModularPipelinesPipelineProjectSpecified>
+    <ModularPipelinesRepositoryRoot Condition="'$(ModularPipelinesRepositoryRoot.Length)' == '0'">$(MSBuildProjectDirectory)</ModularPipelinesRepositoryRoot>
+    <ModularPipelinesBuildBranch Condition="'$(ModularPipelinesBuildBranch.Length)' == '0'">main</ModularPipelinesBuildBranch>
+    <ModularPipelinesDotNetVersion Condition="'$(ModularPipelinesDotNetVersion.Length)' == '0'">10.0.x</ModularPipelinesDotNetVersion>
+    <ModularPipelinesDotNetSdkImage Condition="'$(ModularPipelinesDotNetSdkImage.Length)' == '0'">mcr.microsoft.com/dotnet/sdk:10.0</ModularPipelinesDotNetSdkImage>
+    <ModularPipelinesOverwriteBuildServerFiles Condition="'$(ModularPipelinesOverwriteBuildServerFiles.Length)' == '0'">false</ModularPipelinesOverwriteBuildServerFiles>
   </PropertyGroup>
 
   <Target
     Name="GenerateModularPipelinesBuildServerFiles"
     BeforeTargets="BeforeBuild"
-    Condition="'$(ModularPipelinesBuildSystem)' != '' and '$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'">
-    <PropertyGroup>
-      <_ModularPipelinesRepositoryRoot>$([System.IO.Path]::GetFullPath('$(ModularPipelinesRepositoryRoot)'))</_ModularPipelinesRepositoryRoot>
-      <_ModularPipelinesPipelineProject Condition="'$(ModularPipelinesPipelineProject)' == ''">$([MSBuild]::MakeRelative('$(_ModularPipelinesRepositoryRoot)', '$(MSBuildProjectFullPath)'))</_ModularPipelinesPipelineProject>
-      <_ModularPipelinesPipelineProject Condition="'$(ModularPipelinesPipelineProject)' != ''">$(ModularPipelinesPipelineProject)</_ModularPipelinesPipelineProject>
-      <_ModularPipelinesPipelineProject>$([System.String]::Copy('$(_ModularPipelinesPipelineProject)').Replace('\', '/'))</_ModularPipelinesPipelineProject>
+    Condition="'$(ModularPipelinesBuildSystem.Length)' != '0' and '$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'">
+    <ConvertToAbsolutePath Paths="$(ModularPipelinesRepositoryRoot)">
+      <Output TaskParameter="AbsolutePaths" PropertyName="_ModularPipelinesRepositoryRoot" />
+    </ConvertToAbsolutePath>
+    <FindUnderPath
+      Path="$(_ModularPipelinesRepositoryRoot)"
+      Files="$(MSBuildProjectFullPath)"
+      Condition="'$(_ModularPipelinesPipelineProjectSpecified)' == 'false'">
+      <Output TaskParameter="OutOfPath" ItemName="_ModularPipelinesProjectOutsideRoot" />
+    </FindUnderPath>
+    <AssignTargetPath
+      Files="$(MSBuildProjectFullPath)"
+      RootFolder="$(_ModularPipelinesRepositoryRoot)"
+      Condition="'$(_ModularPipelinesPipelineProjectSpecified)' == 'false'">
+      <Output TaskParameter="AssignedFiles" ItemName="_ModularPipelinesAssignedProject" />
+    </AssignTargetPath>
 
-      <_ModularPipelinesGitHubFile>$(_ModularPipelinesRepositoryRoot)\.github\workflows\modular-pipelines.yml</_ModularPipelinesGitHubFile>
-      <_ModularPipelinesGitLabFile>$(_ModularPipelinesRepositoryRoot)\.gitlab-ci.yml</_ModularPipelinesGitLabFile>
-      <_ModularPipelinesAzureFile>$(_ModularPipelinesRepositoryRoot)\azure-pipelines.yml</_ModularPipelinesAzureFile>
+    <PropertyGroup>
+      <_ModularPipelinesPipelineProject Condition="'$(_ModularPipelinesPipelineProjectSpecified)' == 'false'">@(_ModularPipelinesAssignedProject->'%(TargetPath)')</_ModularPipelinesPipelineProject>
+      <_ModularPipelinesPipelineProject Condition="'$(_ModularPipelinesPipelineProjectSpecified)' == 'true'">$(ModularPipelinesPipelineProject)</_ModularPipelinesPipelineProject>
+      <_ModularPipelinesPipelineProject>$(_ModularPipelinesPipelineProject.Replace('\', '/'))</_ModularPipelinesPipelineProject>
+
+      <_ModularPipelinesGitHubDirectory>$(_ModularPipelinesRepositoryRoot)/.github/workflows</_ModularPipelinesGitHubDirectory>
+      <_ModularPipelinesGitHubFile>$(_ModularPipelinesGitHubDirectory)/modular-pipelines.yml</_ModularPipelinesGitHubFile>
+      <_ModularPipelinesGitLabFile>$(_ModularPipelinesRepositoryRoot)/.gitlab-ci.yml</_ModularPipelinesGitLabFile>
+      <_ModularPipelinesAzureFile>$(_ModularPipelinesRepositoryRoot)/azure-pipelines.yml</_ModularPipelinesAzureFile>
+
+      <_ModularPipelinesYamlBranch>$(ModularPipelinesBuildBranch.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlBranch>
+      <_ModularPipelinesYamlDotNetVersion>$(ModularPipelinesDotNetVersion.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlDotNetVersion>
+      <_ModularPipelinesYamlDotNetSdkImage>$(ModularPipelinesDotNetSdkImage.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlDotNetSdkImage>
 
       <_ModularPipelinesGitHubWorkflow><![CDATA[name: ModularPipelines
 
 on:
   push:
-    branches: [$(ModularPipelinesBuildBranch)]
+    branches: ["$(_ModularPipelinesYamlBranch)"]
   pull_request:
-    branches: [$(ModularPipelinesBuildBranch)]
+    branches: ["$(_ModularPipelinesYamlBranch)"]
 
 jobs:
   pipeline:
@@ -36,7 +58,7 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-dotnet@v6.0.0
         with:
-          dotnet-version: $(ModularPipelinesDotNetVersion)
+          dotnet-version: "$(_ModularPipelinesYamlDotNetVersion)"
       - run: dotnet run --project "$(_ModularPipelinesPipelineProject)" --configuration Release
 ]]></_ModularPipelinesGitHubWorkflow>
 
@@ -44,17 +66,17 @@ jobs:
   - pipeline
 
 modular-pipelines:
-  image: $(ModularPipelinesDotNetSdkImage)
+  image: "$(_ModularPipelinesYamlDotNetSdkImage)"
   stage: pipeline
   script:
     - dotnet run --project "$(_ModularPipelinesPipelineProject)" --configuration Release
 ]]></_ModularPipelinesGitLabPipeline>
 
       <_ModularPipelinesAzurePipeline><![CDATA[trigger:
-  - $(ModularPipelinesBuildBranch)
+  - "$(_ModularPipelinesYamlBranch)"
 
 pr:
-  - $(ModularPipelinesBuildBranch)
+  - "$(_ModularPipelinesYamlBranch)"
 
 pool:
   vmImage: ubuntu-latest
@@ -63,7 +85,7 @@ steps:
   - task: UseDotNet@2
     inputs:
       packageType: sdk
-      version: $(ModularPipelinesDotNetVersion)
+      version: "$(_ModularPipelinesYamlDotNetVersion)"
   - script: dotnet run --project "$(_ModularPipelinesPipelineProject)" --configuration Release
     displayName: Run ModularPipelines
 ]]></_ModularPipelinesAzurePipeline>
@@ -71,22 +93,39 @@ steps:
       <_ModularPipelinesOutputFile Condition="'$(ModularPipelinesBuildSystem)' == 'GitHubActions'">$(_ModularPipelinesGitHubFile)</_ModularPipelinesOutputFile>
       <_ModularPipelinesOutputFile Condition="'$(ModularPipelinesBuildSystem)' == 'GitLab'">$(_ModularPipelinesGitLabFile)</_ModularPipelinesOutputFile>
       <_ModularPipelinesOutputFile Condition="'$(ModularPipelinesBuildSystem)' == 'AzurePipelines'">$(_ModularPipelinesAzureFile)</_ModularPipelinesOutputFile>
+      <_ModularPipelinesOutputDirectory Condition="'$(ModularPipelinesBuildSystem)' == 'GitHubActions'">$(_ModularPipelinesGitHubDirectory)</_ModularPipelinesOutputDirectory>
+      <_ModularPipelinesOutputDirectory Condition="'$(ModularPipelinesBuildSystem)' == 'GitLab'">$(_ModularPipelinesRepositoryRoot)</_ModularPipelinesOutputDirectory>
+      <_ModularPipelinesOutputDirectory Condition="'$(ModularPipelinesBuildSystem)' == 'AzurePipelines'">$(_ModularPipelinesRepositoryRoot)</_ModularPipelinesOutputDirectory>
       <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'GitHubActions'">$(_ModularPipelinesGitHubWorkflow)</_ModularPipelinesOutputContent>
       <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'GitLab'">$(_ModularPipelinesGitLabPipeline)</_ModularPipelinesOutputContent>
       <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'AzurePipelines'">$(_ModularPipelinesAzurePipeline)</_ModularPipelinesOutputContent>
-      <_ModularPipelinesOutputFileExisted>$([System.IO.File]::Exists('$(_ModularPipelinesOutputFile)'))</_ModularPipelinesOutputFileExisted>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_ModularPipelinesRepositoryRootCandidate Include="$(_ModularPipelinesRepositoryRoot)" />
+      <_ModularPipelinesExistingRepositoryRoot Include="@(_ModularPipelinesRepositoryRootCandidate->Exists())" />
+      <_ModularPipelinesOutputFileCandidate Include="$(_ModularPipelinesOutputFile)" />
+      <_ModularPipelinesExistingOutputFile Include="@(_ModularPipelinesOutputFileCandidate->Exists())" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_ModularPipelinesRepositoryRootExists>@(_ModularPipelinesExistingRepositoryRoot->Count())</_ModularPipelinesRepositoryRootExists>
+      <_ModularPipelinesOutputFileExists>@(_ModularPipelinesExistingOutputFile->Count())</_ModularPipelinesOutputFileExists>
+      <_ModularPipelinesProjectOutsideRootCount>@(_ModularPipelinesProjectOutsideRoot->Count())</_ModularPipelinesProjectOutsideRootCount>
     </PropertyGroup>
 
     <Error
       Condition="'$(ModularPipelinesBuildSystem)' != 'GitHubActions' and '$(ModularPipelinesBuildSystem)' != 'GitLab' and '$(ModularPipelinesBuildSystem)' != 'AzurePipelines'"
       Text="Unsupported ModularPipelinesBuildSystem '$(ModularPipelinesBuildSystem)'. Use GitHubActions, GitLab, or AzurePipelines." />
     <Error
-      Condition="!Exists('$(_ModularPipelinesRepositoryRoot)')"
+      Condition="'$(_ModularPipelinesRepositoryRootExists)' == '0'"
       Text="ModularPipelinesRepositoryRoot '$(_ModularPipelinesRepositoryRoot)' does not exist." />
+    <Error
+      Condition="'$(_ModularPipelinesProjectOutsideRootCount)' != '0'"
+      Text="The pipeline project must be inside ModularPipelinesRepositoryRoot, or ModularPipelinesPipelineProject must be set explicitly." />
 
     <MakeDir
-      Directories="$([System.IO.Path]::GetDirectoryName('$(_ModularPipelinesOutputFile)'))"
-      Condition="'$(_ModularPipelinesOutputFileExisted)' != 'True'" />
+      Directories="$(_ModularPipelinesOutputDirectory)"
+      Condition="'$(_ModularPipelinesOutputFileExists)' == '0'" />
 
     <WriteLinesToFile
       File="$(_ModularPipelinesOutputFile)"
@@ -94,15 +133,15 @@ steps:
       Overwrite="true"
       WriteOnlyWhenDifferent="true"
       Encoding="UTF-8"
-      Condition="'$(_ModularPipelinesOutputFileExisted)' != 'True' or '$(ModularPipelinesOverwriteBuildServerFiles)' == 'true'" />
+      Condition="'$(_ModularPipelinesOutputFileExists)' == '0' or '$(ModularPipelinesOverwriteBuildServerFiles)' == 'true'" />
 
     <Message
       Importance="high"
       Text="Generated $(_ModularPipelinesOutputFile)"
-      Condition="'$(_ModularPipelinesOutputFileExisted)' != 'True' or '$(ModularPipelinesOverwriteBuildServerFiles)' == 'true'" />
+      Condition="'$(_ModularPipelinesOutputFileExists)' == '0' or '$(ModularPipelinesOverwriteBuildServerFiles)' == 'true'" />
     <Message
       Importance="high"
       Text="Kept existing $(_ModularPipelinesOutputFile). Set ModularPipelinesOverwriteBuildServerFiles=true to replace it."
-      Condition="'$(_ModularPipelinesOutputFileExisted)' == 'True' and '$(ModularPipelinesOverwriteBuildServerFiles)' != 'true'" />
+      Condition="'$(_ModularPipelinesOutputFileExists)' != '0' and '$(ModularPipelinesOverwriteBuildServerFiles)' != 'true'" />
   </Target>
 </Project>

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -9,6 +9,7 @@
     <ModularPipelinesTargetFramework Condition="'$(ModularPipelinesTargetFramework.Length)' == '0' and '$(TargetFramework.Length)' != '0'">$(TargetFramework)</ModularPipelinesTargetFramework>
     <ModularPipelinesTargetFramework Condition="'$(ModularPipelinesTargetFramework.Length)' == '0' and '$(TargetFrameworks.Length)' != '0'">$(TargetFrameworks.Split(';')[0])</ModularPipelinesTargetFramework>
     <ModularPipelinesOverwriteBuildServerFiles Condition="'$(ModularPipelinesOverwriteBuildServerFiles.Length)' == '0'">false</ModularPipelinesOverwriteBuildServerFiles>
+    <_ModularPipelinesIsWindows Condition="'$(_ModularPipelinesIsWindows.Length)' == '0'">$([MSBuild]::IsOSPlatform('Windows'))</_ModularPipelinesIsWindows>
   </PropertyGroup>
 
   <Target
@@ -50,7 +51,7 @@
     <PropertyGroup>
       <_ModularPipelinesPipelineProject Condition="'$(_ModularPipelinesPipelineProjectSpecified)' == 'false'">@(_ModularPipelinesAssignedProject->'%(TargetPath)')</_ModularPipelinesPipelineProject>
       <_ModularPipelinesPipelineProject Condition="'$(_ModularPipelinesPipelineProjectSpecified)' == 'true'">$(ModularPipelinesPipelineProject)</_ModularPipelinesPipelineProject>
-      <_ModularPipelinesPipelineProject>$(_ModularPipelinesPipelineProject.Replace('\', '/'))</_ModularPipelinesPipelineProject>
+      <_ModularPipelinesPipelineProject Condition="'$(_ModularPipelinesIsWindows)' == 'true'">$(_ModularPipelinesPipelineProject.Replace('\', '/'))</_ModularPipelinesPipelineProject>
       <_ModularPipelinesPipelineProjectEncoded>$([System.Uri]::EscapeDataString($(_ModularPipelinesPipelineProject)))</_ModularPipelinesPipelineProjectEncoded>
       <_ModularPipelinesTargetFrameworkEncoded>$([System.Uri]::EscapeDataString($(ModularPipelinesTargetFramework)))</_ModularPipelinesTargetFrameworkEncoded>
 

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -121,6 +121,8 @@ modular-pipelines:
       <_ModularPipelinesAzurePipeline><![CDATA[trigger:
   - "$(_ModularPipelinesYamlBranch)"
 
+# YAML PR triggers apply to GitHub and Bitbucket Cloud repositories.
+# Azure Repos Git requires a Build Validation branch policy instead.
 pr:
   - "$(_ModularPipelinesYamlBranch)"
 

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -7,13 +7,25 @@
     <ModularPipelinesDotNetVersion Condition="'$(ModularPipelinesDotNetVersion.Length)' == '0'">10.0.x</ModularPipelinesDotNetVersion>
     <ModularPipelinesDotNetSdkImage Condition="'$(ModularPipelinesDotNetSdkImage.Length)' == '0'">mcr.microsoft.com/dotnet/sdk:10.0</ModularPipelinesDotNetSdkImage>
     <ModularPipelinesOverwriteBuildServerFiles Condition="'$(ModularPipelinesOverwriteBuildServerFiles.Length)' == '0'">false</ModularPipelinesOverwriteBuildServerFiles>
-    <_ModularPipelinesFirstTargetFramework Condition="'$(TargetFrameworks.Length)' != '0'">$([System.Text.RegularExpressions.Regex]::Match('$(TargetFrameworks)', '^[^;]+').Value)</_ModularPipelinesFirstTargetFramework>
   </PropertyGroup>
+
+  <Target
+    Name="_GenerateModularPipelinesBuildServerFilesForCrossTargetingBuild"
+    BeforeTargets="DispatchToInnerBuilds"
+    DependsOnTargets="_ComputeTargetFrameworkItems"
+    Condition="'$(ModularPipelinesBuildSystem.Length)' != '0' and '$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' == 'true'">
+    <CallTarget Targets="GenerateModularPipelinesBuildServerFiles" />
+    <ItemGroup>
+      <_InnerBuildProjects Update="@(_InnerBuildProjects)">
+        <AdditionalProperties>%(AdditionalProperties);_ModularPipelinesSkipBuildServerFileGeneration=true</AdditionalProperties>
+      </_InnerBuildProjects>
+    </ItemGroup>
+  </Target>
 
   <Target
     Name="GenerateModularPipelinesBuildServerFiles"
     BeforeTargets="BeforeBuild"
-    Condition="'$(ModularPipelinesBuildSystem.Length)' != '0' and '$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true' and ('$(TargetFrameworks.Length)' == '0' or '$(TargetFramework)' == '$(_ModularPipelinesFirstTargetFramework)')">
+    Condition="'$(ModularPipelinesBuildSystem.Length)' != '0' and '$(DesignTimeBuild)' != 'true' and '$(_ModularPipelinesSkipBuildServerFileGeneration)' != 'true'">
     <ConvertToAbsolutePath Paths="$(ModularPipelinesRepositoryRoot)">
       <Output TaskParameter="AbsolutePaths" PropertyName="_ModularPipelinesRepositoryRoot" />
     </ConvertToAbsolutePath>
@@ -66,12 +78,17 @@ jobs:
           PIPELINE_PROJECT: "$(_ModularPipelinesYamlPipelineProject)"
 ]]></_ModularPipelinesGitHubWorkflow>
 
-      <_ModularPipelinesGitLabPipeline><![CDATA[stages:
+      <_ModularPipelinesGitLabPipeline><![CDATA[variables:
+  MODULAR_PIPELINES_BUILD_BRANCH: "$(_ModularPipelinesYamlBranch)"
+
+stages:
   - pipeline
 
 modular-pipelines:
   image: "$(_ModularPipelinesYamlDotNetSdkImage)"
   stage: pipeline
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $MODULAR_PIPELINES_BUILD_BRANCH'
   variables:
     PIPELINE_PROJECT: "$(_ModularPipelinesYamlPipelineProject)"
   script:
@@ -107,6 +124,7 @@ steps:
       <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'GitHubActions'">$(_ModularPipelinesGitHubWorkflow)</_ModularPipelinesOutputContent>
       <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'GitLab'">$(_ModularPipelinesGitLabPipeline)</_ModularPipelinesOutputContent>
       <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'AzurePipelines'">$(_ModularPipelinesAzurePipeline)</_ModularPipelinesOutputContent>
+      <_ModularPipelinesEscapedOutputContent>$([MSBuild]::Escape($(_ModularPipelinesOutputContent)))</_ModularPipelinesEscapedOutputContent>
     </PropertyGroup>
 
     <ItemGroup>
@@ -137,7 +155,7 @@ steps:
 
     <WriteLinesToFile
       File="$(_ModularPipelinesOutputFile)"
-      Lines="$(_ModularPipelinesOutputContent)"
+      Lines="$(_ModularPipelinesEscapedOutputContent)"
       Overwrite="true"
       WriteOnlyWhenDifferent="true"
       Encoding="UTF-8"

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -1,4 +1,27 @@
 <Project>
+  <UsingTask
+    TaskName="_ModularPipelinesWriteTextFile"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)/Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <FilePath ParameterType="System.String" Required="true" />
+      <Content ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+var encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+if (!File.Exists(FilePath)
+    || !string.Equals(File.ReadAllText(FilePath, encoding), Content, StringComparison.Ordinal))
+{
+    File.WriteAllText(FilePath, Content, encoding);
+}
+      ]]></Code>
+    </Task>
+  </UsingTask>
+
   <PropertyGroup>
     <_ModularPipelinesPipelineProjectSpecified Condition="'$(ModularPipelinesPipelineProject.Length)' == '0'">false</_ModularPipelinesPipelineProjectSpecified>
     <_ModularPipelinesPipelineProjectSpecified Condition="'$(ModularPipelinesPipelineProject.Length)' != '0'">true</_ModularPipelinesPipelineProjectSpecified>
@@ -153,7 +176,6 @@ steps:
       <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'GitHubActions'">$(_ModularPipelinesGitHubWorkflow)</_ModularPipelinesOutputContent>
       <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'GitLab'">$(_ModularPipelinesGitLabPipeline)</_ModularPipelinesOutputContent>
       <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'AzurePipelines'">$(_ModularPipelinesAzurePipeline)</_ModularPipelinesOutputContent>
-      <_ModularPipelinesEscapedOutputContent>$([MSBuild]::Escape($(_ModularPipelinesOutputContent)))</_ModularPipelinesEscapedOutputContent>
     </PropertyGroup>
 
     <ItemGroup>
@@ -185,12 +207,9 @@ steps:
       Directories="$(_ModularPipelinesOutputDirectory)"
       Condition="'$(_ModularPipelinesOutputFileExists)' == '0'" />
 
-    <WriteLinesToFile
-      File="$(_ModularPipelinesOutputFile)"
-      Lines="$(_ModularPipelinesEscapedOutputContent)"
-      Overwrite="true"
-      WriteOnlyWhenDifferent="true"
-      Encoding="UTF-8"
+    <_ModularPipelinesWriteTextFile
+      FilePath="$(_ModularPipelinesOutputFile)"
+      Content="$(_ModularPipelinesOutputContent)"
       Condition="'$(_ModularPipelinesOutputFileExists)' == '0' or '$(ModularPipelinesOverwriteBuildServerFiles)' == 'true'" />
 
     <Message

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -60,7 +60,7 @@
       <_ModularPipelinesGitLabFile>$(_ModularPipelinesRepositoryRoot)/.gitlab-ci.yml</_ModularPipelinesGitLabFile>
       <_ModularPipelinesAzureFile>$(_ModularPipelinesRepositoryRoot)/azure-pipelines.yml</_ModularPipelinesAzureFile>
 
-      <_ModularPipelinesGitHubBranchPattern>$(ModularPipelinesBuildBranch.Replace('\', '\\').Replace('*', '\*').Replace('+', '\+').Replace('?', '\?').Replace('!', '\!').Replace('[', '\[').Replace(']', '\]'))</_ModularPipelinesGitHubBranchPattern>
+      <_ModularPipelinesGitHubBranchPattern>$(ModularPipelinesBuildBranch.Replace('\', '\\').Replace('*', '\*').Replace('+', '\+').Replace('?', '\?').Replace('!', '\!').Replace('[', '\[').Replace(']', '\]').Replace('$', '[$]'))</_ModularPipelinesGitHubBranchPattern>
       <_ModularPipelinesYamlGitHubBranchPattern>$(_ModularPipelinesGitHubBranchPattern.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlGitHubBranchPattern>
       <_ModularPipelinesYamlBranch>$(ModularPipelinesBuildBranch.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlBranch>
       <_ModularPipelinesYamlDotNetVersion>$(ModularPipelinesDotNetVersion.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlDotNetVersion>

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -26,7 +26,10 @@
     Name="GenerateModularPipelinesBuildServerFiles"
     BeforeTargets="BeforeBuild"
     Condition="'$(ModularPipelinesBuildSystem.Length)' != '0' and '$(DesignTimeBuild)' != 'true' and '$(_ModularPipelinesSkipBuildServerFileGeneration)' != 'true'">
-    <ConvertToAbsolutePath Paths="$(ModularPipelinesRepositoryRoot)">
+    <PropertyGroup>
+      <_ModularPipelinesEscapedRepositoryRoot>$([MSBuild]::Escape($(ModularPipelinesRepositoryRoot)))</_ModularPipelinesEscapedRepositoryRoot>
+    </PropertyGroup>
+    <ConvertToAbsolutePath Paths="$(_ModularPipelinesEscapedRepositoryRoot)">
       <Output TaskParameter="AbsolutePaths" PropertyName="_ModularPipelinesRepositoryRoot" />
     </ConvertToAbsolutePath>
     <FindUnderPath
@@ -46,24 +49,26 @@
       <_ModularPipelinesPipelineProject Condition="'$(_ModularPipelinesPipelineProjectSpecified)' == 'false'">@(_ModularPipelinesAssignedProject->'%(TargetPath)')</_ModularPipelinesPipelineProject>
       <_ModularPipelinesPipelineProject Condition="'$(_ModularPipelinesPipelineProjectSpecified)' == 'true'">$(ModularPipelinesPipelineProject)</_ModularPipelinesPipelineProject>
       <_ModularPipelinesPipelineProject>$(_ModularPipelinesPipelineProject.Replace('\', '/'))</_ModularPipelinesPipelineProject>
+      <_ModularPipelinesPipelineProjectEncoded>$([System.Uri]::EscapeDataString($(_ModularPipelinesPipelineProject)))</_ModularPipelinesPipelineProjectEncoded>
 
       <_ModularPipelinesGitHubDirectory>$(_ModularPipelinesRepositoryRoot)/.github/workflows</_ModularPipelinesGitHubDirectory>
       <_ModularPipelinesGitHubFile>$(_ModularPipelinesGitHubDirectory)/modular-pipelines.yml</_ModularPipelinesGitHubFile>
       <_ModularPipelinesGitLabFile>$(_ModularPipelinesRepositoryRoot)/.gitlab-ci.yml</_ModularPipelinesGitLabFile>
       <_ModularPipelinesAzureFile>$(_ModularPipelinesRepositoryRoot)/azure-pipelines.yml</_ModularPipelinesAzureFile>
 
+      <_ModularPipelinesGitHubBranchPattern>$(ModularPipelinesBuildBranch.Replace('\', '\\').Replace('*', '\*').Replace('+', '\+').Replace('?', '\?').Replace('!', '\!').Replace('[', '\[').Replace(']', '\]'))</_ModularPipelinesGitHubBranchPattern>
+      <_ModularPipelinesYamlGitHubBranchPattern>$(_ModularPipelinesGitHubBranchPattern.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlGitHubBranchPattern>
       <_ModularPipelinesYamlBranch>$(ModularPipelinesBuildBranch.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlBranch>
       <_ModularPipelinesYamlDotNetVersion>$(ModularPipelinesDotNetVersion.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlDotNetVersion>
       <_ModularPipelinesYamlDotNetSdkImage>$(ModularPipelinesDotNetSdkImage.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlDotNetSdkImage>
-      <_ModularPipelinesYamlPipelineProject>$(_ModularPipelinesPipelineProject.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlPipelineProject>
 
       <_ModularPipelinesGitHubWorkflow><![CDATA[name: ModularPipelines
 
 on:
   push:
-    branches: ["$(_ModularPipelinesYamlBranch)"]
+    branches: ["$(_ModularPipelinesYamlGitHubBranchPattern)"]
   pull_request:
-    branches: ["$(_ModularPipelinesYamlBranch)"]
+    branches: ["$(_ModularPipelinesYamlGitHubBranchPattern)"]
 
 jobs:
   pipeline:
@@ -73,9 +78,12 @@ jobs:
       - uses: actions/setup-dotnet@v6.0.0
         with:
           dotnet-version: "$(_ModularPipelinesYamlDotNetVersion)"
-      - run: dotnet run --project "$PIPELINE_PROJECT" --configuration Release
+      - run: |
+          PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\\\x/g'`
+          PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
+          dotnet run --project "$PIPELINE_PROJECT" --configuration Release
         env:
-          PIPELINE_PROJECT: "$(_ModularPipelinesYamlPipelineProject)"
+          PIPELINE_PROJECT_ENCODED: "$(_ModularPipelinesPipelineProjectEncoded)"
 ]]></_ModularPipelinesGitHubWorkflow>
 
       <_ModularPipelinesGitLabPipeline><![CDATA[variables:
@@ -93,10 +101,12 @@ modular-pipelines:
     - if: '$CI_COMMIT_BRANCH == $MODULAR_PIPELINES_BUILD_BRANCH'
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == $MODULAR_PIPELINES_BUILD_BRANCH'
   variables:
-    PIPELINE_PROJECT:
-      value: "$(_ModularPipelinesYamlPipelineProject)"
+    PIPELINE_PROJECT_ENCODED:
+      value: "$(_ModularPipelinesPipelineProjectEncoded)"
       expand: false
   script:
+    - PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\\\x/g'`
+    - PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
     - dotnet run --project "$PIPELINE_PROJECT" --configuration Release
 ]]></_ModularPipelinesGitLabPipeline>
 
@@ -114,10 +124,13 @@ steps:
     inputs:
       packageType: sdk
       version: "$(_ModularPipelinesYamlDotNetVersion)"
-  - script: dotnet run --project "$PIPELINE_PROJECT" --configuration Release
+  - script: |
+      PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\\\x/g'`
+      PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
+      dotnet run --project "$PIPELINE_PROJECT" --configuration Release
     displayName: Run ModularPipelines
     env:
-      PIPELINE_PROJECT: "$(_ModularPipelinesYamlPipelineProject)"
+      PIPELINE_PROJECT_ENCODED: "$(_ModularPipelinesPipelineProjectEncoded)"
 ]]></_ModularPipelinesAzurePipeline>
 
       <_ModularPipelinesOutputFile Condition="'$(ModularPipelinesBuildSystem)' == 'GitHubActions'">$(_ModularPipelinesGitHubFile)</_ModularPipelinesOutputFile>

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -79,7 +79,9 @@ jobs:
 ]]></_ModularPipelinesGitHubWorkflow>
 
       <_ModularPipelinesGitLabPipeline><![CDATA[variables:
-  MODULAR_PIPELINES_BUILD_BRANCH: "$(_ModularPipelinesYamlBranch)"
+  MODULAR_PIPELINES_BUILD_BRANCH:
+    value: "$(_ModularPipelinesYamlBranch)"
+    expand: false
 
 stages:
   - pipeline
@@ -89,8 +91,11 @@ modular-pipelines:
   stage: pipeline
   rules:
     - if: '$CI_COMMIT_BRANCH == $MODULAR_PIPELINES_BUILD_BRANCH'
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == $MODULAR_PIPELINES_BUILD_BRANCH'
   variables:
-    PIPELINE_PROJECT: "$(_ModularPipelinesYamlPipelineProject)"
+    PIPELINE_PROJECT:
+      value: "$(_ModularPipelinesYamlPipelineProject)"
+      expand: false
   script:
     - dotnet run --project "$PIPELINE_PROJECT" --configuration Release
 ]]></_ModularPipelinesGitLabPipeline>

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -7,12 +7,13 @@
     <ModularPipelinesDotNetVersion Condition="'$(ModularPipelinesDotNetVersion.Length)' == '0'">10.0.x</ModularPipelinesDotNetVersion>
     <ModularPipelinesDotNetSdkImage Condition="'$(ModularPipelinesDotNetSdkImage.Length)' == '0'">mcr.microsoft.com/dotnet/sdk:10.0</ModularPipelinesDotNetSdkImage>
     <ModularPipelinesOverwriteBuildServerFiles Condition="'$(ModularPipelinesOverwriteBuildServerFiles.Length)' == '0'">false</ModularPipelinesOverwriteBuildServerFiles>
+    <_ModularPipelinesFirstTargetFramework Condition="'$(TargetFrameworks.Length)' != '0'">$([System.Text.RegularExpressions.Regex]::Match('$(TargetFrameworks)', '^[^;]+').Value)</_ModularPipelinesFirstTargetFramework>
   </PropertyGroup>
 
   <Target
     Name="GenerateModularPipelinesBuildServerFiles"
     BeforeTargets="BeforeBuild"
-    Condition="'$(ModularPipelinesBuildSystem.Length)' != '0' and '$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'">
+    Condition="'$(ModularPipelinesBuildSystem.Length)' != '0' and '$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true' and ('$(TargetFrameworks.Length)' == '0' or '$(TargetFramework)' == '$(_ModularPipelinesFirstTargetFramework)')">
     <ConvertToAbsolutePath Paths="$(ModularPipelinesRepositoryRoot)">
       <Output TaskParameter="AbsolutePaths" PropertyName="_ModularPipelinesRepositoryRoot" />
     </ConvertToAbsolutePath>
@@ -42,6 +43,7 @@
       <_ModularPipelinesYamlBranch>$(ModularPipelinesBuildBranch.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlBranch>
       <_ModularPipelinesYamlDotNetVersion>$(ModularPipelinesDotNetVersion.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlDotNetVersion>
       <_ModularPipelinesYamlDotNetSdkImage>$(ModularPipelinesDotNetSdkImage.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlDotNetSdkImage>
+      <_ModularPipelinesYamlPipelineProject>$(_ModularPipelinesPipelineProject.Replace('\', '\\').Replace('&quot;', '\&quot;'))</_ModularPipelinesYamlPipelineProject>
 
       <_ModularPipelinesGitHubWorkflow><![CDATA[name: ModularPipelines
 
@@ -59,7 +61,9 @@ jobs:
       - uses: actions/setup-dotnet@v6.0.0
         with:
           dotnet-version: "$(_ModularPipelinesYamlDotNetVersion)"
-      - run: dotnet run --project "$(_ModularPipelinesPipelineProject)" --configuration Release
+      - run: dotnet run --project "$PIPELINE_PROJECT" --configuration Release
+        env:
+          PIPELINE_PROJECT: "$(_ModularPipelinesYamlPipelineProject)"
 ]]></_ModularPipelinesGitHubWorkflow>
 
       <_ModularPipelinesGitLabPipeline><![CDATA[stages:
@@ -68,8 +72,10 @@ jobs:
 modular-pipelines:
   image: "$(_ModularPipelinesYamlDotNetSdkImage)"
   stage: pipeline
+  variables:
+    PIPELINE_PROJECT: "$(_ModularPipelinesYamlPipelineProject)"
   script:
-    - dotnet run --project "$(_ModularPipelinesPipelineProject)" --configuration Release
+    - dotnet run --project "$PIPELINE_PROJECT" --configuration Release
 ]]></_ModularPipelinesGitLabPipeline>
 
       <_ModularPipelinesAzurePipeline><![CDATA[trigger:
@@ -86,8 +92,10 @@ steps:
     inputs:
       packageType: sdk
       version: "$(_ModularPipelinesYamlDotNetVersion)"
-  - script: dotnet run --project "$(_ModularPipelinesPipelineProject)" --configuration Release
+  - script: dotnet run --project "$PIPELINE_PROJECT" --configuration Release
     displayName: Run ModularPipelines
+    env:
+      PIPELINE_PROJECT: "$(_ModularPipelinesYamlPipelineProject)"
 ]]></_ModularPipelinesAzurePipeline>
 
       <_ModularPipelinesOutputFile Condition="'$(ModularPipelinesBuildSystem)' == 'GitHubActions'">$(_ModularPipelinesGitHubFile)</_ModularPipelinesOutputFile>

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -6,6 +6,8 @@
     <ModularPipelinesBuildBranch Condition="'$(ModularPipelinesBuildBranch.Length)' == '0'">main</ModularPipelinesBuildBranch>
     <ModularPipelinesDotNetVersion Condition="'$(ModularPipelinesDotNetVersion.Length)' == '0'">10.0.x</ModularPipelinesDotNetVersion>
     <ModularPipelinesDotNetSdkImage Condition="'$(ModularPipelinesDotNetSdkImage.Length)' == '0'">mcr.microsoft.com/dotnet/sdk:10.0</ModularPipelinesDotNetSdkImage>
+    <ModularPipelinesTargetFramework Condition="'$(ModularPipelinesTargetFramework.Length)' == '0' and '$(TargetFramework.Length)' != '0'">$(TargetFramework)</ModularPipelinesTargetFramework>
+    <ModularPipelinesTargetFramework Condition="'$(ModularPipelinesTargetFramework.Length)' == '0' and '$(TargetFrameworks.Length)' != '0'">$(TargetFrameworks.Split(';')[0])</ModularPipelinesTargetFramework>
     <ModularPipelinesOverwriteBuildServerFiles Condition="'$(ModularPipelinesOverwriteBuildServerFiles.Length)' == '0'">false</ModularPipelinesOverwriteBuildServerFiles>
   </PropertyGroup>
 
@@ -50,6 +52,7 @@
       <_ModularPipelinesPipelineProject Condition="'$(_ModularPipelinesPipelineProjectSpecified)' == 'true'">$(ModularPipelinesPipelineProject)</_ModularPipelinesPipelineProject>
       <_ModularPipelinesPipelineProject>$(_ModularPipelinesPipelineProject.Replace('\', '/'))</_ModularPipelinesPipelineProject>
       <_ModularPipelinesPipelineProjectEncoded>$([System.Uri]::EscapeDataString($(_ModularPipelinesPipelineProject)))</_ModularPipelinesPipelineProjectEncoded>
+      <_ModularPipelinesTargetFrameworkEncoded>$([System.Uri]::EscapeDataString($(ModularPipelinesTargetFramework)))</_ModularPipelinesTargetFrameworkEncoded>
 
       <_ModularPipelinesGitHubDirectory>$(_ModularPipelinesRepositoryRoot)/.github/workflows</_ModularPipelinesGitHubDirectory>
       <_ModularPipelinesGitHubFile>$(_ModularPipelinesGitHubDirectory)/modular-pipelines.yml</_ModularPipelinesGitHubFile>
@@ -81,9 +84,12 @@ jobs:
       - run: |
           PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\\\x/g'`
           PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
-          dotnet run --project "$PIPELINE_PROJECT" --configuration Release
+          PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\\\x/g'`
+          PIPELINE_FRAMEWORK=`printf '%b' "$PIPELINE_FRAMEWORK"`
+          dotnet run --project "$PIPELINE_PROJECT" --configuration Release --framework "$PIPELINE_FRAMEWORK"
         env:
           PIPELINE_PROJECT_ENCODED: "$(_ModularPipelinesPipelineProjectEncoded)"
+          PIPELINE_FRAMEWORK_ENCODED: "$(_ModularPipelinesTargetFrameworkEncoded)"
 ]]></_ModularPipelinesGitHubWorkflow>
 
       <_ModularPipelinesGitLabPipeline><![CDATA[variables:
@@ -104,10 +110,15 @@ modular-pipelines:
     PIPELINE_PROJECT_ENCODED:
       value: "$(_ModularPipelinesPipelineProjectEncoded)"
       expand: false
+    PIPELINE_FRAMEWORK_ENCODED:
+      value: "$(_ModularPipelinesTargetFrameworkEncoded)"
+      expand: false
   script:
     - PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\\\x/g'`
     - PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
-    - dotnet run --project "$PIPELINE_PROJECT" --configuration Release
+    - PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\\\x/g'`
+    - PIPELINE_FRAMEWORK=`printf '%b' "$PIPELINE_FRAMEWORK"`
+    - dotnet run --project "$PIPELINE_PROJECT" --configuration Release --framework "$PIPELINE_FRAMEWORK"
 ]]></_ModularPipelinesGitLabPipeline>
 
       <_ModularPipelinesAzurePipeline><![CDATA[trigger:
@@ -127,10 +138,13 @@ steps:
   - script: |
       PIPELINE_PROJECT=`printf '%s' "$PIPELINE_PROJECT_ENCODED" | sed 's/%/\\\\x/g'`
       PIPELINE_PROJECT=`printf '%b' "$PIPELINE_PROJECT"`
-      dotnet run --project "$PIPELINE_PROJECT" --configuration Release
+      PIPELINE_FRAMEWORK=`printf '%s' "$PIPELINE_FRAMEWORK_ENCODED" | sed 's/%/\\\\x/g'`
+      PIPELINE_FRAMEWORK=`printf '%b' "$PIPELINE_FRAMEWORK"`
+      dotnet run --project "$PIPELINE_PROJECT" --configuration Release --framework "$PIPELINE_FRAMEWORK"
     displayName: Run ModularPipelines
     env:
       PIPELINE_PROJECT_ENCODED: "$(_ModularPipelinesPipelineProjectEncoded)"
+      PIPELINE_FRAMEWORK_ENCODED: "$(_ModularPipelinesTargetFrameworkEncoded)"
 ]]></_ModularPipelinesAzurePipeline>
 
       <_ModularPipelinesOutputFile Condition="'$(ModularPipelinesBuildSystem)' == 'GitHubActions'">$(_ModularPipelinesGitHubFile)</_ModularPipelinesOutputFile>
@@ -166,6 +180,9 @@ steps:
     <Error
       Condition="'$(_ModularPipelinesProjectOutsideRootCount)' != '0'"
       Text="The pipeline project must be inside ModularPipelinesRepositoryRoot, or ModularPipelinesPipelineProject must be set explicitly." />
+    <Error
+      Condition="'$(ModularPipelinesTargetFramework.Length)' == '0'"
+      Text="A target framework is required. Set TargetFramework, TargetFrameworks, or ModularPipelinesTargetFramework." />
 
     <MakeDir
       Directories="$(_ModularPipelinesOutputDirectory)"

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -1,0 +1,108 @@
+<Project>
+  <PropertyGroup>
+    <ModularPipelinesRepositoryRoot Condition="'$(ModularPipelinesRepositoryRoot)' == ''">$(MSBuildProjectDirectory)</ModularPipelinesRepositoryRoot>
+    <ModularPipelinesBuildBranch Condition="'$(ModularPipelinesBuildBranch)' == ''">main</ModularPipelinesBuildBranch>
+    <ModularPipelinesDotNetVersion Condition="'$(ModularPipelinesDotNetVersion)' == ''">10.0.x</ModularPipelinesDotNetVersion>
+    <ModularPipelinesDotNetSdkImage Condition="'$(ModularPipelinesDotNetSdkImage)' == ''">mcr.microsoft.com/dotnet/sdk:10.0</ModularPipelinesDotNetSdkImage>
+    <ModularPipelinesOverwriteBuildServerFiles Condition="'$(ModularPipelinesOverwriteBuildServerFiles)' == ''">false</ModularPipelinesOverwriteBuildServerFiles>
+  </PropertyGroup>
+
+  <Target
+    Name="GenerateModularPipelinesBuildServerFiles"
+    BeforeTargets="BeforeBuild"
+    Condition="'$(ModularPipelinesBuildSystem)' != '' and '$(DesignTimeBuild)' != 'true' and '$(IsCrossTargetingBuild)' != 'true'">
+    <PropertyGroup>
+      <_ModularPipelinesRepositoryRoot>$([System.IO.Path]::GetFullPath('$(ModularPipelinesRepositoryRoot)'))</_ModularPipelinesRepositoryRoot>
+      <_ModularPipelinesPipelineProject Condition="'$(ModularPipelinesPipelineProject)' == ''">$([MSBuild]::MakeRelative('$(_ModularPipelinesRepositoryRoot)', '$(MSBuildProjectFullPath)'))</_ModularPipelinesPipelineProject>
+      <_ModularPipelinesPipelineProject Condition="'$(ModularPipelinesPipelineProject)' != ''">$(ModularPipelinesPipelineProject)</_ModularPipelinesPipelineProject>
+      <_ModularPipelinesPipelineProject>$([System.String]::Copy('$(_ModularPipelinesPipelineProject)').Replace('\', '/'))</_ModularPipelinesPipelineProject>
+
+      <_ModularPipelinesGitHubFile>$(_ModularPipelinesRepositoryRoot)\.github\workflows\modular-pipelines.yml</_ModularPipelinesGitHubFile>
+      <_ModularPipelinesGitLabFile>$(_ModularPipelinesRepositoryRoot)\.gitlab-ci.yml</_ModularPipelinesGitLabFile>
+      <_ModularPipelinesAzureFile>$(_ModularPipelinesRepositoryRoot)\azure-pipelines.yml</_ModularPipelinesAzureFile>
+
+      <_ModularPipelinesGitHubWorkflow><![CDATA[name: ModularPipelines
+
+on:
+  push:
+    branches: [$(ModularPipelinesBuildBranch)]
+  pull_request:
+    branches: [$(ModularPipelinesBuildBranch)]
+
+jobs:
+  pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-dotnet@v6.0.0
+        with:
+          dotnet-version: $(ModularPipelinesDotNetVersion)
+      - run: dotnet run --project "$(_ModularPipelinesPipelineProject)" --configuration Release
+]]></_ModularPipelinesGitHubWorkflow>
+
+      <_ModularPipelinesGitLabPipeline><![CDATA[stages:
+  - pipeline
+
+modular-pipelines:
+  image: $(ModularPipelinesDotNetSdkImage)
+  stage: pipeline
+  script:
+    - dotnet run --project "$(_ModularPipelinesPipelineProject)" --configuration Release
+]]></_ModularPipelinesGitLabPipeline>
+
+      <_ModularPipelinesAzurePipeline><![CDATA[trigger:
+  - $(ModularPipelinesBuildBranch)
+
+pr:
+  - $(ModularPipelinesBuildBranch)
+
+pool:
+  vmImage: ubuntu-latest
+
+steps:
+  - task: UseDotNet@2
+    inputs:
+      packageType: sdk
+      version: $(ModularPipelinesDotNetVersion)
+  - script: dotnet run --project "$(_ModularPipelinesPipelineProject)" --configuration Release
+    displayName: Run ModularPipelines
+]]></_ModularPipelinesAzurePipeline>
+
+      <_ModularPipelinesOutputFile Condition="'$(ModularPipelinesBuildSystem)' == 'GitHubActions'">$(_ModularPipelinesGitHubFile)</_ModularPipelinesOutputFile>
+      <_ModularPipelinesOutputFile Condition="'$(ModularPipelinesBuildSystem)' == 'GitLab'">$(_ModularPipelinesGitLabFile)</_ModularPipelinesOutputFile>
+      <_ModularPipelinesOutputFile Condition="'$(ModularPipelinesBuildSystem)' == 'AzurePipelines'">$(_ModularPipelinesAzureFile)</_ModularPipelinesOutputFile>
+      <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'GitHubActions'">$(_ModularPipelinesGitHubWorkflow)</_ModularPipelinesOutputContent>
+      <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'GitLab'">$(_ModularPipelinesGitLabPipeline)</_ModularPipelinesOutputContent>
+      <_ModularPipelinesOutputContent Condition="'$(ModularPipelinesBuildSystem)' == 'AzurePipelines'">$(_ModularPipelinesAzurePipeline)</_ModularPipelinesOutputContent>
+      <_ModularPipelinesOutputFileExisted>$([System.IO.File]::Exists('$(_ModularPipelinesOutputFile)'))</_ModularPipelinesOutputFileExisted>
+    </PropertyGroup>
+
+    <Error
+      Condition="'$(ModularPipelinesBuildSystem)' != 'GitHubActions' and '$(ModularPipelinesBuildSystem)' != 'GitLab' and '$(ModularPipelinesBuildSystem)' != 'AzurePipelines'"
+      Text="Unsupported ModularPipelinesBuildSystem '$(ModularPipelinesBuildSystem)'. Use GitHubActions, GitLab, or AzurePipelines." />
+    <Error
+      Condition="!Exists('$(_ModularPipelinesRepositoryRoot)')"
+      Text="ModularPipelinesRepositoryRoot '$(_ModularPipelinesRepositoryRoot)' does not exist." />
+
+    <MakeDir
+      Directories="$([System.IO.Path]::GetDirectoryName('$(_ModularPipelinesOutputFile)'))"
+      Condition="'$(_ModularPipelinesOutputFileExisted)' != 'True'" />
+
+    <WriteLinesToFile
+      File="$(_ModularPipelinesOutputFile)"
+      Lines="$(_ModularPipelinesOutputContent)"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true"
+      Encoding="UTF-8"
+      Condition="'$(_ModularPipelinesOutputFileExisted)' != 'True' or '$(ModularPipelinesOverwriteBuildServerFiles)' == 'true'" />
+
+    <Message
+      Importance="high"
+      Text="Generated $(_ModularPipelinesOutputFile)"
+      Condition="'$(_ModularPipelinesOutputFileExisted)' != 'True' or '$(ModularPipelinesOverwriteBuildServerFiles)' == 'true'" />
+    <Message
+      Importance="high"
+      Text="Kept existing $(_ModularPipelinesOutputFile). Set ModularPipelinesOverwriteBuildServerFiles=true to replace it."
+      Condition="'$(_ModularPipelinesOutputFileExisted)' == 'True' and '$(ModularPipelinesOverwriteBuildServerFiles)' != 'true'" />
+  </Target>
+</Project>


### PR DESCRIPTION
## Summary
- ship an opt-in `buildTransitive` MSBuild target that generates minimal GitHub Actions, GitLab CI, or Azure Pipelines YAML during a normal build
- derive the pipeline project path relative to a configurable repository root and expose branch/.NET image customization
- preserve existing CI files unless overwrite is explicitly enabled
- document setup, output paths, customization, and overwrite behavior

## Validation
- core `ModularPipelines.sln` Release build: succeeded, 0 errors (existing warnings only)
- black-box generation: all three providers produced the expected file and repository-relative project path
- unsupported provider: rejected with a clear MSBuild error
- existing file: preserved by default; explicit overwrite and customization verified
- packed `ModularPipelines` nupkg: `buildTransitive/ModularPipelines.targets` verified
- fresh package consumer: ordinary Release build imported target and generated GitLab YAML, 0 warnings/errors
- Docusaurus production build: succeeded

Closes #2108