### PR TITLE
Restore module analyzer detection

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AnalyzerConstants.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AnalyzerConstants.cs
@@ -20,11 +20,6 @@ internal static class AnalyzerConstants
         internal const string Module = "Module";
 
         /// <summary>
-        /// The ModuleBase type name.
-        /// </summary>
-        internal const string ModuleBase = "ModuleBase";
-
-        /// <summary>
         /// The DependsOn attribute type name.
         /// </summary>
         internal const string DependsOn = "DependsOn";

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -48,7 +48,7 @@ public class Module1 : Module<CommandResult>
     protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
         // This is fine - awaiting something else
-        var otherModule = GetModule<Module2>();
+        var otherModule = context.GetModule<Module2>();
         await otherModule;
         return null;
     }}
@@ -86,7 +86,7 @@ public class NotAModule
 }
 ";
 
-    private const string GoodModuleSourceAwaitThisInOnAfterExecute = $@"
+    private const string GoodModuleSourceAwaitThisInOnAfterExecuteAsync = $@"
 {TestSourceConstants.StandardModuleHeaderWithOptions}
 
 public class Module1 : Module<CommandResult>
@@ -96,10 +96,13 @@ public class Module1 : Module<CommandResult>
         return Task.FromResult<CommandResult?>(null);
     }}
 
-    protected override async Task OnAfterExecute(IModuleContext context)
+    protected override async Task<ModuleResult<CommandResult>?> OnAfterExecuteAsync(
+        IModuleContext context,
+        ModuleResult<CommandResult> result,
+        CancellationToken cancellationToken)
     {{
-        // This should NOT trigger the analyzer - await this is allowed in OnAfterExecute
-        var result = await this;
+        // This should NOT trigger the analyzer - await this is allowed in OnAfterExecuteAsync
+        return await this;
     }}
 }}
 ";
@@ -133,8 +136,8 @@ public class Module1 : Module<CommandResult>
     }
 
     [TestMethod]
-    public async Task AnalyzerIsNotTriggered_When_AwaitThis_InOnAfterExecute()
+    public async Task AnalyzerIsNotTriggered_When_AwaitThis_InOnAfterExecuteAsync()
     {
-        await VerifyCS.VerifyAnalyzerAsync(GoodModuleSourceAwaitThisInOnAfterExecute);
+        await VerifyCS.VerifyAnalyzerAsync(GoodModuleSourceAwaitThisInOnAfterExecuteAsync);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerConstants.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerConstants.cs
@@ -66,9 +66,9 @@ internal static class AnalyzerConstants
         internal const string FromResult = "FromResult";
 
         /// <summary>
-        /// The OnAfterExecute method name from Module.
+        /// The OnAfterExecuteAsync method name from Module.
         /// </summary>
-        internal const string OnAfterExecute = "OnAfterExecute";
+        internal const string OnAfterExecuteAsync = "OnAfterExecuteAsync";
     }
 
     /// <summary>

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerConstants.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerConstants.cs
@@ -20,11 +20,6 @@ internal static class AnalyzerConstants
         internal const string Module = "Module";
 
         /// <summary>
-        /// The ModuleBase type name.
-        /// </summary>
-        internal const string ModuleBase = "ModuleBase";
-
-        /// <summary>
         /// The DependsOn attribute type name.
         /// </summary>
         internal const string DependsOn = "DependsOn";
