### PR TITLE
Make scheduler event-driven

### DIFF
--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -32,6 +32,7 @@ internal class ModuleScheduler : IModuleScheduler
     private readonly HashSet<ModuleState> _queuedModules;
     private readonly HashSet<ModuleState> _executingModules;
     private readonly ModuleStateQueries _stateQueries;
+    private readonly ModuleStateCounters _stateCounters;
     private readonly SchedulerExitConditions _exitConditions;
     private readonly Channel<ModuleState> _readyChannel;
     private readonly SemaphoreSlim _schedulerNotification;
@@ -39,6 +40,7 @@ internal class ModuleScheduler : IModuleScheduler
     private readonly ReaderWriterLockSlim _stateLock = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
     private readonly IModuleStateTracker _stateTracker;
 
+    private bool _hasSchedulingConstraints;
     private bool _schedulerCompleted;
     private int _disposeState;
 
@@ -67,6 +69,7 @@ internal class ModuleScheduler : IModuleScheduler
         _queuedModules = new HashSet<ModuleState>();
         _executingModules = new HashSet<ModuleState>();
         _stateQueries = new ModuleStateQueries(_moduleStates);
+        _stateCounters = new ModuleStateCounters();
         _exitConditions = new SchedulerExitConditions();
         _readyChannel = Channel.CreateUnbounded<ModuleState>(new UnboundedChannelOptions
         {
@@ -88,7 +91,8 @@ internal class ModuleScheduler : IModuleScheduler
             _stateQueries,
             _stateLock,
             _schedulerNotification,
-            () => _schedulerCompleted);
+            () => _schedulerCompleted,
+            _stateCounters);
     }
 
     /// <summary>
@@ -216,6 +220,7 @@ internal class ModuleScheduler : IModuleScheduler
             }
 
             _moduleStates[moduleType] = state;
+            _stateCounters.AddPendingModule();
             _dependencyGraph.Clear();
             foreach (var (registeredType, registeredDependencies) in declaredDependenciesByType)
             {
@@ -263,7 +268,10 @@ internal class ModuleScheduler : IModuleScheduler
         foreach (var module in modules)
         {
             var moduleType = module.GetType();
-            _moduleStates.TryAdd(moduleType, new ModuleState(module, moduleType));
+            if (_moduleStates.TryAdd(moduleType, new ModuleState(module, moduleType)))
+            {
+                _stateCounters.AddPendingModule();
+            }
         }
     }
 
@@ -317,6 +325,7 @@ internal class ModuleScheduler : IModuleScheduler
         if (constraintKeys.Count == 0)
         {
             state.RequiresSequentialExecution = true;
+            _hasSchedulingConstraints = true;
             _logger.LogDebug(
                 "Module {ModuleName} requires sequential execution (NotInParallel)",
                 state.ModuleType.Name);
@@ -324,6 +333,7 @@ internal class ModuleScheduler : IModuleScheduler
         }
 
         state.RequiredLockKeys = [.. constraintKeys];
