### PR TITLE
Confirm scheduler deadlocks across idle cycles

### DIFF
--- a/src/ModularPipelines/Engine/SchedulerExitConditions.cs
+++ b/src/ModularPipelines/Engine/SchedulerExitConditions.cs
@@ -9,6 +9,8 @@ namespace ModularPipelines.Engine;
 /// </remarks>
 internal class SchedulerExitConditions
 {
+    private bool _previousSnapshotWasIdle;
+
     /// <summary>
     /// Determines if the scheduler should exit based on current state.
     /// </summary>
@@ -20,31 +22,35 @@ internal class SchedulerExitConditions
         // Exit if all work is done
         if (snapshot.AllCompleted)
         {
+            _previousSnapshotWasIdle = false;
             return true;
         }
 
-        // Exit if we're deadlocked (nothing active, work pending, but nothing could be queued)
-        if (IsDeadlocked(snapshot, queuedCount))
-        {
-            return true;
-        }
+        // A module can be returned from Queued to Pending when its execution-time
+        // constraints change. Give that transient state one scheduling cycle to
+        // requeue before treating consecutive idle snapshots as a deadlock.
+        var isIdle = IsDeadlocked(snapshot, queuedCount);
+        var shouldExit = isIdle && _previousSnapshotWasIdle;
+        _previousSnapshotWasIdle = isIdle;
 
-        return false;
+        return shouldExit;
     }
 
     /// <summary>
-    /// Detects deadlock condition: modules are pending but cannot make progress.
+    /// Detects a potential deadlock condition: modules are pending but cannot make progress.
     /// </summary>
     /// <param name="snapshot">Current state snapshot.</param>
     /// <param name="queuedCount">Number of modules queued in this iteration.</param>
-    /// <returns>True if deadlocked, false otherwise.</returns>
+    /// <returns>True if the current snapshot is idle with pending work, false otherwise.</returns>
     /// <remarks>
-    /// Deadlock occurs when:
+    /// A potential deadlock occurs when:
     /// - No modules are currently active (executing or queued)
     /// - Modules are still pending (waiting for dependencies)
     /// - No modules could be queued (dependencies will never complete)
     ///
-    /// This typically indicates circular dependencies or missing module registrations.
+    /// Two consecutive potential deadlocks indicate circular dependencies or missing
+    /// module registrations. A single idle snapshot can occur while a deferred module
+    /// transitions from queued back to pending.
     /// </remarks>
     public bool IsDeadlocked(ModuleStateSnapshot snapshot, int queuedCount)
     {

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -121,6 +121,35 @@ public class ModuleSchedulerDynamicCycleTests
     }
 
     [Test]
+    public async Task RunSchedulerAsync_WhenOnlyModuleIsDeferred_DoesNotReportDeadlock()
+    {
+        var constraintEvaluator = new Mock<IModuleConstraintEvaluator>();
+        constraintEvaluator
+            .SetupSequence(x => x.CanQueue(It.IsAny<ModuleState>(), It.IsAny<IEnumerable<ModuleState>>()))
+            .Returns(true)
+            .Returns(false)
+            .Returns(true);
+        constraintEvaluator
+            .SetupSequence(x => x.CanStartExecution(It.IsAny<ModuleState>(), It.IsAny<IEnumerable<ModuleState>>()))
+            .Returns(false)
+            .Returns(true);
+
+        using var scheduler = CreateScheduler(constraintEvaluator.Object);
+        scheduler.InitializeModules([new CompletedDependencyModule()]);
+
+        var schedulerTask = scheduler.RunSchedulerAsync(CancellationToken.None);
+        var firstAttempt = await scheduler.ReadyModules.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(scheduler.MarkModuleStarted(firstAttempt.ModuleType)).IsFalse();
+
+        var secondAttempt = await scheduler.ReadyModules.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(scheduler.MarkModuleStarted(secondAttempt.ModuleType)).IsTrue();
+
+        scheduler.MarkModuleCompleted(secondAttempt.ModuleType, success: true);
+        await schedulerTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
     public async Task AddModule_WhenExistingPredicateCreatesCycle_ThrowsAndRollsBack()
     {
         using var scheduler = CreateScheduler();
@@ -221,7 +250,7 @@ public class ModuleSchedulerDynamicCycleTests
         await Assert.That(state!.UnresolvedDependencies).Contains(typeof(CompletedDependencyModule));
     }
 
-    private static ModuleScheduler CreateScheduler()
+    private static ModuleScheduler CreateScheduler(IModuleConstraintEvaluator? constraintEvaluator = null)
     {
         return new ModuleScheduler(
             NullLogger.Instance,
@@ -230,7 +259,7 @@ public class ModuleSchedulerDynamicCycleTests
             new ModuleDependencyRegistry(),
             new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
             Mock.Of<IMetricsCollector>(),
-            Mock.Of<IModuleConstraintEvaluator>(),
+            constraintEvaluator ?? Mock.Of<IModuleConstraintEvaluator>(),
             Mock.Of<ISchedulerStatusReporter>());
     }
 }


### PR DESCRIPTION
## Summary

- require two consecutive idle scheduler snapshots before declaring deadlock
- allow a module deferred from Queued to Pending one cycle to requeue
- preserve hard failures for genuine dependency deadlocks

## Validation

- failing-first regression reproduced DependencyCollisionException for the sole deferred module
- ModuleSchedulerDynamicCycleTests: 11 passed, 0 failed
- ModularPipelines.sln Release build: 0 errors (248 existing warnings)

Closes #3242