### PR TITLE
Make dynamic module insertion incremental

### DIFF
--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -239,6 +239,127 @@ internal class ModuleScheduler : IModuleScheduler
         _schedulerNotification.Release();
     }
 
+    /// <summary>
+    /// Starts the scheduler loop that continuously queues ready modules.
+    /// </summary>
+    public Task RunSchedulerAsync(CancellationToken cancellationToken)
+    {
+        if (IsDisposed)
+        {
+            return Task.CompletedTask;
+        }
+
+        return Task.Run(async () =>
+        {
+            try
+            {
+                _logger.LogDebug("Module scheduler started");
+                await RunSchedulerLoopAsync(cancellationToken).ConfigureAwait(false);
+                CompleteScheduler();
+                _logger.LogDebug("Module scheduler completed");
+            }
+            catch (Exception ex)
+            {
+                // Catch ALL exceptions including fatal ones - we need to complete the channel
+                // and log before re-throwing. The immediate throw ensures exceptions propagate.
+                _logger.LogError(ex, "Module scheduler encountered an error");
+                _readyChannel.Writer.Complete(ex);
+                throw;
+            }
+        }, cancellationToken);
+    }
+
+    /// <summary>
+    /// Marks a module as started execution.
+    /// </summary>
+    /// <returns>True if the module can proceed with execution, false if constraints prevent execution.</returns>
+    public bool MarkModuleStarted(Type moduleType)
+    {
+        if (IsDisposed)
+        {
+            return false;
+        }
+
+        return _stateTracker.MarkModuleStarted(moduleType);
+    }
+
+    /// <summary>
+    /// Marks a module as completed and notifies dependents.
+    /// </summary>
+    public void MarkModuleCompleted(Type moduleType, bool success, Exception? exception = null, Status? statusOverride = null)
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        _stateTracker.MarkModuleCompleted(moduleType, success, exception, statusOverride);
+    }
+
+    /// <summary>
+    /// Gets the completion task for a specific module.
+    /// </summary>
+    public Task<IModule>? GetModuleCompletionTask(Type moduleType)
+    {
+        return _stateTracker.GetModuleCompletionTask(moduleType);
+    }
+
+    /// <summary>
+    /// Gets the state for a specific module.
+    /// </summary>
+    public ModuleState? GetModuleState(Type moduleType)
+    {
+        return _stateTracker.GetModuleState(moduleType);
+    }
+
+    /// <summary>
+    /// Gets statistics about the current scheduler state.
+    /// </summary>
+    public (int Total, int Queued, int Executing, int Completed, int Pending) GetStatistics()
+    {
+        _stateLock.EnterReadLock();
+        try
+        {
+            var snapshot = _stateCounters.CreateSnapshot();
+            return (snapshot.Total, snapshot.Queued, snapshot.Executing, snapshot.Completed, snapshot.Pending);
+        }
+        finally
+        {
+            _stateLock.ExitReadLock();
+        }
+    }
+
+    /// <summary>
+    /// Cancels all modules that are queued or pending (not yet executing)
+    /// This is used when the pipeline is cancelled to ensure TaskCompletionSources are properly completed
+    /// Note: AlwaysRun modules are not cancelled as they should be allowed to complete.
+    /// </summary>
+    public void CancelPendingModules()
+    {
+        if (IsDisposed)
+        {
+            return;
+        }
+
+        _stateTracker.CancelPendingModules();
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposeState, 1) != 0)
+        {
+            return;
+        }
+
+        _disposalCancellationTokenSource.Cancel();
+        _disposalCancellationTokenSource.Dispose();
+
+        // Wake the scheduler so it observes disposal promptly. The lock and semaphore
+        // deliberately remain undisposed because in-flight workers may still be using
+        // them while unwinding; they become collectible with this scheduler.
+        _schedulerNotification.Release();
+    }
+
     private (
         Dictionary<Type, bool> DependenciesByType,
         HashSet<Type> SelectorDependents) ResolveNewlyAvailableDependencies(Type moduleType)
@@ -485,36 +606,6 @@ internal class ModuleScheduler : IModuleScheduler
             $"Dependency collision detected: {string.Join(" -> ", formattedCycle)}");
     }
 
