### PR TITLE
Add focused CI analyzer lane

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,6 +19,79 @@ on:
         default: true
 
 jobs:
+  analyzers:
+    name: analyzers
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      EnableCiAnalyzers: "true"
+      MSBUILDDISABLENODEREUSE: "1"
+      DOTNET_gcServer: "0"
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6.0.0
+        with:
+          dotnet-version: 10.0.x
+      - name: Cache NuGet
+        uses: actions/cache@v6
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-analyzers-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-analyzers-
+            ${{ runner.os }}-nuget-
+      - name: Restore core solution
+        run: dotnet restore ModularPipelines.sln
+      - name: Build core solution with analyzers
+        # Report existing analyzer debt without failing; the next step gates warning-level
+        # diagnostics in changed files so the baseline can only improve.
+        run: >
+          dotnet build ModularPipelines.sln
+          -c Release
+          --no-restore
+          -p:RunAnalyzers=true
+          -p:RunAnalyzersDuringBuild=true
+          -p:TreatWarningsAsErrors=false
+      - name: Verify analyzer fixes in changed C# files
+        shell: pwsh
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          $baseSha = $env:BASE_SHA
+          if ([string]::IsNullOrWhiteSpace($baseSha) -or $baseSha -match '^0+$') {
+            $baseSha = 'HEAD^'
+          }
+
+          $changedFiles = @(
+            git diff --name-only --diff-filter=ACMRT $baseSha $env:GITHUB_SHA -- '*.cs'
+          )
+
+          if ($changedFiles.Count -eq 0) {
+            Write-Output 'No changed C# files require analyzer verification.'
+            exit 0
+          }
+
+          $formatArguments = @(
+            'format',
+            'ModularPipelines.sln',
+            'analyzers',
+            '--no-restore',
+            '--verify-no-changes',
+            '--severity',
+            'warn',
+            '--include'
+          ) + $changedFiles
+
+          & dotnet @formatArguments
+          exit $LASTEXITCODE
+
   pipeline:
     name: ${{ matrix.check_name }}
     environment: ${{ github.ref == 'refs/heads/main' && 'Production' || 'Pull Requests' }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,9 +14,15 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- The dedicated analyzer job opts back in while other CI builds stay lean. -->
+    <EnableCiAnalyzers Condition="'$(EnableCiAnalyzers)' == ''">false</EnableCiAnalyzers>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true' and '$(EnableCiAnalyzers)' != 'true'">
     <RunAnalyzers>false</RunAnalyzers>
     <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
@@ -31,7 +37,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Condition="$(MSBuildProjectFile.Contains('Test')) == false and '$(GITHUB_ACTIONS)' != 'true'" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Condition="$(MSBuildProjectFile.Contains('Test')) == false and ('$(GITHUB_ACTIONS)' != 'true' or '$(EnableCiAnalyzers)' == 'true')" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' != 'ModularPipelines.Development.Analyzers'">


### PR DESCRIPTION
## Summary
- add a bounded `analyzers` GitHub Actions job for the lightweight core solution
- let that job opt back into project analyzers and StyleCop while regular matrix builds remain lean
- report existing warning debt, then gate warning-level analyzer fixes in changed C# files

## Validation
- simulated `GITHUB_ACTIONS=true` core restore succeeds
- simulated analyzer-enabled core Release build succeeds with analyzers loaded
- changed-file `dotnet format analyzers --verify-no-changes` command succeeds
- `Directory.Build.props` parses as XML

Closes #3316