### PR TITLE
Dispose engine cancellation plumbing

### DIFF
--- a/src/ModularPipelines/Engine/EngineCancellationToken.cs
+++ b/src/ModularPipelines/Engine/EngineCancellationToken.cs
@@ -22,7 +22,7 @@ internal class EngineCancellationToken : IDisposable
     public CancellationToken Token => _cts.Token;
 
     /// <summary>
-    /// Gets whether cancellation has been requested on the underlying token source.
+    /// Gets a value indicating whether cancellation has been requested on the underlying token source.
     /// </summary>
     public bool IsCancellationRequested => _cts.IsCancellationRequested;
 
@@ -50,13 +50,8 @@ internal class EngineCancellationToken : IDisposable
     {
         _primaryExceptionContainer = primaryExceptionContainer;
 
-        System.Console.CancelKeyPress += (_, args) =>
-        {
-            args.Cancel = true;
-            TryCancel();
-        };
-
-        AppDomain.CurrentDomain.ProcessExit += (_, _) => TryCancel();
+        System.Console.CancelKeyPress += OnCancelKeyPress;
+        AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
     }
 
     public void CancelWithReason(string? reason)
@@ -104,13 +99,23 @@ internal class EngineCancellationToken : IDisposable
             return;
         }
 
+        _disposed = true;
+
         if (disposing)
         {
+            System.Console.CancelKeyPress -= OnCancelKeyPress;
+            AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
             _cts.Dispose();
         }
-
-        _disposed = true;
     }
+
+    private void OnCancelKeyPress(object? sender, ConsoleCancelEventArgs args)
+    {
+        args.Cancel = true;
+        TryCancel();
+    }
+
+    private void OnProcessExit(object? sender, EventArgs args) => TryCancel();
 
     private void TryCancel()
     {

--- a/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
+++ b/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
@@ -105,7 +105,9 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
             _hasRun = true;
         }
 
-        cancellationToken.Register(() => _engineCancellationToken.CancelWithReason("The user's cancellation token passed into the pipeline was cancelled."));
+        using var cancellationRegistration = cancellationToken.Register(
+            () => _engineCancellationToken.CancelWithReason(
+                "The user's cancellation token passed into the pipeline was cancelled."));
 
         _threadPoolConfigurator.Configure();
 

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -57,6 +57,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         var moduleName = executionContext.ModuleType.Name;
         ModuleResult<T>? moduleResult = null;
         var beforeHooksExecuted = false;
+        var originalCancellationTokenSource = executionContext.ModuleCancellationTokenSource;
 
         // Get configuration once at the start
         var config = ((IModule) module).Configuration;
