### PR TITLE
Report Markdown formatting diffs in CI

### DIFF
--- a/src/ModularPipelines.Build/GitHelpers.cs
+++ b/src/ModularPipelines.Build/GitHelpers.cs
@@ -3,7 +3,6 @@ using ModularPipelines.Build.Settings;
 using ModularPipelines.Context;
 using ModularPipelines.Git.Extensions;
 using ModularPipelines.Git.Options;
-using ModularPipelines.Options;
 
 namespace ModularPipelines.Build;
 
@@ -43,20 +42,35 @@ public static class GitHelpers
         }, cancellationToken: cancellationToken);
     }
 
-    public static async Task<bool> HasUncommittedChanges(IModuleContext context, IEnumerable<string> paths)
+    internal static async Task<GitDiffDetails?> GetUncommittedChanges(
+        IModuleContext context,
+        IEnumerable<string> paths,
+        CancellationToken cancellationToken)
     {
-        var result = await context.Git().Commands.Diff(
+        var pathArguments = paths.ToArray();
+        var changedFilesResult = await context.Git().Commands.Diff(
             new GitDiffOptions
             {
-                Quiet = true,
-                Arguments = ["--", .. paths],
+                NameOnly = true,
+                Arguments = ["-z", "--", .. pathArguments],
             },
-            new CommandExecutionOptions
-            {
-                ThrowOnNonZeroExitCode = false,
-            });
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        var changedFiles = changedFilesResult.StandardOutput
+            .Split('\0', StringSplitOptions.RemoveEmptyEntries);
+        if (changedFiles.Length == 0)
+        {
+            return null;
+        }
 
-        return result.ExitCode != 0;
+        var diffStatResult = await context.Git().Commands.Diff(
+            new GitDiffOptions
+            {
+                Stat = true,
+                Arguments = ["--", .. pathArguments],
+            },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        return new GitDiffDetails(changedFiles, diffStatResult.StandardOutput.TrimEnd());
     }
 
     private static GitHubSettings GetGitHubSettings(IModuleContext context)
@@ -65,3 +79,5 @@ public static class GitHelpers
         return options?.Value ?? new GitHubSettings();
     }
 }
+
+internal sealed record GitDiffDetails(IReadOnlyList<string> ChangedFiles, string DiffStat);

--- a/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
+++ b/src/ModularPipelines.Build/Modules/FormatMarkdownModule.cs
@@ -72,10 +72,26 @@ public class FormatMarkdownModule : Module<CommandResult>
             }, cancellationToken);
         }
 
-        if (await GitHelpers.HasUncommittedChanges(context, filesToFormat))
+        var changes = await GitHelpers.GetUncommittedChanges(context, filesToFormat, cancellationToken)
+            .ConfigureAwait(false);
+        if (changes is not null)
         {
+            var changedFiles = string.Join(
+                Environment.NewLine,
+                changes.ChangedFiles.Select(file => $"- {file}"));
+
             throw new InvalidOperationException(
-                "Markdown files are not formatted. Run FormatMarkdownModule locally and commit the changes.");
+                $"""
+                 Markdown files are not formatted.
+
+                 Offending files:
+                 {changedFiles}
+
+                 Diff summary:
+                 {changes.DiffStat}
+
+                 Run FormatMarkdownModule locally and commit the changes.
+                 """);
         }
 
         return null;


### PR DESCRIPTION
## Summary
- report each Markdown file changed by the formatter
- include `git diff --stat` output in the CI failure
- keep the existing local-fix guidance

## Validation
- guarded Release build of `src/ModularPipelines.Build/ModularPipelines.Build.csproj`
- targeted `dotnet format --verify-no-changes`
- deterministic source assertions for file and diff diagnostics
- `git diff --check`

Closes #3333