### PR TITLE
Cancel module retry back-off

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -388,7 +388,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             if (!timeoutException.WasCancellationTokenRespected)
             {
                 logger.LogWarning(
-                    "Module {ModuleName} did not respond to cancellation token and was forcibly terminated after {ElapsedTime}",
+                    "Module {ModuleName} did not complete within the cancellation grace period; timeout enforcement stopped waiting after {ElapsedTime}",
                     executionContext.ModuleType.Name,
                     timeoutException.ElapsedTime.ToDisplayString());
             }

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -276,10 +276,26 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         // Get retry policy if applicable
         var retryPolicy = GetRetryPolicy<T>(config, moduleContext);
+        var moduleAttemptRespondedToCancellation = 0;
+
+        async Task<T?> ExecuteModuleAttempt(CancellationToken ct)
+        {
+            try
+            {
+                return await module.ExecuteAsync(moduleContext, ct).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (ct.IsCancellationRequested)
+                {
+                    Volatile.Write(ref moduleAttemptRespondedToCancellation, 1);
+                }
+            }
+        }
 
         // Create the execution function that optionally includes retry
         Func<CancellationToken, Task<T?>> executeFunc = retryPolicy != null
-            ? ct => retryPolicy.ExecuteAsync(c => module.ExecuteAsync(moduleContext, c), ct)
+            ? ct => retryPolicy.ExecuteAsync(ExecuteModuleAttempt, ct)
             : ct => module.ExecuteAsync(moduleContext, ct);
 
         // Use TimeoutHelper with detailed results to get information about token cooperation
@@ -291,12 +307,16 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         if (timeoutResult.TimedOut)
         {
+            var wasCancellationTokenRespected = timeoutResult.WasCancellationTokenRespected
+                                                && (retryPolicy is null
+                                                    || Volatile.Read(ref moduleAttemptRespondedToCancellation) == 1);
+
             // Create a detailed timeout exception with information about token cooperation
             throw new ModuleTimeoutException(
                 executionContext.ModuleType,
                 timeout,
                 timeoutResult.ElapsedTime,
-                timeoutResult.WasCancellationTokenRespected);
+                wasCancellationTokenRespected);
         }
 
         return timeoutResult.Value;

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -15,22 +15,6 @@ using Polly;
 namespace ModularPipelines.Engine;
 
 /// <summary>
-/// Interface for the module execution pipeline.
-/// </summary>
-internal interface IModuleExecutionPipeline
-{
-    /// <summary>
-    /// Executes a module with all applicable behaviors.
-    /// </summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    Task<ModuleResult<T>> ExecuteAsync<T>(
-        Module<T> module,
-        ModuleExecutionContext<T> executionContext,
-        IModuleContext moduleContext,
-        CancellationToken engineCancellationToken);
-}
-
-/// <summary>
 /// Orchestrates module execution by applying behaviors based on module configuration.
 /// </summary>
 /// <remarks>
@@ -393,11 +377,11 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
                     timeoutException.ElapsedTime.ToDisplayString());
             }
         }
-
         else if (IsTimeout(config, executionContext, exception))
         {
             executionContext.Status = Status.TimedOut;
         }
+
         // Check for pipeline cancellation
         else if (IsPipelineCancelled(exception))
         {
@@ -506,4 +490,20 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         logger.Log(logLevel, message);
     }
+}
+
+/// <summary>
+/// Interface for the module execution pipeline.
+/// </summary>
+internal interface IModuleExecutionPipeline
+{
+    /// <summary>
+    /// Executes a module with all applicable behaviors.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task<ModuleResult<T>> ExecuteAsync<T>(
+        Module<T> module,
+        ModuleExecutionContext<T> executionContext,
+        IModuleContext moduleContext,
+        CancellationToken engineCancellationToken);
 }

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -279,7 +279,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         // Create the execution function that optionally includes retry
         Func<CancellationToken, Task<T?>> executeFunc = retryPolicy != null
