### PR TITLE
Kill command descendant processes on cancellation

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -1,8 +1,11 @@
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 using CliWrap;
 using CliWrap.Exceptions;
+using Microsoft.Win32.SafeHandles;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.Engine;
 using ModularPipelines.Exceptions;
@@ -117,7 +120,7 @@ internal sealed class Command : ICommand, ICommandContext
             : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         using var forcefulCancellationToken = new CancellationTokenSource();
-        var processTreeTerminator = new ProcessTreeTerminator();
+        using var processTreeTerminator = new ProcessTreeTerminator();
         using var processTreeCancellationRegistration =
             forcefulCancellationToken.Token.Register(processTreeTerminator.Kill);
 
@@ -139,7 +142,7 @@ internal sealed class Command : ICommand, ICommandContext
         {
             try
             {
-                var result = await command
+                var executionTask = command
                     .WithStandardOutputPipe(PipeTarget.ToStringBuilder(standardOutputStringBuilder))
                     .WithStandardErrorPipe(PipeTarget.ToStringBuilder(standardErrorStringBuilder))
                     .WithValidation(CommandResultValidation.None)
@@ -153,8 +156,14 @@ internal sealed class Command : ICommand, ICommandContext
                         },
                         configureProcess: processTreeTerminator.Attach,
                         forcefulCancellationToken: CancellationToken.None,
-                        gracefulCancellationToken: linkedCancellationToken.Token)
-                    .ConfigureAwait(false);
+                        gracefulCancellationToken: linkedCancellationToken.Token);
+                using var descendantCaptureRegistration =
+                    linkedCancellationToken.Token.Register(processTreeTerminator.CaptureDescendants);
+                var result = await executionTask.ConfigureAwait(false);
+
+                await WaitForForcefulCancellationAsync(
+                    linkedCancellationToken.Token,
+                    forcefulCancellationToken.Token).ConfigureAwait(false);
 
                 standardOutput = standardOutputStringBuilder.ToString();
                 standardError = standardErrorStringBuilder.ToString();
@@ -180,6 +189,10 @@ internal sealed class Command : ICommand, ICommandContext
             }
             catch (CommandExecutionException e)
             {
+                await WaitForForcefulCancellationAsync(
+                    linkedCancellationToken.Token,
+                    forcefulCancellationToken.Token).ConfigureAwait(false);
+
                 standardOutput = standardOutputStringBuilder.ToString();
                 standardError = standardErrorStringBuilder.ToString();
 
@@ -198,6 +211,10 @@ internal sealed class Command : ICommand, ICommandContext
             }
             catch (Exception e) when (e is not CommandExecutionException and not CommandException)
             {
+                await WaitForForcefulCancellationAsync(
+                    linkedCancellationToken.Token,
+                    forcefulCancellationToken.Token).ConfigureAwait(false);
+
                 standardOutput = standardOutputStringBuilder.ToString();
                 standardError = standardErrorStringBuilder.ToString();
 
@@ -217,17 +234,42 @@ internal sealed class Command : ICommand, ICommandContext
         }
     }
 
