### PR TITLE
Limit deferred module output buffering

### DIFF
--- a/docs/docs/how-to/console-progress.md
+++ b/docs/docs/how-to/console-progress.md
@@ -14,10 +14,19 @@ Buffered output from modules that are still running is flushed once per minute b
 This preserves recent diagnostic output if the process is killed before normal pipeline
 teardown. Incremental sections use an ellipsis (`…`) because the module has not completed.
 
-Configure the interval globally, or set it to zero to keep all output buffered until each
-module completes:
+Configure the interval globally. Setting it to zero disables time-based flushing, but the
+entry threshold still protects against unbounded buffering:
 
 ```csharp
 builder.Options.ModuleOutputFlushInterval = TimeSpan.FromSeconds(30);
 ```
 
+To keep all output buffered until each module completes, disable both triggers:
+
+```csharp
+builder.Options.ModuleOutputFlushInterval = TimeSpan.Zero;
+builder.Options.ModuleOutputFlushThreshold = 0;
+```
+
+`ModuleOutputFlushThreshold` counts entries, not bytes. Its default is 1,000 entries per
+module.

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -410,6 +410,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
 
     private void RequestThresholdFlush(IModuleOutputBuffer buffer)
     {
+        // EnqueueAndFlushAsync registers pending work before its first await, so teardown sees this flush.
         _ = FlushThresholdAsync(buffer);
     }
 

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -43,31 +43,21 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     private readonly ILoggerFactory _loggerFactory;
     private readonly IBuildSystemDetector _buildSystemDetector;
     private readonly IServiceProvider _serviceProvider;
-
-    // Console state
+    private readonly object _phaseLock = new();
+    private readonly ConcurrentDictionary<Type, ModuleOutputBuffer> _moduleBuffers = new();
+    private readonly ModuleOutputBuffer _unattributedBuffer;
+    private readonly ConcurrentQueue<string> _deferredExceptions = new();
+    private readonly IOutputCoordinator _outputCoordinator;
+    private readonly ISpectreConsoleLoggerControl _loggerControl;
     private TextWriter? _originalConsoleOut;
     private TextWriter? _originalConsoleError;
     private IAnsiConsole? _originalAnsiConsole;
     private CoordinatedTextWriter? _coordinatedOut;
     private CoordinatedTextWriter? _coordinatedError;
-
-    // Phase management
     private volatile bool _isProgressActive;
-    private readonly object _phaseLock = new();
     private bool _isInstalled;
     private IProgressSession? _activeSession;
-
-    // Module buffers
-    private readonly ConcurrentDictionary<Type, ModuleOutputBuffer> _moduleBuffers = new();
-    private readonly ModuleOutputBuffer _unattributedBuffer;
-
-    // Deferred exceptions
-    private readonly ConcurrentQueue<string> _deferredExceptions = new();
-
-    // Logger for output
     private ILogger? _outputLogger;
-    private readonly IOutputCoordinator _outputCoordinator;
-    private readonly ISpectreConsoleLoggerControl _loggerControl;
 
     public ConsoleCoordinator(
         IBuildSystemFormatterProvider formatterProvider,
@@ -280,20 +270,6 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         return session;
     }
 
-    /// <summary>
-    /// Ends the progress phase. Called by ProgressSession.DisposeAsync().
-    /// </summary>
-    internal void EndProgressPhase()
-    {
-        lock (_phaseLock)
-        {
-            _outputCoordinator.SetProgressController(NoOpProgressController.Instance);
-            _outputCoordinator.SetProgressActive(false);
-            _isProgressActive = false;
-            _activeSession = null;
-        }
-    }
-
     /// <inheritdoc />
     public IModuleOutputBuffer GetModuleBuffer(Type moduleType)
     {
@@ -312,36 +288,6 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     public Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync()
     {
         return FlushPendingWritesAsync(OutputFlushKind.Complete);
-    }
-
-    private async Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync(OutputFlushKind flushKind)
-    {
-        var populatedBeforeFlush = _moduleBuffers.Values
-            .Where(buffer => buffer.HasOutput)
-            .ToHashSet();
-
-        CoordinatedTextWriter? output;
-        CoordinatedTextWriter? error;
-        lock (_phaseLock)
-        {
-            output = _coordinatedOut;
-            error = _coordinatedError;
-        }
-
-        if (output is not null)
-        {
-            await FlushWriterAsync(output, flushKind).ConfigureAwait(false);
-        }
-
-        if (error is not null && !ReferenceEquals(error, output))
-        {
-            await FlushWriterAsync(error, flushKind).ConfigureAwait(false);
-        }
-
-        return _moduleBuffers.Values
-            .Where(buffer => buffer.HasOutput && !populatedBeforeFlush.Contains(buffer))
-            .Cast<IModuleOutputBuffer>()
-            .ToArray();
     }
 
     /// <inheritdoc />
@@ -374,84 +320,6 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                     cancellationToken)
                 .ConfigureAwait(false);
         }
