### PR TITLE
Cache module attribute metadata

### DIFF
--- a/src/ModularPipelines/Context/ModuleRegistrationContext.cs
+++ b/src/ModularPipelines/Context/ModuleRegistrationContext.cs
@@ -1,5 +1,4 @@
 // src/ModularPipelines/Context/ModuleRegistrationContext.cs
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -82,7 +81,7 @@ internal class ModuleRegistrationContext : IModuleRegistrationContext
         => _registeredModuleTypes.Where(t => typeof(TBase).IsAssignableFrom(t) && t != ModuleType);
 
     public IEnumerable<Type> GetModulesWithAttribute<TAttribute>() where TAttribute : Attribute
-        => _registeredModuleTypes.Where(t => t.GetCustomAttribute<TAttribute>() != null);
+        => _registeredModuleTypes.Where(_metadataRegistry.HasAttribute<TAttribute>);
 
     public void AddDependency<TModule>() where TModule : IModule
         => AddDependency(typeof(TModule));

--- a/src/ModularPipelines/Engine/Attributes/ModuleAttributeEventService.cs
+++ b/src/ModularPipelines/Engine/Attributes/ModuleAttributeEventService.cs
@@ -13,10 +13,10 @@ namespace ModularPipelines.Engine.Attributes;
 /// </summary>
 internal class ModuleAttributeEventService : IModuleAttributeEventService
 {
-    private readonly ConcurrentDictionary<Type, AttributeHandlerCache> _cache = new();
+    private readonly ConcurrentDictionary<Type, Lazy<AttributeHandlerCache>> _cache = new();
 
     public IReadOnlyList<Attribute> GetAttributes(Type moduleType)
-        => CreateAttributes(moduleType);
+        => GetCache(moduleType).Attributes;
 
     public IReadOnlyList<IModuleRegistrationEventReceiver> GetRegistrationReceivers(Type moduleType)
         => GetCache(moduleType).RegistrationReceivers;
@@ -37,11 +37,16 @@ internal class ModuleAttributeEventService : IModuleAttributeEventService
         => GetCache(moduleType).SkippedHandlers;
 
     private AttributeHandlerCache GetCache(Type moduleType)
-        => _cache.GetOrAdd(moduleType, DiscoverHandlers);
+        => _cache.GetOrAdd(
+            moduleType,
+            static type => new Lazy<AttributeHandlerCache>(
+                () => DiscoverHandlers(type),
+                LazyThreadSafetyMode.ExecutionAndPublication)).Value;
 
     private static AttributeHandlerCache DiscoverHandlers(Type moduleType)
     {
-        return CreateHandlerCache(CreateAttributes(moduleType));
+        var attributes = CreateAttributes(moduleType);
+        return CreateHandlerCache(attributes);
     }
 
     private static IReadOnlyList<Attribute> CreateAttributes(Type moduleType)
@@ -96,6 +101,7 @@ internal class ModuleAttributeEventService : IModuleAttributeEventService
         // Sort all handlers by priority (lower values first)
         // Handlers without IEventHandlerPriority default to 0
         return new AttributeHandlerCache(
+            attributes,
             SortByPriority(registrationReceivers),
             SortByPriority(readyHandlers),
             SortByPriority(startHandlers),
@@ -131,6 +137,7 @@ internal class ModuleAttributeEventService : IModuleAttributeEventService
         => handler is IEventHandlerPriority prioritized ? prioritized.Priority : 0;
 
     private sealed record AttributeHandlerCache(
+        IReadOnlyList<Attribute> Attributes,
         IReadOnlyList<IModuleRegistrationEventReceiver> RegistrationReceivers,
         IReadOnlyList<IModuleReadyHandler> ReadyHandlers,
         IReadOnlyList<IModuleStartHandler> StartHandlers,

--- a/src/ModularPipelines/Engine/Dependencies/IModuleMetadataRegistry.cs
+++ b/src/ModularPipelines/Engine/Dependencies/IModuleMetadataRegistry.cs
@@ -17,6 +17,7 @@ internal interface IModuleMetadataRegistry : IDependencyContext
     /// </summary>
     /// <param name="moduleType">The module type.</param>
     /// <param name="tags">The tags to add.</param>
+    /// <remarks>Call <see cref="FinalizeMetadata"/> again before reading metadata after this mutation.</remarks>
     void AddRegistrationTags(Type moduleType, IEnumerable<string> tags);
 
     /// <summary>
@@ -24,6 +25,7 @@ internal interface IModuleMetadataRegistry : IDependencyContext
     /// </summary>
     /// <param name="moduleType">The module type.</param>
     /// <param name="category">The category to set.</param>
+    /// <remarks>Call <see cref="FinalizeMetadata"/> again before reading metadata after this mutation.</remarks>
     void SetRegistrationCategory(Type moduleType, string category);
 
     /// <summary>

--- a/src/ModularPipelines/Engine/Dependencies/ModuleMetadataRegistry.cs
+++ b/src/ModularPipelines/Engine/Dependencies/ModuleMetadataRegistry.cs
@@ -22,11 +22,6 @@ internal class ModuleMetadataRegistry : IModuleMetadataRegistry
     private readonly ConcurrentDictionary<(Type ModuleType, Type AttributeType), Attribute[]> _attributesByType = new();
     private readonly IModuleAttributeEventService _attributeEventService;
 
-    public ModuleMetadataRegistry(IOptions<ModuleRegistrationOptions> registrationOptions)
-        : this(registrationOptions, new ModuleAttributeEventService())
-    {
-    }
-
     public ModuleMetadataRegistry(
         IOptions<ModuleRegistrationOptions> registrationOptions,
         IModuleAttributeEventService attributeEventService)

--- a/src/ModularPipelines/Engine/Dependencies/ModuleMetadataRegistry.cs
+++ b/src/ModularPipelines/Engine/Dependencies/ModuleMetadataRegistry.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 
@@ -17,10 +18,21 @@ internal class ModuleMetadataRegistry : IModuleMetadataRegistry
     private readonly ConcurrentDictionary<(Type, string), object> _metadata = new();
     private readonly ConcurrentDictionary<Type, HashSet<string>> _registrationTags = new();
     private readonly ConcurrentDictionary<Type, string> _registrationCategories = new();
-    private readonly ConcurrentDictionary<Type, ModuleMetadata> _finalizedMetadata = new();
+    private readonly ConcurrentDictionary<Type, Lazy<ModuleMetadata>> _finalizedMetadata = new();
+    private readonly ConcurrentDictionary<(Type ModuleType, Type AttributeType), Attribute[]> _attributesByType = new();
+    private readonly IModuleAttributeEventService _attributeEventService;
 
     public ModuleMetadataRegistry(IOptions<ModuleRegistrationOptions> registrationOptions)
+        : this(registrationOptions, new ModuleAttributeEventService())
     {
+    }
+
+    public ModuleMetadataRegistry(
+        IOptions<ModuleRegistrationOptions> registrationOptions,
+        IModuleAttributeEventService attributeEventService)
+    {
+        _attributeEventService = attributeEventService;
+
         // Import tags and categories from registration-time configuration
         var options = registrationOptions.Value;
 
@@ -60,22 +72,66 @@ internal class ModuleMetadataRegistry : IModuleMetadataRegistry
                 existing.UnionWith(tags);
                 return existing;
             });
+        _finalizedMetadata.TryRemove(moduleType, out _);
     }
 
     public void SetRegistrationCategory(Type moduleType, string category)
     {
         _registrationCategories[moduleType] = category;
+        _finalizedMetadata.TryRemove(moduleType, out _);
     }
 
     public void FinalizeMetadata(Type moduleType, IModule instance)
     {
+        var metadata = _finalizedMetadata.GetOrAdd(
+            moduleType,
+            _ => new Lazy<ModuleMetadata>(
+                () => CreateMetadata(moduleType, instance),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+        _ = metadata.Value;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlySet<string> GetTags(Type moduleType)
+        => _finalizedMetadata.TryGetValue(moduleType, out var meta) ? meta.Value.Tags : FrozenSet<string>.Empty;
+
+    /// <inheritdoc />
+    public string? GetCategory(Type moduleType)
+        => _finalizedMetadata.TryGetValue(moduleType, out var meta) ? meta.Value.Category : null;
+
+    /// <inheritdoc />
+    public bool HasAttribute<TAttribute>(Type moduleType)
+        where TAttribute : Attribute
+        => GetCachedAttributes(moduleType, typeof(TAttribute)).Length > 0;
+
+    /// <inheritdoc />
+    public TAttribute? GetAttribute<TAttribute>(Type moduleType)
+        where TAttribute : Attribute
+    {
+        var attributes = GetCachedAttributes(moduleType, typeof(TAttribute));
+        return attributes.Length switch
+        {
+            0 => null,
+            1 => (TAttribute) attributes[0],
+            _ => throw new AmbiguousMatchException(
+                $"Multiple custom attributes of the same type '{typeof(TAttribute)}' found."),
+        };
+    }
+
+    /// <inheritdoc />
+    public IEnumerable<TAttribute> GetAttributes<TAttribute>(Type moduleType)
+        where TAttribute : Attribute
+        => GetCachedAttributes(moduleType, typeof(TAttribute)).Cast<TAttribute>();
+
+    private ModuleMetadata CreateMetadata(Type moduleType, IModule instance)
+    {
+        var configuration = instance.Configuration;
         var tags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         // Module<T> configuration combines attributes, overrides, and fluent metadata.
-        // Attribute reflection preserves metadata for direct IModule implementations.
-        tags.UnionWith(instance.Configuration.Tags);
-        tags.UnionWith(moduleType
-            .GetCustomAttributes<ModuleTagAttribute>(inherit: true)
+        // Cached attributes preserve metadata for direct IModule implementations.
+        tags.UnionWith(configuration.Tags);
+        tags.UnionWith(GetAttributes<ModuleTagAttribute>(moduleType)
             .Select(attribute => attribute.Tag));
         if (instance is ITaggedModule taggedModule)
         {
@@ -96,36 +152,22 @@ internal class ModuleMetadataRegistry : IModuleMetadataRegistry
         }
         else
         {
-            category = instance.Configuration.Category
+            category = configuration.Category
                        ?? (instance as ITaggedModule)?.Category
-                       ?? moduleType.GetCustomAttribute<ModuleCategoryAttribute>(inherit: true)?.Category;
+                       ?? GetAttribute<ModuleCategoryAttribute>(moduleType)?.Category;
         }
 
-        _finalizedMetadata[moduleType] = new ModuleMetadata(tags.ToFrozenSet(), category);
+        return new ModuleMetadata(tags.ToFrozenSet(), category);
     }
 
-    /// <inheritdoc />
-    public IReadOnlySet<string> GetTags(Type moduleType)
-        => _finalizedMetadata.TryGetValue(moduleType, out var meta) ? meta.Tags : FrozenSet<string>.Empty;
-
-    /// <inheritdoc />
-    public string? GetCategory(Type moduleType)
-        => _finalizedMetadata.TryGetValue(moduleType, out var meta) ? meta.Category : null;
-
-    /// <inheritdoc />
-    public bool HasAttribute<TAttribute>(Type moduleType)
-        where TAttribute : Attribute
-        => moduleType.GetCustomAttribute<TAttribute>(inherit: true) != null;
-
-    /// <inheritdoc />
-    public TAttribute? GetAttribute<TAttribute>(Type moduleType)
-        where TAttribute : Attribute
-        => moduleType.GetCustomAttribute<TAttribute>(inherit: true);
-
-    /// <inheritdoc />
-    public IEnumerable<TAttribute> GetAttributes<TAttribute>(Type moduleType)
-        where TAttribute : Attribute
-        => moduleType.GetCustomAttributes<TAttribute>(inherit: true);
+    private Attribute[] GetCachedAttributes(Type moduleType, Type attributeType)
+    {
+        return _attributesByType.GetOrAdd(
+            (moduleType, attributeType),
+            key => _attributeEventService.GetAttributes(key.ModuleType)
+                .Where(key.AttributeType.IsInstanceOfType)
+                .ToArray());
+    }
 
     internal sealed record ModuleMetadata(FrozenSet<string> Tags, string? Category);
 }

--- a/src/ModularPipelines/Engine/PipelineSetupExecutor.cs
+++ b/src/ModularPipelines/Engine/PipelineSetupExecutor.cs
@@ -1,4 +1,5 @@
 using ModularPipelines.Context;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Interfaces;
 using ModularPipelines.Models;
@@ -8,19 +9,22 @@ namespace ModularPipelines.Engine;
 internal class PipelineSetupExecutor : IPipelineSetupExecutor
 {
     private readonly IEnumerable<IPipelineGlobalHooks> _globalHooks;
-    private readonly IEnumerable<IPipelineModuleHooks> _moduleHooks;
+    private readonly IReadOnlyCollection<IPipelineModuleHooks> _moduleHooks;
     private readonly IPipelineContextProvider _moduleContextProvider;
     private readonly IModuleMetadataRegistry _metadataRegistry;
+    private readonly IModuleAttributeEventService _attributeEventService;
 
     public PipelineSetupExecutor(IEnumerable<IPipelineGlobalHooks> globalHooks,
         IEnumerable<IPipelineModuleHooks> moduleHooks,
         IPipelineContextProvider moduleContextProvider,
-        IModuleMetadataRegistry metadataRegistry)
+        IModuleMetadataRegistry metadataRegistry,
+        IModuleAttributeEventService attributeEventService)
     {
         _globalHooks = globalHooks;
-        _moduleHooks = moduleHooks;
+        _moduleHooks = moduleHooks as IReadOnlyCollection<IPipelineModuleHooks> ?? moduleHooks.ToArray();
         _moduleContextProvider = moduleContextProvider;
         _metadataRegistry = metadataRegistry;
+        _attributeEventService = attributeEventService;
     }
 
     public Task OnPipelineStartAsync()
@@ -34,33 +38,41 @@ internal class PipelineSetupExecutor : IPipelineSetupExecutor
     }
 
     public Task OnModuleReadyAsync(ModuleState moduleState)
-    {
-        var context = CreateModuleHookContext(moduleState);
-        return Task.WhenAll(_moduleHooks.Select(x => x.OnModuleReadyAsync(context)));
-    }
+        => InvokeModuleHooksAsync(
+            moduleState,
+            static (hook, context) => hook.OnModuleReadyAsync(context));
 
     public Task OnModuleStartAsync(ModuleState moduleState)
-    {
-        var context = CreateModuleHookContext(moduleState);
-        return Task.WhenAll(_moduleHooks.Select(x => x.OnModuleStartAsync(context)));
-    }
+        => InvokeModuleHooksAsync(
+            moduleState,
+            static (hook, context) => hook.OnModuleStartAsync(context));
 
     public Task OnModuleEndAsync(ModuleState moduleState)
-    {
-        var context = CreateModuleHookContext(moduleState);
-        return Task.WhenAll(_moduleHooks.Select(x => x.OnModuleEndAsync(context)));
-    }
+        => InvokeModuleHooksAsync(
+            moduleState,
+            static (hook, context) => hook.OnModuleEndAsync(context));
 
     public Task OnModuleFailureAsync(ModuleState moduleState)
-    {
-        var context = CreateModuleHookContext(moduleState);
-        return Task.WhenAll(_moduleHooks.Select(x => x.OnModuleFailureAsync(context)));
-    }
+        => InvokeModuleHooksAsync(
+            moduleState,
+            static (hook, context) => hook.OnModuleFailureAsync(context));
 
     public Task OnModuleSkippedAsync(ModuleState moduleState)
+        => InvokeModuleHooksAsync(
+            moduleState,
+            static (hook, context) => hook.OnModuleSkippedAsync(context));
+
+    private Task InvokeModuleHooksAsync(
+        ModuleState moduleState,
+        Func<IPipelineModuleHooks, IModuleHookContext, Task> invokeHook)
     {
+        if (_moduleHooks.Count == 0)
+        {
+            return Task.CompletedTask;
+        }
+
         var context = CreateModuleHookContext(moduleState);
-        return Task.WhenAll(_moduleHooks.Select(x => x.OnModuleSkippedAsync(context)));
+        return Task.WhenAll(_moduleHooks.Select(hook => invokeHook(hook, context)));
     }
 
     private IPipelineHookContext GetPipelineContext()
@@ -71,7 +83,7 @@ internal class PipelineSetupExecutor : IPipelineSetupExecutor
     private ModuleHookContext CreateModuleHookContext(ModuleState moduleState)
     {
         var moduleType = moduleState.ModuleType;
-        var moduleAttributes = Attribute.GetCustomAttributes(moduleType).ToList().AsReadOnly();
+        var moduleAttributes = _attributeEventService.GetAttributes(moduleType);
         var startTime = moduleState.ExecutionStartTime ?? moduleState.QueuedTime ?? DateTimeOffset.UtcNow;
 
         return new ModuleHookContext(

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -27,7 +27,9 @@ public class DistributedModuleExecutorTests
     private static ModuleDependencyRegistry NewDependencyRegistry() => new();
 
     private static ModuleMetadataRegistry NewMetadataRegistry() =>
-        new(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()));
+        new(
+            Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+            new ModuleAttributeEventService());
 
     // --- Test module types ---
 

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedWorkPublisherTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedWorkPublisherTests.cs
@@ -4,6 +4,7 @@ using ModularPipelines.Distributed.Coordination;
 using ModularPipelines.Distributed.Master;
 using ModularPipelines.Distributed.Serialization;
 using ModularPipelines.Engine;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Enums;
 using ModularPipelines.Models;
@@ -192,7 +193,8 @@ public class DistributedWorkPublisherTests
         resultRegistry.RegisterResult(typeof(TaggedDependencyModule), dependencyResult);
         var dependencyRegistry = new ModuleDependencyRegistry();
         var metadataRegistry = new ModuleMetadataRegistry(
-            Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()));
+            Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+            new ModuleAttributeEventService());
         var dependencyModule = new TaggedDependencyModule();
         var consumerModule = new TaggedConsumerModule();
         metadataRegistry.FinalizeMetadata(typeof(TaggedDependencyModule), dependencyModule);

--- a/test/ModularPipelines.UnitTests/Attributes/GeneratedAttributeEventMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/GeneratedAttributeEventMetadataTests.cs
@@ -164,7 +164,7 @@ public class GeneratedAttributeEventMetadataTests
         await Assert.That(ReferenceEquals(
                 handlers[0],
                 contextAttributes.OfType<GeneratedStartAttribute>().First()))
-            .IsFalse();
+            .IsTrue();
         await Assert.That(contextAttributes
             .OfType<GeneratedMarkerAttribute>()
             .Single()

--- a/test/ModularPipelines.UnitTests/Attributes/ModuleAttributeEventServiceTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/ModuleAttributeEventServiceTests.cs
@@ -21,6 +21,20 @@ public class ModuleAttributeEventServiceTests
         public Task OnModuleFailureAsync(IModuleHookContext context, Exception exception) => Task.CompletedTask;
     }
 
+    private sealed class CountingAttribute : Attribute
+    {
+        private static int _instanceCount;
+
+        public CountingAttribute()
+        {
+            Interlocked.Increment(ref _instanceCount);
+        }
+
+        public static int InstanceCount => Volatile.Read(ref _instanceCount);
+
+        public static void Reset() => Volatile.Write(ref _instanceCount, 0);
+    }
+
     /// <summary>
     /// A start handler with priority 100 (runs last).
     /// </summary>
@@ -66,6 +80,13 @@ public class ModuleAttributeEventServiceTests
     }
 
     private class ModuleWithoutAttributes : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult<string?>("test");
+    }
+
+    [Counting]
+    private class ModuleWithCountingAttribute : Module<string>
     {
         protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string?>("test");
@@ -132,6 +153,37 @@ public class ModuleAttributeEventServiceTests
         var handlers2 = service.GetStartHandlers(typeof(ModuleWithAttributes));
 
         await Assert.That(ReferenceEquals(handlers1, handlers2)).IsTrue();
+    }
+
+    [Test]
+    public async Task GetAttributes_CachesResultsAndHandlerInstances()
+    {
+        var service = new ModuleAttributeEventService();
+
+        var attributes1 = service.GetAttributes(typeof(ModuleWithAttributes));
+        var attributes2 = service.GetAttributes(typeof(ModuleWithAttributes));
+        var startHandler = service.GetStartHandlers(typeof(ModuleWithAttributes)).Single();
+
+        await Assert.That(ReferenceEquals(attributes1, attributes2)).IsTrue();
+        await Assert.That(ReferenceEquals(
+                attributes1.OfType<TestStartAttribute>().Single(),
+                startHandler))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task GetAttributes_ConcurrentCalls_CreateAttributesOnce()
+    {
+        var service = new ModuleAttributeEventService();
+        CountingAttribute.Reset();
+
+        var calls = Enumerable.Range(0, 32)
+            .Select(_ => Task.Run(() => service.GetAttributes(typeof(ModuleWithCountingAttribute))))
+            .ToArray();
+        var results = await Task.WhenAll(calls);
+
+        await Assert.That(CountingAttribute.InstanceCount).IsEqualTo(1);
+        await Assert.That(results.All(attributes => ReferenceEquals(attributes, results[0]))).IsTrue();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Attributes/ModuleMetadataRegistryTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/ModuleMetadataRegistryTests.cs
@@ -98,7 +98,9 @@ public class ModuleMetadataRegistryTests
     }
 
     private static ModuleMetadataRegistry CreateRegistry()
-        => new(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()));
+        => new(
+            Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+            new ModuleAttributeEventService());
 
     private static ModuleMetadataRegistry CreateRegistry(IModuleAttributeEventService attributeEventService)
         => new(

--- a/test/ModularPipelines.UnitTests/Attributes/ModuleMetadataRegistryTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/ModuleMetadataRegistryTests.cs
@@ -1,7 +1,9 @@
+using System.Reflection;
 using ModularPipelines.Configuration;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -45,8 +47,63 @@ public class ModuleMetadataRegistryTests
         public bool TrySetDistributedResult(IModuleResult result) => false;
     }
 
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    private sealed class CachedAttribute : Attribute
+    {
+    }
+
+    [Cached]
+    private sealed class DirectCachedModule : IModule
+    {
+        public Type ResultType => typeof(string);
+
+        public ModuleConfiguration Configuration { get; } = ModuleConfiguration.Default;
+
+        public Task<IModuleResult> ResultTask => null!;
+
+        public bool TrySetDistributedResult(IModuleResult result) => false;
+    }
+
+    [Cached]
+    [Cached]
+    private sealed class DirectMultiplyAttributedModule : IModule
+    {
+        public Type ResultType => typeof(string);
+
+        public ModuleConfiguration Configuration { get; } = ModuleConfiguration.Default;
+
+        public Task<IModuleResult> ResultTask => null!;
+
+        public bool TrySetDistributedResult(IModuleResult result) => false;
+    }
+
+    private sealed class ConfigurationCountingModule : IModule
+    {
+        public int ConfigurationReadCount { get; private set; }
+
+        public Type ResultType => typeof(string);
+
+        public ModuleConfiguration Configuration
+        {
+            get
+            {
+                ConfigurationReadCount++;
+                return ModuleConfiguration.Default;
+            }
+        }
+
+        public Task<IModuleResult> ResultTask => null!;
+
+        public bool TrySetDistributedResult(IModuleResult result) => false;
+    }
+
     private static ModuleMetadataRegistry CreateRegistry()
         => new(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()));
