### PR TITLE
Run scheduler continuations asynchronously

### DIFF
--- a/src/ModularPipelines/Console/ProgressSession.cs
+++ b/src/ModularPipelines/Console/ProgressSession.cs
@@ -43,7 +43,7 @@ internal class ProgressSession : IProgressSession, IProgressController
 
     private ProgressContext? _progressContext;
     private ProgressTask? _totalTask;
-    private readonly TaskCompletionSource _progressCompleted = new();
+    private readonly TaskCompletionSource _progressCompleted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private int _totalModuleCount;
     private int _completedModuleCount;
 

--- a/src/ModularPipelines/Engine/IModuleResultRegistry.cs
+++ b/src/ModularPipelines/Engine/IModuleResultRegistry.cs
@@ -170,7 +170,7 @@ internal class ModuleResultRegistry : IModuleResultRegistry
     /// </remarks>
     public void RegisterModule(Type moduleType)
     {
-        _completionSources.GetOrAdd(moduleType, _ => new TaskCompletionSource<object?>());
+        _completionSources.GetOrAdd(moduleType, CreateCompletionSource);
     }
 
     /// <inheritdoc />
@@ -191,7 +191,7 @@ internal class ModuleResultRegistry : IModuleResultRegistry
         // Get or create TCS first - this ensures it exists before we store the result
         // Critical: TCS must be retrieved BEFORE storing the result to ensure proper
         // happens-before ordering when awaiters check _results after TCS completion
-        var tcs = _completionSources.GetOrAdd(moduleType, _ => new TaskCompletionSource<object?>());
+        var tcs = _completionSources.GetOrAdd(moduleType, CreateCompletionSource);
 
         // Store result
         _results[moduleType] = result;
@@ -299,7 +299,7 @@ internal class ModuleResultRegistry : IModuleResultRegistry
         // Get or create TCS first - this ensures it exists before we store the result
         // Critical: TCS must be retrieved BEFORE storing the result to ensure proper
         // happens-before ordering when awaiters check _results after TCS completion
-        var tcs = _completionSources.GetOrAdd(moduleType, _ => new TaskCompletionSource<object?>());
+        var tcs = _completionSources.GetOrAdd(moduleType, CreateCompletionSource);
 
         // Store result
         _results[moduleType] = result;
@@ -311,4 +311,7 @@ internal class ModuleResultRegistry : IModuleResultRegistry
         // Now signal completion - awaiters are guaranteed to see the result
         tcs.TrySetResult(result);
     }
+
+    private static TaskCompletionSource<object?> CreateCompletionSource(Type _) =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 }

--- a/src/ModularPipelines/Engine/ModuleState.cs
+++ b/src/ModularPipelines/Engine/ModuleState.cs
@@ -49,7 +49,7 @@ internal class ModuleState
     {
         Module = module;
         ModuleType = moduleType;
-        CompletionSource = new TaskCompletionSource<IModule>();
+        CompletionSource = new TaskCompletionSource<IModule>(TaskCreationOptions.RunContinuationsAsynchronously);
         Dependencies = new Dictionary<Type, bool>();
         UnresolvedDependencies = new HashSet<Type>();
         DependentModules = new List<ModuleState>();

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -177,19 +177,6 @@ internal class ModuleStateTracker : IModuleStateTracker
             queuedCount = _queuedModules.Count;
             executingCount = _executingModules.Count;
 
-            if (success)
-            {
-                state.CompletionSource.TrySetResult(state.Module);
-            }
-            else if (exception != null)
-            {
-                state.CompletionSource.TrySetException(exception);
-            }
-            else
-            {
-                state.CompletionSource.TrySetCanceled();
-            }
-
             // Process dependent modules and capture updates for logging outside lock
             dependentUpdates = ProcessDependentModules(state, moduleType);
 
@@ -198,6 +185,19 @@ internal class ModuleStateTracker : IModuleStateTracker
         finally
         {
             _stateLock.ExitWriteLock();
+        }
+
+        if (success)
+        {
+            state.CompletionSource.TrySetResult(state.Module);
+        }
+        else if (exception != null)
+        {
+            state.CompletionSource.TrySetException(exception);
+        }
+        else
+        {
+            state.CompletionSource.TrySetCanceled();
         }
 
         // Record metrics outside lock to prevent lock recursion
@@ -253,7 +253,6 @@ internal class ModuleStateTracker : IModuleStateTracker
                     _queuedModules.Remove(moduleState);
                     _executingModules.Remove(moduleState);
                     moduleState.State = ModuleExecutionState.Completed;
-                    moduleState.CompletionSource.TrySetCanceled();
                     cancelledModules.Add((moduleState, originalState));
                 }
             }
@@ -261,6 +260,11 @@ internal class ModuleStateTracker : IModuleStateTracker
         finally
         {
             _stateLock.ExitWriteLock();
+        }
+
+        foreach (var (moduleState, _) in cancelledModules)
+        {
+            moduleState.CompletionSource.TrySetCanceled();
         }
 
         // Logging outside lock

--- a/test/ModularPipelines.UnitTests/Engine/TaskCompletionSourceTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/TaskCompletionSourceTests.cs
@@ -1,0 +1,48 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Console;
+using ModularPipelines.Engine;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class TaskCompletionSourceTests
+{
+    [Test]
+    public async Task ModuleState_CompletionSource_RunsContinuationsAsynchronously()
+    {
+        var state = new ModuleState(Mock.Of<IModule>(), typeof(IModule));
+
+        await Assert.That(RunsContinuationsAsynchronously(state.CompletionSource.Task)).IsTrue();
+    }
+
+    [Test]
+    public async Task ModuleResultRegistry_CompletionSource_RunsContinuationsAsynchronously()
+    {
+        var registry = new ModuleResultRegistry();
+        registry.RegisterModule(typeof(IModule));
+
+        await Assert.That(RunsContinuationsAsynchronously(registry.GetCompletionTask(typeof(IModule))!)).IsTrue();
+    }
+
+    [Test]
+    public async Task ProgressSession_CompletionSource_RunsContinuationsAsynchronously()
+    {
+        var session = new ProgressSession(
+            null!,
+            new OrganizedModules([], []),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
+            NullLoggerFactory.Instance,
+            CancellationToken.None);
+        var field = typeof(ProgressSession).GetField("_progressCompleted", BindingFlags.Instance | BindingFlags.NonPublic);
+        var completionSource = (TaskCompletionSource) field!.GetValue(session)!;
+
+        await Assert.That(RunsContinuationsAsynchronously(completionSource.Task)).IsTrue();
+    }
+
+    private static bool RunsContinuationsAsynchronously(Task task) =>
+        task.CreationOptions.HasFlag(TaskCreationOptions.RunContinuationsAsynchronously);
+}


### PR DESCRIPTION
## Summary
- run scheduler, result-registry, and progress completion continuations asynchronously
- complete and cancel scheduler tasks only after releasing the state write lock
- cover every named completion-source construction site with focused regressions

## Validation
- TaskCompletionSourceTests: 3 passed
- ModuleExecutorLoggingTests: 3 passed
- ModularPipelines.sln Release build: 0 errors

Closes #3240