### PR TITLE
Fix WaitForAllModules worker fault handling

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -33,6 +33,7 @@ internal class ModuleExecutor : IModuleExecutor
     private readonly IMetricsCollector _metricsCollector;
     private readonly IModuleDependencyRegistry _dependencyRegistry;
     private readonly IModuleMetadataRegistry _metadataRegistry;
+    private readonly ISecondaryExceptionContainer _secondaryExceptionContainer;
     private readonly IOptions<PipelineOptions> _pipelineOptions;
     private readonly ILogger<ModuleExecutor> _logger;
 
@@ -47,6 +48,7 @@ internal class ModuleExecutor : IModuleExecutor
         IMetricsCollector metricsCollector,
         IModuleDependencyRegistry dependencyRegistry,
         IModuleMetadataRegistry metadataRegistry,
+        ISecondaryExceptionContainer secondaryExceptionContainer,
         IOptions<PipelineOptions> pipelineOptions,
         ILogger<ModuleExecutor> logger)
     {
@@ -60,6 +62,7 @@ internal class ModuleExecutor : IModuleExecutor
         _metricsCollector = metricsCollector;
         _dependencyRegistry = dependencyRegistry;
         _metadataRegistry = metadataRegistry;
+        _secondaryExceptionContainer = secondaryExceptionContainer;
         _pipelineOptions = pipelineOptions;
         _logger = logger;
     }
@@ -220,15 +223,18 @@ internal class ModuleExecutor : IModuleExecutor
                         Interlocked.CompareExchange(ref firstException, ex, null);
                         cancellationTokenSource.Cancel();
                     }
+                    catch (Exception ex)
+                    {
+                        _secondaryExceptionContainer.RegisterException(ex);
+                        _logger.LogError(
+                            ex,
+                            "Module worker failed but remaining modules will continue due to ExecutionMode.WaitForAllModules");
+                    }
                 }).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (firstException != null)
         {
             // Expected when we cancelled due to StopOnFirstException
-        }
-        catch (Exception ex) when (_pipelineOptions.Value.ExecutionMode != ExecutionMode.StopOnFirstException)
-        {
-            _logger.LogDebug(ex, "Module execution failed but continuing due to ExecutionMode.WaitForAllModules");
         }
 
         return firstException;

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -225,15 +225,7 @@ internal class ModuleExecutor : IModuleExecutor
                     }
                     catch (Exception ex)
                     {
-                        if (moduleState.State != ModuleExecutionState.Completed)
-                        {
-                            scheduler.MarkModuleCompleted(moduleState.ModuleType, success: false, ex);
-                        }
-
-                        _secondaryExceptionContainer.RegisterException(ex);
-                        _logger.LogError(
-                            ex,
-                            "Module worker failed but remaining modules will continue due to ExecutionMode.WaitForAllModules");
+                        HandleWaitForAllWorkerFailure(moduleState, scheduler, ex);
                     }
                 }).ConfigureAwait(false);
         }
@@ -243,6 +235,61 @@ internal class ModuleExecutor : IModuleExecutor
         }
 
         return firstException;
