### PR TITLE
Run AlwaysRun cleanup modules reliably

### DIFF
--- a/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
@@ -1,4 +1,6 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -8,18 +10,14 @@ namespace ModularPipelines.Engine.Execution;
 /// <summary>
 /// Responsible for handling AlwaysRun modules that must complete even after pipeline failure.
 /// </summary>
-internal class AlwaysRunHandler : IAlwaysRunHandler
+internal class AlwaysRunHandler(
+    IModuleRunner moduleRunner,
+    IParallelLimitProvider parallelLimitProvider,
+    ILogger<AlwaysRunHandler> logger) : IAlwaysRunHandler
 {
-    private readonly IModuleRunner _moduleRunner;
-    private readonly ILogger<AlwaysRunHandler> _logger;
-
-    public AlwaysRunHandler(
-        IModuleRunner moduleRunner,
-        ILogger<AlwaysRunHandler> logger)
-    {
-        _moduleRunner = moduleRunner;
-        _logger = logger;
-    }
+    private readonly IModuleRunner _moduleRunner = moduleRunner;
+    private readonly IParallelLimitProvider _parallelLimitProvider = parallelLimitProvider;
+    private readonly ILogger<AlwaysRunHandler> _logger = logger;
 
     /// <inheritdoc />
     public async Task WaitForAlwaysRunModulesAsync(IModuleScheduler scheduler, IReadOnlyList<IModule> modules)
@@ -27,21 +25,45 @@ internal class AlwaysRunHandler : IAlwaysRunHandler
         var alwaysRunModules = modules.Where(x => x.ModuleRunType == ModuleRunType.AlwaysRun).ToList();
         _logger.LogDebug("Found {Count} AlwaysRun modules", alwaysRunModules.Count);
 
-        var exceptions = new List<Exception>();
+        var exceptions = new ConcurrentQueue<Exception>();
+        var modulesToProcess = alwaysRunModules;
 
-        foreach (var module in alwaysRunModules)
+        while (modulesToProcess.Count > 0)
         {
-            var exception = await WaitForSingleAlwaysRunModuleAsync(scheduler, module).ConfigureAwait(false);
-            if (exception != null)
-            {
-                exceptions.Add(exception);
-            }
+            await ProcessAlwaysRunModulesAsync(scheduler, modulesToProcess, exceptions).ConfigureAwait(false);
+
+            // Constraint checks can defer a late start. Each pass waits for active modules,
+            // then retries only modules that remained pending.
+            modulesToProcess = [.. modulesToProcess.Where(module => scheduler.GetModuleState(module.GetType())?.State == ModuleExecutionState.Pending)];
         }
 
-        if (exceptions.Count > 0)
+        if (!exceptions.IsEmpty)
         {
             throw new AggregateException("One or more AlwaysRun modules failed", exceptions);
         }
+    }
+
+    private async Task ProcessAlwaysRunModulesAsync(
+        IModuleScheduler scheduler,
+        IReadOnlyCollection<IModule> modules,
+        ConcurrentQueue<Exception> exceptions)
+    {
+        var parallelOptions = new ParallelOptions
+        {
+            MaxDegreeOfParallelism = _parallelLimitProvider.GetMaxDegreeOfParallelism(),
+        };
+
+        await Parallel.ForEachAsync(
+            modules,
+            parallelOptions,
+            async (module, _) =>
+            {
+                var exception = await WaitForSingleAlwaysRunModuleAsync(scheduler, module).ConfigureAwait(false);
+                if (exception != null)
+                {
+                    exceptions.Enqueue(exception);
+                }
+            }).ConfigureAwait(false);
     }
 
     private async Task<Exception?> WaitForSingleAlwaysRunModuleAsync(IModuleScheduler scheduler, IModule module)