+
+    private static ModuleMetadataRegistry CreateRegistry(IModuleAttributeEventService attributeEventService)
+        => new(
+            Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+            attributeEventService);
 
     [Test]
     public async Task SetMetadata_GetMetadata_ReturnsValue()
@@ -102,5 +159,44 @@ public class ModuleMetadataRegistryTests
 
         await Assert.That(registry.GetTags(typeof(DirectAttributedModule))).Contains("attribute-tag");
         await Assert.That(registry.GetCategory(typeof(DirectAttributedModule))).IsEqualTo("attribute-category");
+    }
+
+    [Test]
+    public async Task AttributeQueries_ShareCachedEventAttributeInstances()
+    {
+        var attributeEventService = new ModuleAttributeEventService();
+        var registry = CreateRegistry(attributeEventService);
+
+        var contextAttribute = attributeEventService
+            .GetAttributes(typeof(DirectCachedModule))
+            .OfType<CachedAttribute>()
+            .Single();
+        var first = registry.GetAttribute<CachedAttribute>(typeof(DirectCachedModule));
+        var second = registry.GetAttributes<CachedAttribute>(typeof(DirectCachedModule)).Single();
+
+        await Assert.That(ReferenceEquals(contextAttribute, first)).IsTrue();
+        await Assert.That(ReferenceEquals(first, second)).IsTrue();
+        await Assert.That(registry.HasAttribute<CachedAttribute>(typeof(DirectCachedModule))).IsTrue();
+    }
+
+    [Test]
+    public async Task GetAttribute_WithMultipleMatches_PreservesAmbiguousMatchError()
+    {
+        var registry = CreateRegistry();
+
+        await Assert.That(() => registry.GetAttribute<CachedAttribute>(typeof(DirectMultiplyAttributedModule)))
+            .Throws<AmbiguousMatchException>();
+    }
+
+    [Test]
+    public async Task FinalizeMetadata_WhenAlreadyFinalized_DoesNotReadConfigurationAgain()
+    {
+        var registry = CreateRegistry();
+        var module = new ConfigurationCountingModule();
+
+        registry.FinalizeMetadata(typeof(ConfigurationCountingModule), module);
+        registry.FinalizeMetadata(typeof(ConfigurationCountingModule), module);
+
+        await Assert.That(module.ConfigurationReadCount).IsEqualTo(1);
     }
 }

