### PR TITLE
Deduplicate descendant dependency traversal

### DIFF
--- a/src/ModularPipelines/Models/ModuleDependencyModel.cs
+++ b/src/ModularPipelines/Models/ModuleDependencyModel.cs
@@ -4,9 +4,9 @@ namespace ModularPipelines.Models;
 
 internal record ModuleDependencyModel(IModule Module)
 {
-    public List<ModuleDependencyModel> IsDependencyFor { get; } = new();
+    public List<ModuleDependencyModel> IsDependencyFor { get; } = [];
 
-    public List<ModuleDependencyModel> IsDependentOn { get; } = new();
+    public List<ModuleDependencyModel> IsDependentOn { get; } = [];
 
     public IEnumerable<ModuleDependencyModel> AllDescendantDependenciesAndSelf()
     {
@@ -20,30 +20,28 @@ internal record ModuleDependencyModel(IModule Module)
 
     public IEnumerable<ModuleDependencyModel> AllDescendantDependencies()
     {
-        foreach (var moduleDependencyModel in IsDependentOn)
-        {
-            yield return moduleDependencyModel;
+        var remainingDependencies = new Queue<ModuleDependencyModel>(IsDependentOn);
+        var visitedDependencies = new HashSet<ModuleDependencyModel>();
 
-            if (moduleDependencyModel.Module.GetType() == Module.GetType())
+        while (remainingDependencies.TryDequeue(out var dependency))
+        {
+            if (!visitedDependencies.Add(dependency))
             {
-                yield break;
+                continue;
             }
-        }
 
-        foreach (var moduleDependencyModel in IsDependentOn.SelectMany(d => d.AllDescendantDependencies()))
-        {
-            yield return moduleDependencyModel;
+            yield return dependency;
 
-            if (moduleDependencyModel.Module.GetType() == Module.GetType())
+            foreach (var descendantDependency in dependency.IsDependentOn)
             {
-                yield break;
+                remainingDependencies.Enqueue(descendantDependency);
             }
         }
     }
 
     public virtual bool Equals(ModuleDependencyModel? other)
     {
-        if (ReferenceEquals(null, other))
+        if (other is null)
         {
             return false;
         }

--- a/test/ModularPipelines.UnitTests/Models/ModuleDependencyModelTests.cs
+++ b/test/ModularPipelines.UnitTests/Models/ModuleDependencyModelTests.cs
@@ -1,0 +1,49 @@
+using ModularPipelines.Context;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.UnitTests.Models;
+
+public class ModuleDependencyModelTests
+{
+    [Test]
+    public async Task AllDescendantDependencies_ReturnsEachReachableModuleOnce()
+    {
+        var root = CreateModel<RootModule>();
+        var left = CreateModel<LeftModule>();
+        var right = CreateModel<RightModule>();
+        var sharedLeaf = CreateModel<SharedLeafModule>();
+
+        root.IsDependentOn.AddRange([left, right]);
+        left.IsDependentOn.Add(sharedLeaf);
+        right.IsDependentOn.Add(sharedLeaf);
+
+        var descendants = root.AllDescendantDependencies().ToList();
+
+        await Assert.That(descendants).IsEquivalentTo([left, right, sharedLeaf]);
+    }
+
+    private static ModuleDependencyModel CreateModel<T>()
+        where T : IModule, new()
+    {
+        return new ModuleDependencyModel(new T());
+    }
+
+    private abstract class TestModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class RootModule : TestModule;
+
+    private sealed class LeftModule : TestModule;
+
+    private sealed class RightModule : TestModule;
+
+    private sealed class SharedLeafModule : TestModule;
+}


### PR DESCRIPTION
## Summary
- traverse descendant dependencies with a queue and visited set
- expand every reachable module once, preventing exponential diamond-graph enumeration
- add a regression test for a shared-leaf diamond

## Test plan
- [x] regression test failed before the fix (4 results instead of 3)
- [x] focused `ModuleDependencyModelTests`
- [x] `DirectCollisionTests`
- [x] `DependencyTreeFormatterTests`
- [x] targeted `dotnet format --verify-no-changes --severity info`
- [x] Release build of `ModularPipelines.sln`

Closes #3251