### PR TITLE
Restore latest main unit-test compilation

### DIFF
--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -72,7 +72,7 @@ public class CommandLoggerTests : TestBase
         const string firstLine = "first-output-line";
         const string secondLine = "second-output-line";
         var receivedOutputs = new List<string>();
-        var command = await GetService<ICommand>();
+        var command = await GetService<ICommandContext>();
 
         var result = await command.ExecuteCommandLineTool(
             new PowershellScriptOptions($"Write-Output '{firstLine}'; Write-Output '{secondLine}'"),
@@ -314,7 +314,7 @@ public class CommandLoggerTests : TestBase
         var readyFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".ready");
         var releaseFile = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".release");
         using var logObserver = new StreamingLogObserver(marker, errorMarker);
-        var result = await GetService<ICommand>((_, collection) =>
+        var result = await GetService<ICommandContext>((_, collection) =>
         {
             collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
             collection.AddLogging(builder => builder.AddProvider(logObserver));

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -475,7 +475,9 @@ public class ModuleExecutorLoggingTests
             registrationEvents.Object,
             Mock.Of<IMetricsCollector>(),
             new ModuleDependencyRegistry(),
-            new ModuleMetadataRegistry(Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions())),
+            new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()),
             new SecondaryExceptionContainer(),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -39,7 +39,7 @@ public class CommandTests : TestBase
     [Test]
     public async Task Command_Execution_Caps_Captured_Output_With_Head_And_Tail()
     {
-        var command = await GetService<ICommand>();
+        var command = await GetService<ICommandContext>();
         var result = await command.ExecuteCommandLineTool(
             new PowershellScriptOptions("Write-Output '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'"),
             new CommandExecutionOptions { MaxCapturedOutputLength = 10 });


### PR DESCRIPTION
## Summary
- supply `ModuleAttributeEventService` to the `ModuleMetadataRegistry` test fixture
- migrate stale test-only `ICommand` resolutions to the public `ICommandContext`
- restore compilation of `ModularPipelines.UnitTests` on latest `main`

## Validation
- `ModularPipelines.UnitTests.csproj` Release build: 0 warnings, 0 errors
- `CommandLoggerTests`: 41 passed
- `CommandTests`: 14 passed
- `ModuleExecutorLoggingTests`: 10 passed
- `git diff --check`

Follow-up to #3353, #3363, and #3372.