--- a/test/ModularPipelines.UnitTests/Attributes/ModuleRegistrationContextTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/ModuleRegistrationContextTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes.Events;
 using ModularPipelines.Context;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
@@ -67,7 +68,9 @@ public class ModuleRegistrationContextTests
     [Test]
     public async Task SetMetadata_GetMetadata_RoundTrips()
     {
-        var metadataRegistry = new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()));
+        var metadataRegistry = new ModuleMetadataRegistry(
+            Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+            new ModuleAttributeEventService());
         var context = CreateContext(typeof(ModuleA), metadataRegistry: metadataRegistry);
 
         context.SetMetadata("key", "value");
@@ -93,6 +96,8 @@ public class ModuleRegistrationContextTests
             registeredModules ?? new List<Type> { moduleType },
             services,
             dependencyRegistry ?? new ModuleDependencyRegistry(),
-            metadataRegistry ?? new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())));
+            metadataRegistry ?? new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()));
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -77,7 +77,9 @@ public class ModuleExecutorLoggingTests
             registrationEvents.Object,
             Mock.Of<IMetricsCollector>(),
             new ModuleDependencyRegistry(),
-            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()),
             Mock.Of<ISecondaryExceptionContainer>(),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
             new StringLogger<ModuleExecutor>(logs));
@@ -94,7 +96,8 @@ public class ModuleExecutorLoggingTests
     {
         var dependencyRegistry = new ModuleDependencyRegistry();
         var metadataRegistry = new ModuleMetadataRegistry(
-            Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()));
+            Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+            new ModuleAttributeEventService());
         var scheduler = new ModuleScheduler(
             NullLogger.Instance,
             TimeProvider.System,
@@ -234,7 +237,9 @@ public class ModuleExecutorLoggingTests
             registrationEvents.Object,
             Mock.Of<IMetricsCollector>(),
             new ModuleDependencyRegistry(),
-            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()),
             secondaryExceptionContainer.Object,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerConfigurationTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Attributes;
 using ModularPipelines.Configuration;
 using ModularPipelines.Engine;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Scheduling;
 using ModularPipelines.Enums;
