### PR TITLE
Retain concurrent module failures

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -223,7 +223,7 @@ internal class ModuleExecutor : IModuleExecutor
                     }
                     catch (Exception ex) when (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                     {
-                        if (!IsExpectedFailFastCancellation(ex, cancellationTokenSource)
+                        if (!IsExpectedFailFastCancellation(ex, ct)
                             && recordedWorkerExceptions.TryAdd(ex, 0))
                         {
                             _secondaryExceptionContainer.RegisterException(ex);
@@ -248,10 +248,10 @@ internal class ModuleExecutor : IModuleExecutor
 
     private static bool IsExpectedFailFastCancellation(
         Exception exception,
-        CancellationTokenSource cancellationTokenSource)
+        CancellationToken workerCancellationToken)
     {
-        return cancellationTokenSource.IsCancellationRequested
-               && exception is OperationCanceledException;
+        return exception is OperationCanceledException operationCanceledException
+               && operationCanceledException.CancellationToken == workerCancellationToken;
     }
 
     private void HandleWaitForAllWorkerFailure(

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Engine.Attributes;
@@ -206,6 +207,8 @@ internal class ModuleExecutor : IModuleExecutor
         };
 
         Exception? firstException = null;
+        var recordedWorkerExceptions =
+            new ConcurrentDictionary<Exception, byte>(ReferenceEqualityComparer.Instance);
 
         try
         {
@@ -220,9 +223,14 @@ internal class ModuleExecutor : IModuleExecutor
                     }
                     catch (Exception ex) when (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                     {
-                        _secondaryExceptionContainer.RegisterException(ex);
-                        Interlocked.CompareExchange(ref firstException, ex, null);
-                        cancellationTokenSource.Cancel();
+                        if (!IsExpectedFailFastCancellation(ex, cancellationTokenSource)
+                            && recordedWorkerExceptions.TryAdd(ex, 0))
+                        {
+                            _secondaryExceptionContainer.RegisterException(ex);
+                            Interlocked.CompareExchange(ref firstException, ex, null);
+                        }
+
+                        EnsureCancellation(cancellationTokenSource);
                     }
                     catch (Exception ex)
                     {
@@ -236,6 +244,14 @@ internal class ModuleExecutor : IModuleExecutor
         }
 
         return firstException;
+    }
+
+    private static bool IsExpectedFailFastCancellation(
+        Exception exception,
+        CancellationTokenSource cancellationTokenSource)
+    {
+        return cancellationTokenSource.IsCancellationRequested
+               && exception is OperationCanceledException;
     }
 
     private void HandleWaitForAllWorkerFailure(

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -223,7 +223,7 @@ internal class ModuleExecutor : IModuleExecutor
                     }
                     catch (Exception ex) when (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                     {
-                        if (!IsExpectedFailFastCancellation(ex, ct)
+                        if (!IsExpectedWorkerCancellation(ex, ct)
                             && recordedWorkerExceptions.TryAdd(ex, 0))
                         {
                             _secondaryExceptionContainer.RegisterException(ex);
@@ -246,7 +246,9 @@ internal class ModuleExecutor : IModuleExecutor
         return firstException;
     }
 
-    private static bool IsExpectedFailFastCancellation(
+    // Engine-linked module cancellation is converted to a PipelineTerminated result
+    // by ModuleExecutionPipeline. Only worker-token cancellation can reach this layer.
+    private static bool IsExpectedWorkerCancellation(
         Exception exception,
         CancellationToken workerCancellationToken)
     {

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -220,6 +220,7 @@ internal class ModuleExecutor : IModuleExecutor
                     }
                     catch (Exception ex) when (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                     {
+                        _secondaryExceptionContainer.RegisterException(ex);
                         Interlocked.CompareExchange(ref firstException, ex, null);
                         cancellationTokenSource.Cancel();
                     }

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -179,7 +179,7 @@ internal class ModuleExecutor : IModuleExecutor
             _resultRegistrar.RegisterTerminatedResultsForCancelledModules(modules, firstException);
         }
 
-        RethrowFirstExceptionIfPresent(firstException);
+        ThrowWorkerExceptionsIfPresent(firstException);
 
         _logger.LogDebug("ExecuteAsync returning normally with {Count} modules", modules.Count);
         return modules;
@@ -301,11 +301,14 @@ internal class ModuleExecutor : IModuleExecutor
         }
     }
 
-    private void RethrowFirstExceptionIfPresent(Exception? firstException)
+    private void ThrowWorkerExceptionsIfPresent(Exception? firstException)
     {
         if (firstException != null)
         {
-            _logger.LogDebug("Rethrowing first exception: {ExceptionType}", firstException.GetType().Name);
+            _logger.LogDebug("Throwing worker exceptions after first failure: {ExceptionType}", firstException.GetType().Name);
+            _secondaryExceptionContainer.ThrowExceptions();
+
+            // Defensive fallback for custom container implementations that do not throw.
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(firstException).Throw();
         }
     }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -90,6 +90,85 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
+    public async Task StopOnFirstException_RegistersAllConcurrentWorkerFaults()
+    {
+        var faultingModule = new FaultingModule();
+        var laterModule = new LaterModule();
+        var readyModules = Channel.CreateUnbounded<ModuleState>();
+        await readyModules.Writer.WriteAsync(new ModuleState(faultingModule, typeof(FaultingModule)));
+        await readyModules.Writer.WriteAsync(new ModuleState(laterModule, typeof(LaterModule)));
+        readyModules.Writer.Complete();
+
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler.SetupGet(x => x.ReadyModules).Returns(readyModules.Reader);
+        scheduler.Setup(x => x.RunSchedulerAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var schedulerFactory = new Mock<IModuleSchedulerFactory>();
+        schedulerFactory.Setup(x => x.Create()).Returns(scheduler.Object);
+
+        var registrationEvents = new Mock<IRegistrationEventExecutor>();
+        registrationEvents.Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(Task.CompletedTask);
+
+        var parallelLimitProvider = new Mock<IParallelLimitProvider>();
+        parallelLimitProvider.Setup(x => x.GetMaxDegreeOfParallelism()).Returns(2);
+
+        var workersStarted = 0;
+        var bothWorkersStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var moduleRunner = new Mock<IModuleRunner>();
+        moduleRunner
+            .Setup(x => x.ExecuteAsync(
+                It.IsAny<ModuleState>(),
+                It.IsAny<IModuleScheduler>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<ModuleState, IModuleScheduler, CancellationToken>(async (moduleState, _, _) =>
+            {
+                if (Interlocked.Increment(ref workersStarted) == 2)
+                {
+                    bothWorkersStarted.TrySetResult();
+                }
+
+                await bothWorkersStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                throw new InvalidOperationException(moduleState.ModuleType.Name);
+            });
+
+        var registeredExceptions = new ConcurrentBag<string>();
+        var secondaryExceptionContainer = new Mock<ISecondaryExceptionContainer>();
+        secondaryExceptionContainer
+            .Setup(x => x.RegisterException(It.IsAny<Exception>()))
+            .Callback<Exception>(exception => registeredExceptions.Add(exception.Message));
+        var alwaysRunHandler = new Mock<IAlwaysRunHandler>();
+        alwaysRunHandler
+            .Setup(x => x.WaitForAlwaysRunModulesAsync(
+                It.IsAny<IModuleScheduler>(),
+                It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(Task.CompletedTask);
+        var executor = new ModuleExecutor(
+            schedulerFactory.Object,
+            moduleRunner.Object,
+            alwaysRunHandler.Object,
+            Mock.Of<IModuleResultRegistrar>(),
+            Mock.Of<IModuleResultRegistry>(),
+            parallelLimitProvider.Object,
+            registrationEvents.Object,
+            Mock.Of<IMetricsCollector>(),
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            secondaryExceptionContainer.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                ExecutionMode = ExecutionMode.StopOnFirstException,
+            }),
+            Mock.Of<Microsoft.Extensions.Logging.ILogger<ModuleExecutor>>());
+
+        await Assert.That(async () => { await executor.ExecuteAsync([faultingModule, laterModule]); })
+            .Throws<InvalidOperationException>();
+        await Assert.That(registeredExceptions)
+            .IsEquivalentTo([nameof(FaultingModule), nameof(LaterModule)]);
+    }
+
+    [Test]
     public async Task WaitForAllModules_WorkerFault_DoesNotStopRemainingModules()
     {
         var dependencyRegistry = new ModuleDependencyRegistry();

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -170,6 +170,45 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
+    public async Task StopOnFirstException_SurfacesIndependentWorkerCancellation()
+    {
+        var faultingModule = new FaultingModule();
+        var laterModule = new LaterModule();
+        var workersStarted = 0;
+        var bothWorkersStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var failFastCancellationObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var independentCancellationToken = new CancellationToken(canceled: true);
+        var executor = CreateStopOnFirstExceptionExecutor(
+            faultingModule,
+            laterModule,
+            async (moduleState, _, cancellationToken) =>
+            {
+                if (Interlocked.Increment(ref workersStarted) == 2)
+                {
+                    bothWorkersStarted.TrySetResult();
+                }
+
+                await bothWorkersStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+                if (moduleState.ModuleType == typeof(FaultingModule))
+                {
+                    throw new InvalidOperationException("Primary failure");
+                }
+
+                using var registration = cancellationToken.Register(failFastCancellationObserved.SetResult);
+                await failFastCancellationObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+                throw new OperationCanceledException(independentCancellationToken);
+            });
+
+        var exception = await Assert.That(async () =>
+                await executor.ExecuteAsync([faultingModule, laterModule]))
+            .Throws<AggregateException>();
+
+        await Assert.That(exception!.InnerExceptions.Select(x => x.GetType()))
+            .IsEquivalentTo([typeof(InvalidOperationException), typeof(OperationCanceledException)]);
+    }
+
+    [Test]
     public async Task WaitForAllModules_WorkerFault_DoesNotStopRemainingModules()
     {
         var dependencyRegistry = new ModuleDependencyRegistry();

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -90,7 +90,7 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
-    public async Task StopOnFirstException_RegistersAllConcurrentWorkerFaults()
+    public async Task StopOnFirstException_SurfacesAllConcurrentWorkerFaults()
     {
         var faultingModule = new FaultingModule();
         var laterModule = new LaterModule();
@@ -133,11 +133,7 @@ public class ModuleExecutorLoggingTests
                 throw new InvalidOperationException(moduleState.ModuleType.Name);
             });
 
-        var registeredExceptions = new ConcurrentBag<string>();
-        var secondaryExceptionContainer = new Mock<ISecondaryExceptionContainer>();
-        secondaryExceptionContainer
-            .Setup(x => x.RegisterException(It.IsAny<Exception>()))
-            .Callback<Exception>(exception => registeredExceptions.Add(exception.Message));
+        var secondaryExceptionContainer = new SecondaryExceptionContainer();
         var alwaysRunHandler = new Mock<IAlwaysRunHandler>();
         alwaysRunHandler
             .Setup(x => x.WaitForAlwaysRunModulesAsync(
@@ -155,16 +151,17 @@ public class ModuleExecutorLoggingTests
             Mock.Of<IMetricsCollector>(),
             new ModuleDependencyRegistry(),
             new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
-            secondaryExceptionContainer.Object,
+            secondaryExceptionContainer,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
                 ExecutionMode = ExecutionMode.StopOnFirstException,
             }),
             Mock.Of<Microsoft.Extensions.Logging.ILogger<ModuleExecutor>>());
 
-        await Assert.That(async () => { await executor.ExecuteAsync([faultingModule, laterModule]); })
-            .Throws<InvalidOperationException>();
-        await Assert.That(registeredExceptions)
+        var exception = await Assert.That(async () =>
+                await executor.ExecuteAsync([faultingModule, laterModule]))
+            .Throws<AggregateException>();
+        await Assert.That(exception!.InnerExceptions.Select(x => x.Message))
             .IsEquivalentTo([nameof(FaultingModule), nameof(LaterModule)]);
     }
 

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -136,7 +136,7 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
-    public async Task StopOnFirstException_IgnoresCooperativeWorkerCancellation()
+    public async Task StopOnFirstException_IgnoresWorkerCancellation()
     {
         var faultingModule = new FaultingModule();
         var laterModule = new LaterModule();

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -94,35 +94,12 @@ public class ModuleExecutorLoggingTests
     {
         var faultingModule = new FaultingModule();
         var laterModule = new LaterModule();
-        var readyModules = Channel.CreateUnbounded<ModuleState>();
-        await readyModules.Writer.WriteAsync(new ModuleState(faultingModule, typeof(FaultingModule)));
-        await readyModules.Writer.WriteAsync(new ModuleState(laterModule, typeof(LaterModule)));
-        readyModules.Writer.Complete();
-
-        var scheduler = new Mock<IModuleScheduler>();
-        scheduler.SetupGet(x => x.ReadyModules).Returns(readyModules.Reader);
-        scheduler.Setup(x => x.RunSchedulerAsync(It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
-
-        var schedulerFactory = new Mock<IModuleSchedulerFactory>();
-        schedulerFactory.Setup(x => x.Create()).Returns(scheduler.Object);
-
-        var registrationEvents = new Mock<IRegistrationEventExecutor>();
-        registrationEvents.Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IReadOnlyList<IModule>>()))
-            .Returns(Task.CompletedTask);
-
-        var parallelLimitProvider = new Mock<IParallelLimitProvider>();
-        parallelLimitProvider.Setup(x => x.GetMaxDegreeOfParallelism()).Returns(2);
-
         var workersStarted = 0;
         var bothWorkersStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var moduleRunner = new Mock<IModuleRunner>();
-        moduleRunner
-            .Setup(x => x.ExecuteAsync(
-                It.IsAny<ModuleState>(),
-                It.IsAny<IModuleScheduler>(),
-                It.IsAny<CancellationToken>()))
-            .Returns<ModuleState, IModuleScheduler, CancellationToken>(async (moduleState, _, _) =>
+        var executor = CreateStopOnFirstExceptionExecutor(
+            faultingModule,
+            laterModule,
+            async (moduleState, _, _) =>
             {
                 if (Interlocked.Increment(ref workersStarted) == 2)
                 {
@@ -133,36 +110,63 @@ public class ModuleExecutorLoggingTests
                 throw new InvalidOperationException(moduleState.ModuleType.Name);
             });
 
-        var secondaryExceptionContainer = new SecondaryExceptionContainer();
-        var alwaysRunHandler = new Mock<IAlwaysRunHandler>();
-        alwaysRunHandler
-            .Setup(x => x.WaitForAlwaysRunModulesAsync(
-                It.IsAny<IModuleScheduler>(),
-                It.IsAny<IReadOnlyList<IModule>>()))
-            .Returns(Task.CompletedTask);
-        var executor = new ModuleExecutor(
-            schedulerFactory.Object,
-            moduleRunner.Object,
-            alwaysRunHandler.Object,
-            Mock.Of<IModuleResultRegistrar>(),
-            Mock.Of<IModuleResultRegistry>(),
-            parallelLimitProvider.Object,
-            registrationEvents.Object,
-            Mock.Of<IMetricsCollector>(),
-            new ModuleDependencyRegistry(),
-            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
-            secondaryExceptionContainer,
-            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
-            {
-                ExecutionMode = ExecutionMode.StopOnFirstException,
-            }),
-            Mock.Of<Microsoft.Extensions.Logging.ILogger<ModuleExecutor>>());
-
         var exception = await Assert.That(async () =>
                 await executor.ExecuteAsync([faultingModule, laterModule]))
             .Throws<AggregateException>();
         await Assert.That(exception!.InnerExceptions.Select(x => x.Message))
             .IsEquivalentTo([nameof(FaultingModule), nameof(LaterModule)]);
+    }
+
+    [Test]
+    public async Task StopOnFirstException_DoesNotDuplicateSharedWorkerFault()
+    {
+        var sharedException = new InvalidOperationException("Shared failure");
+        var faultingModule = new FaultingModule();
+        var laterModule = new LaterModule();
+        var executor = CreateStopOnFirstExceptionExecutor(
+            faultingModule,
+            laterModule,
+            (_, _, _) => Task.FromException(sharedException));
+
+        var exception = await Assert.That(async () =>
+                await executor.ExecuteAsync([faultingModule, laterModule]))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(exception).IsSameReferenceAs(sharedException);
+    }
+
+    [Test]
+    public async Task StopOnFirstException_IgnoresCooperativeWorkerCancellation()
+    {
+        var faultingModule = new FaultingModule();
+        var laterModule = new LaterModule();
+        var workersStarted = 0;
+        var bothWorkersStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var executor = CreateStopOnFirstExceptionExecutor(
+            faultingModule,
+            laterModule,
+            async (moduleState, _, cancellationToken) =>
+            {
+                if (Interlocked.Increment(ref workersStarted) == 2)
+                {
+                    bothWorkersStarted.TrySetResult();
+                }
+
+                await bothWorkersStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+                if (moduleState.ModuleType == typeof(FaultingModule))
+                {
+                    throw new InvalidOperationException("Primary failure");
+                }
+
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            });
+
+        var exception = await Assert.That(async () =>
+                await executor.ExecuteAsync([faultingModule, laterModule]))
+            .Throws<InvalidOperationException>();
+
+        await Assert.That(exception!.Message).IsEqualTo("Primary failure");
     }
 
     [Test]
@@ -375,6 +379,65 @@ public class ModuleExecutorLoggingTests
         tracker.CancelPendingModules();
 
         await Assert.That(logs.ToString()).Contains("Cancelling 1 pending/queued modules");
+    }
+
+    private static ModuleExecutor CreateStopOnFirstExceptionExecutor(
+        FaultingModule faultingModule,
+        LaterModule laterModule,
+        Func<ModuleState, IModuleScheduler, CancellationToken, Task> executeModule)
+    {
+        var readyModules = Channel.CreateUnbounded<ModuleState>();
+        readyModules.Writer.TryWrite(new ModuleState(faultingModule, typeof(FaultingModule)));
+        readyModules.Writer.TryWrite(new ModuleState(laterModule, typeof(LaterModule)));
+        readyModules.Writer.Complete();
+
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler.SetupGet(x => x.ReadyModules).Returns(readyModules.Reader);
+        scheduler.Setup(x => x.RunSchedulerAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var schedulerFactory = new Mock<IModuleSchedulerFactory>();
+        schedulerFactory.Setup(x => x.Create()).Returns(scheduler.Object);
+
+        var registrationEvents = new Mock<IRegistrationEventExecutor>();
+        registrationEvents.Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(Task.CompletedTask);
+
+        var parallelLimitProvider = new Mock<IParallelLimitProvider>();
+        parallelLimitProvider.Setup(x => x.GetMaxDegreeOfParallelism()).Returns(2);
+
+        var moduleRunner = new Mock<IModuleRunner>();
+        moduleRunner
+            .Setup(x => x.ExecuteAsync(
+                It.IsAny<ModuleState>(),
+                It.IsAny<IModuleScheduler>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<ModuleState, IModuleScheduler, CancellationToken>(executeModule);
+
+        var alwaysRunHandler = new Mock<IAlwaysRunHandler>();
+        alwaysRunHandler
+            .Setup(x => x.WaitForAlwaysRunModulesAsync(
+                It.IsAny<IModuleScheduler>(),
+                It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(Task.CompletedTask);
+
+        return new ModuleExecutor(
+            schedulerFactory.Object,
+            moduleRunner.Object,
+            alwaysRunHandler.Object,
+            Mock.Of<IModuleResultRegistrar>(),
+            Mock.Of<IModuleResultRegistry>(),
+            parallelLimitProvider.Object,
+            registrationEvents.Object,
+            Mock.Of<IMetricsCollector>(),
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            new SecondaryExceptionContainer(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                ExecutionMode = ExecutionMode.StopOnFirstException,
+            }),
+            Mock.Of<Microsoft.Extensions.Logging.ILogger<ModuleExecutor>>());
     }
 
     private static ModuleStateTracker CreateModuleStateTracker(

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -123,9 +123,10 @@ public class EngineCancellationTokenTests : TestBase
 
         await Task.Delay(WaitForCancellationDelay);
 
-        await Assert.That(async () => await pipelineTask).ThrowsException();
+        var exception = await Assert.ThrowsAsync<ModuleFailedException>(async () => await pipelineTask);
 
         var longRunningModuleResult = resultRegistry.GetResult(typeof(LongRunningModule));
+        await Assert.That(exception).IsNotNull();
         await Assert.That(longRunningModuleResult).IsNotNull();
         await Assert.That(longRunningModuleResult!.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
         await Assert.That(longRunningModuleResult.ModuleDuration).IsLessThan(TimeSpan.FromSeconds(5));


### PR DESCRIPTION
## Summary

- register every fail-fast worker exception in the thread-safe secondary container
- throw that container from the fail-fast exit so concurrent sibling failures reach callers
- preserve the original single-failure stack trace through `ExceptionDispatchInfo`
- cover two synchronized workers failing concurrently with the real container and caller-visible `AggregateException`

## Validation

- failing-first caller-visible regression threw only one `InvalidOperationException` before the fix
- ModuleExecutorLoggingTests: 7 passed, 0 failed
- ModularPipelines.sln Release build: 0 errors (250 baseline warnings)

Closes #3245