### PR TITLE
Index and prune estimated-time cache

### DIFF
--- a/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
+++ b/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
@@ -11,8 +11,7 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
     private readonly object _subModuleIndexLock = new();
     private readonly string _directory;
     private readonly TimeProvider _timeProvider;
-    private IReadOnlyDictionary<string, FileInfo[]>? _subModuleFilesByModule;
-    private long _subModuleIndexExpiresAtTicks;
+    private SubModuleFileIndex? _subModuleFileIndex;
 
     public FileSystemModuleEstimatedTimeProvider()
         : this(
@@ -86,37 +85,33 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
 
         lock (_subModuleIndexLock)
         {
-            Volatile.Write(ref _subModuleFilesByModule, null);
-            Volatile.Write(ref _subModuleIndexExpiresAtTicks, 0);
+            Volatile.Write(ref _subModuleFileIndex, null);
         }
     }
 
     private IReadOnlyDictionary<string, FileInfo[]> GetSubModuleFilesByModule()
     {
         var now = _timeProvider.GetUtcNow();
-        var filesByModule = Volatile.Read(ref _subModuleFilesByModule);
-        if (filesByModule is not null
-            && now.UtcTicks < Volatile.Read(ref _subModuleIndexExpiresAtTicks))
+        var index = Volatile.Read(ref _subModuleFileIndex);
+        if (index is not null && now.UtcTicks < index.ExpiresAtTicks)
         {
-            return filesByModule;
+            return index.FilesByModule;
         }
 
         lock (_subModuleIndexLock)
         {
             now = _timeProvider.GetUtcNow();
-            filesByModule = _subModuleFilesByModule;
-            if (filesByModule is not null
-                && now.UtcTicks < _subModuleIndexExpiresAtTicks)
+            index = _subModuleFileIndex;
+            if (index is not null && now.UtcTicks < index.ExpiresAtTicks)
             {
-                return filesByModule;
+                return index.FilesByModule;
             }
 
-            filesByModule = BuildSubModuleFileIndex(now);
-            Volatile.Write(
-                ref _subModuleIndexExpiresAtTicks,
+            index = new SubModuleFileIndex(
+                BuildSubModuleFileIndex(now),
                 now.Add(IndexRefreshInterval).UtcTicks);
-            Volatile.Write(ref _subModuleFilesByModule, filesByModule);
-            return filesByModule;
+            Volatile.Write(ref _subModuleFileIndex, index);
+            return index.FilesByModule;
         }
     }
 
@@ -216,4 +211,8 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
 
         await File.WriteAllTextAsync(path, duration.ToString()).ConfigureAwait(false);
     }
+
+    private sealed record SubModuleFileIndex(
+        IReadOnlyDictionary<string, FileInfo[]> FilesByModule,
+        long ExpiresAtTicks);
 }