@@ -49,7 +50,9 @@ public class ModuleSchedulerConfigurationTests
             TimeProvider.System,
             Microsoft.Extensions.Options.Options.Create(new SchedulerOptions()),
             new ModuleDependencyRegistry(),
-            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()),
             Mock.Of<IMetricsCollector>(),
             Mock.Of<IModuleConstraintEvaluator>(),
             Mock.Of<ISchedulerStatusReporter>());

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDisposalTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDisposalTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Scheduling;
 using ModularPipelines.Modules;
@@ -85,7 +86,9 @@ public class ModuleSchedulerDisposalTests
             TimeProvider.System,
             Microsoft.Extensions.Options.Options.Create(new SchedulerOptions()),
             new ModuleDependencyRegistry(),
-            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()),
             Mock.Of<IMetricsCollector>(),
             constraintEvaluator,
             Mock.Of<ISchedulerStatusReporter>());

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Scheduling;
 using ModularPipelines.Exceptions;
@@ -332,7 +333,9 @@ public class ModuleSchedulerDynamicCycleTests
             TimeProvider.System,
             Microsoft.Extensions.Options.Options.Create(schedulerOptions ?? new SchedulerOptions()),
             new ModuleDependencyRegistry(),
-            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()),
             Mock.Of<IMetricsCollector>(),
             constraintEvaluator ?? Mock.Of<IModuleConstraintEvaluator>(),
             statusReporter ?? Mock.Of<ISchedulerStatusReporter>());

