### PR TITLE
Stream command output with bounded capture

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -103,12 +103,8 @@ internal sealed class Command : ICommand, ICommandContext
     {
         var standardOutputBuffer = new BoundedCommandOutputBuffer(execOpts.MaxCapturedOutputLength);
         var standardErrorBuffer = new BoundedCommandOutputBuffer(execOpts.MaxCapturedOutputLength);
-        var completeStandardOutputBuffer = execOpts.OutputLoggingManipulator is null
-            ? null
-            : new BoundedCommandOutputBuffer(maximumLength: 0);
-        var completeStandardErrorBuffer = execOpts.OutputLoggingManipulator is null
-            ? null
-            : new BoundedCommandOutputBuffer(maximumLength: 0);
+        var completeStandardOutputBuffer = CreateCompleteOutputBuffer(execOpts);
+        var completeStandardErrorBuffer = CreateCompleteOutputBuffer(execOpts);
         var outputLogger = _commandLogger as ICommandOutputLogger;
         var streamsOutput = outputLogger is not null && execOpts.OutputLoggingManipulator is null;
         var stopwatch = Stopwatch.StartNew();
@@ -116,37 +112,21 @@ internal sealed class Command : ICommand, ICommandContext
         var standardOutput = string.Empty;
         var standardError = string.Empty;
 
-        var inputToLog = execOpts.InputLoggingManipulator == null ? command.ToString() : execOpts.InputLoggingManipulator(command.ToString());
+        var inputToLog = GetInputToLog(command, execOpts);
 
         // Only create timeout token if ExecutionTimeout is specified to avoid unnecessary allocations
-        using var timeoutCancellationToken = execOpts.ExecutionTimeout.HasValue
-            ? new CancellationTokenSource(execOpts.ExecutionTimeout.Value)
-            : null;
+        using var timeoutCancellationToken = CreateTimeoutCancellationToken(execOpts);
 
         // Link the timeout token with the passed cancellation token, or just wrap the original if no timeout
-        using var linkedCancellationToken = timeoutCancellationToken != null
-            ? CancellationTokenSource.CreateLinkedTokenSource(timeoutCancellationToken.Token, cancellationToken)
-            : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var linkedCancellationToken = CreateLinkedCancellationToken(timeoutCancellationToken, cancellationToken);
 
         using var forcefulCancellationToken = new CancellationTokenSource();
         using var processTreeTerminator = new ProcessTreeTerminator();
         using var processTreeCancellationRegistration =
             forcefulCancellationToken.Token.Register(processTreeTerminator.Kill);
 
-        var registration = linkedCancellationToken.Token.Register(() =>
-        {
-            try
-            {
-                if (forcefulCancellationToken.Token.CanBeCanceled)
-                {
-                    forcefulCancellationToken.CancelAfter(execOpts.GracefulShutdownTimeout);
-                }
-            }
-            catch (ObjectDisposedException)
-            {
-                // Ignored
-            }
-        });
+        var registration = linkedCancellationToken.Token.Register(
+            () => ScheduleForcefulCancellation(forcefulCancellationToken, execOpts.GracefulShutdownTimeout));
         await using (registration.ConfigureAwait(false))
         {
             try
@@ -155,24 +135,22 @@ internal sealed class Command : ICommand, ICommandContext
                     .WithStandardOutputPipe(CreateOutputTarget(
                         standardOutputBuffer,
                         completeStandardOutputBuffer,
-                        streamsOutput
-                            ? line => outputLogger!.LogStandardOutputLine(options, execOpts, line)
-                            : null))
+                        CreateStandardOutputLogger(
+                            streamsOutput,
+                            outputLogger,
+                            options,
+                            execOpts)))
                     .WithStandardErrorPipe(CreateOutputTarget(
                         standardErrorBuffer,
                         completeStandardErrorBuffer,
-                        streamsOutput
-                            ? line => outputLogger!.LogStandardErrorLine(options, execOpts, line)
-                            : null))
+                        CreateStandardErrorLogger(
+                            streamsOutput,
+                            outputLogger,
+                            options,
+                            execOpts)))
                     .WithValidation(CommandResultValidation.None)
                     .ExecuteAsync(
-                        configureStartInfo: startInfo =>
-                        {
-                            if (OperatingSystem.IsWindows())
-                            {
-                                startInfo.CreateNewProcessGroup = true;
-                            }
-                        },
+                        configureStartInfo: ConfigureStartInfo,
                         configureProcess: processTreeTerminator.Attach,
                         forcefulCancellationToken: CancellationToken.None,
                         gracefulCancellationToken: linkedCancellationToken.Token);
@@ -201,11 +179,13 @@ internal sealed class Command : ICommand, ICommandContext
                     streamsOutput,
                     command.WorkingDirPath);
 
-                if (result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode)
-                {
-                    var input = inputToLog;
-                    throw new CommandException(input, result.ExitCode, result.RunTime, standardOutput, standardError);
-                }
+                ThrowOnFailure(
+                    execOpts,
+                    inputToLog,
+                    result.ExitCode,
+                    result.RunTime,
+                    standardOutput,
+                    standardError);
 
                 return new CommandResult(command, result, standardOutput, standardError);
             }
@@ -259,6 +239,98 @@ internal sealed class Command : ICommand, ICommandContext
 
                 throw new CommandException(inputToLog, -1, stopwatch.Elapsed, standardOutput, standardError, e);
             }
+        }
+    }
+
+    private static BoundedCommandOutputBuffer? CreateCompleteOutputBuffer(CommandExecutionOptions options)
+    {
+        return options.OutputLoggingManipulator is null
+            ? null
+            : new BoundedCommandOutputBuffer(maximumLength: 0);
+    }
+
+    private static string GetInputToLog(CliWrap.Command command, CommandExecutionOptions options)
+    {
+        var commandText = command.ToString();
+        return options.InputLoggingManipulator is null
+            ? commandText
+            : options.InputLoggingManipulator(commandText);
+    }
+
+    private static CancellationTokenSource? CreateTimeoutCancellationToken(CommandExecutionOptions options)
+    {
+        return options.ExecutionTimeout.HasValue
+            ? new CancellationTokenSource(options.ExecutionTimeout.Value)
+            : null;
+    }
+
+    private static CancellationTokenSource CreateLinkedCancellationToken(
+        CancellationTokenSource? timeoutCancellationToken,
+        CancellationToken cancellationToken)
+    {
+        return timeoutCancellationToken is null
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+            : CancellationTokenSource.CreateLinkedTokenSource(timeoutCancellationToken.Token, cancellationToken);
+    }
+
+    private static void ScheduleForcefulCancellation(
+        CancellationTokenSource forcefulCancellationToken,
+        TimeSpan gracefulShutdownTimeout)
+    {
+        try
+        {
+            if (forcefulCancellationToken.Token.CanBeCanceled)
+            {
+                forcefulCancellationToken.CancelAfter(gracefulShutdownTimeout);
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // Ignored
+        }
+    }
+
+    private static Action<string>? CreateStandardOutputLogger(
+        bool streamsOutput,
+        ICommandOutputLogger? outputLogger,
+        CommandLineToolOptions options,
+        CommandExecutionOptions executionOptions)
+    {
+        return streamsOutput
+            ? line => outputLogger!.LogStandardOutputLine(options, executionOptions, line)
+            : null;
+    }
+
+    private static Action<string>? CreateStandardErrorLogger(
+        bool streamsOutput,
+        ICommandOutputLogger? outputLogger,
+        CommandLineToolOptions options,
+        CommandExecutionOptions executionOptions)
+    {
+        return streamsOutput
+            ? line => outputLogger!.LogStandardErrorLine(options, executionOptions, line)
+            : null;
+    }
+
+    private static void ConfigureStartInfo(ProcessStartInfo startInfo)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            startInfo.CreateNewProcessGroup = true;
+        }
+    }
+
+    private static void ThrowOnFailure(
+        CommandExecutionOptions options,
+        string input,
+        int exitCode,
+        TimeSpan runTime,
+        string standardOutput,
+        string standardError)
+    {
+        if (exitCode != 0 && options.ThrowOnNonZeroExitCode)
+        {
+            throw new CommandException(input, exitCode, runTime, standardOutput, standardError);
         }
     }
 

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -104,6 +104,7 @@ internal sealed class Command : ICommand, ICommandContext
         var standardOutputBuffer = new BoundedCommandOutputBuffer(execOpts.MaxCapturedOutputLength);
         var standardErrorBuffer = new BoundedCommandOutputBuffer(execOpts.MaxCapturedOutputLength);
         var outputLogger = _commandLogger as ICommandOutputLogger;
