### PR TITLE
Ship dotnet new pipeline template

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -67,8 +67,7 @@ jobs:
             "$RUNNER_TEMP/template-pack/ModularPipelines.Templates.$template_package_version.nupkg"
           dotnet new modularpipeline \
             --name TemplateVersionSmoke \
-            --output "$RUNNER_TEMP/template-version-smoke" \
-            --no-restore
+            --output "$RUNNER_TEMP/template-version-smoke"
           test "$(grep -Fc "Version=\"$template_package_version\"" \
             "$RUNNER_TEMP/template-version-smoke/Directory.Packages.props")" -eq 2
           dotnet new modularpipeline \
@@ -76,8 +75,7 @@ jobs:
             --output "$RUNNER_TEMP/template-smoke" \
             --solution ../Example.slnx \
             --publish-project ../src/Example/Example.csproj \
-            --framework-version "$framework_version" \
-            --no-restore
+            --framework-version "$framework_version"
           grep -F '"Solution": "../Example.slnx"' \
             "$RUNNER_TEMP/template-smoke/appsettings.json"
           grep -F '"PublishProject": "../src/Example/Example.csproj"' \
@@ -100,8 +98,7 @@ jobs:
             --output "$RUNNER_TEMP/template-run" \
             --solution ../Example.slnx \
             --publish-project ../src/Example/Example.csproj \
-            --framework-version "$framework_version" \
-            --no-restore
+            --framework-version "$framework_version"
           mkdir "$RUNNER_TEMP/template-caller"
           (
             cd "$RUNNER_TEMP/template-caller"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -116,12 +116,17 @@ jobs:
             "$RUNNER_TEMP/template-run/TemplateRun.csproj" \
             --configuration Release \
             --output "$RUNNER_TEMP/template-published"
+          cp -R \
+            "$RUNNER_TEMP/template-run" \
+            "$RUNNER_TEMP/relocated-template-run"
+          rm -rf "$RUNNER_TEMP/relocated-template-run/artifacts"
           mkdir "$RUNNER_TEMP/published-caller"
           (
             cd "$RUNNER_TEMP/published-caller"
-            dotnet "$RUNNER_TEMP/template-published/TemplateRun.dll"
+            MODULAR_PIPELINES_DIRECTORY="$RUNNER_TEMP/relocated-template-run" \
+              dotnet "$RUNNER_TEMP/template-published/TemplateRun.dll"
           )
-          test -f "$RUNNER_TEMP/template-run/artifacts/publish/Example.dll"
+          test -f "$RUNNER_TEMP/relocated-template-run/artifacts/publish/Example.dll"
           test ! -d "$RUNNER_TEMP/published-caller/artifacts"
       - name: Run OptionsGenerator unit tests
         run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -98,8 +98,8 @@ jobs:
           dotnet new modularpipeline \
             --name TemplateRun \
             --output "$RUNNER_TEMP/template-run" \
-            --solution "$RUNNER_TEMP/Example.slnx" \
-            --publish-project "$RUNNER_TEMP/src/Example/Example.csproj" \
+            --solution ../Example.slnx \
+            --publish-project ../src/Example/Example.csproj \
             --framework-version "$framework_version" \
             --no-restore
           mkdir "$RUNNER_TEMP/template-caller"
@@ -109,6 +109,8 @@ jobs:
               --project "$RUNNER_TEMP/template-run/TemplateRun.csproj" \
               --configuration Release
           )
+          test -f "$RUNNER_TEMP/template-run/artifacts/publish/Example.dll"
+          test ! -d "$RUNNER_TEMP/template-caller/artifacts"
       - name: Run OptionsGenerator unit tests
         run: |
           dotnet restore tools/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.sln

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -57,17 +57,26 @@ jobs:
       - name: Validate pipeline template
         shell: bash
         run: |
+          framework_version=3.2.8
+          template_package_version=0.0.0-local
           dotnet pack src/ModularPipelines.Templates/ModularPipelines.Templates.csproj \
             -c Release \
-            -p:PackageVersion=0.0.0-local \
+            -p:PackageVersion="$template_package_version" \
             --output "$RUNNER_TEMP/template-pack"
           dotnet new install \
-            "$RUNNER_TEMP/template-pack/ModularPipelines.Templates.0.0.0-local.nupkg"
+            "$RUNNER_TEMP/template-pack/ModularPipelines.Templates.$template_package_version.nupkg"
+          dotnet new modularpipeline \
+            --name TemplateVersionSmoke \
+            --output "$RUNNER_TEMP/template-version-smoke" \
+            --no-restore
+          test "$(grep -Fc "Version=\"$template_package_version\"" \
+            "$RUNNER_TEMP/template-version-smoke/Directory.Packages.props")" -eq 2
           dotnet new modularpipeline \
             --name TemplateSmoke \
             --output "$RUNNER_TEMP/template-smoke" \
             --solution ../Example.slnx \
             --publish-project ../src/Example/Example.csproj \
+            --framework-version "$framework_version" \
             --no-restore
           grep -F '"Solution": "../Example.slnx"' \
             "$RUNNER_TEMP/template-smoke/appsettings.json"
@@ -76,6 +85,30 @@ jobs:
           grep -F 'namespace TemplateSmoke.Modules;' \
             "$RUNNER_TEMP/template-smoke/Modules/BuildModule.cs"
           dotnet build "$RUNNER_TEMP/template-smoke/TemplateSmoke.csproj" -c Release
+          dotnet new classlib \
+            --name Example \
+            --output "$RUNNER_TEMP/src/Example" \
+            --no-restore
+          dotnet new sln \
+            --name Example \
+            --output "$RUNNER_TEMP" \
+            --format slnx
+          dotnet sln "$RUNNER_TEMP/Example.slnx" \
+            add "$RUNNER_TEMP/src/Example/Example.csproj"
+          dotnet new modularpipeline \
+            --name TemplateRun \
+            --output "$RUNNER_TEMP/template-run" \
+            --solution "$RUNNER_TEMP/Example.slnx" \
+            --publish-project "$RUNNER_TEMP/src/Example/Example.csproj" \
+            --framework-version "$framework_version" \
+            --no-restore
+          mkdir "$RUNNER_TEMP/template-caller"
+          (
+            cd "$RUNNER_TEMP/template-caller"
+            dotnet run \
+              --project "$RUNNER_TEMP/template-run/TemplateRun.csproj" \
+              --configuration Release
+          )
       - name: Run OptionsGenerator unit tests
         run: |
           dotnet restore tools/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.sln

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -65,6 +65,7 @@ jobs:
             --output "$RUNNER_TEMP/template-pack"
           dotnet new install \
             "$RUNNER_TEMP/template-pack/ModularPipelines.Templates.$template_package_version.nupkg"