-    /// <summary>
-    /// Starts the scheduler loop that continuously queues ready modules.
-    /// </summary>
-    public Task RunSchedulerAsync(CancellationToken cancellationToken)
-    {
-        if (IsDisposed)
-        {
-            return Task.CompletedTask;
-        }
-
-        return Task.Run(async () =>
-        {
-            try
-            {
-                _logger.LogDebug("Module scheduler started");
-                await RunSchedulerLoopAsync(cancellationToken).ConfigureAwait(false);
-                CompleteScheduler();
-                _logger.LogDebug("Module scheduler completed");
-            }
-            catch (Exception ex)
-            {
-                // Catch ALL exceptions including fatal ones - we need to complete the channel
-                // and log before re-throwing. The immediate throw ensures exceptions propagate.
-                _logger.LogError(ex, "Module scheduler encountered an error");
-                _readyChannel.Writer.Complete(ex);
-                throw;
-            }
-        }, cancellationToken);
-    }
-
     private async Task RunSchedulerLoopAsync(CancellationToken cancellationToken)
     {
         while (ShouldContinueScheduling(cancellationToken))
@@ -634,97 +725,6 @@ internal class ModuleScheduler : IModuleScheduler
         }
 
         _readyChannel.Writer.Complete();
-    }
-
-    /// <summary>
-    /// Marks a module as started execution.
-    /// </summary>
-    /// <returns>True if the module can proceed with execution, false if constraints prevent execution.</returns>
-    public bool MarkModuleStarted(Type moduleType)
-    {
-        if (IsDisposed)
-        {
-            return false;
-        }
-
-        return _stateTracker.MarkModuleStarted(moduleType);
-    }
-
-    /// <summary>
-    /// Marks a module as completed and notifies dependents.
-    /// </summary>
-    public void MarkModuleCompleted(Type moduleType, bool success, Exception? exception = null, Status? statusOverride = null)
-    {
-        if (IsDisposed)
-        {
-            return;
-        }
-
-        _stateTracker.MarkModuleCompleted(moduleType, success, exception, statusOverride);
-    }
-
-    /// <summary>
-    /// Gets the completion task for a specific module.
-    /// </summary>
-    public Task<IModule>? GetModuleCompletionTask(Type moduleType)
-    {
-        return _stateTracker.GetModuleCompletionTask(moduleType);
-    }
-
-    /// <summary>
-    /// Gets the state for a specific module.
-    /// </summary>
-    public ModuleState? GetModuleState(Type moduleType)
-    {
-        return _stateTracker.GetModuleState(moduleType);
-    }
-
-    /// <summary>
-    /// Gets statistics about the current scheduler state.
-    /// </summary>
-    public (int Total, int Queued, int Executing, int Completed, int Pending) GetStatistics()
-    {
-        _stateLock.EnterReadLock();
-        try
-        {
-            var snapshot = _stateCounters.CreateSnapshot();
-            return (snapshot.Total, snapshot.Queued, snapshot.Executing, snapshot.Completed, snapshot.Pending);
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
-    }
-
-    /// <summary>
-    /// Cancels all modules that are queued or pending (not yet executing)
-    /// This is used when the pipeline is cancelled to ensure TaskCompletionSources are properly completed
-    /// Note: AlwaysRun modules are not cancelled as they should be allowed to complete.
-    /// </summary>
-    public void CancelPendingModules()
-    {
-        if (IsDisposed)
-        {
-            return;
-        }
-
-        _stateTracker.CancelPendingModules();
-    }
-
-    public void Dispose()
-    {
-        if (Interlocked.Exchange(ref _disposeState, 1) != 0)
-        {
-            return;
-        }
-
-        _disposalCancellationTokenSource.Cancel();
-        _disposalCancellationTokenSource.Dispose();
-
-        // Wake the scheduler so it observes disposal promptly. The lock and semaphore
-        // deliberately remain undisposed because in-flight workers may still be using
-        // them while unwinding; they become collectible with this scheduler.
-        _schedulerNotification.Release();
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -164,55 +164,17 @@ internal class ModuleScheduler : IModuleScheduler
                 availableModuleTypes,
                 _dependencyRegistry,
                 _metadataRegistry).ToArray();
-            var declaredDependenciesByType = _dependencyGraph.ToDictionary(
-                pair => pair.Key,
-                pair => new HashSet<Type>(pair.Value));
-            var newlyResolvedDependenciesByType = new Dictionary<Type, (Type DependencyType, bool Optional)[]>();
+            var (newlyAvailableDependenciesByType, selectorDependents) =
+                ResolveNewlyAvailableDependencies(moduleType);
 
-            foreach (var existingModuleType in _moduleStates.Keys)
-            {
-                var newlyResolvedDependencies = ModuleDependencyResolver.GetAllDependencies(
-                        _moduleStates[existingModuleType].Module,
-                        availableModuleTypes,
-                        _dependencyRegistry,
-                        _metadataRegistry)
-                    .Where(dependency => dependency.DependencyType == moduleType)
-                    .ToArray();
-
-                newlyResolvedDependenciesByType[existingModuleType] = newlyResolvedDependencies;
-
-                declaredDependenciesByType[existingModuleType]
-                    .UnionWith(newlyResolvedDependencies.Select(dependency => dependency.DependencyType));
-            }
-
-            declaredDependenciesByType[moduleType] = newModuleDependencies
+            var newModuleDependencyTypes = newModuleDependencies
                 .Select(dependency => dependency.DependencyType)
                 .ToHashSet();
 
-            var candidateGraph = declaredDependenciesByType.ToDictionary(
-                pair => pair.Key,
-                pair => pair.Key == moduleType || _moduleStates[pair.Key].State == ModuleExecutionState.Pending
-                    ? pair.Value.Where(dependencyType =>
-                            !_moduleStates.TryGetValue(dependencyType, out var dependencyState)
-                            || dependencyState.State != ModuleExecutionState.Completed)
-                        .ToHashSet()
-                    : new HashSet<Type>());
-
-            ModuleDependencyValidator.ValidateCircularDependencies(candidateGraph);
-
-            foreach (var (existingModuleType, newlyResolvedDependencies) in newlyResolvedDependenciesByType)
-            {
-                var existingState = _moduleStates[existingModuleType];
-                if (existingState.State != ModuleExecutionState.Pending)
-                {
-                    continue;
-                }
-
-                foreach (var (dependencyType, optional) in newlyResolvedDependencies)
-                {
-                    ModuleStateDependencyInitializer.Record(existingState, dependencyType, optional);
-                }
-            }
+            ValidateNoDynamicCycle(
+                moduleType,
+                newModuleDependencyTypes,
+                newlyAvailableDependenciesByType.Keys);
 
             foreach (var (dependencyType, optional) in newModuleDependencies)
             {
@@ -221,13 +183,27 @@ internal class ModuleScheduler : IModuleScheduler
 
             _moduleStates[moduleType] = state;
             _stateCounters.AddPendingModule();
-            _dependencyGraph.Clear();
-            foreach (var (registeredType, registeredDependencies) in declaredDependenciesByType)
+            _dependencyGraph[moduleType] = newModuleDependencyTypes;
+
+            foreach (var selectorDependent in selectorDependents)
             {
-                _dependencyGraph[registeredType] = registeredDependencies;
+                _dependencyGraph[selectorDependent].Add(moduleType);
             }
 
-            RebuildPendingDependencyState(declaredDependenciesByType);
+            foreach (var (existingModuleType, optional) in newlyAvailableDependenciesByType)
+            {
+                var existingState = _moduleStates[existingModuleType];
+                if (existingState.State == ModuleExecutionState.Pending)
+                {
+                    ModuleStateDependencyInitializer.Record(existingState, moduleType, optional);
+                    LinkDependencyState(existingState, moduleType, optional);
+                }
+            }
+
+            foreach (var (dependencyType, optional) in newModuleDependencies)
+            {
+                LinkDependencyState(state, dependencyType, optional);
+            }
 
             foreach (var (dependencyType, ignoreIfNotRegistered) in newModuleDependencies)
             {
@@ -261,6 +237,42 @@ internal class ModuleScheduler : IModuleScheduler
             state.UnresolvedDependencies.Count);
 
         _schedulerNotification.Release();
+    }
+
+    private (
+        Dictionary<Type, bool> DependenciesByType,
+        HashSet<Type> SelectorDependents) ResolveNewlyAvailableDependencies(Type moduleType)
+    {
+        var dependenciesByType = new Dictionary<Type, bool>();
+        var selectorDependents = new HashSet<Type>();
+
+        foreach (var existingModuleType in _moduleStates.Keys)
+        {
+            var existingState = _moduleStates[existingModuleType];
+            bool? isOptional = existingState.Dependencies.TryGetValue(moduleType, out var declaredOptional)
+                ? declaredOptional
+                : null;
+
+            var selectorDependencies = ModuleDependencyResolver.GetSelectorDependencies(
+                    existingModuleType,
+                    [moduleType],
+                    _metadataRegistry)
+                .ToArray();
+
+            if (selectorDependencies.Length > 0)
+            {
+                selectorDependents.Add(existingModuleType);
+                isOptional = (isOptional ?? true)
+                             && selectorDependencies.All(dependency => dependency.Optional);
+            }
+
+            if (isOptional is not null)
+            {
+                dependenciesByType[existingModuleType] = isOptional.Value;
+            }
+        }
+
+        return (dependenciesByType, selectorDependents);
     }
 
     private void AddModuleStates(IEnumerable<IModule> modules)
@@ -366,7 +378,8 @@ internal class ModuleScheduler : IModuleScheduler
     {
         if (_moduleStates.TryGetValue(dependencyType, out var dependencyState))
         {
-            if (state.UnresolvedDependencies.Add(dependencyType))
+            if (dependencyState.State != ModuleExecutionState.Completed
+                && state.UnresolvedDependencies.Add(dependencyType))
             {
                 dependencyState.DependentModules.Add(state);
             }
@@ -383,35 +396,93 @@ internal class ModuleScheduler : IModuleScheduler
         }
     }
 
-    private void RebuildPendingDependencyState(
-        IReadOnlyDictionary<Type, HashSet<Type>> dependenciesByType)
+    private void ValidateNoDynamicCycle(
+        Type moduleType,
+        IReadOnlySet<Type> newModuleDependencies,
+        IEnumerable<Type> newlyAvailableDependentTypes)
     {
-        foreach (var registeredState in _moduleStates.Values)
+        if (newModuleDependencies.Contains(moduleType))
         {
-            registeredState.UnresolvedDependencies.Clear();
-            registeredState.DependentModules.Clear();
+            ThrowDependencyCollision([moduleType, moduleType]);
         }
 
-        foreach (var (dependentType, dependencies) in dependenciesByType)
+        var pendingDependents = newlyAvailableDependentTypes
+            .Where(type => _moduleStates[type].State == ModuleExecutionState.Pending)
+            .ToHashSet();
+        if (pendingDependents.Count == 0)
         {
-            var dependentState = _moduleStates[dependentType];
-            if (dependentState.State != ModuleExecutionState.Pending)
-            {
-                continue;
-            }
+            return;
+        }
 
-            foreach (var dependencyType in dependencies)
+        var parentByType = new Dictionary<Type, Type?>
+        {
+            [moduleType] = null,
+        };
+
+        var modulesToVisit = new Stack<Type>();
+        modulesToVisit.Push(moduleType);
+
+        while (modulesToVisit.TryPop(out var currentType))
+        {
+            foreach (var dependencyType in GetPendingDependencies(currentType, moduleType, newModuleDependencies))
             {
-                if (!_moduleStates.TryGetValue(dependencyType, out var dependencyState)
-                    || dependencyState.State == ModuleExecutionState.Completed)
+                if (!parentByType.TryAdd(dependencyType, currentType))
                 {
                     continue;
                 }
 
-                dependentState.UnresolvedDependencies.Add(dependencyType);
-                dependencyState.DependentModules.Add(dependentState);
+                if (pendingDependents.Contains(dependencyType))
+                {
+                    ThrowDependencyCollision(BuildDynamicCycle(moduleType, dependencyType, parentByType));
+                }
+
+                modulesToVisit.Push(dependencyType);
             }
         }
+    }
+
+    private IEnumerable<Type> GetPendingDependencies(
+        Type currentType,
+        Type addedModuleType,
+        IReadOnlySet<Type> newModuleDependencies)
+    {
+        var dependencies = currentType == addedModuleType
+            ? newModuleDependencies
+            : _moduleStates[currentType].State == ModuleExecutionState.Pending
+                ? _dependencyGraph[currentType]
+                : [];
+
+        return dependencies.Where(dependencyType =>
+            dependencyType != addedModuleType
+            && _moduleStates.TryGetValue(dependencyType, out var dependencyState)
+            && dependencyState.State != ModuleExecutionState.Completed);
+    }
+
+    private static Type[] BuildDynamicCycle(
+        Type moduleType,
+        Type dependentType,
+        IReadOnlyDictionary<Type, Type?> parentByType)
+    {
+        var pathFromModule = new Stack<Type>();
+        Type? currentType = dependentType;
+
+        while (currentType is not null && currentType != moduleType)
+        {
+            pathFromModule.Push(currentType);
+            currentType = parentByType[currentType];
+        }
+
+        return [dependentType, moduleType, .. pathFromModule];
+    }
+
+    private static void ThrowDependencyCollision(IReadOnlyList<Type> cycle)
+    {
+        var formattedCycle = cycle.Select(type => type.Name).ToArray();
+        formattedCycle[0] = $"**{formattedCycle[0]}**";
+        formattedCycle[^1] = $"**{formattedCycle[^1]}**";
+
+        throw new DependencyCollisionException(
+            $"Dependency collision detected: {string.Join(" -> ", formattedCycle)}");
     }
 
     /// <summary>

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -105,6 +105,63 @@ public class ModuleSchedulerDynamicCycleTests
             CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(LateDynamicModule));
     }
 