+        var streamsOutput = outputLogger is not null && execOpts.OutputLoggingManipulator is null;
         var stopwatch = Stopwatch.StartNew();
 
         var standardOutput = string.Empty;
@@ -145,14 +146,16 @@ internal sealed class Command : ICommand, ICommandContext
             try
             {
                 var executionTask = command
-                    .WithStandardOutputPipe(PipeTarget.Merge(
-                        CreateCaptureTarget(standardOutputBuffer),
-                        PipeTarget.ToDelegate(line =>
-                            outputLogger?.LogStandardOutputLine(options, execOpts, line))))
-                    .WithStandardErrorPipe(PipeTarget.Merge(
-                        CreateCaptureTarget(standardErrorBuffer),
-                        PipeTarget.ToDelegate(line =>
-                            outputLogger?.LogStandardErrorLine(options, execOpts, line))))
+                    .WithStandardOutputPipe(CreateOutputTarget(
+                        standardOutputBuffer,
+                        streamsOutput
+                            ? line => outputLogger!.LogStandardOutputLine(options, execOpts, line)
+                            : null))
+                    .WithStandardErrorPipe(CreateOutputTarget(
+                        standardErrorBuffer,
+                        streamsOutput
+                            ? line => outputLogger!.LogStandardErrorLine(options, execOpts, line)
+                            : null))
                     .WithValidation(CommandResultValidation.None)
                     .ExecuteAsync(
                         configureStartInfo: startInfo =>
@@ -177,16 +180,16 @@ internal sealed class Command : ICommand, ICommandContext
                 standardOutput = standardOutputBuffer.ToString();
                 standardError = standardErrorBuffer.ToString();
 
-                _commandLogger.Log(
-                    options: options,
-                    execOpts: execOpts,
-                    inputToLog: inputToLog,
-                    exitCode: result.ExitCode,
-                    runTime: result.RunTime,
-                    standardOutput: outputLogger is null ? standardOutput : string.Empty,
-                    standardError: outputLogger is null ? standardError : string.Empty,
-                    commandWorkingDirPath: command.WorkingDirPath
-                );
+                LogCommandCompletion(
+                    options,
+                    execOpts,
+                    inputToLog,
+                    result.ExitCode,
+                    result.RunTime,
+                    standardOutput,
+                    standardError,
+                    streamsOutput,
+                    command.WorkingDirPath);
 
                 if (result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode)
                 {
@@ -206,16 +209,16 @@ internal sealed class Command : ICommand, ICommandContext
                 standardOutput = standardOutputBuffer.ToString();
                 standardError = standardErrorBuffer.ToString();
 
-                _commandLogger.Log(
-                    options: options,
-                    execOpts: execOpts,
-                    inputToLog: inputToLog,
-                    exitCode: e.ExitCode,
-                    runTime: stopwatch.Elapsed,
-                    standardOutput: outputLogger is null ? standardOutput : string.Empty,
-                    standardError: outputLogger is null ? standardError : string.Empty,
-                    commandWorkingDirPath: command.WorkingDirPath
-                );
+                LogCommandCompletion(
+                    options,
+                    execOpts,
+                    inputToLog,
+                    e.ExitCode,
+                    stopwatch.Elapsed,
+                    standardOutput,
+                    standardError,
+                    streamsOutput,
+                    command.WorkingDirPath);
 
                 throw new CommandException(inputToLog, e.ExitCode, stopwatch.Elapsed, standardOutput, standardError, e);
             }
@@ -229,16 +232,16 @@ internal sealed class Command : ICommand, ICommandContext
                 standardOutput = standardOutputBuffer.ToString();
                 standardError = standardErrorBuffer.ToString();
 
-                _commandLogger.Log(
-                    options: options,
-                    execOpts: execOpts,
-                    inputToLog: inputToLog,
-                    exitCode: -1,
-                    runTime: stopwatch.Elapsed,
-                    standardOutput: outputLogger is null ? standardOutput : string.Empty,
-                    standardError: outputLogger is null ? standardError : string.Empty,
-                    commandWorkingDirPath: command.WorkingDirPath
-                );
+                LogCommandCompletion(
+                    options,
+                    execOpts,
+                    inputToLog,
+                    -1,
+                    stopwatch.Elapsed,
+                    standardOutput,
+                    standardError,
+                    streamsOutput,
+                    command.WorkingDirPath);
 
                 throw new CommandException(inputToLog, -1, stopwatch.Elapsed, standardOutput, standardError, e);
             }
@@ -683,6 +686,38 @@ internal sealed class Command : ICommand, ICommandContext
                 int byteCount);
 #pragma warning restore SYSLIB1054
         }
