### PR TITLE
Stop rooting scoped module loggers

### DIFF
--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
-using ModularPipelines.Helpers;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -89,8 +88,6 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
         _formattedLogValuesObfuscator = formattedLogValuesObfuscator;
         _buffer = consoleCoordinator.GetModuleBuffer(typeof(T));
         _outputCoordinator = outputCoordinator;
-
-        Disposer.RegisterOnShutdown(this);
     }
 
     public override IDisposable? BeginScope<TState>(TState state)

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -1,10 +1,15 @@
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
+using ModularPipelines.Console;
 using ModularPipelines.Context;
+using ModularPipelines.Engine;
 using ModularPipelines.Extensions;
+using ModularPipelines.Logging;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
+using Moq;
 using NReco.Logging.File;
 using File = ModularPipelines.FileSystem.File;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
@@ -96,6 +101,42 @@ public class ModuleLoggerTests
 
         await Assert.That(await file.ReadAsync()).DoesNotContain("Secret Value!!!");
         await Assert.That(await file.ReadAsync()).Contains("**********");
+    }
+
+    [Test]
+    public async Task Disposed_Logger_Is_Not_Rooted_By_ProcessExit()
+    {
+        var loggerReference = CreateDisposedLoggerReference();
+
+        for (var attempt = 0; attempt < 10 && loggerReference.IsAlive; attempt++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            await Task.Delay(10);
+        }
+
+        await Assert.That(loggerReference.IsAlive).IsFalse();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference CreateDisposedLoggerReference()
+    {
+        var moduleOutputBuffer = Mock.Of<IModuleOutputBuffer>();
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.GetModuleBuffer(typeof(ModuleLoggerTests)))
+            .Returns(moduleOutputBuffer);
+
+        var logger = new ModuleLogger<ModuleLoggerTests>(
+            Mock.Of<ILogger<ModuleLoggerTests>>(),
+            Mock.Of<ISecretObfuscator>(),
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            Mock.Of<IOutputCoordinator>());
+
+        logger.Dispose();
+        return new WeakReference(logger);
     }
 
     private class MySecrets


### PR DESCRIPTION
## Summary
- remove the per-ModuleLogger ProcessExit subscription
- rely on ModuleRunner's existing await-using async DI scope for logger disposal and output flushing
- add a weak-reference regression test proving disposed loggers can be collected

## Validation
- ModuleLoggerTests: 4/4 passed
- ModularPipelines.sln Release build: passed with 0 errors
- touched-file whitespace verification: passed

Closes #3268