+        _hasSchedulingConstraints = true;
         _logger.LogDebug(
             "Module {ModuleName} requires locks: {Keys}",
             state.ModuleType.Name,
@@ -440,7 +450,7 @@ internal class ModuleScheduler : IModuleScheduler
         {
             var queuedCount = await FindAndQueueReadyModulesAsync(cancellationToken).ConfigureAwait(false);
 
-            if (ShouldExitScheduler(queuedCount))
+            if (ShouldExitScheduler(queuedCount, out var requiresDeadlockConfirmation))
             {
                 _logger.LogDebug("All modules scheduled, completing scheduler");
                 break;
@@ -451,7 +461,7 @@ internal class ModuleScheduler : IModuleScheduler
                 _statusReporter.LogStatusIfIntervalElapsed(_stateQueries, _stateLock);
             }
 
-            await WaitForNextSchedulingOpportunity(cancellationToken).ConfigureAwait(false);
+            await WaitForNextSchedulingOpportunity(requiresDeadlockConfirmation, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -460,7 +470,7 @@ internal class ModuleScheduler : IModuleScheduler
         return !IsDisposed && !cancellationToken.IsCancellationRequested;
     }
 
-    private bool ShouldExitScheduler(int queuedCount)
+    private bool ShouldExitScheduler(int queuedCount, out bool requiresDeadlockConfirmation)
     {
         // Use a single write lock since we may need to modify _schedulerCompleted
         // This avoids the inefficient pattern of read lock -> release -> write lock
@@ -472,9 +482,11 @@ internal class ModuleScheduler : IModuleScheduler
         _stateLock.EnterWriteLock();
         try
         {
-            snapshot = ModuleStateSnapshot.Create(_moduleStates.Values);
+            snapshot = _stateCounters.CreateSnapshot();
             shouldExit = _exitConditions.ShouldExit(snapshot, queuedCount);
-            isDeadlocked = shouldExit && _exitConditions.IsDeadlocked(snapshot, queuedCount);
+            var isPotentiallyDeadlocked = _exitConditions.IsDeadlocked(snapshot, queuedCount);
+            isDeadlocked = shouldExit && isPotentiallyDeadlocked;
+            requiresDeadlockConfirmation = isPotentiallyDeadlocked && !shouldExit;
             pendingModules = isDeadlocked
                 ? _moduleStates.Values
                     .Where(x => x.State == ModuleExecutionState.Pending)
@@ -504,11 +516,20 @@ internal class ModuleScheduler : IModuleScheduler
         return shouldExit;
     }
 
-    private async Task WaitForNextSchedulingOpportunity(CancellationToken cancellationToken)
+    private async Task WaitForNextSchedulingOpportunity(
+        bool requiresDeadlockConfirmation,
+        CancellationToken cancellationToken)
     {
         try
         {
-            await _schedulerNotification.WaitAsync(_options.NotificationTimeout, cancellationToken).ConfigureAwait(false);
+            if (requiresDeadlockConfirmation)
+            {
+                await _schedulerNotification.WaitAsync(_options.NotificationTimeout, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await _schedulerNotification.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
         }
         catch (OperationCanceledException)
         {
@@ -595,8 +616,8 @@ internal class ModuleScheduler : IModuleScheduler
         _stateLock.EnterReadLock();
         try
         {
-            var stats = _stateQueries.GetStatistics();
-            return (stats.Total, stats.Queued, stats.Executing, stats.Completed, stats.Pending);
+            var snapshot = _stateCounters.CreateSnapshot();
+            return (snapshot.Total, snapshot.Queued, snapshot.Executing, snapshot.Completed, snapshot.Pending);
         }
         finally
         {
@@ -669,26 +690,20 @@ internal class ModuleScheduler : IModuleScheduler
                 .OrderByDescending(m => (int) m.Priority)
                 .ToArray();
 
-            // Take immutable snapshot of already-active modules (queued or executing)
-            // This captures the state at the start of this scheduling cycle
-            var existingActiveModules = _moduleStates.Values
-                .Where(m => m.State == ModuleExecutionState.Queued || m.State == ModuleExecutionState.Executing)
-                .ToList();
-
-            // Track modules queued during this scheduling cycle separately
-            // This prevents mutation of the original snapshot and makes intent explicit
-            var newlyQueuedInThisCycle = new List<ModuleState>();
+            // Constraint-free pipelines need no active-module scan or pairwise evaluation.
+            // When constraints exist, keep one list and append modules queued in this cycle.
+            var activeModules = _hasSchedulingConstraints
+                ? _moduleStates.Values
+                    .Where(m => m.State == ModuleExecutionState.Queued || m.State == ModuleExecutionState.Executing)
+                    .ToList()
+                : null;
 
             modulesToQueue = new List<ModuleState>();
             metricsData = new List<(Type, DateTimeOffset, ModulePriority, ExecutionType, DateTimeOffset)>();
 
             foreach (var moduleState in potentiallyReadyModules)
             {
-                // Combine existing active modules with newly-queued ones for constraint checking
-                // This ensures modules queued earlier in this cycle are visible to later constraint checks
-                var allActiveModules = existingActiveModules.Concat(newlyQueuedInThisCycle).ToList();
-
-                if (!_constraintEvaluator.CanQueue(moduleState, allActiveModules))
+                if (activeModules is not null && !_constraintEvaluator.CanQueue(moduleState, activeModules))
                 {
                     continue;
                 }
@@ -700,12 +715,12 @@ internal class ModuleScheduler : IModuleScheduler
                 // Collect metrics data for recording outside lock
                 metricsData.Add((moduleState.ModuleType, moduleState.ReadyTime.Value, moduleState.Priority, moduleState.ExecutionType, now));
 
+                _stateCounters.Transition(moduleState.State, ModuleExecutionState.Queued);
                 moduleState.State = ModuleExecutionState.Queued;
                 moduleState.QueuedTime = now;
                 _queuedModules.Add(moduleState);
 
-                // Track in separate collection (not mutating the original snapshot)
-                newlyQueuedInThisCycle.Add(moduleState);
+                activeModules?.Add(moduleState);
 
                 modulesToQueue.Add(moduleState);
             }

--- a/src/ModularPipelines/Engine/ModuleStateCounters.cs
+++ b/src/ModularPipelines/Engine/ModuleStateCounters.cs
@@ -1,0 +1,84 @@
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Maintains scheduler state counts while the scheduler state lock is held.
+/// </summary>
+internal sealed class ModuleStateCounters
+{
+    public int Total { get; private set; }
+
+    public int Queued { get; private set; }
+
+    public int Executing { get; private set; }
+
+    public int Completed { get; private set; }
+
+    public int Pending { get; private set; }
+
+    public void AddPendingModule()
+    {
+        Total++;
+        Pending++;
+    }
+
+    public void Transition(ModuleExecutionState from, ModuleExecutionState to)
+    {
+        if (from == to)
+        {
+            return;
+        }
+
+        Decrement(from);
+        Increment(to);
+    }
+
+    public ModuleStateSnapshot CreateSnapshot()
+    {
+        return new ModuleStateSnapshot
+        {
+            Total = Total,
+            Queued = Queued,
+            Executing = Executing,
+            Completed = Completed,
+            Pending = Pending,
+        };
+    }
+
+    private void Increment(ModuleExecutionState state)
+    {
+        switch (state)
+        {
+            case ModuleExecutionState.Pending:
+                Pending++;
+                break;
+            case ModuleExecutionState.Queued:
+                Queued++;
+                break;
+            case ModuleExecutionState.Executing:
+                Executing++;
+                break;
+            case ModuleExecutionState.Completed:
+                Completed++;
+                break;
+        }
+    }
+
+    private void Decrement(ModuleExecutionState state)
+    {
+        switch (state)
+        {
+            case ModuleExecutionState.Pending:
+                Pending--;
+                break;
+            case ModuleExecutionState.Queued:
+                Queued--;
+                break;
+            case ModuleExecutionState.Executing:
+                Executing--;
+                break;
+            case ModuleExecutionState.Completed:
+                Completed--;
+                break;
+        }
+    }
+}

--- a/src/ModularPipelines/Engine/ModuleStateSnapshot.cs
+++ b/src/ModularPipelines/Engine/ModuleStateSnapshot.cs
@@ -48,46 +48,4 @@ internal class ModuleStateSnapshot
     /// Gets a value indicating whether whether any modules are pending execution.
     /// </summary>
     public bool HasPendingModules => Pending > 0;
-
-    /// <summary>
-    /// Creates a snapshot from current module states.
-    /// </summary>
-    public static ModuleStateSnapshot Create(IEnumerable<ModuleState> moduleStates)
-    {
-        var total = 0;
-        var queued = 0;
-        var executing = 0;
-        var completed = 0;
-        var pending = 0;
-
-        foreach (var state in moduleStates)
-        {
-            total++;
-
-            switch (state.State)
-            {
-                case ModuleExecutionState.Completed:
-                    completed++;
-                    break;
-                case ModuleExecutionState.Executing:
-                    executing++;
-                    break;
-                case ModuleExecutionState.Queued:
-                    queued++;
-                    break;
-                case ModuleExecutionState.Pending:
-                    pending++;
-                    break;
-            }
-        }
-
-        return new ModuleStateSnapshot
-        {
-            Total = total,
-            Queued = queued,
-            Executing = executing,
-            Completed = completed,
-            Pending = pending,
-        };
-    }
 }

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -26,6 +26,7 @@ internal class ModuleStateTracker : IModuleStateTracker
     private readonly HashSet<ModuleState> _queuedModules;
     private readonly HashSet<ModuleState> _executingModules;
     private readonly ModuleStateQueries _stateQueries;
+    private readonly ModuleStateCounters _stateCounters;
     private readonly ReaderWriterLockSlim _stateLock;
     private readonly SemaphoreSlim _schedulerNotification;
     private readonly Func<bool> _isSchedulerCompleted;
@@ -44,6 +45,7 @@ internal class ModuleStateTracker : IModuleStateTracker
     /// <param name="stateLock">Shared lock for state access synchronization.</param>
     /// <param name="schedulerNotification">Semaphore to notify scheduler of state changes.</param>
     /// <param name="isSchedulerCompleted">Function to check if scheduler has completed.</param>
+    /// <param name="stateCounters">Incrementally maintained module state counts.</param>
     public ModuleStateTracker(
         ILogger logger,
         TimeProvider timeProvider,
@@ -55,7 +57,8 @@ internal class ModuleStateTracker : IModuleStateTracker
         ModuleStateQueries stateQueries,
         ReaderWriterLockSlim stateLock,
         SemaphoreSlim schedulerNotification,
-        Func<bool> isSchedulerCompleted)
+        Func<bool> isSchedulerCompleted,
+        ModuleStateCounters? stateCounters = null)
     {
         _logger = logger;
         _timeProvider = timeProvider;
@@ -65,6 +68,7 @@ internal class ModuleStateTracker : IModuleStateTracker
         _queuedModules = queuedModules;
         _executingModules = executingModules;
         _stateQueries = stateQueries;
+        _stateCounters = stateCounters ?? CreateCounters(moduleStates);
         _stateLock = stateLock;
         _schedulerNotification = schedulerNotification;
         _isSchedulerCompleted = isSchedulerCompleted;
@@ -105,21 +109,24 @@ internal class ModuleStateTracker : IModuleStateTracker
             {
                 // Reset to Pending so scheduler will retry when constraints allow
                 _queuedModules.Remove(state);
+                _stateCounters.Transition(state.State, ModuleExecutionState.Pending);
                 state.State = ModuleExecutionState.Pending;
                 state.QueuedTime = null;
                 needsReschedule = true;
-                return false;
             }
+            else
+            {
+                _queuedModules.Remove(state);
+                _stateCounters.Transition(state.State, ModuleExecutionState.Executing);
+                state.State = ModuleExecutionState.Executing;
+                _executingModules.Add(state);
+                state.ExecutionStartTime = _timeProvider.GetUtcNow();
 
-            _queuedModules.Remove(state);
-            state.State = ModuleExecutionState.Executing;
-            _executingModules.Add(state);
-            state.ExecutionStartTime = _timeProvider.GetUtcNow();
-
-            // Capture data for metrics recording outside lock
-            executionStartTime = state.ExecutionStartTime;
-            executingCount = _executingModules.Count;
-            result = true;
+                // Capture data for metrics recording outside lock
+                executionStartTime = state.ExecutionStartTime;
+                executingCount = _executingModules.Count;
+                result = true;
+            }
         }
         finally
         {
@@ -171,6 +178,7 @@ internal class ModuleStateTracker : IModuleStateTracker
 
             _queuedModules.Remove(state);
             _executingModules.Remove(state);
+            _stateCounters.Transition(state.State, ModuleExecutionState.Completed);
             state.State = ModuleExecutionState.Completed;
             state.CompletionTime = _timeProvider.GetUtcNow();
 
@@ -261,6 +269,7 @@ internal class ModuleStateTracker : IModuleStateTracker
                     var originalState = moduleState.State;
                     _queuedModules.Remove(moduleState);
                     _executingModules.Remove(moduleState);
+                    _stateCounters.Transition(originalState, ModuleExecutionState.Completed);
                     moduleState.State = ModuleExecutionState.Completed;
                     cancelledModules.Add((moduleState, originalState));
                 }
@@ -289,6 +298,19 @@ internal class ModuleStateTracker : IModuleStateTracker
                 moduleState.ModuleType.Name,
                 originalState);
         }
+    }
+
+    private static ModuleStateCounters CreateCounters(
+        ConcurrentDictionary<Type, ModuleState> moduleStates)
+    {
+        var counters = new ModuleStateCounters();
+        foreach (var state in moduleStates.Values)
+        {
+            counters.AddPendingModule();
+            counters.Transition(ModuleExecutionState.Pending, state.State);
+        }
+
+        return counters;
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Engine/Scheduling/ModuleConstraintEvaluator.cs
+++ b/src/ModularPipelines/Engine/Scheduling/ModuleConstraintEvaluator.cs
@@ -18,16 +18,16 @@ internal class ModuleConstraintEvaluator : IModuleConstraintEvaluator
     /// <inheritdoc />
     public bool CanQueue(ModuleState moduleState, IEnumerable<ModuleState> activeModules)
     {
-        var activeList = activeModules.ToList();
+        var activeCollection = AsReadOnlyCollection(activeModules);
 
         // Check lock key conflicts
-        if (!CheckLockKeyConstraints(moduleState, activeList, logBlocking: false))
+        if (!CheckLockKeyConstraints(moduleState, activeCollection, logBlocking: false))
         {
             return false;
         }
 
         // Check sequential execution constraints
-        if (!CheckSequentialConstraints(moduleState, activeList, logBlocking: false))
+        if (!CheckSequentialConstraints(moduleState, activeCollection, logBlocking: false))
         {
             return false;
         }
@@ -38,16 +38,16 @@ internal class ModuleConstraintEvaluator : IModuleConstraintEvaluator
     /// <inheritdoc />
     public bool CanStartExecution(ModuleState moduleState, IEnumerable<ModuleState> executingModules)
     {
-        var executingList = executingModules.ToList();
+        var executingCollection = AsReadOnlyCollection(executingModules);
 
         // Primary constraint check: verify no executing module has conflicting lock keys
-        if (!CheckLockKeyConstraints(moduleState, executingList, logBlocking: true))
+        if (!CheckLockKeyConstraints(moduleState, executingCollection, logBlocking: true))
         {
             return false;
         }
 
         // Secondary check: sequential execution constraints
-        if (!CheckSequentialConstraints(moduleState, executingList, logBlocking: true))
+        if (!CheckSequentialConstraints(moduleState, executingCollection, logBlocking: true))
         {
             return false;
         }
@@ -55,7 +55,15 @@ internal class ModuleConstraintEvaluator : IModuleConstraintEvaluator
         return true;
     }
 
-    private bool CheckLockKeyConstraints(ModuleState moduleState, List<ModuleState> otherModules, bool logBlocking)
+    private static IReadOnlyCollection<ModuleState> AsReadOnlyCollection(IEnumerable<ModuleState> modules)
+    {
+        return modules as IReadOnlyCollection<ModuleState> ?? modules.ToArray();
+    }
+
+    private bool CheckLockKeyConstraints(
+        ModuleState moduleState,
+        IReadOnlyCollection<ModuleState> otherModules,
+        bool logBlocking)
     {
         if (moduleState.RequiredLockKeys.Length == 0)
         {
@@ -74,16 +82,18 @@ internal class ModuleConstraintEvaluator : IModuleConstraintEvaluator
                 continue;
             }
 
-            var intersection = other.RequiredLockKeys.Intersect(moduleState.RequiredLockKeys).ToArray();
-            if (intersection.Length > 0)
+            if (HasLockConflict(other.RequiredLockKeys, moduleState.RequiredLockKeys))
             {
                 if (logBlocking)
                 {
+                    var conflictingKeys = other.RequiredLockKeys
+                        .Where(key => Array.IndexOf(moduleState.RequiredLockKeys, key) >= 0)
+                        .ToArray();
                     _logger.LogDebug(
                         "Module {ModuleName} BLOCKED - {OtherModule} has conflicting keys [{Keys}]",
                         moduleState.ModuleType.Name,
                         other.ModuleType.Name,
-                        string.Join(", ", intersection));
+                        string.Join(", ", conflictingKeys));
                 }
 
                 return false;
@@ -93,27 +103,45 @@ internal class ModuleConstraintEvaluator : IModuleConstraintEvaluator
         return true;
     }
 
-    private bool CheckSequentialConstraints(ModuleState moduleState, List<ModuleState> otherModules, bool logBlocking)
+    private static bool HasLockConflict(string[] left, string[] right)
     {
-        var otherActiveModules = otherModules.Where(m => m != moduleState).ToList();
-
-        // If this module requires sequential execution, no other modules can be active
-        if (moduleState.RequiresSequentialExecution && otherActiveModules.Count > 0)
+        foreach (var key in left)
         {
-            if (logBlocking)
+            if (Array.IndexOf(right, key) >= 0)
             {
-                _logger.LogDebug(
-                    "Sequential module {ModuleName} blocked - {Count} modules already active",
-                    moduleState.ModuleType.Name,
-                    otherActiveModules.Count);
+                return true;
             }
-
-            return false;
         }
 
-        // If any other active module requires sequential execution, this module is blocked
-        foreach (var other in otherActiveModules)
+        return false;
+    }
+
+    private bool CheckSequentialConstraints(
+        ModuleState moduleState,
+        IReadOnlyCollection<ModuleState> otherModules,
+        bool logBlocking)
+    {
+        var otherActiveModuleCount = 0;
+
+        foreach (var other in otherModules)
         {
+            if (other == moduleState)
+            {
+                continue;
+            }
+
+            otherActiveModuleCount++;
+
+            if (moduleState.RequiresSequentialExecution)
+            {
+                if (!logBlocking)
+                {
+                    return false;
+                }
+
+                continue;
+            }
+
             if (other.RequiresSequentialExecution)
             {
                 if (logBlocking)
@@ -126,6 +154,16 @@ internal class ModuleConstraintEvaluator : IModuleConstraintEvaluator
 
                 return false;
             }
+        }
+
+        if (moduleState.RequiresSequentialExecution && otherActiveModuleCount > 0)
+        {
+            _logger.LogDebug(
+                "Sequential module {ModuleName} blocked - {Count} modules already active",
+                moduleState.ModuleType.Name,
+                otherActiveModuleCount);
+
+            return false;
         }
 
         return true;

--- a/src/ModularPipelines/Options/SchedulerOptions.cs
+++ b/src/ModularPipelines/Options/SchedulerOptions.cs
@@ -9,8 +9,7 @@ namespace ModularPipelines.Options;
 public record SchedulerOptions
 {
     /// <summary>
-    /// Gets or sets timeout for waiting on scheduler notifications before re-checking state.
-    /// This periodic re-check ensures we don't miss signals due to race conditions.
+    /// Gets or sets the confirmation delay before treating a blocked scheduler as deadlocked.
     /// Default: 100ms.
     /// </summary>
     public TimeSpan NotificationTimeout { get; set; } = TimeSpan.FromMilliseconds(100);

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -74,6 +74,14 @@ public class ModuleSchedulerDynamicCycleTests
             CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(CompletedDependencyModule));
     }
 
+    [ModularPipelines.Attributes.NotInParallel]
+    private class DeferredConstraintModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DeferredConstraintModule));
+    }
+
     private class ConditionalExistingModule : Module<string>
     {
         public bool IncludeDependency { get; set; } = true;
@@ -135,7 +143,7 @@ public class ModuleSchedulerDynamicCycleTests
             .Returns(true);
 
         using var scheduler = CreateScheduler(constraintEvaluator.Object);
-        scheduler.InitializeModules([new CompletedDependencyModule()]);
+        scheduler.InitializeModules([new DeferredConstraintModule()]);
 
         var schedulerTask = scheduler.RunSchedulerAsync(CancellationToken.None);
         var firstAttempt = await scheduler.ReadyModules.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
@@ -147,6 +155,70 @@ public class ModuleSchedulerDynamicCycleTests
 
         scheduler.MarkModuleCompleted(secondAttempt.ModuleType, success: true);
         await schedulerTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task RunSchedulerAsync_DoesNotPollWhileModuleIsExecuting()
+    {
+        var constraintEvaluator = new Mock<IModuleConstraintEvaluator>();
+        constraintEvaluator
+            .Setup(x => x.CanStartExecution(It.IsAny<ModuleState>(), It.IsAny<IEnumerable<ModuleState>>()))
+            .Returns(true);
+        var statusReporter = new Mock<ISchedulerStatusReporter>();
+
+        using var scheduler = CreateScheduler(
+            constraintEvaluator.Object,
+            statusReporter.Object,
+            new SchedulerOptions
+            {
+                NotificationTimeout = TimeSpan.FromMilliseconds(20),
+            });
+        scheduler.InitializeModules([new CompletedDependencyModule()]);
+
+        var schedulerTask = scheduler.RunSchedulerAsync(CancellationToken.None);
+        var module = await scheduler.ReadyModules.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(scheduler.MarkModuleStarted(module.ModuleType)).IsTrue();
+
+        await Task.Delay(150);
+
+        statusReporter.Verify(
+            x => x.LogStatusIfIntervalElapsed(
+                It.IsAny<ModuleStateQueries>(),
+                It.IsAny<ReaderWriterLockSlim>()),
+            Times.Never);
+
+        scheduler.MarkModuleCompleted(module.ModuleType, success: true);
+        await schedulerTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        constraintEvaluator.Verify(
+            x => x.CanQueue(It.IsAny<ModuleState>(), It.IsAny<IEnumerable<ModuleState>>()),
+            Times.Never);
+    }
+
+    [Test]
+    public async Task GetStatistics_TracksStateTransitionsIncrementally()
+    {
+        var constraintEvaluator = new Mock<IModuleConstraintEvaluator>();
+        constraintEvaluator
+            .Setup(x => x.CanStartExecution(It.IsAny<ModuleState>(), It.IsAny<IEnumerable<ModuleState>>()))
+            .Returns(true);
+
+        using var scheduler = CreateScheduler(constraintEvaluator.Object);
+        scheduler.InitializeModules([new CompletedDependencyModule()]);
+
+        await Assert.That(scheduler.GetStatistics()).IsEqualTo((1, 0, 0, 0, 1));
+
+        var schedulerTask = scheduler.RunSchedulerAsync(CancellationToken.None);
+        var module = await scheduler.ReadyModules.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(scheduler.GetStatistics()).IsEqualTo((1, 1, 0, 0, 0));
+
+        await Assert.That(scheduler.MarkModuleStarted(module.ModuleType)).IsTrue();
+        await Assert.That(scheduler.GetStatistics()).IsEqualTo((1, 0, 1, 0, 0));
+
+        scheduler.MarkModuleCompleted(module.ModuleType, success: true);
+        await schedulerTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(scheduler.GetStatistics()).IsEqualTo((1, 0, 0, 1, 0));
     }
 
     [Test]
@@ -250,16 +322,19 @@ public class ModuleSchedulerDynamicCycleTests
         await Assert.That(state!.UnresolvedDependencies).Contains(typeof(CompletedDependencyModule));
     }
 
-    private static ModuleScheduler CreateScheduler(IModuleConstraintEvaluator? constraintEvaluator = null)
+    private static ModuleScheduler CreateScheduler(
+        IModuleConstraintEvaluator? constraintEvaluator = null,
+        ISchedulerStatusReporter? statusReporter = null,
+        SchedulerOptions? schedulerOptions = null)
     {
         return new ModuleScheduler(
             NullLogger.Instance,
             TimeProvider.System,
-            Microsoft.Extensions.Options.Options.Create(new SchedulerOptions()),
+            Microsoft.Extensions.Options.Options.Create(schedulerOptions ?? new SchedulerOptions()),
             new ModuleDependencyRegistry(),
             new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
             Mock.Of<IMetricsCollector>(),
             constraintEvaluator ?? Mock.Of<IModuleConstraintEvaluator>(),
-            Mock.Of<ISchedulerStatusReporter>());
+            statusReporter ?? Mock.Of<ISchedulerStatusReporter>());
     }
 }


### PR DESCRIPTION
Closes #3256

## Summary
- wait on scheduler notifications during normal execution and reserve the timeout for deadlock confirmation
- maintain module-state counters incrementally instead of rescanning all states for exit checks
- build the active-module list once per constrained cycle and skip constraint evaluation entirely for unconstrained pipelines
- remove repeated constraint evaluator list/intersection allocations and restore the deferred-module reschedule notification

## Validation
- `ModuleScheduler*Tests`: 16/16 passed
- `TaskCompletionSourceTests`: 5/5 passed
- `ModuleExecutorLoggingTests`: 6/6 passed
- `ModularPipelines.sln` Release build: 0 errors (251 existing warnings)
- changed-file whitespace verification passed

Full solution formatting verification remains blocked by pre-existing repository-wide violations in untouched files.