+    }
+
+    private static PipeTarget CreateOutputTarget(
+        BoundedCommandOutputBuffer buffer,
+        Action<string>? logLine)
+    {
+        var captureTarget = CreateCaptureTarget(buffer);
+        return logLine is null
+            ? captureTarget
+            : PipeTarget.Merge(captureTarget, PipeTarget.ToDelegate(logLine));
+    }
+
+    private void LogCommandCompletion(
+        CommandLineToolOptions options,
+        CommandExecutionOptions executionOptions,
+        string input,
+        int exitCode,
+        TimeSpan runTime,
+        string standardOutput,
+        string standardError,
+        bool streamsOutput,
+        string workingDirectory)
+    {
+        _commandLogger.Log(
+            options,
+            executionOptions,
+            input,
+            exitCode,
+            runTime,
+            streamsOutput ? string.Empty : standardOutput,
+            streamsOutput ? string.Empty : standardError,
+            workingDirectory);
     }
 
     private static PipeTarget CreateCaptureTarget(BoundedCommandOutputBuffer buffer)

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -101,8 +101,9 @@ internal sealed class Command : ICommand, ICommandContext
         CommandExecutionOptions execOpts,
         CancellationToken cancellationToken = default)
     {
-        StringBuilder standardOutputStringBuilder = new();
-        StringBuilder standardErrorStringBuilder = new();
+        var standardOutputBuffer = new BoundedCommandOutputBuffer(execOpts.MaxCapturedOutputLength);
+        var standardErrorBuffer = new BoundedCommandOutputBuffer(execOpts.MaxCapturedOutputLength);
+        var outputLogger = _commandLogger as ICommandOutputLogger;
         var stopwatch = Stopwatch.StartNew();
 
         var standardOutput = string.Empty;
@@ -144,8 +145,14 @@ internal sealed class Command : ICommand, ICommandContext
             try
             {
                 var executionTask = command
-                    .WithStandardOutputPipe(PipeTarget.ToStringBuilder(standardOutputStringBuilder))
-                    .WithStandardErrorPipe(PipeTarget.ToStringBuilder(standardErrorStringBuilder))
+                    .WithStandardOutputPipe(PipeTarget.Merge(
+                        CreateCaptureTarget(standardOutputBuffer),
+                        PipeTarget.ToDelegate(line =>
+                            outputLogger?.LogStandardOutputLine(options, execOpts, line))))
+                    .WithStandardErrorPipe(PipeTarget.Merge(
+                        CreateCaptureTarget(standardErrorBuffer),
+                        PipeTarget.ToDelegate(line =>
+                            outputLogger?.LogStandardErrorLine(options, execOpts, line))))
                     .WithValidation(CommandResultValidation.None)
                     .ExecuteAsync(
                         configureStartInfo: startInfo =>
@@ -167,8 +174,8 @@ internal sealed class Command : ICommand, ICommandContext
                     linkedCancellationToken.Token,
                     forcefulCancellationToken.Token).ConfigureAwait(false);
 
-                standardOutput = standardOutputStringBuilder.ToString();
-                standardError = standardErrorStringBuilder.ToString();
+                standardOutput = standardOutputBuffer.ToString();
+                standardError = standardErrorBuffer.ToString();
 
                 _commandLogger.Log(
                     options: options,
@@ -176,8 +183,8 @@ internal sealed class Command : ICommand, ICommandContext
                     inputToLog: inputToLog,
                     exitCode: result.ExitCode,
                     runTime: result.RunTime,
-                    standardOutput: standardOutput,
-                    standardError: standardError,
+                    standardOutput: outputLogger is null ? standardOutput : string.Empty,
+                    standardError: outputLogger is null ? standardError : string.Empty,
                     commandWorkingDirPath: command.WorkingDirPath
                 );
 
@@ -196,8 +203,8 @@ internal sealed class Command : ICommand, ICommandContext
                     linkedCancellationToken.Token,
                     forcefulCancellationToken.Token).ConfigureAwait(false);
 
-                standardOutput = standardOutputStringBuilder.ToString();
-                standardError = standardErrorStringBuilder.ToString();
+                standardOutput = standardOutputBuffer.ToString();
+                standardError = standardErrorBuffer.ToString();
 
                 _commandLogger.Log(
                     options: options,
@@ -205,8 +212,8 @@ internal sealed class Command : ICommand, ICommandContext
                     inputToLog: inputToLog,
                     exitCode: e.ExitCode,
                     runTime: stopwatch.Elapsed,
-                    standardOutput: standardOutput,
-                    standardError: standardError,
+                    standardOutput: outputLogger is null ? standardOutput : string.Empty,
+                    standardError: outputLogger is null ? standardError : string.Empty,
                     commandWorkingDirPath: command.WorkingDirPath
                 );
 
@@ -219,8 +226,8 @@ internal sealed class Command : ICommand, ICommandContext
                     linkedCancellationToken.Token,
                     forcefulCancellationToken.Token).ConfigureAwait(false);
 
-                standardOutput = standardOutputStringBuilder.ToString();
-                standardError = standardErrorStringBuilder.ToString();
+                standardOutput = standardOutputBuffer.ToString();
+                standardError = standardErrorBuffer.ToString();
 
                 _commandLogger.Log(
                     options: options,
@@ -228,8 +235,8 @@ internal sealed class Command : ICommand, ICommandContext
                     inputToLog: inputToLog,
                     exitCode: -1,
                     runTime: stopwatch.Elapsed,
-                    standardOutput: standardOutput,
-                    standardError: standardError,
+                    standardOutput: outputLogger is null ? standardOutput : string.Empty,
+                    standardError: outputLogger is null ? standardError : string.Empty,
                     commandWorkingDirPath: command.WorkingDirPath
                 );
 
@@ -676,5 +683,24 @@ internal sealed class Command : ICommand, ICommandContext
                 int byteCount);
 #pragma warning restore SYSLIB1054
         }
+    }
+
+    private static PipeTarget CreateCaptureTarget(BoundedCommandOutputBuffer buffer)
+    {
+        return PipeTarget.Create(async (stream, cancellationToken) =>
+        {
+            using var reader = new StreamReader(
+                stream,
+                Encoding.Default,
+                detectEncodingFromByteOrderMarks: true,
+                bufferSize: 4096,
+                leaveOpen: true);
+            var characters = new char[4096];
+            int charactersRead;
+            while ((charactersRead = await reader.ReadAsync(characters, cancellationToken).ConfigureAwait(false)) > 0)
+            {
+                buffer.Append(characters.AsSpan(0, charactersRead));
+            }
+        });
     }
 }

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -103,6 +103,12 @@ internal sealed class Command : ICommand, ICommandContext
     {
         var standardOutputBuffer = new BoundedCommandOutputBuffer(execOpts.MaxCapturedOutputLength);
         var standardErrorBuffer = new BoundedCommandOutputBuffer(execOpts.MaxCapturedOutputLength);
+        var completeStandardOutputBuffer = execOpts.OutputLoggingManipulator is null
+            ? null
+            : new BoundedCommandOutputBuffer(maximumLength: 0);
+        var completeStandardErrorBuffer = execOpts.OutputLoggingManipulator is null
+            ? null
+            : new BoundedCommandOutputBuffer(maximumLength: 0);
         var outputLogger = _commandLogger as ICommandOutputLogger;
         var streamsOutput = outputLogger is not null && execOpts.OutputLoggingManipulator is null;
         var stopwatch = Stopwatch.StartNew();
@@ -148,11 +154,13 @@ internal sealed class Command : ICommand, ICommandContext
                 var executionTask = command
                     .WithStandardOutputPipe(CreateOutputTarget(
                         standardOutputBuffer,
+                        completeStandardOutputBuffer,
                         streamsOutput
                             ? line => outputLogger!.LogStandardOutputLine(options, execOpts, line)
                             : null))
                     .WithStandardErrorPipe(CreateOutputTarget(
                         standardErrorBuffer,
+                        completeStandardErrorBuffer,
                         streamsOutput
                             ? line => outputLogger!.LogStandardErrorLine(options, execOpts, line)
                             : null))
@@ -188,6 +196,8 @@ internal sealed class Command : ICommand, ICommandContext
                     result.RunTime,
                     standardOutput,
                     standardError,
+                    completeStandardOutputBuffer,
+                    completeStandardErrorBuffer,
                     streamsOutput,
                     command.WorkingDirPath);
 