--- a/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
+++ b/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
@@ -5,35 +5,47 @@ namespace ModularPipelines.Engine;
 
 internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvider
 {
-    private readonly string _directory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-        "ModularPipelines", "EstimatedTimes");
+    private static readonly TimeSpan CacheRetention = TimeSpan.FromDays(90);
+
+    private readonly object _subModuleIndexLock = new();
+    private readonly string _directory;
+    private readonly TimeProvider _timeProvider;
+    private IReadOnlyDictionary<string, FileInfo[]>? _subModuleFilesByModule;
+
+    public FileSystemModuleEstimatedTimeProvider()
+        : this(
+            Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "ModularPipelines",
+                "EstimatedTimes"),
+            TimeProvider.System)
+    {
+    }
+
+    internal FileSystemModuleEstimatedTimeProvider(string directory, TimeProvider timeProvider)
+    {
+        _directory = directory;
+        _timeProvider = timeProvider;
+    }
 
     public async Task<TimeSpan> GetModuleEstimatedTimeAsync(Type moduleType)
     {
-        var fileName = $"{moduleType.FullName}.txt";
+        var fileName = $"{GetModuleName(moduleType)}.txt";
         return await GetEstimatedTimeAsync(fileName).ConfigureAwait(false);
     }
 
     public async Task SaveModuleTimeAsync(Type moduleType, TimeSpan duration)
     {
-        var fileName = $"{moduleType.FullName}.txt";
+        var fileName = $"{GetModuleName(moduleType)}.txt";
 
         await SaveModuleTimeAsync(duration, fileName).ConfigureAwait(false);
     }
 
     public async Task<IEnumerable<SubModuleEstimation>> GetSubModuleEstimatedTimesAsync(Type moduleType)
     {
-        var directoryInfo = new DirectoryInfo(_directory);
-
-        if (!directoryInfo.Exists)
-        {
-            directoryInfo.Create();
-        }
-
-        var paths = directoryInfo
-            .EnumerateFiles("*.txt", SearchOption.TopDirectoryOnly)
-            .Where(x => x.Name.StartsWith($"Mod-{moduleType.FullName}"))
-            .ToList();
+        var filesByModule = GetSubModuleFilesByModule();
+        var moduleName = GetModuleName(moduleType);
+        var paths = filesByModule.GetValueOrDefault(moduleName, []);
 
         var subModuleEstimations = await paths.ToAsyncProcessorBuilder()
             .SelectAsync(async file =>
@@ -66,9 +78,94 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
 
     public async Task SaveSubModuleTimeAsync(Type moduleType, SubModuleEstimation subModuleEstimation)
     {
-        var fileName = $"Mod-{moduleType.FullName}-Sub-{subModuleEstimation.SubModuleName}.txt";
+        var fileName = $"Mod-{GetModuleName(moduleType)}-Sub-{subModuleEstimation.SubModuleName}.txt";
 
         await SaveModuleTimeAsync(subModuleEstimation.EstimatedDuration, fileName).ConfigureAwait(false);
+
+        lock (_subModuleIndexLock)
+        {
+            _subModuleFilesByModule = null;
+        }
+    }
+
+    private IReadOnlyDictionary<string, FileInfo[]> GetSubModuleFilesByModule()
+    {
+        var filesByModule = Volatile.Read(ref _subModuleFilesByModule);
+        if (filesByModule is not null)
+        {
+            return filesByModule;
+        }
+
+        lock (_subModuleIndexLock)
+        {
+            return _subModuleFilesByModule ??= BuildSubModuleFileIndex();
+        }
+    }
+
+    private IReadOnlyDictionary<string, FileInfo[]> BuildSubModuleFileIndex()
+    {
+        var directoryInfo = Directory.CreateDirectory(_directory);
+        var expirationTime = _timeProvider.GetUtcNow().UtcDateTime - CacheRetention;
+        var filesByModule = new Dictionary<string, List<FileInfo>>(StringComparer.Ordinal);
+
+        foreach (var file in directoryInfo.EnumerateFiles("*.txt", SearchOption.TopDirectoryOnly))
+        {
+            if (file.LastWriteTimeUtc < expirationTime)
+            {
+                TryDelete(file);
+                continue;
+            }
+
+            if (!TryGetModuleName(file.Name, out var moduleName))
+            {
+                continue;
+            }
+
+            if (!filesByModule.TryGetValue(moduleName, out var files))
+            {
+                files = [];
+                filesByModule[moduleName] = files;
+            }
+
+            files.Add(file);
+        }
+
+        return filesByModule.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value.ToArray(),
+            StringComparer.Ordinal);
+    }
+
+    private static bool TryGetModuleName(string fileName, out string moduleName)
+    {
+        const string prefix = "Mod-";
+        const string separator = "-Sub-";
+
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+        var subModuleSeparatorIndex = fileNameWithoutExtension.IndexOf(separator, StringComparison.Ordinal);
+        if (!fileNameWithoutExtension.StartsWith(prefix, StringComparison.Ordinal)
+            || subModuleSeparatorIndex <= prefix.Length)
+        {
+            moduleName = string.Empty;
+            return false;
+        }
+
+        moduleName = fileNameWithoutExtension[prefix.Length..subModuleSeparatorIndex];
+        return true;
+    }
+
+    private static string GetModuleName(Type moduleType) => moduleType.FullName ?? moduleType.Name;
+
+    private static void TryDelete(FileInfo file)
+    {
+        try
+        {
+            file.Delete();
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+        {
+            // Best-effort pruning. A locked cache entry can be retried on the next process run.
+        }
     }
 
     private async Task<TimeSpan> GetEstimatedTimeAsync(string fileName)

--- a/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
+++ b/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
@@ -91,25 +91,25 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
 
     private IReadOnlyDictionary<string, FileInfo[]> GetSubModuleFilesByModule()
     {
-        var now = _timeProvider.GetUtcNow();
         var index = Volatile.Read(ref _subModuleFileIndex);
-        if (index is not null && now.UtcTicks < index.ExpiresAtTicks)
+        if (index is not null
+            && _timeProvider.GetElapsedTime(index.CreatedTimestamp) < IndexRefreshInterval)
         {
             return index.FilesByModule;
         }
 
         lock (_subModuleIndexLock)
         {
-            now = _timeProvider.GetUtcNow();
             index = _subModuleFileIndex;
-            if (index is not null && now.UtcTicks < index.ExpiresAtTicks)
+            if (index is not null
+                && _timeProvider.GetElapsedTime(index.CreatedTimestamp) < IndexRefreshInterval)
             {
                 return index.FilesByModule;
             }
 
             index = new SubModuleFileIndex(
-                BuildSubModuleFileIndex(now),
-                now.Add(IndexRefreshInterval).UtcTicks);
+                BuildSubModuleFileIndex(_timeProvider.GetUtcNow()),
+                _timeProvider.GetTimestamp());
             Volatile.Write(ref _subModuleFileIndex, index);
             return index.FilesByModule;
         }
@@ -214,5 +214,5 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
 
     private sealed record SubModuleFileIndex(
         IReadOnlyDictionary<string, FileInfo[]> FilesByModule,
-        long ExpiresAtTicks);
+        long CreatedTimestamp);
 }