-    }
-
-    private async Task FlushBufferSafelyAsync(
-        IModuleOutputBuffer buffer,
-        OutputFlushKind flushKind,
-        CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        try
-        {
-            if (flushKind is OutputFlushKind.Complete)
-            {
-                await _outputCoordinator
-                    .OnModuleCompletedAsync(buffer, buffer.ModuleType, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            else
-            {
-                await _outputCoordinator
-                    .EnqueueAndFlushAsync(buffer, flushKind, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception exception)
-        {
-            ReportFlushFailure(buffer, exception);
-        }
-    }
-
-    private void RequestThresholdFlush(IModuleOutputBuffer buffer)
-    {
-        // EnqueueAndFlushAsync registers pending work before its first await, so teardown sees this flush.
-        _ = FlushThresholdAsync(buffer);
-    }
-
-    private async Task FlushThresholdAsync(IModuleOutputBuffer buffer)
-    {
-        try
-        {
-            await _outputCoordinator
-                .EnqueueAndFlushAsync(buffer, OutputFlushKind.Incremental)
-                .ConfigureAwait(false);
-        }
-        catch (Exception exception)
-        {
-            ReportFlushFailure(buffer, exception);
-        }
-    }
-
-    private void ReportFlushFailure(IModuleOutputBuffer buffer, Exception exception)
-    {
-        try
-        {
-            var logger = _outputLogger ?? _loggerFactory.CreateLogger<ConsoleCoordinator>();
-            logger.LogWarning(
-                exception,
-                "Failed to flush output for {ModuleType}",
-                buffer.ModuleType);
-        }
-        catch
-        {
-            // The output provider itself may be the failing sink. Preserve a fallback
-            // diagnostic without preventing unrelated buffers from being flushed.
-            _deferredExceptions.Enqueue(
-                $"Failed to flush output for {buffer.ModuleType}: {exception}");
-        }
-    }
-
-    private static Task FlushWriterAsync(CoordinatedTextWriter writer, OutputFlushKind flushKind)
-    {
-        return flushKind is OutputFlushKind.Complete
-            ? writer.FlushAsync()
-            : writer.FlushAvailableAsync();
     }
 
     /// <inheritdoc />
@@ -549,42 +417,6 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         await Task.CompletedTask;
     }
 
-    private void ConfigureConsoleWidth()
-    {
-        var configuredWidth = _options.Value.ConsoleWidth;
-
-        if (configuredWidth.HasValue)
-        {
-            // User explicitly configured a width
-            AnsiConsole.Console.Profile.Width = configuredWidth.Value;
-        }
-        else if (_buildSystemDetector.IsKnownBuildAgent)
-        {
-            // Running in a known CI environment - use expanded width
-            // CI environments typically don't have a TTY, causing Spectre.Console to default to 80 chars
-            AnsiConsole.Console.Profile.Width = DefaultCiConsoleWidth;
-        }
-
-        // Otherwise, leave Spectre.Console's auto-detected width (works well for local terminals)
-    }
-
-    internal static AnsiConsoleSettings CreateAnsiConsoleSettings(TextWriter output, bool isKnownBuildAgent)
-    {
-        var settings = new AnsiConsoleSettings
-        {
-            Out = new AnsiConsoleOutput(output),
-        };
-
-        if (isKnownBuildAgent)
-        {
-            settings.Ansi = AnsiSupport.Yes;
-            settings.ColorSystem = ColorSystemSupport.Standard;
-            settings.Interactive = InteractionSupport.No;
-        }
-
-        return settings;
-    }
-
     #region IProgressDisplay Implementation
 
     /// <summary>
@@ -643,4 +475,162 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     }
 
     #endregion
+
+    /// <summary>
+    /// Ends the progress phase. Called by ProgressSession.DisposeAsync().
+    /// </summary>
+    internal void EndProgressPhase()
+    {
+        lock (_phaseLock)
+        {
+            _outputCoordinator.SetProgressController(NoOpProgressController.Instance);
+            _outputCoordinator.SetProgressActive(false);
+            _isProgressActive = false;
+            _activeSession = null;
+        }
+    }
+
+    internal static AnsiConsoleSettings CreateAnsiConsoleSettings(TextWriter output, bool isKnownBuildAgent)
+    {
+        var settings = new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(output),
+        };
+
+        if (isKnownBuildAgent)
+        {
+            settings.Ansi = AnsiSupport.Yes;
+            settings.ColorSystem = ColorSystemSupport.Standard;
+            settings.Interactive = InteractionSupport.No;
+        }
+
+        return settings;
+    }
+
+    private async Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync(OutputFlushKind flushKind)
+    {
+        var populatedBeforeFlush = _moduleBuffers.Values
+            .Where(buffer => buffer.HasOutput)
+            .ToHashSet();
+
+        CoordinatedTextWriter? output;
+        CoordinatedTextWriter? error;
+        lock (_phaseLock)
+        {
+            output = _coordinatedOut;
+            error = _coordinatedError;
+        }
+
+        if (output is not null)
+        {
+            await FlushWriterAsync(output, flushKind).ConfigureAwait(false);
+        }
+
+        if (error is not null && !ReferenceEquals(error, output))
+        {
+            await FlushWriterAsync(error, flushKind).ConfigureAwait(false);
+        }
+
+        return _moduleBuffers.Values
+            .Where(buffer => buffer.HasOutput && !populatedBeforeFlush.Contains(buffer))
+            .Cast<IModuleOutputBuffer>()
+            .ToArray();
+    }
+
+    private async Task FlushBufferSafelyAsync(
+        IModuleOutputBuffer buffer,
+        OutputFlushKind flushKind,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        try
+        {
+            if (flushKind is OutputFlushKind.Complete)
+            {
+                await _outputCoordinator
+                    .OnModuleCompletedAsync(buffer, buffer.ModuleType, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                await _outputCoordinator
+                    .EnqueueAndFlushAsync(buffer, flushKind, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            ReportFlushFailure(buffer, exception);
+        }
+    }
+
+    private void RequestThresholdFlush(IModuleOutputBuffer buffer)
+    {
+        // EnqueueAndFlushAsync registers pending work before its first await, so teardown sees this flush.
+        _ = FlushThresholdAsync(buffer);
+    }
+
+    private async Task FlushThresholdAsync(IModuleOutputBuffer buffer)
+    {
+        try
+        {
+            await _outputCoordinator
+                .EnqueueAndFlushAsync(buffer, OutputFlushKind.Incremental)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            ReportFlushFailure(buffer, exception);
+        }
+    }
+
+    private void ReportFlushFailure(IModuleOutputBuffer buffer, Exception exception)
+    {
+        try
+        {
+            var logger = _outputLogger ?? _loggerFactory.CreateLogger<ConsoleCoordinator>();
+            logger.LogWarning(
+                exception,
+                "Failed to flush output for {ModuleType}",
+                buffer.ModuleType);
+        }
+        catch
+        {
+            // The output provider itself may be the failing sink. Preserve a fallback
+            // diagnostic without preventing unrelated buffers from being flushed.
+            _deferredExceptions.Enqueue(
+                $"Failed to flush output for {buffer.ModuleType}: {exception}");
+        }
+    }
+
+    private static Task FlushWriterAsync(CoordinatedTextWriter writer, OutputFlushKind flushKind)
+    {
+        return flushKind is OutputFlushKind.Complete
+            ? writer.FlushAsync()
+            : writer.FlushAvailableAsync();
+    }
+
+    private void ConfigureConsoleWidth()
+    {
+        var configuredWidth = _options.Value.ConsoleWidth;
+
+        if (configuredWidth.HasValue)
+        {
+            // User explicitly configured a width
+            AnsiConsole.Console.Profile.Width = configuredWidth.Value;
+        }
+        else if (_buildSystemDetector.IsKnownBuildAgent)
+        {
+            // Running in a known CI environment - use expanded width
+            // CI environments typically don't have a TTY, causing Spectre.Console to default to 80 chars
+            AnsiConsole.Console.Profile.Width = DefaultCiConsoleWidth;
+        }
+
+        // Otherwise, leave Spectre.Console's auto-detected width (works well for local terminals)
+    }
 }

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -91,7 +91,11 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         _serviceProvider = serviceProvider;
         _outputCoordinator = outputCoordinator;
         _loggerControl = loggerControl;
-        _unattributedBuffer = new ModuleOutputBuffer("Pipeline", typeof(void));
+        _unattributedBuffer = new ModuleOutputBuffer(
+            "Pipeline",
+            typeof(void),
+            _options.Value.ModuleOutputFlushThreshold,
+            RequestThresholdFlush);
     }
 
     /// <inheritdoc />
@@ -293,7 +297,12 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     /// <inheritdoc />
     public IModuleOutputBuffer GetModuleBuffer(Type moduleType)
     {
-        return _moduleBuffers.GetOrAdd(moduleType, t => new ModuleOutputBuffer(t));
+        return _moduleBuffers.GetOrAdd(
+            moduleType,
+            t => new ModuleOutputBuffer(
+                t,
+                _options.Value.ModuleOutputFlushThreshold,
+                RequestThresholdFlush));
     }
 
     /// <inheritdoc />
@@ -392,6 +401,25 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
+        }
+        catch (Exception exception)
+        {
+            ReportFlushFailure(buffer, exception);
+        }
+    }
+
+    private void RequestThresholdFlush(IModuleOutputBuffer buffer)
+    {
+        _ = FlushThresholdAsync(buffer);
+    }
+
+    private async Task FlushThresholdAsync(IModuleOutputBuffer buffer)
+    {
+        try
+        {
+            await _outputCoordinator
+                .EnqueueAndFlushAsync(buffer, OutputFlushKind.Incremental)
+                .ConfigureAwait(false);
         }
         catch (Exception exception)
         {

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -40,7 +40,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     public Type ModuleType { get; }
 
     /// <summary>
-    /// Initializes a new buffer for the specified module type.
+    /// Initialises a new instance of the <see cref="ModuleOutputBuffer"/> class
+    /// for the specified module type.
     /// </summary>
     /// <param name="moduleType">The module type.</param>
     public ModuleOutputBuffer(
@@ -52,7 +53,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     /// <summary>
-    /// Initializes a buffer for unattributed output (not from any module).
+    /// Initialises a new instance of the <see cref="ModuleOutputBuffer"/> class
+    /// for unattributed output.
     /// </summary>
     /// <param name="name">Display name for the buffer.</param>
     /// <param name="moduleType">Placeholder type.</param>
@@ -466,7 +468,7 @@ internal readonly struct BufferedOutput
     public LogEventData? LogEvent { get; private init; }
 
     /// <summary>
-    /// Gets whether this is a string output.
+    /// Gets a value indicating whether this output contains a string.
     /// </summary>
     public bool IsString => StringValue != null;
 
@@ -493,9 +495,13 @@ internal readonly struct BufferedOutput
 internal readonly struct LogEventData
 {
     public LogLevel Level { get; }
+
     public EventId EventId { get; }
+
     public object State { get; }
+
     public Exception? Exception { get; }
+
     public Func<object, Exception?, string> Formatter { get; }
 
     public LogEventData(

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -28,10 +28,13 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly object _lock = new();
     private readonly string _moduleName;
     private readonly DateTime _startTimeUtc;
+    private readonly int _outputFlushThreshold;
+    private readonly Action<IModuleOutputBuffer>? _requestIncrementalFlush;
     private Exception? _exception;
     private bool _isComplete;
     private bool _isIncrementalFlushInProgress;
     private bool _hasRenderedIncrementalOutput;
+    private bool _thresholdFlushRequested;
 
     /// <inheritdoc />
     public Type ModuleType { get; }
@@ -40,11 +43,12 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// Initializes a new buffer for the specified module type.
     /// </summary>
     /// <param name="moduleType">The module type.</param>
-    public ModuleOutputBuffer(Type moduleType)
+    public ModuleOutputBuffer(
+        Type moduleType,
+        int outputFlushThreshold = 0,
+        Action<IModuleOutputBuffer>? requestIncrementalFlush = null)
+        : this(moduleType.Name, moduleType, outputFlushThreshold, requestIncrementalFlush)
     {
-        ModuleType = moduleType;
-        _moduleName = moduleType.Name;
-        _startTimeUtc = DateTime.UtcNow;
     }
 
     /// <summary>
@@ -52,20 +56,23 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// </summary>
     /// <param name="name">Display name for the buffer.</param>
     /// <param name="moduleType">Placeholder type.</param>
-    internal ModuleOutputBuffer(string name, Type moduleType)
+    internal ModuleOutputBuffer(
+        string name,
+        Type moduleType,
+        int outputFlushThreshold = 0,
+        Action<IModuleOutputBuffer>? requestIncrementalFlush = null)
     {
         ModuleType = moduleType;
         _moduleName = name;
         _startTimeUtc = DateTime.UtcNow;
+        _outputFlushThreshold = outputFlushThreshold;
+        _requestIncrementalFlush = requestIncrementalFlush;
     }
 
     /// <inheritdoc />
     public void WriteLine(string message)
     {
-        lock (_lock)
-        {
-            _outputs.Add(BufferedOutput.FromString(message));
-        }
+        AddOutput(BufferedOutput.FromString(message));
     }
 
     /// <inheritdoc />
@@ -76,10 +83,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         Exception? exception,
         Func<object, Exception?, string> formatter)
     {
-        lock (_lock)
-        {
-            _outputs.Add(BufferedOutput.FromLogEvent(level, eventId, state, exception, formatter));
-        }
+        AddOutput(BufferedOutput.FromLogEvent(level, eventId, state, exception, formatter));
     }
 
     /// <inheritdoc />
@@ -184,6 +188,26 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         return Task.CompletedTask;
     }
 
+    private void AddOutput(BufferedOutput output)
+    {
+        Action<IModuleOutputBuffer>? requestIncrementalFlush = null;
+
+        lock (_lock)
+        {
+            _outputs.Add(output);
+            if (_requestIncrementalFlush is not null
+                && _outputFlushThreshold > 0
+                && _outputs.Count >= _outputFlushThreshold
+                && !_thresholdFlushRequested)
+            {
+                _thresholdFlushRequested = true;
+                requestIncrementalFlush = _requestIncrementalFlush;
+            }
+        }
+
+        requestIncrementalFlush?.Invoke(this);
+    }
+
     private bool TryTakeOutputs(
         OutputFlushKind flushKind,
         out List<BufferedOutput> outputs,
@@ -208,6 +232,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
             outputs = new List<BufferedOutput>(_outputs);
             _outputs.Clear();
+            _thresholdFlushRequested = false;
             _isIncrementalFlushInProgress = flushKind is OutputFlushKind.Incremental;
             exception = _exception;
             return true;

--- a/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
+++ b/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
@@ -199,8 +199,32 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
         var moduleDisposeExecutor = _moduleDisposeExecutor;
         await using (moduleDisposeExecutor.ConfigureAwait(false))
         {
-            await using var outputScope = await _outputCoordinator.InitializeAsync().ConfigureAwait(false);
-            return await _pipelineExecutor.ExecuteAsync(runnableModules, organizedModules).ConfigureAwait(false);
+            var outputScope = await _outputCoordinator.InitializeAsync().ConfigureAwait(false);
+            Exception? pipelineException = null;
+
+            try
+            {
+                return await _pipelineExecutor.ExecuteAsync(runnableModules, organizedModules).ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                pipelineException = exception;
+                throw;
+            }
+            finally
+            {
+                try
+                {
+                    await outputScope.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception teardownException) when (pipelineException is not null)
+                {
+                    _logger.LogError(
+                        teardownException,
+                        "Pipeline output teardown failed while the pipeline was already failing with {ExceptionType}.",
+                        pipelineException.GetType().Name);
+                }
+            }
         }
     }
 }

--- a/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
+++ b/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
@@ -219,10 +219,17 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
                 }
                 catch (Exception teardownException) when (pipelineException is not null)
                 {
-                    _logger.LogError(
-                        teardownException,
-                        "Pipeline output teardown failed while the pipeline was already failing with {ExceptionType}.",
-                        pipelineException.GetType().Name);
+                    try
+                    {
+                        _logger.LogError(
+                            teardownException,
+                            "Pipeline output teardown failed while the pipeline was already failing with {ExceptionType}.",
+                            pipelineException.GetType().Name);
+                    }
+                    catch
+                    {
+                        // Diagnostic providers must not replace the primary pipeline failure.
+                    }
                 }
             }
         }

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Console;
@@ -141,56 +142,88 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
 
         public async ValueTask DisposeAsync()
         {
+            var exceptions = new List<Exception>();
+
+            await CaptureExceptionAsync(
+                () => _liveFlushCancellation.CancelAsync(),
+                exceptions).ConfigureAwait(false);
+            await CaptureExceptionAsync(
+                () => _liveFlushTask,
+                exceptions).ConfigureAwait(false);
+
+            // A canceled caller can finish before its queue processor releases the buffer.
+            // Final drains must not start until that processor has quiesced.
+            await CaptureExceptionAsync(
+                () => _outputCoordinator.WaitForPendingFlushesAsync(),
+                exceptions).ConfigureAwait(false);
+
+            IReadOnlyList<IModuleOutputBuffer> newlyPopulatedBuffers = [];
+            await CaptureExceptionAsync(
+                async () =>
+                {
+                    // CRITICAL: Order matters!
+                    // 1. Flush retained console fragments while progress deferral is still active.
+                    newlyPopulatedBuffers = await _consoleCoordinator
+                        .FlushPendingWritesAsync()
+                        .ConfigureAwait(false);
+                },
+                exceptions).ConfigureAwait(false);
+
+            // 2. Schedule buffers populated after their modules completed.
+            foreach (var buffer in newlyPopulatedBuffers)
+            {
+                await CaptureExceptionAsync(
+                    () => _outputCoordinator
+                        .OnModuleCompletedAsync(buffer, buffer.ModuleType),
+                    exceptions).ConfigureAwait(false);
+            }
+
+            // 3. Stop progress display (ends buffering phase).
+            await CaptureExceptionAsync(
+                () => _printProgressExecutor.DisposeAsync().AsTask(),
+                exceptions).ConfigureAwait(false);
+
+            // 4. Flush deferred module output (in completion order).
+            await CaptureExceptionAsync(
+                () => _outputCoordinator.FlushDeferredAsync(),
+                exceptions).ConfigureAwait(false);
+
+            // 5. Flush any unattributed output from coordinator.
+            await CaptureExceptionAsync(
+                () => _consoleCoordinator.FlushModuleOutputAsync(),
+                exceptions).ConfigureAwait(false);
+
             try
             {
-                await _liveFlushCancellation.CancelAsync().ConfigureAwait(false);
-                await _liveFlushTask.ConfigureAwait(false);
-
-                // A canceled caller can finish before its queue processor releases the buffer.
-                // Final drains must not start until that processor has quiesced.
-                await _outputCoordinator.WaitForPendingFlushesAsync().ConfigureAwait(false);
-
-                // CRITICAL: Order matters!
-                // 1. Flush retained console fragments while progress deferral is still active.
-                var newlyPopulatedBuffers = await _consoleCoordinator
-                    .FlushPendingWritesAsync()
-                    .ConfigureAwait(false);
-
-                // 2. Schedule buffers populated after their modules completed.
-                foreach (var buffer in newlyPopulatedBuffers)
-                {
-                    await _outputCoordinator
-                        .OnModuleCompletedAsync(buffer, buffer.ModuleType)
-                        .ConfigureAwait(false);
-                }
+                _liveFlushCancellation.Dispose();
             }
-            finally
+            catch (Exception exception)
             {
-                try
-                {
-                    // 3. Stop progress display (ends buffering phase).
-                    await _printProgressExecutor.DisposeAsync().ConfigureAwait(false);
-                }
-                finally
-                {
-                    try
-                    {
-                        // 4. Flush deferred module output (in completion order).
-                        await _outputCoordinator.FlushDeferredAsync().ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        try
-                        {
-                            // 5. Flush any unattributed output from coordinator.
-                            await _consoleCoordinator.FlushModuleOutputAsync().ConfigureAwait(false);
-                        }
-                        finally
-                        {
-                            _liveFlushCancellation.Dispose();
-                        }
-                    }
-                }
+                exceptions.Add(exception);
+            }
+
+            if (exceptions.Count == 1)
+            {
+                ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+            }
+
+            if (exceptions.Count > 1)
+            {
+                throw new AggregateException("Pipeline output teardown failed.", exceptions);
+            }
+        }
+
+        private static async Task CaptureExceptionAsync(
+            Func<Task> operation,
+            ICollection<Exception> exceptions)
+        {
+            try
+            {
+                await operation().ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                exceptions.Add(exception);
             }
         }
 

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -141,36 +141,57 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
 
         public async ValueTask DisposeAsync()
         {
-            await _liveFlushCancellation.CancelAsync().ConfigureAwait(false);
-            await _liveFlushTask.ConfigureAwait(false);
-
-            // A canceled caller can finish before its queue processor releases the buffer.
-            // Final drains must not start until that processor has quiesced.
-            await _outputCoordinator.WaitForPendingFlushesAsync().ConfigureAwait(false);
-            _liveFlushCancellation.Dispose();
-
-            // CRITICAL: Order matters!
-            // 1. Flush retained console fragments while progress deferral is still active.
-            var newlyPopulatedBuffers = await _consoleCoordinator
-                .FlushPendingWritesAsync()
-                .ConfigureAwait(false);
-
-            // 2. Schedule buffers populated after their modules completed.
-            foreach (var buffer in newlyPopulatedBuffers)
+            try
             {
-                await _outputCoordinator
-                    .OnModuleCompletedAsync(buffer, buffer.ModuleType)
+                await _liveFlushCancellation.CancelAsync().ConfigureAwait(false);
+                await _liveFlushTask.ConfigureAwait(false);
+
+                // A canceled caller can finish before its queue processor releases the buffer.
+                // Final drains must not start until that processor has quiesced.
+                await _outputCoordinator.WaitForPendingFlushesAsync().ConfigureAwait(false);
+
+                // CRITICAL: Order matters!
+                // 1. Flush retained console fragments while progress deferral is still active.
+                var newlyPopulatedBuffers = await _consoleCoordinator
+                    .FlushPendingWritesAsync()
                     .ConfigureAwait(false);
+
+                // 2. Schedule buffers populated after their modules completed.
+                foreach (var buffer in newlyPopulatedBuffers)
+                {
+                    await _outputCoordinator
+                        .OnModuleCompletedAsync(buffer, buffer.ModuleType)
+                        .ConfigureAwait(false);
+                }
             }
-
-            // 3. Stop progress display (ends buffering phase).
-            await _printProgressExecutor.DisposeAsync().ConfigureAwait(false);
-
-            // 4. Flush deferred module output (in completion order).
-            await _outputCoordinator.FlushDeferredAsync().ConfigureAwait(false);
-
-            // 5. Flush any unattributed output from coordinator.
-            await _consoleCoordinator.FlushModuleOutputAsync().ConfigureAwait(false);
+            finally
+            {
+                try
+                {
+                    // 3. Stop progress display (ends buffering phase).
+                    await _printProgressExecutor.DisposeAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    try
+                    {
+                        // 4. Flush deferred module output (in completion order).
+                        await _outputCoordinator.FlushDeferredAsync().ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            // 5. Flush any unattributed output from coordinator.
+                            await _consoleCoordinator.FlushModuleOutputAsync().ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            _liveFlushCancellation.Dispose();
+                        }
+                    }
+                }
+            }
         }
 
         private async Task FlushPeriodicallyAsync(TimeSpan interval)

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -216,7 +216,8 @@ public record PipelineOptions
     /// </summary>
     /// <remarks>
     /// The default is 1,000 entries per module. This limits retained output between periodic flushes