+    private sealed class CountingDependsOnAttribute : ModularPipelines.Attributes.DependsOnBaseAttribute
+    {
+        public static int EvaluationCount;
+
+        public override bool ShouldDependOn(Type candidateModule, IDependencyContext context)
+        {
+            Interlocked.Increment(ref EvaluationCount);
+            return candidateModule == typeof(IndependentDynamicModule);
+        }
+    }
+
+    [CountingDependsOn]
+    private class CountingPredicateModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(CountingPredicateModule));
+    }
+
+    private class ExistingCandidateOne : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(ExistingCandidateOne));
+    }
+
+    private class ExistingCandidateTwo : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(ExistingCandidateTwo));
+    }
+
+    [ModularPipelines.Attributes.DependsOn<DeepDynamicModule>(Optional = true)]
+    private class DeepExistingModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DeepExistingModule));
+    }
+
+    [ModularPipelines.Attributes.DependsOn<DeepExistingModule>]
+    private class DeepMiddleModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DeepMiddleModule));
+    }
+
+    [ModularPipelines.Attributes.DependsOn<DeepMiddleModule>]
+    private class DeepDynamicModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DeepDynamicModule));
+    }
+
     [Test]
     public async Task AddModule_WhenModuleIntroducesCycle_ThrowsAndRollsBack()
     {
@@ -116,6 +173,20 @@ public class ModuleSchedulerDynamicCycleTests
             .And.HasMessageEqualTo(
                 "Dependency collision detected: **ExistingModule** -> DynamicModule -> **ExistingModule**");
         await Assert.That(scheduler.GetModuleState(typeof(DynamicModule))).IsNull();
+    }
+
+    [Test]
+    public async Task AddModule_WhenModuleClosesLongCycle_ThrowsAndRollsBack()
+    {
+        using var scheduler = CreateScheduler();
+        scheduler.InitializeModules([new DeepExistingModule(), new DeepMiddleModule()]);
+
+        await Assert.That(() => scheduler.AddModule(new DeepDynamicModule()))
+            .Throws<DependencyCollisionException>()
+            .And.HasMessageEqualTo(
+                "Dependency collision detected: **DeepExistingModule** -> " +
+                "DeepDynamicModule -> DeepMiddleModule -> **DeepExistingModule**");
+        await Assert.That(scheduler.GetModuleState(typeof(DeepDynamicModule))).IsNull();
     }
 
     [Test]
