### PR TITLE
Cache secret obfuscation search data

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -43,6 +43,7 @@ internal sealed class Command : ICommand, ICommandContext
         var execOpts = executionOptions ?? new CommandExecutionOptions();
 
         _secretRegistry.AddSecrets(_secretProvider.GetSecretsInObject(options));
+        _secretRegistry.AddSecrets(_secretProvider.GetSecretsInObject(execOpts));
 
         var commandLine = _commandLineBuilder.Build(options);
         var resolvedTool = commandLine.Tool;

--- a/src/ModularPipelines/Engine/ISecretProvider.cs
+++ b/src/ModularPipelines/Engine/ISecretProvider.cs
@@ -3,6 +3,11 @@ namespace ModularPipelines.Engine;
 internal interface ISecretProvider
 {
     /// <summary>
+    /// Gets the version of the registered secret collection.
+    /// </summary>
+    long Version { get; }
+
+    /// <summary>
     /// Gets a list of the detected secrets from IOptions objects.
     /// </summary>
     IEnumerable<string> Secrets { get; }

--- a/src/ModularPipelines/Engine/ISecretProvider.cs
+++ b/src/ModularPipelines/Engine/ISecretProvider.cs
@@ -13,9 +13,16 @@ internal interface ISecretProvider
     IEnumerable<string> Secrets { get; }
 
     /// <summary>
+    /// Gets an atomic snapshot of the registered secrets and their version.
+    /// </summary>
+    SecretSnapshot GetSnapshot();
+
+    /// <summary>
     /// Returns any values in the object marked with the [SecretValue] attribute.
     /// </summary>
     /// <param name="value">Object to check for secret values within its properties.</param>
     /// <returns>Array of secrets.</returns>
     IEnumerable<string> GetSecretsInObject(object? value);
 }
+
+internal readonly record struct SecretSnapshot(long Version, IReadOnlyList<string> Secrets);

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Text;
 using Initialization.Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -29,6 +30,9 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
 {
     private readonly ISecretProvider _secretProvider;
     private readonly IOptions<SecretMaskingOptions> _maskingOptions;
+    private readonly object _secretCacheLock = new();
+
+    private SecretCache? _secretCache;
 
     public int Order => int.MaxValue;
 
@@ -61,21 +65,9 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         var maskValue = string.IsNullOrWhiteSpace(options.MaskValue) ? "**********" : options.MaskValue;
         var caseInsensitive = options.CaseInsensitive;
 
-        var minimumLength = Math.Max(1, options.MinimumSecretLength);
-        var secretsFromExtraObject = _secretProvider.GetSecretsInObject(optionsObject)
-            .Where(secret => secret.Length >= minimumLength)
-            .SelectMany(SecretMaskingPatternGenerator.Generate);
-
-        // Combine all secrets and sort by length (longest first) to ensure
-        // longer secrets are replaced before shorter ones that might be substrings
-        var allSecrets = _secretProvider.Secrets
-            .Concat(secretsFromExtraObject)
-            .Where(s => !string.IsNullOrWhiteSpace(s))
-            .Distinct(caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal)
-            .OrderByDescending(s => s.Length)
-            .ToList();
-
-        if (allSecrets.Count == 0)
+        var secretCache = GetSecretCache(optionsObject, options, caseInsensitive);
+        if (secretCache.SearchValues is null ||
+            !input.AsSpan().ContainsAny(secretCache.SearchValues))
         {
             return input;
         }
@@ -84,17 +76,89 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         // For case-insensitive matching, we need a different approach
         if (caseInsensitive)
         {
-            return ObfuscateCaseInsensitive(input, allSecrets, maskValue);
+            return ObfuscateCaseInsensitive(input, secretCache.Secrets, maskValue);
         }
 
-        return ObfuscateCaseSensitive(input, allSecrets, maskValue);
+        return ObfuscateCaseSensitive(input, secretCache.Secrets, maskValue);
+    }
+
+    private SecretCache GetSecretCache(
+        object? optionsObject,
+        SecretMaskingOptions options,
+        bool caseInsensitive)
+    {
+        var registeredSecrets = GetRegisteredSecretCache(caseInsensitive);
+        if (optionsObject is null)
+        {
+            return registeredSecrets;
+        }
+
+        var minimumLength = Math.Max(1, options.MinimumSecretLength);
+        var extraSecrets = _secretProvider.GetSecretsInObject(optionsObject)
+            .Where(secret => secret.Length >= minimumLength)
+            .SelectMany(SecretMaskingPatternGenerator.Generate)
+            .ToArray();
+
+        return extraSecrets.Length == 0
+            ? registeredSecrets
+            : CreateSecretCache(
+                registeredSecrets.Secrets.Concat(extraSecrets),
+                registeredSecrets.Version,
+                caseInsensitive);
+    }
+
+    private SecretCache GetRegisteredSecretCache(bool caseInsensitive)
+    {
+        var version = _secretProvider.Version;
+        var currentCache = Volatile.Read(ref _secretCache);
+        if (currentCache is not null &&
+            currentCache.Version == version &&
+            currentCache.CaseInsensitive == caseInsensitive)
+        {
+            return currentCache;
+        }
+
+        lock (_secretCacheLock)
+        {
+            version = _secretProvider.Version;
+            currentCache = _secretCache;
+            if (currentCache is not null &&
+                currentCache.Version == version &&
+                currentCache.CaseInsensitive == caseInsensitive)
+            {
+                return currentCache;
+            }
+
+            var newCache = CreateSecretCache(_secretProvider.Secrets, version, caseInsensitive);
+            Volatile.Write(ref _secretCache, newCache);
+            return newCache;
+        }
+    }
+
+    private static SecretCache CreateSecretCache(
+        IEnumerable<string> secrets,
+        long version,
+        bool caseInsensitive)
+    {
+        var comparer = caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        var orderedSecrets = secrets
+            .Where(secret => !string.IsNullOrWhiteSpace(secret))
+            .Distinct(comparer)
+            .OrderByDescending(secret => secret.Length)
+            .ToArray();
+        var comparison = caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var searchValues = orderedSecrets.Length == 0
+            ? null
+            : SearchValues.Create(orderedSecrets, comparison);
+
+        return new SecretCache(version, caseInsensitive, orderedSecrets, searchValues);
     }
 
     /// <summary>
     /// Performs case-sensitive obfuscation using StringBuilder.Replace.
     /// This is the most efficient approach for case-sensitive matching.
     /// </summary>