-    /// without changing the order or final completion status of module output.
+    /// without changing the order or final completion status of module output. The threshold counts
+    /// entries and does not impose a byte-size cap.
     /// </remarks>
     public int ModuleOutputFlushThreshold { get; set; } = 1_000;
 

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -201,13 +201,24 @@ public record PipelineOptions
 
     /// <summary>
     /// Gets or sets how often buffered output from still-running modules is written to the console.
-    /// Set to <see cref="TimeSpan.Zero"/> to retain all module output until the module completes.
+    /// Set to <see cref="TimeSpan.Zero"/> to disable time-based flushing.
     /// </summary>
     /// <remarks>
     /// Periodic flushing preserves diagnostic output when a process is killed before pipeline
-    /// teardown can run. The default is one minute.
+    /// teardown can run. Size-triggered flushing remains controlled separately by
+    /// <see cref="ModuleOutputFlushThreshold"/>. The default is one minute.
     /// </remarks>
     public TimeSpan ModuleOutputFlushInterval { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Gets or sets the number of buffered output entries that triggers an immediate incremental flush.
+    /// Set to 0 to disable size-triggered flushing.
+    /// </summary>
+    /// <remarks>
+    /// The default is 1,000 entries per module. This limits retained output between periodic flushes
+    /// without changing the order or final completion status of module output.
+    /// </remarks>
+    public int ModuleOutputFlushThreshold { get; set; } = 1_000;
 
     /// <summary>
     /// Gets or sets the default execution options for all commands.

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -281,6 +281,7 @@ public sealed class PipelineBuilder
                 opts.DefaultExecutionOptions = _options.DefaultExecutionOptions;
                 opts.ThrowOnPipelineFailure = _options.ThrowOnPipelineFailure;
                 opts.ModuleOutputFlushInterval = _options.ModuleOutputFlushInterval;
+                opts.ModuleOutputFlushThreshold = _options.ModuleOutputFlushThreshold;
             });
 
             // Auto-register any missing required dependencies

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -450,21 +450,37 @@ public sealed class PipelineBuilder
         private readonly SemaphoreSlim _lock = new(1, 1);
         private volatile IDistributedCoordinator? _inner;
 
