### PR TITLE
Reduce pipeline startup discovery work

### DIFF
--- a/docs/docs/how-to/generate-private-cli-integration.md
+++ b/docs/docs/how-to/generate-private-cli-integration.md
@@ -158,3 +158,15 @@ Referencing the `ModularPipelines` package includes the source generator as an a
 The generator emits immutable assembly registration metadata, which each pipeline consumes
 independently. Remove the old parameterless module initializer and any call to
 `ModularPipelinesContextRegistry.RegisterContext`.
+
+If the integration DLL is copied beside the application without a compile-time reference,
+opt in to filename-based assembly discovery before building the pipeline:
+
+```csharp
+builder.ConfigurePipelineOptions(options =>
+    options.LoadModularPipelineAssemblies = true);
+```
+
+The option is disabled by default to avoid scanning and loading every matching assembly at
+pipeline startup. Integrations already loaded through normal application use and explicitly
+registered services do not need it.

--- a/src/ModularPipelines.Build/Program.cs
+++ b/src/ModularPipelines.Build/Program.cs
@@ -18,6 +18,7 @@ using Octokit;
 using Octokit.Internal;
 
 var builder = Pipeline.CreateBuilder(args);
+builder.ConfigurePipelineOptions(options => options.LoadModularPipelineAssemblies = true);
 
 builder.Configuration
     .AddJsonFile("appsettings.json")