@@ -217,6 +227,8 @@ internal sealed class Command : ICommand, ICommandContext
                     stopwatch.Elapsed,
                     standardOutput,
                     standardError,
+                    completeStandardOutputBuffer,
+                    completeStandardErrorBuffer,
                     streamsOutput,
                     command.WorkingDirPath);
 
@@ -240,6 +252,8 @@ internal sealed class Command : ICommand, ICommandContext
                     stopwatch.Elapsed,
                     standardOutput,
                     standardError,
+                    completeStandardOutputBuffer,
+                    completeStandardErrorBuffer,
                     streamsOutput,
                     command.WorkingDirPath);
 
@@ -690,9 +704,10 @@ internal sealed class Command : ICommand, ICommandContext
 
     private static PipeTarget CreateOutputTarget(
         BoundedCommandOutputBuffer buffer,
+        BoundedCommandOutputBuffer? completeOutputBuffer,
         Action<string>? logLine)
     {
-        var captureTarget = CreateCaptureTarget(buffer);
+        var captureTarget = CreateCaptureTarget(buffer, completeOutputBuffer);
         return logLine is null
             ? captureTarget
             : PipeTarget.Merge(captureTarget, PipeTarget.ToDelegate(logLine));
@@ -706,6 +721,8 @@ internal sealed class Command : ICommand, ICommandContext
         TimeSpan runTime,
         string standardOutput,
         string standardError,
+        BoundedCommandOutputBuffer? completeStandardOutputBuffer,
+        BoundedCommandOutputBuffer? completeStandardErrorBuffer,
         bool streamsOutput,
         string workingDirectory)
     {
@@ -715,12 +732,18 @@ internal sealed class Command : ICommand, ICommandContext
             input,
             exitCode,
             runTime,
-            streamsOutput ? string.Empty : standardOutput,
-            streamsOutput ? string.Empty : standardError,
+            streamsOutput
+                ? string.Empty
+                : completeStandardOutputBuffer?.ToString() ?? standardOutput,
+            streamsOutput
+                ? string.Empty
+                : completeStandardErrorBuffer?.ToString() ?? standardError,
             workingDirectory);
     }
 
-    private static PipeTarget CreateCaptureTarget(BoundedCommandOutputBuffer buffer)
+    private static PipeTarget CreateCaptureTarget(
+        BoundedCommandOutputBuffer buffer,
+        BoundedCommandOutputBuffer? completeOutputBuffer)
     {
         return PipeTarget.Create(async (stream, cancellationToken) =>
         {
@@ -735,6 +758,7 @@ internal sealed class Command : ICommand, ICommandContext
             while ((charactersRead = await reader.ReadAsync(characters, cancellationToken).ConfigureAwait(false)) > 0)
             {
                 buffer.Append(characters.AsSpan(0, charactersRead));
+                completeOutputBuffer?.Append(characters.AsSpan(0, charactersRead));
             }
         });
     }

--- a/src/ModularPipelines/Helpers/Internal/BoundedCommandOutputBuffer.cs
+++ b/src/ModularPipelines/Helpers/Internal/BoundedCommandOutputBuffer.cs
@@ -1,0 +1,125 @@
+using System.Text;
+
+namespace ModularPipelines.Helpers.Internal;
+
+internal sealed class BoundedCommandOutputBuffer
+{
+    private readonly int _maximumLength;
+    private readonly int _headCapacity;
+    private readonly int _tailCapacity;
+    private readonly StringBuilder _head;
+    private readonly StringBuilder? _unbounded;
+    private char[]? _tail;
+    private int _tailCount;
+    private int _tailStart;
+    private long _totalLength;
+
+    public BoundedCommandOutputBuffer(int maximumLength)
+    {
+        _maximumLength = maximumLength;
+        if (maximumLength <= 0)
+        {
+            _unbounded = new StringBuilder();
+            _head = new StringBuilder();
+            return;
+        }
+
+        _headCapacity = maximumLength / 2;
+        _tailCapacity = maximumLength - _headCapacity;
+        _head = new StringBuilder(Math.Min(_headCapacity, 256));
+    }
+
+    public override string ToString()
+    {
+        if (_unbounded is not null)
+        {
+            return _unbounded.ToString();
+        }
+
+        var result = new StringBuilder(_head.Length + _tailCount);
+        result.Append(_head);
+
+        if (_totalLength > _maximumLength)
+        {
+            result.AppendLine();
+            result.Append("... [truncated ");
+            result.Append(_totalLength - _maximumLength);
+            result.AppendLine(" characters] ...");
+        }
+
+        AppendTailTo(result);
+        return result.ToString();
+    }
+
+    public void Append(ReadOnlySpan<char> value)
+    {
+        _totalLength += value.Length;
+
+        if (_unbounded is not null)
+        {
+            _unbounded.Append(value);
+            return;
+        }
+
+        var remaining = value;
+        var headRemaining = _headCapacity - _head.Length;
+        if (headRemaining > 0)
+        {
+            var headLength = Math.Min(headRemaining, remaining.Length);
+            _head.Append(remaining[..headLength]);
+            remaining = remaining[headLength..];
+        }
+
+        AppendToTail(remaining);
+    }
+
+    private void AppendToTail(ReadOnlySpan<char> value)
+    {
+        if (_tailCapacity == 0 || value.IsEmpty)
+        {
+            return;
+        }
+
+        var tail = _tail ??= new char[_tailCapacity];
+        if (value.Length >= tail.Length)
+        {
+            value[^tail.Length..].CopyTo(tail);
+            _tailStart = 0;
+            _tailCount = tail.Length;
+            return;
+        }
+
+        var available = tail.Length - _tailCount;
+        var initialLength = Math.Min(available, value.Length);
+        WriteToTail(tail, (_tailStart + _tailCount) % tail.Length, value[..initialLength]);
+        _tailCount += initialLength;
+        value = value[initialLength..];
+
+        if (value.IsEmpty)
+        {
+            return;
+        }
+
+        WriteToTail(tail, _tailStart, value);
+        _tailStart = (_tailStart + value.Length) % tail.Length;
+    }
+
+    private static void WriteToTail(char[] tail, int index, ReadOnlySpan<char> value)
+    {
+        var firstLength = Math.Min(tail.Length - index, value.Length);
+        value[..firstLength].CopyTo(tail.AsSpan(index));
+        value[firstLength..].CopyTo(tail);
+    }
+
+    private void AppendTailTo(StringBuilder result)
+    {
+        if (_tailCount == 0 || _tail is null)
+        {
+            return;
+        }
+
+        var firstLength = Math.Min(_tail.Length - _tailStart, _tailCount);
+        result.Append(_tail, _tailStart, firstLength);
+        result.Append(_tail, 0, _tailCount - firstLength);
+    }
+}

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -109,19 +109,10 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
             return;
         }
 