-            ? ct => retryPolicy.ExecuteAsync(() => module.ExecuteAsync(moduleContext, ct))
+            ? ct => retryPolicy.ExecuteAsync(c => module.ExecuteAsync(moduleContext, c), ct)
             : ct => module.ExecuteAsync(moduleContext, ct);
 
         // Use TimeoutHelper with detailed results to get information about token cooperation

--- a/src/ModularPipelines/Exceptions/ModuleTimeoutException.cs
+++ b/src/ModularPipelines/Exceptions/ModuleTimeoutException.cs
@@ -20,7 +20,7 @@ namespace ModularPipelines.Exceptions;
 /// <item><see cref="ModuleType"/> - The type of the module that timed out</item>
 /// <item><see cref="ConfiguredTimeout"/> - The timeout duration that was configured</item>
 /// <item><see cref="ElapsedTime"/> - The actual time elapsed before timeout was enforced</item>
-/// <item><see cref="WasCancellationTokenRespected"/> - Whether the module observed the cancellation token</item>
+/// <item><see cref="WasCancellationTokenRespected"/> - Whether the module completed within the cancellation grace period</item>
 /// </list>
 /// <para><b>Handling example:</b></para>
 /// <code>
@@ -36,7 +36,7 @@ namespace ModularPipelines.Exceptions;
 ///
 ///     if (!ex.WasCancellationTokenRespected)
 ///     {
-///         Console.WriteLine("Warning: Module did not respond to cancellation token");
+///         Console.WriteLine("Warning: Module did not complete within the cancellation grace period");
 ///     }
 /// }
 /// </code>
@@ -68,7 +68,7 @@ public class ModuleTimeoutException : PipelineException
     /// <param name="moduleType">The type of the module that timed out.</param>
     /// <param name="configuredTimeout">The timeout duration that was configured.</param>
     /// <param name="elapsedTime">The actual time elapsed before timeout was enforced.</param>
