### PR TITLE
Run consumer analyzer tests in CI

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,6 +62,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="2.3.3" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="18.5.40034" />
     <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="MSTest" Version="4.3.3" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.3.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,8 +63,6 @@
     <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="18.5.40034" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="MSTest" Version="4.3.3" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NReco.Logging.File" Version="1.3.1" />
     <PackageVersion Include="NUnit" Version="4.6.1" />

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AnalyzerConstants.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AnalyzerConstants.cs
@@ -20,11 +20,6 @@ internal static class AnalyzerConstants
         internal const string Module = "Module";
 
         /// <summary>
-        /// The ModuleBase type name.
-        /// </summary>
-        internal const string ModuleBase = "ModuleBase";
-
-        /// <summary>
         /// The DependsOn attribute type name.
         /// </summary>
         internal const string DependsOn = "DependsOn";

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelines.Analyzers.Test.csproj
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelines.Analyzers.Test.csproj
@@ -1,15 +1,17 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="MSTest.TestAdapter" />
-    <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="Microsoft.Testing.Extensions.HangDump" />
+    <PackageReference Include="MSTest" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" />

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
@@ -19,7 +19,7 @@ public class Module1 : Module<CommandResult>
 
     private async Task<CommandResult?> ExecuteCommand(IModuleContext context)
     {{
-        return await context.Command.ExecuteCommandLineTool(new CommandLineToolOptions(""git""));
+        return await context.Shell.Command.ExecuteCommandLineTool(new GenericCommandLineToolOptions(""git""));
     }}
 }}
 ";
@@ -59,7 +59,7 @@ public class Module1 : Module<CommandResult>
 
     private async Task<CommandResult?> ExecuteCommand(IModuleContext context)
     {{
-        return await context.Command.ExecuteCommandLineTool(new CommandLineToolOptions(""git""));
+        return await context.Shell.Command.ExecuteCommandLineTool(new GenericCommandLineToolOptions(""git""));
     }}
 }}
 ";
@@ -124,19 +124,19 @@ public class Module1 : Module<string>
     {
         await VerifyCS.VerifyAnalyzerAsync(GoodModuleSource);
     }
-    
+
     [TestMethod]
     public async Task AnalyzerIsNotTriggered_When_TaskFromResult()
     {
         await VerifyCS.VerifyAnalyzerAsync(GoodModuleSource2);
     }
-    
+
     [TestMethod]
     public async Task AnalyzerIsNotTriggered_When_AsTaskExtension()
     {
         await VerifyCS.VerifyAnalyzerAsync(GoodModuleSource3);
     }
-    
+
     [TestMethod]
     public async Task CodeFixWorks()
     {
@@ -144,7 +144,7 @@ public class Module1 : Module<string>
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSource, expected, GoodModuleSource);
     }
-    
+
     [TestMethod]
     public async Task CodeFixWorks_With_Mixed_TaskFromResult_And_Actual_Async()
     {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -48,7 +48,7 @@ public class Module1 : Module<CommandResult>
     protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
         // This is fine - awaiting something else
-        var otherModule = GetModule<Module2>();
+        var otherModule = context.GetModule<Module2>();
         await otherModule;
         return null;
     }}
@@ -86,7 +86,7 @@ public class NotAModule
 }
 ";
 
-    private const string GoodModuleSourceAwaitThisInOnAfterExecute = $@"
+    private const string GoodModuleSourceAwaitThisInOnAfterExecuteAsync = $@"
 {TestSourceConstants.StandardModuleHeaderWithOptions}
 
 public class Module1 : Module<CommandResult>
@@ -96,10 +96,13 @@ public class Module1 : Module<CommandResult>
         return Task.FromResult<CommandResult?>(null);
     }}
 