-    private static string ObfuscateCaseSensitive(string input, List<string> secrets, string maskValue)
+    private static string ObfuscateCaseSensitive(string input, IReadOnlyList<string> secrets, string maskValue)
     {
         var stringBuilder = new StringBuilder(input);
 
@@ -109,7 +173,7 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
     /// <summary>
     /// Performs case-insensitive obfuscation using IndexOf with OrdinalIgnoreCase.
     /// </summary>
-    private static string ObfuscateCaseInsensitive(string input, List<string> secrets, string maskValue)
+    private static string ObfuscateCaseInsensitive(string input, IReadOnlyList<string> secrets, string maskValue)
     {
         var result = input;
 
@@ -131,15 +195,21 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
             return input;
         }
 
+        var firstIndex = input.IndexOf(pattern, StringComparison.OrdinalIgnoreCase);
+        if (firstIndex < 0)
+        {
+            return input;
+        }
+
         var result = new StringBuilder(input.Length);
         var lastIndex = 0;
-        int index;
-
-        while ((index = input.IndexOf(pattern, lastIndex, StringComparison.OrdinalIgnoreCase)) >= 0)
+        var index = firstIndex;
+        while (index >= 0)
         {
             result.Append(input, lastIndex, index - lastIndex);
             result.Append(replacement);
             lastIndex = index + pattern.Length;
+            index = input.IndexOf(pattern, lastIndex, StringComparison.OrdinalIgnoreCase);
         }
 
         // Append the remaining part after the last match
@@ -147,4 +217,10 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
 
         return result.ToString();
     }
