### PR TITLE
Run .NET CI after pushes to main

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,8 @@
 name: .NET
 
 on:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
   workflow_dispatch:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -116,7 +116,15 @@ jobs:
           done < <(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' BuildSolutions.txt)
 
       - name: Run Pipeline
-        run: dotnet run -c Release --framework net10.0
+        shell: bash
+        run: |
+          # version-tag.yml exclusively owns tags for main pushes. With no standard token,
+          # SkipIfNoStandardGitHubToken prevents this pipeline from creating a second tag.
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            unset GitHub__StandardToken
+          fi
+
+          dotnet run -c Release --framework net10.0
         working-directory: "src/ModularPipelines.Build"
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- run the .NET build and test workflow after every push to main
- retain existing pull-request and manual triggers

## Test plan
- [x] git diff --check
- [x] parsed .github/workflows/dotnet.yml as YAML
- [ ] GitHub Actions validates and runs the workflow

Closes #3337