### PR TITLE
Remove startup estimate rate limit

### DIFF
--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -115,7 +115,7 @@ internal class ModuleRetriever
 
                 return new RunnableModule(module, estimatedTime, subModules.ToImmutableList());
             })
-            .ProcessInParallel(100, TimeSpan.FromSeconds(1));
+            .ProcessInParallel();
 
         return new OrganizedModules(
             RunnableModules: runnableModulesWithEstimatatedDuration,

--- a/test/ModularPipelines.UnitTests/Engine/ModuleRetrieverTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleRetrieverTests.cs
@@ -1,0 +1,61 @@
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Modules;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class ModuleRetrieverTests
+{
+    [Test]
+    public async Task EstimatedTimeLookups_AreNotRateLimited()
+    {
+        var modules = Enumerable.Range(0, 101)
+            .Select(_ => Mock.Of<IModule>())
+            .ToArray();
+        var conditionHandler = new Mock<IModuleConditionHandler>();
+        conditionHandler
+            .Setup(x => x.ShouldIgnore(It.IsAny<IModule>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((false, null));
+        var registrationEventExecutor = new Mock<IRegistrationEventExecutor>();
+        registrationEventExecutor
+            .Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IEnumerable<IModule>>()))
+            .Returns(Task.CompletedTask);
+        var estimatedTimeProvider = new Mock<ISafeModuleEstimatedTimeProvider>();
+        var releaseLookups = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var allLookupsStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var startedLookupCount = 0;
+        estimatedTimeProvider
+            .Setup(x => x.GetModuleEstimatedTimeAsync(It.IsAny<Type>()))
+            .Returns(async () =>
+            {
+                if (Interlocked.Increment(ref startedLookupCount) == modules.Length)
+                {
+                    allLookupsStarted.TrySetResult();
+                }
+
+                await releaseLookups.Task;
+                return TimeSpan.Zero;
+            });
+        estimatedTimeProvider
+            .Setup(x => x.GetSubModuleEstimatedTimesAsync(It.IsAny<Type>()))
+            .ReturnsAsync([]);
+        var retriever = new ModuleRetriever(
+            conditionHandler.Object,
+            registrationEventExecutor.Object,
+            modules,
+            estimatedTimeProvider.Object,
+            Mock.Of<IModuleDependencyRegistry>(),
+            Mock.Of<IModuleMetadataRegistry>());
+
+        var organizedModulesTask = retriever.GetOrganizedModules();
+        var allStartedBeforeRelease = await Task.WhenAny(
+            allLookupsStarted.Task,
+            Task.Delay(TimeSpan.FromSeconds(2))) == allLookupsStarted.Task;
+        releaseLookups.TrySetResult();
+        await organizedModulesTask;
+
+        await Assert.That(allStartedBeforeRelease).IsTrue();
+    }
+}


### PR DESCRIPTION
Closes #3261

## Summary
- remove the 100-lookups-per-second startup throttle
- allow estimated-time reads to run with the processor's unbounded parallel overload
- add a deterministic regression test proving lookup 101 can start before earlier lookups complete

## Validation
- `ModuleRetrieverTests`: 1 passed
- `SafeEstimatedTimeProviderTests`: 3 passed
- changed-file whitespace verification passed
- `ModularPipelines.sln` Release build: 0 errors (250 existing warnings)