+          dotnet new modularpipeline --help | grep -F -- '--no-restore'
           dotnet new modularpipeline \
             --name TemplateVersionSmoke \
             --output "$RUNNER_TEMP/template-version-smoke"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -54,6 +54,28 @@ jobs:
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.props', '**/global.json') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
+      - name: Validate pipeline template
+        shell: bash
+        run: |
+          dotnet pack src/ModularPipelines.Templates/ModularPipelines.Templates.csproj \
+            -c Release \
+            -p:PackageVersion=0.0.0-local \
+            --output "$RUNNER_TEMP/template-pack"
+          dotnet new install \
+            "$RUNNER_TEMP/template-pack/ModularPipelines.Templates.0.0.0-local.nupkg"
+          dotnet new modularpipeline \
+            --name TemplateSmoke \
+            --output "$RUNNER_TEMP/template-smoke" \
+            --solution ../Example.slnx \
+            --publish-project ../src/Example/Example.csproj \
+            --no-restore
+          grep -F '"Solution": "../Example.slnx"' \
+            "$RUNNER_TEMP/template-smoke/appsettings.json"
+          grep -F '"PublishProject": "../src/Example/Example.csproj"' \
+            "$RUNNER_TEMP/template-smoke/appsettings.json"
+          grep -F 'namespace TemplateSmoke.Modules;' \
+            "$RUNNER_TEMP/template-smoke/Modules/BuildModule.cs"
+          dotnet build "$RUNNER_TEMP/template-smoke/TemplateSmoke.csproj" -c Release
       - name: Run OptionsGenerator unit tests
         run: |
           dotnet restore tools/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.sln

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -68,7 +68,8 @@ jobs:
           dotnet new modularpipeline --help | grep -F -- '--no-restore'
           dotnet new modularpipeline \
             --name TemplateVersionSmoke \
-            --output "$RUNNER_TEMP/template-version-smoke"
+            --output "$RUNNER_TEMP/template-version-smoke" \
+            --no-restore
           test "$(grep -Fc "Version=\"$template_package_version\"" \
             "$RUNNER_TEMP/template-version-smoke/Directory.Packages.props")" -eq 2
           dotnet new modularpipeline \
@@ -76,7 +77,8 @@ jobs:
             --output "$RUNNER_TEMP/template-smoke" \
             --solution ../Example.slnx \
             --publish-project ../src/Example/Example.csproj \
-            --framework-version "$framework_version"
+            --framework-version "$framework_version" \
+            --no-restore
           grep -F '"Solution": "../Example.slnx"' \
             "$RUNNER_TEMP/template-smoke/appsettings.json"
           grep -F '"PublishProject": "../src/Example/Example.csproj"' \
@@ -99,7 +101,8 @@ jobs:
             --output "$RUNNER_TEMP/template-run" \
             --solution ../Example.slnx \
             --publish-project ../src/Example/Example.csproj \
-            --framework-version "$framework_version"
+            --framework-version "$framework_version" \
+            --no-restore
           mkdir "$RUNNER_TEMP/template-caller"
           (
             cd "$RUNNER_TEMP/template-caller"
@@ -109,6 +112,17 @@ jobs:
           )
           test -f "$RUNNER_TEMP/template-run/artifacts/publish/Example.dll"
           test ! -d "$RUNNER_TEMP/template-caller/artifacts"
+          dotnet publish \
+            "$RUNNER_TEMP/template-run/TemplateRun.csproj" \
+            --configuration Release \
+            --output "$RUNNER_TEMP/template-published"
+          mkdir "$RUNNER_TEMP/published-caller"
+          (
+            cd "$RUNNER_TEMP/published-caller"
+            dotnet "$RUNNER_TEMP/template-published/TemplateRun.dll"
+          )
+          test -f "$RUNNER_TEMP/template-run/artifacts/publish/Example.dll"
+          test ! -d "$RUNNER_TEMP/published-caller/artifacts"
       - name: Run OptionsGenerator unit tests
         run: |
           dotnet restore tools/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.sln

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,11 +40,11 @@
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" Condition="$(MSBuildProjectFile.Contains('Test')) == false and ('$(GITHUB_ACTIONS)' != 'true' or '$(EnableCiAnalyzers)' == 'true')" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(MSBuildProjectName)' != 'ModularPipelines.Development.Analyzers'">
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'ModularPipelines.Development.Analyzers' and '$(MSBuildProjectName)' != 'ModularPipelines.Templates'">
       <ProjectReference Include="$(MSBuildThisFileDirectory)src\ModularPipelines.Development.Analyzers\ModularPipelines.Development.Analyzers.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(MSBuildProjectName)' != 'ModularPipelines' and '$(MSBuildProjectName)' != 'ModularPipelines.SourceGenerator' and '$(MSBuildProjectName)' != 'ModularPipelines.Development.Analyzers' and '$(MSBuildProjectName)' != 'ModularPipelines.Build'">
+  <ItemGroup Condition="'$(MSBuildProjectName)' != 'ModularPipelines' and '$(MSBuildProjectName)' != 'ModularPipelines.SourceGenerator' and '$(MSBuildProjectName)' != 'ModularPipelines.Development.Analyzers' and '$(MSBuildProjectName)' != 'ModularPipelines.Build' and '$(MSBuildProjectName)' != 'ModularPipelines.Templates'">
       <ProjectReference Include="$(MSBuildThisFileDirectory)src\ModularPipelines.SourceGenerator\ModularPipelines.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 </Project>

