### PR TITLE
Restore incremental generator caching

### DIFF
--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -192,7 +192,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 GetNamedInt(attribute, "Phase", defaultValue: PassthroughCommandLinePhase),
                 0,
                 null,
-                [],
+                EquatableArray<string>.Empty,
                 isGlobalOption);
         }
 
@@ -209,7 +209,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 GetNamedInt(attribute, "Phase"),
                 0,
                 null,
-                [],
+                EquatableArray<string>.Empty,
                 isGlobalOption);
         }
 
@@ -224,7 +224,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             GetNamedInt(attribute, "Phase"),
             GetNamedInt(attribute, "ValueArity"),
             GetNamedString(attribute, "CustomSeparator"),
-            [],
+            EquatableArray<string>.Empty,
             isGlobalOption);
     }
 
@@ -436,8 +436,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
 
     private static string NullableLiteral(string? value) => value is null ? "null" : Literal(value);
 
-    private static string StringArrayLiteral(ImmutableArray<string> values) =>
-        values.Length == 0
+    private static string StringArrayLiteral(EquatableArray<string> values) =>
+        values.Count == 0
             ? "global::System.Array.Empty<string>()"
             : $"new string[] {{ {string.Join(", ", values.Select(Literal))} }}";
 
@@ -451,11 +451,11 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         PropertyCollection SecretMetadata);
 
     private sealed record PropertyCollection(
-        ImmutableArray<PropertyMetadata> Properties,
+        EquatableArray<PropertyMetadata> Properties,
         bool IsComplete,
         bool HasAttributes)
     {
-        public static PropertyCollection Empty { get; } = new([], true, false);
+        public static PropertyCollection Empty { get; } = new(EquatableArray<PropertyMetadata>.Empty, true, false);
     }
 
     private sealed record PropertyMetadata(
@@ -469,7 +469,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         int Phase,
         int ValueArity,
         string? CustomSeparator,
-        ImmutableArray<string> SecretValueKeys,
+        EquatableArray<string> SecretValueKeys,
         bool IsGlobalOption);
 
     private enum PropertyKind

