### PR TITLE
Unify typed module result contracts

### DIFF
--- a/src/ModularPipelines/Context/IModuleContext.cs
+++ b/src/ModularPipelines/Context/IModuleContext.cs
@@ -83,7 +83,7 @@ public interface IModuleContext : IPipelineContext
     ///         var buildResult = await context.GetModule&lt;BuildModule&gt;();
     ///         // buildResult is ModuleResult&lt;BuildOutput&gt;
     ///
-    ///         if (buildResult.TryGetValue(out var buildOutput))
+    ///         if (buildResult.TryGetValue(out var buildOutput) &amp;&amp; buildOutput is not null)
     ///         {
     ///             var artifactPath = buildOutput.ArtifactPath;
     ///             return await Deploy(artifactPath);

--- a/src/ModularPipelines/Context/IModuleContext.cs
+++ b/src/ModularPipelines/Context/IModuleContext.cs
@@ -81,11 +81,11 @@ public interface IModuleContext : IPipelineContext
     ///     {
     ///         // Single type parameter - result type inferred from BuildModule : Module&lt;BuildOutput&gt;
     ///         var buildResult = await context.GetModule&lt;BuildModule&gt;();
-    ///         // buildResult is ModuleResult&lt;BuildOutput?&gt;
+    ///         // buildResult is ModuleResult&lt;BuildOutput&gt;
     ///
-    ///         if (buildResult.IsSuccess)
+    ///         if (buildResult.TryGetValue(out var buildOutput))
     ///         {
-    ///             var artifactPath = buildResult.ValueOrDefault!.ArtifactPath;
+    ///             var artifactPath = buildOutput.ArtifactPath;
     ///             return await Deploy(artifactPath);
     ///         }
     ///
@@ -96,7 +96,7 @@ public interface IModuleContext : IPipelineContext
     /// <para>
     /// <b>How it works:</b> The module class hierarchy encodes the result type.
     /// When <c>BuildModule : Module&lt;BuildOutput&gt;</c>, awaiting the module
-    /// returns <c>ModuleResult&lt;BuildOutput?&gt;</c> because <see cref="Module{T}"/>
+    /// returns <c>ModuleResult&lt;BuildOutput&gt;</c> because <see cref="Module{T}"/>
     /// implements <see cref="Module{T}.GetAwaiter"/>.
     /// </para>
     /// <para>

--- a/src/ModularPipelines/Engine/Execution/ModuleResultFactory.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleResultFactory.cs
@@ -11,7 +11,7 @@ internal static class ModuleResultFactory
     /// <summary>
     /// Creates a successful ModuleResult for the specified value.
     /// </summary>
-    public static ModuleResult<T> CreateSuccess<T>(T value, ModuleExecutionContext ctx)
+    public static ModuleResult<T> CreateSuccess<T>(T? value, ModuleExecutionContext ctx)
     {
         return ModuleResult<T>.CreateSuccess(value, ctx);
     }