@@ -64,6 +86,15 @@ internal class AlwaysRunHandler : IAlwaysRunHandler
             try
             {
                 await _moduleRunner.ExecuteWithoutDependencyWaitAsync(moduleState, scheduler, CancellationToken.None).ConfigureAwait(false);
+
+                if (moduleState.State == ModuleExecutionState.Pending)
+                {
+                    _logger.LogDebug(
+                        "AlwaysRun module {ModuleName} was deferred and will be retried",
+                        moduleType.Name);
+                    return null;
+                }
+
                 _logger.LogDebug("AlwaysRun module {ModuleName} completed after late start", moduleType.Name);
             }
             catch (Exception alwaysRunEx)

--- a/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
@@ -1,9 +1,11 @@
 using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 
 namespace ModularPipelines.Engine.Execution;
 
@@ -13,10 +15,12 @@ namespace ModularPipelines.Engine.Execution;
 internal class AlwaysRunHandler(
     IModuleRunner moduleRunner,
     IParallelLimitProvider parallelLimitProvider,
+    IOptions<PipelineOptions> pipelineOptions,
     ILogger<AlwaysRunHandler> logger) : IAlwaysRunHandler
 {
     private readonly IModuleRunner _moduleRunner = moduleRunner;
     private readonly IParallelLimitProvider _parallelLimitProvider = parallelLimitProvider;
+    private readonly TimeSpan _schedulerProgressTimeout = pipelineOptions.Value.DefaultModuleTimeout;
     private readonly ILogger<AlwaysRunHandler> _logger = logger;
 
     /// <inheritdoc />
@@ -26,20 +30,100 @@ internal class AlwaysRunHandler(
         _logger.LogDebug("Found {Count} AlwaysRun modules", alwaysRunModules.Count);
 
         var exceptions = new ConcurrentQueue<Exception>();
-        var modulesToProcess = alwaysRunModules;
+        var remainingModules = alwaysRunModules;
 
-        while (modulesToProcess.Count > 0)
+        while (remainingModules.Count > 0)
         {
+            var modulesToProcess = GetDependencyReadyModules(scheduler, remainingModules);
+            if (modulesToProcess.Count == 0)
+            {
+                exceptions.Enqueue(new InvalidOperationException(
+                    "AlwaysRun modules could not make progress because their dependency graph has no ready modules."));
+                break;
+            }
+
             await ProcessAlwaysRunModulesAsync(scheduler, modulesToProcess, exceptions).ConfigureAwait(false);
 
-            // Constraint checks can defer a late start. Each pass waits for active modules,
-            // then retries only modules that remained pending.
-            modulesToProcess = [.. modulesToProcess.Where(module => scheduler.GetModuleState(module.GetType())?.State == ModuleExecutionState.Pending)];
+            var deferredModules = modulesToProcess
+                .Where(module => scheduler.GetModuleState(module.GetType())?.State == ModuleExecutionState.Pending)
+                .ToList();
+            var processedModules = modulesToProcess.Except(deferredModules).ToHashSet();
+            remainingModules.RemoveAll(processedModules.Contains);
+
+            if (deferredModules.Count > 0 &&
+                !await WaitForSchedulerProgressAsync(scheduler, modules, deferredModules, exceptions).ConfigureAwait(false))
+            {
+                break;
+            }
         }
 
         if (!exceptions.IsEmpty)
         {
             throw new AggregateException("One or more AlwaysRun modules failed", exceptions);
+        }
+    }
+
+    private static List<IModule> GetDependencyReadyModules(
+        IModuleScheduler scheduler,
+        IReadOnlyCollection<IModule> remainingModules)
+    {
+        var remainingModuleTypes = remainingModules.Select(module => module.GetType()).ToHashSet();
+
+        return
+        [
+            .. remainingModules.Where(module =>
+            {
+                var moduleState = scheduler.GetModuleState(module.GetType());
+                return moduleState == null ||
+                       moduleState.Dependencies.Keys.All(dependencyType => !remainingModuleTypes.Contains(dependencyType));
+            }),
+        ];
+    }
+
+    private async Task<bool> WaitForSchedulerProgressAsync(
+        IModuleScheduler scheduler,
+        IReadOnlyCollection<IModule> modules,
+        IReadOnlyCollection<IModule> deferredModules,
+        ConcurrentQueue<Exception> exceptions)
+    {
+        var deferredModuleTypes = deferredModules.Select(module => module.GetType()).ToHashSet();
+        var deferredModuleNames = string.Join(", ", deferredModuleTypes.Select(type => type.Name));
+        var activeModuleTasks = modules
+            .Select(module => scheduler.GetModuleState(module.GetType()))
+            .Where(state => state is { State: ModuleExecutionState.Executing } &&
+                            !deferredModuleTypes.Contains(state.ModuleType))
+            .Select(state => scheduler.GetModuleCompletionTask(state!.ModuleType))
+            .Where(task => task != null)
+            .Select(task => task!)
+            .ToList();
+
+        if (activeModuleTasks.Count == 0)
+        {
+            var exception = new InvalidOperationException(
+                $"AlwaysRun modules were deferred with no active module able to release their constraints: {deferredModuleNames}.");
+            _logger.LogWarning(exception, "AlwaysRun modules could not be retried");
+            exceptions.Enqueue(exception);
+            return false;
+        }
+
+        try
+        {
+            var schedulerProgress = Task.WhenAny(activeModuleTasks);
+            var completedTask = _schedulerProgressTimeout > TimeSpan.Zero
+                ? await schedulerProgress.WaitAsync(_schedulerProgressTimeout).ConfigureAwait(false)
+                : await schedulerProgress.ConfigureAwait(false);
+
+            _ = completedTask.Exception;
+            return true;
+        }
+        catch (TimeoutException timeoutException)
+        {
+            var exception = new TimeoutException(
+                $"Timed out waiting for scheduler progress before retrying AlwaysRun modules: {deferredModuleNames}.",
+                timeoutException);
+            _logger.LogWarning(exception, "AlwaysRun modules could not be retried");
+            exceptions.Enqueue(exception);
+            return false;
         }
     }
 

--- a/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
@@ -31,6 +31,10 @@ internal class AlwaysRunHandler(
 
         var exceptions = new ConcurrentQueue<Exception>();
         var remainingModules = alwaysRunModules;
+        using var schedulerProgressTimeoutSource = _schedulerProgressTimeout > TimeSpan.Zero
+            ? new CancellationTokenSource()
+            : null;
+        var schedulerProgressTimeoutStarted = false;
 
         while (remainingModules.Count > 0)
         {
@@ -50,11 +54,23 @@ internal class AlwaysRunHandler(
             var processedModules = modulesToProcess.Except(deferredModules).ToHashSet();
             remainingModules.RemoveAll(processedModules.Contains);
 
-            if (deferredModules.Count > 0 &&
-                processedModules.Count == 0 &&
-                !await WaitForSchedulerProgressAsync(scheduler, modules, deferredModules, exceptions).ConfigureAwait(false))
+            if (deferredModules.Count > 0 && processedModules.Count == 0)
             {
-                break;
+                if (schedulerProgressTimeoutSource != null && !schedulerProgressTimeoutStarted)
+                {
+                    schedulerProgressTimeoutSource.CancelAfter(_schedulerProgressTimeout);
+                    schedulerProgressTimeoutStarted = true;
+                }
+
+                if (!await WaitForSchedulerProgressAsync(
+                        scheduler,
+                        modules,
+                        deferredModules,
+                        exceptions,
+                        schedulerProgressTimeoutSource?.Token ?? CancellationToken.None).ConfigureAwait(false))
+                {
+                    break;
+                }
             }
         }
 
@@ -85,7 +101,8 @@ internal class AlwaysRunHandler(
         IModuleScheduler scheduler,
         IReadOnlyCollection<IModule> modules,
         IReadOnlyCollection<IModule> deferredModules,
-        ConcurrentQueue<Exception> exceptions)
+        ConcurrentQueue<Exception> exceptions,
+        CancellationToken schedulerProgressTimeoutToken)
     {
         var deferredModuleTypes = deferredModules.Select(module => module.GetType()).ToHashSet();
         var deferredModuleNames = string.Join(", ", deferredModuleTypes.Select(type => type.Name));
@@ -110,18 +127,19 @@ internal class AlwaysRunHandler(
         try
         {
             var schedulerProgress = Task.WhenAny(activeModuleTasks);
-            var completedTask = _schedulerProgressTimeout > TimeSpan.Zero
-                ? await schedulerProgress.WaitAsync(_schedulerProgressTimeout).ConfigureAwait(false)
-                : await schedulerProgress.ConfigureAwait(false);
+            var completedTask = await schedulerProgress
+                .WaitAsync(schedulerProgressTimeoutToken)
+                .ConfigureAwait(false);
 
             _ = completedTask.Exception;
             return true;
         }
-        catch (TimeoutException timeoutException)
+        catch (OperationCanceledException operationCanceledException)
+            when (schedulerProgressTimeoutToken.IsCancellationRequested)
         {
             var exception = new TimeoutException(
                 $"Timed out waiting for scheduler progress before retrying AlwaysRun modules: {deferredModuleNames}.",
-                timeoutException);
+                operationCanceledException);
             _logger.LogWarning(exception, "AlwaysRun modules could not be retried");
             exceptions.Enqueue(exception);
             return false;

--- a/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
@@ -51,6 +51,7 @@ internal class AlwaysRunHandler(
             remainingModules.RemoveAll(processedModules.Contains);
 
             if (deferredModules.Count > 0 &&
+                processedModules.Count == 0 &&
                 !await WaitForSchedulerProgressAsync(scheduler, modules, deferredModules, exceptions).ConfigureAwait(false))
             {
                 break;

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -1,0 +1,172 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Configuration;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Execution;
+using ModularPipelines.Helpers;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine.Execution;
+
+public class AlwaysRunHandlerTests
+{
+    [Test]
+    public async Task WaitForAlwaysRunModulesAsync_ExecutesPendingModulesConcurrently()
+    {
+        var firstModule = new FirstAlwaysRunModule();
+        var secondModule = new SecondAlwaysRunModule();
+        var thirdModule = new ThirdAlwaysRunModule();
+        var firstState = new ModuleState(firstModule, firstModule.GetType());
+        var secondState = new ModuleState(secondModule, secondModule.GetType());
+        var thirdState = new ModuleState(thirdModule, thirdModule.GetType());
+        var scheduler = CreateScheduler(firstState, secondState, thirdState);
+        var moduleRunner = new Mock<IModuleRunner>();
+        var releaseExecutions = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var bothStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var executionLock = new object();
+        var activeExecutions = 0;
+        var maximumActiveExecutions = 0;
+
+        moduleRunner
+            .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
+                It.IsAny<ModuleState>(),
+                scheduler.Object,
+                CancellationToken.None))
+            .Returns(async (ModuleState state, IModuleScheduler _, CancellationToken _) =>
+            {
+                lock (executionLock)
+                {
+                    activeExecutions++;
+                    maximumActiveExecutions = Math.Max(maximumActiveExecutions, activeExecutions);
+                    if (activeExecutions == 2)
+                    {
+                        bothStarted.TrySetResult();
+                    }
+                }
+
+                await releaseExecutions.Task;
+                state.State = ModuleExecutionState.Completed;
+                state.CompletionSource.TrySetResult(state.Module);
+
+                lock (executionLock)
+                {
+                    activeExecutions--;
+                }
+            });
+
+        var handler = CreateHandler(moduleRunner.Object);
+        var executionTask = handler.WaitForAlwaysRunModulesAsync(
+            scheduler.Object,
+            [firstModule, secondModule, thirdModule]);
+
+        var ranConcurrently = true;
+        try
+        {
+            await bothStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        catch (TimeoutException)
+        {
+            ranConcurrently = false;
+        }
+        finally
+        {
+            releaseExecutions.TrySetResult();
+            await executionTask;
+        }
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(ranConcurrently).IsTrue();
+            await Assert.That(maximumActiveExecutions).IsEqualTo(2);
+        }
+    }
+
+    [Test]
+    public async Task WaitForAlwaysRunModulesAsync_RetriesDeferredPendingModule()
+    {
+        var module = new FirstAlwaysRunModule();
+        var moduleState = new ModuleState(module, module.GetType());
+        var scheduler = CreateScheduler(moduleState);
+        var moduleRunner = new Mock<IModuleRunner>();
+        var attempts = 0;
+
+        moduleRunner
+            .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
+                moduleState,
+                scheduler.Object,
+                CancellationToken.None))
+            .Returns(() =>
+            {
+                if (Interlocked.Increment(ref attempts) == 2)
+                {
+                    moduleState.State = ModuleExecutionState.Completed;
+                    moduleState.CompletionSource.TrySetResult(module);
+                }
+
+                return Task.CompletedTask;
+            });
+
+        var handler = CreateHandler(moduleRunner.Object);
+
+        await handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [module]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(attempts).IsEqualTo(2);
+            await Assert.That(moduleState.State).IsEqualTo(ModuleExecutionState.Completed);
+        }
+    }
+
+    private static Mock<IModuleScheduler> CreateScheduler(params ModuleState[] moduleStates)
+    {
+        var statesByType = moduleStates.ToDictionary(x => x.ModuleType);
+        var scheduler = new Mock<IModuleScheduler>();
+
+        scheduler
+            .Setup(x => x.GetModuleState(It.IsAny<Type>()))
+            .Returns((Type moduleType) => statesByType.GetValueOrDefault(moduleType));
+        scheduler
+            .Setup(x => x.GetModuleCompletionTask(It.IsAny<Type>()))
+            .Returns((Type moduleType) => statesByType.GetValueOrDefault(moduleType)?.CompletionSource.Task);
+
+        return scheduler;
+    }
+
+    private static AlwaysRunHandler CreateHandler(IModuleRunner moduleRunner)
+    {
+        var parallelLimitProvider = new Mock<IParallelLimitProvider>();
+        parallelLimitProvider
+            .Setup(x => x.GetMaxDegreeOfParallelism())
+            .Returns(2);
+
+        return new AlwaysRunHandler(
+            moduleRunner,
+            parallelLimitProvider.Object,
+            NullLogger<AlwaysRunHandler>.Instance);
+    }
+
+    private abstract class AlwaysRunTestModule : Module<bool>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            return ModuleConfiguration.Create()
+                .WithAlwaysRun()
+                .Build();
+        }
+
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class FirstAlwaysRunModule : AlwaysRunTestModule;
+
+    private sealed class SecondAlwaysRunModule : AlwaysRunTestModule;
+
+    private sealed class ThirdAlwaysRunModule : AlwaysRunTestModule;
+}

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -138,6 +138,52 @@ public class AlwaysRunHandlerTests
     }
 
     [Test]