-    /// <param name="wasCancellationTokenRespected">Whether the module observed the cancellation token.</param>
+    /// <param name="wasCancellationTokenRespected">Whether the module completed within the cancellation grace period.</param>
     internal ModuleTimeoutException(
         Type moduleType,
         TimeSpan configuredTimeout,
@@ -102,12 +102,11 @@ public class ModuleTimeoutException : PipelineException
     public TimeSpan ElapsedTime { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the module properly observed the cancellation token.
+    /// Gets a value indicating whether the module completed within the cancellation grace period.
     /// </summary>
     /// <remarks>
-    /// When <c>true</c>, the module responded to the cancellation token and exited gracefully.
-    /// When <c>false</c>, the module ignored the cancellation token and was forcibly terminated
-    /// by the timeout enforcement mechanism (Task.WhenAny pattern).
+    /// This is a timing-based signal: it cannot prove that the module observed the cancellation token.
+    /// When <c>false</c>, the timeout enforcement mechanism stopped waiting after the grace period.
     /// </remarks>
     public bool WasCancellationTokenRespected { get; }
 
@@ -121,7 +120,7 @@ public class ModuleTimeoutException : PipelineException
 
         if (!wasCancellationTokenRespected)
         {
-            return $"{baseMessage}. The module did not respond to the cancellation token and was forcibly terminated after {elapsedTime.ToDisplayString()}.";
+            return $"{baseMessage}. The module did not complete within the cancellation grace period; timeout enforcement stopped waiting after {elapsedTime.ToDisplayString()}.";
         }
 
         return baseMessage;

--- a/src/ModularPipelines/Exceptions/ModuleTimeoutException.cs
+++ b/src/ModularPipelines/Exceptions/ModuleTimeoutException.cs
@@ -52,7 +52,7 @@ namespace ModularPipelines.Exceptions;
 public class ModuleTimeoutException : PipelineException
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ModuleTimeoutException"/> class.
+    /// Initialises a new instance of the <see cref="ModuleTimeoutException"/> class.
     /// </summary>
     /// <param name="moduleType">The type of the module that timed out.</param>
     /// <param name="configuredTimeout">The timeout duration that was configured.</param>
@@ -62,8 +62,8 @@ public class ModuleTimeoutException : PipelineException
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ModuleTimeoutException"/> class
-    /// with detailed timeout information.
+    /// Initialises a new instance of the <see cref="ModuleTimeoutException"/> class with
+    /// detailed timeout information.
     /// </summary>
     /// <param name="moduleType">The type of the module that timed out.</param>
     /// <param name="configuredTimeout">The timeout duration that was configured.</param>

--- a/src/ModularPipelines/Helpers/TimeoutExecutionResult.cs
+++ b/src/ModularPipelines/Helpers/TimeoutExecutionResult.cs
@@ -29,12 +29,11 @@ internal readonly struct TimeoutExecutionResult<T>
     public bool TimedOut { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the cancellation token was properly observed.
+    /// Gets a value indicating whether the operation completed within the cancellation grace period.
     /// </summary>
     /// <remarks>
-    /// When <c>true</c>, the operation responded to the cancellation token and exited gracefully.
-    /// When <c>false</c>, the operation ignored the cancellation token and had to be forcibly
-    /// abandoned by the timeout enforcement mechanism.
+    /// This is a timing-based signal: it cannot prove that the operation observed the cancellation token.
+    /// When <c>false</c>, the timeout enforcement mechanism stopped waiting after the grace period.
     /// </remarks>
     public bool WasCancellationTokenRespected { get; }
 

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -173,12 +173,12 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
-    public async Task Timeout_Exception_Message_Includes_Warning_When_Token_Ignored()
+    public async Task Timeout_Exception_Message_Reports_Grace_Period_Expiry()
     {
         var exception = await Assert.ThrowsAsync<ModuleFailedException>(RunModule<Module_NotUsingCancellationToken>);
 
         var timeoutException = exception!.InnerException as ModuleTimeoutException;
         await Assert.That(timeoutException).IsNotNull();
-        await Assert.That(timeoutException!.Message).Contains("did not respond to the cancellation token");
+        await Assert.That(timeoutException!.Message).Contains("did not complete within the cancellation grace period");
     }
 }

--- a/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
@@ -210,6 +210,9 @@ public class RetryTests : TestBase
             })
             .AddModule<FailedModuleWithTimeout>()
             .ExecutePipelineAsync());
-        await Assert.That(moduleFailedException?.InnerException).IsTypeOf<ModuleTimeoutException>();
+
+        var timeoutException = moduleFailedException?.InnerException as ModuleTimeoutException;
+        await Assert.That(timeoutException).IsNotNull();
+        await Assert.That(timeoutException!.WasCancellationTokenRespected).IsTrue();
     }
 }

--- a/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
@@ -108,6 +108,19 @@ public class RetryTests : TestBase
         }
     }
 
