### PR TITLE
Pack referenced analyzer outputs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,7 +38,7 @@
       <ProjectReference Include="$(MSBuildThisFileDirectory)src\ModularPipelines.Development.Analyzers\ModularPipelines.Development.Analyzers.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(MSBuildProjectName)' != 'ModularPipelines.SourceGenerator' and '$(MSBuildProjectName)' != 'ModularPipelines.Development.Analyzers' and '$(MSBuildProjectName)' != 'ModularPipelines.Build'">
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'ModularPipelines' and '$(MSBuildProjectName)' != 'ModularPipelines.SourceGenerator' and '$(MSBuildProjectName)' != 'ModularPipelines.Development.Analyzers' and '$(MSBuildProjectName)' != 'ModularPipelines.Build'">
       <ProjectReference Include="$(MSBuildThisFileDirectory)src\ModularPipelines.SourceGenerator\ModularPipelines.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 </Project>

--- a/src/ModularPipelines/ModularPipelines.csproj
+++ b/src/ModularPipelines/ModularPipelines.csproj
@@ -129,24 +129,34 @@
     <PackageReference Include="YamlDotNet" />
   </ItemGroup>
   <ItemGroup>
-    <!-- Build analyzers (but don't apply them to this project - they're for consumers) -->
-    <ProjectReference Include="..\ModularPipelines.Analyzers\ModularPipelines.Analyzers\ModularPipelines.Analyzers.csproj" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
-    <ProjectReference Include="..\ModularPipelines.Analyzers\ModularPipelines.Analyzers.CodeFixes\ModularPipelines.Analyzers.CodeFixes.csproj" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
+    <!-- Build package analyzers and capture their actual target paths for packing. -->
+    <ProjectReference Include="..\ModularPipelines.SourceGenerator\ModularPipelines.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" PackAsAnalyzer="true" />
+    <ProjectReference Include="..\ModularPipelines.Analyzers\ModularPipelines.Analyzers\ModularPipelines.Analyzers.csproj" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" PackAsAnalyzer="true" />
+    <ProjectReference Include="..\ModularPipelines.Analyzers\ModularPipelines.Analyzers.CodeFixes\ModularPipelines.Analyzers.CodeFixes.csproj" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" PackAsAnalyzer="true" />
   </ItemGroup>
   <ItemGroup>
     <None Include="buildTransitive\ModularPipelines.targets" Pack="true" PackagePath="buildTransitive\ModularPipelines.targets" />
   </ItemGroup>
   <!-- Include source generator and analyzers in NuGet package for consumers -->
   <PropertyGroup>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddSourceGeneratorToPackage</TargetsForTfmSpecificContentInPackage>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzerOutputsToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
-  <Target Name="_AddSourceGeneratorToPackage">
+  <Target Name="_AddAnalyzerOutputsToPackage" DependsOnTargets="PrepareProjectReferences">
     <ItemGroup>
-      <!-- Source Generator -->
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\ModularPipelines.SourceGenerator\bin\$(Configuration)\netstandard2.0\ModularPipelines.SourceGenerator.dll" PackagePath="analyzers/dotnet/cs" />
-      <!-- Analyzers -->
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\ModularPipelines.Analyzers\ModularPipelines.Analyzers\bin\$(Configuration)\netstandard2.0\ModularPipelines.Analyzers.dll" PackagePath="analyzers/dotnet/cs" />
-      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)..\ModularPipelines.Analyzers\ModularPipelines.Analyzers.CodeFixes\bin\$(Configuration)\netstandard2.0\ModularPipelines.Analyzers.CodeFixes.dll" PackagePath="analyzers/dotnet/cs" />
+      <_PackAnalyzerProjectReference Include="@(_MSBuildProjectReferenceExistent)" Condition="'%(_MSBuildProjectReferenceExistent.PackAsAnalyzer)' == 'true'" />
+    </ItemGroup>
+    <MSBuild
+      Projects="@(_PackAnalyzerProjectReference)"
+      Targets="GetTargetPath"
+      BuildInParallel="$(BuildInParallel)"
+      Properties="%(_PackAnalyzerProjectReference.SetConfiguration); %(_PackAnalyzerProjectReference.SetPlatform); %(_PackAnalyzerProjectReference.SetTargetFramework)"
+      RemoveProperties="%(_PackAnalyzerProjectReference.GlobalPropertiesToRemove)$(_GlobalPropertiesToRemoveFromProjectReferences)">
+      <Output TaskParameter="TargetOutputs" ItemName="_PackAnalyzerOutput" />
+    </MSBuild>
+    <Error Condition="'@(_PackAnalyzerOutput)' == ''" Text="No source generator or analyzer project outputs were resolved for packaging." />
+    <Error Condition="!Exists('%(_PackAnalyzerOutput.Identity)')" Text="Package analyzer output '%(_PackAnalyzerOutput.Identity)' does not exist. Build the referenced project before packing." />
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="@(_PackAnalyzerOutput)" PackagePath="analyzers/dotnet/cs" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
Closes #3308

## Summary
- resolve source-generator and analyzer DLLs from their project references via `GetTargetPath`
- make the source generator an explicit packaging project reference so MSBuild owns build ordering
- fail packing when expected analyzer outputs cannot be resolved or are missing

## Validation
- Release pack succeeds and contains exactly the source generator, analyzer, and code-fix DLLs under `analyzers/dotnet/cs`
- pack with a nonstandard absolute `BaseOutputPath` succeeds and resolves all three DLLs from that custom output tree
- Release `--no-build` pack succeeds from existing outputs with the same exact package contents
- XML parsing and `git diff --check` pass