+        public async Task EnqueueModuleAsync(ModuleAssignment a, CancellationToken ct) => await (await GetAsync(ct)).EnqueueModuleAsync(a, ct);
+
+        public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<string> c, CancellationToken ct) => await (await GetAsync(ct)).DequeueModuleAsync(c, ct);
+
+        public async Task PublishResultAsync(SerializedModuleResult r, CancellationToken ct) => await (await GetAsync(ct)).PublishResultAsync(r, ct);
+
+        public async Task<SerializedModuleResult> WaitForResultAsync(string m, CancellationToken ct) => await (await GetAsync(ct)).WaitForResultAsync(m, ct);
+
+        public async Task RegisterWorkerAsync(WorkerRegistration r, CancellationToken ct) => await (await GetAsync(ct)).RegisterWorkerAsync(r, ct);
+
+        public async Task<IReadOnlyList<WorkerRegistration>> GetRegisteredWorkersAsync(CancellationToken ct) => await (await GetAsync(ct)).GetRegisteredWorkersAsync(ct);
+
+        public async Task SignalCompletionAsync(CancellationToken ct) => await (await GetAsync(ct)).SignalCompletionAsync(ct);
+
         private async ValueTask<IDistributedCoordinator> GetAsync(CancellationToken ct)
         {
-            if (_inner is not null) return _inner;
-            await _lock.WaitAsync(ct);
-            try { return _inner ??= await factory.CreateAsync(ct); }
-            finally { _lock.Release(); }
-        }
+            if (_inner is not null)
+            {
+                return _inner;
+            }
 
