### PR TITLE
Cache PipelineBuilder environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Then configure and execute the pipeline from `Program.cs`:
 ```csharp
 using ModularPipelines;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 await builder.ExecutePipelineAsync();
 ```
 

--- a/README_Template.md
+++ b/README_Template.md
@@ -137,7 +137,7 @@ Then configure and execute the pipeline from `Program.cs`:
 ```csharp
 using ModularPipelines;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 await builder.ExecutePipelineAsync();
 ```
 

--- a/docs/docs/distributed/getting-started.md
+++ b/docs/docs/distributed/getting-started.md
@@ -33,7 +33,7 @@ In your `Program.cs`, enable distributed mode and register the Redis coordinator
 using ModularPipelines.Distributed.Extensions;
 using ModularPipelines.Distributed.Redis.Extensions;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 // Parse instance info from arguments or environment
 var instanceIndex = int.Parse(
@@ -118,7 +118,7 @@ using ModularPipelines.Distributed.Redis.Extensions;
 using ModularPipelines.Modules;
 using Microsoft.Extensions.DependencyInjection;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 var instanceIndex = int.Parse(
     Environment.GetEnvironmentVariable("INSTANCE_INDEX") ?? "0");

--- a/docs/docs/distributed/github-actions.md
+++ b/docs/docs/distributed/github-actions.md
@@ -81,7 +81,7 @@ using ModularPipelines.Distributed.Redis.Extensions;
 using ModularPipelines.Modules;
 using Microsoft.Extensions.DependencyInjection;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 var instanceIndex = int.Parse(
     Environment.GetEnvironmentVariable("INSTANCE_INDEX") ?? "0");

--- a/docs/docs/examples/fsharp-interactive.md
+++ b/docs/docs/examples/fsharp-interactive.md
@@ -45,7 +45,7 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
                 context.DotNet().Sdk.Check(cancellationToken = cancellationToken);
 
     let args = System.Environment.GetCommandLineArgs()
-    let builder = Pipeline.CreateBuilder(args)
+    use builder = Pipeline.CreateBuilder(args)
 
     builder.Services.RegisterDotNetContext()
 

--- a/docs/docs/examples/fsharp-interactive.md
+++ b/docs/docs/examples/fsharp-interactive.md
@@ -45,17 +45,26 @@ F# Interactive (FSI) is a powerful tool for executing F# code snippets and scrip
                 context.DotNet().Sdk.Check(cancellationToken = cancellationToken);
 
     let args = System.Environment.GetCommandLineArgs()
-    use builder = Pipeline.CreateBuilder(args)
+    let builder = Pipeline.CreateBuilder(args)
+    // PipelineBuilder became disposable in v4; retain compatibility with the v3 package above.
+    let builderLifetime =
+        match box builder with
+        | :? System.IDisposable as disposable -> disposable
+        | _ -> null
 
-    builder.Services.RegisterDotNetContext()
+    try
+        builder.Services.RegisterDotNetContext()
 
-    builder
-        .AddModule<UpdateDotnetWorkloads>()
-        .AddModule<CheckDotnetSdkModule>()
+        builder
+            .AddModule<UpdateDotnetWorkloads>()
+            .AddModule<CheckDotnetSdkModule>()
 
-    builder.ExecutePipelineAsync()
-    |> Async.AwaitTask
-    |> Async.RunSynchronously   
+        builder.ExecutePipelineAsync()
+        |> Async.AwaitTask
+        |> Async.RunSynchronously
+    finally
+        if not (isNull builderLifetime) then
+            builderLifetime.Dispose()
     ``` 
 4. **Run your F# script:** You can run your F# script using the F# Interactive environment. If you are using Visual Studio, you can simply open the `example.fsx` file and execute it. Alternatively, you can run it from the command line using:
 

--- a/docs/docs/examples/single-file-csharp.md
+++ b/docs/docs/examples/single-file-csharp.md
@@ -34,7 +34,7 @@ To use ModularPipelines in a single file C# application, you can follow these st
     using ModularPipelines.Models;
     using ModularPipelines.Modules;
 
-    var builder = Pipeline.CreateBuilder(args);
+    using var builder = Pipeline.CreateBuilder(args);
 
     builder
         .AddModule<UpdateDotnetWorkloads>()

--- a/docs/docs/examples/single-file-csharp.md
+++ b/docs/docs/examples/single-file-csharp.md
@@ -34,7 +34,9 @@ To use ModularPipelines in a single file C# application, you can follow these st
     using ModularPipelines.Models;
     using ModularPipelines.Modules;
 
-    using var builder = Pipeline.CreateBuilder(args);
+    var builder = Pipeline.CreateBuilder(args);
+    // PipelineBuilder became disposable in v4; retain compatibility with the v3 package above.
+    using var builderLifetime = ((object)builder) as System.IDisposable;
 
     builder
         .AddModule<UpdateDotnetWorkloads>()

--- a/docs/docs/fundamentals.md
+++ b/docs/docs/fundamentals.md
@@ -10,10 +10,13 @@ sidebar_position: 1
 Your pipeline is created using `Pipeline.CreateBuilder()`. This follows the ASP.NET Core minimal API pattern, providing direct access to `Configuration`, `Services`, and `Options`. Setup should feel familiar if you've used ASP.NET Core.
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<MyModule>();
 await builder.ExecutePipelineAsync();
 ```
+
+`PipelineBuilder` owns its content-root file provider, so keep it in a `using`
+scope until configuration and execution are complete.
 
 ## Modules
 

--- a/docs/docs/how-to/categories.md
+++ b/docs/docs/how-to/categories.md
@@ -21,7 +21,7 @@ If "Ignore Categories" have been set with some values, if a Module has one of th
 ## Example of Running Specific Categories
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()
@@ -38,7 +38,7 @@ await builder.ExecutePipelineAsync();
 ## Example of Ignoring Specific Categories
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/execution-and-dependencies.md
+++ b/docs/docs/how-to/execution-and-dependencies.md
@@ -47,7 +47,7 @@ public class Module2 : Module<string>
 When you declare a required dependency, you don't need to explicitly register it:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<Module2>(); // Module1 is auto-registered because Module2 depends on it
 
 await builder.ExecutePipelineAsync();

--- a/docs/docs/how-to/fsharp.md
+++ b/docs/docs/how-to/fsharp.md
@@ -40,7 +40,7 @@ type TestModule() =
             return $"tested {build.ValueOrDefault}"
         }
 
