### PR TITLE
Load Git repository information lazily

### DIFF
--- a/RELEASE_NOTES_V3.md
+++ b/RELEASE_NOTES_V3.md
@@ -38,7 +38,7 @@ protected internal override Task<SkipDecision> ShouldSkip(...) => ...;
 protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
     .WithTimeout(TimeSpan.FromMinutes(5))
     .WithRetryCount(3)
-    .WithSkipWhen(ctx => ctx.Git().Information.BranchName != "main"
+    .WithSkipWhen(async ctx => (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main"
         ? SkipDecision.Skip("Only runs on main")
         : SkipDecision.DoNotSkip)
     .Build();

--- a/docs/docs/examples/dotnet-test-build-publish.md
+++ b/docs/docs/examples/dotnet-test-build-publish.md
@@ -28,7 +28,9 @@ public class PackProjectsModule : Module<CommandResult[]>
     {
         var packageVersion = await context.GetModule<NugetVersionGeneratorModule>();
 
-        var projects = context.Git().RootDirectory
+        var repositoryInfo = await context.Git().Information.GetInfoAsync()
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
+        var projects = repositoryInfo.Root
             .GetFiles(x =>
                 x.Extension == ".csproj" && !x.Name.Contains("test", StringComparison.InvariantCultureIgnoreCase))
             .ToList();
@@ -59,7 +61,9 @@ public class RunUnitTestsModule : Module<DotNetTestResult[]>
 {
     protected override async Task<DotNetTestResult[]?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        return await context.Git().RootDirectory
+        var repositoryInfo = await context.Git().Information.GetInfoAsync()
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
+        return await repositoryInfo.Root
             .GetFiles(file => file.Path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)
                               && file.Path.Contains("UnitTests", StringComparison.OrdinalIgnoreCase))
             .ToAsyncProcessorBuilder()
@@ -92,7 +96,9 @@ public class UploadPackagesToNugetModule : Module<CommandResult[]>
     {
         ArgumentNullException.ThrowIfNull(_nugetSettings.Value.ApiKey);
 
-        var packages = context.Git().RootDirectory
+        var repositoryInfo = await context.Git().Information.GetInfoAsync()
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
+        var packages = repositoryInfo.Root
             .GetFiles(x =>
                 x.Extension == ".nupkg")
             .ToList();

--- a/docs/docs/how-to/skipping.md
+++ b/docs/docs/how-to/skipping.md
@@ -39,7 +39,8 @@ When you need access to the pipeline context for your skip condition:
 public class MyModule : Module<CommandResult>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-        .WithSkipWhen(ctx => ctx.Git().Information.BranchName != "main")
+        .WithSkipWhen(async ctx =>
+            (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main")
         .Build();
 
     protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -57,9 +58,10 @@ For better reporting, you can return a `SkipDecision` with a reason:
 public class MyModule : Module<CommandResult>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-        .WithSkipWhen(ctx =>
+        .WithSkipWhen(async ctx =>
         {
-            if (ctx.Git().Information.BranchName == "main")
+            var repositoryInfo = await ctx.Git().Information.GetInfoAsync();
+            if (repositoryInfo?.BranchName == "main")
             {
                 return SkipDecision.DoNotSkip;
             }
@@ -99,7 +101,8 @@ You can combine skip conditions with other module behaviors:
 public class CleanupModule : Module<CommandResult>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-        .WithSkipWhen(ctx => ctx.Git().Information.BranchName != "main")
+        .WithSkipWhen(async ctx =>
+            (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main")
         .WithAlwaysRun()  // Run even if dependencies fail (when not skipped)
         .WithTimeout(TimeSpan.FromMinutes(5))
         .Build();

--- a/docs/docs/how-to/storing-and-retrieving-results.md
+++ b/docs/docs/how-to/storing-and-retrieving-results.md
@@ -40,13 +40,15 @@ public class MyModuleRepository : IModuleResultRepository
     
     public async Task SaveResultAsync<T>(ModuleBase module, ModuleResult<T> moduleResult, IPipelineContext pipelineContext)
     {
-        var commit = pipelineContext.Git().Information.LastCommitSha;
+        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync();
+        var commit = repositoryInfo?.LastCommitSha;
         await _blobContainerClient.UploadBlobAsync(module.GetType().FullName + commit, new BinaryData(JsonSerializer.Serialize(moduleResult)));
     }
 
     public async Task<ModuleResult<T>?> GetResultAsync<T>(ModuleBase module, IPipelineContext pipelineContext)
     {
-        var commit = pipelineContext.Git().Information.LastCommitSha;
+        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync();
+        var commit = repositoryInfo?.LastCommitSha;
         
         var blobContent = await _blobContainerClient.GetBlobClient(module.GetType().FullName + commit).DownloadContentAsync();
 

--- a/docs/docs/how-to/sub-modules.md
+++ b/docs/docs/how-to/sub-modules.md
@@ -26,7 +26,9 @@ public class PackProjectsModule : Module<CommandResult[]>
     {
         var packageVersion = await context.GetModule<NugetVersionGeneratorModule>();
 
-        var projects = context.Git().RootDirectory
+        var repositoryInfo = await context.Git().Information.GetInfoAsync()
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
+        var projects = repositoryInfo.Root
             .GetFiles(x =>
                 x.Extension == ".csproj" && !x.Name.Contains("test", StringComparison.InvariantCultureIgnoreCase))
             .ToList();

--- a/docs/docs/migrating-to-v3.md
+++ b/docs/docs/migrating-to-v3.md
@@ -219,7 +219,7 @@ public class MyModule : Module<string>
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
         .WithTimeout(TimeSpan.FromMinutes(5))
         .WithRetryCount(3)
-        .WithSkipWhen(ctx => ctx.Git().Information.BranchName != "main"
+        .WithSkipWhen(async ctx => (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main"
             ? SkipDecision.Skip("Only runs on main branch")
             : SkipDecision.DoNotSkip)
         .WithIgnoreFailures()
@@ -833,14 +833,16 @@ The `WithSkipWhen` and `WithIgnoreFailuresWhen` methods accept both sync and asy
 // Async lambda - same method name
 .WithSkipWhen(async () => await CheckConditionAsync())
 
-// With context - sync
-.WithSkipWhen(ctx => ctx.Git().Information.BranchName != "main")
+// With context - async repository lookup
+.WithSkipWhen(async ctx =>
+    (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main")
 
 // With context - async
 .WithSkipWhen(async ctx => await ctx.SomeAsyncCheck())
 
 // Returning SkipDecision
-.WithSkipWhen(ctx => ctx.Git().Information.BranchName != "main"
+.WithSkipWhen(async ctx =>
+    (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main"
     ? SkipDecision.Skip("Not main branch")
     : SkipDecision.DoNotSkip)
 ```
@@ -1159,7 +1161,7 @@ public class BuildModule : Module<BuildOutput>
 public class DeployModule : Module<bool>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-        .WithSkipWhen(ctx => ctx.Git().Information.BranchName != "main"
+        .WithSkipWhen(async ctx => (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main"
             ? SkipDecision.Skip("Not main branch")
             : SkipDecision.DoNotSkip)
         .Build();

--- a/src/ModularPipelines.Build/Attributes/SkipOnMainBranch.cs
+++ b/src/ModularPipelines.Build/Attributes/SkipOnMainBranch.cs
@@ -8,9 +8,10 @@ namespace ModularPipelines.Build.Attributes;
 public class SkipOnMainBranch : MandatoryRunConditionAttribute
 {
     /// <inheritdoc/>
-    public override Task<bool> Condition(IPipelineContext pipelineContext)
+    public override async Task<bool> Condition(IPipelineContext pipelineContext)
     {
-        return Task.FromResult(pipelineContext.Git().Information.BranchName != "main");
+        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync().ConfigureAwait(false);
+        return repositoryInfo?.BranchName != "main";
     }
 }
 #pragma warning restore CS0618

--- a/src/ModularPipelines.Build/Modules/BuildSolutionOnPlatformModule.cs
+++ b/src/ModularPipelines.Build/Modules/BuildSolutionOnPlatformModule.cs
@@ -12,9 +12,12 @@ public abstract class BuildSolutionOnPlatformModule : Module<CommandResult>
 {
     protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
+        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
+
         return await context.DotNet().Build(new DotNetBuildOptions
         {
-            ProjectSolution = Path.Combine(context.Git().RootDirectory.Path, "ModularPipelines.All.sln"),
+            ProjectSolution = Path.Combine(repositoryInfo.Root.Path, "ModularPipelines.All.sln"),
             Configuration = "Release",
             NoRestore = true,
         }, cancellationToken: cancellationToken);

--- a/src/ModularPipelines.Build/Modules/BuildSolutionsModule.cs
+++ b/src/ModularPipelines.Build/Modules/BuildSolutionsModule.cs
@@ -15,7 +15,9 @@ public class BuildSolutionsModule : Module<CommandResult[]>
 {
     protected override async Task<CommandResult[]?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var gitRoot = context.Git().RootDirectory.Path;
+        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
+        var gitRoot = repositoryInfo.Root.Path;
         var solutions = File.ReadLines(Path.Combine(gitRoot, "BuildSolutions.txt"))
             .Select(line => line.Trim())
             .Where(line => !string.IsNullOrEmpty(line) && !line.StartsWith('#'))

--- a/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
+++ b/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
@@ -42,10 +42,12 @@ public class FormatMarkdownModule : Module<CommandResult>
             SaveDev = true,
         }, cancellationToken);
 
+        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
         var filesToFormat = new List<string>
         {
-            context.Git().RootDirectory.FindFile(x => x.Name == "README.md")!.Path,
-            context.Git().RootDirectory.FindFile(x => x.Name == "README_Template.md")!.Path,
+            repositoryInfo.Root.FindFile(x => x.Name == "README.md")!.Path,
+            repositoryInfo.Root.FindFile(x => x.Name == "README_Template.md")!.Path,
         };
 
         foreach (var fileToFormat in filesToFormat)

--- a/src/ModularPipelines.Build/Modules/GenerateReadMeModule.cs
+++ b/src/ModularPipelines.Build/Modules/GenerateReadMeModule.cs
@@ -19,7 +19,9 @@ public class GenerateReadMeModule : Module<IDictionary<string, object>>
 
     protected override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var gitRootDirectory = context.Git().RootDirectory;
+        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
+        var gitRootDirectory = repositoryInfo.Root;
 
         var readMeActualOriginalContents = await gitRootDirectory.GetFile("README.md").ReadAsync(cancellationToken);
         var readmeTemplateContents = await gitRootDirectory.GetFile("README_Template.md").ReadAsync(cancellationToken);

--- a/src/ModularPipelines.Build/Modules/PackageFilesRemovalModule.cs
+++ b/src/ModularPipelines.Build/Modules/PackageFilesRemovalModule.cs
@@ -6,10 +6,11 @@ namespace ModularPipelines.Build.Modules;
 
 public class PackageFilesRemovalModule : Module<int>
 {
-    protected override Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var packageFiles = context.Git()
-            .RootDirectory
+        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
+        var packageFiles = repositoryInfo.Root
             .GetFiles(path => path.Extension is ".nupkg");
 
         var count = 0;
@@ -19,6 +20,6 @@ public class PackageFilesRemovalModule : Module<int>
             count++;
         }
 
-        return Task.FromResult(count);
+        return count;
     }
 }

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
@@ -39,7 +39,9 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
 
     protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var testProject = context.Git().RootDirectory
+        var repositoryInfo = await context.Git().Information.GetInfoAsync().ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
+        var testProject = repositoryInfo.Root
             .GetFiles(file => file.Name.Equals(TestProjectFileName, StringComparison.OrdinalIgnoreCase))
             .Single();
         var trxFile = GetTrxFile(testProject);

--- a/src/ModularPipelines.Development.Analyzers/Readme.md
+++ b/src/ModularPipelines.Development.Analyzers/Readme.md
@@ -115,13 +115,13 @@ await PipelineHostBuilder.Create()
 ```csharp
 public class FindNugetPackagesModule : Module<FileInfo>
 {
-    protected override Task<List<File>?> ExecuteAsync(IPipelineContext context, CancellationToken cancellationToken)
+    protected override async Task<List<File>?> ExecuteAsync(IPipelineContext context, CancellationToken cancellationToken)
     {
-        return context.Git()
-            .RootDirectory
+        var repositoryInfo = await context.Git().Information.GetInfoAsync()
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
+        return repositoryInfo.Root
             .GetFiles(path => path.Extension is ".nupkg")
-            .ToList()
-            .AsTask();
+            .ToList();
     }
 }
 ```

--- a/src/ModularPipelines.Git/Attributes/BranchConditionHelper.cs
+++ b/src/ModularPipelines.Git/Attributes/BranchConditionHelper.cs
@@ -12,12 +12,13 @@ internal static class BranchConditionHelper
     /// <summary>
     /// Checks if the current branch matches the expected branch name.
     /// </summary>
-    internal static bool CheckBranchMatches(
+    internal static async Task<bool> CheckBranchMatches(
         IPipelineContext pipelineContext,
         string expectedBranchName,
         string logMessageFormat)
     {
-        var currentBranchName = pipelineContext.Git().Information.BranchName;
+        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync().ConfigureAwait(false);
+        var currentBranchName = repositoryInfo?.BranchName;
         pipelineContext.Logger.LogDebug(logMessageFormat, GetDisplayBranchName(currentBranchName), expectedBranchName);
         return currentBranchName == expectedBranchName;
     }
@@ -25,12 +26,13 @@ internal static class BranchConditionHelper
     /// <summary>
     /// Checks if the current branch starts with the expected prefix.
     /// </summary>
-    internal static bool CheckBranchStartsWith(
+    internal static async Task<bool> CheckBranchStartsWith(
         IPipelineContext pipelineContext,
         string expectedPrefix,
         string logMessageFormat)
     {
-        var currentBranchName = pipelineContext.Git().Information.BranchName;
+        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync().ConfigureAwait(false);
+        var currentBranchName = repositoryInfo?.BranchName;
         pipelineContext.Logger.LogDebug(logMessageFormat, GetDisplayBranchName(currentBranchName), expectedPrefix);
         return currentBranchName?.StartsWith(expectedPrefix) ?? false;
     }

--- a/src/ModularPipelines.Git/Attributes/RunIfBranchAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunIfBranchAttribute.cs
@@ -17,10 +17,10 @@ public class RunIfBranchAttribute : RunConditionAttribute
 
     public override Task<bool> Condition(IPipelineContext pipelineContext)
     {
-        return Task.FromResult(BranchConditionHelper.CheckBranchMatches(
+        return BranchConditionHelper.CheckBranchMatches(
             pipelineContext,
             BranchName,
-            "Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}"));
+            "Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}");
     }
 }
 #pragma warning restore CS0618

--- a/src/ModularPipelines.Git/Attributes/RunIfBranchStartsWithAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunIfBranchStartsWithAttribute.cs
@@ -17,10 +17,10 @@ public class RunIfBranchStartsWithAttribute : RunConditionAttribute
 
     public override Task<bool> Condition(IPipelineContext pipelineContext)
     {
-        return Task.FromResult(BranchConditionHelper.CheckBranchStartsWith(
+        return BranchConditionHelper.CheckBranchStartsWith(
             pipelineContext,
             BranchNamePrefix,
-            "Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}"));
+            "Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}");
     }
 }
 #pragma warning restore CS0618

--- a/src/ModularPipelines.Git/Attributes/RunOnlyIfBranchStartsWithAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunOnlyIfBranchStartsWithAttribute.cs
@@ -17,10 +17,10 @@ public class RunOnlyIfBranchStartsWithAttribute : MandatoryRunConditionAttribute
 
     public override Task<bool> Condition(IPipelineContext pipelineContext)
     {
-        return Task.FromResult(BranchConditionHelper.CheckBranchStartsWith(
+        return BranchConditionHelper.CheckBranchStartsWith(
             pipelineContext,
             BranchNamePrefix,
-            "Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}"));
+            "Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}");
     }
 }
 #pragma warning restore CS0618

--- a/src/ModularPipelines.Git/Attributes/RunOnlyOnBranchAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunOnlyOnBranchAttribute.cs
@@ -17,10 +17,10 @@ public class RunOnlyOnBranchAttribute : MandatoryRunConditionAttribute
 
     public override Task<bool> Condition(IPipelineContext pipelineContext)
     {
-        return Task.FromResult(BranchConditionHelper.CheckBranchMatches(
+        return BranchConditionHelper.CheckBranchMatches(
             pipelineContext,
             BranchName,
-            "Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}"));
+            "Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}");
     }
 }
 #pragma warning restore CS0618

--- a/src/ModularPipelines.Git/Attributes/SkipIfBranchAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/SkipIfBranchAttribute.cs
@@ -15,12 +15,12 @@ public class SkipIfBranchAttribute : MandatoryRunConditionAttribute
         BranchName = branchName;
     }
 
-    public override Task<bool> Condition(IPipelineContext pipelineContext)
+    public override async Task<bool> Condition(IPipelineContext pipelineContext)
     {
-        return Task.FromResult(!BranchConditionHelper.CheckBranchMatches(
+        return !await BranchConditionHelper.CheckBranchMatches(
             pipelineContext,
             BranchName,
-            "Current Branch: {CurrentBranch} | Will skip on: {SkipBranch}"));
+            "Current Branch: {CurrentBranch} | Will skip on: {SkipBranch}").ConfigureAwait(false);
     }
 }
 #pragma warning restore CS0618

--- a/src/ModularPipelines.Git/Git.cs
+++ b/src/ModularPipelines.Git/Git.cs
@@ -1,5 +1,3 @@
-using ModularPipelines.FileSystem;
-
 namespace ModularPipelines.Git;
 
 internal class Git : IGit
@@ -18,7 +16,4 @@ internal class Git : IGit
     public IGitInformation Information { get; }
 
     public IGitVersioning Versioning { get; }
-
-    public Folder RootDirectory => Information.Root ?? throw new InvalidOperationException(
-        "Git repository root directory not detected. Ensure this code is running from within a Git repository.");
 }

--- a/src/ModularPipelines.Git/GitInformation.cs
+++ b/src/ModularPipelines.Git/GitInformation.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using Initialization.Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Context;
@@ -11,11 +10,11 @@ using ModularPipelines.Options;
 
 namespace ModularPipelines.Git;
 
-internal class GitInformation : IGitInformation, IInitializer
+internal class GitInformation : IGitInformation
 {
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly IGitCommitMapper _gitCommitMapper;
-    private Folder? _root;
+    private readonly Lazy<Task<GitRepositoryInfo?>> _repositoryInfo;
 
     public GitInformation(
         IServiceScopeFactory serviceScopeFactory,
@@ -23,89 +22,113 @@ internal class GitInformation : IGitInformation, IInitializer
     {
         _serviceScopeFactory = serviceScopeFactory;
         _gitCommitMapper = gitCommitMapper;
+        _repositoryInfo = new Lazy<Task<GitRepositoryInfo?>>(
+            LoadInfoAsync,
+            LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
-    public Folder Root
+    public Task<GitRepositoryInfo?> GetInfoAsync() => _repositoryInfo.Value;
+
+    public IAsyncEnumerable<GitCommit> Commits(
+        GitOptions? options = null,
+        CancellationToken cancellationToken = default)
     {
-        get => _root ?? throw new InvalidOperationException("GitInformation has not been initialized. Ensure InitializeAsync has completed.");
-        private set => _root = value;
+        return Commits(null, options, cancellationToken);
     }
-    public string BranchName { get; private set; } = "";
-    public string DefaultBranchName { get; private set; } = "";
-    public string LastCommitSha { get; private set; } = "";
-    public string LastCommitShortSha { get; private set; } = "";
-    public string Tag { get; private set; } = "";
-    public int CommitsOnBranch { get; private set; }
-    public DateTimeOffset LastCommitDateTime { get; private set; }
-    public GitCommit? PreviousCommit { get; private set; }
 
-    public async Task InitializeAsync()
+    public async IAsyncEnumerable<GitCommit> Commits(
+        string? branch,
+        GitOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        var gitCommandRunner = scope.ServiceProvider.GetRequiredService<IGitCommandRunner>();
+
+        var index = 0;
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var output = await gitCommandRunner.RunCommandsOrNull(
+                null,
+                "log",
+                branch,
+                $"--skip={index}",
+                "-1",
+                $"--format={GitConstants.CommitLogFormat}").ConfigureAwait(false);
+
+            if (string.IsNullOrWhiteSpace(output))
+            {
+                yield break;
+            }
+
+            index++;
+            yield return _gitCommitMapper.Map(output);
+        }
+    }
+
+    private async Task<GitRepositoryInfo?> LoadInfoAsync()
     {
         await using var scope = _serviceScopeFactory.CreateAsyncScope();
         var logger = scope.ServiceProvider.GetRequiredService<ILogger<GitInformation>>();
         var command = scope.ServiceProvider.GetRequiredService<ICommandContext>();
         var gitCommandRunner = scope.ServiceProvider.GetRequiredService<IGitCommandRunner>();
+        var root = await GetOutput(
+            command,
+            logger,
+            new GitRevParseOptions { ShowToplevel = true }).ConfigureAwait(false);
 
-        await VerifyGitAvailable(command).ConfigureAwait(false);
-
-        var tasks = new List<Task>();
-
-        Async(async () =>
+        if (string.IsNullOrWhiteSpace(root))
         {
-            var root = await GetOutput(command, logger, new GitRevParseOptions { ShowToplevel = true }).ConfigureAwait(false);
-            Root = root != null ? new Folder(root) : throw new InvalidOperationException("Not a git repository");
-        });
-
-        Async(async () => BranchName = await GetOutput(command, logger, new GitBranchOptions { ShowCurrent = true }).ConfigureAwait(false) ?? "");
-
-        Async(async () => DefaultBranchName = await GetDefaultBranchName(command, logger).ConfigureAwait(false) ?? "");
-
-        Async(async () => LastCommitSha = await GetOutput(command, logger, new GitRevParseOptions { Committish = "HEAD" }).ConfigureAwait(false) ?? "");
-
-        Async(async () => LastCommitShortSha = await GetOutput(command, logger, new GitRevParseOptions { Short = true, Committish = "HEAD" }).ConfigureAwait(false) ?? "");
-
-        Async(async () => Tag = await GetOutput(command, logger, new GitDescribeOptions { Tags = true }).ConfigureAwait(false) ?? "");
-
-        Async(async () =>
-        {
-            var countStr = await GetOutput(command, logger, new GitRevListOptions { Count = true, Ref = "HEAD" }).ConfigureAwait(false);
-            CommitsOnBranch = int.TryParse(countStr, out var count) ? count : 0;
-        });
-
-        Async(async () =>
-        {
-            var timestampStr = await GetOutput(command, logger, new GitLogOptions { Format = GitConstants.AuthorTimestampFormat, MaxCount = "1" }).ConfigureAwait(false);
-            LastCommitDateTime = long.TryParse(timestampStr, out var timestamp)
-                ? DateTimeOffset.FromUnixTimeSeconds(timestamp)
-                : DateTimeOffset.MinValue;
-        });
-
-        Async(async () => PreviousCommit = await GetPreviousCommit(gitCommandRunner).ConfigureAwait(false));
-
-        await Task.WhenAll(tasks).ConfigureAwait(false);
-        return;
-
-        void Async(Func<Task> task) => tasks.Add(task());
-    }
-
-    private static async Task VerifyGitAvailable(ICommandContext command)
-    {
-        try
-        {
-            await command.ExecuteCommandLineTool(
-                new GenericCommandLineToolOptions("git")
-                {
-                    Arguments = ["version"],
-                },
-                new CommandExecutionOptions
-                {
-                    LogSettings = CommandLoggingOptions.Silent,
-                }).ConfigureAwait(false);
+            return null;
         }
-        catch (Exception e)
+
+        var branchName = GetOutput(
+            command,
+            logger,
+            new GitBranchOptions { ShowCurrent = true });
+        var defaultBranchName = GetDefaultBranchName(command, logger);
+        var lastCommitSha = GetOutput(
+            command,
+            logger,
+            new GitRevParseOptions { Committish = "HEAD" });
+        var lastCommitShortSha = GetOutput(
+            command,
+            logger,
+            new GitRevParseOptions { Short = true, Committish = "HEAD" });
+        var tag = GetOutput(
+            command,
+            logger,
+            new GitDescribeOptions { Tags = true });
+        var commitCount = GetOutput(
+            command,
+            logger,
+            new GitRevListOptions { Count = true, Ref = "HEAD" });
+        var lastCommitTimestamp = GetOutput(
+            command,
+            logger,
+            new GitLogOptions { Format = GitConstants.AuthorTimestampFormat, MaxCount = "1" });
+        var previousCommit = GetPreviousCommit(gitCommandRunner);
+
+        await Task.WhenAll(
+            branchName,
+            defaultBranchName,
+            lastCommitSha,
+            lastCommitShortSha,
+            tag,
+            commitCount,
+            lastCommitTimestamp,
+            previousCommit).ConfigureAwait(false);
+
+        return new GitRepositoryInfo(new Folder(root))
         {
-            throw new InvalidOperationException("Git is not available. Ensure git is installed and in PATH.", e);
-        }
+            BranchName = NullIfEmpty(await branchName.ConfigureAwait(false)),
+            DefaultBranchName = NullIfEmpty(await defaultBranchName.ConfigureAwait(false)),
+            LastCommitSha = NullIfEmpty(await lastCommitSha.ConfigureAwait(false)),
+            LastCommitShortSha = NullIfEmpty(await lastCommitShortSha.ConfigureAwait(false)),
+            Tag = NullIfEmpty(await tag.ConfigureAwait(false)),
+            CommitsOnBranch = ParseInt32(await commitCount.ConfigureAwait(false)),
+            LastCommitDateTime = ParseTimestamp(await lastCommitTimestamp.ConfigureAwait(false)),
+            PreviousCommit = await previousCommit.ConfigureAwait(false),
+        };
     }
 
     private static async Task<string?> GetDefaultBranchName(ICommandContext command, ILogger logger)
@@ -170,28 +193,20 @@ internal class GitInformation : IGitInformation, IInitializer
         return string.IsNullOrWhiteSpace(output) ? null : _gitCommitMapper.Map(output);
     }
 
-    public IAsyncEnumerable<GitCommit> Commits(GitOptions? options = null, CancellationToken cancellationToken = default)
+    private static string? NullIfEmpty(string? value)
     {
-        return Commits(null, options, cancellationToken);
+        return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 
-    public async IAsyncEnumerable<GitCommit> Commits(string? branch, GitOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    private static int? ParseInt32(string? value)
     {
-        await using var scope = _serviceScopeFactory.CreateAsyncScope();
-        var gitCommandRunner = scope.ServiceProvider.GetRequiredService<IGitCommandRunner>();
+        return int.TryParse(value, out var result) ? result : null;
+    }
 
-        var index = 0;
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            var output = await gitCommandRunner.RunCommandsOrNull(null, "log", branch, $"--skip={index}", "-1", $"--format={GitConstants.CommitLogFormat}").ConfigureAwait(false);
-
-            if (string.IsNullOrWhiteSpace(output))
-            {
-                yield break;
-            }
-
-            index++;
-            yield return _gitCommitMapper.Map(output);
-        }
+    private static DateTimeOffset? ParseTimestamp(string? value)
+    {
+        return long.TryParse(value, out var timestamp)
+            ? DateTimeOffset.FromUnixTimeSeconds(timestamp)
+            : null;
     }
 }

--- a/src/ModularPipelines.Git/GitVersioning.cs
+++ b/src/ModularPipelines.Git/GitVersioning.cs
@@ -61,6 +61,9 @@ internal class GitVersioning : IGitVersioning
                 return _prefetchedGitVersionInformation;
             }
 
+            var repositoryInfo = await _gitInformation.GetInfoAsync().ConfigureAwait(false)
+                ?? throw new InvalidOperationException("Git repository information is unavailable.");
+
             await _command.ExecuteCommandLineTool(new GenericCommandLineToolOptions("dotnet")
             {
                 Arguments =
@@ -73,7 +76,7 @@ internal class GitVersioning : IGitVersioning
                 ],
             }).ConfigureAwait(false);
 
-            await TryWriteConfigurationFile().ConfigureAwait(false);
+            await TryWriteConfigurationFile(repositoryInfo.Root).ConfigureAwait(false);
 
             var gitVersionOutput = await _command.ExecuteCommandLineTool(
                 new GenericCommandLineToolOptions(Path.Combine(_temporaryFolder, "dotnet-gitversion"))
@@ -85,7 +88,7 @@ internal class GitVersioning : IGitVersioning
                 },
                 new CommandExecutionOptions
                 {
-                    WorkingDirectory = _gitInformation.Root.Path,
+                    WorkingDirectory = repositoryInfo.Root.Path,
                 }).ConfigureAwait(false);
 
             return _prefetchedGitVersionInformation ??=
@@ -97,11 +100,11 @@ internal class GitVersioning : IGitVersioning
         }
     }
 
-    private async Task TryWriteConfigurationFile()
+    private async Task TryWriteConfigurationFile(Folder root)
     {
         try
         {
-            var file = new File(Path.Combine(_gitInformation.Root.Path, "GitVersion.yml"));
+            var file = new File(Path.Combine(root.Path, "GitVersion.yml"));
 
             if (!file.Exists)
             {

--- a/src/ModularPipelines.Git/IGit.cs
+++ b/src/ModularPipelines.Git/IGit.cs
@@ -1,5 +1,3 @@
-using ModularPipelines.FileSystem;
-
 namespace ModularPipelines.Git;
 
 public interface IGit
@@ -9,6 +7,4 @@ public interface IGit
     IGitInformation Information { get; }
 
     IGitVersioning Versioning { get; }
-
-    Folder RootDirectory { get; }
 }

--- a/src/ModularPipelines.Git/IGitInformation.cs
+++ b/src/ModularPipelines.Git/IGitInformation.cs
@@ -1,17 +1,18 @@
-using ModularPipelines.FileSystem;
 using ModularPipelines.Git.Models;
+using ModularPipelines.Git.Options;
 
 namespace ModularPipelines.Git;
 
 public interface IGitInformation
 {
-    Folder Root { get; }
-    string BranchName { get; }
-    string DefaultBranchName { get; }
-    string LastCommitSha { get; }
-    string LastCommitShortSha { get; }
-    string Tag { get; }
-    int CommitsOnBranch { get; }
-    DateTimeOffset LastCommitDateTime { get; }
-    GitCommit? PreviousCommit { get; }
+    Task<GitRepositoryInfo?> GetInfoAsync();
+
+    IAsyncEnumerable<GitCommit> Commits(
+        GitOptions? options = null,
+        CancellationToken cancellationToken = default);
+
+    IAsyncEnumerable<GitCommit> Commits(
+        string? branch,
+        GitOptions? options = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines.Git/Models/GitRepositoryInfo.cs
+++ b/src/ModularPipelines.Git/Models/GitRepositoryInfo.cs
@@ -1,0 +1,22 @@
+using ModularPipelines.FileSystem;
+
+namespace ModularPipelines.Git.Models;
+
+public sealed record GitRepositoryInfo(Folder Root)
+{
+    public string? BranchName { get; init; }
+
+    public string? DefaultBranchName { get; init; }
+
+    public string? LastCommitSha { get; init; }
+
+    public string? LastCommitShortSha { get; init; }
+
+    public string? Tag { get; init; }
+
+    public int? CommitsOnBranch { get; init; }
+
+    public DateTimeOffset? LastCommitDateTime { get; init; }
+
+    public GitCommit? PreviousCommit { get; init; }
+}

--- a/test/ModularPipelines.UnitTests/Attributes/BranchConditionLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/BranchConditionLoggingTests.cs
@@ -3,6 +3,7 @@ using ModularPipelines.Context;
 using ModularPipelines.Context.Domains;
 using ModularPipelines.Git;
 using ModularPipelines.Git.Attributes;
+using ModularPipelines.Git.Models;
 using ModularPipelines.Logging;
 using Moq;
 
@@ -15,8 +16,11 @@ public class BranchConditionLoggingTests
     {
         var logger = new Mock<IModuleLogger>();
         logger.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(true);
-        var gitInformation = Mock.Of<IGitInformation>(x => x.BranchName == string.Empty);
-        var git = Mock.Of<IGit>(x => x.Information == gitInformation);
+        var gitInformation = new Mock<IGitInformation>();
+        gitInformation.Setup(x => x.GetInfoAsync())
+            .ReturnsAsync(new GitRepositoryInfo(
+                new ModularPipelines.FileSystem.Folder(TestContext.WorkingDirectory)));
+        var git = Mock.Of<IGit>(x => x.Information == gitInformation.Object);
         var services = new Mock<IServicesContext>();
         services.Setup(x => x.Get<IGit>()).Returns(git);
         var context = Mock.Of<IPipelineContext>(x =>

--- a/test/ModularPipelines.UnitTests/Context/GitInformationTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/GitInformationTests.cs
@@ -1,5 +1,10 @@
-using ModularPipelines.Context;
+﻿using ModularPipelines.Context;
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Context.Domains.Shell;
+using Moq;
+using ModularPipelines.Git;
 using ModularPipelines.Git.Extensions;
+using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 
 namespace ModularPipelines.UnitTests.Context;
@@ -7,15 +12,44 @@ namespace ModularPipelines.UnitTests.Context;
 public class GitInformationTests : TestBase
 {
     [Test]
-    public async Task Can_Send_Request_With_String_To_Request_Implicit_Conversion()
+    public async Task Repository_Info_Is_Cached()
     {
         var context = await GetService<IPipelineContext>();
-
         var gitInformation = context.Git().Information;
+        var first = await gitInformation.GetInfoAsync();
+        var second = await gitInformation.GetInfoAsync();
 
-        var branch = gitInformation.BranchName;
+        using (Assert.Multiple())
+        {
+            await Assert.That(first).IsNotNull();
+            await Assert.That(ReferenceEquals(first, second)).IsTrue();
+        }
+    }
 
-        // BranchName is empty string in detached HEAD (e.g., CI merge ref checkout)
-        await Assert.That(branch).IsNotNull();
+    [Test]
+    public async Task Resolving_Service_Does_Not_Run_Git_Commands()
+    {
+        var command = new Mock<ICommandContext>();
+        var result = await GetService<IGitInformation>((_, services) =>
+            services.AddSingleton<ICommandContext>(command.Object));
+
+        command.VerifyNoOtherCalls();
+        await result.Host.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Unavailable_Git_Returns_Null()
+    {
+        var command = new Mock<ICommandContext>();
+        command.Setup(x => x.ExecuteCommandLineTool(
+                It.IsAny<CommandLineToolOptions>(),
+                It.IsAny<CommandExecutionOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("git unavailable"));
+        var result = await GetService<IGitInformation>((_, services) =>
+            services.AddSingleton<ICommandContext>(command.Object));
+
+        await Assert.That(await result.T.GetInfoAsync()).IsNull();
+        await result.Host.DisposeAsync();
     }
 }

--- a/test/ModularPipelines.UnitTests/FileSystem/FolderTests.cs
+++ b/test/ModularPipelines.UnitTests/FileSystem/FolderTests.cs
@@ -38,9 +38,9 @@ public class FolderTests : TestBase
     {
         protected internal override async Task<ModularPipelines.FileSystem.File?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            await Task.CompletedTask;
-
-            return context.Git().RootDirectory.FindFile(x => x.Name == "README.md");
+            var repositoryInfo = await context.Git().Information.GetInfoAsync()
+                ?? throw new InvalidOperationException("Git repository information is unavailable.");
+            return repositoryInfo.Root.FindFile(x => x.Name == "README.md");
         }
     }
 
@@ -65,8 +65,8 @@ public class FolderTests : TestBase
     public async Task FindFile()
     {
         var git = await GetService<IGit>();
-
-        var readme = git.RootDirectory.FindFile(x => x.Name == "README.md");
+        var repositoryInfo = await git.Information.GetInfoAsync();
+        var readme = repositoryInfo?.Root.FindFile(x => x.Name == "README.md");
         await Assert.That(readme).IsNotNull();
         await Assert.That(readme!.Exists).IsTrue();
     }
@@ -94,8 +94,8 @@ public class FolderTests : TestBase
     public async Task FindFolder()
     {
         var git = await GetService<IGit>();
-
-        var src = git.RootDirectory.FindFolder(x => x.Name == "src");
+        var repositoryInfo = await git.Information.GetInfoAsync();
+        var src = repositoryInfo?.Root.FindFolder(x => x.Name == "src");
         await Assert.That(src).IsNotNull();
         await Assert.That(src!.Exists).IsTrue();
     }

--- a/test/ModularPipelines.UnitTests/Helpers/BashTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/BashTests.cs
@@ -23,7 +23,9 @@ public class BashTests : TestBase
     {
         protected internal override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            var file = context.Git().RootDirectory.FindFile(x => x.Name == "BashTest.sh");
+            var repositoryInfo = await context.Git().Information.GetInfoAsync()
+                ?? throw new InvalidOperationException("Git repository information is unavailable.");
+            var file = repositoryInfo.Root.FindFile(x => x.Name == "BashTest.sh");
             return await context.Shell.Bash.FromFile(new BashFileOptions(file!), cancellationToken: cancellationToken);
         }
     }

--- a/test/ModularPipelines.UnitTests/Helpers/ChecksumTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/ChecksumTests.cs
@@ -11,8 +11,8 @@ public class ChecksumTests : TestBase
     public async Task Md5_Checksum()
     {
         var git = await GetService<IGit>();
-
-        var file = git.RootDirectory.FindFile(x => x.Name == "Foo.txt");
+        var repositoryInfo = await git.Information.GetInfoAsync();
+        var file = repositoryInfo?.Root.FindFile(x => x.Name == "Foo.txt");
 
         var checksum = await GetService<IChecksumContext>();
 

--- a/test/ModularPipelines.UnitTests/Helpers/DotNetTestResultsTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DotNetTestResultsTests.cs
@@ -22,7 +22,9 @@ public class DotNetTestResultsTests : TestBase
     {
         protected internal override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            var testProject = context.Git().RootDirectory
+            var repositoryInfo = await context.Git().Information.GetInfoAsync()
+                ?? throw new InvalidOperationException("Git repository information is unavailable.");
+            var testProject = repositoryInfo.Root
                 .FindFile(x => x.Name == "ModularPipelines.TestsForTests.csproj")!;
 
             return await context.DotNet().Test(
@@ -51,7 +53,9 @@ public class DotNetTestResultsTests : TestBase
 
         protected internal override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            var testProject = context.Git().RootDirectory
+            var repositoryInfo = await context.Git().Information.GetInfoAsync()
+                ?? throw new InvalidOperationException("Git repository information is unavailable.");
+            var testProject = repositoryInfo.Root
                 .FindFile(x => x.Name == "ModularPipelines.TestsForTests.csproj")!;
 
             var outputDir = testProject.Folder!.GetFolder("bin/Debug/net10.0/TestResults");

--- a/test/ModularPipelines.UnitTests/Helpers/DotNetTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DotNetTests.cs
@@ -16,11 +16,14 @@ public class DotNetTests : TestBase
     {
         protected internal override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
+            var repositoryInfo = await context.Git().Information.GetInfoAsync()
+                ?? throw new InvalidOperationException("Git repository information is unavailable.");
+
             // Use main solution explicitly - FindFile returns first match alphabetically
             // which could be ModularPipelines.Analyzers.sln causing flaky failures
             return await context.DotNet().Package.List(new DotNetPackageListOptions
             {
-                Project = context.Git().RootDirectory.FindFile(x => x.Name == "ModularPipelines.sln").AssertExists(),
+                Project = repositoryInfo.Root.FindFile(x => x.Name == "ModularPipelines.sln").AssertExists(),
             }, cancellationToken: cancellationToken);
         }
     }
@@ -29,9 +32,12 @@ public class DotNetTests : TestBase
     {
         protected internal override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
+            var repositoryInfo = await context.Git().Information.GetInfoAsync()
+                ?? throw new InvalidOperationException("Git repository information is unavailable.");
+
             return await context.DotNet().Format(new DotNetFormatOptions
             {
-                ProjectSolution = context.Git().RootDirectory.FindFile(x => x.Name.Contains("TestsForTests")).AssertExists(),
+                ProjectSolution = repositoryInfo.Root.FindFile(x => x.Name.Contains("TestsForTests")).AssertExists(),
             }, cancellationToken: cancellationToken);
         }
     }

--- a/test/ModularPipelines.UnitTests/Helpers/GitTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/GitTests.cs
@@ -43,14 +43,15 @@ public class GitTests : TestBase
     }
 
     [Test]
-    public async Task GitRootDirectory()
+    public async Task GitRepositoryInfo()
     {
         var git = await GetService<IGit>();
+        var repositoryInfo = await git.Information.GetInfoAsync();
 
         using (Assert.Multiple())
         {
-            await Assert.That(git.RootDirectory.Name).IsEqualTo("ModularPipelines");
-            await Assert.That(git.RootDirectory.ListFiles().Select(x => x.Name)).Contains("README.md");
+            await Assert.That(repositoryInfo).IsNotNull();
+            await Assert.That(repositoryInfo!.Root.ListFiles().Select(x => x.Name)).Contains("README.md");
         }
     }
 
@@ -58,6 +59,16 @@ public class GitTests : TestBase
     public async Task DefaultBranchName()
     {
         var git = await GetService<IGit>();
-        await Assert.That(git.Information.DefaultBranchName).IsEqualTo("main");
+        var repositoryInfo = await git.Information.GetInfoAsync();
+        await Assert.That(repositoryInfo?.DefaultBranchName).IsEqualTo("main");
+    }
+
+    [Test]
+    public async Task Commits_Are_Available_Through_Interface()
+    {
+        var git = await GetService<IGit>();
+        await using var commits = git.Information.Commits().GetAsyncEnumerator();
+
+        await Assert.That(await commits.MoveNextAsync()).IsTrue();
     }
 }

--- a/test/ModularPipelines.UnitTests/Helpers/ZipTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/ZipTests.cs
@@ -71,9 +71,9 @@ public class ZipTests : TestBase
     {
         protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            await Task.Yield();
-
-            var directory = context.Git().RootDirectory.GetFolder("test")
+            var repositoryInfo = await context.Git().Information.GetInfoAsync()
+                ?? throw new InvalidOperationException("Git repository information is unavailable.");
+            var directory = repositoryInfo.Root.GetFolder("test")
                 .GetFolder("ModularPipelines.UnitTests")
                 .GetFolder("Data")
                 .GetFolder("Zip");

--- a/test/ModularPipelines.UnitTests/Models/TrxParsingTests.cs
+++ b/test/ModularPipelines.UnitTests/Models/TrxParsingTests.cs
@@ -53,7 +53,9 @@ public class TrxParsingTests : TestBase
 
         protected internal override async Task<DotNetTestResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            var testProject = context.Git().RootDirectory
+            var repositoryInfo = await context.Git().Information.GetInfoAsync()
+                ?? throw new InvalidOperationException("Git repository information is unavailable.");
+            var testProject = repositoryInfo.Root
                 .FindFile(x => x.Name == "ModularPipelines.TestsForTests.csproj")!;
 
             // Create a temp directory for test results


### PR DESCRIPTION
## Summary
- load Git repository metadata only when `GetInfoAsync()` is called and cache the result
- represent unavailable repositories and unavailable metadata with honest nullable values
- expose `Commits(...)` through `IGitInformation` and migrate consumers/docs

## Validation
- `ModularPipelines.Git.sln` Release build (0 warnings, 0 errors)
- `ModularPipelines.Build.csproj` Release build (0 errors; existing baseline warnings)
- focused `GitInformationTests`, `GitTests`, and `BranchConditionLoggingTests` (8 passed)
- scoped whitespace format verification

Closes #3280