### PR TITLE
Make environment working directory read-only

### DIFF
--- a/src/ModularPipelines/Context/Domains/IEnvironmentDomainContext.cs
+++ b/src/ModularPipelines/Context/Domains/IEnvironmentDomainContext.cs
@@ -29,9 +29,13 @@ public interface IEnvironmentDomainContext
     string UserName { get; }
 
     /// <summary>
-    /// The current working directory.
+    /// Gets the working directory captured when the pipeline context was created.
     /// </summary>
-    string WorkingDirectory { get; set; }
+    /// <remarks>
+    /// To run a command in another directory, set
+    /// <see cref="Options.CommandExecutionOptions.WorkingDirectory"/>.
+    /// </remarks>
+    string WorkingDirectory { get; }
 
     /// <summary>
     /// Environment variable operations.

--- a/src/ModularPipelines/Context/Domains/IEnvironmentDomainContext.cs
+++ b/src/ModularPipelines/Context/Domains/IEnvironmentDomainContext.cs
@@ -9,22 +9,22 @@ namespace ModularPipelines.Context.Domains;
 public interface IEnvironmentDomainContext
 {
     /// <summary>
-    /// The current operating system.
+    /// Gets the current operating system.
     /// </summary>
     OSPlatform OperatingSystem { get; }
 
     /// <summary>
-    /// The processor architecture.
+    /// Gets the processor architecture.
     /// </summary>
     Architecture Architecture { get; }
 
     /// <summary>
-    /// The machine name.
+    /// Gets the machine name.
     /// </summary>
     string MachineName { get; }
 
     /// <summary>
-    /// The current user name.
+    /// Gets the current user name.
     /// </summary>
     string UserName { get; }
 
@@ -38,12 +38,12 @@ public interface IEnvironmentDomainContext
     string WorkingDirectory { get; }
 
     /// <summary>
-    /// Environment variable operations.
+    /// Gets environment variable operations.
     /// </summary>
     IEnvironmentVariablesContext Variables { get; }
 
     /// <summary>
-    /// CI/CD build system detection.
+    /// Gets CI/CD build system detection.
     /// </summary>
     IBuildSystemContext BuildSystem { get; }
 }

--- a/src/ModularPipelines/Context/Domains/Implementations/EnvironmentDomainContext.cs
+++ b/src/ModularPipelines/Context/Domains/Implementations/EnvironmentDomainContext.cs
@@ -11,10 +11,10 @@ internal class EnvironmentDomainContext : IEnvironmentDomainContext
     /// <summary>
     /// Cached operating system platform detected at class load time.
     /// </summary>
-    private static readonly OSPlatform s_operatingSystem = DetectOperatingSystem();
+    private static readonly OSPlatform OperatingSystemValue = DetectOperatingSystem();
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="EnvironmentDomainContext"/> class.
+    /// Initialises a new instance of the <see cref="EnvironmentDomainContext"/> class.
     /// </summary>
     /// <param name="variables">The environment variables context.</param>
     /// <param name="buildSystem">The build system context.</param>
@@ -28,7 +28,7 @@ internal class EnvironmentDomainContext : IEnvironmentDomainContext
     }
 
     /// <inheritdoc />
-    public OSPlatform OperatingSystem => s_operatingSystem;
+    public OSPlatform OperatingSystem => OperatingSystemValue;
 
     /// <summary>
     /// Detects the operating system platform.

--- a/src/ModularPipelines/Context/Domains/Implementations/EnvironmentDomainContext.cs
+++ b/src/ModularPipelines/Context/Domains/Implementations/EnvironmentDomainContext.cs
@@ -70,7 +70,7 @@ internal class EnvironmentDomainContext : IEnvironmentDomainContext
     public string UserName => System.Environment.UserName;
 
     /// <inheritdoc />
-    public string WorkingDirectory { get; set; }
+    public string WorkingDirectory { get; }
 
     /// <inheritdoc />
     public IEnvironmentVariablesContext Variables { get; }

--- a/test/ModularPipelines.UnitTests/Context/ContextHierarchyTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextHierarchyTests.cs
@@ -79,6 +79,17 @@ public class ContextHierarchyTests
     }
 
     [Test]
+    public async Task IEnvironmentDomainContext_WorkingDirectory_ShouldBeReadOnly()
+    {
+        var workingDirectoryProperty = typeof(IEnvironmentDomainContext).GetProperty("WorkingDirectory");
+
+        await Assert.That(workingDirectoryProperty).IsNotNull();
+        await Assert.That(workingDirectoryProperty!.CanRead).IsTrue();
+        await Assert.That(workingDirectoryProperty.CanWrite).IsFalse()
+            .Because("parallel modules must not mutate shared working-directory state");
+    }
+
+    [Test]
     public async Task IModuleContext_ShouldHaveGetModuleMethods()
     {
         var moduleContextType = typeof(IModuleContext);


### PR DESCRIPTION
## Summary
- remove the public setter from IEnvironmentDomainContext.WorkingDirectory
- keep the pipeline-initialization working-directory snapshot immutable
- document CommandExecutionOptions.WorkingDirectory as the per-command alternative
- add API regression coverage for the read-only contract

## Validation
- ContextHierarchyTests: 6 passed
- EnvironmentContextTests: 5 passed

Closes #3300