-    private sealed class ProcessTreeTerminator
+    private static async Task WaitForForcefulCancellationAsync(
+        CancellationToken gracefulCancellationToken,
+        CancellationToken forcefulCancellationToken)
+    {
+        if (!gracefulCancellationToken.IsCancellationRequested ||
+            forcefulCancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        try
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, forcefulCancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (forcefulCancellationToken.IsCancellationRequested)
+        {
+            // The graceful shutdown window elapsed.
+        }
+    }
+
+    private sealed class ProcessTreeTerminator : IDisposable
     {
         private readonly Lock _lock = new();
+        private readonly Dictionary<int, Process> _descendants = [];
         private Process? _process;
+        private SafeFileHandle? _windowsJob;
         private bool _killRequested;
 
         public void Attach(Process process)
         {
+            var windowsJob = OperatingSystem.IsWindows() ? TryCreateWindowsJob(process) : null;
+
             lock (_lock)
             {
                 _process = process;
+                _windowsJob = windowsJob;
 
                 if (!_killRequested)
                 {
@@ -235,29 +277,209 @@ internal sealed class Command : ICommand, ICommandContext
                 }
             }
 
-            TryKill(process);
+            TryKill(process, windowsJob);
+        }
+
+        public void CaptureDescendants()
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                return;
+            }
+
+            Process? process;
+
+            lock (_lock)
+            {
+                process = _process;
+            }
+
+            if (process is null)
+            {
+                return;
+            }
+
+            try
+            {
+                foreach (var processId in GetDescendantProcessIds(process.Id))
+                {
+                    Process? descendant = null;
+
+                    try
+                    {
+                        descendant = Process.GetProcessById(processId);
+                        var capturedDescendant = descendant;
+                        var killDescendant = false;
+
+                        lock (_lock)
+                        {
+                            if (_descendants.TryAdd(processId, descendant))
+                            {
+                                killDescendant = _killRequested;
+                            }
+                            else
+                            {
+                                descendant.Dispose();
+                            }
+
+                            descendant = null;
+                        }
+
+                        if (killDescendant)
+                        {
+                            TryKill(capturedDescendant, null);
+                        }
+                    }
+                    catch (ArgumentException)
+                    {
+                        // The descendant exited while it was being captured.
+                    }
+                    finally
+                    {
+                        descendant?.Dispose();
+                    }
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // The root process exited before its descendants could be captured.
+            }
         }
 
         public void Kill()
         {
             Process? process;
+            SafeFileHandle? windowsJob;
+            Process[] descendants;
 
             lock (_lock)
             {
                 _killRequested = true;
                 process = _process;
+                windowsJob = _windowsJob;
+                descendants = [.. _descendants.Values];
             }
 
             if (process is not null)
             {
-                TryKill(process);
+                TryKill(process, windowsJob);
+            }
+
+            foreach (var descendant in descendants)
+            {
+                TryKill(descendant, null);
             }
         }
 
-        private static void TryKill(Process process)
+        public void Dispose()
+        {
+            SafeFileHandle? windowsJob;
+            Process[] descendants;
+
+            lock (_lock)
+            {
+                windowsJob = _windowsJob;
+                descendants = [.. _descendants.Values];
+                _windowsJob = null;
+                _process = null;
+                _descendants.Clear();
+            }
+
+            windowsJob?.Dispose();
+
+            foreach (var descendant in descendants)
+            {
+                descendant.Dispose();
+            }
+        }
+
+        private static HashSet<int> GetDescendantProcessIds(int rootProcessId)
+        {
+            var pendingProcessIds = new Queue<int>();
+            var descendantProcessIds = new HashSet<int>();
+            pendingProcessIds.Enqueue(rootProcessId);
+
+            while (pendingProcessIds.TryDequeue(out var parentProcessId))
+            {
+                foreach (var childProcessId in GetChildProcessIds(parentProcessId))
+                {
+                    if (descendantProcessIds.Add(childProcessId))
+                    {
+                        pendingProcessIds.Enqueue(childProcessId);
+                    }
+                }
+            }
+
+            return descendantProcessIds;
+        }
+
+        private static int[] GetChildProcessIds(int parentProcessId)
+        {
+            if (OperatingSystem.IsLinux())
+            {
+                var childrenFile = $"/proc/{parentProcessId}/task/{parentProcessId}/children";
+
+                try
+                {
+                    var processIds = File.ReadAllText(childrenFile)
+                        .Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries);
+                    return Array.ConvertAll(processIds, int.Parse);
+                }
+                catch (IOException)
+                {
+                    return [];
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    return [];
+                }
+            }
+
+            if (OperatingSystem.IsMacOS())
+            {
+                return MacNativeMethods.GetChildProcessIds(parentProcessId);
+            }
+
+            return [];
+        }
+
+        [SupportedOSPlatform("windows")]
+        private static SafeFileHandle? TryCreateWindowsJob(Process process)
+        {
+            var job = WindowsNativeMethods.CreateJobObject(nint.Zero, null);
+            if (job.IsInvalid)
+            {
+                job.Dispose();
+                return null;
+            }
+
+            try
+            {
+                if (WindowsNativeMethods.AssignProcessToJobObject(job, process.SafeHandle))
+                {
+                    return job;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+                // The process exited before it could be assigned.
+            }
+
+            job.Dispose();
+            return null;
+        }
+
+        private static void TryKill(Process process, SafeFileHandle? windowsJob)
         {
             try
             {
+                if (OperatingSystem.IsWindows() &&
+                    windowsJob is { IsInvalid: false, IsClosed: false } &&
+                    WindowsNativeMethods.TerminateJobObject(windowsJob, 1))
+                {
+                    return;
+                }
+
                 process.Kill(entireProcessTree: true);
             }
             catch (InvalidOperationException)
@@ -272,6 +494,52 @@ internal sealed class Command : ICommand, ICommandContext
             {
                 // The process is remote.
             }
+        }
+
+        private static class WindowsNativeMethods
+        {
+#pragma warning disable SYSLIB1054 // LibraryImport requires unsafe blocks, which this project does not enable.
+            [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+            public static extern SafeFileHandle CreateJobObject(nint jobAttributes, string? name);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool AssignProcessToJobObject(
+                SafeFileHandle job,
+                SafeProcessHandle process);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            public static extern bool TerminateJobObject(SafeFileHandle job, uint exitCode);
+#pragma warning restore SYSLIB1054
+        }
+
+        [SupportedOSPlatform("macos")]
+        private static class MacNativeMethods
+        {
+            public static int[] GetChildProcessIds(int parentProcessId)
+            {
+                var processCount = ProcListChildPids(parentProcessId, null, 0);
+                if (processCount <= 0)
+                {
+                    return [];
+                }
+
+                var processIds = new int[processCount];
+                var actualProcessCount =
+                    ProcListChildPids(parentProcessId, processIds, processIds.Length * sizeof(int));
+                return actualProcessCount > 0
+                    ? processIds[..Math.Min(actualProcessCount, processIds.Length)]
+                    : [];
+            }
+
+#pragma warning disable SYSLIB1054 // LibraryImport requires unsafe blocks, which this project does not enable.
+            [DllImport("libproc", EntryPoint = "proc_listchildpids")]
+            private static extern int ProcListChildPids(
+                int parentProcessId,
+                int[]? processIds,
+                int byteCount);
+#pragma warning restore SYSLIB1054
         }
     }
 }

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -158,10 +158,11 @@ internal sealed class Command : ICommand, ICommandContext
                         forcefulCancellationToken: CancellationToken.None,
                         gracefulCancellationToken: linkedCancellationToken.Token);
                 using var descendantCaptureRegistration =