--- a/test/ModularPipelines.UnitTests/Engine/PipelineSetupExecutorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineSetupExecutorTests.cs
@@ -8,6 +8,7 @@ using Moq;
 
 namespace ModularPipelines.UnitTests.Engine;
 
+[TUnit.Core.NotInParallel(nameof(PipelineSetupExecutorTests))]
 public class PipelineSetupExecutorTests
 {
     [AttributeUsage(AttributeTargets.Class)]

--- a/test/ModularPipelines.UnitTests/Engine/PipelineSetupExecutorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineSetupExecutorTests.cs
@@ -1,0 +1,73 @@
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Interfaces;
+using ModularPipelines.Modules;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class PipelineSetupExecutorTests
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class CountingAttribute : Attribute
+    {
+        public CountingAttribute()
+        {
+            InstanceCount++;
+        }
+
+        public static int InstanceCount { get; set; }
+    }
+
+    [Counting]
+    private sealed class TestModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(TestModule));
+    }
+
+    [Test]
+    public async Task OnModuleReadyAsync_WithoutHooks_DoesNotCreateAttributes()
+    {
+        var executor = new PipelineSetupExecutor(
+            [],
+            [],
+            Mock.Of<IPipelineContextProvider>(),
+            Mock.Of<IModuleMetadataRegistry>(),
+            new ModuleAttributeEventService());
+        var module = new TestModule();
+        CountingAttribute.InstanceCount = 0;
+
+        await executor.OnModuleReadyAsync(new ModuleState(module, module.GetType()));
+
+        await Assert.That(CountingAttribute.InstanceCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task OnModuleReadyAsync_WithHook_UsesCachedAttributeInstances()
+    {
+        var attributeEventService = new ModuleAttributeEventService();
+        IReadOnlyList<Attribute>? hookAttributes = null;
+        var hook = new Mock<IPipelineModuleHooks>();
+        hook.Setup(x => x.OnModuleReadyAsync(It.IsAny<IModuleHookContext>()))
+            .Callback<IModuleHookContext>(context => hookAttributes = context.ModuleAttributes)
+            .Returns(Task.CompletedTask);
+        var executor = new PipelineSetupExecutor(
+            [],
+            [hook.Object],
+            Mock.Of<IPipelineContextProvider>(),
+            Mock.Of<IModuleMetadataRegistry>(),
+            attributeEventService);
+        var module = new TestModule();
+
+        await executor.OnModuleReadyAsync(new ModuleState(module, module.GetType()));
+
+        await Assert.That(ReferenceEquals(
+                hookAttributes,
+                attributeEventService.GetAttributes(module.GetType())))
+            .IsTrue();
+    }
+}


### PR DESCRIPTION
Closes #3260

## Summary
- cache each module type's attribute instances once, including concurrent access
- reuse that cache across event handlers, hook contexts, registration queries, and metadata
- skip module-hook context/attribute creation when no module hooks are registered
- memoize finalized metadata while preserving reflection ambiguity semantics

## Validation
- targeted unit tests: 34 passed
- metadata cross-phase integration: 1 passed
- flexible dependency integration: 15 passed
- `ModularPipelines.sln` Release build: 0 errors (250 existing warnings)
- changed-file whitespace verification passed