### PR TITLE
Preserve module output during provider disposal

### DIFF
--- a/src/ModularPipelines/Logging/ModuleLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/ModuleLoggerProvider.cs
@@ -13,7 +13,7 @@ namespace ModularPipelines.Logging;
 /// - Service provider: Creates new logger instances
 /// The provider maintains thread-safe singleton behavior per module type.
 /// </remarks>
-internal class ModuleLoggerProvider : IInternalModuleLoggerProvider, IDisposable
+internal class ModuleLoggerProvider : IInternalModuleLoggerProvider
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly IStackTraceModuleDetector _stackTraceDetector;
@@ -40,7 +40,7 @@ internal class ModuleLoggerProvider : IInternalModuleLoggerProvider, IDisposable
     public IModuleLogger GetLogger(Type type)
     {
         var loggerType = typeof(ModuleLogger<>).MakeGenericType(type);
-        return (IModuleLogger)_serviceProvider.GetRequiredService(loggerType);
+        return (IModuleLogger) _serviceProvider.GetRequiredService(loggerType);
     }
 
     public IModuleLogger GetLogger()
@@ -77,11 +77,5 @@ internal class ModuleLoggerProvider : IInternalModuleLoggerProvider, IDisposable
 
             return _moduleLogger = GetLogger(detectedType);
         }
-    }
-
-    public void Dispose()
-    {
-        _moduleLogger?.Dispose();
-        _pipelineLevelLogger?.Dispose();
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerProviderTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
@@ -23,38 +24,39 @@ public class ModuleLoggerProviderTests
                 typeof(TestModule),
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
-        var logger = new ModuleLogger<TestModule>(
-            NullLogger<TestModule>.Instance,
-            Mock.Of<ISecretObfuscator>(),
-            Mock.Of<IFormattedLogValuesObfuscator>(),
-            consoleCoordinator.Object,
-            outputCoordinator.Object);
-        var provider = new ModuleLoggerProvider(
-            Mock.Of<IServiceProvider>(),
-            Mock.Of<IStackTraceModuleDetector>(),
-            NullLoggerFactory.Instance);
+        var services = new ServiceCollection()
+            .AddSingleton<Microsoft.Extensions.Logging.ILoggerFactory>(NullLoggerFactory.Instance)
+            .AddSingleton(typeof(Microsoft.Extensions.Logging.ILogger<>), typeof(NullLogger<>))
+            .AddSingleton(Mock.Of<ISecretObfuscator>())
+            .AddSingleton(Mock.Of<IFormattedLogValuesObfuscator>())
+            .AddSingleton(consoleCoordinator.Object)
+            .AddSingleton(outputCoordinator.Object)
+            .AddSingleton(Mock.Of<IStackTraceModuleDetector>())
+            .AddScoped<ModuleLoggerProvider>()
+            .AddScoped(typeof(ModuleLogger<>));
+        await using var serviceProvider = services.BuildServiceProvider();
+        var scope = serviceProvider.CreateAsyncScope();
         var previousLogger = ModuleLogger.Values.Value;
 
         try
         {
+            var logger = scope.ServiceProvider.GetRequiredService<ModuleLogger<TestModule>>();
+            var provider = scope.ServiceProvider.GetRequiredService<ModuleLoggerProvider>();
             ModuleLogger.Values.Value = logger;
             _ = provider.GetLogger();
-
-            (provider as IDisposable)?.Dispose();
-            await logger.DisposeAsync();
-
-            outputCoordinator.Verify(
-                x => x.OnModuleCompletedAsync(
-                    buffer.Object,
-                    typeof(TestModule),
-                    It.IsAny<CancellationToken>()),
-                Times.Once);
         }
         finally
         {
             ModuleLogger.Values.Value = previousLogger;
-            await logger.DisposeAsync();
+            await scope.DisposeAsync();
         }
+
+        outputCoordinator.Verify(
+            x => x.OnModuleCompletedAsync(
+                buffer.Object,
+                typeof(TestModule),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     private sealed class TestModule;

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerProviderTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Console;
+using ModularPipelines.Engine;
+using ModularPipelines.Logging;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Logging;
+
+public class ModuleLoggerProviderTests
+{
+    [Test]
+    public async Task ProviderLifetimeEnd_DoesNotPreventAsyncLoggerFlush()
+    {
+        var buffer = new Mock<IModuleOutputBuffer>();
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.GetModuleBuffer(typeof(TestModule)))
+            .Returns(buffer.Object);
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(x => x.OnModuleCompletedAsync(
+                buffer.Object,
+                typeof(TestModule),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var logger = new ModuleLogger<TestModule>(
+            NullLogger<TestModule>.Instance,
+            Mock.Of<ISecretObfuscator>(),
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            outputCoordinator.Object);
+        var provider = new ModuleLoggerProvider(
+            Mock.Of<IServiceProvider>(),
+            Mock.Of<IStackTraceModuleDetector>(),
+            NullLoggerFactory.Instance);
+        var previousLogger = ModuleLogger.Values.Value;
+
+        try
+        {
+            ModuleLogger.Values.Value = logger;
+            _ = provider.GetLogger();
+
+            (provider as IDisposable)?.Dispose();
+            await logger.DisposeAsync();
+
+            outputCoordinator.Verify(
+                x => x.OnModuleCompletedAsync(
+                    buffer.Object,
+                    typeof(TestModule),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+        finally
+        {
+            ModuleLogger.Values.Value = previousLogger;
+            await logger.DisposeAsync();
+        }
+    }
+
+    private sealed class TestModule;
+}


### PR DESCRIPTION
Closes #3247

- stop `ModuleLoggerProvider` from owning or synchronously disposing scoped loggers
- leave logger lifetime to the scope so `ModuleLogger<T>.DisposeAsync` can flush buffered output
- add a regression proving provider teardown cannot suppress the logger's asynchronous completion flush

Validation:
- ModuleLoggerProviderTests: 1 passed on net10.0 (verified failing before the fix)
- ModuleLoggerTests: 3 passed on net10.0
- ModularPipelines.sln Release build: 0 errors (250 existing warnings)
- scoped format/analyzer verification: only pre-existing IDE0290 and IDE0330 findings