-                    linkedCancellationToken.Token.Register(processTreeTerminator.CaptureDescendants);
+                    linkedCancellationToken.Token.Register(processTreeTerminator.BeginGracefulShutdown);
                 var result = await executionTask.ConfigureAwait(false);
 
                 await WaitForForcefulCancellationAsync(
+                    processTreeTerminator,
                     linkedCancellationToken.Token,
                     forcefulCancellationToken.Token).ConfigureAwait(false);
 
@@ -190,6 +191,7 @@ internal sealed class Command : ICommand, ICommandContext
             catch (CommandExecutionException e)
             {
                 await WaitForForcefulCancellationAsync(
+                    processTreeTerminator,
                     linkedCancellationToken.Token,
                     forcefulCancellationToken.Token).ConfigureAwait(false);
 
@@ -212,6 +214,7 @@ internal sealed class Command : ICommand, ICommandContext
             catch (Exception e) when (e is not CommandExecutionException and not CommandException)
             {
                 await WaitForForcefulCancellationAsync(
+                    processTreeTerminator,
                     linkedCancellationToken.Token,
                     forcefulCancellationToken.Token).ConfigureAwait(false);
 
@@ -235,6 +238,7 @@ internal sealed class Command : ICommand, ICommandContext
     }
 
     private static async Task WaitForForcefulCancellationAsync(
+        ProcessTreeTerminator processTreeTerminator,
         CancellationToken gracefulCancellationToken,
         CancellationToken forcefulCancellationToken)
     {
@@ -246,7 +250,10 @@ internal sealed class Command : ICommand, ICommandContext
 
         try
         {
-            await Task.Delay(Timeout.InfiniteTimeSpan, forcefulCancellationToken).ConfigureAwait(false);
+            while (processTreeTerminator.HasRunningProcesses())
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(10), forcefulCancellationToken).ConfigureAwait(false);
+            }
         }
         catch (OperationCanceledException) when (forcefulCancellationToken.IsCancellationRequested)
         {
@@ -256,10 +263,13 @@ internal sealed class Command : ICommand, ICommandContext
 
     private sealed class ProcessTreeTerminator : IDisposable
     {
+        private static readonly TimeSpan DescendantPollingInterval = TimeSpan.FromMilliseconds(10);
         private readonly Lock _lock = new();
         private readonly Dictionary<int, Process> _descendants = [];
         private Process? _process;
         private SafeFileHandle? _windowsJob;
+        private Timer? _descendantCaptureTimer;
+        private bool _disposed;
         private bool _killRequested;
 
         public void Attach(Process process)
@@ -280,28 +290,136 @@ internal sealed class Command : ICommand, ICommandContext
             TryKill(process, windowsJob);
         }
 
-        public void CaptureDescendants()
+        public void BeginGracefulShutdown()
         {
             if (OperatingSystem.IsWindows())
             {
                 return;
             }
 
+            CaptureDescendants();
+
+            lock (_lock)
+            {
+                if (_disposed || _killRequested)
+                {
+                    return;
+                }
+
+                _descendantCaptureTimer ??= new Timer(
+                    static state => ((ProcessTreeTerminator) state!).CaptureDescendants(),
+                    this,
+                    DescendantPollingInterval,
+                    DescendantPollingInterval);
+            }
+        }
+
+        public bool HasRunningProcesses()
+        {
             Process? process;
+            SafeFileHandle? windowsJob;
+            Process[] descendants;
 
             lock (_lock)
             {
                 process = _process;
+                windowsJob = _windowsJob;
+                descendants = [.. _descendants.Values];
             }
 
-            if (process is null)
+            if (OperatingSystem.IsWindows() &&
+                windowsJob is { IsInvalid: false, IsClosed: false })
             {
-                return;
+                return WindowsNativeMethods.HasActiveProcesses(windowsJob);
+            }
+
+            return (process is not null && IsRunning(process)) ||
+                   descendants.Any(IsRunning);
+        }
+
+        public void Kill()
+        {
+            Process? process;
+            SafeFileHandle? windowsJob;
+            Process[] descendants;
+            Timer? descendantCaptureTimer;
+
+            lock (_lock)
+            {
+                _killRequested = true;
+                process = _process;
+                windowsJob = _windowsJob;
+                descendants = [.. _descendants.Values];
+                descendantCaptureTimer = _descendantCaptureTimer;
+                _descendantCaptureTimer = null;
+            }
+
+            descendantCaptureTimer?.Dispose();
+
+            if (process is not null)
+            {
+                TryKill(process, windowsJob);
+            }
+
+            foreach (var descendant in descendants)
+            {
+                TryKill(descendant, null);
+            }
+        }
+
+        public void Dispose()
+        {
+            SafeFileHandle? windowsJob;
+            Process[] descendants;
+            Timer? descendantCaptureTimer;
+
+            lock (_lock)
+            {
+                _disposed = true;
+                windowsJob = _windowsJob;
+                descendants = [.. _descendants.Values];
+                descendantCaptureTimer = _descendantCaptureTimer;
+                _windowsJob = null;
+                _process = null;
+                _descendantCaptureTimer = null;
+                _descendants.Clear();
+            }
+
+            descendantCaptureTimer?.Dispose();
+            windowsJob?.Dispose();
+
+            foreach (var descendant in descendants)
+            {
+                descendant.Dispose();
+            }
+        }
+
+        private void CaptureDescendants()
+        {
+            int[] processIds;
+
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                try
+                {
+                    processIds = _process is null
+                        ? []
+                        : [_process.Id, .. _descendants.Keys];
+                }
+                catch (InvalidOperationException)
+                {
+                    processIds = [.. _descendants.Keys];
+                }
             }
 
             try
             {
-                foreach (var processId in GetDescendantProcessIds(process.Id))
+                foreach (var processId in processIds.SelectMany(GetDescendantProcessIds).Distinct())
                 {
                     Process? descendant = null;
 
@@ -313,7 +431,11 @@ internal sealed class Command : ICommand, ICommandContext
 
                         lock (_lock)
                         {
-                            if (_descendants.TryAdd(processId, descendant))
+                            if (_disposed)
+                            {
+                                descendant.Dispose();
+                            }
+                            else if (_descendants.TryAdd(processId, descendant))
                             {
                                 killDescendant = _killRequested;
                             }
@@ -342,54 +464,27 @@ internal sealed class Command : ICommand, ICommandContext
             }
             catch (InvalidOperationException)
             {
-                // The root process exited before its descendants could be captured.
+                // A process exited while its descendants were being captured.
+            }
+            catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
+            {
+                // Timer and cancellation callbacks must never propagate process-discovery failures.
             }
         }
 
-        public void Kill()
+        private static bool IsRunning(Process process)
         {
-            Process? process;
-            SafeFileHandle? windowsJob;
-            Process[] descendants;
-
-            lock (_lock)
+            try
             {
-                _killRequested = true;
-                process = _process;
-                windowsJob = _windowsJob;
-                descendants = [.. _descendants.Values];
+                return !process.HasExited;
             }
-
-            if (process is not null)
+            catch (InvalidOperationException)
             {
-                TryKill(process, windowsJob);
+                return false;
             }
-
-            foreach (var descendant in descendants)
+            catch (Win32Exception)
             {
-                TryKill(descendant, null);
-            }
-        }
-
-        public void Dispose()
-        {
-            SafeFileHandle? windowsJob;
-            Process[] descendants;
-
-            lock (_lock)
-            {
-                windowsJob = _windowsJob;
-                descendants = [.. _descendants.Values];
-                _windowsJob = null;
-                _process = null;
-                _descendants.Clear();
-            }
-
-            windowsJob?.Dispose();
-
-            foreach (var descendant in descendants)
-            {
-                descendant.Dispose();
+                return false;
             }
         }
 
@@ -498,6 +593,23 @@ internal sealed class Command : ICommand, ICommandContext
 
         private static class WindowsNativeMethods
         {
+            private const int JobObjectBasicAccountingInformation = 1;
+
+            public static bool HasActiveProcesses(SafeFileHandle job)
+            {
+                if (!QueryInformationJobObject(
+                        job,
+                        JobObjectBasicAccountingInformation,
+                        out var information,
+                        (uint) Marshal.SizeOf<BasicAccountingInformation>(),
+                        out _))
+                {
+                    return true;
+                }
+
+                return information.ActiveProcesses > 0;
+            }
+
 #pragma warning disable SYSLIB1054 // LibraryImport requires unsafe blocks, which this project does not enable.
             [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
             public static extern SafeFileHandle CreateJobObject(nint jobAttributes, string? name);
@@ -511,7 +623,29 @@ internal sealed class Command : ICommand, ICommandContext
             [DllImport("kernel32.dll", SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
             public static extern bool TerminateJobObject(SafeFileHandle job, uint exitCode);
+
+            [DllImport("kernel32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            private static extern bool QueryInformationJobObject(
+                SafeFileHandle job,
+                int informationClass,
+                out BasicAccountingInformation information,
+                uint informationLength,
+                out uint returnLength);
 #pragma warning restore SYSLIB1054
+
+            [StructLayout(LayoutKind.Sequential)]
+            private struct BasicAccountingInformation
+            {
+                public long TotalUserTime;
+                public long TotalKernelTime;
+                public long ThisPeriodTotalUserTime;
+                public long ThisPeriodTotalKernelTime;
+                public uint TotalPageFaultCount;
+                public uint TotalProcesses;
+                public uint ActiveProcesses;
+                public uint TotalTerminatedProcesses;
+            }
         }
 
         [SupportedOSPlatform("macos")]

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 using CliWrap;
@@ -116,6 +117,9 @@ internal sealed class Command : ICommand, ICommandContext
             : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         using var forcefulCancellationToken = new CancellationTokenSource();
+        var processTreeTerminator = new ProcessTreeTerminator();
+        using var processTreeCancellationRegistration =
+            forcefulCancellationToken.Token.Register(processTreeTerminator.Kill);
 
         var registration = linkedCancellationToken.Token.Register(() =>
         {
@@ -139,7 +143,18 @@ internal sealed class Command : ICommand, ICommandContext
                     .WithStandardOutputPipe(PipeTarget.ToStringBuilder(standardOutputStringBuilder))
                     .WithStandardErrorPipe(PipeTarget.ToStringBuilder(standardErrorStringBuilder))
                     .WithValidation(CommandResultValidation.None)
-                    .ExecuteAsync(forcefulCancellationToken.Token, linkedCancellationToken.Token).ConfigureAwait(false);
+                    .ExecuteAsync(
+                        configureStartInfo: startInfo =>
+                        {
+                            if (OperatingSystem.IsWindows())
+                            {
+                                startInfo.CreateNewProcessGroup = true;
+                            }
+                        },
+                        configureProcess: processTreeTerminator.Attach,
+                        forcefulCancellationToken: CancellationToken.None,
+                        gracefulCancellationToken: linkedCancellationToken.Token)
+                    .ConfigureAwait(false);
 
                 standardOutput = standardOutputStringBuilder.ToString();
                 standardError = standardErrorStringBuilder.ToString();
@@ -198,6 +213,64 @@ internal sealed class Command : ICommand, ICommandContext
                 );
 
                 throw new CommandException(inputToLog, -1, stopwatch.Elapsed, standardOutput, standardError, e);
+            }
+        }
+    }
+
+    private sealed class ProcessTreeTerminator
+    {
+        private readonly Lock _lock = new();
+        private Process? _process;
+        private bool _killRequested;
+
+        public void Attach(Process process)
+        {
+            lock (_lock)
+            {
+                _process = process;
+
+                if (!_killRequested)
+                {
+                    return;
+                }
+            }
+
+            TryKill(process);
+        }
+
+        public void Kill()
+        {
+            Process? process;
+
+            lock (_lock)
+            {
+                _killRequested = true;
+                process = _process;
+            }
+
+            if (process is not null)
+            {
+                TryKill(process);
+            }
+        }
+
+        private static void TryKill(Process process)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException)
+            {
+                // The process already exited.
+            }
+            catch (Win32Exception)
+            {
+                // The process already exited or could not be terminated.
+            }
+            catch (NotSupportedException)
+            {
+                // The process is remote.
             }
         }
     }

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -402,6 +402,7 @@ public class CommandTests : TestBase
         var fileSuffix = Guid.NewGuid().ToString("N");
         var triggerFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-trigger-{fileSuffix}");
         var intermediatePidFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-intermediate-{fileSuffix}.pid");
+        var intermediateReadyFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-intermediate-{fileSuffix}.ready");
         var grandchildPidFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-grandchild-{fileSuffix}.pid");
         Process? intermediateProcess = null;
         Process? grandchildProcess = null;
@@ -412,6 +413,7 @@ public class CommandTests : TestBase
             using var cancellationTokenSource = new CancellationTokenSource();
             var intermediateScript = string.Join(
                 "; ",
+                $"Set-Content -LiteralPath '{EscapePowerShellLiteral(intermediateReadyFile)}' -Value 'ready'",
                 $"while (-not (Test-Path -LiteralPath '{EscapePowerShellLiteral(triggerFile)}')) {{ Start-Sleep -Milliseconds 10 }}",
                 "$grandchild = Start-Process pwsh -ArgumentList '-NoProfile', '-Command', 'Start-Sleep -Seconds 60' -PassThru",
                 $"Set-Content -LiteralPath '{EscapePowerShellLiteral(grandchildPidFile)}' -Value $grandchild.Id",
@@ -440,6 +442,7 @@ public class CommandTests : TestBase
                 intermediatePidFile,
                 intermediatePidFileTimeout.Token);
             intermediateProcess = Process.GetProcessById(intermediateProcessId);
+            await WaitForFileAsync(intermediateReadyFile, intermediatePidFileTimeout.Token);
             cancellationTokenSource.Cancel();
             await File.WriteAllTextAsync(triggerFile, string.Empty);
 
@@ -468,6 +471,7 @@ public class CommandTests : TestBase
 
             File.Delete(triggerFile);
             File.Delete(intermediatePidFile);
+            File.Delete(intermediateReadyFile);
             File.Delete(grandchildPidFile);
         }
     }