+    public async Task WaitForAlwaysRunModulesAsync_RetriesDeferredModuleAfterSameBatchProgress()
+    {
+        var firstModule = new FirstAlwaysRunModule();
+        var secondModule = new SecondAlwaysRunModule();
+        var firstState = new ModuleState(firstModule, firstModule.GetType());
+        var secondState = new ModuleState(secondModule, secondModule.GetType());
+        var scheduler = CreateScheduler(firstState, secondState);
+        var moduleRunner = new Mock<IModuleRunner>();
+        var secondAttemptObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+
+        moduleRunner
+            .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
+                It.IsAny<ModuleState>(),
+                scheduler.Object,
+                CancellationToken.None))
+            .Returns(async (ModuleState state, IModuleScheduler _, CancellationToken _) =>
+            {
+                var attempt = Interlocked.Increment(ref attempts);
+                if (attempt == 1)
+                {
+                    await secondAttemptObserved.Task;
+                }
+                else if (attempt == 2)
+                {
+                    secondAttemptObserved.TrySetResult();
+                    return;
+                }
+
+                state.State = ModuleExecutionState.Completed;
+                state.CompletionSource.TrySetResult(state.Module);
+            });
+
+        var handler = CreateHandler(moduleRunner.Object);
+
+        await handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [firstModule, secondModule]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(attempts).IsEqualTo(3);
+            await Assert.That(firstState.State).IsEqualTo(ModuleExecutionState.Completed);
+            await Assert.That(secondState.State).IsEqualTo(ModuleExecutionState.Completed);
+        }
+    }
+
+    [Test]
     public async Task WaitForAlwaysRunModulesAsync_PreservesAlwaysRunDependencyOrder()
     {
         var prerequisite = new FirstAlwaysRunModule();

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -265,6 +265,77 @@ public class AlwaysRunHandlerTests
         await Assert.That(exception!.InnerExceptions).Contains(x => x is TimeoutException);
     }
 
