### PR TITLE
Prevent scheduler disposal races

### DIFF
--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -40,7 +40,9 @@ internal class ModuleScheduler : IModuleScheduler
     private readonly IModuleStateTracker _stateTracker;
 
     private bool _schedulerCompleted;
-    private bool _isDisposed;
+    private int _disposeState;
+
+    private bool IsDisposed => Volatile.Read(ref _disposeState) != 0;
 
     public ModuleScheduler(
         ILogger logger,
@@ -101,6 +103,11 @@ internal class ModuleScheduler : IModuleScheduler
     {
         ArgumentNullException.ThrowIfNull(modules);
 
+        if (IsDisposed)
+        {
+            return;
+        }
+
         var moduleArray = modules.ToArray();
         AddModuleStates(moduleArray);
         var availableModuleTypes = _moduleStates.Keys.ToArray();
@@ -124,6 +131,11 @@ internal class ModuleScheduler : IModuleScheduler
     public void AddModule(IModule module)
     {
         ArgumentNullException.ThrowIfNull(module);
+
+        if (IsDisposed)
+        {
+            return;
+        }
 
         var moduleType = module.GetType();
         ModuleState state;
@@ -397,6 +409,11 @@ internal class ModuleScheduler : IModuleScheduler
     /// </summary>
     public Task RunSchedulerAsync(CancellationToken cancellationToken)
     {
+        if (IsDisposed)
+        {
+            return Task.CompletedTask;
+        }
+
         return Task.Run(async () =>
         {
             try
@@ -440,7 +457,7 @@ internal class ModuleScheduler : IModuleScheduler
 
     private bool ShouldContinueScheduling(CancellationToken cancellationToken)
     {
-        return !_isDisposed && !cancellationToken.IsCancellationRequested;
+        return !IsDisposed && !cancellationToken.IsCancellationRequested;
     }
 
     private bool ShouldExitScheduler(int queuedCount)
@@ -533,6 +550,11 @@ internal class ModuleScheduler : IModuleScheduler
     /// <returns>True if the module can proceed with execution, false if constraints prevent execution.</returns>
     public bool MarkModuleStarted(Type moduleType)
     {
+        if (IsDisposed)
+        {
+            return false;
+        }
+
         return _stateTracker.MarkModuleStarted(moduleType);
     }
 
@@ -541,6 +563,11 @@ internal class ModuleScheduler : IModuleScheduler
     /// </summary>
     public void MarkModuleCompleted(Type moduleType, bool success, Exception? exception = null, Status? statusOverride = null)
     {
+        if (IsDisposed)
+        {
+            return;
+        }
+
         _stateTracker.MarkModuleCompleted(moduleType, success, exception, statusOverride);
     }
 
@@ -584,21 +611,28 @@ internal class ModuleScheduler : IModuleScheduler
     /// </summary>
     public void CancelPendingModules()
     {
+        if (IsDisposed)
+        {
+            return;
+        }
+
         _stateTracker.CancelPendingModules();
     }
 
     public void Dispose()
     {
-        if (_isDisposed)
+        if (Interlocked.Exchange(ref _disposeState, 1) != 0)
         {
             return;
         }
 
-        _isDisposed = true;
         _disposalCancellationTokenSource.Cancel();
-        _schedulerNotification.Dispose();
         _disposalCancellationTokenSource.Dispose();
-        _stateLock.Dispose();
+
+        // Wake the scheduler so it observes disposal promptly. The lock and semaphore
+        // deliberately remain undisposed because in-flight workers may still be using
+        // them while unwinding; they become collectible with this scheduler.
+        _schedulerNotification.Release();
     }
 
     /// <summary>

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDisposalTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDisposalTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Configuration;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Engine.Scheduling;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class ModuleSchedulerDisposalTests
+{
+    private sealed class TestModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(TestModule));
+    }
+
+    [Test]
+    public async Task Dispose_WhileStateTransitionIsInFlight_DoesNotThrow()
+    {
+        var transitionEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var continueTransition = new ManualResetEventSlim();
+        var constraintEvaluator = new Mock<IModuleConstraintEvaluator>();
+        constraintEvaluator
+            .Setup(x => x.CanStartExecution(It.IsAny<ModuleState>(), It.IsAny<IEnumerable<ModuleState>>()))
+            .Returns(() =>
+            {
+                transitionEntered.TrySetResult();
+                continueTransition.Wait(TimeSpan.FromSeconds(5));
+                return true;
+            });
+        var scheduler = CreateScheduler(constraintEvaluator.Object);
+        scheduler.InitializeModules([new TestModule()]);
+
+        var transitionTask = Task.Run(() => scheduler.MarkModuleStarted(typeof(TestModule)));
+        await transitionEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Exception? disposeException = null;
+        try
+        {
+            scheduler.Dispose();
+        }
+        catch (Exception exception)
+        {
+            disposeException = exception;
+        }
+        finally
+        {
+            continueTransition.Set();
+        }
+
+        Exception? transitionException = null;
+        try
+        {
+            await transitionTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        catch (Exception exception)
+        {
+            transitionException = exception;
+        }
+
+        await Assert.That(disposeException).IsNull();
+        await Assert.That(transitionException).IsNull();
+    }
+
+    [Test]
+    public async Task MarkModuleCompleted_AfterDispose_DoesNotThrow()
+    {
+        var scheduler = CreateScheduler(Mock.Of<IModuleConstraintEvaluator>());
+        scheduler.InitializeModules([new TestModule()]);
+        scheduler.Dispose();
+
+        await Assert.That(() => scheduler.MarkModuleCompleted(typeof(TestModule), success: false))
+            .ThrowsNothing();
+    }
+
+    private static ModuleScheduler CreateScheduler(IModuleConstraintEvaluator constraintEvaluator)
+    {
+        return new ModuleScheduler(
+            NullLogger.Instance,
+            TimeProvider.System,
+            Microsoft.Extensions.Options.Options.Create(new SchedulerOptions()),
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            Mock.Of<IMetricsCollector>(),
+            constraintEvaluator,
+            Mock.Of<ISchedulerStatusReporter>());
+    }
+}


### PR DESCRIPTION
## Summary

- make ModuleScheduler disposal interlocked and idempotent
- ignore scheduler mutations after disposal
- wake the scheduler without destroying synchronization still used by late workers
- cover in-flight transitions and post-dispose completion

## Validation

- failing-first late-completion regression reproduced ObjectDisposedException from ReaderWriterLockSlim
- ModuleScheduler tests: 13 passed, 0 failed
- ModularPipelines.sln Release build: 0 errors (250 baseline warnings)

Closes #3243