--- a/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
+++ b/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
@@ -6,11 +6,13 @@ namespace ModularPipelines.Engine;
 internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvider
 {
     private static readonly TimeSpan CacheRetention = TimeSpan.FromDays(90);
+    private static readonly TimeSpan IndexRefreshInterval = TimeSpan.FromMinutes(1);
 
     private readonly object _subModuleIndexLock = new();
     private readonly string _directory;
     private readonly TimeProvider _timeProvider;
     private IReadOnlyDictionary<string, FileInfo[]>? _subModuleFilesByModule;
+    private long _subModuleIndexExpiresAtTicks;
 
     public FileSystemModuleEstimatedTimeProvider()
         : this(
@@ -84,28 +86,44 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
 
         lock (_subModuleIndexLock)
         {
-            _subModuleFilesByModule = null;
+            Volatile.Write(ref _subModuleFilesByModule, null);
+            Volatile.Write(ref _subModuleIndexExpiresAtTicks, 0);
         }
     }
 
     private IReadOnlyDictionary<string, FileInfo[]> GetSubModuleFilesByModule()
     {
+        var now = _timeProvider.GetUtcNow();
         var filesByModule = Volatile.Read(ref _subModuleFilesByModule);
-        if (filesByModule is not null)
+        if (filesByModule is not null
+            && now.UtcTicks < Volatile.Read(ref _subModuleIndexExpiresAtTicks))
         {
             return filesByModule;
         }
 
         lock (_subModuleIndexLock)
         {
-            return _subModuleFilesByModule ??= BuildSubModuleFileIndex();
+            now = _timeProvider.GetUtcNow();
+            filesByModule = _subModuleFilesByModule;
+            if (filesByModule is not null
+                && now.UtcTicks < _subModuleIndexExpiresAtTicks)
+            {
+                return filesByModule;
+            }
+
+            filesByModule = BuildSubModuleFileIndex(now);
+            Volatile.Write(
+                ref _subModuleIndexExpiresAtTicks,
+                now.Add(IndexRefreshInterval).UtcTicks);
+            Volatile.Write(ref _subModuleFilesByModule, filesByModule);
+            return filesByModule;
         }
     }
 
-    private IReadOnlyDictionary<string, FileInfo[]> BuildSubModuleFileIndex()
+    private IReadOnlyDictionary<string, FileInfo[]> BuildSubModuleFileIndex(DateTimeOffset now)
     {
         var directoryInfo = Directory.CreateDirectory(_directory);
-        var expirationTime = _timeProvider.GetUtcNow().UtcDateTime - CacheRetention;
+        var expirationTime = now.UtcDateTime - CacheRetention;
         var filesByModule = new Dictionary<string, List<FileInfo>>(StringComparer.Ordinal);
 
         foreach (var file in directoryInfo.EnumerateFiles("*.txt", SearchOption.TopDirectoryOnly))

--- a/test/ModularPipelines.UnitTests/Engine/FileSystemModuleEstimatedTimeProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/FileSystemModuleEstimatedTimeProviderTests.cs
@@ -92,6 +92,25 @@ public class FileSystemModuleEstimatedTimeProviderTests
         });
     }
 