--- a/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
@@ -184,7 +184,7 @@ internal static class CompletionSourceSetterCache
 
     private static Action<IModule, IModuleResult> CreateSetter(Type resultType)
     {
-        // Create compiled delegate for: ((Module<T>)module).CompletionSource.TrySetResult((ModuleResult<T?>)result)
+        // Create compiled delegate for: ((Module<T>)module).CompletionSource.TrySetResult((ModuleResult<T>)result)
         var moduleType = typeof(Module<>).MakeGenericType(resultType);
 
         // Parameters
@@ -203,9 +203,9 @@ internal static class CompletionSourceSetterCache
         // Get the actual property type and its TrySetResult method
         // This ensures we use the correct generic type as declared on the property
         var completionSourceType = completionSourceProp.PropertyType;
-        var moduleResultType = completionSourceType.GetGenericArguments()[0]; // ModuleResult<T?>
+        var moduleResultType = completionSourceType.GetGenericArguments()[0]; // ModuleResult<T>
 
-        // Cast result to ModuleResult<T?>
+        // Cast result to ModuleResult<T>
         var castResult = Expression.Convert(resultParam, moduleResultType);
 
         // Call TrySetResult using the method from the actual property type

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -129,7 +129,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             executionContext.RecordEndTime();
             executionContext.Status = Status.Successful;
 
-            moduleResult = ModuleResult<T>.CreateSuccess(result!, executionContext);
+            moduleResult = ModuleResult<T>.CreateSuccess(result, executionContext);
 
             module.CompletionSource.TrySetResult(moduleResult!);
 

--- a/src/ModularPipelines/Models/ModuleResult.cs
+++ b/src/ModularPipelines/Models/ModuleResult.cs
@@ -277,6 +277,26 @@ public abstract record ModuleResult<T> : ModuleResult
     [JsonIgnore]
     public T? ValueOrDefault => this is Success s ? s.Value : default;
 
+    /// <summary>
+    /// Attempts to get the successful value.
+    /// </summary>
+    /// <param name="value">
+    /// When this method returns <c>true</c>, contains the successful value;
+    /// otherwise, contains the default value for <typeparamref name="T"/>.
+    /// </param>
+    /// <returns><c>true</c> for a successful result; otherwise, <c>false</c>.</returns>
+    public bool TryGetValue([MaybeNullWhen(false)] out T value)
+    {
+        if (this is Success success)
+        {
+            value = success.Value;
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
     /// <inheritdoc />
     protected override object? GetValueOrDefault() => ValueOrDefault;
 

--- a/src/ModularPipelines/Models/ModuleResult.cs
+++ b/src/ModularPipelines/Models/ModuleResult.cs
@@ -281,11 +281,12 @@ public abstract record ModuleResult<T> : ModuleResult
     /// Attempts to get the successful value.
     /// </summary>
     /// <param name="value">
-    /// When this method returns <c>true</c>, contains the successful value;
+    /// When this method returns <c>true</c>, contains the successful value, which may
+    /// be <c>null</c> when the module returned <c>null</c>;
     /// otherwise, contains the default value for <typeparamref name="T"/>.
     /// </param>
     /// <returns><c>true</c> for a successful result; otherwise, <c>false</c>.</returns>
-    public bool TryGetValue([MaybeNullWhen(false)] out T value)
+    public bool TryGetValue(out T? value)
     {
         if (this is Success success)
         {
@@ -311,7 +312,7 @@ public abstract record ModuleResult<T> : ModuleResult
     /// <param name="onSkipped">Function to call if skipped.</param>
     /// <returns>The result of the matched function.</returns>
     public TResult Match<TResult>(
-        Func<T, TResult> onSuccess,
+        Func<T?, TResult> onSuccess,
         Func<Exception, TResult> onFailure,
         Func<SkipDecision, TResult> onSkipped) => this switch
         {
@@ -330,7 +331,7 @@ public abstract record ModuleResult<T> : ModuleResult
     /// <param name="onFailure">Action to call if failed.</param>
     /// <param name="onSkipped">Action to call if skipped.</param>
     public void Switch(
-        Action<T> onSuccess,
+        Action<T?> onSuccess,
         Action<Exception> onFailure,
         Action<SkipDecision> onSkipped)
     {
@@ -359,8 +360,8 @@ public abstract record ModuleResult<T> : ModuleResult
     /// <summary>
     /// Represents a successful module execution with a value.
     /// </summary>
-    /// <param name="Value">The value produced by the module.</param>
-    public sealed record Success(T Value) : ModuleResult<T>, ISuccessResult;
+    /// <param name="Value">The value produced by the module, which may be <c>null</c>.</param>
+    public sealed record Success(T? Value) : ModuleResult<T>, ISuccessResult;
 
     // === Implicit conversions from non-generic Failure/Skipped ===
 
@@ -434,7 +435,7 @@ public abstract record ModuleResult<T> : ModuleResult
 
     // === Internal factory methods ===
 
-    internal static Success CreateSuccess(T value, ModuleExecutionContext ctx)
+    internal static Success CreateSuccess(T? value, ModuleExecutionContext ctx)
     {
         var (start, end, duration) = GetTimingInfo(ctx);
         return new(value)
@@ -880,7 +881,7 @@ internal sealed class ModuleResultJsonConverter<T> : JsonConverter<ModuleResult<
 
         return discriminator switch
         {
-            "Success" => new ModuleResult<T>.Success(value!)
+            "Success" => new ModuleResult<T>.Success(value)
             {
                 ModuleName = moduleName,
                 ModuleTypeName = moduleTypeName,

--- a/src/ModularPipelines/Modules/Module.cs
+++ b/src/ModularPipelines/Modules/Module.cs
@@ -54,7 +54,7 @@ namespace ModularPipelines.Modules;
 /// </example>
 public abstract class Module<T> : IModule, ITaggedModule
 {
-    internal TaskCompletionSource<ModuleResult<T?>> CompletionSource { get; } = new();
+    internal TaskCompletionSource<ModuleResult<T>> CompletionSource { get; } = new();
 
     /// <inheritdoc />
     Task<IModuleResult> IModule.ResultTask => CompletionSource.Task.ContinueWith(
@@ -296,11 +296,11 @@ public abstract class Module<T> : IModule, ITaggedModule
     /// <inheritdoc />
     bool IModule.TrySetDistributedResult(IModuleResult result)
     {
-        return CompletionSource.TrySetResult((ModuleResult<T?>) result);
+        return CompletionSource.TrySetResult((ModuleResult<T>) result);
     }
 
     /// <summary>
     /// Gets an awaiter for this module's result.
     /// </summary>
-    public TaskAwaiter<ModuleResult<T?>> GetAwaiter() => CompletionSource.Task.GetAwaiter();
+    public TaskAwaiter<ModuleResult<T>> GetAwaiter() => CompletionSource.Task.GetAwaiter();
 }

--- a/test/ModularPipelines.TestHelpers/Assertions/ModuleResultAssertions.cs
+++ b/test/ModularPipelines.TestHelpers/Assertions/ModuleResultAssertions.cs
@@ -13,10 +13,10 @@ public static class ModuleResultAssertions
     /// Checks: ModuleResultType is Success, Exception is null, Value is not null.
     /// </summary>
     /// <remarks>
-    /// The signature uses <c>ModuleResult&lt;T?&gt;</c> because <see cref="Module{T}.GetAwaiter()"/>
-    /// returns <c>ModuleResult&lt;T?&gt;</c>, matching the nullable return type of ExecuteAsync.
+    /// The signature matches the <c>ModuleResult&lt;T&gt;</c> returned by
+    /// <see cref="Module{T}.GetAwaiter"/>.
     /// </remarks>
-    public static async Task AssertSuccessWithValue<T>(ModuleResult<T?> moduleResult)
+    public static async Task AssertSuccessWithValue<T>(ModuleResult<T> moduleResult)
         where T : class
     {
         using (Assert.Multiple())
@@ -32,10 +32,10 @@ public static class ModuleResultAssertions
     /// Checks: ModuleResultType is Success, Exception is null.
     /// </summary>
     /// <remarks>
-    /// The signature uses <c>ModuleResult&lt;T?&gt;</c> because <see cref="Module{T}.GetAwaiter()"/>
-    /// returns <c>ModuleResult&lt;T?&gt;</c>, matching the nullable return type of ExecuteAsync.
+    /// The signature matches the <c>ModuleResult&lt;T&gt;</c> returned by
+    /// <see cref="Module{T}.GetAwaiter"/>.
     /// </remarks>
-    public static async Task AssertSuccess<T>(ModuleResult<T?> moduleResult)
+    public static async Task AssertSuccess<T>(ModuleResult<T> moduleResult)
         where T : class
     {
         using (Assert.Multiple())
@@ -51,7 +51,7 @@ public static class ModuleResultAssertions
     /// </summary>
     /// <param name="moduleResult">The module result containing a CommandResult.</param>
     /// <param name="expectedOutput">The expected standard output value (will be compared after trimming).</param>
-    public static async Task AssertCommandOutput(ModuleResult<CommandResult?> moduleResult, string expectedOutput)
+    public static async Task AssertCommandOutput(ModuleResult<CommandResult> moduleResult, string expectedOutput)
     {
         using (Assert.Multiple())
         {

--- a/test/ModularPipelines.UnitTests/Dependencies/SingleTypeParameterGetModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/SingleTypeParameterGetModuleTests.cs
@@ -56,7 +56,7 @@ public class SingleTypeParameterGetModuleTests : TestBase
             // Use the new single-type-parameter API
             var result = await context.GetModule<StringModule>();
 
-            // Verify the result is properly typed (ModuleResult<string?>)
+            // Verify the result is properly typed (ModuleResult<string>)
             if (result.IsSuccess)
             {
                 return result.ValueOrDefault;
@@ -74,7 +74,7 @@ public class SingleTypeParameterGetModuleTests : TestBase
     {
         protected internal override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            // Type inference should work: result is ModuleResult<ComplexResult?>
+            // Type inference should work: result is ModuleResult<ComplexResult>
             var result = await context.GetModule<ComplexResultModule>();
 
             if (result.IsSuccess && result.ValueOrDefault is not null)

--- a/test/ModularPipelines.UnitTests/Modules/ModuleResultContractTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/ModuleResultContractTests.cs
@@ -44,7 +44,7 @@ public class ModuleResultContractTests
     [Test]
     public async Task NullSuccess_TryGetValue_ReturnsTrue()
     {
-        ModuleResult<string> result = new ModuleResult<string>.Success(null!)
+        ModuleResult<string> result = new ModuleResult<string>.Success(null)
         {
             ModuleName = "NullableModule",
             ModuleDuration = TimeSpan.Zero,
@@ -59,6 +59,11 @@ public class ModuleResultContractTests
         {
             await Assert.That(hasValue).IsTrue();
             await Assert.That(value).IsNull();
+            await Assert.That(((ModuleResult<string>.Success) result).Value).IsNull();
+            await Assert.That(result.Match(
+                onSuccess: success => success,
+                onFailure: _ => "failure",
+                onSkipped: _ => "skipped")).IsNull();
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Modules/ModuleResultContractTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/ModuleResultContractTests.cs
@@ -1,0 +1,98 @@
+using ModularPipelines.Context;
+using ModularPipelines.Distributed;
+using ModularPipelines.Enums;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.UnitTests.Modules;
+
+public class ModuleResultContractTests
+{
+    [Test]
+    public async Task DistributedValueTypeResult_AppliesToModule()
+    {
+        var module = new IntModule();
+        var distributedResult = CreateSuccess(42);
+
+        var applied = ModuleCompletionSourceApplicator.TryApply(module, distributedResult);
+        var result = await module;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(applied).IsTrue();
+            await Assert.That(result).IsSameReferenceAs(distributedResult);
+            await Assert.That(result.TryGetValue(out var value)).IsTrue();
+            await Assert.That(value).IsEqualTo(42);
+            await Assert.That(((ModuleResult<int>.Success) result).Value).IsEqualTo(42);
+        }
+    }
+
+    [Test]
+    public async Task Failure_TryGetValue_ReturnsFalse()
+    {
+        ModuleResult<int> result = CreateFailure();
+
+        var hasValue = result.TryGetValue(out var value);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(hasValue).IsFalse();
+            await Assert.That(value).IsEqualTo(default);
+        }
+    }
+
+    [Test]
+    public async Task NullSuccess_TryGetValue_ReturnsTrue()
+    {
+        ModuleResult<string> result = new ModuleResult<string>.Success(null!)
+        {
+            ModuleName = "NullableModule",
+            ModuleDuration = TimeSpan.Zero,
+            ModuleStart = DateTimeOffset.UtcNow,
+            ModuleEnd = DateTimeOffset.UtcNow,
+            ModuleStatus = Status.Successful,
+        };
+
+        var hasValue = result.TryGetValue(out var value);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(hasValue).IsTrue();
+            await Assert.That(value).IsNull();
+        }
+    }
+
+    private static ModuleResult<int>.Success CreateSuccess(int value)
+    {
+        return new ModuleResult<int>.Success(value)
+        {
+            ModuleName = nameof(IntModule),
+            ModuleDuration = TimeSpan.Zero,
+            ModuleStart = DateTimeOffset.UtcNow,
+            ModuleEnd = DateTimeOffset.UtcNow,
+            ModuleStatus = Status.Successful,
+        };
+    }
+
+    private static ModuleResult<int> CreateFailure()
+    {
+        return new ModuleResult.Failure(new InvalidOperationException("Failed"))
+        {
+            ModuleName = nameof(IntModule),
+            ModuleDuration = TimeSpan.Zero,
+            ModuleStart = DateTimeOffset.UtcNow,
+            ModuleEnd = DateTimeOffset.UtcNow,
+            ModuleStatus = Status.Failed,
+        };
+    }
+
+    private sealed class IntModule : Module<int>
+    {
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(42);
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Results/ReturnNothingTests.cs
+++ b/test/ModularPipelines.UnitTests/Results/ReturnNothingTests.cs
@@ -44,7 +44,7 @@ public class ReturnNothingTests : TestBase
         await Assert(result);
     }
 
-    private static async Task Assert(ModuleResult<CommandResult?> result)
+    private static async Task Assert(ModuleResult<CommandResult> result)
     {
         using (TUnit.Assertions.Assert.Multiple())
         {


### PR DESCRIPTION
## Summary
- normalize `Module<T>` completion, awaiter, and distributed-result contracts to `ModuleResult<T>`
- add `TryGetValue(out T)` while retaining `Success.Value` and `ValueOrDefault`
- update API examples and test helpers to use the unified result type

## Validation
- failing-first compile: `TryGetValue` was absent
- `ModuleResultContractTests`: 3 passed
- `SingleTypeParameterGetModuleTests`: 6 passed
- `ReturnNothingTests`: 3 passed
- `IgnoredModuleResultRegistrarTests`: 1 passed
- `JsonSerializationTests`: 1 passed
- `ModularPipelines.sln` Release build: 0 errors (247 existing warnings)

Closes #3279