+
+    private sealed record SecretCache(
+        long Version,
+        bool CaseInsensitive,
+        string[] Secrets,
+        SearchValues<string>? SearchValues);
 }

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -112,24 +112,26 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         var version = _secretProvider.Version;
         var currentCache = Volatile.Read(ref _secretCache);
         if (currentCache is not null &&
+            (version & 1) == 0 &&
             currentCache.Version == version &&
-            currentCache.CaseInsensitive == caseInsensitive)
+            currentCache.CaseInsensitive == caseInsensitive &&
+            _secretProvider.Version == version)
         {
             return currentCache;
         }
 
         lock (_secretCacheLock)
         {
-            version = _secretProvider.Version;
+            var snapshot = _secretProvider.GetSnapshot();
             currentCache = _secretCache;
             if (currentCache is not null &&
-                currentCache.Version == version &&
+                currentCache.Version == snapshot.Version &&
                 currentCache.CaseInsensitive == caseInsensitive)
             {
                 return currentCache;
             }
 
-            var newCache = CreateSecretCache(_secretProvider.Secrets, version, caseInsensitive);
+            var newCache = CreateSecretCache(snapshot.Secrets, snapshot.Version, caseInsensitive);
             Volatile.Write(ref _secretCache, newCache);
             return newCache;
         }

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -41,7 +41,11 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
     private readonly ConcurrentDictionary<string, byte> _shortSecretWarnings = new();
     private readonly object _initLock = new();
 
+    private long _version;
     private volatile bool _initialized;
+
+    /// <inheritdoc />
+    public long Version => Volatile.Read(ref _version);
 
     /// <summary>
     /// Gets all registered secrets.
@@ -91,9 +95,15 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             return;
         }
 
+        var secretAdded = false;
         foreach (var pattern in patterns)
         {
-            _secrets.TryAdd(pattern, 0);
+            secretAdded |= _secrets.TryAdd(pattern, 0);
+        }
+
+        if (secretAdded)
+        {
+            Interlocked.Increment(ref _version);
         }
     }
 

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -36,10 +36,11 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
     private readonly IBuildSystemSecretMasker _buildSystemSecretMasker;
     private readonly IOptions<SecretMaskingOptions> _maskingOptions;
     private readonly ILogger<SecretProvider> _logger;
-    private readonly ConcurrentDictionary<string, byte> _secrets = new();
+    private readonly HashSet<string> _secrets = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, byte> _nativeMaskPatterns = new();
     private readonly ConcurrentDictionary<string, byte> _shortSecretWarnings = new();
     private readonly object _initLock = new();
+    private readonly object _secretsLock = new();
 
     private long _version;
     private volatile bool _initialized;
@@ -55,7 +56,7 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
     /// Secrets added during enumeration will not be included in the current iteration.
     /// Each enumeration creates a new snapshot.
     /// </remarks>
-    public IEnumerable<string> Secrets => _secrets.Keys;
+    public IEnumerable<string> Secrets => GetSnapshot().Secrets;
 
     public SecretProvider(
         IOptionsProvider optionsProvider,
@@ -95,14 +96,21 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             return;
         }
 
-        var secretAdded = false;
-        foreach (var pattern in patterns)
+        lock (_secretsLock)
         {
-            secretAdded |= _secrets.TryAdd(pattern, 0);
-        }
+            if (patterns.All(_secrets.Contains))
+            {
+                return;
+            }
 
-        if (secretAdded)
-        {
+            // Odd versions mark an in-progress publication so readers cannot reuse
+            // a cache while the matching secret collection is being updated.
+            Interlocked.Increment(ref _version);
+            foreach (var pattern in patterns)
+            {
+                _secrets.Add(pattern);
+            }
+
             Interlocked.Increment(ref _version);
         }
     }