@@ -134,26 +135,39 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         }
         finally
         {
-            // Call direct OnAfterExecuteAsync hook - runs on both success and failure
-            // Only run if before hooks were executed (module actually started)
-            if (beforeHooksExecuted && moduleResult != null)
+            try
             {
-                try
+                // Call direct OnAfterExecuteAsync hook - runs on both success and failure
+                // Only run if before hooks were executed (module actually started)
+                if (beforeHooksExecuted && moduleResult != null)
                 {
-                    var modifiedResult = await _directHookInvoker.InvokeAfterExecuteAsync(module, moduleContext, moduleResult, executionContext.ModuleCancellationTokenSource.Token).ConfigureAwait(false);
-                    if (modifiedResult != null)
+                    try
                     {
-                        moduleResult = modifiedResult;
-                        executionContext.SetTypedResult(moduleResult);
+                        var modifiedResult = await _directHookInvoker.InvokeAfterExecuteAsync(module, moduleContext, moduleResult, executionContext.ModuleCancellationTokenSource.Token).ConfigureAwait(false);
+                        if (modifiedResult != null)
+                        {
+                            moduleResult = modifiedResult;
+                            executionContext.SetTypedResult(moduleResult);
+                        }
+                    }
+                    catch (Exception afterHookException)
+                    {
+                        logger.LogError(afterHookException, "Error in OnAfterExecuteAsync hook");
                     }
                 }
-                catch (Exception afterHookException)
+
+                LogModuleStatus(executionContext, logger);
+            }
+            finally
+            {
+                var activeCancellationTokenSource = executionContext.ModuleCancellationTokenSource;
+                activeCancellationTokenSource.Dispose();
+
+                if (!ReferenceEquals(activeCancellationTokenSource, originalCancellationTokenSource))
                 {
-                    logger.LogError(afterHookException, "Error in OnAfterExecuteAsync hook");
+                    originalCancellationTokenSource.Dispose();
                 }
             }
-
-            LogModuleStatus(executionContext, logger);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
@@ -13,6 +13,70 @@ namespace ModularPipelines.UnitTests.Engine;
 public class ExecutionOrchestratorTests
 {
     [Test]
+    public async Task CallerCancellationRegistration_IsDisposedAfterExecution()
+    {
+        var organizedModules = new OrganizedModules([], []);
+        var summary = new PipelineSummary(
+            [],
+            [],
+            TimeSpan.Zero,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+
+        var pipelineInitializer = new Mock<IPipelineInitializer>();
+        pipelineInitializer
+            .Setup(x => x.Initialize(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(organizedModules);
+
+        var ignoredModuleResultRegistrar = new Mock<IIgnoredModuleResultRegistrar>();
+        ignoredModuleResultRegistrar
+            .Setup(x => x.RegisterIgnoredModuleResultsAsync(organizedModules))
+            .ReturnsAsync(organizedModules);
+
+        var pipelineExecutor = new Mock<IPipelineExecutor>();
+        pipelineExecutor
+            .Setup(x => x.ExecuteAsync(It.IsAny<List<IModule>>(), organizedModules))
+            .ReturnsAsync(summary);
+
+        var outputScope = new Mock<IPipelineOutputScope>();
+        outputScope
+            .Setup(x => x.DisposeAsync())
+            .Returns(ValueTask.CompletedTask);
+
+        var outputCoordinator = new Mock<IPipelineOutputCoordinator>();
+        outputCoordinator
+            .Setup(x => x.InitializeAsync())
+            .ReturnsAsync(outputScope.Object);
+
+        var moduleDisposeExecutor = new Mock<IModuleDisposeExecutor>();
+        moduleDisposeExecutor
+            .Setup(x => x.DisposeAsync())
+            .Returns(ValueTask.CompletedTask);
+
+        using var engineCancellationToken =
+            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+        var orchestrator = new ExecutionOrchestrator(
+            pipelineInitializer.Object,
+            moduleDisposeExecutor.Object,
+            pipelineExecutor.Object,
+            outputCoordinator.Object,
+            ignoredModuleResultRegistrar.Object,
+            Mock.Of<IModuleResultRegistry>(),
+            Mock.Of<IPipelineSummaryFactory>(),
+            engineCancellationToken,
+            Mock.Of<IThreadPoolConfigurator>(),
+            Mock.Of<IExceptionRethrowService>(),
+            OptionsFactory.Create(new PipelineOptions()),
+            Mock.Of<ILogger<ExecutionOrchestrator>>());
+        using var callerCancellationTokenSource = new CancellationTokenSource();
+
+        await orchestrator.ExecuteAsync(callerCancellationTokenSource.Token);
+        callerCancellationTokenSource.Cancel();
+
+        await Assert.That(engineCancellationToken.IsCancellationRequested).IsFalse();
+    }
+
+    [Test]
     public async Task PipelineFailure_IsNotMaskedByOutputTeardownOrLoggingFailure()
     {
         var organizedModules = new OrganizedModules([], []);

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -1,0 +1,74 @@
+using ModularPipelines.Context;
+using ModularPipelines.Context.Domains;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Execution;
+using ModularPipelines.Logging;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+using Moq;
+using OptionsFactory = Microsoft.Extensions.Options.Options;
+using PipelineEngineCancellationToken = ModularPipelines.Engine.EngineCancellationToken;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class ModuleExecutionPipelineTests
+{
+    private class SuccessfulModule : Module<int>
+    {
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(42);
+        }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_DisposesOriginalAndLinkedCancellationTokenSources()
+    {
+        var module = new SuccessfulModule();
+        var executionContext = new ModuleExecutionContext<int>(module, module.GetType());
+        var originalCancellationTokenSource = executionContext.ModuleCancellationTokenSource;
+        var logger = new Mock<IModuleLogger>();
+        var services = new Mock<IServicesContext>();
+        services.SetupGet(x => x.Options).Returns(new PipelineOptions());
+        var moduleContext = new Mock<IModuleContext>();
+        moduleContext.SetupGet(x => x.Logger).Returns(logger.Object);
+        moduleContext.SetupGet(x => x.Services).Returns(services.Object);
+
+        var resultRepository = new Mock<IModuleResultRepository>();
+        resultRepository.SetupGet(x => x.IsEnabled).Returns(false);
+        var directHookInvoker = new Mock<IDirectHookInvoker>();
+        directHookInvoker
+            .Setup(x => x.InvokeBeforeExecuteAsync(
+                module,
+                moduleContext.Object,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        directHookInvoker
+            .Setup(x => x.InvokeAfterExecuteAsync(
+                module,
+                moduleContext.Object,
+                It.IsAny<ModuleResult<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ModuleResult<int>?) null);
+        using var engineCancellationToken =
+            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+        var pipeline = new ModuleExecutionPipeline(
+            resultRepository.Object,
+            engineCancellationToken,
+            directHookInvoker.Object,
+            OptionsFactory.Create(new PipelineOptions()));
+
+        await pipeline.ExecuteAsync(
+            module,
+            executionContext,
+            moduleContext.Object,
+            CancellationToken.None);
+
+        var linkedCancellationTokenSource = executionContext.ModuleCancellationTokenSource;
+        Assert.Throws<ObjectDisposedException>(() => _ = originalCancellationTokenSource.Token);
+        Assert.Throws<ObjectDisposedException>(() => _ = linkedCancellationTokenSource.Token);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Attributes;
 using ModularPipelines.Configuration;
@@ -8,6 +9,7 @@ using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
+using PipelineEngineCancellationToken = ModularPipelines.Engine.EngineCancellationToken;
 using Status = ModularPipelines.Enums.Status;
 
 namespace ModularPipelines.UnitTests.Execution;
@@ -80,6 +82,18 @@ public class EngineCancellationTokenTests : TestBase
         {
             return Task.FromResult(true);
         }
+    }
+
+    [Test]
+    public async Task Dispose_Releases_Global_Event_Subscriptions()
+    {
+        var weakReference = CreateDisposedEngineCancellationToken();
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        await Assert.That(weakReference.IsAlive).IsFalse();
     }
 
     [Test]
@@ -201,5 +215,17 @@ public class EngineCancellationTokenTests : TestBase
 
         await Assert.That(exception!.InnerException).IsTypeOf<InvalidOperationException>();
         await Assert.That(exception.InnerException!).HasMessageEqualTo("Expected test failure");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateDisposedEngineCancellationToken()
+    {
+        var engineCancellationToken =
+            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+        var weakReference = new WeakReference(engineCancellationToken);
+
+        engineCancellationToken.Dispose();
+
+        return weakReference;
     }
 }


### PR DESCRIPTION
## Summary
- dispose per-module linked cancellation token sources on every exit path
- scope caller-token registrations to orchestration lifetime
- detach process-wide cancellation event handlers when the engine token is disposed
- add regression coverage for disposal and handler rooting

## Validation
- targeted ModuleExecutionPipelineTests: 1/1 passed
- targeted ExecutionOrchestratorTests: 2/2 passed
- targeted EngineCancellationTokenTests: 6/6 passed
- core ModularPipelines.sln Release build: passed
- whitespace verification: passed
- full unit-test project exceeded the required 2 GB agent guard; not retried with higher limits

Closes #3248