--- a/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
+++ b/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
@@ -1,17 +1,34 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using ModularPipelines.Modules;
 
 namespace ModularPipelines.Engine;
 
 internal class AssemblyLoadedTypesProvider : IAssemblyLoadedTypesProvider
 {
+    private static readonly Assembly ModularPipelinesAssembly = typeof(IModule).Assembly;
+    private static readonly string ModularPipelinesAssemblyName = ModularPipelinesAssembly.GetName().Name!;
+
     public Type[] GetLoadedTypesAssignableTo(Type type)
     {
         return AppDomain.CurrentDomain
             .GetAssemblies()
+            .Where(ReferencesModularPipelines)
             .SelectMany(GetLoadableTypes)
             .Where(t => t.IsAssignableTo(type))
             .Where(t => !t.IsAbstract)
             .ToArray();
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Unused-module diagnostics tolerate assembly references removed by trimming.")]
+    internal static bool ReferencesModularPipelines(Assembly assembly)
+    {
+        return assembly == ModularPipelinesAssembly
+               || assembly.GetReferencedAssemblies().Any(reference =>
+                   string.Equals(reference.Name, ModularPipelinesAssemblyName, StringComparison.Ordinal));
     }
 
     private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)

--- a/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
+++ b/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
@@ -31,6 +31,10 @@ internal class AssemblyLoadedTypesProvider : IAssemblyLoadedTypesProvider
                    string.Equals(reference.Name, ModularPipelinesAssemblyName, StringComparison.Ordinal));
     }
 
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Unused-module diagnostics tolerate types removed by trimming.")]
     private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
     {
         try

--- a/src/ModularPipelines/Engine/DependencyChainProvider.cs
+++ b/src/ModularPipelines/Engine/DependencyChainProvider.cs
@@ -30,9 +30,24 @@ internal class DependencyChainProvider : IDependencyChainProvider
 
     private ModuleDependencyModel[] Detect(ModuleDependencyModel[] allModules)
     {
+        var availableModuleTypes = new Type[allModules.Length];
+        var moduleModelsByType = new Dictionary<Type, ModuleDependencyModel>(allModules.Length);
+
+        for (var i = 0; i < allModules.Length; i++)
+        {
+            var moduleModel = allModules[i];
+            var moduleType = moduleModel.Module.GetType();
+            availableModuleTypes[i] = moduleType;
+            moduleModelsByType.TryAdd(moduleType, moduleModel);
+        }
+
         foreach (var moduleDependencyModel in allModules)
         {
-            var dependencies = GetModuleDependencies(moduleDependencyModel, allModules).ToArray();
+            var dependencies = GetModuleDependencies(
+                    moduleDependencyModel,
+                    availableModuleTypes,
+                    moduleModelsByType)
+                .ToArray();
 
             moduleDependencyModel.IsDependentOn.AddRange(dependencies);
 
@@ -45,11 +60,11 @@ internal class DependencyChainProvider : IDependencyChainProvider
         return allModules;
     }
 
-    private IEnumerable<ModuleDependencyModel> GetModuleDependencies(ModuleDependencyModel moduleDependencyModel, ModuleDependencyModel[] allModules)
+    private IEnumerable<ModuleDependencyModel> GetModuleDependencies(
+        ModuleDependencyModel moduleDependencyModel,
+        IReadOnlyList<Type> availableModuleTypes,
+        Dictionary<Type, ModuleDependencyModel> moduleModelsByType)
     {
-        // Get all available module types for DependsOnAllModulesInheritingFrom and predicate-based resolution
-        var availableModuleTypes = allModules.Select(m => m.Module.GetType()).ToArray();
-
         var dependencies = ModuleDependencyResolver.GetAllDependencies(
             moduleDependencyModel.Module,
             availableModuleTypes,
@@ -57,17 +72,10 @@ internal class DependencyChainProvider : IDependencyChainProvider
 
         foreach (var (dependencyType, _) in dependencies)
         {
-            var dependencyModel = GetModuleDependencyModel(dependencyType, allModules);
-
-            if (dependencyModel is not null)
+            if (moduleModelsByType.TryGetValue(dependencyType, out var dependencyModel))
             {
                 yield return dependencyModel;
             }
         }
-    }
-
-    private ModuleDependencyModel? GetModuleDependencyModel(Type type, IEnumerable<ModuleDependencyModel> allModules)
-    {
-        return allModules.FirstOrDefault(x => x.Module.GetType() == type);
     }
 }

--- a/src/ModularPipelines/Engine/UnusedModuleDetector.cs
+++ b/src/ModularPipelines/Engine/UnusedModuleDetector.cs
@@ -24,6 +24,11 @@ internal class UnusedModuleDetector : IUnusedModuleDetector
 
     public void Log()
     {
+        if (!_logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
         // Use the centralized helper that works with factory-based registrations
         var registeredServices = ServiceCollectionExtensions.GetRegisteredModuleTypes(_serviceContainerWrapper.ServiceCollection);
 

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -96,6 +96,16 @@ public record PipelineOptions
     public bool PrintDependencyChains { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether assemblies whose filenames contain
+    /// <c>ModularPipeline</c> are eagerly loaded from the application directory.
+    /// </summary>
+    /// <remarks>
+    /// Disabled by default. Enable this only when a plugin relies on module initializers
+    /// instead of explicit assembly or service registration.
+    /// </remarks>
+    public bool LoadModularPipelineAssemblies { get; set; }
+
+    /// <summary>
     /// Gets or sets the default number of retry attempts for failed operations.
     /// </summary>
     /// <remarks>

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -272,6 +272,7 @@ public sealed class PipelineBuilder
                 opts.PrintResults = _options.PrintResults;
                 opts.PrintLogo = _options.PrintLogo;
                 opts.PrintDependencyChains = _options.PrintDependencyChains;
+                opts.LoadModularPipelineAssemblies = _options.LoadModularPipelineAssemblies;
                 opts.DefaultRetryCount = _options.DefaultRetryCount;
                 opts.DefaultLoggingOptions = _options.DefaultLoggingOptions;
                 opts.DefaultHttpLoggingOptions = _options.DefaultHttpLoggingOptions;
@@ -301,6 +302,11 @@ public sealed class PipelineBuilder
 
     private void LoadModularPipelineAssembliesIfNotLoadedYet()
     {
+        if (!_options.LoadModularPipelineAssemblies)
+        {
+            return;
+        }
+
         var coreVersion = typeof(PipelineBuilder).Assembly.GetName().Version;
         var currentAssemblies = AppDomain.CurrentDomain.GetAssemblies();
 

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Configuration;
@@ -321,50 +320,23 @@ public sealed class PipelineBuilder
 
         foreach (var modularPipelineAssembly in unloadedModularPipelineAssemblies)
         {
-            var assembly = Assembly.Load(new AssemblyName(modularPipelineAssembly));
-            PluginVersionValidator.Validate(assembly, coreVersion);
-            RuntimeHelpers.RunModuleConstructor(assembly.ManifestModule.ModuleHandle);
+            LoadAndInitializeAssembly(new AssemblyName(modularPipelineAssembly), coreVersion);
         }
     }
 
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2026",
-        Justification = "Referenced integrations removed by trimming do not need runtime registration.")]
     private static void LoadReferencedModularPipelineAssemblies(Version? coreVersion)
     {
-        var currentAssemblies = AppDomain.CurrentDomain.GetAssemblies();
-        var loadedAssemblyNames = currentAssemblies
-            .Select(static assembly => assembly.GetName().Name)
-            .OfType<string>()
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-        var entryAssembly = Assembly.GetEntryAssembly();
-        var assembliesToVisit = new Queue<Assembly>(currentAssemblies.Where(assembly =>
-            !assembly.IsDynamic
-            && (ReferenceEquals(assembly, entryAssembly)
-                || IsModularPipelinesAssembly(assembly.GetName()))));
-
-        while (assembliesToVisit.TryDequeue(out var assembly))
-        {
-            foreach (var referencedAssemblyName in assembly.GetReferencedAssemblies()
-                         .Where(IsModularPipelinesAssembly))
-            {
-                if (referencedAssemblyName.Name is not { } name || !loadedAssemblyNames.Add(name))
-                {
-                    continue;
-                }
-
-                var referencedAssembly = Assembly.Load(referencedAssemblyName);
-                PluginVersionValidator.Validate(referencedAssembly, coreVersion);
-                RuntimeHelpers.RunModuleConstructor(referencedAssembly.ManifestModule.ModuleHandle);
-                assembliesToVisit.Enqueue(referencedAssembly);
-            }
-        }
+        ReferencedAssemblyTraversal.LoadModularPipelinesAssemblies(
+            AppDomain.CurrentDomain.GetAssemblies(),
+            assemblyName => LoadAndInitializeAssembly(assemblyName, coreVersion));
     }
 
-    private static bool IsModularPipelinesAssembly(AssemblyName assemblyName)
+    private static Assembly LoadAndInitializeAssembly(AssemblyName assemblyName, Version? coreVersion)
     {
-        return assemblyName.Name?.Contains("ModularPipeline", StringComparison.OrdinalIgnoreCase) is true;
+        var assembly = Assembly.Load(assemblyName);
+        PluginVersionValidator.Validate(assembly, coreVersion);
+        RuntimeHelpers.RunModuleConstructor(assembly.ManifestModule.ModuleHandle);
+        return assembly;
     }
 
     private static IEnumerable<string> GetDlls()

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Configuration;
@@ -302,12 +303,14 @@ public sealed class PipelineBuilder
 
     private void LoadModularPipelineAssembliesIfNotLoadedYet()
     {
+        var coreVersion = typeof(PipelineBuilder).Assembly.GetName().Version;
+        LoadReferencedModularPipelineAssemblies(coreVersion);
+
         if (!_options.LoadModularPipelineAssemblies)
         {
             return;
         }
 
-        var coreVersion = typeof(PipelineBuilder).Assembly.GetName().Version;
         var currentAssemblies = AppDomain.CurrentDomain.GetAssemblies();
 
         var unloadedModularPipelineAssemblies = GetDlls()
@@ -322,6 +325,46 @@ public sealed class PipelineBuilder
             PluginVersionValidator.Validate(assembly, coreVersion);
             RuntimeHelpers.RunModuleConstructor(assembly.ManifestModule.ModuleHandle);
         }
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Referenced integrations removed by trimming do not need runtime registration.")]
+    private static void LoadReferencedModularPipelineAssemblies(Version? coreVersion)
+    {
+        var currentAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+        var loadedAssemblyNames = currentAssemblies
+            .Select(static assembly => assembly.GetName().Name)
+            .OfType<string>()
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var entryAssembly = Assembly.GetEntryAssembly();
+        var assembliesToVisit = new Queue<Assembly>(currentAssemblies.Where(assembly =>
+            !assembly.IsDynamic
+            && (ReferenceEquals(assembly, entryAssembly)
+                || IsModularPipelinesAssembly(assembly.GetName()))));
+
+        while (assembliesToVisit.TryDequeue(out var assembly))
+        {
+            foreach (var referencedAssemblyName in assembly.GetReferencedAssemblies()
+                         .Where(IsModularPipelinesAssembly))
+            {
+                if (referencedAssemblyName.Name is not { } name || !loadedAssemblyNames.Add(name))
+                {
+                    continue;
+                }
+
+                var referencedAssembly = Assembly.Load(referencedAssemblyName);
+                PluginVersionValidator.Validate(referencedAssembly, coreVersion);
+                RuntimeHelpers.RunModuleConstructor(referencedAssembly.ManifestModule.ModuleHandle);
+                assembliesToVisit.Enqueue(referencedAssembly);
+            }
+        }
+    }
+
+    private static bool IsModularPipelinesAssembly(AssemblyName assemblyName)
+    {
+        return assemblyName.Name?.Contains("ModularPipeline", StringComparison.OrdinalIgnoreCase) is true;
     }
 
     private static IEnumerable<string> GetDlls()

--- a/src/ModularPipelines/ReferencedAssemblyTraversal.cs
+++ b/src/ModularPipelines/ReferencedAssemblyTraversal.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace ModularPipelines;
+
+internal static class ReferencedAssemblyTraversal
+{
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Referenced integrations removed by trimming do not need runtime registration.")]
+    public static void LoadModularPipelinesAssemblies(
+        IEnumerable<Assembly> currentAssemblies,
+        Func<AssemblyName, Assembly> loadAssembly)
+    {
+        var loadedAssemblies = currentAssemblies
+            .Where(static assembly => !assembly.IsDynamic)
+            .ToArray();
+        var loadedAssemblyNames = loadedAssemblies
+            .Select(static assembly => assembly.GetName().Name)
+            .OfType<string>()
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var assembliesToVisit = new Queue<Assembly>(loadedAssemblies);
+
+        while (assembliesToVisit.TryDequeue(out var assembly))
+        {
+            foreach (var referencedAssemblyName in assembly.GetReferencedAssemblies()
+                         .Where(IsModularPipelinesAssembly))
+            {
+                if (referencedAssemblyName.Name is not { } name || !loadedAssemblyNames.Add(name))
+                {
+                    continue;
+                }
+
+                assembliesToVisit.Enqueue(loadAssembly(referencedAssemblyName));
+            }
+        }
+    }
+
+    private static bool IsModularPipelinesAssembly(AssemblyName assemblyName)
+    {
+        return assemblyName.Name?.Contains("ModularPipeline", StringComparison.OrdinalIgnoreCase) is true;
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/AssemblyLoadedTypesProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/AssemblyLoadedTypesProviderTests.cs
@@ -1,0 +1,22 @@
+using ModularPipelines.Engine;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class AssemblyLoadedTypesProviderTests
+{
+    [Test]
+    public async Task ReferencesModularPipelines_IncludesCoreAndReferencingAssemblies()
+    {
+        await Assert.That(AssemblyLoadedTypesProvider.ReferencesModularPipelines(typeof(PipelineBuilder).Assembly))
+            .IsTrue();
+        await Assert.That(AssemblyLoadedTypesProvider.ReferencesModularPipelines(GetType().Assembly))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task ReferencesModularPipelines_ExcludesUnrelatedAssemblies()
+    {
+        await Assert.That(AssemblyLoadedTypesProvider.ReferencesModularPipelines(typeof(string).Assembly))
+            .IsFalse();
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/DependencyChainProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyChainProviderTests.cs
@@ -1,0 +1,35 @@
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.TestHelpers;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class DependencyChainProviderTests
+{
+    [Test]
+    public async Task Initialize_IndexesDependencyModelsByType()
+    {
+        var dependency = new DependencyModule();
+        var dependent = new DependentModule();
+        var provider = new DependencyChainProvider(Mock.Of<IModuleMetadataRegistry>());
+
+        provider.Initialize([dependent, dependency]);
+
+        var dependentModel = provider.ModuleDependencyModels.Single(model => model.Module == dependent);
+        var dependencyModel = provider.ModuleDependencyModels.Single(model => model.Module == dependency);
+        await Assert.That(dependentModel.IsDependentOn).IsEquivalentTo([dependencyModel]);
+        await Assert.That(dependencyModel.IsDependencyFor).IsEquivalentTo([dependentModel]);
+    }
+
+    private class DependencyModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    [ModularPipelines.Attributes.DependsOn<DependencyModule>]
+    private class DependentModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/UnusedModuleDetectorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/UnusedModuleDetectorTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using ModularPipelines.DependencyInjection;
 using ModularPipelines.Engine;
 using ModularPipelines.Extensions;
@@ -60,6 +61,25 @@ public class UnusedModuleDetectorTests
         var expected = "⚠ Unregistered Modules:\n  • Module2\n  • Module5";
 
         await Assert.That(actual).IsEqualTo(expected);
+    }
+
+    [Test]
+    public async Task Log_WhenWarningDisabled_DoesNotScanAssembliesOrServices()
+    {
+        var logger = new Mock<ILogger<UnusedModuleDetector>>();
+        logger.Setup(x => x.IsEnabled(LogLevel.Warning)).Returns(false);
+        var detector = new UnusedModuleDetector(
+            _assemblyLoadedTypesProvider.Object,
+            _serviceContainerWrapper.Object,
+            logger.Object);
+
+        detector.Log();
+
+        _assemblyLoadedTypesProvider.Verify(
+            x => x.GetLoadedTypesAssignableTo(It.IsAny<Type>()),
+            Times.Never);
+        _serviceContainerWrapper.VerifyGet(x => x.ServiceCollection, Times.Never);
+        await Assert.That(_sb.ToString()).IsEmpty();
     }
 
     private class Module1 : SimpleTestModule<bool>

--- a/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
@@ -57,6 +57,18 @@ public class PipelineBuilderRegistrationTests
     }
 
     [Test]
+    public async Task ModularPipelineAssemblyLoading_IsOptIn()
+    {
+        var builder = TestPipelineHostBuilder.Create();
+
+        await Assert.That(builder.Options.LoadModularPipelineAssemblies).IsFalse();
+
+        builder.ConfigurePipelineOptions(options => options.LoadModularPipelineAssemblies = true);
+
+        await Assert.That(builder.Options.LoadModularPipelineAssemblies).IsTrue();
+    }
+
+    [Test]
     public async Task ExecutePipelineAsync_ValidatesBeforeRunning()
     {
         var builder = Pipeline.CreateBuilder();

--- a/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Context;
@@ -21,6 +22,19 @@ public class PipelineBuilderRegistrationTests
     private class TestModuleB : SimpleTestModule<bool>
     {
         protected override bool Result => true;
+    }
+
+    private sealed class TestAssembly(
+        AssemblyName assemblyName,
+        params AssemblyName[] referencedAssemblies) : Assembly
+    {
+        public override bool IsDynamic => false;
+
+        public override AssemblyName GetName() => assemblyName;
+
+        public override AssemblyName GetName(bool copiedName) => assemblyName;
+
+        public override AssemblyName[] GetReferencedAssemblies() => referencedAssemblies;
     }
 
     [Test]
@@ -66,6 +80,27 @@ public class PipelineBuilderRegistrationTests
         builder.ConfigurePipelineOptions(options => options.LoadModularPipelineAssemblies = true);
 
         await Assert.That(builder.Options.LoadModularPipelineAssemblies).IsTrue();
+    }
+
+    [Test]
+    public async Task ReferencedIntegrationLoading_TraversesNonModularAssemblies()
+    {
+        var integrationName = new AssemblyName("ModularPipelines.FakeIntegration");
+        var integrationAssembly = new TestAssembly(integrationName);
+        var intermediateAssembly = new TestAssembly(
+            new AssemblyName("Acme.Pipeline.Modules"),
+            integrationName);
+        var loadedAssemblyNames = new List<AssemblyName>();
+
+        ReferencedAssemblyTraversal.LoadModularPipelinesAssemblies(
+            [intermediateAssembly],
+            assemblyName =>
+            {
+                loadedAssemblyNames.Add(assemblyName);
+                return integrationAssembly;
+            });
+
+        await Assert.That(loadedAssemblyNames).Contains(integrationName);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- skip unused-module discovery when warning logging is disabled and scan only assemblies referencing ModularPipelines
- make filename-based eager assembly loading opt-in through `PipelineOptions.LoadModularPipelineAssemblies`
- build one module-type index for dependency-chain linking instead of repeated linear scans

## Validation
- `UnusedModuleDetectorTests`: 2 passed
- `AssemblyLoadedTypesProviderTests`: 2 passed
- `DependencyChainProviderTests`: 1 passed
- `PipelineBuilderRegistrationTests`: 15 passed
- `ModularPipelines.sln` Release build: succeeded with 0 errors
- changed-file whitespace verification: passed

Closes #3263