@@ -494,6 +498,14 @@ public class CommandTests : TestBase
                 }
             }
 
+            await Task.Delay(20, cancellationToken);
+        }
+    }
+
+    private static async Task WaitForFileAsync(string path, CancellationToken cancellationToken)
+    {
+        while (!File.Exists(path))
+        {
             await Task.Delay(20, cancellationToken);
         }
     }

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -264,7 +264,7 @@ public class CommandTests : TestBase
             var script = string.Join(
                 "; ",
                 "$child = Start-Process pwsh -ArgumentList '-NoProfile', '-Command', 'Start-Sleep -Seconds 60' -PassThru",
-                $"Set-Content -LiteralPath '{pidFile.Replace("'", "''")}' -Value $child.Id",
+                $"Set-Content -LiteralPath '{EscapePowerShellLiteral(pidFile)}' -Value $child.Id",
                 "Wait-Process -Id $child.Id");
 
             var executionTask = command.ExecuteCommandLineTool(
@@ -300,6 +300,62 @@ public class CommandTests : TestBase
             File.Delete(pidFile);
         }
     }
+
+    [Test]
+    public async Task ExecuteCommandLineTool_ForcefulCancellation_KillsDescendantAfterParentExits()
+    {
+        var fileSuffix = Guid.NewGuid().ToString("N");
+        var pidFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-child-{fileSuffix}.pid");
+        var parentExitFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-parent-exit-{fileSuffix}");
+        Process? childProcess = null;
+
+        try
+        {
+            var command = await GetService<ICommand>();
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var script = string.Join(
+                "; ",
+                "$child = Start-Process pwsh -ArgumentList '-NoProfile', '-Command', 'Start-Sleep -Seconds 60' -PassThru",
+                $"Set-Content -LiteralPath '{EscapePowerShellLiteral(pidFile)}' -Value $child.Id",
+                $"while (-not (Test-Path -LiteralPath '{EscapePowerShellLiteral(parentExitFile)}')) {{ Start-Sleep -Milliseconds 10 }}");
+
+            var executionTask = command.ExecuteCommandLineTool(
+                new GenericCommandLineToolOptions("pwsh")
+                {
+                    Arguments = ["-NoProfile", "-Command", script],
+                },
+                new CommandExecutionOptions
+                {
+                    GracefulShutdownTimeout = TimeSpan.FromMilliseconds(100),
+                },
+                cancellationTokenSource.Token);
+
+            using var pidFileTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var childProcessId = await WaitForProcessIdAsync(pidFile, pidFileTimeout.Token);
+            childProcess = Process.GetProcessById(childProcessId);
+            cancellationTokenSource.Cancel();
+            await File.WriteAllTextAsync(parentExitFile, string.Empty);
+
+            await Assert.ThrowsAsync<CommandException>(async () => await executionTask);
+
+            var childExited = await WaitForExitAsync(childProcess, TimeSpan.FromSeconds(2));
+            await Assert.That(childExited).IsTrue();
+        }
+        finally
+        {
+            if (childProcess is { HasExited: false })
+            {
+                childProcess.Kill(entireProcessTree: true);
+                await childProcess.WaitForExitAsync();
+            }
+
+            childProcess?.Dispose();
+            File.Delete(pidFile);
+            File.Delete(parentExitFile);
+        }
+    }
+
+    private static string EscapePowerShellLiteral(string value) => value.Replace("'", "''");
 
     private static async Task<int> WaitForProcessIdAsync(string pidFile, CancellationToken cancellationToken)
     {

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 using ModularPipelines.Context;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers.Internal;
@@ -352,6 +353,122 @@ public class CommandTests : TestBase
             childProcess?.Dispose();
             File.Delete(pidFile);
             File.Delete(parentExitFile);
+        }
+    }
+
+    [Test]
+    public async Task ExecuteCommandLineTool_GracefulExit_DoesNotWaitForForcefulTimeout()
+    {
+        var parentExitFile = Path.Combine(
+            Path.GetTempPath(),
+            $"modular-pipelines-parent-exit-{Guid.NewGuid():N}");
+
+        try
+        {
+            var command = await GetService<ICommand>();
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var script =
+                $"while (-not (Test-Path -LiteralPath '{EscapePowerShellLiteral(parentExitFile)}')) " +
+                "{ Start-Sleep -Milliseconds 10 }";
+
+            var executionTask = command.ExecuteCommandLineTool(
+                new GenericCommandLineToolOptions("pwsh")
+                {
+                    Arguments = ["-NoProfile", "-Command", script],
+                },
+                new CommandExecutionOptions
+                {
+                    GracefulShutdownTimeout = TimeSpan.FromSeconds(10),
+                },
+                cancellationTokenSource.Token);
+
+            await Task.Delay(100);
+            var stopwatch = Stopwatch.StartNew();
+            cancellationTokenSource.Cancel();
+            await File.WriteAllTextAsync(parentExitFile, string.Empty);
+
+            await Assert.ThrowsAsync<CommandException>(async () => await executionTask);
+            await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            File.Delete(parentExitFile);
+        }
+    }
+
+    [Test]
+    public async Task ExecuteCommandLineTool_ForcefulCancellation_CapturesDescendantSpawnedDuringGrace()
+    {
+        var fileSuffix = Guid.NewGuid().ToString("N");
+        var triggerFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-trigger-{fileSuffix}");
+        var intermediatePidFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-intermediate-{fileSuffix}.pid");
+        var grandchildPidFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-grandchild-{fileSuffix}.pid");
+        Process? intermediateProcess = null;
+        Process? grandchildProcess = null;
+
+        try
+        {
+            var command = await GetService<ICommand>();
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var intermediateScript = string.Join(
+                "; ",
+                $"while (-not (Test-Path -LiteralPath '{EscapePowerShellLiteral(triggerFile)}')) {{ Start-Sleep -Milliseconds 10 }}",
+                "$grandchild = Start-Process pwsh -ArgumentList '-NoProfile', '-Command', 'Start-Sleep -Seconds 60' -PassThru",
+                $"Set-Content -LiteralPath '{EscapePowerShellLiteral(grandchildPidFile)}' -Value $grandchild.Id",
+                "Start-Sleep -Milliseconds 500");
+            var encodedIntermediateScript =
+                Convert.ToBase64String(Encoding.Unicode.GetBytes(intermediateScript));
+            var parentScript = string.Join(
+                "; ",
+                $"$intermediate = Start-Process pwsh -ArgumentList '-NoProfile', '-EncodedCommand', '{encodedIntermediateScript}' -PassThru",
+                $"Set-Content -LiteralPath '{EscapePowerShellLiteral(intermediatePidFile)}' -Value $intermediate.Id",
+                "Wait-Process -Id $intermediate.Id");
+
+            var executionTask = command.ExecuteCommandLineTool(
+                new GenericCommandLineToolOptions("pwsh")
+                {
+                    Arguments = ["-NoProfile", "-Command", parentScript],
+                },
+                new CommandExecutionOptions
+                {
+                    GracefulShutdownTimeout = TimeSpan.FromSeconds(1),
+                },
+                cancellationTokenSource.Token);
+
+            using var intermediatePidFileTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var intermediateProcessId = await WaitForProcessIdAsync(
+                intermediatePidFile,
+                intermediatePidFileTimeout.Token);
+            intermediateProcess = Process.GetProcessById(intermediateProcessId);
+            cancellationTokenSource.Cancel();
+            await File.WriteAllTextAsync(triggerFile, string.Empty);
+
+            using var grandchildPidFileTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            var grandchildProcessId = await WaitForProcessIdAsync(
+                grandchildPidFile,
+                grandchildPidFileTimeout.Token);
+            grandchildProcess = Process.GetProcessById(grandchildProcessId);
+            await Assert.ThrowsAsync<CommandException>(async () => await executionTask);
+
+            var grandchildExited = await WaitForExitAsync(grandchildProcess, TimeSpan.FromSeconds(2));
+            await Assert.That(grandchildExited).IsTrue();
+        }
+        finally
+        {
+            foreach (var process in new[] { intermediateProcess, grandchildProcess })
+            {
+                if (process is { HasExited: false })
+                {
+                    process.Kill(entireProcessTree: true);
+                    await process.WaitForExitAsync();
+                }
+
+                process?.Dispose();
+            }
+
+            File.Delete(triggerFile);
+            File.Delete(intermediatePidFile);
+            File.Delete(grandchildPidFile);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -250,4 +250,78 @@ public class CommandTests : TestBase
             Directory.Delete(scriptDirectory, recursive: true);
         }
     }
