### PR TITLE
Centralize HangDump test dependency

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,6 +6,9 @@
     <LangVersion>preview</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+  </ItemGroup>
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'ModularPipelines.UnitTests'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)..\src\ModularPipelines.SourceGenerator\ModularPipelines.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,7 +6,7 @@
     <LangVersion>preview</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.UnitTests')) or '$(MSBuildProjectName)' == 'ModularPipelines.TestsForTests'">
     <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
   </ItemGroup>
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'ModularPipelines.UnitTests'">

--- a/test/ModularPipelines.Ansible.UnitTests/ModularPipelines.Ansible.UnitTests.csproj
+++ b/test/ModularPipelines.Ansible.UnitTests/ModularPipelines.Ansible.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.ArgoCd.UnitTests/ModularPipelines.ArgoCd.UnitTests.csproj
+++ b/test/ModularPipelines.ArgoCd.UnitTests/ModularPipelines.ArgoCd.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Azure.UnitTests/ModularPipelines.Azure.UnitTests.csproj
+++ b/test/ModularPipelines.Azure.UnitTests/ModularPipelines.Azure.UnitTests.csproj
@@ -13,7 +13,6 @@
             Include="..\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
         <PackageReference Include="TUnit" />
     </ItemGroup>
 

--- a/test/ModularPipelines.Cosign.UnitTests/ModularPipelines.Cosign.UnitTests.csproj
+++ b/test/ModularPipelines.Cosign.UnitTests/ModularPipelines.Cosign.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Development.Analyzers.UnitTests/ModularPipelines.Development.Analyzers.UnitTests.csproj
+++ b/test/ModularPipelines.Development.Analyzers.UnitTests/ModularPipelines.Development.Analyzers.UnitTests.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Distributed.Artifacts.S3.UnitTests/ModularPipelines.Distributed.Artifacts.S3.UnitTests.csproj
+++ b/test/ModularPipelines.Distributed.Artifacts.S3.UnitTests/ModularPipelines.Distributed.Artifacts.S3.UnitTests.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="Moq" />
     <PackageReference Include="TUnit" />
   </ItemGroup>

--- a/test/ModularPipelines.Distributed.Discovery.Redis.UnitTests/ModularPipelines.Distributed.Discovery.Redis.UnitTests.csproj
+++ b/test/ModularPipelines.Distributed.Discovery.Redis.UnitTests/ModularPipelines.Distributed.Discovery.Redis.UnitTests.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="Moq" />
     <PackageReference Include="TUnit" />
   </ItemGroup>

--- a/test/ModularPipelines.Distributed.Redis.UnitTests/ModularPipelines.Distributed.Redis.UnitTests.csproj
+++ b/test/ModularPipelines.Distributed.Redis.UnitTests/ModularPipelines.Distributed.Redis.UnitTests.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="Moq" />
     <PackageReference Include="TUnit" />
   </ItemGroup>

--- a/test/ModularPipelines.Distributed.SignalR.UnitTests/ModularPipelines.Distributed.SignalR.UnitTests.csproj
+++ b/test/ModularPipelines.Distributed.SignalR.UnitTests/ModularPipelines.Distributed.SignalR.UnitTests.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="Moq" />
     <PackageReference Include="TUnit" />
   </ItemGroup>

--- a/test/ModularPipelines.Distributed.UnitTests/ModularPipelines.Distributed.UnitTests.csproj
+++ b/test/ModularPipelines.Distributed.UnitTests/ModularPipelines.Distributed.UnitTests.csproj
@@ -11,7 +11,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="Moq" />
     <PackageReference Include="TUnit" />
   </ItemGroup>

--- a/test/ModularPipelines.Docker.UnitTests/ModularPipelines.Docker.UnitTests.csproj
+++ b/test/ModularPipelines.Docker.UnitTests/ModularPipelines.Docker.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Eksctl.UnitTests/ModularPipelines.Eksctl.UnitTests.csproj
+++ b/test/ModularPipelines.Eksctl.UnitTests/ModularPipelines.Eksctl.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Email.UnitTests/ModularPipelines.Email.UnitTests.csproj
+++ b/test/ModularPipelines.Email.UnitTests/ModularPipelines.Email.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Ftp.UnitTests/ModularPipelines.Ftp.UnitTests.csproj
+++ b/test/ModularPipelines.Ftp.UnitTests/ModularPipelines.Ftp.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.GitHub.UnitTests/ModularPipelines.GitHub.UnitTests.csproj
+++ b/test/ModularPipelines.GitHub.UnitTests/ModularPipelines.GitHub.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="Moq" />
     <PackageReference Include="TUnit" />
   </ItemGroup>

--- a/test/ModularPipelines.Hadolint.UnitTests/ModularPipelines.Hadolint.UnitTests.csproj
+++ b/test/ModularPipelines.Hadolint.UnitTests/ModularPipelines.Hadolint.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Java.UnitTests/ModularPipelines.Java.UnitTests.csproj
+++ b/test/ModularPipelines.Java.UnitTests/ModularPipelines.Java.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Jq.UnitTests/ModularPipelines.Jq.UnitTests.csproj
+++ b/test/ModularPipelines.Jq.UnitTests/ModularPipelines.Jq.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Liquibase.UnitTests/ModularPipelines.Liquibase.UnitTests.csproj
+++ b/test/ModularPipelines.Liquibase.UnitTests/ModularPipelines.Liquibase.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.NerdbankGitVersioning.UnitTests/ModularPipelines.NerdbankGitVersioning.UnitTests.csproj
+++ b/test/ModularPipelines.NerdbankGitVersioning.UnitTests/ModularPipelines.NerdbankGitVersioning.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Node.UnitTests/ModularPipelines.Node.UnitTests.csproj
+++ b/test/ModularPipelines.Node.UnitTests/ModularPipelines.Node.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Shellcheck.UnitTests/ModularPipelines.Shellcheck.UnitTests.csproj
+++ b/test/ModularPipelines.Shellcheck.UnitTests/ModularPipelines.Shellcheck.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.Snyk.UnitTests/ModularPipelines.Snyk.UnitTests.csproj
+++ b/test/ModularPipelines.Snyk.UnitTests/ModularPipelines.Snyk.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.SonarScanner.UnitTests/ModularPipelines.SonarScanner.UnitTests.csproj
+++ b/test/ModularPipelines.SonarScanner.UnitTests/ModularPipelines.SonarScanner.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="Moq" />
     <PackageReference Include="TUnit" />
   </ItemGroup>

--- a/test/ModularPipelines.Trivy.UnitTests/ModularPipelines.Trivy.UnitTests.csproj
+++ b/test/ModularPipelines.Trivy.UnitTests/ModularPipelines.Trivy.UnitTests.csproj
@@ -8,7 +8,6 @@
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
+++ b/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
@@ -9,7 +9,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CliWrap" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="NReco.Logging.File" />


### PR DESCRIPTION
## Summary
- add `Microsoft.Testing.Extensions.HangDump` once in `test/Directory.Build.props`
- remove 26 duplicate per-project package references
- make new test projects automatically support the CI pipeline's `--hangdump` arguments

## Validation
- representative `ModularPipelines.UnitTests` run accepted `--hangdump --hangdump-timeout 1m`: 3 tests passed
- restored assets contain `Microsoft.Testing.Extensions.HangDump/2.3.3`
- all 27 edited MSBuild XML files parse successfully
- `git diff --check` passes

Config-only dependency centralization; no meaningful failing unit test exists for the pre-change MSBuild import shape.

Closes #3332