@@ -120,6 +128,15 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
     public void AddSecrets(params string?[] secrets)
     {
         AddSecrets((IEnumerable<string?>) secrets);
+    }
+
+    /// <inheritdoc />
+    public SecretSnapshot GetSnapshot()
+    {
+        lock (_secretsLock)
+        {
+            return new SecretSnapshot(Version, _secrets.ToArray());
+        }
     }
 
     [RequiresUnreferencedCode("Calls ModularPipelines.Engine.SecretProvider.GetSecretProperties(Type)")]

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -89,7 +89,7 @@ internal class CommandLogger : ICommandLogger
     {
         var isSuccess = exitCode == 0;
         var obfuscatedInput = ShouldShowInput(options)
-            ? _secretObfuscator.Obfuscate(input, execOpts)
+            ? _secretObfuscator.Obfuscate(input, null)
             : LoggingConstants.CommandMask;
 
         var commandMessage = new StringBuilder();
@@ -113,7 +113,7 @@ internal class CommandLogger : ICommandLogger
             && options.ShowStandardOutput;
 
         var inlineOutput = hasShortOutput && isSuccess
-            ? $" → {_secretObfuscator.Obfuscate(trimmedOutput, execOpts)}"
+            ? $" → {_secretObfuscator.Obfuscate(trimmedOutput, null)}"
             : string.Empty;
 
         // Add status indicator and metadata
@@ -164,7 +164,7 @@ internal class CommandLogger : ICommandLogger
             && options.Verbosity >= CommandLogVerbosity.Normal
             && options.ShowStandardOutput)
         {
-            Logger.LogInformation("  ↳ {CommandOutput}", _secretObfuscator.Obfuscate(trimmedOutput, execOpts));
+            Logger.LogInformation("  ↳ {CommandOutput}", _secretObfuscator.Obfuscate(trimmedOutput, null));
         }
 
         // Log errors on separate line
@@ -173,7 +173,7 @@ internal class CommandLogger : ICommandLogger
             && options.ShowStandardError
             && exitCode != 0)
         {
-            Logger.LogWarning("  ✗ {CommandError}", _secretObfuscator.Obfuscate(standardErrorToLog, execOpts));
+            Logger.LogWarning("  ✗ {CommandError}", _secretObfuscator.Obfuscate(standardErrorToLog, null));
         }
 
         // Log working directory only at Diagnostic level (separate line, indented)

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Engine;
+using ModularPipelines.Options;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Logging;
+
+public class SecretObfuscatorCachingTests
+{
+    [Test]
+    public async Task ReusesSecretSnapshotUntilProviderChanges()
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Secrets).Returns(["long-secret", "secret"]);
+        var obfuscator = CreateObfuscator(secretProvider.Object);
+
+        await Assert.That(obfuscator.Obfuscate("long-secret", null)).IsEqualTo("**********");
+        await Assert.That(obfuscator.Obfuscate("secret", null)).IsEqualTo("**********");
+
+        secretProvider.VerifyGet(x => x.Secrets, Times.Once);
+    }
+
+    [Test]
+    public async Task ReturnsOriginalStringWhenNoSecretMatches()
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Secrets).Returns(["secret"]);
+        var obfuscator = CreateObfuscator(secretProvider.Object);
+        const string input = "safe output";
+
+        var result = obfuscator.Obfuscate(input, null);
+
+        await Assert.That(result).IsSameReferenceAs(input);
+    }
+
+    [Test]
+    public async Task RebuildsSecretSnapshotWhenProviderVersionChanges()
+    {
+        var version = 0L;
+        string[] secrets = ["first-secret"];
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(() => version);
+        secretProvider.SetupGet(x => x.Secrets).Returns(() => secrets);
+        var obfuscator = CreateObfuscator(secretProvider.Object);
+
+        await Assert.That(obfuscator.Obfuscate("first-secret", null)).IsEqualTo("**********");
+
+        secrets = ["second-secret"];
+        version++;
+
+        await Assert.That(obfuscator.Obfuscate("second-secret", null)).IsEqualTo("**********");
+        secretProvider.VerifyGet(x => x.Secrets, Times.Exactly(2));
+    }
+
+    [Test]
+    public async Task MasksSecretRegisteredAfterSnapshotWasCreated()
+    {
+        var optionsProvider = new Mock<IOptionsProvider>();
+        optionsProvider.Setup(x => x.GetOptions()).Returns([]);
+        var secretProvider = new SecretProvider(
+            optionsProvider.Object,
+            Mock.Of<IBuildSystemSecretMasker>(),
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()),
+            Mock.Of<ILogger<SecretProvider>>());
+        var obfuscator = CreateObfuscator(secretProvider);
+
+        await Assert.That(obfuscator.Obfuscate("safe output", null)).IsEqualTo("safe output");
+
+        secretProvider.AddSecret("dynamic-secret");
+
+        await Assert.That(obfuscator.Obfuscate("dynamic-secret", null)).IsEqualTo("**********");
+    }
+
+    private static SecretObfuscator CreateObfuscator(ISecretProvider secretProvider)
+    {
+        return new SecretObfuscator(
+            secretProvider,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+    }
+}

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
@@ -11,20 +11,22 @@ public class SecretObfuscatorCachingTests
     public async Task ReusesSecretSnapshotUntilProviderChanges()
     {
         var secretProvider = new Mock<ISecretProvider>();
-        secretProvider.SetupGet(x => x.Secrets).Returns(["long-secret", "secret"]);
+        secretProvider.Setup(x => x.GetSnapshot())
+            .Returns(new SecretSnapshot(0, ["long-secret", "secret"]));
         var obfuscator = CreateObfuscator(secretProvider.Object);
 
         await Assert.That(obfuscator.Obfuscate("long-secret", null)).IsEqualTo("**********");
         await Assert.That(obfuscator.Obfuscate("secret", null)).IsEqualTo("**********");
 
-        secretProvider.VerifyGet(x => x.Secrets, Times.Once);
+        secretProvider.Verify(x => x.GetSnapshot(), Times.Once);
     }
 
     [Test]
     public async Task ReturnsOriginalStringWhenNoSecretMatches()
     {
         var secretProvider = new Mock<ISecretProvider>();
-        secretProvider.SetupGet(x => x.Secrets).Returns(["secret"]);
+        secretProvider.Setup(x => x.GetSnapshot())
+            .Returns(new SecretSnapshot(0, ["secret"]));
         var obfuscator = CreateObfuscator(secretProvider.Object);
         const string input = "safe output";
 
@@ -40,16 +42,17 @@ public class SecretObfuscatorCachingTests
         string[] secrets = ["first-secret"];
         var secretProvider = new Mock<ISecretProvider>();
         secretProvider.SetupGet(x => x.Version).Returns(() => version);
-        secretProvider.SetupGet(x => x.Secrets).Returns(() => secrets);
+        secretProvider.Setup(x => x.GetSnapshot())
+            .Returns(() => new SecretSnapshot(version, secrets));
         var obfuscator = CreateObfuscator(secretProvider.Object);
 
         await Assert.That(obfuscator.Obfuscate("first-secret", null)).IsEqualTo("**********");
 
         secrets = ["second-secret"];
-        version++;
+        version += 2;
 
         await Assert.That(obfuscator.Obfuscate("second-secret", null)).IsEqualTo("**********");
-        secretProvider.VerifyGet(x => x.Secrets, Times.Exactly(2));
+        secretProvider.Verify(x => x.GetSnapshot(), Times.Exactly(2));
     }
 
     [Test]