-    protected override async Task OnAfterExecute(IModuleContext context)
+    protected override async Task<ModuleResult<CommandResult>?> OnAfterExecuteAsync(
+        IModuleContext context,
+        ModuleResult<CommandResult> result,
+        CancellationToken cancellationToken)
     {{
-        // This should NOT trigger the analyzer - await this is allowed in OnAfterExecute
-        var result = await this;
+        // This should NOT trigger the analyzer - await this is allowed in OnAfterExecuteAsync
+        return await this;
     }}
 }}
 ";
@@ -133,8 +136,8 @@ public class Module1 : Module<CommandResult>
     }
 
     [TestMethod]
-    public async Task AnalyzerIsNotTriggered_When_AwaitThis_InOnAfterExecute()
+    public async Task AnalyzerIsNotTriggered_When_AwaitThis_InOnAfterExecuteAsync()
     {
-        await VerifyCS.VerifyAnalyzerAsync(GoodModuleSourceAwaitThisInOnAfterExecute);
+        await VerifyCS.VerifyAnalyzerAsync(GoodModuleSourceAwaitThisInOnAfterExecuteAsync);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersBaseClassAttributeUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersBaseClassAttributeUnitTests.cs
@@ -24,7 +24,7 @@ namespace ModularPipelines.Examples.Modules;";
 
     private const string BaseTypeWithAttribute = $@"{SimplerModuleHeader}
 
-public class Module1 : Module
+public class Module1 : Module<IDictionary<string, object>>
 {{
     protected override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
@@ -37,20 +37,20 @@ public class Module2 : DependsOnModule1
 {{
     protected override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
-        var module1 = await {{|#0:GetModule<Module1>()|}};
+        var module1 = await {{|#0:context.GetModule<Module1>()|}};
         return null;
     }}
 }}
 
 [DependsOn<Module1>]
-public abstract class DependsOnModule1 : Module
+public abstract class DependsOnModule1 : Module<IDictionary<string, object>>
 {{
 }}
 ";
 
     private const string InterfaceWithAttribute = $@"{SimplerModuleHeader}
 
-public class Module1 : Module
+public class Module1 : Module<IDictionary<string, object>>
 {{
     protected override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
@@ -59,11 +59,11 @@ public class Module1 : Module
     }}
 }}
 
-public class Module2 : Module, IDependsOnModule1
+public class Module2 : Module<IDictionary<string, object>>, IDependsOnModule1
 {{
     protected override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
-        var module1 = await {{|#0:GetModule<Module1>()|}};
+        var module1 = await {{|#0:context.GetModule<Module1>()|}};
         return null;
     }}
 }}

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -7,7 +7,9 @@ namespace ModularPipelines.Analyzers.Test;
 public class ModularPipelinesAnalyzersConsoleUnitTests
 {
     private static string CreateBadModuleSource(string consoleCall, bool isAsync = false) => $@"
-{TestSourceConstants.StandardModuleHeader}
+{TestSourceConstants.StandardUsings}
+
+namespace AnalyzerExamples;
 
 public class Module1 : Module<List<string>>
 {{

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersIEnumerableUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersIEnumerableUnitTests.cs
@@ -14,7 +14,7 @@ public class Module1 : {{|#0:Module<IEnumerable<string>>|}}
     protected override async Task<IEnumerable<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
         await Task.Delay(1, cancellationToken);
-        return new ModuleResult<IEnumerable<string>>(Array.Empty<string>().Select(x => x));
+        return Array.Empty<string>().Select(x => x);
     }}
 }}
 ";

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersInvalidDependsOnTypeUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersInvalidDependsOnTypeUnitTests.cs
@@ -20,7 +20,7 @@ public class ModularPipelinesAnalyzersInvalidDependsOnTypeUnitTests
 
 public class NotAModule {{ }}
 
-[{{|#0:DependsOn<NotAModule>|}}]
+[{{|#0:DependsOn(typeof(NotAModule))|}}]
 public class Module1 : Module<List<string>>
 {SimpleModuleBody}
 ";

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -12,7 +12,7 @@ public class ModularPipelinesAnalyzersStatefulModuleUnitTests
 
 public class Module1 : Module<string>
 {{
-    private string {{|#0:_state|}};
+    private string {{|#0:_state|}} = string.Empty;
 
     protected override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
@@ -30,7 +30,7 @@ public class Module1 : Module<int>
 {{
     private List<string> {{|#0:_items|}} = new();
 
-    protected override async Task<int?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
         await Task.Delay(1, cancellationToken);
         _items.Add(""item"");
@@ -46,7 +46,7 @@ public class Module1 : Module<int>
 {{
     private Dictionary<string, int> {{|#0:_cache|}} = new();
 
-    protected override async Task<int?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
         await Task.Delay(1, cancellationToken);
         _cache[""key""] = 42;
@@ -62,7 +62,7 @@ public class Module1 : Module<int>
 {{
     private int {{|#0:_counter|}};
 
-    protected override async Task<int?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
         await Task.Delay(1, cancellationToken);
         _counter++;
@@ -83,7 +83,7 @@ public class Module1 : Module<int>
 {{
     private MyCache {{|#0:_cache|}} = new();
 
-    protected override async Task<int?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
         await Task.Delay(1, cancellationToken);
         _cache.Items[""key""] = ""value"";
@@ -180,7 +180,7 @@ namespace ModularPipelines.Examples.Other;
 
 public class NotAModule
 {
-    private string _state;
+    private string _state = string.Empty;
 
     public void DoSomething()
     {
@@ -192,7 +192,7 @@ public class NotAModule
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableField()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0);
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0).WithArguments("_state", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableField, expected);
     }
@@ -200,7 +200,7 @@ public class NotAModule
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableCollection()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0);
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0).WithArguments("_items", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableCollection, expected);
     }
@@ -208,7 +208,7 @@ public class NotAModule
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableDictionary()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0);
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0).WithArguments("_cache", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableDictionary, expected);
     }
@@ -216,7 +216,7 @@ public class NotAModule
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableCounter()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0);
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0).WithArguments("_counter", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableCounter, expected);
     }
@@ -224,7 +224,7 @@ public class NotAModule
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableCustomClass()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0);
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0).WithArguments("_cache", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableCustomClass, expected);
     }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
@@ -20,7 +20,7 @@ using ModularPipelines.Modules;
 
 namespace ModularPipelines.Examples.Modules;
 
-public class Module1 : Module
+public class Module1 : Module<IDictionary<string, object>>
 {
     protected override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -29,11 +29,11 @@ public class Module1 : Module
     }
 }
 
-public class Module2 : Module
+public class Module2 : Module<IDictionary<string, object>>
 {
     protected override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var module1 = await {|#0:GetModule<Module1>()|};
+        var module1 = await {|#0:context.GetModule<Module1>()|};
         return null;
     }
 }";
@@ -49,7 +49,7 @@ using ModularPipelines.Modules;
 using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Examples.Modules;
-public class Module1 : Module
+public class Module1 : Module<IDictionary<string, object>>
 {
     protected override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
@@ -59,11 +59,11 @@ public class Module1 : Module
 }
 
 [DependsOn<Module1>]
-public class Module2 : Module
+public class Module2 : Module<IDictionary<string, object>>
 {
     protected override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var module1 = await GetModule<Module1>();
+        var module1 = await context.GetModule<Module1>();
         return null;
     }
 }";
@@ -105,6 +105,9 @@ public class Module2 : Module
 
         var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId).WithArguments("Module1").WithLocation(0);
 
-        await VerifyCS.VerifyCodeFixAsync(BadModuleSource, expected, FixedModuleSource);
+        await VerifyCS.VerifyCodeFixAsync(
+            BadModuleSource.ReplaceLineEndings(),
+            expected,
+            FixedModuleSource.ReplaceLineEndings());
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Net.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Net.cs
@@ -5,27 +5,15 @@ namespace ModularPipelines.Analyzers.Test;
 
 internal static class Net
 {
-    private static readonly Lazy<ReferenceAssemblies> LazyNet60 = new(() =>
-        new ReferenceAssemblies(
-                "net6.0",
-                new PackageIdentity(
-                    "Microsoft.NETCore.App.Ref",
-                    "6.0.21"),
-                Path.Combine("ref", "net6.0"))
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.Extensions.Logging", "6.0.0")))
-        );
-
-    public static ReferenceAssemblies Net60 => LazyNet60.Value;
-
-    private static readonly Lazy<ReferenceAssemblies> LazyNet80 = new(() =>
+    private static readonly Lazy<ReferenceAssemblies> LazyNet100 = new(() =>
         new ReferenceAssemblies(
                 "net10.0",
                 new PackageIdentity(
                     "Microsoft.NETCore.App.Ref",
-                    "8.0.6"),
+                    "10.0.10"),
                 Path.Combine("ref", "net10.0"))
-            .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.Extensions.Logging", "8.0.0")))
-    );
+            .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.Extensions.Logging", "10.0.10")))
+        );
 
-    public static ReferenceAssemblies Net80 => LazyNet80.Value;
+    public static ReferenceAssemblies Net100 => LazyNet100.Value;
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier`1.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Verifiers/CSharpAnalyzerVerifier`1.cs
@@ -27,7 +27,7 @@ public static partial class CSharpAnalyzerVerifier<TAnalyzer>
         var test = new Test
         {
             TestCode = source,
-            ReferenceAssemblies = Net.Net80,
+            ReferenceAssemblies = Net.Net100,
             TestState =
             {
                 AdditionalReferences = { typeof(IModuleContext).Assembly.Location },

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -29,7 +29,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         var test = new Test
         {
             TestCode = source,
-            ReferenceAssemblies = Net.Net80,
+            ReferenceAssemblies = Net.Net100,
             CodeActionValidationMode = CodeActionValidationMode.SemanticStructure,
             TestState =
             {
@@ -56,7 +56,7 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         {
             TestCode = source,
             FixedCode = fixedSource,
-            ReferenceAssemblies = Net.Net80,
+            ReferenceAssemblies = Net.Net100,
             TestState =
             {
                 AdditionalReferences = { typeof(IModuleContext).Assembly.Location },

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerConstants.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerConstants.cs
@@ -66,9 +66,9 @@ internal static class AnalyzerConstants
         internal const string FromResult = "FromResult";
 
         /// <summary>
-        /// The OnAfterExecute method name from Module.
+        /// The OnAfterExecuteAsync method name from Module.
         /// </summary>
-        internal const string OnAfterExecute = "OnAfterExecute";
+        internal const string OnAfterExecuteAsync = "OnAfterExecuteAsync";
     }
 
     /// <summary>

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerConstants.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AnalyzerConstants.cs
@@ -20,11 +20,6 @@ internal static class AnalyzerConstants
         internal const string Module = "Module";
 
         /// <summary>
-        /// The ModuleBase type name.
-        /// </summary>
-        internal const string ModuleBase = "ModuleBase";
-
-        /// <summary>
         /// The DependsOn attribute type name.
         /// </summary>
         internal const string DependsOn = "DependsOn";
@@ -113,6 +108,11 @@ internal static class AnalyzerConstants
     /// </summary>
     internal static class FullyQualifiedTypeNames
     {
+        /// <summary>
+        /// The metadata name for the generic Module&lt;T&gt; base type.
+        /// </summary>
+        internal const string Module = "ModularPipelines.Modules.Module`1";
+
         /// <summary>
         /// The fully qualified System.Console type in global:: format.
         /// </summary>

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AsyncModuleAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AsyncModuleAnalyzer.cs
@@ -54,7 +54,7 @@ public class AsyncModuleAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (context.GetClassThatNodeIsIn().GetSelfAndAllBaseTypes().All(x => x.Name != AnalyzerConstants.TypeNames.ModuleBase))
+        if (!context.GetClassThatNodeIsIn().IsModule(context.Compilation))
         {
             return;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
@@ -45,14 +45,14 @@ public class AwaitThisAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check if we're inside a module class (inherits from ModuleBase)
+        // Check if we're inside a module class.
         var containingClass = context.GetClassThatNodeIsIn();
         if (containingClass == null)
         {
             return;
         }
 
-        if (containingClass.GetSelfAndAllBaseTypes().All(x => x.Name != AnalyzerConstants.TypeNames.ModuleBase))
+        if (!containingClass.IsModule(context.Compilation))
         {
             return;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AwaitThisAnalyzer.cs
@@ -57,9 +57,9 @@ public class AwaitThisAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check if we're inside the OnAfterExecute method - if so, allow await this
+        // Check if we're inside the OnAfterExecuteAsync method - if so, allow await this
         var containingMethod = awaitExpression.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-        if (containingMethod?.Identifier.Text == AnalyzerConstants.MethodNames.OnAfterExecute)
+        if (containingMethod?.Identifier.Text == AnalyzerConstants.MethodNames.OnAfterExecuteAsync)
         {
             return;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Extensions/SymbolExtensions.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Extensions/SymbolExtensions.cs
@@ -53,6 +53,16 @@ internal static class SymbolExtensions
     }
 
     /// <summary>
+    /// Checks if the type inherits from the generic module base type.
+    /// </summary>
+    internal static bool IsModule(this ITypeSymbol? typeSymbol, Compilation compilation)
+    {
+        return typeSymbol.InheritsFrom(
+            compilation,
+            AnalyzerConstants.FullyQualifiedTypeNames.Module);
+    }
+
+    /// <summary>
     /// Checks if the type symbol matches the specified type by metadata name.
     /// Handles both generic and non-generic types using OriginalDefinition for generic type comparison.
     /// </summary>
@@ -124,15 +134,6 @@ internal static class SymbolExtensions
             }
 
             classSymbol = baseType;
-        }
-    }
-
-    internal static IEnumerable<INamedTypeSymbol> GetSelfAndAllBaseTypes(this INamedTypeSymbol? classSymbol)
-    {
-        while (classSymbol != null)
-        {
-            yield return classSymbol;
-            classSymbol = classSymbol.BaseType;
         }
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/MissingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/MissingDependsOnAttributeAnalyzer.cs
@@ -39,7 +39,14 @@ public class MissingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (invocationExpressionSyntax.Expression is not GenericNameSyntax genericNameSyntax)
+        var genericNameSyntax = invocationExpressionSyntax.Expression switch
+        {
+            GenericNameSyntax directGenericName => directGenericName,
+            MemberAccessExpressionSyntax { Name: GenericNameSyntax memberGenericName } => memberGenericName,
+            _ => null,
+        };
+
+        if (genericNameSyntax is null)
         {
             return;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
@@ -22,7 +22,7 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
     public const string DiagnosticId = "StatefulModule";
 
     /// <summary>
-    /// Diagnostic rule for stateful modules.
+    /// Gets the diagnostic rule for stateful modules.
     /// </summary>
     public static DiagnosticDescriptor Rule { get; } = DiagnosticDescriptorFactory.Create(
         DiagnosticId,

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
@@ -57,8 +57,8 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Check if this class inherits from Module<T> or ModuleBase
-        if (!IsModuleClass(classSymbol, context.Compilation))
+        // Check if this class inherits from Module<T>.
+        if (!classSymbol.IsModule(context.Compilation))
         {
             return;
         }
@@ -71,25 +71,6 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
                 AnalyzeField(context, fieldSymbol, classSymbol);
             }
         }
-    }
-
-    private static bool IsModuleClass(INamedTypeSymbol classSymbol, Compilation compilation)
-    {
-        // Check for Module<T> (generic)
-        var moduleGenericType = compilation.GetTypeByMetadataName("ModularPipelines.Modules.Module`1");
-        if (moduleGenericType is not null && classSymbol.InheritsFrom(moduleGenericType))
-        {
-            return true;
-        }
-
-        // Check for ModuleBase (non-generic base)
-        var moduleBaseType = compilation.GetTypeByMetadataName("ModularPipelines.Modules.ModuleBase");
-        if (moduleBaseType is not null && classSymbol.InheritsFrom(moduleBaseType))
-        {
-            return true;
-        }
-
-        return false;
     }
 
     private static void AnalyzeField(SyntaxNodeAnalysisContext context, IFieldSymbol fieldSymbol, INamedTypeSymbol classSymbol)

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunConsumerAnalyzersUnitTestsModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunConsumerAnalyzersUnitTestsModule.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Options;
+using ModularPipelines.Build.Settings;
+
+namespace ModularPipelines.Build.Modules.UnitTests;
+
+public class RunConsumerAnalyzersUnitTestsModule(IOptions<PipelineSettings> pipelineSettings)
+    : RunUnitTestModule(pipelineSettings)
+{
+    protected override string TestProjectFileName => "ModularPipelines.Analyzers.Test.csproj";
+}

--- a/src/ModularPipelines.Build/Program.cs
+++ b/src/ModularPipelines.Build/Program.cs
@@ -58,6 +58,7 @@ builder
     .AddModule<RunTrivyUnitTestsModule>()
     .AddModule<RunAzureUnitTestsModule>()
     .AddModule<RunAnalyzersUnitTestsModule>()
+    .AddModule<RunConsumerAnalyzersUnitTestsModule>()
     .AddModule<RunDistributedUnitTestsModule>()
     .AddModule<RunDistributedRedisUnitTestsModule>()
     .AddModule<RunDistributedArtifactsS3UnitTestsModule>()

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -72,7 +72,7 @@ public class CommandLoggerTests : TestBase
         const string firstLine = "first-output-line";
         const string secondLine = "second-output-line";
         var receivedOutputs = new List<string>();
-        var command = await GetService<ICommand>();
+        var command = await GetService<ICommandContext>();
 
         var result = await command.ExecuteCommandLineTool(
             new PowershellScriptOptions($"Write-Output '{firstLine}'; Write-Output '{secondLine}'"),
@@ -314,7 +314,7 @@ public class CommandLoggerTests : TestBase
         var readyFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".ready");
         var releaseFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".release");
         using var logObserver = new StreamingLogObserver(marker, errorMarker);
-        var result = await GetService<ICommand>((_, collection) =>
+        var result = await GetService<ICommandContext>((_, collection) =>
         {
             collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
             collection.AddLogging(builder => builder.AddProvider(logObserver));

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -475,7 +475,9 @@ public class ModuleExecutorLoggingTests
             registrationEvents.Object,
             Mock.Of<IMetricsCollector>(),
             new ModuleDependencyRegistry(),
-            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()),
             new SecondaryExceptionContainer(),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -39,7 +39,7 @@ public class CommandTests : TestBase
     [Test]
     public async Task Command_Execution_Caps_Captured_Output_With_Head_And_Tail()
     {
-        var command = await GetService<ICommand>();
+        var command = await GetService<ICommandContext>();
         var result = await command.ExecuteCommandLineTool(
             new PowershellScriptOptions("Write-Output '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'"),
             new CommandExecutionOptions { MaxCapturedOutputLength = 10 });


### PR DESCRIPTION
Closes #3310

## Summary
- add and register a build-pipeline module for the consumer analyzer test project
- migrate that legacy MSTest project to the repository's Microsoft.Testing.Platform runner so the module actually executes tests
- replace dead/mislabeled net6/net8 fixtures with one net10.0 reference-assembly fixture pinned to 10.0.10
- include the coverage, TRX, and hang-dump extensions expected by `RunUnitTestModule`

## Validation
- Microsoft.Testing.Platform discovers and executes all 49 consumer analyzer tests with the pipeline's coverage/TRX/hang-dump options
- the now-live suite exposes 27 pre-existing analyzer/v4-fixture failures being addressed by #3309, #3311, and follow-up fixture cleanup
- `git diff --check` passes