-        public async Task EnqueueModuleAsync(ModuleAssignment a, CancellationToken ct) => await (await GetAsync(ct)).EnqueueModuleAsync(a, ct);
-        public async Task<ModuleAssignment?> DequeueModuleAsync(IReadOnlySet<string> c, CancellationToken ct) => await (await GetAsync(ct)).DequeueModuleAsync(c, ct);
-        public async Task PublishResultAsync(SerializedModuleResult r, CancellationToken ct) => await (await GetAsync(ct)).PublishResultAsync(r, ct);
-        public async Task<SerializedModuleResult> WaitForResultAsync(string m, CancellationToken ct) => await (await GetAsync(ct)).WaitForResultAsync(m, ct);
-        public async Task RegisterWorkerAsync(WorkerRegistration r, CancellationToken ct) => await (await GetAsync(ct)).RegisterWorkerAsync(r, ct);
-        public async Task<IReadOnlyList<WorkerRegistration>> GetRegisteredWorkersAsync(CancellationToken ct) => await (await GetAsync(ct)).GetRegisteredWorkersAsync(ct);
-        public async Task SignalCompletionAsync(CancellationToken ct) => await (await GetAsync(ct)).SignalCompletionAsync(ct);
+            await _lock.WaitAsync(ct);
+            try
+            {
+                return _inner ??= await factory.CreateAsync(ct);
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
     }
 
     /// <summary>