+    private class CancellableModuleWithTimeout : Module<bool>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithTimeout(TimeSpan.FromMilliseconds(ModuleTimeoutMs))
+            .Build();
+
+        protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return true;
+        }
+    }
+
     [Test]
     public async Task When_Successful_Do_Not_Retry()
     {
@@ -203,12 +216,38 @@ public class RetryTests : TestBase
     [Test]
     public async Task When_Retry_With_Timeout_Then_Honour_Overall_Timeout()
     {
-        var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(async () => await TestPipelineHostBuilder.Create()
+        var host = await TestPipelineHostBuilder.Create()
             .ConfigurePipelineOptions((_, options) =>
             {
                 options.DefaultRetryCount = DefaultRetryCount;
             })
             .AddModule<FailedModuleWithTimeout>()
+            .BuildHostAsync();
+
+        var executionTask = host.ExecutePipelineAsync();
+        var completedPromptly = await Task.WhenAny(
+            executionTask,
+            Task.Delay(TimeSpan.FromMilliseconds(500))) == executionTask;
+        var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(async () => await executionTask);
+
+        var timeoutException = moduleFailedException?.InnerException as ModuleTimeoutException;
+        await Assert.That(timeoutException).IsNotNull();
+        using (Assert.Multiple())
+        {
+            await Assert.That(completedPromptly).IsTrue();
+            await Assert.That(timeoutException!.WasCancellationTokenRespected).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task When_Retry_Timeouts_During_Module_Then_Report_Token_Respected()
+    {
+        var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(async () => await TestPipelineHostBuilder.Create()
+            .ConfigurePipelineOptions((_, options) =>
+            {
+                options.DefaultRetryCount = DefaultRetryCount;
+            })
+            .AddModule<CancellableModuleWithTimeout>()
             .ExecutePipelineAsync());
 
         var timeoutException = moduleFailedException?.InnerException as ModuleTimeoutException;

--- a/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
@@ -96,12 +96,15 @@ public class RetryTests : TestBase
 
     private class FailedModuleWithTimeout : Module<bool>
     {
+        internal int ExecutionCount;
+
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
             .WithTimeout(TimeSpan.FromMilliseconds(ModuleTimeoutMs))
             .Build();
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
+            ExecutionCount++;
             await Task.Delay(TimeSpan.FromMilliseconds(ModuleDelayMs), cancellationToken);
 
             throw new Exception();
@@ -224,17 +227,14 @@ public class RetryTests : TestBase
             .AddModule<FailedModuleWithTimeout>()
             .BuildHostAsync();
 
-        var executionTask = host.ExecutePipelineAsync();
-        var completedPromptly = await Task.WhenAny(
-            executionTask,
-            Task.Delay(TimeSpan.FromMilliseconds(500))) == executionTask;
-        var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(async () => await executionTask);
+        var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(async () => await host.ExecutePipelineAsync());
 
+        var module = host.RootServices.GetServices<IModule>().OfType<FailedModuleWithTimeout>().Single();
         var timeoutException = moduleFailedException?.InnerException as ModuleTimeoutException;
         await Assert.That(timeoutException).IsNotNull();
         using (Assert.Multiple())
         {
-            await Assert.That(completedPromptly).IsTrue();
+            await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedSingleExecutionCount);
             await Assert.That(timeoutException!.WasCancellationTokenRespected).IsFalse();
         }
     }

--- a/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
@@ -30,15 +30,14 @@ public class RetryTests : TestBase
     private const int ExpectedSingleExecutionCount = 1;
 
     /// <summary>
-    /// The timeout duration for the FailedModuleWithTimeout test module (in milliseconds).
+    /// The timeout duration for timeout test modules (in milliseconds).
     /// </summary>
-    private const int ModuleTimeoutMs = 50;
+    private const int ModuleTimeoutMs = 250;
 
     /// <summary>
-    /// The delay duration for the FailedModuleWithTimeout test module (in milliseconds).
-    /// Must be less than ModuleTimeoutMs to allow timeout to trigger.
+    /// The retry back-off duration for the FailedModuleWithTimeout test module (in milliseconds).
     /// </summary>
-    private const int ModuleDelayMs = 30;
+    private const int RetryDelayMs = 750;
 
     private class SuccessModule : Module<bool>
     {
@@ -100,14 +99,15 @@ public class RetryTests : TestBase
 
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
             .WithTimeout(TimeSpan.FromMilliseconds(ModuleTimeoutMs))
+            .WithRetryPolicy(Policy
+                .Handle<Exception>()
+                .WaitAndRetryAsync(DefaultRetryCount, _ => TimeSpan.FromMilliseconds(RetryDelayMs)))
             .Build();
 
-        protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             ExecutionCount++;
-            await Task.Delay(TimeSpan.FromMilliseconds(ModuleDelayMs), cancellationToken);
-
-            throw new Exception();
+            return Task.FromException<bool>(new Exception());
         }
     }
 


### PR DESCRIPTION
Closes #3249

## Summary
- pass the module timeout token into Polly retry execution
- pass Polly's cancellation token into each module attempt
- verify timed-out retries report cancellation as respected

## Validation
- `RetryTests`: 5 passed
- `ModularPipelines.sln` Release build: 0 errors (250 existing warnings)