--- a/ModularPipelines.All.sln
+++ b/ModularPipelines.All.sln
@@ -189,6 +189,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.NerdbankGi
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "ModularPipelines.FSharp.TestFixtures", "test\ModularPipelines.FSharp.TestFixtures\ModularPipelines.FSharp.TestFixtures.fsproj", "{C294970E-BDBD-413C-A431-3012ECA5FC1C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Templates", "src\ModularPipelines.Templates\ModularPipelines.Templates.csproj", "{89576148-F56C-463D-BCEB-6C3C9E75550B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1231,6 +1233,18 @@ Global
 		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Release|x64.Build.0 = Release|Any CPU
 		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Release|x86.ActiveCfg = Release|Any CPU
 		{C294970E-BDBD-413C-A431-3012ECA5FC1C}.Release|x86.Build.0 = Release|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Debug|x64.Build.0 = Debug|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Debug|x86.Build.0 = Debug|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Release|x64.ActiveCfg = Release|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Release|x64.Build.0 = Release|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Release|x86.ActiveCfg = Release|Any CPU
+		{89576148-F56C-463D-BCEB-6C3C9E75550B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1323,6 +1337,7 @@ Global
 		{639D67F3-3C80-4DBC-BD20-0D3475EC7948} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{6259C165-F4E7-4666-B245-859AB1A53721} = {F213898F-1E32-48F1-AB8C-83D2BD01A93B}
 		{C294970E-BDBD-413C-A431-3012ECA5FC1C} = {F213898F-1E32-48F1-AB8C-83D2BD01A93B}
+		{89576148-F56C-463D-BCEB-6C3C9E75550B} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A5905A5D-B4E1-4A7A-9279-0283D86A9F7F}

--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ explicit dependencies and configurable paths. See the
 [template source](src/ModularPipelines.Templates/templates/modularpipeline) for a
 complete copy-ready example.
 
+Adding pipeline modules to an existing project instead? Install the core framework and
+the .NET CLI integration used by the examples above:
+
+```bash
+dotnet add package ModularPipelines
+dotnet add package ModularPipelines.DotNet
+```
+
+Then configure and execute the pipeline from `Program.cs`:
+
+```csharp
+using ModularPipelines;
+
+var builder = Pipeline.CreateBuilder(args);
+await builder.ExecutePipelineAsync();
+```
+
 ## Console Progress
 
 See exactly what's happening as your pipeline runs:

--- a/README.md
+++ b/README.md
@@ -111,78 +111,18 @@ Built-in Roslyn analyzers catch common mistakes before you even run:
 ## Quick Start
 
 ```bash
-dotnet new console -n MyPipeline
+dotnet new install ModularPipelines.Templates
+dotnet new modularpipeline -n MyPipeline \
+  --solution ../MySolution.slnx \
+  --publish-project ../src/MyApp/MyApp.csproj
 cd MyPipeline
-dotnet add package ModularPipelines
-dotnet add package ModularPipelines.DotNet
-```
-
-```csharp
-// Program.cs
-using ModularPipelines;
-using ModularPipelines.Extensions;
-
-var builder = Pipeline.CreateBuilder(args);
-
-builder
-    .AddModule<BuildModule>()
-    .AddModule<TestModule>()
-    .AddModule<PublishModule>();
-
-await builder.ExecutePipelineAsync();
-```
-
-```csharp
-// BuildModule.cs
-using ModularPipelines.Context;
-using ModularPipelines.DotNet.Extensions;
-using ModularPipelines.DotNet.Options;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-
-public class BuildModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-    {
-        return await context.DotNet().Build(new DotNetBuildOptions
-        {
-            ProjectSolution = "MySolution.sln",
-            Configuration = "Release"
-        }, cancellationToken: cancellationToken);
-    }
-}
-```
-
-```csharp
-// TestModule.cs
-using ModularPipelines.Attributes;
-using ModularPipelines.Context;
-using ModularPipelines.DotNet.Extensions;
-using ModularPipelines.DotNet.Options;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-
-[DependsOn<BuildModule>]
-public class TestModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-    {
-        return await context.DotNet().Test(new DotNetTestOptions
-        {
-            Project = "MySolution.sln",
-            Configuration = "Release"
-        }, cancellationToken: cancellationToken);
-    }
-}
-```
-
-Run it:
-
-```bash
 dotnet run
 ```
 
-That's it. No YAML. No waiting for CI. Just `dotnet run` and watch your pipeline execute.
+The generated project contains separate restore, build, test, and publish modules with
+explicit dependencies and configurable paths. See the
+[template source](src/ModularPipelines.Templates/templates/modularpipeline) for a
+complete copy-ready example.
 
 ## Console Progress
 
