### PR TITLE
Make TryGetService return null when missing

### DIFF
--- a/src/ModularPipelines/Context/ContextExtensions.cs
+++ b/src/ModularPipelines/Context/ContextExtensions.cs
@@ -26,9 +26,7 @@ public static class ContextExtensions
     /// </example>
     public static T GetService<T>(this IPipelineContext context) where T : class
     {
-        return context.Services.Get<T>() ?? throw new InvalidOperationException(
-            $"Service '{typeof(T).FullName}' is not registered in the service provider. " +
-            $"Ensure the service is registered during pipeline configuration.");
+        return context.Services.Get<T>();
     }
 
     /// <summary>
@@ -48,7 +46,7 @@ public static class ContextExtensions
     /// </example>
     public static T? TryGetService<T>(this IPipelineContext context) where T : class
     {
-        return context.Services.Get<T>();
+        return context.Services.TryGet<T>();
     }
 
     /// <summary>

--- a/src/ModularPipelines/Context/Domains/IServicesContext.cs
+++ b/src/ModularPipelines/Context/Domains/IServicesContext.cs
@@ -9,11 +9,19 @@ namespace ModularPipelines.Context.Domains;
 public interface IServicesContext
 {
     /// <summary>
-    /// Resolve a service from the DI container.
+    /// Resolves a required service from the DI container.
     /// </summary>
     /// <typeparam name="T">The service type to resolve.</typeparam>
     /// <returns>The resolved service instance.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the service is not registered.</exception>
     T Get<T>() where T : class;
+
+    /// <summary>
+    /// Tries to resolve a service from the DI container.
+    /// </summary>
+    /// <typeparam name="T">The service type to resolve.</typeparam>
+    /// <returns>The resolved service instance, or <see langword="null"/> when it is not registered.</returns>
+    T? TryGet<T>() where T : class;
 
     /// <summary>
     /// Application configuration.

--- a/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
+++ b/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
@@ -33,6 +33,9 @@ internal class ServicesContext : IServicesContext
     public T Get<T>() where T : class => _serviceProvider.GetRequiredService<T>();
 
     /// <inheritdoc />
+    public T? TryGet<T>() where T : class => _serviceProvider.GetService<T>();
+
+    /// <inheritdoc />
     public IConfiguration Configuration { get; }
 
     /// <inheritdoc />

--- a/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
@@ -1,6 +1,9 @@
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains;
+using ModularPipelines.Context.Domains.Implementations;
+using ModularPipelines.Options;
 using Moq;
 
 namespace ModularPipelines.UnitTests.Context;
@@ -32,11 +35,11 @@ public class ContextExtensionsTests
     public async Task GetService_WhenServiceNotRegistered_ShouldThrow()
     {
         // Arrange
-        var mockServices = new Mock<IServicesContext>();
-        mockServices.Setup(s => s.Get<TestService>()).Returns((TestService?)null!);
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var servicesContext = CreateServicesContext(serviceProvider);
 
         var mockContext = new Mock<IModuleContext>();
-        mockContext.Setup(c => c.Services).Returns(mockServices.Object);
+        mockContext.Setup(c => c.Services).Returns(servicesContext);
 
         // Act & Assert
         await Assert.That(() => mockContext.Object.GetService<TestService>())
@@ -44,14 +47,14 @@ public class ContextExtensionsTests
     }
 
     [Test]
-    public async Task TryGetService_ShouldReturnServiceOrNull()
+    public async Task TryGetService_WhenServiceNotRegistered_ShouldReturnNull()
     {
         // Arrange
-        var mockServices = new Mock<IServicesContext>();
-        mockServices.Setup(s => s.Get<TestService>()).Returns((TestService?)null!);
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var servicesContext = CreateServicesContext(serviceProvider);
 
         var mockContext = new Mock<IModuleContext>();
-        mockContext.Setup(c => c.Services).Returns(mockServices.Object);
+        mockContext.Setup(c => c.Services).Returns(servicesContext);
 
         // Act
         var result = mockContext.Object.TryGetService<TestService>();
@@ -64,12 +67,14 @@ public class ContextExtensionsTests
     public async Task TryGetService_WhenServiceExists_ShouldReturnService()
     {
         // Arrange
-        var mockServices = new Mock<IServicesContext>();
         var expectedService = new TestService();
-        mockServices.Setup(s => s.Get<TestService>()).Returns(expectedService);
+        using var serviceProvider = new ServiceCollection()
+            .AddSingleton(expectedService)
+            .BuildServiceProvider();
+        var servicesContext = CreateServicesContext(serviceProvider);
 
         var mockContext = new Mock<IModuleContext>();
-        mockContext.Setup(c => c.Services).Returns(mockServices.Object);
+        mockContext.Setup(c => c.Services).Returns(servicesContext);
 
         // Act
         var result = mockContext.Object.TryGetService<TestService>();
@@ -134,6 +139,14 @@ public class ContextExtensionsTests
         // Act & Assert
         await Assert.That(() => mockContext.Object.GetRequiredConfigValue("MissingKey"))
             .ThrowsExactly<InvalidOperationException>();
+    }
+
+    private static ServicesContext CreateServicesContext(IServiceProvider serviceProvider)
+    {
+        return new ServicesContext(
+            serviceProvider,
+            new ConfigurationBuilder().Build(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
     }
 
     private class TestService


### PR DESCRIPTION
## Summary
- add nullable `IServicesContext.TryGet<T>()` backed by `IServiceProvider.GetService<T>()`
- route `ContextExtensions.TryGetService<T>()` through the optional lookup
- make the required `Get<T>()` contract explicit and remove the dead null fallback from `GetService<T>()`
- exercise missing and registered services through the real `ServicesContext`

## Validation
- failing-first compile: `IServicesContext.TryGet<T>()` did not exist
- `ContextExtensionsTests`: 7 passed
- `ModularPipelines.sln` Release build: 0 errors (existing analyzer warnings remain)
- `git diff --check` passes

Closes #3277