+    [Test]
+    public async Task GetSubModuleEstimatedTimes_RefreshesExpiredDirectoryIndex()
+    {
+        await RunWithTemporaryDirectoryAsync(async directory =>
+        {
+            WriteEstimation(directory, typeof(PrefixModule), "first", TimeSpan.FromSeconds(1));
+            var timeProvider = new FakeTimeProvider(CurrentTime);
+            var provider = new FileSystemModuleEstimatedTimeProvider(directory, timeProvider);
+            _ = await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModule));
+
+            WriteEstimation(directory, typeof(PrefixModule), "external", TimeSpan.FromSeconds(2));
+            timeProvider.Advance(TimeSpan.FromMinutes(2));
+            var estimations = (await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModule))).ToArray();
+
+            await Assert.That(estimations.Select(x => x.SubModuleName))
+                .IsEquivalentTo(["first", "external"]);
+        });
+    }
+
     private static FileSystemModuleEstimatedTimeProvider CreateProvider(string directory)
     {
         return new FileSystemModuleEstimatedTimeProvider(directory, new FakeTimeProvider(CurrentTime));

--- a/test/ModularPipelines.UnitTests/Engine/FileSystemModuleEstimatedTimeProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/FileSystemModuleEstimatedTimeProviderTests.cs
@@ -1,0 +1,128 @@
+using Microsoft.Extensions.Time.Testing;
+using ModularPipelines.Engine;
+using ModularPipelines.Models;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class FileSystemModuleEstimatedTimeProviderTests
+{
+    private static readonly DateTimeOffset CurrentTime = new(2026, 7, 29, 0, 0, 0, TimeSpan.Zero);
+
+    private sealed class PrefixModule;
+
+    private sealed class PrefixModuleSuffix;
+
+    [Test]
+    public async Task GetSubModuleEstimatedTimes_UsesExactModuleName()
+    {
+        await RunWithTemporaryDirectoryAsync(async directory =>
+        {
+            WriteEstimation(directory, typeof(PrefixModule), "expected", TimeSpan.FromSeconds(1));
+            WriteEstimation(directory, typeof(PrefixModuleSuffix), "other", TimeSpan.FromSeconds(2));
+            var provider = CreateProvider(directory);
+
+            var estimations = (await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModule))).ToArray();
+
+            await Assert.That(estimations).HasSingleItem();
+            await Assert.That(estimations[0].SubModuleName).IsEqualTo("expected");
+        });
+    }
+
+    [Test]
+    public async Task GetSubModuleEstimatedTimes_ReusesDirectoryIndexAcrossModules()
+    {
+        await RunWithTemporaryDirectoryAsync(async directory =>
+        {
+            WriteEstimation(directory, typeof(PrefixModule), "first", TimeSpan.FromSeconds(1));
+            var cachedPath = WriteEstimation(
+                directory,
+                typeof(PrefixModuleSuffix),
+                "cached",
+                TimeSpan.FromSeconds(2));
+            var provider = CreateProvider(directory);
+
+            _ = await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModule));
+            File.Delete(cachedPath);
+            var estimations =
+                (await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModuleSuffix))).ToArray();
+
+            await Assert.That(estimations).HasSingleItem();
+            await Assert.That(estimations[0].SubModuleName).IsEqualTo("cached");
+        });
+    }
+
+    [Test]
+    public async Task GetSubModuleEstimatedTimes_PrunesExpiredFiles()
+    {
+        await RunWithTemporaryDirectoryAsync(async directory =>
+        {
+            var expiredPath = WriteEstimation(
+                directory,
+                typeof(PrefixModule),
+                "expired",
+                TimeSpan.FromSeconds(1));
+            File.SetLastWriteTimeUtc(expiredPath, CurrentTime.UtcDateTime.AddDays(-91));
+            WriteEstimation(directory, typeof(PrefixModule), "current", TimeSpan.FromSeconds(2));
+            var provider = CreateProvider(directory);
+
+            var estimations = (await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModule))).ToArray();
+
+            await Assert.That(estimations).HasSingleItem();
+            await Assert.That(estimations[0].SubModuleName).IsEqualTo("current");
+            await Assert.That(File.Exists(expiredPath)).IsFalse();
+        });
+    }
+
+    [Test]
+    public async Task SaveSubModuleTime_InvalidatesDirectoryIndex()
+    {
+        await RunWithTemporaryDirectoryAsync(async directory =>
+        {
+            WriteEstimation(directory, typeof(PrefixModule), "first", TimeSpan.FromSeconds(1));
+            var provider = CreateProvider(directory);
+            _ = await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModule));
+
+            await provider.SaveSubModuleTimeAsync(
+                typeof(PrefixModule),
+                new SubModuleEstimation("second", TimeSpan.FromSeconds(2)));
+            var estimations = (await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModule))).ToArray();
+
+            await Assert.That(estimations.Select(x => x.SubModuleName))
+                .IsEquivalentTo(["first", "second"]);
+        });
+    }
+
+    private static FileSystemModuleEstimatedTimeProvider CreateProvider(string directory)
+    {
+        return new FileSystemModuleEstimatedTimeProvider(directory, new FakeTimeProvider(CurrentTime));
+    }
+
+    private static string WriteEstimation(
+        string directory,
+        Type moduleType,
+        string subModuleName,
+        TimeSpan duration)
+    {
+        var path = Path.Combine(
+            directory,
+            $"Mod-{moduleType.FullName}-Sub-{subModuleName}.txt");
+        File.WriteAllText(path, duration.ToString());
+        File.SetLastWriteTimeUtc(path, CurrentTime.UtcDateTime);
+        return path;
+    }
+
+    private static async Task RunWithTemporaryDirectoryAsync(Func<string, Task> test)
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"ModularPipelines-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            await test(directory);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- build one thread-safe estimated-time file index per provider
- group submodule cache files by exact module name
- prune cache entries older than 90 days on index creation
- invalidate the index after saving a submodule estimate
- cover exact matching, reuse, pruning, and invalidation

## Validation
- focused `FileSystemModuleEstimatedTimeProviderTests`: 4 passed
- touched-file whitespace verification: passed
- `ModularPipelines.sln` Release build: 0 errors (existing warnings remain)

Closes #3262