-        var output = executionOptions.OutputLoggingManipulator is null
-            ? line
-            : executionOptions.OutputLoggingManipulator(line);
-        var obfuscatedOutput = _secretObfuscator.Obfuscate(output, executionOptions);
-
-        if (isError)
-        {
-            Logger.LogWarning("  ✗ {CommandError}", obfuscatedOutput);
-        }
-        else
-        {
-            Logger.LogInformation("  ↳ {CommandOutput}", obfuscatedOutput);
-        }
+        var obfuscatedOutput = _secretObfuscator.Obfuscate(line, null);
+        Logger.LogInformation(
+            isError ? "  ↳ {CommandError}" : "  ↳ {CommandOutput}",
+            obfuscatedOutput);
     }
 
     private void LogCompact(
@@ -151,83 +142,100 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
             ? execOpts.OutputLoggingManipulator(standardError)
             : standardError;
 
-        // Add inline output for short, single-line output on successful commands
         var trimmedOutput = standardOutputToLog.Trim();
-        var hasShortOutput = !string.IsNullOrEmpty(trimmedOutput)
-            && !trimmedOutput.Contains('\n')
-            && trimmedOutput.Length <= 100
-            && options.Verbosity >= CommandLogVerbosity.Normal
-            && options.ShowStandardOutput;
-
+        var hasShortOutput = ShouldInlineOutput(options, trimmedOutput);
         var inlineOutput = hasShortOutput && isSuccess
             ? $" → {_secretObfuscator.Obfuscate(trimmedOutput, null)}"
             : string.Empty;
-
-        // Add status indicator and metadata
-        var commandStatus = new StringBuilder();
-        if (options.Verbosity >= CommandLogVerbosity.Detailed || options.ShowExitCode || options.ShowExecutionTime)
-        {
-            commandStatus.Append(' ');
-            commandStatus.Append(isSuccess ? '✓' : '✗');
-
-            var hasMetadata = false;
-            if (options.Verbosity >= CommandLogVerbosity.Detailed || options.ShowExecutionTime)
-            {
-                commandStatus.Append(" [");
-                commandStatus.Append(runTime?.ToDisplayString() ?? "?");
-                hasMetadata = true;
-            }
-
-            if (options.Verbosity >= CommandLogVerbosity.Detailed || options.ShowExitCode)
-            {
-                if (hasMetadata)
-                {
-                    commandStatus.Append(", ");
-                }
-                else
-                {
-                    commandStatus.Append(" [");
-                    hasMetadata = true;
-                }
-
-                commandStatus.Append("exit ");
-                commandStatus.Append(exitCode);
-            }
-
-            if (hasMetadata)
-            {
-                commandStatus.Append(']');
-            }
-        }
+        var commandStatus = BuildCommandStatus(options, isSuccess, exitCode, runTime);
 
         Logger.LogInformation(
             "{CommandMessage}{CommandOutput}{CommandStatus}",
             commandMessage.ToString(),
             inlineOutput,
-            commandStatus.ToString());
+            commandStatus);
 
-        // Log multi-line or long output on separate lines (only if not already shown inline)
-        if (!hasShortOutput && !string.IsNullOrWhiteSpace(trimmedOutput)
-            && options.Verbosity >= CommandLogVerbosity.Normal
-            && options.ShowStandardOutput)
-        {
-            Logger.LogInformation("  ↳ {CommandOutput}", _secretObfuscator.Obfuscate(trimmedOutput, null));
-        }
-
-        // Log errors on separate line
-        if (!string.IsNullOrWhiteSpace(standardErrorToLog)
-            && options.Verbosity >= CommandLogVerbosity.Normal
-            && options.ShowStandardError
-            && exitCode != 0)
-        {
-            Logger.LogWarning("  ✗ {CommandError}", _secretObfuscator.Obfuscate(standardErrorToLog, null));
-        }
+        LogCapturedOutput(options, trimmedOutput, hasShortOutput);
+        LogCapturedError(options, standardErrorToLog, exitCode);
 
         // Log working directory only at Diagnostic level (separate line, indented)
         if (options.Verbosity >= CommandLogVerbosity.Diagnostic || options.ShowWorkingDirectory)
         {
             Logger.LogInformation("  Working Directory: {WorkingDirectory}", workingDirectory);
         }
+    }
+
+    private static bool ShouldInlineOutput(CommandLoggingOptions options, string output)
+    {
+        return !string.IsNullOrEmpty(output)
+               && !output.Contains('\n')
+               && output.Length <= 100
+               && options.Verbosity >= CommandLogVerbosity.Normal
+               && options.ShowStandardOutput;
+    }
+
+    private static string BuildCommandStatus(
+        CommandLoggingOptions options,
+        bool isSuccess,
+        int? exitCode,
+        TimeSpan? runTime)
+    {
+        if (options.Verbosity < CommandLogVerbosity.Detailed
+            && !options.ShowExitCode
+            && !options.ShowExecutionTime)
+        {
+            return string.Empty;
+        }
+
+        var status = new StringBuilder()
+            .Append(' ')
+            .Append(isSuccess ? '✓' : '✗');
+        var showExecutionTime = options.Verbosity >= CommandLogVerbosity.Detailed || options.ShowExecutionTime;
+        var showExitCode = options.Verbosity >= CommandLogVerbosity.Detailed || options.ShowExitCode;
+
+        if (showExecutionTime)
+        {
+            status.Append(" [").Append(runTime?.ToDisplayString() ?? "?");
+        }
+
+        if (showExitCode)
+        {
+            status.Append(showExecutionTime ? ", " : " [").Append("exit ").Append(exitCode);
+        }
+
+        return status.Append(']').ToString();
+    }
+
+    private void LogCapturedOutput(
+        CommandLoggingOptions options,
+        string output,
+        bool wasInlined)
+    {
+        if (wasInlined
+            || string.IsNullOrWhiteSpace(output)
+            || options.Verbosity < CommandLogVerbosity.Normal
+            || !options.ShowStandardOutput)
+        {
+            return;
+        }
+
+        Logger.LogInformation("  ↳ {CommandOutput}", _secretObfuscator.Obfuscate(output, null));
+    }
+
+    private void LogCapturedError(
+        CommandLoggingOptions options,
+        string error,
+        int? exitCode)
+    {
+        if (string.IsNullOrWhiteSpace(error)
+            || options.Verbosity < CommandLogVerbosity.Normal
+            || !options.ShowStandardError
+            || exitCode == 0)
+        {
+            return;
+        }
+
+        Logger.LogWarning("  ✗ {CommandError}", _secretObfuscator.Obfuscate(error, null));
     }
 
     private static bool ShouldShowInput(CommandLoggingOptions options)

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -8,7 +8,7 @@ using ModularPipelines.Options;
 
 namespace ModularPipelines.Logging;
 