+    }
+
+    private void HandleWaitForAllWorkerFailure(
+        ModuleState moduleState,
+        IModuleScheduler scheduler,
+        Exception exception)
+    {
+        _secondaryExceptionContainer.RegisterException(exception);
+        TryMarkModuleFailed(moduleState, scheduler, exception);
+        TryRegisterTerminatedResult(moduleState, exception);
+
+        _logger.LogError(
+            exception,
+            "Module worker failed but remaining modules will continue due to ExecutionMode.WaitForAllModules");
+    }
+
+    private void TryMarkModuleFailed(
+        ModuleState moduleState,
+        IModuleScheduler scheduler,
+        Exception exception)
+    {
+        try
+        {
+            scheduler.MarkModuleCompleted(moduleState.ModuleType, success: false, exception);
+        }
+        catch (Exception recoveryException)
+        {
+            _secondaryExceptionContainer.RegisterException(recoveryException);
+            _logger.LogError(
+                recoveryException,
+                "Failed to complete scheduler state for faulted module {ModuleName}",
+                moduleState.ModuleType.Name);
+        }
+    }
+
+    private void TryRegisterTerminatedResult(ModuleState moduleState, Exception exception)
+    {
+        try
+        {
+            if (_resultRegistry.GetResult(moduleState.ModuleType) == null)
+            {
+                _resultRegistrar.RegisterTerminatedResult(
+                    moduleState.Module,
+                    moduleState.ModuleType,
+                    exception);
+            }
+        }
+        catch (Exception recoveryException)
+        {
+            _secondaryExceptionContainer.RegisterException(recoveryException);
+            _logger.LogError(
+                recoveryException,
+                "Failed to register terminated result for faulted module {ModuleName}",
+                moduleState.ModuleType.Name);
+        }
     }
 
     private void EnsureCancellation(CancellationTokenSource cancellationTokenSource)

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -225,6 +225,11 @@ internal class ModuleExecutor : IModuleExecutor
                     }
                     catch (Exception ex)
                     {
+                        if (moduleState.State != ModuleExecutionState.Completed)
+                        {
+                            scheduler.MarkModuleCompleted(moduleState.ModuleType, success: false, ex);
+                        }
+
                         _secondaryExceptionContainer.RegisterException(ex);
                         _logger.LogError(
                             ex,

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -164,6 +164,11 @@ internal class ModuleStateTracker : IModuleStateTracker
         _stateLock.EnterWriteLock();
         try
         {
+            if (state.State == ModuleExecutionState.Completed)
+            {
+                return;
+            }
+
             _queuedModules.Remove(state);
             _executingModules.Remove(state);
             state.State = ModuleExecutionState.Completed;

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -164,6 +164,7 @@ internal class ModuleStateTracker : IModuleStateTracker
         _stateLock.EnterWriteLock();
         try
         {
+            _queuedModules.Remove(state);
             _executingModules.Remove(state);
             state.State = ModuleExecutionState.Completed;
             state.CompletionTime = _timeProvider.GetUtcNow();

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text;
 using System.Threading.Channels;
+using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
@@ -90,18 +91,20 @@ public class ModuleExecutorLoggingTests
     [Test]
     public async Task WaitForAllModules_WorkerFault_DoesNotStopRemainingModules()
     {
-        var readyModules = Channel.CreateUnbounded<ModuleState>();
-        readyModules.Writer.TryWrite(new ModuleState(new FaultingModule(), typeof(FaultingModule)));
-        readyModules.Writer.TryWrite(new ModuleState(new LaterModule(), typeof(LaterModule)));
-        readyModules.Writer.Complete();
-
-        var scheduler = new Mock<IModuleScheduler>();
-        scheduler.SetupGet(x => x.ReadyModules).Returns(readyModules.Reader);
-        scheduler.Setup(x => x.RunSchedulerAsync(It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-
+        var dependencyRegistry = new ModuleDependencyRegistry();
+        var metadataRegistry = new ModuleMetadataRegistry(
+            Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()));
+        var scheduler = new ModuleScheduler(
+            NullLogger.Instance,
+            TimeProvider.System,
+            Microsoft.Extensions.Options.Options.Create(new SchedulerOptions()),
+            dependencyRegistry,
+            metadataRegistry,
+            Mock.Of<IMetricsCollector>(),
+            new ModuleConstraintEvaluator(NullLogger<ModuleConstraintEvaluator>.Instance),
+            Mock.Of<ISchedulerStatusReporter>());
         var schedulerFactory = new Mock<IModuleSchedulerFactory>();
-        schedulerFactory.Setup(x => x.Create()).Returns(scheduler.Object);
+        schedulerFactory.Setup(x => x.Create()).Returns(scheduler);
 
         var registrationEvents = new Mock<IRegistrationEventExecutor>();
         registrationEvents.Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IReadOnlyList<IModule>>()))
@@ -118,14 +121,20 @@ public class ModuleExecutorLoggingTests
                 It.IsAny<ModuleState>(),
                 It.IsAny<IModuleScheduler>(),
                 It.IsAny<CancellationToken>()))
-            .Returns<ModuleState, IModuleScheduler, CancellationToken>((moduleState, _, _) =>
+            .Returns<ModuleState, IModuleScheduler, CancellationToken>((moduleState, moduleScheduler, _) =>
             {
                 if (moduleState.ModuleType == typeof(FaultingModule))
                 {
                     throw new InvalidOperationException("Worker fault");
                 }
 
+                if (!moduleScheduler.MarkModuleStarted(moduleState.ModuleType))
+                {
+                    throw new InvalidOperationException("Later module could not start");
+                }
+
                 laterModuleRan = true;
+                moduleScheduler.MarkModuleCompleted(moduleState.ModuleType, success: true);
                 return Task.CompletedTask;
             });
 
@@ -138,8 +147,8 @@ public class ModuleExecutorLoggingTests
             parallelLimitProvider.Object,
             registrationEvents.Object,
             Mock.Of<IMetricsCollector>(),
-            new ModuleDependencyRegistry(),
-            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            dependencyRegistry,
+            metadataRegistry,
             secondaryExceptionContainer.Object,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
@@ -147,7 +156,8 @@ public class ModuleExecutorLoggingTests
             }),
             Mock.Of<Microsoft.Extensions.Logging.ILogger<ModuleExecutor>>());
 