@@ -69,6 +72,25 @@ public class SecretObfuscatorCachingTests
         secretProvider.AddSecret("dynamic-secret");
 
         await Assert.That(obfuscator.Obfuscate("dynamic-secret", null)).IsEqualTo("**********");
+    }
+
+    [Test]
+    public async Task RevalidatesCacheWhenPublicationStartsDuringFastPath()
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupSequence(x => x.Version)
+            .Returns(0)
+            .Returns(0)
+            .Returns(1);
+        secretProvider.SetupSequence(x => x.GetSnapshot())
+            .Returns(new SecretSnapshot(0, ["initial-secret"]))
+            .Returns(new SecretSnapshot(2, ["initial-secret", "dynamic-secret"]));
+        var obfuscator = CreateObfuscator(secretProvider.Object);
+
+        await Assert.That(obfuscator.Obfuscate("initial-secret", null)).IsEqualTo("**********");
+        await Assert.That(obfuscator.Obfuscate("dynamic-secret", null)).IsEqualTo("**********");
+
+        secretProvider.Verify(x => x.GetSnapshot(), Times.Exactly(2));
     }
 
     private static SecretObfuscator CreateObfuscator(ISecretProvider secretProvider)


### PR DESCRIPTION
Closes #3254

## Summary
- version registered secrets and cache ordered/deduplicated search data until registration changes
- use .NET 10 `SearchValues<string>` to return the original input without replacement allocations when no secret matches
- register command execution-option secrets once before execution instead of reflecting over them on every log line
- avoid case-insensitive replacement allocations for individual secrets that are absent

## Validation
- `SecretObfuscatorCachingTests`: 4 passed
- secret-related tests: 42 passed
- `CommandLoggerTests`: 39 passed
- `CommandTests`: 9 passed
- `ModularPipelines.sln` Release build: 0 errors (250 existing warnings)