+    [Test]
+    public async Task WaitForAlwaysRunModulesAsync_UsesCumulativeSchedulerProgressTimeout()
+    {
+        var module = new FirstAlwaysRunModule();
+        var firstBlocker = new FirstBlockingModule();
+        var secondBlocker = new SecondBlockingModule();
+        var moduleState = new ModuleState(module, module.GetType());
+        var firstBlockerState = new ModuleState(firstBlocker, firstBlocker.GetType())
+        {
+            State = ModuleExecutionState.Executing,
+        };
+        var secondBlockerState = new ModuleState(secondBlocker, secondBlocker.GetType())
+        {
+            State = ModuleExecutionState.Executing,
+        };
+        var scheduler = CreateScheduler(moduleState, firstBlockerState, secondBlockerState);
+        var moduleRunner = new Mock<IModuleRunner>();
+        var firstWaitObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondWaitObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondBlockerTaskRequests = 0;
+        var attempts = 0;
+
+        scheduler
+            .Setup(x => x.GetModuleCompletionTask(firstBlocker.GetType()))
+            .Callback(() => firstWaitObserved.TrySetResult())
+            .Returns(firstBlockerState.CompletionSource.Task);
+        scheduler
+            .Setup(x => x.GetModuleCompletionTask(secondBlocker.GetType()))
+            .Callback(() =>
+            {
+                if (Interlocked.Increment(ref secondBlockerTaskRequests) == 2)
+                {
+                    secondWaitObserved.TrySetResult();
+                }
+            })
+            .Returns(secondBlockerState.CompletionSource.Task);
+        moduleRunner
+            .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
+                moduleState,
+                scheduler.Object,
+                CancellationToken.None))
+            .Callback(() => Interlocked.Increment(ref attempts))
+            .Returns(Task.CompletedTask);
+
+        var handler = CreateHandler(moduleRunner.Object, TimeSpan.FromMilliseconds(200));
+        var handlerTask = handler.WaitForAlwaysRunModulesAsync(
+            scheduler.Object,
+            [module, firstBlocker, secondBlocker]);
+
+        await firstWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await Task.Delay(TimeSpan.FromMilliseconds(150));
+        firstBlockerState.State = ModuleExecutionState.Completed;
+        firstBlockerState.CompletionSource.TrySetResult(firstBlocker);
+        await secondWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        var completedWithinRemainingBudget = await Task.WhenAny(
+            handlerTask,
+            Task.Delay(TimeSpan.FromMilliseconds(100))) == handlerTask;
+
+        secondBlockerState.State = ModuleExecutionState.Completed;
+        secondBlockerState.CompletionSource.TrySetResult(secondBlocker);
+        var exception = await Assert.ThrowsAsync<AggregateException>(() => handlerTask);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(completedWithinRemainingBudget).IsTrue();
+            await Assert.That(attempts).IsEqualTo(2);
+            await Assert.That(exception!.InnerExceptions).Contains(x => x is TimeoutException);
+        }
+    }
+
     private static Mock<IModuleScheduler> CreateScheduler(params ModuleState[] moduleStates)
     {
         var statesByType = moduleStates.ToDictionary(x => x.ModuleType);
@@ -322,7 +393,7 @@ public class AlwaysRunHandlerTests
 
     private sealed class ThirdAlwaysRunModule : AlwaysRunTestModule;
 
-    private sealed class BlockingModule : Module<bool>
+    private class BlockingModule : Module<bool>
     {
         protected internal override Task<bool> ExecuteAsync(
             IModuleContext context,
@@ -331,4 +402,8 @@ public class AlwaysRunHandlerTests
             return Task.FromResult(true);
         }
     }
+
+    private sealed class FirstBlockingModule : BlockingModule;
+
+    private sealed class SecondBlockingModule : BlockingModule;
 }

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -6,6 +6,7 @@ using ModularPipelines.Engine.Execution;
 using ModularPipelines.Helpers;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 using Moq;
 
 namespace ModularPipelines.UnitTests.Engine.Execution;