--- a/src/ModularPipelines.SourceGenerator/EquatableArray.cs
+++ b/src/ModularPipelines.SourceGenerator/EquatableArray.cs
@@ -1,0 +1,72 @@
+using System.Collections;
+using System.Collections.Immutable;
+
+namespace ModularPipelines.SourceGenerator;
+
+/// <summary>
+/// An immutable array whose equality is based on its elements.
+/// </summary>
+internal readonly struct EquatableArray<T> : IReadOnlyList<T>, IEquatable<EquatableArray<T>>
+{
+    private readonly ImmutableArray<T> _items;
+
+    public EquatableArray(ImmutableArray<T> items)
+    {
+        _items = items.IsDefault ? ImmutableArray<T>.Empty : items;
+    }
+
+    public static EquatableArray<T> Empty { get; } = new(ImmutableArray<T>.Empty);
+
+    public int Count => Items.Length;
+
+    public bool IsEmpty => Items.IsEmpty;
+
+    public T this[int index] => Items[index];
+
+    private ImmutableArray<T> Items => _items.IsDefault ? ImmutableArray<T>.Empty : _items;
+
+    public bool Equals(EquatableArray<T> other)
+    {
+        var items = Items;
+        var otherItems = other.Items;
+        if (items.Length != otherItems.Length)
+        {
+            return false;
+        }
+
+        var comparer = EqualityComparer<T>.Default;
+        for (var i = 0; i < items.Length; i++)
+        {
+            if (!comparer.Equals(items[i], otherItems[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override bool Equals(object? obj) => obj is EquatableArray<T> other && Equals(other);
+
+    public override int GetHashCode()
+    {
+        var hashCode = 17;
+        var comparer = EqualityComparer<T>.Default;
+        foreach (var item in Items)
+        {
+            hashCode = unchecked((hashCode * 31) + (item is null ? 0 : comparer.GetHashCode(item)));
+        }
+
+        return hashCode;
+    }
+
+    public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>) Items).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public static implicit operator EquatableArray<T>(ImmutableArray<T> items) => new(items);
+
+    public static bool operator ==(EquatableArray<T> left, EquatableArray<T> right) => left.Equals(right);
+
+    public static bool operator !=(EquatableArray<T> left, EquatableArray<T> right) => !left.Equals(right);
+}

--- a/src/ModularPipelines.SourceGenerator/ModuleClassInfo.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleClassInfo.cs
@@ -1,5 +1,3 @@
-using Microsoft.CodeAnalysis;
-
 namespace ModularPipelines.SourceGenerator;
 
 /// <summary>
@@ -7,8 +5,5 @@ namespace ModularPipelines.SourceGenerator;
 /// </summary>
 internal sealed record ModuleClassInfo(
     string Namespace,
-    string ClassName,
-    string ResultTypeName,
-    string ResultTypeFullName,
-    Location Location
+    string ClassName
 );

--- a/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
@@ -485,11 +485,11 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
 
     private sealed record ModuleEventMetadata(
         string TypeName,
-        ImmutableArray<string> Attributes,
+        EquatableArray<string> Attributes,
         bool IsComplete);
 
     private sealed record AttributeMetadata(
-        ImmutableArray<string> Expressions,
+        EquatableArray<string> Expressions,
         bool IsComplete);
 
     private sealed record AttributeCandidate(

--- a/src/ModularPipelines.SourceGenerator/ModuleExtensionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleExtensionsGenerator.cs
@@ -55,7 +55,7 @@ public sealed class ModuleExtensionsGenerator : IIncrementalGenerator
     /// </summary>
     private static ModuleClassInfo? GetModuleClassInfo(GeneratorSyntaxContext context)
     {
-        var classDeclaration = (ClassDeclarationSyntax)context.Node;
+        var classDeclaration = (ClassDeclarationSyntax) context.Node;
         var semanticModel = context.SemanticModel;
 
         // Get the declared symbol for this type
@@ -77,9 +77,8 @@ public sealed class ModuleExtensionsGenerator : IIncrementalGenerator
             return null;
         }
 
-        // Check if this type inherits from Module<T> and get the result type
-        var resultType = GetModuleResultType(typeSymbol, semanticModel.Compilation);
-        if (resultType is null)
+        // Check if this type inherits from Module<T>
+        if (GetModuleResultType(typeSymbol, semanticModel.Compilation) is null)
         {
             return null;
         }
@@ -89,16 +88,9 @@ public sealed class ModuleExtensionsGenerator : IIncrementalGenerator
             ? string.Empty
             : typeSymbol.ContainingNamespace.ToDisplayString();
 
-        // Get type names for code generation
-        var resultTypeName = resultType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-        var resultTypeFullName = resultType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-
         return new ModuleClassInfo(
             Namespace: namespaceName,
-            ClassName: typeSymbol.Name,
-            ResultTypeName: resultTypeName,
-            ResultTypeFullName: resultTypeFullName,
-            Location: classDeclaration.Identifier.GetLocation()
+            ClassName: typeSymbol.Name
         );
     }
 

--- a/test/ModularPipelines.Development.Analyzers.UnitTests/IncrementalGeneratorCachingTests.cs
+++ b/test/ModularPipelines.Development.Analyzers.UnitTests/IncrementalGeneratorCachingTests.cs
@@ -1,0 +1,115 @@
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using ModularPipelines.SourceGenerator;
+
+namespace ModularPipelines.Development.Analyzers.UnitTests;
+
+public class IncrementalGeneratorCachingTests
+{
+    [Test]
+    public async Task Module_Extensions_Are_Cached_After_Trivia_Changes()
+    {
+        const string source = """
+                              namespace ModularPipelines.Modules
+                              {
+                                  public abstract class Module<T>;
+                              }
+
+                              namespace Consumer
+                              {
+                                  public class CacheTarget : ModularPipelines.Modules.Module<string>;
+                              }
+                              """;
+
+        await AssertOutputIsCachedAfterTriviaChange(new ModuleExtensionsGenerator(), source);
+    }
+
+    [Test]
+    public async Task Command_Metadata_Is_Cached_After_Trivia_Changes()
+    {
+        const string source = """
+                              namespace ModularPipelines.Options
+                              {
+                                  public abstract class CommandLineToolOptions;
+                              }
+
+                              namespace ModularPipelines.Attributes
+                              {
+                                  [System.AttributeUsage(System.AttributeTargets.Property)]
+                                  public sealed class CliOptionAttribute(string name) : System.Attribute;
+                              }
+
+                              namespace Consumer
+                              {
+                                  public class CacheTarget : ModularPipelines.Options.CommandLineToolOptions
+                                  {
+                                      [ModularPipelines.Attributes.CliOptionAttribute("--value")]
+                                      public string? Value { get; init; }
+                                  }
+                              }
+                              """;
+
+        await AssertOutputIsCachedAfterTriviaChange(new CommandOptionsGenerator(), source);
+    }
+
+    [Test]
+    public async Task Module_Event_Metadata_Is_Cached_After_Trivia_Changes()
+    {
+        const string source = """
+                              namespace ModularPipelines.Modules
+                              {
+                                  public abstract class Module<T>;
+                              }
+
+                              namespace Consumer
+                              {
+                                  [System.AttributeUsage(System.AttributeTargets.Class)]
+                                  public sealed class SampleAttribute(string value) : System.Attribute;
+
+                                  [Sample("value")]
+                                  public class CacheTarget : ModularPipelines.Modules.Module<string>;
+                              }
+                              """;
+
+        await AssertOutputIsCachedAfterTriviaChange(new ModuleEventMetadataGenerator(), source);
+    }
+
+    private static async Task AssertOutputIsCachedAfterTriviaChange(
+        IIncrementalGenerator generator,
+        string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create(
+            "GeneratorCachingTests",
+            [syntaxTree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            [generator.AsSourceGenerator()],
+            driverOptions: new GeneratorDriverOptions(
+                IncrementalGeneratorOutputKind.None,
+                trackIncrementalGeneratorSteps: true));
+
+        driver = driver.RunGenerators(compilation);
+
+        var changedSource = source.Replace(
+            "public class CacheTarget",
+            "public  class CacheTarget",
+            StringComparison.Ordinal);
+        var changedSyntaxTree = syntaxTree.WithChangedText(SourceText.From(changedSource, Encoding.UTF8));
+        driver = driver.RunGenerators(compilation.ReplaceSyntaxTree(syntaxTree, changedSyntaxTree));
+
+        var result = driver.GetRunResult().Results.Single();
+        var outputReasons = result.TrackedOutputSteps.Values
+            .SelectMany(steps => steps)
+            .SelectMany(step => step.Outputs)
+            .Select(output => output.Reason)
+            .ToArray();
+
+        await Assert.That(result.GeneratedSources).IsNotEmpty();
+        await Assert.That(outputReasons).IsNotEmpty();
+        await Assert.That(outputReasons.All(reason => reason == IncrementalStepRunReason.Cached)).IsTrue();
+    }
+}

--- a/test/ModularPipelines.Development.Analyzers.UnitTests/ModularPipelines.Development.Analyzers.UnitTests.csproj
+++ b/test/ModularPipelines.Development.Analyzers.UnitTests/ModularPipelines.Development.Analyzers.UnitTests.csproj
@@ -15,5 +15,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ModularPipelines.Development.Analyzers\ModularPipelines.Development.Analyzers.csproj" />
+    <ProjectReference Include="..\..\src\ModularPipelines.SourceGenerator\ModularPipelines.SourceGenerator.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #3303

## Summary
- reduce module extension cache inputs to the two strings used by generation
- add value-equality `EquatableArray<T>` for incremental generator model collections
- use deep-equal collections throughout command and module-event metadata models
- add generator-driver regressions that require cached output after trivia-only edits

## Validation
- `ModularPipelines.sln` Release build: passed (0 errors; 254 existing warnings)
- `IncrementalGeneratorCachingTests`: 3/3 passed
- source-generator project Release build: passed
- changed-file whitespace format and `git diff --check`: passed