### PR TITLE
Reduce module logging allocations

### DIFF
--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -38,17 +38,8 @@ internal interface IModuleOutputBuffer
     /// Adds a structured log event to the buffer.
     /// Used for ILogger calls.
     /// </summary>
-    /// <param name="level">Log level.</param>
-    /// <param name="eventId">Event identifier.</param>
-    /// <param name="state">Log state object.</param>
-    /// <param name="exception">Optional exception.</param>
-    /// <param name="formatter">Formatter function.</param>
-    void AddLogEvent(
-        LogLevel level,
-        EventId eventId,
-        object state,
-        Exception? exception,
-        Func<object, Exception?, string> formatter);
+    /// <param name="logEvent">The structured log event.</param>
+    void AddLogEvent(IBufferedLogEvent logEvent);
 
     /// <summary>
     /// Sets the exception if the module failed.

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -536,7 +536,7 @@ internal sealed class BufferedLogEvent<TState> : IBufferedLogEvent
             Format);
     }
 
-    private string Format(object _, Exception? exception)
+    private string Format(object state, Exception? exception)
     {
         var formatted = _formatter(_originalState, exception);
         return _secretObfuscator.Obfuscate(formatted, null) ?? string.Empty;

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
@@ -30,6 +31,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly DateTime _startTimeUtc;
     private readonly int _outputFlushThreshold;
     private readonly Action<IModuleOutputBuffer>? _requestIncrementalFlush;
+    private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = new();
     private Exception? _exception;
     private bool _isComplete;
     private bool _isIncrementalFlushInProgress;
@@ -82,14 +84,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     /// <inheritdoc />
-    public void AddLogEvent(
-        LogLevel level,
-        EventId eventId,
-        object state,
-        Exception? exception,
-        Func<object, Exception?, string> formatter)
+    public void AddLogEvent(IBufferedLogEvent logEvent)
     {
-        AddOutput(BufferedOutput.FromLogEvent(level, eventId, state, exception, formatter));
+        AddOutput(BufferedOutput.FromLogEvent(logEvent));
     }
 
     /// <inheritdoc />
@@ -162,7 +159,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             return Task.CompletedTask;
         }
 
-        var directConsole = CreateDirectConsole(console);
+        var directConsole = GetDirectConsole(console);
         var renderedCount = 0;
 
         try
@@ -192,6 +189,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         RecordRenderedOutput(flushKind, renderedCount);
         return Task.CompletedTask;
+    }
+
+    internal IAnsiConsole GetDirectConsole(TextWriter writer)
+    {
+        return _directConsoles.GetValue(writer, static value => CreateDirectConsole(value));
     }
 
     private void AddOutput(BufferedOutput output)
@@ -348,14 +350,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             {
                 WriteDirect(directConsole, console, output.StringValue);
             }
-            else if (output.LogEvent.HasValue)
+            else if (output.LogEvent is { } logEvent)
             {
-                var logEvent = output.LogEvent.Value;
-
                 // Synchronous MEL.Spectre rendering preserves this buffer's position
                 // while other providers (for example file logging) still receive the event.
-                logger.Log(logEvent.Level, logEvent.EventId, logEvent.State, logEvent.Exception,
-                    (state, ex) => logEvent.Formatter(state, ex));
+                logEvent.WriteTo(logger);
             }
 
             // Advance only after the sink returns successfully. A sink that accepts
@@ -469,7 +468,7 @@ internal readonly struct BufferedOutput
     /// <summary>
     /// Gets the log event if this is a structured log event.
     /// </summary>
-    public LogEventData? LogEvent { get; private init; }
+    public IBufferedLogEvent? LogEvent { get; private init; }
 
     /// <summary>
     /// Gets a value indicating whether this output contains a string.
@@ -484,41 +483,62 @@ internal readonly struct BufferedOutput
     /// <summary>
     /// Creates a buffered output from a log event.
     /// </summary>
-    public static BufferedOutput FromLogEvent(
-        LogLevel level,
-        EventId eventId,
-        object state,
-        Exception? exception,
-        Func<object, Exception?, string> formatter)
-        => new() { LogEvent = new LogEventData(level, eventId, state, exception, formatter) };
+    public static BufferedOutput FromLogEvent(IBufferedLogEvent logEvent)
+        => new() { LogEvent = logEvent };
 }
 
 /// <summary>
 /// Holds structured log event data for deferred output.
 /// </summary>