@@ -113,6 +108,11 @@ internal static class AnalyzerConstants
     /// </summary>
     internal static class FullyQualifiedTypeNames
     {
+        /// <summary>
+        /// The metadata name for the generic Module&lt;T&gt; base type.
+        /// </summary>
+        internal const string Module = "ModularPipelines.Modules.Module`1";
+
         /// <summary>
         /// The fully qualified System.Console type in global:: format.
         /// </summary>

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AsyncModuleAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AsyncModuleAnalyzer.cs
@@ -54,7 +54,7 @@ public class AsyncModuleAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (context.GetClassThatNodeIsIn().GetSelfAndAllBaseTypes().All(x => x.Name != AnalyzerConstants.TypeNames.ModuleBase))
+        if (!context.GetClassThatNodeIsIn().IsModule(context.Compilation))
         {
             return;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
@@ -45,14 +45,14 @@ public class AwaitThisAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check if we're inside a module class (inherits from ModuleBase)
+        // Check if we're inside a module class.
         var containingClass = context.GetClassThatNodeIsIn();
         if (containingClass == null)
         {
             return;
         }
 
-        if (containingClass.GetSelfAndAllBaseTypes().All(x => x.Name != AnalyzerConstants.TypeNames.ModuleBase))
+        if (!containingClass.IsModule(context.Compilation))
         {
             return;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
@@ -57,9 +57,9 @@ public class AwaitThisAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check if we're inside the OnAfterExecute method - if so, allow await this
+        // Check if we're inside the OnAfterExecuteAsync method - if so, allow await this
         var containingMethod = awaitExpression.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-        if (containingMethod?.Identifier.Text == AnalyzerConstants.MethodNames.OnAfterExecute)
+        if (containingMethod?.Identifier.Text == AnalyzerConstants.MethodNames.OnAfterExecuteAsync)
         {
             return;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Extensions/SymbolExtensions.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Extensions/SymbolExtensions.cs
@@ -53,6 +53,16 @@ internal static class SymbolExtensions
     }
 
     /// <summary>
+    /// Checks if the type inherits from the generic module base type.
+    /// </summary>
+    internal static bool IsModule(this ITypeSymbol? typeSymbol, Compilation compilation)
+    {
+        return typeSymbol.InheritsFrom(
+            compilation,
+            AnalyzerConstants.FullyQualifiedTypeNames.Module);
+    }
+
+    /// <summary>
     /// Checks if the type symbol matches the specified type by metadata name.
     /// Handles both generic and non-generic types using OriginalDefinition for generic type comparison.
     /// </summary>
@@ -124,15 +134,6 @@ internal static class SymbolExtensions
             }
 
             classSymbol = baseType;
-        }
-    }
-
-    internal static IEnumerable<INamedTypeSymbol> GetSelfAndAllBaseTypes(this INamedTypeSymbol? classSymbol)
-    {
-        while (classSymbol != null)
-        {
-            yield return classSymbol;
-            classSymbol = classSymbol.BaseType;
         }
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
@@ -22,7 +22,7 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
     public const string DiagnosticId = "StatefulModule";
 
     /// <summary>
-    /// Diagnostic rule for stateful modules.
+    /// Gets the diagnostic rule for stateful modules.
     /// </summary>
     public static DiagnosticDescriptor Rule { get; } = DiagnosticDescriptorFactory.Create(
         DiagnosticId,

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
@@ -57,8 +57,8 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check if this class inherits from Module<T> or ModuleBase
-        if (!IsModuleClass(classSymbol, context.Compilation))
+        // Check if this class inherits from Module<T>.
+        if (!classSymbol.IsModule(context.Compilation))
         {
             return;
         }
@@ -71,25 +71,6 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
                 AnalyzeField(context, fieldSymbol, classSymbol);
             }
         }
-    }
-
-    private static bool IsModuleClass(INamedTypeSymbol classSymbol, Compilation compilation)
-    {
-        // Check for Module<T> (generic)
-        var moduleGenericType = compilation.GetTypeByMetadataName("ModularPipelines.Modules.Module`1");
-        if (moduleGenericType is not null && classSymbol.InheritsFrom(moduleGenericType))
-        {
-            return true;
-        }
-
-        // Check for ModuleBase (non-generic base)
-        var moduleBaseType = compilation.GetTypeByMetadataName("ModularPipelines.Modules.ModuleBase");
-        if (moduleBaseType is not null && classSymbol.InheritsFrom(moduleBaseType))
-        {
-            return true;
-        }
-
-        return false;
     }
 
     private static void AnalyzeField(SyntaxNodeAnalysisContext context, IFieldSymbol fieldSymbol, INamedTypeSymbol classSymbol)

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -72,7 +72,7 @@ public class CommandLoggerTests : TestBase
         const string firstLine = "first-output-line";
         const string secondLine = "second-output-line";
         var receivedOutputs = new List<string>();
-        var command = await GetService<ICommand>();
+        var command = await GetService<ICommandContext>();
 
         var result = await command.ExecuteCommandLineTool(
             new PowershellScriptOptions($"Write-Output '{firstLine}'; Write-Output '{secondLine}'"),
@@ -314,7 +314,7 @@ public class CommandLoggerTests : TestBase
         var readyFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".ready");
         var releaseFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".release");
         using var logObserver = new StreamingLogObserver(marker, errorMarker);
-        var result = await GetService<ICommand>((_, collection) =>
+        var result = await GetService<ICommandContext>((_, collection) =>
         {
             collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
             collection.AddLogging(builder => builder.AddProvider(logObserver));

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -475,7 +475,9 @@ public class ModuleExecutorLoggingTests
             registrationEvents.Object,
             Mock.Of<IMetricsCollector>(),
             new ModuleDependencyRegistry(),
-            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()),
             new SecondaryExceptionContainer(),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -39,7 +39,7 @@ public class CommandTests : TestBase
     [Test]
     public async Task Command_Execution_Caps_Captured_Output_With_Head_And_Tail()
     {
-        var command = await GetService<ICommand>();
+        var command = await GetService<ICommandContext>();
         var result = await command.ExecuteCommandLineTool(
             new PowershellScriptOptions("Write-Output '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'"),
             new CommandExecutionOptions { MaxCapturedOutputLength = 10 });


### PR DESCRIPTION
## Summary
- recognize `Module<T>` through Roslyn symbol identity instead of the removed `ModuleBase` name
- share the generic module semantic check across AsyncModule, AwaitThis, and StatefulModule
- remove dead ModuleBase constants and inheritance traversal

## Validation
- `ModularPipelines.Analyzers.sln` Release build passes
- analyzer project Release build passes
- changed-file whitespace verification passes
- focused legacy tests emit all three expected diagnostics; assertions remain blocked by the existing net8/net10 reference mismatch tracked in #3310

Closes #3309