-        await executor.ExecuteAsync([new FaultingModule(), new LaterModule()]);
+        await executor.ExecuteAsync([new FaultingModule(), new LaterModule()])
+            .WaitAsync(TimeSpan.FromSeconds(5));
 
         await Assert.That(laterModuleRan).IsTrue();
         secondaryExceptionContainer.Verify(

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Text;
 using System.Threading.Channels;
 using ModularPipelines.Configuration;
+using ModularPipelines.Context;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
@@ -19,6 +20,26 @@ namespace ModularPipelines.UnitTests.Engine;
 
 public class ModuleExecutorLoggingTests
 {
+    private class FaultingModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
+    private class LaterModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
     [Test]
     public async Task SuccessfulCompletion_DoesNotLogCancellation()
     {
@@ -55,6 +76,7 @@ public class ModuleExecutorLoggingTests
             Mock.Of<IMetricsCollector>(),
             new ModuleDependencyRegistry(),
             new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            Mock.Of<ISecondaryExceptionContainer>(),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
             new StringLogger<ModuleExecutor>(logs));
 
@@ -63,6 +85,74 @@ public class ModuleExecutorLoggingTests
         var logOutput = logs.ToString();
         await Assert.That(logOutput).DoesNotContain("Cancellation triggered");
         scheduler.Verify(x => x.CancelPendingModules(), Times.Once);
+    }
+
+    [Test]
+    public async Task WaitForAllModules_WorkerFault_DoesNotStopRemainingModules()
+    {
+        var readyModules = Channel.CreateUnbounded<ModuleState>();
+        readyModules.Writer.TryWrite(new ModuleState(new FaultingModule(), typeof(FaultingModule)));
+        readyModules.Writer.TryWrite(new ModuleState(new LaterModule(), typeof(LaterModule)));
+        readyModules.Writer.Complete();
+
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler.SetupGet(x => x.ReadyModules).Returns(readyModules.Reader);
+        scheduler.Setup(x => x.RunSchedulerAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var schedulerFactory = new Mock<IModuleSchedulerFactory>();
+        schedulerFactory.Setup(x => x.Create()).Returns(scheduler.Object);
+
+        var registrationEvents = new Mock<IRegistrationEventExecutor>();
+        registrationEvents.Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(Task.CompletedTask);
+
+        var parallelLimitProvider = new Mock<IParallelLimitProvider>();
+        parallelLimitProvider.Setup(x => x.GetMaxDegreeOfParallelism()).Returns(1);
+
+        var laterModuleRan = false;
+        var secondaryExceptionContainer = new Mock<ISecondaryExceptionContainer>();
+        var moduleRunner = new Mock<IModuleRunner>();
+        moduleRunner
+            .Setup(x => x.ExecuteAsync(
+                It.IsAny<ModuleState>(),
+                It.IsAny<IModuleScheduler>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<ModuleState, IModuleScheduler, CancellationToken>((moduleState, _, _) =>
+            {
+                if (moduleState.ModuleType == typeof(FaultingModule))
+                {
+                    throw new InvalidOperationException("Worker fault");
+                }
+
+                laterModuleRan = true;
+                return Task.CompletedTask;
+            });
+
+        var executor = new ModuleExecutor(
+            schedulerFactory.Object,
+            moduleRunner.Object,
+            Mock.Of<IAlwaysRunHandler>(),
+            Mock.Of<IModuleResultRegistrar>(),
+            Mock.Of<IModuleResultRegistry>(),
+            parallelLimitProvider.Object,
+            registrationEvents.Object,
+            Mock.Of<IMetricsCollector>(),
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            secondaryExceptionContainer.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                ExecutionMode = ExecutionMode.WaitForAllModules,
+            }),
+            Mock.Of<Microsoft.Extensions.Logging.ILogger<ModuleExecutor>>());
+
+        await executor.ExecuteAsync([new FaultingModule(), new LaterModule()]);
+
+        await Assert.That(laterModuleRan).IsTrue();
+        secondaryExceptionContainer.Verify(
+            x => x.RegisterException(It.Is<InvalidOperationException>(exception => exception.Message == "Worker fault")),
+            Times.Once);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -9,6 +9,7 @@ using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Engine.Scheduling;
+using ModularPipelines.Enums;
 using ModularPipelines.Helpers;
 using ModularPipelines.Interfaces;
 using ModularPipelines.Models;
@@ -115,6 +116,7 @@ public class ModuleExecutorLoggingTests
 
         var laterModuleRan = false;
         var secondaryExceptionContainer = new Mock<ISecondaryExceptionContainer>();
+        var resultRegistrar = new Mock<IModuleResultRegistrar>();
         var moduleRunner = new Mock<IModuleRunner>();
         moduleRunner
             .Setup(x => x.ExecuteAsync(
@@ -142,7 +144,7 @@ public class ModuleExecutorLoggingTests
             schedulerFactory.Object,
             moduleRunner.Object,
             Mock.Of<IAlwaysRunHandler>(),
-            Mock.Of<IModuleResultRegistrar>(),
+            resultRegistrar.Object,
             Mock.Of<IModuleResultRegistry>(),
             parallelLimitProvider.Object,
             registrationEvents.Object,
@@ -162,6 +164,112 @@ public class ModuleExecutorLoggingTests
         await Assert.That(laterModuleRan).IsTrue();
         secondaryExceptionContainer.Verify(
             x => x.RegisterException(It.Is<InvalidOperationException>(exception => exception.Message == "Worker fault")),
+            Times.Once);
+        resultRegistrar.Verify(
+            x => x.RegisterTerminatedResult(
+                It.IsAny<FaultingModule>(),
+                typeof(FaultingModule),
+                It.Is<InvalidOperationException>(exception => exception.Message == "Worker fault")),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task WaitForAllModules_RecoveryFault_DoesNotStopRemainingModules()
+    {
+        var faultingModule = new FaultingModule();
+        var laterModule = new LaterModule();
+        var readyModules = Channel.CreateUnbounded<ModuleState>();
+        await readyModules.Writer.WriteAsync(new ModuleState(faultingModule, typeof(FaultingModule)));
+        await readyModules.Writer.WriteAsync(new ModuleState(laterModule, typeof(LaterModule)));
+        readyModules.Writer.Complete();
+
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler.SetupGet(x => x.ReadyModules).Returns(readyModules.Reader);
+        scheduler.Setup(x => x.RunSchedulerAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        scheduler
+            .Setup(x => x.MarkModuleCompleted(
+                typeof(FaultingModule),
+                false,
+                It.IsAny<Exception>(),
+                It.IsAny<Status?>()))
+            .Throws(new InvalidOperationException("Recovery fault"));
+
+        var schedulerFactory = new Mock<IModuleSchedulerFactory>();
+        schedulerFactory.Setup(x => x.Create()).Returns(scheduler.Object);
+
+        var registrationEvents = new Mock<IRegistrationEventExecutor>();
+        registrationEvents.Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(Task.CompletedTask);
+
+        var parallelLimitProvider = new Mock<IParallelLimitProvider>();
+        parallelLimitProvider.Setup(x => x.GetMaxDegreeOfParallelism()).Returns(1);
+
+        var laterModuleRan = false;
+        var moduleRunner = new Mock<IModuleRunner>();
+        moduleRunner
+            .Setup(x => x.ExecuteAsync(
+                It.IsAny<ModuleState>(),
+                It.IsAny<IModuleScheduler>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<ModuleState, IModuleScheduler, CancellationToken>((moduleState, _, _) =>
+            {
+                if (moduleState.ModuleType == typeof(FaultingModule))
+                {
+                    throw new InvalidOperationException("Worker fault");
+                }
+
+                laterModuleRan = true;
+                return Task.CompletedTask;
+            });
+
+        var secondaryExceptionContainer = new Mock<ISecondaryExceptionContainer>();
+        var executor = new ModuleExecutor(
+            schedulerFactory.Object,
+            moduleRunner.Object,
+            Mock.Of<IAlwaysRunHandler>(),
+            Mock.Of<IModuleResultRegistrar>(),
+            Mock.Of<IModuleResultRegistry>(),
+            parallelLimitProvider.Object,
+            registrationEvents.Object,
+            Mock.Of<IMetricsCollector>(),
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            secondaryExceptionContainer.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                ExecutionMode = ExecutionMode.WaitForAllModules,
+            }),
+            Mock.Of<Microsoft.Extensions.Logging.ILogger<ModuleExecutor>>());
+
+        await executor.ExecuteAsync([faultingModule, laterModule]);
+
+        await Assert.That(laterModuleRan).IsTrue();
+        secondaryExceptionContainer.Verify(
+            x => x.RegisterException(It.Is<InvalidOperationException>(exception => exception.Message == "Recovery fault")),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task MarkModuleCompleted_WhenAlreadyCompleted_RecordsMetricsOnce()
+    {
+        var module = new FaultingModule();
+        var state = new ModuleState(module, typeof(FaultingModule));
+        var moduleStates = new ConcurrentDictionary<Type, ModuleState>();
+        moduleStates[state.ModuleType] = state;
+        var metricsCollector = new Mock<IMetricsCollector>();
+        var tracker = CreateModuleStateTracker(new StringBuilder(), moduleStates, metricsCollector.Object);
+
+        tracker.MarkModuleCompleted(state.ModuleType, success: false, new InvalidOperationException("First"));
+        tracker.MarkModuleCompleted(state.ModuleType, success: false, new InvalidOperationException("Second"));
+
+        metricsCollector.Verify(
+            x => x.RecordModuleCompleted(
+                state.ModuleType,
+                It.IsAny<DateTimeOffset>(),
+                false,
+                false,
+                Status.Failed),
             Times.Once);
     }
 
@@ -195,12 +303,13 @@ public class ModuleExecutorLoggingTests
 
     private static ModuleStateTracker CreateModuleStateTracker(
         StringBuilder logs,
-        ConcurrentDictionary<Type, ModuleState> moduleStates)
+        ConcurrentDictionary<Type, ModuleState> moduleStates,
+        IMetricsCollector? metricsCollector = null)
     {
         return new ModuleStateTracker(
             new StringLogger<ModuleStateTracker>(logs),
             TimeProvider.System,
-            Mock.Of<IMetricsCollector>(),
+            metricsCollector ?? Mock.Of<IMetricsCollector>(),
             Mock.Of<IModuleConstraintEvaluator>(),
             moduleStates,
             [],


### PR DESCRIPTION
## Summary
- keep WaitForAllModules worker enumeration alive after infrastructure faults
- atomically complete faulted scheduler state and make completion idempotent under the tracker lock
- contain recovery-operation failures so remaining workers still drain
- register PipelineTerminated results for escaped worker faults
- record all escaped and recovery failures in the secondary exception container
- deliberately allow scheduler/channel faults to propagate instead of swallowing them at Debug level

## Test plan
- [x] failing-first coverage for terminated-result registration, recovery faults, and idempotent completion
- [x] ModuleExecutorLoggingTests (6 passed)
- [x] guarded Release build of ModularPipelines.sln (0 errors; 247 existing warnings)
- [x] targeted dotnet format

Closes #3244