@@ -87,11 +88,21 @@ public class AlwaysRunHandlerTests
     public async Task WaitForAlwaysRunModulesAsync_RetriesDeferredPendingModule()
     {
         var module = new FirstAlwaysRunModule();
+        var blocker = new BlockingModule();
         var moduleState = new ModuleState(module, module.GetType());
-        var scheduler = CreateScheduler(moduleState);
+        var blockerState = new ModuleState(blocker, blocker.GetType())
+        {
+            State = ModuleExecutionState.Executing,
+        };
+        var scheduler = CreateScheduler(moduleState, blockerState);
         var moduleRunner = new Mock<IModuleRunner>();
+        var blockerWaitObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var attempts = 0;
 
+        scheduler
+            .Setup(x => x.GetModuleCompletionTask(blocker.GetType()))
+            .Callback(() => blockerWaitObserved.TrySetResult())
+            .Returns(blockerState.CompletionSource.Task);
         moduleRunner
             .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
                 moduleState,
@@ -110,13 +121,102 @@ public class AlwaysRunHandlerTests
 
         var handler = CreateHandler(moduleRunner.Object);
 
-        await handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [module]);
+        var handlerTask = handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [module, blocker]);
+        await blockerWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var attemptsBeforeProgress = attempts;
+
+        blockerState.State = ModuleExecutionState.Completed;
+        blockerState.CompletionSource.TrySetResult(blocker);
+        await handlerTask;
 
         using (Assert.Multiple())
         {
+            await Assert.That(attemptsBeforeProgress).IsEqualTo(1);
             await Assert.That(attempts).IsEqualTo(2);
             await Assert.That(moduleState.State).IsEqualTo(ModuleExecutionState.Completed);
         }