@@ -475,17 +491,30 @@ public sealed class PipelineBuilder
         private readonly SemaphoreSlim _lock = new(1, 1);
         private volatile IDistributedArtifactStore? _inner;
 
+        public async Task<ArtifactReference> UploadAsync(ArtifactDescriptor d, Stream s, CancellationToken ct) => await (await GetAsync(ct)).UploadAsync(d, s, ct);
+
+        public async Task<Stream> DownloadAsync(ArtifactReference r, CancellationToken ct) => await (await GetAsync(ct)).DownloadAsync(r, ct);
+
+        public async Task<IReadOnlyList<ArtifactReference>> ListArtifactsAsync(string m, CancellationToken ct) => await (await GetAsync(ct)).ListArtifactsAsync(m, ct);
+
+        public async Task DeleteAsync(ArtifactReference r, CancellationToken ct) => await (await GetAsync(ct)).DeleteAsync(r, ct);
+
         private async ValueTask<IDistributedArtifactStore> GetAsync(CancellationToken ct)
         {
-            if (_inner is not null) return _inner;
-            await _lock.WaitAsync(ct);
-            try { return _inner ??= await factory.CreateAsync(ct); }
-            finally { _lock.Release(); }
-        }
+            if (_inner is not null)
+            {
+                return _inner;
+            }
 
-        public async Task<ArtifactReference> UploadAsync(ArtifactDescriptor d, Stream s, CancellationToken ct) => await (await GetAsync(ct)).UploadAsync(d, s, ct);
-        public async Task<Stream> DownloadAsync(ArtifactReference r, CancellationToken ct) => await (await GetAsync(ct)).DownloadAsync(r, ct);
-        public async Task<IReadOnlyList<ArtifactReference>> ListArtifactsAsync(string m, CancellationToken ct) => await (await GetAsync(ct)).ListArtifactsAsync(m, ct);
-        public async Task DeleteAsync(ArtifactReference r, CancellationToken ct) => await (await GetAsync(ct)).DeleteAsync(r, ct);
+            await _lock.WaitAsync(ct);
+            try
+            {
+                return _inner ??= await factory.CreateAsync(ct);
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
     }
 }

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -58,6 +58,13 @@ internal class OptionsValidator : IOptionsValidator
                 $"Current value: {options.ModuleOutputFlushInterval}"));
         }
 
+        if (options.ModuleOutputFlushThreshold < 0)
+        {
+            result.AddError(new ValidationError(
+                ValidationErrorCategory.Options,
+                $"ModuleOutputFlushThreshold cannot be negative. Current value: {options.ModuleOutputFlushThreshold}"));
+        }
+
         // Validate concurrency options
         if (options.Concurrency.MaxParallelism < 1)
         {

--- a/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
@@ -112,7 +112,45 @@ public class ConsoleCoordinatorTests
             Times.Once);
     }
 
