### PR TITLE
Bound Ubuntu pipeline runtime

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -110,9 +110,10 @@ jobs:
             check_name: pipeline (ubuntu-latest)
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Healthy runs normally finish in 20-25 minutes, with a recent 39-minute outlier.
-    # Bound runner-starvation failures while leaving headroom for that observed variance.
-    timeout-minutes: 45
+    # Most healthy runs finish in 20-25 minutes, but a known successful run took 55 minutes.
+    # Keep margin above that variance while bounding starvation well below GitHub's six-hour
+    # default; hang diagnostics still upload from the always-run artifact step.
+    timeout-minutes: 75
     env:
       # Tear down MSBuild worker/compiler nodes after each build instead of keeping them
       # resident. BuildSolutionsModule builds several solutions in sequence; with node reuse

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -110,10 +110,9 @@ jobs:
             check_name: pipeline (ubuntu-latest)
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    # Bound the job so a stuck pipeline fails fast instead of tying up a runner for the
-    # default 6 hours. The "Upload Hang Dumps" step runs on if:always() so dumps are
-    # still collected when this timeout trips.
-    timeout-minutes: 60
+    # Healthy runs normally finish in 20-25 minutes, with a recent 39-minute outlier.
+    # Bound runner-starvation failures while leaving headroom for that observed variance.
+    timeout-minutes: 45
     env:
       # Tear down MSBuild worker/compiler nodes after each build instead of keeping them
       # resident. BuildSolutionsModule builds several solutions in sequence; with node reuse


### PR DESCRIPTION
## Summary
- raise the Ubuntu pipeline job timeout from 60 to 75 minutes
- retain 20 minutes of headroom above the observed 55-minute successful outlier
- keep the cross-platform build timeout at 60 minutes because its workload is smaller and does not run the full Ubuntu pipeline
- keep existing memory controls instead of adding the disproven `-maxcpucount:2` cap

## Validation
- parsed `.github/workflows/dotnet.yml` successfully
- `git diff --check`
- reviewed recent Ubuntu job durations: typical 18-25 minutes, maximum successful sample about 55 minutes

Closes #3335