@@ -323,6 +394,21 @@ public class ModuleSchedulerDynamicCycleTests
         var state = scheduler.GetModuleState(typeof(ConditionalExistingModule));
         await Assert.That(state).IsNotNull();
         await Assert.That(state!.UnresolvedDependencies).Contains(typeof(CompletedDependencyModule));
+    }
+
+    [Test]
+    public async Task AddModule_EvaluatesExistingSelectorsOnlyForNewModule()
+    {
+        using var scheduler = CreateScheduler();
+        scheduler.InitializeModules(
+            [new CountingPredicateModule(), new ExistingCandidateOne(), new ExistingCandidateTwo()]);
+        CountingDependsOnAttribute.EvaluationCount = 0;
+
+        scheduler.AddModule(new IndependentDynamicModule());
+
+        await Assert.That(CountingDependsOnAttribute.EvaluationCount).IsEqualTo(1);
+        await Assert.That(scheduler.GetModuleState(typeof(CountingPredicateModule))!.UnresolvedDependencies)
+            .Contains(typeof(IndependentDynamicModule));
     }
 
     private static ModuleScheduler CreateScheduler(


### PR DESCRIPTION
## Summary
- resolve existing selector dependencies against only the newly added module
- insert new dependency and reverse-dependency edges incrementally
- detect only cycles reachable through the added module
- preserve pending, active, completed, optional, and conditional dependency semantics
- add selector-evaluation and multi-hop cycle regressions

## Validation
- `ModuleSchedulerDynamicCycleTests`: 15 passed
- scheduler configuration/disposal tests: 3 passed
- touched-file whitespace verification: passed
- `ModularPipelines.sln` Release build: 0 errors (existing warnings remain)

Closes #3257