+    }
+
+    [Test]
+    public async Task WaitForAlwaysRunModulesAsync_PreservesAlwaysRunDependencyOrder()
+    {
+        var prerequisite = new FirstAlwaysRunModule();
+        var dependent = new SecondAlwaysRunModule();
+        var prerequisiteState = new ModuleState(prerequisite, prerequisite.GetType());
+        var dependentState = new ModuleState(dependent, dependent.GetType());
+        dependentState.Dependencies[prerequisite.GetType()] = false;
+        var scheduler = CreateScheduler(prerequisiteState, dependentState);
+        var moduleRunner = new Mock<IModuleRunner>();
+        var prerequisiteStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releasePrerequisite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var dependentStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        moduleRunner
+            .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
+                prerequisiteState,
+                scheduler.Object,
+                CancellationToken.None))
+            .Returns(async () =>
+            {
+                prerequisiteStarted.TrySetResult();
+                await releasePrerequisite.Task;
+                prerequisiteState.State = ModuleExecutionState.Completed;
+                prerequisiteState.CompletionSource.TrySetResult(prerequisite);
+            });
+        moduleRunner
+            .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
+                dependentState,
+                scheduler.Object,
+                CancellationToken.None))
+            .Returns(() =>
+            {
+                dependentStarted.TrySetResult();
+                dependentState.State = ModuleExecutionState.Completed;
+                dependentState.CompletionSource.TrySetResult(dependent);
+                return Task.CompletedTask;
+            });
+
+        var handler = CreateHandler(moduleRunner.Object);
+        var handlerTask = handler.WaitForAlwaysRunModulesAsync(
+            scheduler.Object,
+            [prerequisite, dependent]);
+
+        await prerequisiteStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var dependentStartedBeforePrerequisiteCompleted = await Task.WhenAny(
+            dependentStarted.Task,
+            Task.Delay(TimeSpan.FromMilliseconds(200))) == dependentStarted.Task;
+        releasePrerequisite.TrySetResult();
+        await handlerTask;
+
+        await Assert.That(dependentStartedBeforePrerequisiteCompleted).IsFalse();
+    }
+
+    [Test]
+    public async Task WaitForAlwaysRunModulesAsync_TimesOutWhenSchedulerCannotMakeProgress()
+    {
+        var module = new FirstAlwaysRunModule();
+        var blocker = new BlockingModule();
+        var moduleState = new ModuleState(module, module.GetType());
+        var blockerState = new ModuleState(blocker, blocker.GetType())
+        {
+            State = ModuleExecutionState.Executing,
+        };
+        var scheduler = CreateScheduler(moduleState, blockerState);
+        var moduleRunner = new Mock<IModuleRunner>();
+
+        moduleRunner
+            .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
+                moduleState,
+                scheduler.Object,
+                CancellationToken.None))
+            .Returns(Task.CompletedTask);
+
+        var handler = CreateHandler(moduleRunner.Object, TimeSpan.FromMilliseconds(50));
+
+        var exception = await Assert.ThrowsAsync<AggregateException>(() =>
+            handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [module, blocker]));
+
+        await Assert.That(exception!.InnerExceptions).Contains(x => x is TimeoutException);
     }
 
     private static Mock<IModuleScheduler> CreateScheduler(params ModuleState[] moduleStates)