@@ -235,6 +175,7 @@ ModularPipelines has strongly-typed wrappers for the tools you already use:
 | ModularPipelines.Snyk | Helpers for interacting with Snyk security CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Snyk.svg)](https://www.nuget.org/packages/ModularPipelines.Snyk/) |
 | ModularPipelines.SonarScanner | Helpers for interacting with SonarScanner CLI for SonarQube and SonarCloud. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.SonarScanner.svg)](https://www.nuget.org/packages/ModularPipelines.SonarScanner/) |
 | ModularPipelines.TeamCity | Helpers for interacting with TeamCity build agents. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.TeamCity.svg)](https://www.nuget.org/packages/ModularPipelines.TeamCity/) |
+| ModularPipelines.Templates | Templates for creating realistic ModularPipelines build, test, and publish pipelines. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Templates.svg)](https://www.nuget.org/packages/ModularPipelines.Templates/) |
 | ModularPipelines.Terraform | Helpers for interacting with Terraform CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Terraform.svg)](https://www.nuget.org/packages/ModularPipelines.Terraform/) |
 | ModularPipelines.Trivy | Helpers for interacting with Trivy security scanner CLI. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.Trivy.svg)](https://www.nuget.org/packages/ModularPipelines.Trivy/) |
 | ModularPipelines.WinGet | Helpers for interacting with the Windows Package Manager. | [![nuget](https://img.shields.io/nuget/v/ModularPipelines.WinGet.svg)](https://www.nuget.org/packages/ModularPipelines.WinGet/) |

--- a/README_Template.md
+++ b/README_Template.md
@@ -124,6 +124,23 @@ explicit dependencies and configurable paths. See the
 [template source](src/ModularPipelines.Templates/templates/modularpipeline) for a
 complete copy-ready example.
 
+Adding pipeline modules to an existing project instead? Install the core framework and
+the .NET CLI integration used by the examples above:
+
+```bash
+dotnet add package ModularPipelines
+dotnet add package ModularPipelines.DotNet
+```
+
+Then configure and execute the pipeline from `Program.cs`:
+
+```csharp
+using ModularPipelines;
+
+var builder = Pipeline.CreateBuilder(args);
+await builder.ExecutePipelineAsync();
+```
+
 ## Console Progress
 
 See exactly what's happening as your pipeline runs:

--- a/README_Template.md
+++ b/README_Template.md
@@ -111,78 +111,18 @@ Built-in Roslyn analyzers catch common mistakes before you even run:
 ## Quick Start
 
 ```bash
-dotnet new console -n MyPipeline
+dotnet new install ModularPipelines.Templates
+dotnet new modularpipeline -n MyPipeline \
+  --solution ../MySolution.slnx \
+  --publish-project ../src/MyApp/MyApp.csproj
 cd MyPipeline
-dotnet add package ModularPipelines
-dotnet add package ModularPipelines.DotNet
-```
-
-```csharp
-// Program.cs
-using ModularPipelines;
-using ModularPipelines.Extensions;
-
-var builder = Pipeline.CreateBuilder(args);
-
-builder
-    .AddModule<BuildModule>()
-    .AddModule<TestModule>()
-    .AddModule<PublishModule>();
-
-await builder.ExecutePipelineAsync();
-```
-
-```csharp
-// BuildModule.cs
-using ModularPipelines.Context;
-using ModularPipelines.DotNet.Extensions;
-using ModularPipelines.DotNet.Options;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-
-public class BuildModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-    {
-        return await context.DotNet().Build(new DotNetBuildOptions
-        {
-            ProjectSolution = "MySolution.sln",
-            Configuration = "Release"
-        }, cancellationToken: cancellationToken);
-    }
-}
-```
-
-```csharp
-// TestModule.cs
-using ModularPipelines.Attributes;
-using ModularPipelines.Context;
-using ModularPipelines.DotNet.Extensions;
-using ModularPipelines.DotNet.Options;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-
-[DependsOn<BuildModule>]
-public class TestModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-    {
-        return await context.DotNet().Test(new DotNetTestOptions
-        {
-            Project = "MySolution.sln",
-            Configuration = "Release"
-        }, cancellationToken: cancellationToken);
-    }
-}
-```
-
-Run it:
-
-```bash
 dotnet run
 ```
 
-That's it. No YAML. No waiting for CI. Just `dotnet run` and watch your pipeline execute.
+The generated project contains separate restore, build, test, and publish modules with
+explicit dependencies and configurable paths. See the
+[template source](src/ModularPipelines.Templates/templates/modularpipeline) for a
+complete copy-ready example.
 
 ## Console Progress
 

--- a/src/ModularPipelines.Build/Modules/FindProjectsModule.cs
+++ b/src/ModularPipelines.Build/Modules/FindProjectsModule.cs
@@ -50,6 +50,7 @@ public class FindProjectsModule : Module<IReadOnlyList<File>>
             Sourcy.DotNet.Projects.ModularPipelines_Snyk,
             Sourcy.DotNet.Projects.ModularPipelines_SonarScanner,
             Sourcy.DotNet.Projects.ModularPipelines_TeamCity,
+            Sourcy.DotNet.Projects.ModularPipelines_Templates,
             Sourcy.DotNet.Projects.ModularPipelines_Terraform,
             Sourcy.DotNet.Projects.ModularPipelines_Trivy,
             Sourcy.DotNet.Projects.ModularPipelines_WinGet,

--- a/src/ModularPipelines.Templates/ModularPipelines.Templates.csproj
+++ b/src/ModularPipelines.Templates/ModularPipelines.Templates.csproj
@@ -15,7 +15,7 @@
              Exclude="templates\**\bin\**;templates\**\obj\**;templates\modularpipeline\.template.config\dotnetcli.host.json;templates\modularpipeline\.template.config\template.json;templates\modularpipeline\Directory.Packages.props" />
     <Content Include="templates\modularpipeline\.template.config\dotnetcli.host.json"
              Pack="true"
-             PackagePath="content\templates\modularpipeline\.template.config\dotnetcli.host.json" />
+             PackagePath="content/templates/modularpipeline/.template.config" />
     <Content Include="$(VersionedTemplateRoot).template.config\template.json"
              Pack="true"
              PackagePath="content\templates\modularpipeline\.template.config\" />

--- a/src/ModularPipelines.Templates/ModularPipelines.Templates.csproj
+++ b/src/ModularPipelines.Templates/ModularPipelines.Templates.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>Templates for creating realistic ModularPipelines build, test, and publish pipelines.</Description>
+    <PackageType>Template</PackageType>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <Title>ModularPipelines project templates</Title>
+    <PackageTags>dotnet-new;templates;build;test;publish;pipelines</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
+    <Compile Remove="**\*" />
+  </ItemGroup>
+</Project>

--- a/src/ModularPipelines.Templates/ModularPipelines.Templates.csproj
+++ b/src/ModularPipelines.Templates/ModularPipelines.Templates.csproj
@@ -15,13 +15,13 @@
              Exclude="templates\**\bin\**;templates\**\obj\**;templates\modularpipeline\.template.config\dotnetcli.host.json;templates\modularpipeline\.template.config\template.json;templates\modularpipeline\Directory.Packages.props" />
     <Content Include="templates\modularpipeline\.template.config\dotnetcli.host.json"
              Pack="true"
-             PackagePath="content/templates/modularpipeline/.template.config" />
+             PackagePath="content/templates/modularpipeline/.template.config/dotnetcli.host.json" />
     <Content Include="$(VersionedTemplateRoot).template.config\template.json"
              Pack="true"
-             PackagePath="content\templates\modularpipeline\.template.config\" />
+             PackagePath="content/templates/modularpipeline/.template.config" />
     <Content Include="$(VersionedTemplateRoot)Directory.Packages.props"
              Pack="true"
-             PackagePath="content\templates\modularpipeline\" />
+             PackagePath="content/templates/modularpipeline" />
     <Compile Remove="**\*" />
   </ItemGroup>
   <Target Name="GenerateVersionedTemplateContent" BeforeTargets="GenerateNuspec">

--- a/src/ModularPipelines.Templates/ModularPipelines.Templates.csproj
+++ b/src/ModularPipelines.Templates/ModularPipelines.Templates.csproj
@@ -12,7 +12,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Content Include="templates\**\*"
-             Exclude="templates\**\bin\**;templates\**\obj\**;templates\modularpipeline\.template.config\template.json;templates\modularpipeline\Directory.Packages.props" />
+             Exclude="templates\**\bin\**;templates\**\obj\**;templates\modularpipeline\.template.config\dotnetcli.host.json;templates\modularpipeline\.template.config\template.json;templates\modularpipeline\Directory.Packages.props" />
+    <Content Include="templates\modularpipeline\.template.config\dotnetcli.host.json"
+             Pack="true"
+             PackagePath="content\templates\modularpipeline\.template.config\dotnetcli.host.json" />
     <Content Include="$(VersionedTemplateRoot).template.config\template.json"
              Pack="true"
              PackagePath="content\templates\modularpipeline\.template.config\" />

--- a/src/ModularPipelines.Templates/ModularPipelines.Templates.csproj
+++ b/src/ModularPipelines.Templates/ModularPipelines.Templates.csproj
@@ -8,9 +8,32 @@
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <Title>ModularPipelines project templates</Title>
     <PackageTags>dotnet-new;templates;build;test;publish;pipelines</PackageTags>
+    <VersionedTemplateRoot>$(MSBuildProjectDirectory)\obj\versioned-templates\$(PackageVersion)\</VersionedTemplateRoot>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="templates\**\*" Exclude="templates\**\bin\**;templates\**\obj\**" />
+    <Content Include="templates\**\*"
+             Exclude="templates\**\bin\**;templates\**\obj\**;templates\modularpipeline\.template.config\template.json;templates\modularpipeline\Directory.Packages.props" />
+    <Content Include="$(VersionedTemplateRoot).template.config\template.json"
+             Pack="true"
+             PackagePath="content\templates\modularpipeline\.template.config\" />
+    <Content Include="$(VersionedTemplateRoot)Directory.Packages.props"
+             Pack="true"
+             PackagePath="content\templates\modularpipeline\" />
     <Compile Remove="**\*" />
   </ItemGroup>
+  <Target Name="GenerateVersionedTemplateContent" BeforeTargets="GenerateNuspec">
+    <MakeDir Directories="$(VersionedTemplateRoot).template.config" />
+    <PropertyGroup>
+      <_TemplateConfiguration>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\templates\modularpipeline\.template.config\template.json').Replace('__MODULAR_PIPELINES_VERSION__', '$(PackageVersion)'))</_TemplateConfiguration>
+      <_TemplatePackages>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\templates\modularpipeline\Directory.Packages.props').Replace('__MODULAR_PIPELINES_VERSION__', '$(PackageVersion)'))</_TemplatePackages>
+    </PropertyGroup>
+    <WriteLinesToFile
+      File="$(VersionedTemplateRoot).template.config\template.json"
+      Lines="$(_TemplateConfiguration)"
+      Overwrite="true" />
+    <WriteLinesToFile
+      File="$(VersionedTemplateRoot)Directory.Packages.props"
+      Lines="$(_TemplatePackages)"
+      Overwrite="true" />
+  </Target>
 </Project>

--- a/src/ModularPipelines.Templates/ModularPipelines.Templates.slnx
+++ b/src/ModularPipelines.Templates/ModularPipelines.Templates.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="ModularPipelines.Templates.csproj" />
+</Solution>

--- a/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/dotnetcli.host.json
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/dotnetcli.host.json
@@ -17,9 +17,9 @@
       "longName": "framework-version",
       "shortName": "f"
     },
-    "noRestore": {
+    "skipRestore": {
       "longName": "no-restore",
-      "shortName": "nr"
+      "shortName": ""
     }
   }
 }

--- a/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/dotnetcli.host.json
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/dotnetcli.host.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json.schemastore.org/dotnetcli.host",
+  "symbolInfo": {
+    "solution": {
+      "longName": "solution",
+      "shortName": "s"
+    },
+    "publishProject": {
+      "longName": "publish-project",
+      "shortName": "p"
+    },
+    "configuration": {
+      "longName": "configuration",
+      "shortName": "c"
+    },
+    "frameworkVersion": {
+      "longName": "framework-version",
+      "shortName": "f"
+    },
+    "noRestore": {
+      "longName": "no-restore",
+      "shortName": ""
+    }
+  }
+}