-internal readonly struct LogEventData
+internal interface IBufferedLogEvent
 {
-    public LogLevel Level { get; }
+    void WriteTo(ILogger logger);
+}
 
-    public EventId EventId { get; }
+/// <summary>
+/// Holds generic structured log state and its original formatter for deferred output.
+/// </summary>
+internal sealed class BufferedLogEvent<TState> : IBufferedLogEvent
+{
+    private readonly LogLevel _level;
+    private readonly EventId _eventId;
+    private readonly TState _originalState;
+    private readonly object _obfuscatedState;
+    private readonly Exception? _exception;
+    private readonly Func<TState, Exception?, string> _formatter;
+    private readonly ISecretObfuscator _secretObfuscator;
 
-    public object State { get; }
-
-    public Exception? Exception { get; }
-
-    public Func<object, Exception?, string> Formatter { get; }
-
-    public LogEventData(
+    public BufferedLogEvent(
         LogLevel level,
         EventId eventId,
-        object state,
+        TState originalState,
+        object obfuscatedState,
         Exception? exception,
-        Func<object, Exception?, string> formatter)
+        Func<TState, Exception?, string> formatter,
+        ISecretObfuscator secretObfuscator)
     {
-        Level = level;
-        EventId = eventId;
-        State = state;
-        Exception = exception;
-        Formatter = formatter;
+        _level = level;
+        _eventId = eventId;
+        _originalState = originalState;
+        _obfuscatedState = obfuscatedState;
+        _exception = exception;
+        _formatter = formatter;
+        _secretObfuscator = secretObfuscator;
+    }
+
+    public void WriteTo(ILogger logger)
+    {
+        logger.Log(
+            _level,
+            _eventId,
+            _obfuscatedState,
+            _exception,
+            Format);
+    }
+
+    private string Format(object _, Exception? exception)
+    {
+        var formatted = _formatter(_originalState, exception);
+        return _secretObfuscator.Obfuscate(formatted, null) ?? string.Empty;
     }
 }

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -202,6 +202,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         lock (_lock)
         {
+            if (_isComplete)
+            {
+                return;
+            }
+
             _outputs.Add(output);
             if (_requestIncrementalFlush is not null
                 && _outputFlushThreshold > 0

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -80,13 +80,13 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <inheritdoc />
     public void WriteLine(string message)
     {
-        AddOutput(BufferedOutput.FromString(message));
+        AddOutput(BufferedOutput.FromString(message), allowAfterCompletion: true);
     }
 
     /// <inheritdoc />
     public void AddLogEvent(IBufferedLogEvent logEvent)
     {
-        AddOutput(BufferedOutput.FromLogEvent(logEvent));
+        AddOutput(BufferedOutput.FromLogEvent(logEvent), allowAfterCompletion: false);
     }
 
     /// <inheritdoc />
@@ -196,13 +196,13 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         return _directConsoles.GetValue(writer, static value => CreateDirectConsole(value));
     }
 
-    private void AddOutput(BufferedOutput output)
+    private void AddOutput(BufferedOutput output, bool allowAfterCompletion)
     {
         Action<IModuleOutputBuffer>? requestIncrementalFlush = null;
 
         lock (_lock)
         {
-            if (_isComplete)
+            if (_isComplete && !allowAfterCompletion)
             {
                 return;
             }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -73,7 +73,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
     private readonly StringWriter _renderWriter;
     private readonly IAnsiConsole _renderConsole;
 
-    private volatile bool _isDisposed;
+    private bool _isDisposed;
 
     // ReSharper disable once ContextualLoggerProblem
     public ModuleLogger(
@@ -107,24 +107,32 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
 
     public override void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string>? formatter)
     {
-        if (!IsEnabled(logLevel) || _isDisposed)
+        if (!IsEnabled(logLevel))
         {
             return;
         }
 
-        var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state!);
-        var logEvent = new BufferedLogEvent<TState>(
-            logLevel,
-            eventId,
-            state,
-            obfuscatedState,
-            exception,
-            formatter ?? (static (_, _) => string.Empty),
-            _secretObfuscator);
+        lock (_disposeLock)
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
 
-        // Write to buffer for ordered module output during pipeline execution.
-        // Output will be flushed to console and loggers when the module completes.
-        _buffer.AddLogEvent(logEvent);
+            var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state!);
+            var logEvent = new BufferedLogEvent<TState>(
+                logLevel,
+                eventId,
+                state,
+                obfuscatedState,
+                exception,
+                formatter ?? (static (_, _) => string.Empty),
+                _secretObfuscator);
+
+            // Write to buffer for ordered module output during pipeline execution.
+            // Output will be flushed to console and loggers when the module completes.
+            _buffer.AddLogEvent(logEvent);
+        }
     }
 
     public override void Dispose()

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -39,10 +39,7 @@ internal abstract class ModuleLogger : IInternalModuleLogger, IConsoleWriter, IA
     internal static ILogger Current => (Values.Value as ILogger) ?? NullLogger.Instance;
 
     protected readonly object _disposeLock = new();