-internal class CommandLogger : ICommandLogger
+internal class CommandLogger : ICommandLogger, ICommandOutputLogger
 {
     private readonly IModuleLoggerProvider _moduleLoggerProvider;
     private readonly IOptions<PipelineOptions> _pipelineOptions;
@@ -54,6 +54,22 @@ internal class CommandLogger : ICommandLogger
         LogCompact(effectiveOptions, execOpts, commandWorkingDirPath, inputToLog, exitCode, runTime, standardOutput, standardError);
     }
 
+    void ICommandOutputLogger.LogStandardOutputLine(
+        CommandLineToolOptions options,
+        CommandExecutionOptions executionOptions,
+        string line)
+    {
+        LogOutputLine(options, executionOptions, line, isError: false);
+    }
+
+    void ICommandOutputLogger.LogStandardErrorLine(
+        CommandLineToolOptions options,
+        CommandExecutionOptions executionOptions,
+        string line)
+    {
+        LogOutputLine(options, executionOptions, line, isError: true);
+    }
+
     private CommandLoggingOptions GetEffectiveLoggingOptions(CommandLineToolOptions? options, CommandExecutionOptions? execOpts)
     {
         // Priority: execOpts property > pipeline default > system default
@@ -75,6 +91,37 @@ internal class CommandLogger : ICommandLogger
         Logger.LogInformation("{WorkingDirectory}> {Input} [DRY-RUN]",
             workingDirectory,
             input);
+    }
+
+    private void LogOutputLine(
+        CommandLineToolOptions options,
+        CommandExecutionOptions executionOptions,
+        string line,
+        bool isError)
+    {
+        var effectiveOptions = GetEffectiveLoggingOptions(options, executionOptions);
+        var shouldLog = effectiveOptions.Verbosity >= CommandLogVerbosity.Normal
+                        && (isError
+                            ? effectiveOptions.ShowStandardError
+                            : effectiveOptions.ShowStandardOutput);
+        if (!shouldLog)
+        {
+            return;
+        }
+
+        var output = executionOptions.OutputLoggingManipulator is null
+            ? line
+            : executionOptions.OutputLoggingManipulator(line);
+        var obfuscatedOutput = _secretObfuscator.Obfuscate(output, executionOptions);
+
+        if (isError)
+        {
+            Logger.LogWarning("  ✗ {CommandError}", obfuscatedOutput);
+        }
+        else
+        {
+            Logger.LogInformation("  ↳ {CommandOutput}", obfuscatedOutput);
+        }
     }
 
     private void LogCompact(

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -180,18 +180,20 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
         int? exitCode,
         TimeSpan? runTime)
     {
-        if (options.Verbosity < CommandLogVerbosity.Detailed
-            && !options.ShowExitCode
-            && !options.ShowExecutionTime)
+        var showExecutionTime = options.Verbosity >= CommandLogVerbosity.Detailed || options.ShowExecutionTime;
+        var showExitCode = options.Verbosity >= CommandLogVerbosity.Detailed || options.ShowExitCode;
+        if (!showExecutionTime && !showExitCode)
         {
-            return string.Empty;
+            return !isSuccess
+                   && options.Verbosity >= CommandLogVerbosity.Normal
+                   && options.ShowStandardError
+                ? " ✗"
+                : string.Empty;
         }
 
         var status = new StringBuilder()
             .Append(' ')
             .Append(isSuccess ? '✓' : '✗');
-        var showExecutionTime = options.Verbosity >= CommandLogVerbosity.Detailed || options.ShowExecutionTime;
-        var showExitCode = options.Verbosity >= CommandLogVerbosity.Detailed || options.ShowExitCode;
 
         if (showExecutionTime)
         {

--- a/src/ModularPipelines/Logging/ICommandOutputLogger.cs
+++ b/src/ModularPipelines/Logging/ICommandOutputLogger.cs
@@ -1,0 +1,16 @@
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Logging;
+
+internal interface ICommandOutputLogger
+{
+    void LogStandardOutputLine(
+        CommandLineToolOptions options,
+        CommandExecutionOptions executionOptions,
+        string line);
+
+    void LogStandardErrorLine(
+        CommandLineToolOptions options,
+        CommandExecutionOptions executionOptions,
+        string line);
+}

--- a/src/ModularPipelines/Options/CommandExecutionOptions.cs
+++ b/src/ModularPipelines/Options/CommandExecutionOptions.cs
@@ -35,6 +35,8 @@ public record CommandExecutionOptions
 
     /// <summary>
     /// Gets if logging output, you can use this to edit how the output is logged.
+    /// The complete output stream is retained for this delegate even when
+    /// <see cref="MaxCapturedOutputLength"/> bounds the returned command result.
     /// </summary>
     public Func<string, string>? OutputLoggingManipulator { get; init; }
 

--- a/src/ModularPipelines/Options/CommandExecutionOptions.cs
+++ b/src/ModularPipelines/Options/CommandExecutionOptions.cs
@@ -6,6 +6,7 @@ namespace ModularPipelines.Options;
 public record CommandExecutionOptions
 {
     internal static TimeSpan DefaultExecutionTimeout { get; } = TimeSpan.FromMinutes(30);
+    internal const int DefaultMaxCapturedOutputLength = 1024 * 1024;
 
     /// <summary>
     /// Gets any EnvironmentVariables to pass to the command.
@@ -57,6 +58,13 @@ public record CommandExecutionOptions
     /// Gets or sets the time to wait for graceful shutdown before forcefully terminating.
     /// </summary>
     public TimeSpan GracefulShutdownTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets the maximum number of characters retained from each command output stream.
+    /// When output exceeds this limit, the beginning and end are retained with a truncation marker.
+    /// Set to 0 or a negative value to retain unlimited output.
+    /// </summary>
+    public int MaxCapturedOutputLength { get; init; } = DefaultMaxCapturedOutputLength;
 
     internal bool InternalDryRun { get; set; }
 }

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -329,8 +329,8 @@ public class CommandLoggerTests : TestBase
 
         try
         {
-            await Assert.That(await WaitUntilAsync(() => File.Exists(readyFile), TimeSpan.FromSeconds(5))).IsTrue();
-            await logObserver.OutputObserved.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(await WaitUntilAsync(() => File.Exists(readyFile), TimeSpan.FromSeconds(30))).IsTrue();
+            await logObserver.OutputObserved.WaitAsync(TimeSpan.FromSeconds(30));
             await Assert.That(commandTask.IsCompleted).IsFalse();
         }
         finally

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -66,17 +66,18 @@ public class CommandLoggerTests : TestBase
     }
 
     [Test]
-    public async Task OutputLoggingManipulator_Receives_Complete_Output()
+    public async Task OutputLoggingManipulator_Receives_Complete_Output_When_Result_Is_Truncated()
     {
         const string firstLine = "first-output-line";
         const string secondLine = "second-output-line";
         var receivedOutputs = new List<string>();
         var command = await GetService<ICommand>();
 
-        await command.ExecuteCommandLineTool(
+        var result = await command.ExecuteCommandLineTool(
             new PowershellScriptOptions($"Write-Output '{firstLine}'; Write-Output '{secondLine}'"),
             new CommandExecutionOptions
             {
+                MaxCapturedOutputLength = 10,
                 OutputLoggingManipulator = output =>
                 {
                     receivedOutputs.Add(output);
@@ -84,9 +85,11 @@ public class CommandLoggerTests : TestBase
                 },
             });
 
+        await Assert.That(result.StandardOutput).Contains("truncated");
         await Assert.That(receivedOutputs).Contains(output =>
             output.Contains(firstLine, StringComparison.Ordinal)
-            && output.Contains(secondLine, StringComparison.Ordinal));
+            && output.Contains(secondLine, StringComparison.Ordinal)
+            && !output.Contains("truncated", StringComparison.Ordinal));
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -211,8 +211,9 @@ public class CommandLoggerTests : TestBase
         var logFile = await File.ReadAllTextAsync(file);
         // New compact format: command line includes working directory and command
         await Assert.That(logFile).Contains($"{Environment.CurrentDirectory}>");
-        // Output is shown inline (→ for short output)
-        await Assert.That(logFile).Contains("→");
+        // Output is streamed on a separate line
+        await Assert.That(logFile).Contains("↳");
+        await Assert.That(Regex.Matches(logFile, "↳ Hello").Count).IsEqualTo(1);
         // Normal doesn't show exit code or duration
         await Assert.That(logFile).DoesNotContain("exit ");
         await Assert.That(Regex.IsMatch(logFile, @"\[\d+m?s")).IsFalse();
@@ -228,8 +229,8 @@ public class CommandLoggerTests : TestBase
         var logFile = await File.ReadAllTextAsync(file);
         // New compact format: all info on one line
         await Assert.That(logFile).Contains($"{Environment.CurrentDirectory}>");
-        // Output shown inline
-        await Assert.That(logFile).Contains("→");
+        // Output is streamed on a separate line
+        await Assert.That(logFile).Contains("↳");
         // Exit code and duration shown inline
         await Assert.That(logFile).Contains("exit ");
         await Assert.That(Regex.IsMatch(logFile, @"\[\d+m?s")).IsTrue();
@@ -245,8 +246,8 @@ public class CommandLoggerTests : TestBase
         var logFile = await File.ReadAllTextAsync(file);
         // New compact format: all info on one line
         await Assert.That(logFile).Contains($"{Environment.CurrentDirectory}>");
-        // Output shown inline
-        await Assert.That(logFile).Contains("→");
+        // Output is streamed on a separate line
+        await Assert.That(logFile).Contains("↳");
         // Exit code and duration shown inline
         await Assert.That(logFile).Contains("exit ");
         await Assert.That(Regex.IsMatch(logFile, @"\[\d+m?s")).IsTrue();
@@ -275,6 +276,72 @@ public class CommandLoggerTests : TestBase
         await result.Host.DisposeAsync();
 
         return file;
+    }
+
+    [Test]
+    public async Task Command_Output_Is_Logged_Before_Command_Completes()
+    {
+        var marker = $"live-output-{Guid.NewGuid():N}";
+        var errorMarker = $"live-error-{Guid.NewGuid():N}";
+        var logFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".txt");
+        var readyFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".ready");
+        var releaseFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".release");
+        var result = await GetService<ICommand>((_, collection) =>
+        {
+            collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
+            collection.AddLogging(builder => builder.AddFile(logFile));
+        });
+        var script = $$"""
+                      Write-Output '{{marker}}'
+                      [Console]::Error.WriteLine('{{errorMarker}}')
+                      [System.IO.File]::WriteAllText('{{readyFile}}', 'ready')
+                      while (-not (Test-Path '{{releaseFile}}')) { Start-Sleep -Milliseconds 10 }
+                      """;
+
+        var commandTask = result.T.ExecuteCommandLineTool(new PowershellScriptOptions(script));
+
+        try
+        {
+            await Assert.That(await WaitUntilAsync(() => File.Exists(readyFile), TimeSpan.FromSeconds(5))).IsTrue();
+            var loggedWhileCommandRunning = await WaitUntilAsync(
+                () => FileContains(logFile, marker) && FileContains(logFile, errorMarker),
+                TimeSpan.FromSeconds(1));
+
+            await Assert.That(loggedWhileCommandRunning).IsTrue();
+        }
+        finally
+        {
+            await File.WriteAllTextAsync(releaseFile, "release");
+            await commandTask;
+        }
+    }
+
+    private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var timeoutTask = Task.Delay(timeout);
+        while (!condition())
+        {
+            if (timeoutTask.IsCompleted)
+            {
+                return false;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+
+        return true;
+    }
+
+    private static bool FileContains(string path, string value)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd().Contains(value, StringComparison.Ordinal);
     }
 
     [CliTool("pwsh")]

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -66,6 +66,30 @@ public class CommandLoggerTests : TestBase
     }
 
     [Test]