--- a/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/dotnetcli.host.json
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/dotnetcli.host.json
@@ -19,7 +19,7 @@
     },
     "skipRestore": {
       "longName": "no-restore",
-      "shortName": ""
+      "shortName": "nr"
     }
   }
 }

--- a/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/dotnetcli.host.json
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/dotnetcli.host.json
@@ -19,7 +19,7 @@
     },
     "noRestore": {
       "longName": "no-restore",
-      "shortName": ""
+      "shortName": "nr"
     }
   }
 }

--- a/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/template.json
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/template.json
@@ -57,7 +57,7 @@
       "defaultValue": "__MODULAR_PIPELINES_VERSION__",
       "replaces": "__MODULAR_PIPELINES_VERSION__"
     },
-    "noRestore": {
+    "skipRestore": {
       "type": "parameter",
       "datatype": "bool",
       "displayName": "Skip restore",
@@ -72,7 +72,7 @@
   ],
   "postActions": [
     {
-      "condition": "(!noRestore)",
+      "condition": "(!skipRestore)",
       "description": "Restore NuGet packages required by this project.",
       "manualInstructions": [
         {

--- a/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/template.json
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/template.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Tom Longhurst",
+  "classifications": [
+    "Build",
+    "CI/CD"
+  ],
+  "identity": "ModularPipelines.Templates.BuildPipeline",
+  "name": "ModularPipelines build pipeline",
+  "shortName": "modularpipeline",
+  "sourceName": "TemplatePipeline",
+  "preferNameDirectory": true,
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "symbols": {
+    "solution": {
+      "type": "parameter",
+      "datatype": "text",
+      "displayName": "Solution",
+      "description": "Path to the solution restored, built, and tested.",
+      "defaultValue": "../MySolution.slnx",
+      "replaces": "../MySolution.slnx"
+    },
+    "publishProject": {
+      "type": "parameter",
+      "datatype": "text",
+      "displayName": "Publish project",
+      "description": "Path to the deployable project published after tests pass.",
+      "defaultValue": "../src/MyApp/MyApp.csproj",
+      "replaces": "../src/MyApp/MyApp.csproj"
+    },
+    "configuration": {
+      "type": "parameter",
+      "datatype": "choice",
+      "displayName": "Configuration",
+      "description": "Build configuration used by build, test, and publish.",
+      "defaultValue": "Release",
+      "replaces": "Release",
+      "choices": [
+        {
+          "choice": "Debug",
+          "description": "Build with debug symbols and minimal optimization."
+        },
+        {
+          "choice": "Release",
+          "description": "Build optimized release outputs."
+        }
+      ]
+    },
+    "frameworkVersion": {
+      "type": "parameter",
+      "datatype": "text",
+      "displayName": "ModularPipelines version",
+      "description": "Version of the ModularPipelines packages referenced by the generated project.",
+      "defaultValue": "3.2.8",
+      "replaces": "3.2.8"
+    },
+    "noRestore": {
+      "type": "parameter",
+      "datatype": "bool",
+      "displayName": "Skip restore",
+      "description": "Skip restoring the generated pipeline project.",
+      "defaultValue": "false"
+    }
+  },
+  "primaryOutputs": [
+    {
+      "path": "TemplatePipeline.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(!noRestore)",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'."
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true
+    }
+  ]
+}

--- a/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/template.json
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/.template.config/template.json
@@ -54,8 +54,8 @@
       "datatype": "text",
       "displayName": "ModularPipelines version",
       "description": "Version of the ModularPipelines packages referenced by the generated project.",
-      "defaultValue": "3.2.8",
-      "replaces": "3.2.8"
+      "defaultValue": "__MODULAR_PIPELINES_VERSION__",
+      "replaces": "__MODULAR_PIPELINES_VERSION__"
     },
     "noRestore": {
       "type": "parameter",

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Directory.Packages.props
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="ModularPipelines" Version="3.2.8" />
-    <PackageVersion Include="ModularPipelines.DotNet" Version="3.2.8" />
+    <PackageVersion Include="ModularPipelines" Version="__MODULAR_PIPELINES_VERSION__" />
+    <PackageVersion Include="ModularPipelines.DotNet" Version="__MODULAR_PIPELINES_VERSION__" />
   </ItemGroup>
 </Project>

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Directory.Packages.props
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Directory.Packages.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="ModularPipelines" Version="3.2.8" />
+    <PackageVersion Include="ModularPipelines.DotNet" Version="3.2.8" />
+  </ItemGroup>
+</Project>

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Modules/BuildModule.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Modules/BuildModule.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Options;
+using ModularPipelines.Attributes;
+using ModularPipelines.Context;
+using ModularPipelines.DotNet.Extensions;
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using TemplatePipeline.Settings;
+
+namespace TemplatePipeline.Modules;
+
+[DependsOn<RestoreModule>]
+public sealed class BuildModule(IOptions<BuildSettings> settings) : Module<CommandResult>
+{
+    protected override async Task<CommandResult?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return await context.DotNet().Build(
+            new DotNetBuildOptions
+            {
+                ProjectSolution = settings.Value.Solution,
+                Configuration = settings.Value.Configuration,
+                NoRestore = true,
+            },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Modules/PublishModule.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Modules/PublishModule.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Options;
+using ModularPipelines.Attributes;
+using ModularPipelines.Context;
+using ModularPipelines.DotNet.Extensions;
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using TemplatePipeline.Settings;
+
+namespace TemplatePipeline.Modules;
+
+[DependsOn<TestModule>]
+public sealed class PublishModule(IOptions<BuildSettings> settings) : Module<CommandResult>
+{
+    protected override async Task<CommandResult?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return await context.DotNet().Publish(
+            new DotNetPublishOptions
+            {
+                ProjectSolution = settings.Value.PublishProject,
+                Configuration = settings.Value.Configuration,
+                Output = settings.Value.PublishDirectory,
+                NoBuild = true,
+                NoRestore = true,
+            },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Modules/RestoreModule.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Modules/RestoreModule.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Options;
+using ModularPipelines.Context;
+using ModularPipelines.DotNet.Extensions;
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using TemplatePipeline.Settings;
+
+namespace TemplatePipeline.Modules;
+
+public sealed class RestoreModule(IOptions<BuildSettings> settings) : Module<CommandResult>
+{
+    protected override async Task<CommandResult?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return await context.DotNet().Restore(
+            new DotNetRestoreOptions
+            {
+                ProjectSolution = settings.Value.Solution,
+            },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Modules/TestModule.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Modules/TestModule.cs
@@ -19,7 +19,7 @@ public sealed class TestModule(IOptions<BuildSettings> settings) : Module<Comman
         return await context.DotNet().Test(
             new DotNetTestOptions
             {
-                Solution = settings.Value.Solution,
+                Arguments = [settings.Value.Solution],
                 Configuration = settings.Value.Configuration,
                 NoBuild = true,
                 NoRestore = true,

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Modules/TestModule.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Modules/TestModule.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Options;
+using ModularPipelines.Attributes;
+using ModularPipelines.Context;
+using ModularPipelines.DotNet.Extensions;
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using TemplatePipeline.Settings;
+
+namespace TemplatePipeline.Modules;
+
+[DependsOn<BuildModule>]
+public sealed class TestModule(IOptions<BuildSettings> settings) : Module<CommandResult>
+{
+    protected override async Task<CommandResult?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return await context.DotNet().Test(
+            new DotNetTestOptions
+            {
+                Solution = settings.Value.Solution,
+                Configuration = settings.Value.Configuration,
+                NoBuild = true,
+                NoRestore = true,
+            },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/ModularPipelines.Templates/templates/modularpipeline/PipelineProjectDirectory.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/PipelineProjectDirectory.cs
@@ -1,0 +1,53 @@
+using System.Runtime.CompilerServices;
+
+namespace TemplatePipeline;
+
+internal static class PipelineProjectDirectory
+{
+    private const string DirectoryVariable = "MODULAR_PIPELINES_DIRECTORY";
+
+    public static string Find([CallerFilePath] string sourceFilePath = "")
+    {
+        var configuredDirectory = Environment.GetEnvironmentVariable(DirectoryVariable);
+        if (!string.IsNullOrWhiteSpace(configuredDirectory))
+        {
+            return ValidateConfiguredDirectory(configuredDirectory);
+        }
+
+        var sourceDirectory = Path.GetDirectoryName(sourceFilePath);
+        return IsPipelineDirectory(sourceDirectory)
+            ? sourceDirectory!
+            : FindFromBuildOutput();
+    }
+
+    private static string ValidateConfiguredDirectory(string configuredDirectory)
+    {
+        var fullPath = Path.GetFullPath(configuredDirectory);
+        return IsPipelineDirectory(fullPath)
+            ? fullPath
+            : throw new InvalidOperationException(
+                $"{DirectoryVariable} must point to a directory containing appsettings.json and a project file.");
+    }
+
+    private static string FindFromBuildOutput()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            if (IsPipelineDirectory(directory.FullName))
+            {
+                return directory.FullName;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate the pipeline project directory. Set {DirectoryVariable} to its path.");
+    }
+
+    private static bool IsPipelineDirectory(string? directory) =>
+        directory is not null
+        && Directory.Exists(directory)
+        && File.Exists(Path.Combine(directory, "appsettings.json"))
+        && Directory.EnumerateFiles(directory, "*.csproj").Any();
+}

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -1,12 +1,12 @@
-using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines;
 using ModularPipelines.Extensions;
+using TemplatePipeline;
 using TemplatePipeline.Modules;
 using TemplatePipeline.Settings;
 
-var pipelineDirectory = FindPipelineDirectory();
+var pipelineDirectory = PipelineProjectDirectory.Find();
 Environment.CurrentDirectory = pipelineDirectory;
 
 var builder = Pipeline.CreateBuilder(args);
@@ -24,45 +24,3 @@ builder
     .AddModule<PublishModule>();
 
 await builder.ExecutePipelineAsync();
-
-static string FindPipelineDirectory([CallerFilePath] string sourceFilePath = "")
-{
-    const string directoryVariable = "MODULAR_PIPELINES_DIRECTORY";
-    var configuredDirectory = Environment.GetEnvironmentVariable(directoryVariable);
-    if (!string.IsNullOrWhiteSpace(configuredDirectory))
-    {
-        var fullPath = Path.GetFullPath(configuredDirectory);
-        if (IsPipelineDirectory(fullPath))
-        {
-            return fullPath;
-        }
-
-        throw new InvalidOperationException(
-            $"{directoryVariable} must point to a directory containing appsettings.json and a project file.");
-    }
-
-    var sourceDirectory = Path.GetDirectoryName(sourceFilePath);
-    if (sourceDirectory is not null && IsPipelineDirectory(sourceDirectory))
-    {
-        return sourceDirectory;
-    }
-
-    for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
-         directory is not null;
-         directory = directory.Parent)
-    {
-        if (IsPipelineDirectory(directory.FullName))
-        {
-            return directory.FullName;
-        }
-    }
-
-    throw new InvalidOperationException(
-        $"Could not locate the pipeline project directory. Set {directoryVariable} to its path.");
-}
-
-static bool IsPipelineDirectory(string? directory) =>
-    directory is not null
-    && Directory.Exists(directory)
-    && File.Exists(Path.Combine(directory, "appsettings.json"))
-    && Directory.EnumerateFiles(directory, "*.csproj").Any();

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines;
+using ModularPipelines.Extensions;
+using TemplatePipeline.Modules;
+using TemplatePipeline.Settings;
+
+var builder = Pipeline.CreateBuilder(args);
+
+builder.Configuration
+    .AddJsonFile("appsettings.json", optional: false)
+    .AddEnvironmentVariables();
+
+builder.Services.Configure<BuildSettings>(builder.Configuration.GetSection("Build"));
+
+builder
+    .AddModule<RestoreModule>()
+    .AddModule<BuildModule>()
+    .AddModule<TestModule>()
+    .AddModule<PublishModule>();
+
+await builder.ExecutePipelineAsync();

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines;
@@ -24,14 +25,19 @@ builder
 
 await builder.ExecutePipelineAsync();
 
-static string FindPipelineDirectory()
+static string FindPipelineDirectory([CallerFilePath] string sourceFilePath = "")
 {
-    for (var directory = Directory.GetParent(AppContext.BaseDirectory);
+    var sourceDirectory = Path.GetDirectoryName(sourceFilePath);
+    if (sourceDirectory is not null && IsPipelineDirectory(sourceDirectory))
+    {
+        return sourceDirectory;
+    }
+
+    for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
          directory is not null;
          directory = directory.Parent)
     {
-        if (File.Exists(Path.Combine(directory.FullName, "appsettings.json"))
-            && directory.EnumerateFiles("*.csproj").Any())
+        if (IsPipelineDirectory(directory.FullName))
         {
             return directory.FullName;
         }
@@ -39,3 +45,8 @@ static string FindPipelineDirectory()
 
     return AppContext.BaseDirectory;
 }
+
+static bool IsPipelineDirectory(string? directory) =>
+    directory is not null
+    && File.Exists(Path.Combine(directory, "appsettings.json"))
+    && Directory.EnumerateFiles(directory, "*.csproj").Any();

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -5,10 +5,13 @@ using ModularPipelines.Extensions;
 using TemplatePipeline.Modules;
 using TemplatePipeline.Settings;
 
+var pipelineDirectory = FindPipelineDirectory();
+Environment.CurrentDirectory = pipelineDirectory;
+
 var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
-    .AddJsonFile(Path.Combine(AppContext.BaseDirectory, "appsettings.json"), optional: false)
+    .AddJsonFile(Path.Combine(pipelineDirectory, "appsettings.json"), optional: false)
     .AddEnvironmentVariables();
 
 builder.Services.Configure<BuildSettings>(builder.Configuration.GetSection("Build"));
@@ -20,3 +23,19 @@ builder
     .AddModule<PublishModule>();
 
 await builder.ExecutePipelineAsync();
+
+static string FindPipelineDirectory()
+{
+    for (var directory = Directory.GetParent(AppContext.BaseDirectory);
+         directory is not null;
+         directory = directory.Parent)
+    {
+        if (File.Exists(Path.Combine(directory.FullName, "appsettings.json"))
+            && directory.EnumerateFiles("*.csproj").Any())
+        {
+            return directory.FullName;
+        }
+    }
+
+    return AppContext.BaseDirectory;
+}

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -27,6 +27,20 @@ await builder.ExecutePipelineAsync();
 
 static string FindPipelineDirectory([CallerFilePath] string sourceFilePath = "")
 {
+    const string directoryVariable = "MODULAR_PIPELINES_DIRECTORY";
+    var configuredDirectory = Environment.GetEnvironmentVariable(directoryVariable);
+    if (!string.IsNullOrWhiteSpace(configuredDirectory))
+    {
+        var fullPath = Path.GetFullPath(configuredDirectory);
+        if (IsPipelineDirectory(fullPath))
+        {
+            return fullPath;
+        }
+
+        throw new InvalidOperationException(
+            $"{directoryVariable} must point to a directory containing appsettings.json and a project file.");
+    }
+
     var sourceDirectory = Path.GetDirectoryName(sourceFilePath);
     if (sourceDirectory is not null && IsPipelineDirectory(sourceDirectory))
     {
@@ -43,10 +57,12 @@ static string FindPipelineDirectory([CallerFilePath] string sourceFilePath = "")
         }
     }
 
-    return AppContext.BaseDirectory;
+    throw new InvalidOperationException(
+        $"Could not locate the pipeline project directory. Set {directoryVariable} to its path.");
 }
 
 static bool IsPipelineDirectory(string? directory) =>
     directory is not null
+    && Directory.Exists(directory)
     && File.Exists(Path.Combine(directory, "appsettings.json"))
     && Directory.EnumerateFiles(directory, "*.csproj").Any();

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -8,7 +8,7 @@ using TemplatePipeline.Settings;
 var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
-    .AddJsonFile("appsettings.json", optional: false)
+    .AddJsonFile(Path.Combine(AppContext.BaseDirectory, "appsettings.json"), optional: false)
     .AddEnvironmentVariables();
 
 builder.Services.Configure<BuildSettings>(builder.Configuration.GetSection("Build"));

--- a/src/ModularPipelines.Templates/templates/modularpipeline/README.md
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/README.md
@@ -1,0 +1,23 @@
+# TemplatePipeline
+
+This pipeline restores and builds the configured solution, runs its tests, and then
+publishes the deployable project to `artifacts/publish`.
+
+Edit `appsettings.json` when paths or the build configuration change. Environment
+variables can override any setting, for example:
+
+```bash
+Build__Configuration=Debug dotnet run
+```
+
+The dependency chain is explicit:
+
+```text
+RestoreModule -> BuildModule -> TestModule -> PublishModule
+```
+
+Run the pipeline:
+
+```bash
+dotnet run
+```

--- a/src/ModularPipelines.Templates/templates/modularpipeline/README.md
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/README.md
@@ -21,3 +21,10 @@ Run the pipeline:
 ```bash
 dotnet run
 ```
+
+If you publish the pipeline and move it away from its build machine, point the
+published host at the generated pipeline project directory:
+
+```bash
+MODULAR_PIPELINES_DIRECTORY=/path/to/TemplatePipeline dotnet TemplatePipeline.dll
+```

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Settings/BuildSettings.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Settings/BuildSettings.cs
@@ -1,0 +1,12 @@
+namespace TemplatePipeline.Settings;
+
+public sealed class BuildSettings
+{
+    public string Solution { get; init; } = "../MySolution.slnx";
+
+    public string PublishProject { get; init; } = "../src/MyApp/MyApp.csproj";
+
+    public string Configuration { get; init; } = "Release";
+
+    public string PublishDirectory { get; init; } = "artifacts/publish";
+}

--- a/src/ModularPipelines.Templates/templates/modularpipeline/TemplatePipeline.csproj
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/TemplatePipeline.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ModularPipelines" />
+    <PackageReference Include="ModularPipelines.DotNet" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/ModularPipelines.Templates/templates/modularpipeline/appsettings.json
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Build": {
+    "Solution": "../MySolution.slnx",
+    "PublishProject": "../src/MyApp/MyApp.csproj",
+    "Configuration": "Release",
+    "PublishDirectory": "artifacts/publish"
+  }
+}


### PR DESCRIPTION
## Summary
- add a publishable `ModularPipelines.Templates` template pack
- generate a configurable restore/build/test/publish pipeline with explicit dependencies
- validate package installation, kebab-case options, substitutions, renaming, and generated-project compilation in fast-fail CI
- replace the hand-assembled README quick start with `dotnet new modularpipeline`

## Validation
- built `ModularPipelines.Templates.slnx` in Release through the agent guard
- packed, installed, instantiated, and uninstalled a local template package
- built the generated project against published ModularPipelines 3.2.8 packages with zero warnings
- built `ModularPipelines.Build.csproj` in Release to verify package discovery
- ran targeted `dotnet format --verify-no-changes`
- ran the repository Markdown formatter
- parsed workflow YAML, template JSON, and project XML
- verified README generation invariants and package contents

Closes #3331