### PR TITLE
Initialize module configuration once

### DIFF
--- a/src/ModularPipelines/Engine/ModuleActivator.cs
+++ b/src/ModularPipelines/Engine/ModuleActivator.cs
@@ -27,7 +27,9 @@ internal sealed class ModuleActivator : IModuleActivator
 
         try
         {
-            return (IModule)ActivatorUtilities.CreateInstance(serviceProvider, moduleType);
+            var module = (IModule) ActivatorUtilities.CreateInstance(serviceProvider, moduleType);
+            _ = module.Configuration;
+            return module;
         }
         finally
         {

--- a/src/ModularPipelines/Modules/Module.cs
+++ b/src/ModularPipelines/Modules/Module.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Runtime.CompilerServices;
 using ModularPipelines.Attributes;
 using ModularPipelines.Configuration;
@@ -54,6 +55,22 @@ namespace ModularPipelines.Modules;
 /// </example>
 public abstract class Module<T> : IModule, ITaggedModule
 {
+    private readonly Lazy<ModuleConfiguration> _configuration;
+    private readonly Lazy<FrozenSet<string>> _tags;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Module{T}"/> class.
+    /// </summary>
+    protected Module()
+    {
+        _tags = new Lazy<FrozenSet<string>>(
+            () => Tags.ToFrozenSet(StringComparer.OrdinalIgnoreCase),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+        _configuration = new Lazy<ModuleConfiguration>(
+            CreateConfiguration,
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
     internal TaskCompletionSource<ModuleResult<T>> CompletionSource { get; } = new();
 
     /// <inheritdoc />
@@ -69,8 +86,8 @@ public abstract class Module<T> : IModule, ITaggedModule
     /// <returns>The module configuration.</returns>
     /// <remarks>
     /// <para>
-    /// This method is called once when the <see cref="IModule.Configuration"/> property is first accessed.
-    /// The result is cached for subsequent accesses.
+    /// This method is called once during module activation and cached for subsequent accesses.
+    /// Directly constructed modules initialize on first access.
     /// </para>
     /// <para>
     /// Use <see cref="ModuleConfiguration.Create"/> to build a custom configuration,
@@ -88,16 +105,11 @@ public abstract class Module<T> : IModule, ITaggedModule
     /// </example>
     protected virtual ModuleConfiguration Configure() => ModuleConfiguration.Default;
 
-    // Cached configuration - evaluated once on first access
-    private ModuleConfiguration? _configuration;
+    /// <inheritdoc />
+    ModuleConfiguration IModule.Configuration => _configuration.Value;
 
     /// <inheritdoc />
-    ModuleConfiguration IModule.Configuration => _configuration ??= ModuleConfigurationAttributeAdapter.Apply(
-        GetType(),
-        Configure(),
-        Tags,
-        Category,
-        GetDeclaredDependencies());
+    IReadOnlySet<string> ITaggedModule.Tags => _tags.Value;
 
     /// <summary>
     /// Gets the tags for this module. Override to declare tags programmatically.
@@ -106,7 +118,7 @@ public abstract class Module<T> : IModule, ITaggedModule
     /// Tags can also be declared via <see cref="ModuleTagAttribute"/>.
     /// Both sources are merged together.
     /// </remarks>
-    public virtual IReadOnlySet<string> Tags => new HashSet<string>();
+    public virtual IReadOnlySet<string> Tags => FrozenSet<string>.Empty;
 
     /// <summary>
     /// Gets the category for this module. Override to declare category programmatically.
@@ -303,4 +315,14 @@ public abstract class Module<T> : IModule, ITaggedModule
     /// Gets an awaiter for this module's result.
     /// </summary>
     public TaskAwaiter<ModuleResult<T>> GetAwaiter() => CompletionSource.Task.GetAwaiter();
+
+    private ModuleConfiguration CreateConfiguration()
+    {
+        return ModuleConfigurationAttributeAdapter.Apply(
+            GetType(),
+            Configure(),
+            _tags.Value,
+            Category,
+            GetDeclaredDependencies());
+    }
 }

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
@@ -1,6 +1,9 @@
+using System.Collections.Frozen;
+using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Attributes;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
+using ModularPipelines.Engine;
 using ModularPipelines.Enums;
 using ModularPipelines.Modules;
 
@@ -8,6 +11,33 @@ namespace ModularPipelines.UnitTests.Configuration;
 
 public class ModuleConfigureTests
 {
+    private sealed class CountingModule : Module<string>
+    {
+        public int ConfigureCount { get; private set; }
+
+        public int TagsCount { get; private set; }
+
+        public override IReadOnlySet<string> Tags
+        {
+            get
+            {
+                TagsCount++;
+                return new HashSet<string> { "cached-tag" };
+            }
+        }
+
+        protected override ModuleConfiguration Configure()
+        {
+            ConfigureCount++;
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult<string?>("test");
+    }
+
     private class TestModule : Module<string>
     {
         protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -83,6 +113,31 @@ public class ModuleConfigureTests
         var config2 = ((IModule) module).Configuration;
 
         await Assert.That(config1).IsSameReferenceAs(config2);
+    }
+
+    [Test]
+    public async Task ModuleActivator_Initializes_Configuration_And_Tags_Once()
+    {
+        using var services = new ServiceCollection().BuildServiceProvider();
+        var module = (CountingModule)new ModuleActivator()
+            .CreateModule(typeof(CountingModule), services);
+
+        var configurations = await Task.WhenAll(
+            Enumerable.Range(0, 10)
+                .Select(_ => Task.Run(() => ((IModule)module).Configuration)));
+        var tags = ((ITaggedModule)module).Tags;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(module.ConfigureCount).IsEqualTo(1);
+            await Assert.That(module.TagsCount).IsEqualTo(1);
+            await Assert.That(configurations.All(
+                    configuration => ReferenceEquals(configuration, configurations[0])))
+                .IsTrue();
+            await Assert.That(tags is FrozenSet<string>).IsTrue();
+            await Assert.That(tags).Contains("cached-tag");
+            await Assert.That(((ITaggedModule)module).Tags).IsSameReferenceAs(tags);
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- initialize module configuration once during activation under the module logging context
- use thread-safe lazy initialization for directly constructed or pre-created modules
- cache programmatic module tags as a case-insensitive FrozenSet

## Validation
- `ModularPipelines.sln` Release build (0 errors)
- `ModuleConfigureTests` (6 passed)
- `ModuleMetadataRegistryTests` (5 passed)
- `FlexibleDependencyIntegrationTests` (15 passed)

Closes #3281