+    public async Task OutputLoggingManipulator_Receives_Complete_Output()
+    {
+        const string firstLine = "first-output-line";
+        const string secondLine = "second-output-line";
+        var receivedOutputs = new List<string>();
+        var command = await GetService<ICommand>();
+
+        await command.ExecuteCommandLineTool(
+            new PowershellScriptOptions($"Write-Output '{firstLine}'; Write-Output '{secondLine}'"),
+            new CommandExecutionOptions
+            {
+                OutputLoggingManipulator = output =>
+                {
+                    receivedOutputs.Add(output);
+                    return output;
+                },
+            });
+
+        await Assert.That(receivedOutputs).Contains(output =>
+            output.Contains(firstLine, StringComparison.Ordinal)
+            && output.Contains(secondLine, StringComparison.Ordinal));
+    }
+
+    [Test]
     [MatrixDataSource]
     public async Task Logs_As_Expected_With_Options(
         [Matrix(true, false)] bool logInput,
@@ -283,13 +307,13 @@ public class CommandLoggerTests : TestBase
     {
         var marker = $"live-output-{Guid.NewGuid():N}";
         var errorMarker = $"live-error-{Guid.NewGuid():N}";
-        var logFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".txt");
         var readyFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".ready");
         var releaseFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".release");
+        using var logObserver = new StreamingLogObserver(marker, errorMarker);
         var result = await GetService<ICommand>((_, collection) =>
         {
             collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
-            collection.AddLogging(builder => builder.AddFile(logFile));
+            collection.AddLogging(builder => builder.AddProvider(logObserver));
         });
         var script = $$"""
                       Write-Output '{{marker}}'
@@ -303,11 +327,8 @@ public class CommandLoggerTests : TestBase
         try
         {
             await Assert.That(await WaitUntilAsync(() => File.Exists(readyFile), TimeSpan.FromSeconds(5))).IsTrue();
-            var loggedWhileCommandRunning = await WaitUntilAsync(
-                () => FileContains(logFile, marker) && FileContains(logFile, errorMarker),
-                TimeSpan.FromSeconds(1));
-
-            await Assert.That(loggedWhileCommandRunning).IsTrue();
+            await logObserver.OutputObserved.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(commandTask.IsCompleted).IsFalse();
         }
         finally
         {
@@ -332,16 +353,61 @@ public class CommandLoggerTests : TestBase
         return true;
     }
 
-    private static bool FileContains(string path, string value)
+    private sealed class StreamingLogObserver(string outputMarker, string errorMarker) : ILoggerProvider
     {
-        if (!File.Exists(path))
+        private readonly Lock _lock = new();
+        private readonly TaskCompletionSource _outputObserved =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool _sawOutput;
+        private bool _sawError;
+
+        public Task OutputObserved => _outputObserved.Task;
+
+        public ILogger CreateLogger(string categoryName)
         {
-            return false;
+            return new ObserverLogger(Record);
         }
 
-        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        using var reader = new StreamReader(stream);
-        return reader.ReadToEnd().Contains(value, StringComparison.Ordinal);
+        public void Dispose()
+        {
+        }
+
+        private void Record(string message)
+        {
+            lock (_lock)
+            {
+                _sawOutput |= message.Contains(outputMarker, StringComparison.Ordinal);
+                _sawError |= message.Contains(errorMarker, StringComparison.Ordinal);
+                if (_sawOutput && _sawError)
+                {
+                    _outputObserved.TrySetResult();
+                }
+            }
+        }
+    }
+
+    private sealed class ObserverLogger(Action<string> record) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            record(formatter(state, exception));
+        }
     }
 
     [CliTool("pwsh")]

--- a/test/ModularPipelines.UnitTests/Helpers/BoundedCommandOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/BoundedCommandOutputBufferTests.cs
@@ -1,0 +1,61 @@
+using ModularPipelines.Helpers.Internal;
+
+namespace ModularPipelines.UnitTests.Helpers;
+
+public class BoundedCommandOutputBufferTests
+{
+    [Test]
+    public async Task Retains_Output_Within_Limit()
+    {
+        var buffer = new BoundedCommandOutputBuffer(10);
+
+        buffer.Append("abc\n123".AsSpan());
+
+        await Assert.That(buffer.ToString()).IsEqualTo("abc\n123");
+    }
+
+    [Test]
+    public async Task Retains_Head_And_Tail_When_Truncated()
+    {
+        var buffer = new BoundedCommandOutputBuffer(10);
+
+        buffer.Append("0123".AsSpan());
+        buffer.Append("456789".AsSpan());
+        buffer.Append("ABCDEF".AsSpan());
+
+        var result = buffer.ToString();
+        using (Assert.Multiple())
+        {
+            await Assert.That(result).StartsWith("01234");
+            await Assert.That(result).Contains("truncated 6 characters");
+            await Assert.That(result).EndsWith("BCDEF");
+        }
+    }
+
+    [Test]
+    public async Task Retains_Latest_Tail_Across_Buffer_Wrap()
+    {
+        var buffer = new BoundedCommandOutputBuffer(8);
+
+        buffer.Append("012345".AsSpan());
+        buffer.Append("6789".AsSpan());
+
+        var result = buffer.ToString();
+        using (Assert.Multiple())
+        {
+            await Assert.That(result).StartsWith("0123");
+            await Assert.That(result).EndsWith("6789");
+        }
+    }
+
+    [Test]
+    public async Task NonPositive_Limit_Retains_Unlimited_Output()
+    {
+        var buffer = new BoundedCommandOutputBuffer(0);
+        var output = new string('x', 100);
+
+        buffer.Append(output.AsSpan());
+
+        await Assert.That(buffer.ToString()).IsEqualTo(output);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Helpers/BoundedCommandOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/BoundedCommandOutputBufferTests.cs
@@ -37,14 +37,15 @@ public class BoundedCommandOutputBufferTests
     {
         var buffer = new BoundedCommandOutputBuffer(8);
 
-        buffer.Append("012345".AsSpan());
-        buffer.Append("6789".AsSpan());
+        buffer.Append("01234".AsSpan());
+        buffer.Append("56".AsSpan());
+        buffer.Append("78".AsSpan());
 
         var result = buffer.ToString();
         using (Assert.Multiple())
         {
             await Assert.That(result).StartsWith("0123");
-            await Assert.That(result).EndsWith("6789");
+            await Assert.That(result).EndsWith("5678");
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -22,6 +22,8 @@ public class CommandTests : TestBase
             .IsEqualTo(TimeSpan.FromMinutes(30));
         await Assert.That(executionOptions.ExecutionTimeout)
             .IsEqualTo(CommandExecutionOptions.DefaultExecutionTimeout);
+        await Assert.That(executionOptions.MaxCapturedOutputLength)
+            .IsEqualTo(CommandExecutionOptions.DefaultMaxCapturedOutputLength);
     }
 
     [Test]
@@ -31,6 +33,24 @@ public class CommandTests : TestBase
         var executionOptions = new CommandExecutionOptions { ExecutionTimeout = timeout };
 
         await Assert.That(executionOptions.ExecutionTimeout).IsEqualTo(timeout);
+    }
+
+    [Test]
+    public async Task Command_Execution_Caps_Captured_Output_With_Head_And_Tail()
+    {
+        var command = await GetService<ICommand>();
+        var result = await command.ExecuteCommandLineTool(
+            new PowershellScriptOptions("Write-Output '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'"),
+            new CommandExecutionOptions { MaxCapturedOutputLength = 10 });
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.StandardOutput).StartsWith("01234");
+            await Assert.That(result.StandardOutput).Contains("truncated");
+            await Assert.That(result.StandardOutput).Contains("XYZ");
+            await Assert.That(result.StandardOutput).EndsWith(Environment.NewLine);
+            await Assert.That(result.StandardOutput.Length).IsLessThan(100);
+        }
     }
 
     private class CommandEchoModule : Module<CommandResult>


### PR DESCRIPTION
Closes #3266

## Summary
- stream stdout and stderr lines to the module logger while commands run
- cap retained output per stream at 1 MiB by default, preserving the head and latest tail with a truncation marker
- preserve exact captured line endings and custom `ICommandLogger` completion behavior
- add focused buffer, live-streaming, cap, and cancellation-integration coverage

## Validation
- `build ModularPipelines.sln -c Release` passed through `scripts/Invoke-AgentDotNet.ps1`
- `BoundedCommandOutputBufferTests`: 4/4 passed
- live stdout/stderr logging test: passed
- capped captured-output integration test: passed
- forceful descendant-cancellation regression: passed
- verbosity, secret masking, output manipulator, and exact-output focused tests: passed
- changed-file whitespace verification: passed

A whole-class `CommandLoggerTests` run exceeded the repository agent guard's 2 GB memory limit (exit 137); affected cases were split into focused runs and passed.
