### PR TITLE
Honor pipeline requirement order

### DIFF
--- a/src/ModularPipelines/Engine/RequirementChecker.cs
+++ b/src/ModularPipelines/Engine/RequirementChecker.cs
@@ -20,7 +20,9 @@ internal class RequirementChecker : IRequirementChecker
     {
         var failedRequirementsNames = new ConcurrentBag<string>();
 
-        var groupedRequirements = _requirements.GroupBy(x => x.Order);
+        var groupedRequirements = _requirements
+            .GroupBy(x => x.Order)
+            .OrderBy(group => group.Key);
 
         foreach (var pipelineRequirements in groupedRequirements)
         {
@@ -36,7 +38,7 @@ internal class RequirementChecker : IRequirementChecker
                 }).ProcessInParallel();
         }
 
-        if (failedRequirementsNames.Any())
+        if (!failedRequirementsNames.IsEmpty)
         {
             throw new FailedRequirementsException($"Requirements failed:\r\n{string.Join("\r\n", failedRequirementsNames)}");
         }

--- a/test/ModularPipelines.UnitTests/Engine/RequirementCheckerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RequirementCheckerTests.cs
@@ -1,0 +1,49 @@
+using System.Collections.Concurrent;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Models;
+using ModularPipelines.Requirements;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class RequirementCheckerTests
+{
+    [Test]
+    public async Task Requirements_Are_Checked_In_Ascending_Order()
+    {
+        var executionOrder = new ConcurrentQueue<int>();
+        IPipelineRequirement[] requirements =
+        [
+            new RecordingRequirement(20, executionOrder),
+            new RecordingRequirement(-10, executionOrder),
+            new RecordingRequirement(0, executionOrder),
+        ];
+        var contextProvider = new Mock<IPipelineContextProvider>();
+        contextProvider
+            .Setup(provider => provider.GetModuleContext())
+            .Returns(Mock.Of<IPipelineContext>());
+        var checker = new RequirementChecker(requirements, contextProvider.Object);
+
+        await checker.CheckRequirementsAsync();
+
+        var actualOrder = executionOrder.ToArray();
+        await Assert.That(actualOrder.Length).IsEqualTo(3);
+        await Assert.That(actualOrder[0]).IsEqualTo(-10);
+        await Assert.That(actualOrder[1]).IsEqualTo(0);
+        await Assert.That(actualOrder[2]).IsEqualTo(20);
+    }
+
+    private sealed class RecordingRequirement(
+        int order,
+        ConcurrentQueue<int> executionOrder) : IPipelineRequirement
+    {
+        public int Order => order;
+
+        public Task<RequirementDecision> MustAsync(IPipelineContext context)
+        {
+            executionOrder.Enqueue(order);
+            return Task.FromResult(RequirementDecision.Passed);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- execute requirement order groups in ascending `IPipelineRequirement.Order`
- retain parallel execution within each order group
- add regression coverage for negative, zero, and positive order values
- use `ConcurrentBag.IsEmpty` in the touched validation path

Closes #3246

## Validation

- `RequirementCheckerTests`: 1/1 passed
- exact changed-file analyzers at info severity: clean
- exact changed-file whitespace verification: clean
- `ModularPipelines.sln` Release build: 0 errors