-let builder = Pipeline.CreateBuilder()
+use builder = Pipeline.CreateBuilder()
 
 builder
     .AddModule<TestModule>()

--- a/docs/docs/how-to/logging.md
+++ b/docs/docs/how-to/logging.md
@@ -67,7 +67,7 @@ await context.DotNet().Build(
 Set default logging for all commands at the pipeline level:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 // All commands will use Silent logging unless overridden
 builder.Options.DefaultLoggingOptions = CommandLoggingOptions.Silent;

--- a/docs/docs/how-to/pipeline-host.md
+++ b/docs/docs/how-to/pipeline-host.md
@@ -18,7 +18,7 @@ The pipeline builder follows the ASP.NET Core minimal API pattern, providing dir
 ## Basic Example
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<BuildModule>()
@@ -33,7 +33,7 @@ await builder.ExecutePipelineAsync();
 Add configuration sources directly via the `Configuration` property:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
     .AddJsonFile("appsettings.json", optional: false)
@@ -50,7 +50,7 @@ builder.Services.Configure<MySettings>(builder.Configuration.GetSection("MySetti
 Modules are registered directly on `PipelineBuilder`. Every registration method returns the same builder for chaining:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 // Register modules
 builder
@@ -67,7 +67,7 @@ builder.AddModules(typeof(Module1), typeof(Module2), typeof(Module3));
 Use `builder.Environment` or `builder.Configuration` for conditional module registration:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration.AddJsonFile("appsettings.json");
 
@@ -91,7 +91,7 @@ builder.AddModule<AlwaysRunModule>();
 Configure pipeline behavior via the `Options` property:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 // Execution mode
 builder.Options.ExecutionMode = ExecutionMode.StopOnFirstException;
@@ -117,7 +117,7 @@ builder.Options.Concurrency = new ConcurrencyOptions
 The pipeline follows a two-step build-then-run pattern:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<MyModule>();
 
 // Step 1: Build and validate the pipeline
@@ -136,7 +136,7 @@ if (summary.Status == PipelineStatus.Failed)
 `BuildAsync()` always validates the pipeline configuration before returning:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<MyModule>();
 
 try
@@ -158,7 +158,7 @@ catch (PipelineValidationException ex)
 ### Validate Without Running
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<MyModule>();
 
 var validation = await builder.ValidateAsync();
@@ -183,7 +183,7 @@ using ModularPipelines;
 using ModularPipelines.Extensions;
 using ModularPipelines.Options;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 // Configuration
 builder.Configuration
@@ -228,7 +228,7 @@ await builder.ExecutePipelineAsync();
 Register global hooks and pipeline requirements:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 // Global hooks (run before/after all modules)
 builder.AddPipelineGlobalHooks<MyGlobalHooks>();
@@ -246,7 +246,7 @@ builder.AddRequirement<GitRequirement>();
 For a more fluent API, extension methods are available:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 await builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/pipeline-modes.md
+++ b/docs/docs/how-to/pipeline-modes.md
@@ -15,7 +15,7 @@ If you want to run every module regardless, you can switch to `WaitForAllModules
 ## Example
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/retry-policy.md
+++ b/docs/docs/how-to/retry-policy.md
@@ -85,7 +85,7 @@ public class ResilientModule : Module<CommandResult>
 Retry policies are off by default. You can set a default retry count on the `PipelineOptions`:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/storing-and-retrieving-results.md
+++ b/docs/docs/how-to/storing-and-retrieving-results.md
@@ -16,7 +16,7 @@ It's recommended to store and retrieve results using the Git commit SHA, as then
 ## Example Repository Class using Azure Blobs
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/testing.md
+++ b/docs/docs/how-to/testing.md
@@ -33,7 +33,7 @@ public async Task MyModule_ReadsConfigFile()
         .ReturnsAsync("{\"setting\": \"value\"}");
 
     // Run pipeline with mock
-    var builder = Pipeline.CreateBuilder(args);
+    using var builder = Pipeline.CreateBuilder(args);
 
     builder.Services.AddSingleton<IFileSystemProvider>(mockProvider.Object);
     builder.AddModule<MyModule>();
@@ -53,7 +53,7 @@ public async Task MyModule_WritesOutputFile()
 {
     var mockProvider = new Mock<IFileSystemProvider>();
 
-    var builder = Pipeline.CreateBuilder(args);
+    using var builder = Pipeline.CreateBuilder(args);
 
     builder.Services.AddSingleton<IFileSystemProvider>(mockProvider.Object);
     builder.AddModule<OutputModule>();

--- a/docs/docs/how-to/time-estimator.md
+++ b/docs/docs/how-to/time-estimator.md
@@ -13,7 +13,7 @@ Then on subsequent runs, it'll ask you for an estimated time for a module. You g
 ## Example
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/timeouts.md
+++ b/docs/docs/how-to/timeouts.md
@@ -7,7 +7,7 @@ title: Timeouts
 Modules have a 30-minute timeout by default. Configure the pipeline default when your workloads need a different limit, or use `TimeSpan.Zero` to disable it:
 
 ```csharp
-var builder = Pipeline.CreateBuilder();
+using var builder = Pipeline.CreateBuilder();
 builder.Options.DefaultModuleTimeout = TimeSpan.FromHours(2);
 
 // Disable the default. Per-module timeouts still apply.

--- a/docs/docs/migrating-to-v3.md
+++ b/docs/docs/migrating-to-v3.md
@@ -109,7 +109,7 @@ await PipelineHostBuilder.Create()
 ### After (V3)
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 // Direct property access instead of callbacks
 builder.Configuration
@@ -436,7 +436,7 @@ V3 uses a three-tier configuration system (highest to lowest priority):
 ### Setting Global Defaults
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 // Set global default for all commands
 builder.Options.DefaultLoggingOptions = new CommandLoggingOptions
@@ -915,7 +915,7 @@ nullable == value;      // true - None? and None are always equal
 V3 introduces a validation API to catch configuration errors before execution:
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 builder.Services.AddModule<MyModule>();
 
 // Option 1: Validate without running
@@ -1122,7 +1122,7 @@ public class DeployModule : Module<bool>
 
 ```csharp
 // Program.cs
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration.AddJsonFile("appsettings.json");
 

--- a/docs/docs/migrating-to-v3.md
+++ b/docs/docs/migrating-to-v3.md
@@ -109,7 +109,7 @@ await PipelineHostBuilder.Create()
 ### After (V3)
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 // Direct property access instead of callbacks
 builder.Configuration
@@ -436,7 +436,7 @@ V3 uses a three-tier configuration system (highest to lowest priority):
 ### Setting Global Defaults
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 // Set global default for all commands
 builder.Options.DefaultLoggingOptions = new CommandLoggingOptions
@@ -915,7 +915,7 @@ nullable == value;      // true - None? and None are always equal
 V3 introduces a validation API to catch configuration errors before execution:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 builder.Services.AddModule<MyModule>();
 
 // Option 1: Validate without running
@@ -1122,7 +1122,7 @@ public class DeployModule : Module<bool>
 
 ```csharp
 // Program.cs
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration.AddJsonFile("appsettings.json");
 

--- a/docs/docs/mp-packages/distributed-artifacts-s3.md
+++ b/docs/docs/mp-packages/distributed-artifacts-s3.md
@@ -20,7 +20,7 @@ Register the artifact store after enabling distributed mode:
 using ModularPipelines.Distributed.Artifacts.S3.Extensions;
 using ModularPipelines.Distributed.Extensions;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.AddDistributedMode(options => options.TotalInstances = 2);
 builder.AddS3DistributedArtifactStore(options =>

--- a/docs/docs/mp-packages/distributed-discovery-redis.md
+++ b/docs/docs/mp-packages/distributed-discovery-redis.md
@@ -21,7 +21,7 @@ using ModularPipelines.Distributed.Discovery.Redis;
 using ModularPipelines.Distributed.Extensions;
 using ModularPipelines.Distributed.SignalR.Extensions;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.AddDistributedMode(options => options.TotalInstances = 2);
 builder.AddSignalRDistributedCoordinator();

--- a/docs/docs/mp-packages/distributed-redis.md
+++ b/docs/docs/mp-packages/distributed-redis.md
@@ -20,7 +20,7 @@ Use the combined helper when Redis should provide both services:
 using ModularPipelines.Distributed.Redis.Extensions;
 using ModularPipelines.Distributed.Extensions;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.AddDistributedMode(options => options.TotalInstances = 2);
 builder.AddRedisDistributed(

--- a/docs/docs/mp-packages/distributed-signalr.md
+++ b/docs/docs/mp-packages/distributed-signalr.md
@@ -20,7 +20,7 @@ Register the coordinator after enabling distributed mode:
 using ModularPipelines.Distributed.SignalR.Extensions;
 using ModularPipelines.Distributed.Extensions;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.AddDistributedMode(options => options.TotalInstances = 2);
 builder.AddSignalRDistributedCoordinator(options =>

--- a/docs/docs/mp-packages/github.md
+++ b/docs/docs/mp-packages/github.md
@@ -62,7 +62,7 @@ Modular Pipelines' `GitHub()` automatically authenticates OctoKit client when:
 Configuring OctoKit auth using `GitHubOptions` is straightforward as it follows standard .NET practices for working with `IConfiguration` and `IOptions<T>`. When configuring your pipeline, use the usual practices for working with configuration to configure OctoKit auth:
 
 ```cs
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
     .AddJsonFile("appsettings.json")

--- a/src/ModularPipelines.Build/Program.cs
+++ b/src/ModularPipelines.Build/Program.cs
@@ -17,7 +17,7 @@ using ModularPipelines.Extensions;
 using Octokit;
 using Octokit.Internal;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 builder.ConfigurePipelineOptions(options => options.LoadModularPipelineAssemblies = true);
 
 builder.Configuration

--- a/src/ModularPipelines.Development.Analyzers/Readme.md
+++ b/src/ModularPipelines.Development.Analyzers/Readme.md
@@ -91,7 +91,7 @@ If you want to see how to get started, or want to know more about ModularPipelin
 ### Program.cs - Main method
 
 ```csharp
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.Services
     .Configure<NuGetSettings>(builder.Configuration.GetSection("NuGet"))

--- a/src/ModularPipelines.Examples/Program.cs
+++ b/src/ModularPipelines.Examples/Program.cs
@@ -8,7 +8,7 @@ using ModularPipelines.Examples.Modules.Systems;
 using ModularPipelines.Extensions;
 using ModularPipelines.Options;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
     .AddJsonFile("appsettings.json", optional: false)

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -9,7 +9,7 @@ using TemplatePipeline.Settings;
 var pipelineDirectory = PipelineProjectDirectory.Find();
 Environment.CurrentDirectory = pipelineDirectory;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
     .AddJsonFile(Path.Combine(pipelineDirectory, "appsettings.json"), optional: false)

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -9,7 +9,7 @@ using TemplatePipeline.Settings;
 var pipelineDirectory = PipelineProjectDirectory.Find();
 Environment.CurrentDirectory = pipelineDirectory;
 
-var builder = Pipeline.CreateBuilder(args);
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
     .AddJsonFile(Path.Combine(pipelineDirectory, "appsettings.json"), optional: false)

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -9,7 +9,9 @@ using TemplatePipeline.Settings;
 var pipelineDirectory = PipelineProjectDirectory.Find();
 Environment.CurrentDirectory = pipelineDirectory;
 
+// PipelineBuilder became disposable in v4; retain compatibility with earlier package versions.
 var builder = Pipeline.CreateBuilder(args);
+using var builderLifetime = ((object)builder) as IDisposable;
 
 builder.Configuration
     .AddJsonFile(Path.Combine(pipelineDirectory, "appsettings.json"), optional: false)

--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -225,8 +225,11 @@ public static class PipelineBuilderExtensions
     /// <returns>A summary of the pipeline execution results.</returns>
     public static async Task<Models.PipelineSummary> ExecutePipelineAsync(this PipelineBuilder builder, CancellationToken cancellationToken = default)
     {
-        await using var pipeline = await builder.BuildAsync().ConfigureAwait(false);
-        return await pipeline.RunAsync(cancellationToken).ConfigureAwait(false);
+        using (builder)
+        {
+            await using var pipeline = await builder.BuildAsync().ConfigureAwait(false);
+            return await pipeline.RunAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 
     /// <summary>

--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -225,11 +225,8 @@ public static class PipelineBuilderExtensions
     /// <returns>A summary of the pipeline execution results.</returns>
     public static async Task<Models.PipelineSummary> ExecutePipelineAsync(this PipelineBuilder builder, CancellationToken cancellationToken = default)
     {
-        using (builder)
-        {
-            await using var pipeline = await builder.BuildAsync().ConfigureAwait(false);
-            return await pipeline.RunAsync(cancellationToken).ConfigureAwait(false);
-        }
+        await using var pipeline = await builder.BuildAsync().ConfigureAwait(false);
+        return await pipeline.RunAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/ModularPipelines/Options/SecretMaskingOptions.cs
+++ b/src/ModularPipelines/Options/SecretMaskingOptions.cs
@@ -21,7 +21,7 @@ namespace ModularPipelines.Options;
 /// </remarks>
 /// <example>
 /// <code>
-/// var builder = Pipeline.CreateBuilder();
+/// using var builder = Pipeline.CreateBuilder();
 /// builder.Services.Configure&lt;SecretMaskingOptions&gt;(options =>
 /// {
 ///     options.CaseInsensitive = true;  // Match "Password", "PASSWORD", "password"

--- a/src/ModularPipelines/Pipeline.cs
+++ b/src/ModularPipelines/Pipeline.cs
@@ -12,7 +12,7 @@ public static class Pipeline
     /// <returns>A new pipeline builder instance.</returns>
     /// <example>
     /// <code>
-    /// var builder = Pipeline.CreateBuilder(args);
+    /// using var builder = Pipeline.CreateBuilder(args);
     ///
     /// builder.AddModule&lt;BuildModule&gt;();
     /// builder.Options.ExecutionMode = ExecutionMode.StopOnFirstException;
@@ -33,7 +33,7 @@ public static class Pipeline
     /// <returns>A new pipeline builder instance.</returns>
     /// <example>
     /// <code>
-    /// var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+    /// using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
     /// {
     ///     Args = args,
     ///     EnvironmentName = "Development"

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -26,10 +26,8 @@ namespace ModularPipelines;
 /// <summary>
 /// A builder for configuring and creating a pipeline.
 /// </summary>
-public sealed class PipelineBuilder
+public sealed class PipelineBuilder : IDisposable
 {
-    private static readonly IFileProvider EmptyFileProvider = new NullFileProvider();
-
     private readonly IHostBuilder _hostBuilder;
     private readonly ServiceCollection _services;
     private readonly ConfigurationManager _configuration;
@@ -93,6 +91,15 @@ public sealed class PipelineBuilder
     /// Gets the host environment information.
     /// </summary>
     public IHostEnvironment Environment => _environment;
+
+    /// <summary>
+    /// Releases resources owned by the cached host environment.
+    /// </summary>
+    public void Dispose()
+    {
+        (_environment.ContentRootFileProvider as IDisposable)?.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
     /// <summary>
     /// Sets the minimum log level for the pipeline.
@@ -262,7 +269,7 @@ public sealed class PipelineBuilder
             ApplicationName = applicationName,
             EnvironmentName = environmentName,
             ContentRootPath = contentRootPath,
-            ContentRootFileProvider = EmptyFileProvider,
+            ContentRootFileProvider = new PhysicalFileProvider(contentRootPath),
         };
     }
 

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -26,8 +26,10 @@ namespace ModularPipelines;
 /// <summary>
 /// A builder for configuring and creating a pipeline.
 /// </summary>
-public sealed class PipelineBuilder : IDisposable
+public sealed class PipelineBuilder
 {
+    private static readonly IFileProvider EmptyFileProvider = new NullFileProvider();
+
     private readonly IHostBuilder _hostBuilder;
     private readonly ServiceCollection _services;
     private readonly ConfigurationManager _configuration;
@@ -91,15 +93,6 @@ public sealed class PipelineBuilder : IDisposable
     /// Gets the host environment information.
     /// </summary>
     public IHostEnvironment Environment => _environment;
-
-    /// <summary>
-    /// Releases resources owned by the cached host environment.
-    /// </summary>
-    public void Dispose()
-    {
-        (_environment.ContentRootFileProvider as IDisposable)?.Dispose();
-        GC.SuppressFinalize(this);
-    }
 
     /// <summary>
     /// Sets the minimum log level for the pipeline.
@@ -269,7 +262,7 @@ public sealed class PipelineBuilder : IDisposable
             ApplicationName = applicationName,
             EnvironmentName = environmentName,
             ContentRootPath = contentRootPath,
-            ContentRootFileProvider = new PhysicalFileProvider(contentRootPath),
+            ContentRootFileProvider = EmptyFileProvider,
         };
     }
 

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -26,6 +26,10 @@ namespace ModularPipelines;
 /// <summary>
 /// A builder for configuring and creating a pipeline.
 /// </summary>
+/// <remarks>
+/// The caller owns the builder and should dispose it when finished, especially after using
+/// <see cref="IHostEnvironment.ContentRootFileProvider"/>.
+/// </remarks>
 public sealed class PipelineBuilder : IDisposable
 {
     private readonly IHostBuilder _hostBuilder;

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -26,7 +26,7 @@ namespace ModularPipelines;
 /// <summary>
 /// A builder for configuring and creating a pipeline.
 /// </summary>
-public sealed class PipelineBuilder
+public sealed class PipelineBuilder : IDisposable
 {
     private readonly IHostBuilder _hostBuilder;
     private readonly ServiceCollection _services;
@@ -91,6 +91,15 @@ public sealed class PipelineBuilder
     /// Gets the host environment information.
     /// </summary>
     public IHostEnvironment Environment => _environment;
+
+    /// <summary>
+    /// Releases resources owned by the cached host environment.
+    /// </summary>
+    public void Dispose()
+    {
+        (_environment.ContentRootFileProvider as IDisposable)?.Dispose();
+        GC.SuppressFinalize(this);
+    }
 
     /// <summary>
     /// Sets the minimum log level for the pipeline.

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -31,35 +32,43 @@ public sealed class PipelineBuilder
     private readonly ServiceCollection _services;
     private readonly ConfigurationManager _configuration;
     private readonly PipelineOptions _options;
+    private readonly IHostEnvironment _environment;
 
     internal Type? LastRegisteredModuleType { get; set; }
 
     internal PipelineBuilder(string[]? args)
+        : this(new PipelineBuilderOptions { Args = args })
     {
+    }
+
+    internal PipelineBuilder(PipelineBuilderOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
         _services = new ServiceCollection();
         _configuration = new ConfigurationManager();
         _options = new PipelineOptions();
 
-        _hostBuilder = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args);
+        _hostBuilder = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(options.Args);
 
         // Add default configuration sources
         _configuration.AddEnvironmentVariables();
-        if (args != null)
+        if (options.Args != null)
         {
-            _configuration.AddCommandLine(args);
-        }
-    }
-
-    internal PipelineBuilder(PipelineBuilderOptions options) : this(options.Args)
-    {
-        if (!string.IsNullOrEmpty(options.EnvironmentName))
-        {
-            _hostBuilder.UseEnvironment(options.EnvironmentName);
+            _configuration.AddCommandLine(options.Args);
         }
 
-        if (!string.IsNullOrEmpty(options.ContentRootPath))
+        _environment = CreateHostEnvironment(options);
+        _hostBuilder.UseEnvironment(_environment.EnvironmentName);
+        _hostBuilder.UseContentRoot(_environment.ContentRootPath);
+
+        if (!string.IsNullOrEmpty(_environment.ApplicationName))
         {
-            _hostBuilder.UseContentRoot(options.ContentRootPath);
+            _hostBuilder.ConfigureHostConfiguration(configuration =>
+                configuration.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [HostDefaults.ApplicationKey] = _environment.ApplicationName,
+                }));
         }
     }
 
@@ -81,16 +90,7 @@ public sealed class PipelineBuilder
     /// <summary>
     /// Gets the host environment information.
     /// </summary>
-    public IHostEnvironment Environment
-    {
-        get
-        {
-            // Build a temporary host to get the environment
-            // This is a lightweight operation as we're not running anything
-            using var tempHost = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder().Build();
-            return tempHost.Services.GetRequiredService<IHostEnvironment>();
-        }
-    }
+    public IHostEnvironment Environment => _environment;
 
     /// <summary>
     /// Sets the minimum log level for the pipeline.
@@ -229,6 +229,44 @@ public sealed class PipelineBuilder
         var validationService = services.GetService<IPipelineValidationService>();
         return validationService?.ValidateAsync(services)
                ?? Task.FromResult(ValidationResult.Success());
+    }
+
+    private static IHostEnvironment CreateHostEnvironment(PipelineBuilderOptions options)
+    {
+        var hostConfiguration = new ConfigurationManager();
+        hostConfiguration.AddEnvironmentVariables(prefix: "DOTNET_");
+        if (options.Args is not null)
+        {
+            hostConfiguration.AddCommandLine(options.Args);
+        }
+
+        var environmentName = FirstNonEmpty(
+            Environments.Production,
+            options.EnvironmentName,
+            hostConfiguration[HostDefaults.EnvironmentKey],
+            System.Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"));
+        var contentRootPath = Path.GetFullPath(FirstNonEmpty(
+            Directory.GetCurrentDirectory(),
+            options.ContentRootPath,
+            hostConfiguration[HostDefaults.ContentRootKey]));
+        var applicationName = FirstNonEmpty(
+            string.Empty,
+            options.ApplicationName,
+            hostConfiguration[HostDefaults.ApplicationKey],
+            Assembly.GetEntryAssembly()?.GetName().Name);
+
+        return new PipelineHostEnvironment
+        {
+            ApplicationName = applicationName,
+            EnvironmentName = environmentName,
+            ContentRootPath = contentRootPath,
+            ContentRootFileProvider = new PhysicalFileProvider(contentRootPath),
+        };
+    }
+
+    private static string FirstNonEmpty(string fallback, params string?[] candidates)
+    {
+        return candidates.FirstOrDefault(static value => !string.IsNullOrEmpty(value)) ?? fallback;
     }
 
     private async Task<IPipeline> BuildPipelineAsync()
@@ -458,6 +496,17 @@ public sealed class PipelineBuilder
         {
             services.Remove(descriptor);
         }
+    }
+
+    private sealed class PipelineHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = string.Empty;
+
+        public string ApplicationName { get; set; } = string.Empty;
+
+        public string ContentRootPath { get; set; } = string.Empty;
+
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
     }
 
     /// <summary>

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -36,7 +36,7 @@ public sealed class PipelineBuilder : IDisposable
     private readonly ServiceCollection _services;
     private readonly ConfigurationManager _configuration;
     private readonly PipelineOptions _options;
-    private readonly IHostEnvironment _environment;
+    private readonly PipelineHostEnvironment _environment;
 
     internal Type? LastRegisteredModuleType { get; set; }
 
@@ -123,7 +123,7 @@ public sealed class PipelineBuilder : IDisposable
     /// <returns>The same builder instance for chaining.</returns>
     public PipelineBuilder RunCategories(params string[] categories)
     {
-        _options.RunOnlyCategories ??= new List<string>();
+        _options.RunOnlyCategories ??= [];
         foreach (var category in categories)
         {
             _options.RunOnlyCategories.Add(category);
@@ -139,7 +139,7 @@ public sealed class PipelineBuilder : IDisposable
     /// <returns>The same builder instance for chaining.</returns>
     public PipelineBuilder IgnoreCategories(params string[] categories)
     {
-        _options.IgnoreCategories ??= new List<string>();
+        _options.IgnoreCategories ??= [];
         foreach (var category in categories)
         {
             _options.IgnoreCategories.Add(category);
@@ -244,7 +244,7 @@ public sealed class PipelineBuilder : IDisposable
                ?? Task.FromResult(ValidationResult.Success());
     }
 
-    private static IHostEnvironment CreateHostEnvironment(PipelineBuilderOptions options)
+    private static PipelineHostEnvironment CreateHostEnvironment(PipelineBuilderOptions options)
     {
         var hostConfiguration = new ConfigurationManager();
         hostConfiguration.AddEnvironmentVariables(prefix: "DOTNET_");

--- a/src/ModularPipelines/Requirements/MacOSRequirement.cs
+++ b/src/ModularPipelines/Requirements/MacOSRequirement.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Requirements;
 /// </para>
 /// <para><b>Example:</b></para>
 /// <code>
-/// var builder = Pipeline.CreateBuilder();
+/// using var builder = Pipeline.CreateBuilder();
 /// builder.Services.AddRequirement&lt;MacOSRequirement&gt;();
 /// builder.AddModule&lt;BuildMacAppModule&gt;();
 ///

--- a/src/ModularPipelines/Requirements/WindowsAdminRequirement.cs
+++ b/src/ModularPipelines/Requirements/WindowsAdminRequirement.cs
@@ -20,7 +20,7 @@ namespace ModularPipelines.Requirements;
 /// </para>
 /// <para><b>Example:</b></para>
 /// <code>
-/// var builder = Pipeline.CreateBuilder();
+/// using var builder = Pipeline.CreateBuilder();
 /// builder.Services.AddRequirement&lt;WindowsAdminRequirement&gt;();
 /// builder.AddModule&lt;InstallServiceModule&gt;();
 ///

--- a/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
+++ b/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
@@ -110,10 +110,9 @@ public class DocumentationSnippetTests
             throw new InvalidOperationException($"Could not list tracked Markdown files: {error}");
         }
 
-        return output
+        return [.. output
             .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
             .Where(line => !line.StartsWith("120000 ", StringComparison.Ordinal))
-            .Select(line => line[(line.IndexOf(' ') + 1)..])
-            .ToArray();
+            .Select(line => line[(line.IndexOf(' ') + 1)..])];
     }
 }

--- a/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
+++ b/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
@@ -60,7 +60,7 @@ public class DocumentationSnippetTests
             .ConfigureAwait(false);
 
         await Assert.That(readme).Contains("dotnet add package ModularPipelines.DotNet");
-        await Assert.That(readme).Contains("var builder = Pipeline.CreateBuilder(args);");
+        await Assert.That(readme).Contains("using var builder = Pipeline.CreateBuilder(args);");
         await Assert.That(readme).Contains("await builder.ExecutePipelineAsync();");
     }
 

--- a/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Context;
 using ModularPipelines.Exceptions;
@@ -120,6 +121,7 @@ public class PipelineBuilderRegistrationTests
         await Assert.That(environment.ApplicationName).IsEqualTo("ConfiguredApp");
         await Assert.That(environment.EnvironmentName).IsEqualTo("ConfiguredEnvironment");
         await Assert.That(environment.ContentRootPath).IsEqualTo(Path.GetFullPath(contentRoot));
+        await Assert.That(environment.ContentRootFileProvider).IsTypeOf<NullFileProvider>();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Context;
 using ModularPipelines.Exceptions;
@@ -108,20 +107,31 @@ public class PipelineBuilderRegistrationTests
     public async Task Environment_IsCachedAndHonorsBuilderOptions()
     {
         var contentRoot = Path.GetTempPath();
-        var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+        var fileName = $"pipeline-environment-{Guid.NewGuid():N}.txt";
+        var filePath = Path.Combine(contentRoot, fileName);
+        await File.WriteAllTextAsync(filePath, "content");
+
+        try
         {
-            ApplicationName = "ConfiguredApp",
-            EnvironmentName = "ConfiguredEnvironment",
-            ContentRootPath = contentRoot,
-        });
+            using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+            {
+                ApplicationName = "ConfiguredApp",
+                EnvironmentName = "ConfiguredEnvironment",
+                ContentRootPath = contentRoot,
+            });
 
-        var environment = builder.Environment;
+            var environment = builder.Environment;
 
-        await Assert.That(builder.Environment).IsSameReferenceAs(environment);
-        await Assert.That(environment.ApplicationName).IsEqualTo("ConfiguredApp");
-        await Assert.That(environment.EnvironmentName).IsEqualTo("ConfiguredEnvironment");
-        await Assert.That(environment.ContentRootPath).IsEqualTo(Path.GetFullPath(contentRoot));
-        await Assert.That(environment.ContentRootFileProvider).IsTypeOf<NullFileProvider>();
+            await Assert.That(builder.Environment).IsSameReferenceAs(environment);
+            await Assert.That(environment.ApplicationName).IsEqualTo("ConfiguredApp");
+            await Assert.That(environment.EnvironmentName).IsEqualTo("ConfiguredEnvironment");
+            await Assert.That(environment.ContentRootPath).IsEqualTo(Path.GetFullPath(contentRoot));
+            await Assert.That(environment.ContentRootFileProvider.GetFileInfo(fileName).Exists).IsTrue();
+        }
+        finally
+        {
+            File.Delete(filePath);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
@@ -104,6 +104,41 @@ public class PipelineBuilderRegistrationTests
     }
 
     [Test]
+    public async Task Environment_IsCachedAndHonorsBuilderOptions()
+    {
+        var contentRoot = Path.GetTempPath();
+        var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+        {
+            ApplicationName = "ConfiguredApp",
+            EnvironmentName = "ConfiguredEnvironment",
+            ContentRootPath = contentRoot,
+        });
+
+        var environment = builder.Environment;
+
+        await Assert.That(builder.Environment).IsSameReferenceAs(environment);
+        await Assert.That(environment.ApplicationName).IsEqualTo("ConfiguredApp");
+        await Assert.That(environment.EnvironmentName).IsEqualTo("ConfiguredEnvironment");
+        await Assert.That(environment.ContentRootPath).IsEqualTo(Path.GetFullPath(contentRoot));
+    }
+
+    [Test]
+    public async Task Environment_HonorsCommandLineHostConfiguration()
+    {
+        var contentRoot = Path.GetTempPath();
+        var builder = Pipeline.CreateBuilder(
+        [
+            "--applicationName", "CommandLineApp",
+            "--environment", "CommandLineEnvironment",
+            "--contentRoot", contentRoot,
+        ]);
+
+        await Assert.That(builder.Environment.ApplicationName).IsEqualTo("CommandLineApp");
+        await Assert.That(builder.Environment.EnvironmentName).IsEqualTo("CommandLineEnvironment");
+        await Assert.That(builder.Environment.ContentRootPath).IsEqualTo(Path.GetFullPath(contentRoot));
+    }
+
+    [Test]
     public async Task ExecutePipelineAsync_ValidatesBeforeRunning()
     {
         var builder = Pipeline.CreateBuilder();

--- a/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
@@ -138,7 +138,7 @@ public class PipelineBuilderRegistrationTests
     public async Task Environment_HonorsCommandLineHostConfiguration()
     {
         var contentRoot = Path.GetTempPath();
-        var builder = Pipeline.CreateBuilder(
+        using var builder = Pipeline.CreateBuilder(
         [
             "--applicationName", "CommandLineApp",
             "--environment", "CommandLineEnvironment",


### PR DESCRIPTION
## Summary
- cache a lightweight `IHostEnvironment` when `PipelineBuilder` is created
- honor builder options and host command-line configuration without building a temporary host on every read
- expose a functional content-root provider with explicit caller-owned builder disposal
- update shipped C#/F# entry points and documentation to dispose the builder
- keep the real host builder aligned with the cached environment

## Validation
- `PipelineBuilderRegistrationTests`: 16 passed
- `DocumentationSnippetTests`: 2 passed
- `dotnet build ModularPipelines.sln -c Release --no-restore /m:1 -v:q`: 0 warnings, 0 errors
- changed-file analyzer and whitespace verification passed

Closes #3265