@@ -134,7 +234,9 @@ public class AlwaysRunHandlerTests
         return scheduler;
     }
 
-    private static AlwaysRunHandler CreateHandler(IModuleRunner moduleRunner)
+    private static AlwaysRunHandler CreateHandler(
+        IModuleRunner moduleRunner,
+        TimeSpan? schedulerProgressTimeout = null)
     {
         var parallelLimitProvider = new Mock<IParallelLimitProvider>();
         parallelLimitProvider
@@ -144,6 +246,10 @@ public class AlwaysRunHandlerTests
         return new AlwaysRunHandler(
             moduleRunner,
             parallelLimitProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                DefaultModuleTimeout = schedulerProgressTimeout ?? TimeSpan.FromSeconds(2),
+            }),
             NullLogger<AlwaysRunHandler>.Instance);
     }
 
@@ -169,4 +275,14 @@ public class AlwaysRunHandlerTests
     private sealed class SecondAlwaysRunModule : AlwaysRunTestModule;
 
     private sealed class ThirdAlwaysRunModule : AlwaysRunTestModule;
+
+    private sealed class BlockingModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- run late AlwaysRun cleanup modules with the configured normal parallel limit
- retry cleanup modules deferred by scheduler execution constraints
- preserve constraint enforcement while ensuring deferred cleanup does not silently no-op

## Validation
- added failing-first tests for bounded concurrency and deferred retry
- `AlwaysRunHandlerTests`: 2 passed
- `AlwaysRunTests/*`: 1 passed
- targeted `dotnet format`: passed
- core Release build: 0 warnings, 0 errors

Closes #3253