### PR TITLE
Publish immutable module dependency snapshots

### DIFF
--- a/src/ModularPipelines/Engine/Dependencies/ModuleStateDependencyInitializer.cs
+++ b/src/ModularPipelines/Engine/Dependencies/ModuleStateDependencyInitializer.cs
@@ -27,9 +27,6 @@ internal static class ModuleStateDependencyInitializer
 
     public static void Record(ModuleState state, Type dependencyType, bool optional)
     {
-        state.Dependencies[dependencyType] =
-            state.Dependencies.TryGetValue(dependencyType, out var existingOptional)
-                ? existingOptional && optional
-                : optional;
+        state.RecordDependency(dependencyType, optional);
     }
 }

--- a/src/ModularPipelines/Engine/ModuleState.cs
+++ b/src/ModularPipelines/Engine/ModuleState.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using ModularPipelines.Enums;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -40,17 +41,18 @@ internal enum ModuleExecutionState
 /// - Timing metrics (queued time, execution start, completion)
 /// - Constraint requirements (sequential execution, lock keys)
 ///
-/// Thread Safety: State property and collections are accessed under lock by ModuleScheduler.
-/// State transitions are atomic via enum assignment.
+/// Thread Safety: State and mutable collections are accessed under lock by ModuleScheduler.
+/// Dependencies are published as immutable snapshots for lock-free worker reads.
 /// </remarks>
 internal class ModuleState
 {
+    private ImmutableDictionary<Type, bool> _dependencies = ImmutableDictionary<Type, bool>.Empty;
+
     public ModuleState(IModule module, Type moduleType)
     {
         Module = module;
         ModuleType = moduleType;
         CompletionSource = new TaskCompletionSource<IModule>(TaskCreationOptions.RunContinuationsAsynchronously);
-        Dependencies = new Dictionary<Type, bool>();
         UnresolvedDependencies = new HashSet<Type>();
         DependentModules = new List<ModuleState>();
         RequiredLockKeys = Array.Empty<string>();
@@ -74,7 +76,19 @@ internal class ModuleState
     /// <summary>
     /// Gets all dependency types and whether each dependency is optional.
     /// </summary>
-    public Dictionary<Type, bool> Dependencies { get; }
+    public ImmutableDictionary<Type, bool> Dependencies => Volatile.Read(ref _dependencies);
+
+    /// <summary>
+    /// Adds or updates a dependency by publishing a new immutable snapshot.
+    /// </summary>
+    public void RecordDependency(Type dependencyType, bool optional)
+    {
+        ImmutableInterlocked.AddOrUpdate(
+            ref _dependencies,
+            dependencyType,
+            optional,
+            (_, existingOptional) => existingOptional && optional);
+    }
 
     /// <summary>
     /// Gets set of dependency types that haven't completed yet.

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -190,7 +190,7 @@ public class AlwaysRunHandlerTests
         var dependent = new SecondAlwaysRunModule();
         var prerequisiteState = new ModuleState(prerequisite, prerequisite.GetType());
         var dependentState = new ModuleState(dependent, dependent.GetType());
-        dependentState.Dependencies[prerequisite.GetType()] = false;
+        dependentState.RecordDependency(prerequisite.GetType(), optional: false);
         var scheduler = CreateScheduler(prerequisiteState, dependentState);
         var moduleRunner = new Mock<IModuleRunner>();
         var prerequisiteStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -287,12 +287,14 @@ public class ModuleSchedulerDynamicCycleTests
     {
         using var scheduler = CreateScheduler();
         scheduler.InitializeModules([new ExistingPredicateModule()]);
+        var existingState = scheduler.GetModuleState(typeof(ExistingPredicateModule))!;
+        var dependencySnapshot = existingState.Dependencies;
 
         scheduler.AddModule(new IndependentDynamicModule());
 
-        var existingState = scheduler.GetModuleState(typeof(ExistingPredicateModule));
-        await Assert.That(existingState).IsNotNull();
-        await Assert.That(existingState!.UnresolvedDependencies).Contains(typeof(IndependentDynamicModule));
+        await Assert.That(dependencySnapshot.ContainsKey(typeof(IndependentDynamicModule))).IsFalse();
+        await Assert.That(existingState.Dependencies.ContainsKey(typeof(IndependentDynamicModule))).IsTrue();
+        await Assert.That(existingState.UnresolvedDependencies).Contains(typeof(IndependentDynamicModule));
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- replace the mutable per-module dependency dictionary with atomically published ImmutableDictionary snapshots
- preserve required-over-optional merge semantics through ImmutableInterlocked.AddOrUpdate
- keep worker enumeration lock-free without collection-modified races or torn dictionary reads
- add regression coverage proving old snapshots remain stable during dynamic dependency discovery

## Validation
- ModuleSchedulerDynamicCycleTests: 13/13 passed
- AlwaysRunHandlerTests: 6/6 passed
- ModularPipelines.sln Release build: passed with 0 errors
- touched-file whitespace verification: passed
- whole-solution whitespace verification reports pre-existing failures in untouched files

Closes #3252