-    private static ConsoleCoordinator CreateCoordinator(IOutputCoordinator outputCoordinator)
+    [Test]
+    public async Task BufferThreshold_RequestsImmediateIncrementalFlush()
+    {
+        var flushRequested = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(output => output.EnqueueAndFlushAsync(
+                It.IsAny<IModuleOutputBuffer>(),
+                OutputFlushKind.Incremental,
+                It.IsAny<CancellationToken>()))
+            .Callback(() => flushRequested.TrySetResult())
+            .Returns(Task.CompletedTask);
+        var coordinator = CreateCoordinator(
+            outputCoordinator.Object,
+            new PipelineOptions { ModuleOutputFlushThreshold = 2 });
+        var buffer = coordinator.GetModuleBuffer(typeof(ConsoleCoordinatorTests));
+
+        buffer.WriteLine("first");
+        outputCoordinator.Verify(
+            output => output.EnqueueAndFlushAsync(
+                It.IsAny<IModuleOutputBuffer>(),
+                OutputFlushKind.Incremental,
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        buffer.WriteLine("second");
+        await flushRequested.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+        outputCoordinator.Verify(
+            output => output.EnqueueAndFlushAsync(
+                buffer,
+                OutputFlushKind.Incremental,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private static ConsoleCoordinator CreateCoordinator(
+        IOutputCoordinator outputCoordinator,
+        PipelineOptions? options = null)
     {
         var secretProvider = new Mock<ISecretProvider>();
         secretProvider.SetupGet(provider => provider.Secrets).Returns([]);
@@ -126,7 +164,7 @@ public class ConsoleCoordinatorTests
             Mock.Of<IResultsPrinter>(),
             secretObfuscator.Object,
             secretProvider.Object,
-            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
+            Microsoft.Extensions.Options.Options.Create(options ?? new PipelineOptions()),
             NullLoggerFactory.Instance,
             Mock.Of<IBuildSystemDetector>(),
             Mock.Of<IServiceProvider>(),

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -100,6 +100,33 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task IncrementalFlush_RearmsOutputThreshold()
+    {
+        var thresholdRequests = 0;
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            outputFlushThreshold: 2,
+            _ => thresholdRequests++);
+
+        buffer.WriteLine("first");
+        buffer.WriteLine("second");
+        await Assert.That(thresholdRequests).IsEqualTo(1);
+
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Incremental);
+        buffer.WriteLine("third");
+        buffer.WriteLine("fourth");
+
+        await Assert.That(thresholdRequests).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task IncrementalFlush_DoesNotDrainCompletedModule()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
@@ -13,7 +13,7 @@ namespace ModularPipelines.UnitTests.Engine;
 public class ExecutionOrchestratorTests
 {
     [Test]
-    public async Task PipelineFailure_IsNotMaskedByOutputTeardownFailure()
+    public async Task PipelineFailure_IsNotMaskedByOutputTeardownOrLoggingFailure()
     {
         var organizedModules = new OrganizedModules([], []);
         var summary = new PipelineSummary(
@@ -23,6 +23,7 @@ public class ExecutionOrchestratorTests
             DateTimeOffset.UtcNow);
         var pipelineException = new InvalidOperationException("pipeline failed");
         var teardownException = new IOException("output teardown failed");
+        var loggingException = new InvalidOperationException("logging failed");
 
         var pipelineInitializer = new Mock<IPipelineInitializer>();
         pipelineInitializer
@@ -66,6 +67,14 @@ public class ExecutionOrchestratorTests
         var primaryExceptionContainer = new Mock<IPrimaryExceptionContainer>();
         using var engineCancellationToken = new PipelineEngineCancellationToken(primaryExceptionContainer.Object);
         var logger = new Mock<ILogger<ExecutionOrchestrator>>();
+        logger
+            .Setup(x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()))
+            .Throws(loggingException);
         var orchestrator = new ExecutionOrchestrator(
             pipelineInitializer.Object,
             moduleDisposeExecutor.Object,

--- a/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Executors;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+using Moq;
+using OptionsFactory = Microsoft.Extensions.Options.Options;
+using PipelineEngineCancellationToken = ModularPipelines.Engine.EngineCancellationToken;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class ExecutionOrchestratorTests
+{
+    [Test]
+    public async Task PipelineFailure_IsNotMaskedByOutputTeardownFailure()
+    {
+        var organizedModules = new OrganizedModules([], []);
+        var summary = new PipelineSummary(
+            [],
+            TimeSpan.Zero,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        var pipelineException = new InvalidOperationException("pipeline failed");
+        var teardownException = new IOException("output teardown failed");
+
+        var pipelineInitializer = new Mock<IPipelineInitializer>();
+        pipelineInitializer
+            .Setup(x => x.Initialize(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(organizedModules);
+
+        var ignoredModuleResultRegistrar = new Mock<IIgnoredModuleResultRegistrar>();
+        ignoredModuleResultRegistrar
+            .Setup(x => x.RegisterIgnoredModuleResultsAsync(organizedModules))
+            .ReturnsAsync(organizedModules);
+
+        var pipelineExecutor = new Mock<IPipelineExecutor>();
+        pipelineExecutor
+            .Setup(x => x.ExecuteAsync(It.IsAny<List<IModule>>(), organizedModules))
+            .ThrowsAsync(pipelineException);
+
+        var outputScope = new Mock<IPipelineOutputScope>();
+        outputScope
+            .Setup(x => x.DisposeAsync())
+            .Returns(ValueTask.FromException(teardownException));
+
+        var outputCoordinator = new Mock<IPipelineOutputCoordinator>();
+        outputCoordinator
+            .Setup(x => x.InitializeAsync())
+            .ReturnsAsync(outputScope.Object);
+
+        var moduleDisposeExecutor = new Mock<IModuleDisposeExecutor>();
+        moduleDisposeExecutor
+            .Setup(x => x.DisposeAsync())
+            .Returns(ValueTask.CompletedTask);
+
+        var pipelineSummaryFactory = new Mock<IPipelineSummaryFactory>();
+        pipelineSummaryFactory
+            .Setup(x => x.Create(
+                It.IsAny<IReadOnlyList<IModule>>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<DateTimeOffset>(),
+                It.IsAny<DateTimeOffset>()))
+            .Returns(summary);
+
+        var primaryExceptionContainer = new Mock<IPrimaryExceptionContainer>();
+        using var engineCancellationToken = new PipelineEngineCancellationToken(primaryExceptionContainer.Object);
+        var logger = new Mock<ILogger<ExecutionOrchestrator>>();
+        var orchestrator = new ExecutionOrchestrator(
+            pipelineInitializer.Object,
+            moduleDisposeExecutor.Object,
+            pipelineExecutor.Object,
+            outputCoordinator.Object,
+            ignoredModuleResultRegistrar.Object,
+            Mock.Of<IModuleResultRegistry>(),
+            pipelineSummaryFactory.Object,
+            engineCancellationToken,
+            Mock.Of<IThreadPoolConfigurator>(),
+            Mock.Of<IExceptionRethrowService>(),
+            OptionsFactory.Create(new PipelineOptions()),
+            logger.Object);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => orchestrator.ExecuteAsync());
+
+        await Assert.That(exception).IsSameReferenceAs(pipelineException);
+        logger.Verify(x => x.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((state, _) =>
+                state.ToString()!.Contains(
+                    nameof(InvalidOperationException),
+                    StringComparison.Ordinal)),
+            teardownException,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -22,12 +22,14 @@ public class PipelineOutputCoordinatorTests
     }
 
     [Test]
-    public async Task PipelineBuilder_CopiesModuleOutputFlushInterval()
+    public async Task PipelineBuilder_CopiesModuleOutputFlushSettings()
     {
         var builder = TestPipelineHostBuilder.Create()
             .AddModule<OptionsTestModule>();
         var expectedInterval = TimeSpan.FromSeconds(17);
+        const int expectedThreshold = 23;
         builder.Options.ModuleOutputFlushInterval = expectedInterval;
+        builder.Options.ModuleOutputFlushThreshold = expectedThreshold;
 
         await using var pipeline = await builder.BuildAsync();
         var runtimeOptions = pipeline.Services
@@ -35,6 +37,7 @@ public class PipelineOutputCoordinatorTests
             .Value;
 
         await Assert.That(runtimeOptions.ModuleOutputFlushInterval).IsEqualTo(expectedInterval);
+        await Assert.That(runtimeOptions.ModuleOutputFlushThreshold).IsEqualTo(expectedThreshold);
     }
 
     [Test]
@@ -85,6 +88,48 @@ public class PipelineOutputCoordinatorTests
         await Assert.That(string.Join(",", events))
             .IsEqualTo("quiesced,retained,scheduled,progress,deferred,unattributed");
         outputCoordinator.VerifyAll();
+    }
+
+    [Test]
+    public async Task Dispose_FlushesDeferredOutputWhenEarlierTeardownFails()
+    {
+        var events = new List<string>();
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.FlushPendingWritesAsync())
+            .Callback(() => events.Add("retained"))
+            .ThrowsAsync(new InvalidOperationException("retained flush failed"));
+        consoleCoordinator
+            .Setup(x => x.FlushModuleOutputAsync())
+            .Callback(() => events.Add("unattributed"))
+            .Returns(Task.CompletedTask);
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(x => x.WaitForPendingFlushesAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => events.Add("quiesced"))
+            .Returns(Task.CompletedTask);
+        outputCoordinator
+            .Setup(x => x.FlushDeferredAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => events.Add("deferred"))
+            .Returns(Task.CompletedTask);
+        var coordinator = new PipelineOutputCoordinator(
+            new RecordingProgressExecutor(events),
+            Mock.Of<IConsolePrinter>(),
+            Mock.Of<IInternalSummaryLogger>(),
+            Mock.Of<IExceptionBuffer>(),
+            consoleCoordinator.Object,
+            outputCoordinator.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                ModuleOutputFlushInterval = TimeSpan.Zero,
+            }),
+            Mock.Of<ILogger<PipelineOutputCoordinator>>());
+        var scope = await coordinator.InitializeAsync();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await scope.DisposeAsync());
+
+        await Assert.That(string.Join(",", events))
+            .IsEqualTo("quiesced,retained,progress,deferred,unattributed");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -133,6 +133,55 @@ public class PipelineOutputCoordinatorTests
     }
 
     [Test]
+    public async Task Dispose_AggregatesTeardownFailuresInExecutionOrder()
+    {
+        var events = new List<string>();
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.FlushPendingWritesAsync())
+            .Callback(() => events.Add("retained"))
+            .ThrowsAsync(new InvalidOperationException("retained flush failed"));
+        consoleCoordinator
+            .Setup(x => x.FlushModuleOutputAsync())
+            .Callback(() => events.Add("unattributed"))
+            .ThrowsAsync(new IOException("unattributed flush failed"));
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(x => x.WaitForPendingFlushesAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => events.Add("quiesced"))
+            .Returns(Task.CompletedTask);
+        outputCoordinator
+            .Setup(x => x.FlushDeferredAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => events.Add("deferred"))
+            .ThrowsAsync(new ApplicationException("deferred flush failed"));
+        var coordinator = new PipelineOutputCoordinator(
+            new RecordingProgressExecutor(events),
+            Mock.Of<IConsolePrinter>(),
+            Mock.Of<IInternalSummaryLogger>(),
+            Mock.Of<IExceptionBuffer>(),
+            consoleCoordinator.Object,
+            outputCoordinator.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                ModuleOutputFlushInterval = TimeSpan.Zero,
+            }),
+            Mock.Of<ILogger<PipelineOutputCoordinator>>());
+        var scope = await coordinator.InitializeAsync();
+
+        var exception = await Assert.ThrowsAsync<AggregateException>(async () =>
+            await scope.DisposeAsync());
+
+        await Assert.That(string.Join(",", events))
+            .IsEqualTo("quiesced,retained,progress,deferred,unattributed");
+        await Assert.That(exception!.InnerExceptions.Select(inner => inner.Message))
+            .IsEquivalentTo([
+                "retained flush failed",
+                "deferred flush failed",
+                "unattributed flush failed",
+            ]);
+    }
+
+    [Test]
     public async Task RunningScope_PeriodicallyFlushesInProgressOutput()
     {
         var flushObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -529,6 +529,21 @@ public class ValidationTests
     }
 
     [Test]
+    public async Task ValidateAsync_WithNegativeModuleOutputFlushThreshold_ReturnsError()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.Services.AddModule<SimpleModule>();
+        builder.Options.ModuleOutputFlushThreshold = -1;
+
+        var result = await builder.ValidateAsync();
+
+        await Assert.That(result.HasErrors).IsTrue();
+        await Assert.That(result.Errors.Any(e =>
+            e.Category == ValidationErrorCategory.Options &&
+            e.Message.Contains("ModuleOutputFlushThreshold"))).IsTrue();
+    }
+
+    [Test]
     public async Task ValidateAsync_WithConflictingCategories_ReturnsError()
     {
         // Arrange


### PR DESCRIPTION
Closes #3269

## Summary
- add a configurable `ModuleOutputFlushThreshold` (1,000 entries by default) that requests an immediate incremental drain when a module buffer reaches the threshold
- rearm threshold requests after each successful incremental drain and apply the same protection to unattributed pipeline output
- always stop progress and flush deferred/unattributed output from nested `finally` blocks, even when an earlier teardown step fails
- validate and propagate the new pipeline option

## Validation
- `build ModularPipelines.sln -c Release` passed through `scripts/Invoke-AgentDotNet.ps1` (0 errors; 250 existing repository warnings)
- threshold-trigger test: passed
- threshold-rearm test: passed
- normal output teardown-order regression: passed
- earlier-teardown-failure final-flush regression: passed (failing-first confirmed)
- pipeline option propagation test: passed
- negative threshold validation test: passed
- changed-file whitespace verification: passed
