### PR TITLE
Replace flaky email test with local SMTP

### DIFF
--- a/test/ModularPipelines.Email.UnitTests/Helpers/EmailTests.cs
+++ b/test/ModularPipelines.Email.UnitTests/Helpers/EmailTests.cs
@@ -1,29 +1,20 @@
-using System.Net;
 using MailKit.Security;
 using MimeKit;
 using ModularPipelines.Email;
 using ModularPipelines.Email.Options;
 using ModularPipelines.TestHelpers;
-using TUnit.Core.Exceptions;
 
 namespace ModularPipelines.Email.UnitTests.Helpers;
 
-[Skip("Requires live SMTP credentials")]
 public class EmailTests : TestBase
 {
-    private const string EmailAddress = "modularpipelinestest@gmail.com";
+    private const string EmailAddress = "test@example.com";
 
     [Test]
     public async Task Can_Send_Email()
     {
         var email = await GetService<IEmail>();
-
-        var emailPassword = Environment.GetEnvironmentVariable("EMAIL_PASSWORD");
-
-        if (string.IsNullOrEmpty(emailPassword))
-        {
-            throw new SkipTestException("No email password");
-        }
+        await using var smtpServer = LocalSmtpServer.Start();
 
         var response = await email.SendAsync(
             new EmailSendOptions(
@@ -31,17 +22,18 @@ public class EmailTests : TestBase
                 To: [EmailAddress],
                 Subject: "Email Test",
                 Body: new TextPart { Text = "This is an email test." },
-                SmtpServerHost: "smtp-relay.brevo.com"
+                SmtpServerHost: "127.0.0.1"
             )
             {
-                Port = 587,
-                Credentials = new NetworkCredential(EmailAddress, emailPassword),
-                SecureSocketOptions = SecureSocketOptions.StartTls,
-                ClientConfigurator = client =>
-                {
-                },
+                Port = smtpServer.Port,
+                SecureSocketOptions = SecureSocketOptions.None,
             }
         );
+
+        var message = await smtpServer.Message;
+
         await Assert.That(response).Contains("queued");
+        await Assert.That(message).Contains("Subject: Email Test");
+        await Assert.That(message).Contains("This is an email test.");
     }
 }

--- a/test/ModularPipelines.Email.UnitTests/Helpers/LocalSmtpServer.cs
+++ b/test/ModularPipelines.Email.UnitTests/Helpers/LocalSmtpServer.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace ModularPipelines.Email.UnitTests.Helpers;
+
+internal sealed class LocalSmtpServer : IAsyncDisposable
+{
+    private readonly CancellationTokenSource _cancellationTokenSource = new(TimeSpan.FromSeconds(10));
+    private readonly TcpListener _listener;
+    private readonly TaskCompletionSource<string> _message =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly Task _serverTask;
+
+    private LocalSmtpServer()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        _serverTask = RunAsync(_cancellationTokenSource.Token);
+    }
+
+    public int Port => ((IPEndPoint) _listener.LocalEndpoint).Port;
+
+    public Task<string> Message => _message.Task;
+
+    public static LocalSmtpServer Start() => new();
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cancellationTokenSource.CancelAsync();
+        _listener.Stop();
+        await _serverTask;
+        _cancellationTokenSource.Dispose();
+    }
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var client = await _listener.AcceptTcpClientAsync(cancellationToken);
+            await using var stream = client.GetStream();
+            using var reader = new StreamReader(stream, Encoding.ASCII);
+            await using var writer = new StreamWriter(stream, Encoding.ASCII)
+            {
+                AutoFlush = true,
+                NewLine = "\r\n",
+            };
+
+            await writer.WriteLineAsync("220 localhost ESMTP ready");
+
+            while (await reader.ReadLineAsync(cancellationToken) is { } command)
+            {
+                if (command.StartsWith("EHLO ", StringComparison.OrdinalIgnoreCase)
+                    || command.StartsWith("HELO ", StringComparison.OrdinalIgnoreCase))
+                {
+                    await writer.WriteLineAsync("250-localhost");
+                    await writer.WriteLineAsync("250 SIZE 10485760");
+                }
+                else if (command.Equals("DATA", StringComparison.OrdinalIgnoreCase))
+                {
+                    await writer.WriteLineAsync("354 End data with <CR><LF>.<CR><LF>");
+                    _message.TrySetResult(await ReadMessageAsync(reader, cancellationToken));
+                    await writer.WriteLineAsync("250 2.0.0 queued");
+                }
+                else if (command.Equals("QUIT", StringComparison.OrdinalIgnoreCase))
+                {
+                    await writer.WriteLineAsync("221 2.0.0 Bye");
+                    return;
+                }
+                else
+                {
+                    await writer.WriteLineAsync("250 2.0.0 OK");
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (SocketException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _message.TrySetCanceled(cancellationToken);
+            }
+            else
+            {
+                _message.TrySetException(
+                    new InvalidOperationException("SMTP connection closed before message data was received."));
+            }
+        }
+    }
+
+    private static async Task<string> ReadMessageAsync(
+        StreamReader reader,
+        CancellationToken cancellationToken)
+    {
+        var lines = new List<string>();
+
+        while (await reader.ReadLineAsync(cancellationToken) is { } line && line != ".")
+        {
+            lines.Add(line.StartsWith("..", StringComparison.Ordinal) ? line[1..] : line);
+        }
+
+        return string.Join("\r\n", lines);
+    }
+}


### PR DESCRIPTION
Closes #3334

## Summary
- replace the skipped, credential-backed Brevo test with an in-process loopback SMTP server
- exercise the real `IEmail`/MailKit send path without network access or secrets
- assert the SMTP response and delivered subject/body

## Validation
- `ModularPipelines.Email.sln` Release build: 0 errors (238 existing analyzer warnings)
- `ModularPipelines.Email.UnitTests`: 1 passed, 0 failed, 0 skipped
- focused SMTP test passed repeatedly