+
+    [Test]
+    public async Task ExecuteCommandLineTool_ForcefulCancellation_KillsDescendantProcesses()
+    {
+        var pidFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-child-{Guid.NewGuid():N}.pid");
+        Process? childProcess = null;
+
+        try
+        {
+            var command = await GetService<ICommand>();
+            using var cancellationTokenSource = new CancellationTokenSource();
+            var script = string.Join(
+                "; ",
+                "$child = Start-Process pwsh -ArgumentList '-NoProfile', '-Command', 'Start-Sleep -Seconds 60' -PassThru",
+                $"Set-Content -LiteralPath '{pidFile.Replace("'", "''")}' -Value $child.Id",
+                "Wait-Process -Id $child.Id");
+
+            var executionTask = command.ExecuteCommandLineTool(
+                new GenericCommandLineToolOptions("pwsh")
+                {
+                    Arguments = ["-NoProfile", "-Command", script],
+                },
+                new CommandExecutionOptions
+                {
+                    GracefulShutdownTimeout = TimeSpan.FromMilliseconds(50),
+                },
+                cancellationTokenSource.Token);
+
+            using var pidFileTimeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var childProcessId = await WaitForProcessIdAsync(pidFile, pidFileTimeout.Token);
+            childProcess = Process.GetProcessById(childProcessId);
+            cancellationTokenSource.Cancel();
+
+            await Assert.ThrowsAsync<CommandException>(async () => await executionTask);
+
+            var childExited = await WaitForExitAsync(childProcess, TimeSpan.FromSeconds(2));
+            await Assert.That(childExited).IsTrue();
+        }
+        finally
+        {
+            if (childProcess is { HasExited: false })
+            {
+                childProcess.Kill(entireProcessTree: true);
+                await childProcess.WaitForExitAsync();
+            }
+
+            childProcess?.Dispose();
+            File.Delete(pidFile);
+        }
+    }
+
+    private static async Task<int> WaitForProcessIdAsync(string pidFile, CancellationToken cancellationToken)
+    {
+        while (!File.Exists(pidFile))
+        {
+            await Task.Delay(20, cancellationToken);
+        }
+
+        var processId = await File.ReadAllTextAsync(pidFile, cancellationToken);
+        return int.Parse(processId.Trim());
+    }
+
+    private static async Task<bool> WaitForExitAsync(Process process, TimeSpan timeout)
+    {
+        try
+        {
+            await process.WaitForExitAsync().WaitAsync(timeout);
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+    }
 }

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -476,13 +476,26 @@ public class CommandTests : TestBase
 
     private static async Task<int> WaitForProcessIdAsync(string pidFile, CancellationToken cancellationToken)
     {
-        while (!File.Exists(pidFile))
+        while (true)
         {
+            if (File.Exists(pidFile))
+            {
+                try
+                {
+                    var processId = await File.ReadAllTextAsync(pidFile, cancellationToken);
+                    if (int.TryParse(processId.Trim(), out var parsedProcessId))
+                    {
+                        return parsedProcessId;
+                    }
+                }
+                catch (IOException)
+                {
+                    // The shell may still be creating or writing the PID file.
+                }
+            }
+
             await Task.Delay(20, cancellationToken);
         }
-
-        var processId = await File.ReadAllTextAsync(pidFile, cancellationToken);
-        return int.Parse(processId.Trim());
     }
 
     private static async Task<bool> WaitForExitAsync(Process process, TimeSpan timeout)


### PR DESCRIPTION
Closes #3267

- replace CliWrap's direct-child forceful cancellation with race-safe whole-tree termination
- preserve Windows containment with a Job Object and retain Linux/macOS descendants throughout the graceful shutdown window
- stop waiting as soon as the retained process tree exits
- add regressions for descendants, root exit before escalation, fast graceful exit, and late-spawned descendants

Validation:
- 13 CommandTests pass on net10.0
- ModularPipelines.sln Release build: 0 errors (existing warnings remain)