-    protected readonly object _logLock = new();
     protected Exception? _exception;
-
-    internal DateTime LastLogWritten { get; set; } = DateTime.MinValue;
 
     public abstract void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter);
 
@@ -72,8 +69,11 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
     private readonly IFormattedLogValuesObfuscator _formattedLogValuesObfuscator;
     private readonly IModuleOutputBuffer _buffer;
     private readonly IOutputCoordinator _outputCoordinator;
+    private readonly object _renderLock = new();
+    private readonly StringWriter _renderWriter;
+    private readonly IAnsiConsole _renderConsole;
 
-    private bool _isDisposed;
+    private volatile bool _isDisposed;
 
     // ReSharper disable once ContextualLoggerProblem
     public ModuleLogger(
@@ -88,6 +88,11 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
         _formattedLogValuesObfuscator = formattedLogValuesObfuscator;
         _buffer = consoleCoordinator.GetModuleBuffer(typeof(T));
         _outputCoordinator = outputCoordinator;
+        _renderWriter = new StringWriter();
+        _renderConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Out = new AnsiConsoleOutput(_renderWriter),
+        });
     }
 
     public override IDisposable? BeginScope<TState>(TState state)
@@ -102,22 +107,24 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
 
     public override void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string>? formatter)
     {
-        lock (_logLock)
+        if (!IsEnabled(logLevel) || _isDisposed)
         {
-            if (!IsEnabled(logLevel) || _isDisposed)
-            {
-                return;
-            }
-
-            var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state!);
-            var mappedFormatter = MapFormatter(formatter, state);
-
-            // Write to buffer for ordered module output during pipeline execution
-            // Output will be flushed to console and loggers when the module completes
-            _buffer.AddLogEvent(logLevel, eventId, obfuscatedState, exception, mappedFormatter);
-
-            LastLogWritten = DateTime.UtcNow;
+            return;
         }
+
+        var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state!);
+        var logEvent = new BufferedLogEvent<TState>(
+            logLevel,
+            eventId,
+            state,
+            obfuscatedState,
+            exception,
+            formatter ?? (static (_, _) => string.Empty),
+            _secretObfuscator);
+
+        // Write to buffer for ordered module output during pipeline execution.
+        // Output will be flushed to console and loggers when the module completes.
+        _buffer.AddLogEvent(logEvent);
     }
 
     public override void Dispose()
@@ -199,31 +206,15 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
 
     public override void Write(IRenderable renderable)
     {
-        // Render to string for buffering, then obfuscate
-        using var writer = new StringWriter();
-        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        string rendered;
+        lock (_renderLock)
         {
-            Out = new AnsiConsoleOutput(writer),
-        });
-        console.Write(renderable);
-        var rendered = writer.ToString();
-        var obfuscated = _secretObfuscator.Obfuscate(rendered, null) ?? rendered;
-        _buffer.WriteLine(obfuscated);
-    }
-
-    private Func<object, Exception?, string> MapFormatter<TState>(
-        Func<TState, Exception?, string>? formatter,
-        TState originalState)
-    {
-        if (formatter is null)
-        {
-            return (_, _) => string.Empty;
+            _renderWriter.GetStringBuilder().Clear();
+            _renderConsole.Write(renderable);
+            rendered = _renderWriter.ToString();
         }
 
-        return (_, exception) =>
-        {
-            var formattedString = formatter.Invoke(originalState, exception);
-            return _secretObfuscator.Obfuscate(formattedString, null) ?? string.Empty;
-        };
+        var obfuscated = _secretObfuscator.Obfuscate(rendered, null) ?? rendered;
+        _buffer.WriteLine(obfuscated);
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -91,12 +91,11 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
-    public async Task OutputAddedAfterCompletion_IsIgnored()
+    public async Task LogEventAddedAfterCompletion_IsIgnored()
     {
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
 
         buffer.MarkComplete();
-        buffer.WriteLine("late output");
         buffer.AddLogEvent(new BufferedLogEvent<string>(
             LogLevel.Information,
             default,
@@ -108,6 +107,18 @@ public class ModuleOutputBufferTests
 
         await Assert.That(buffer.HasOutput).IsFalse();
         await Assert.That(buffer.NeedsCompletionFlush).IsFalse();
+    }
+
+    [Test]
+    public async Task ConsoleOutputAddedAfterCompletion_IsRetained()
+    {
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+
+        buffer.MarkComplete();
+        buffer.WriteLine("retained output");
+
+        await Assert.That(buffer.HasOutput).IsTrue();
+        await Assert.That(buffer.NeedsCompletionFlush).IsTrue();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -1,6 +1,7 @@
 using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Console;
+using ModularPipelines.Engine;
 using ModularPipelines.Engine.BuildSystemFormatters;
 
 namespace ModularPipelines.UnitTests.Console;
@@ -74,6 +75,19 @@ public class ModuleOutputBufferTests
         var output = writer.ToString();
         await Assert.That(output).Contains("direct output");
         await Assert.That(output).DoesNotContain("[green]");
+    }
+
+    [Test]
+    public async Task DirectConsole_IsCachedPerWriter()
+    {
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        using var firstWriter = new StringWriter();
+        using var secondWriter = new StringWriter();
+
+        var firstConsole = buffer.GetDirectConsole(firstWriter);
+
+        await Assert.That(buffer.GetDirectConsole(firstWriter)).IsSameReferenceAs(firstConsole);
+        await Assert.That(buffer.GetDirectConsole(secondWriter)).IsNotSameReferenceAs(firstConsole);
     }
 
     [Test]
@@ -433,18 +447,25 @@ public class ModuleOutputBufferTests
     private static ModuleOutputBuffer CreateBufferWithStructuredLog()
     {
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
-        buffer.AddLogEvent(
+        buffer.AddLogEvent(new BufferedLogEvent<string>(
             LogLevel.Information,
             default,
             "structured log",
+            "structured log",
             null,
-            static (state, _) => state.ToString()!);
+            static (state, _) => state,
+            new PassthroughSecretObfuscator()));
         return buffer;
     }
 
     private static int CountOccurrences(string value, string search)
     {
         return value.Split(search, StringSplitOptions.None).Length - 1;
+    }
+
+    private sealed class PassthroughSecretObfuscator : ISecretObfuscator
+    {
+        public string Obfuscate(string? input, object? optionsObject) => input ?? string.Empty;
     }
 
     private sealed class SynchronousLoggerControl(TextWriter writer) : ILogger, ISpectreConsoleLoggerControl

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -91,6 +91,26 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task OutputAddedAfterCompletion_IsIgnored()
+    {
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+
+        buffer.MarkComplete();
+        buffer.WriteLine("late output");
+        buffer.AddLogEvent(new BufferedLogEvent<string>(
+            LogLevel.Information,
+            default,
+            "late log",
+            "late log",
+            null,
+            static (state, _) => state,
+            new PassthroughSecretObfuscator()));
+
+        await Assert.That(buffer.HasOutput).IsFalse();
+        await Assert.That(buffer.NeedsCompletionFlush).IsFalse();
+    }
+
+    [Test]
     public async Task IncrementalFlush_Marks_Module_As_InProgress()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -31,12 +31,14 @@ public class OutputCoordinatorTests
         coordinatedWriter.Write("partial");
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(coordinatedWriter));
         var moduleBuffer = new ModuleOutputBuffer(typeof(OutputCoordinatorTests));
-        moduleBuffer.AddLogEvent(
+        moduleBuffer.AddLogEvent(new BufferedLogEvent<string>(
             LogLevel.Information,
             default,
             "replayed log",
+            "replayed log",
             null,
-            static (state, _) => state.ToString()!);
+            static (state, _) => state,
+            secretObfuscator.Object));
 
         await coordinator.EnqueueAndFlushAsync(moduleBuffer, OutputFlushKind.Complete);
         await coordinatedWriter.FlushAsync();
@@ -483,12 +485,7 @@ public class OutputCoordinatorTests
         {
         }
 
-        public void AddLogEvent(
-            LogLevel level,
-            EventId eventId,
-            object state,
-            Exception? exception,
-            Func<object, Exception?, string> formatter)
+        public void AddLogEvent(IBufferedLogEvent logEvent)
         {
         }
 
@@ -533,12 +530,7 @@ public class OutputCoordinatorTests
         {
         }
 
-        public void AddLogEvent(
-            LogLevel level,
-            EventId eventId,
-            object state,
-            Exception? exception,
-            Func<object, Exception?, string> formatter)
+        public void AddLogEvent(IBufferedLogEvent logEvent)
         {
         }
 
@@ -584,12 +576,7 @@ public class OutputCoordinatorTests
         {
         }
 
-        public void AddLogEvent(
-            LogLevel level,
-            EventId eventId,
-            object state,
-            Exception? exception,
-            Func<object, Exception?, string> formatter)
+        public void AddLogEvent(IBufferedLogEvent logEvent)
         {
         }
 
@@ -637,12 +624,7 @@ public class OutputCoordinatorTests
         {
         }
 
-        public void AddLogEvent(
-            LogLevel level,
-            EventId eventId,
-            object state,
-            Exception? exception,
-            Func<object, Exception?, string> formatter)
+        public void AddLogEvent(IBufferedLogEvent logEvent)
         {
         }
 
@@ -696,12 +678,7 @@ public class OutputCoordinatorTests
         {
         }
 
-        public void AddLogEvent(
-            LogLevel level,
-            EventId eventId,
-            object state,
-            Exception? exception,
-            Func<object, Exception?, string> formatter)
+        public void AddLogEvent(IBufferedLogEvent logEvent)
         {
         }
 
@@ -741,12 +718,7 @@ public class OutputCoordinatorTests
         {
         }
 
-        public void AddLogEvent(
-            LogLevel level,
-            EventId eventId,
-            object state,
-            Exception? exception,
-            Func<object, Exception?, string> formatter)
+        public void AddLogEvent(IBufferedLogEvent logEvent)
         {
         }
 

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -161,6 +161,50 @@ public class ModuleLoggerTests
     }
 
     [Test]
+    public async Task Dispose_WaitsForInProgressLogAdmission()
+    {
+        var logEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLog = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var buffer = new ModuleOutputBuffer(typeof(ModuleLoggerTests));
+        var consoleCoordinator = CreateConsoleCoordinator(buffer);
+        var defaultLogger = new Mock<ILogger<ModuleLoggerTests>>();
+        defaultLogger.Setup(x => x.IsEnabled(LogLevel.Information)).Returns(true);
+        var formattedValuesObfuscator = new Mock<IFormattedLogValuesObfuscator>();
+        formattedValuesObfuscator
+            .Setup(x => x.TryObfuscateValues(It.IsAny<object>()))
+            .Callback(() =>
+            {
+                logEntered.TrySetResult();
+                releaseLog.Task.GetAwaiter().GetResult();
+            })
+            .Returns((object state) => state);
+        var logger = new ModuleLogger<ModuleLoggerTests>(
+            defaultLogger.Object,
+            Mock.Of<ISecretObfuscator>(),
+            formattedValuesObfuscator.Object,
+            consoleCoordinator.Object,
+            Mock.Of<IOutputCoordinator>());
+        var logTask = Task.Run(() => logger.LogInformation("message"));
+
+        await logEntered.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        var disposeTask = Task.Run(logger.Dispose);
+
+        try
+        {
+            await Task.Delay(50);
+            await Assert.That(disposeTask.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            releaseLog.TrySetResult();
+        }
+
+        await Task.WhenAll(logTask, disposeTask);
+        await Assert.That(buffer.HasOutput).IsTrue();
+        await Assert.That(buffer.IsComplete).IsTrue();
+    }
+
+    [Test]
     public async Task Write_ReusesClearedRenderer()
     {
         var renderedLines = new List<string>();

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -11,6 +11,7 @@ using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
 using Moq;
 using NReco.Logging.File;
+using Spectre.Console;
 using File = ModularPipelines.FileSystem.File;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
@@ -119,6 +120,74 @@ public class ModuleLoggerTests
         await Assert.That(loggerReference.IsAlive).IsFalse();
     }
 
+    [Test]
+    public async Task Log_BuffersRawStateAndOriginalFormatter()
+    {
+        IBufferedLogEvent? bufferedLogEvent = null;
+        var moduleOutputBuffer = new Mock<IModuleOutputBuffer>();
+        moduleOutputBuffer
+            .Setup(x => x.AddLogEvent(It.IsAny<IBufferedLogEvent>()))
+            .Callback<IBufferedLogEvent>(logEvent => bufferedLogEvent = logEvent);
+        var consoleCoordinator = CreateConsoleCoordinator(moduleOutputBuffer.Object);
+        var defaultLogger = new Mock<ILogger<ModuleLoggerTests>>();
+        defaultLogger.Setup(x => x.IsEnabled(LogLevel.Information)).Returns(true);
+        var formattedValuesObfuscator = new Mock<IFormattedLogValuesObfuscator>();
+        formattedValuesObfuscator
+            .Setup(x => x.TryObfuscateValues(It.IsAny<object>()))
+            .Returns("sanitized-state");
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? value, object? _) => value?.Replace("secret", "***") ?? string.Empty);
+        var logger = new ModuleLogger<ModuleLoggerTests>(
+            defaultLogger.Object,
+            secretObfuscator.Object,
+            formattedValuesObfuscator.Object,
+            consoleCoordinator.Object,
+            Mock.Of<IOutputCoordinator>());
+        var originalState = new TestLogState("secret");
+
+        logger.Log(
+            LogLevel.Information,
+            default,
+            originalState,
+            null,
+            static (state, _) => $"value:{state.Value}");
+        var captureLogger = new CaptureLogger();
+        bufferedLogEvent!.WriteTo(captureLogger);
+
+        await Assert.That(captureLogger.State).IsEqualTo("sanitized-state");
+        await Assert.That(captureLogger.Message).IsEqualTo("value:***");
+    }
+
+    [Test]
+    public async Task Write_ReusesClearedRenderer()
+    {
+        var renderedLines = new List<string>();
+        var moduleOutputBuffer = new Mock<IModuleOutputBuffer>();
+        moduleOutputBuffer
+            .Setup(x => x.WriteLine(It.IsAny<string>()))
+            .Callback<string>(renderedLines.Add);
+        var consoleCoordinator = CreateConsoleCoordinator(moduleOutputBuffer.Object);
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? value, object? _) => value ?? string.Empty);
+        var logger = new ModuleLogger<ModuleLoggerTests>(
+            Mock.Of<ILogger<ModuleLoggerTests>>(),
+            secretObfuscator.Object,
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            Mock.Of<IOutputCoordinator>());
+
+        logger.Write(new Markup("first"));
+        logger.Write(new Markup("second"));
+
+        await Assert.That(renderedLines).Count().IsEqualTo(2);
+        await Assert.That(renderedLines[1]).Contains("second");
+        await Assert.That(renderedLines[1]).DoesNotContain("first");
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static WeakReference CreateDisposedLoggerReference()
     {
@@ -137,6 +206,41 @@ public class ModuleLoggerTests
 
         logger.Dispose();
         return new WeakReference(logger);
+    }
+
+    private static Mock<IConsoleCoordinator> CreateConsoleCoordinator(IModuleOutputBuffer moduleOutputBuffer)
+    {
+        var consoleCoordinator = new Mock<IConsoleCoordinator>();
+        consoleCoordinator
+            .Setup(x => x.GetModuleBuffer(typeof(ModuleLoggerTests)))
+            .Returns(moduleOutputBuffer);
+        return consoleCoordinator;
+    }
+
+    private readonly record struct TestLogState(string Value);
+
+    private sealed class CaptureLogger : ILogger
+    {
+        public object? State { get; private set; }
+
+        public string? Message { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            State = state;
+            Message = formatter(state, exception);
+        }
     }
 
     private class MySecrets


### PR DESCRIPTION
## Summary
- buffer generic log state with the original formatter, removing the per-call formatter closure and boxing
- serialize log admission with disposal so in-flight events cannot be lost
- reuse render consoles for module renderables and direct buffer flushes
- preserve structured-state and formatted-message secret obfuscation

## Validation
- `ModuleLoggerTests`: 7 passed
- `ModuleOutputBufferTests`: 17 passed
- `ConsoleCoordinatorTests`: 4 passed
- `OutputCoordinatorTests`: 17 passed
- `ModularPipelines.sln` Release build: succeeded with 0 errors
- changed-file analyzer and whitespace verification: passed

Closes #3259