### PR TITLE
Bound module output logger lock wait

### DIFF
--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -50,6 +50,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     private readonly IOutputCoordinator _outputCoordinator;
     private readonly ISpectreConsoleLoggerControl _loggerControl;
     private readonly INonSpectreLoggerFactory _nonSpectreLoggerFactory;
+    private readonly ISpectreLoggerFilter _spectreLoggerFilter;
     private TextWriter? _originalConsoleOut;
     private TextWriter? _originalConsoleError;
     private IAnsiConsole? _originalAnsiConsole;
@@ -71,7 +72,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         IServiceProvider serviceProvider,
         IOutputCoordinator outputCoordinator,
         ISpectreConsoleLoggerControl loggerControl,
-        INonSpectreLoggerFactory nonSpectreLoggerFactory)
+        INonSpectreLoggerFactory nonSpectreLoggerFactory,
+        ISpectreLoggerFilter spectreLoggerFilter)
     {
         _formatterProvider = formatterProvider;
         _resultsPrinter = resultsPrinter;
@@ -84,11 +86,15 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         _outputCoordinator = outputCoordinator;
         _loggerControl = loggerControl;
         _nonSpectreLoggerFactory = nonSpectreLoggerFactory;
+        _spectreLoggerFilter = spectreLoggerFilter;
         _unattributedBuffer = new ModuleOutputBuffer(
             "Pipeline",
             typeof(void),
             _options.Value.ModuleOutputFlushThreshold,
-            RequestThresholdFlush);
+            RequestThresholdFlush,
+            isSpectreEnabled: logLevel => _spectreLoggerFilter.IsEnabled(
+                OutputLoggerCategories.Pipeline,
+                logLevel));
     }
 
     /// <inheritdoc />
@@ -281,7 +287,10 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
             t => new ModuleOutputBuffer(
                 t,
                 _options.Value.ModuleOutputFlushThreshold,
-                RequestThresholdFlush));
+                RequestThresholdFlush,
+                isSpectreEnabled: logLevel => _spectreLoggerFilter.IsEnabled(
+                    OutputLoggerCategories.ForModule(t),
+                    logLevel)));
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -49,6 +49,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     private readonly ConcurrentQueue<string> _deferredExceptions = new();
     private readonly IOutputCoordinator _outputCoordinator;
     private readonly ISpectreConsoleLoggerControl _loggerControl;
+    private readonly INonSpectreLoggerFactory _nonSpectreLoggerFactory;
     private TextWriter? _originalConsoleOut;
     private TextWriter? _originalConsoleError;
     private IAnsiConsole? _originalAnsiConsole;
@@ -69,7 +70,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         IBuildSystemDetector buildSystemDetector,
         IServiceProvider serviceProvider,
         IOutputCoordinator outputCoordinator,
-        ISpectreConsoleLoggerControl loggerControl)
+        ISpectreConsoleLoggerControl loggerControl,
+        INonSpectreLoggerFactory nonSpectreLoggerFactory)
     {
         _formatterProvider = formatterProvider;
         _resultsPrinter = resultsPrinter;
@@ -81,6 +83,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         _serviceProvider = serviceProvider;
         _outputCoordinator = outputCoordinator;
         _loggerControl = loggerControl;
+        _nonSpectreLoggerFactory = nonSpectreLoggerFactory;
         _unattributedBuffer = new ModuleOutputBuffer(
             "Pipeline",
             typeof(void),
@@ -345,7 +348,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                     formatter,
                     unattributedLogger,
                     _loggerControl,
-                    OutputFlushKind.Complete)
+                    OutputFlushKind.Complete,
+                    fallbackLoggers: _nonSpectreLoggerFactory.CreateLoggers("ModularPipelines.Output"))
                 .ConfigureAwait(false);
         }
     }

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -123,7 +123,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                 ConfigureConsoleWidth();
 
                 // Create logger for structured output during flush
-                _outputLogger = _loggerFactory.CreateLogger("ModularPipelines.Output");
+                _outputLogger = _loggerFactory.CreateLogger(OutputLoggerCategories.Pipeline);
 
                 // Install our intercepting writers
                 // Buffer module output while the coordinated output phase is active. Flush paths
@@ -341,7 +341,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         // Flush unattributed output (if any)
         if (_unattributedBuffer.HasOutput)
         {
-            var unattributedLogger = _outputLogger ?? _loggerFactory.CreateLogger("ModularPipelines.Output");
+            var unattributedLogger = _outputLogger
+                                     ?? _loggerFactory.CreateLogger(OutputLoggerCategories.Pipeline);
             await _unattributedBuffer
                 .FlushToAsync(
                     _originalConsoleOut,
@@ -349,8 +350,23 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                     unattributedLogger,
                     _loggerControl,
                     OutputFlushKind.Complete,
-                    fallbackLoggers: _nonSpectreLoggerFactory.CreateLoggers("ModularPipelines.Output"))
+                    fallbackLoggers: _nonSpectreLoggerFactory.CreateLoggers(
+                        OutputLoggerCategories.Pipeline))
                 .ConfigureAwait(false);
+
+            if (_unattributedBuffer.HasStructuredDeliveryRetries)
+            {
+                await _unattributedBuffer
+                    .FlushToAsync(
+                        _originalConsoleOut,
+                        formatter,
+                        unattributedLogger,
+                        _loggerControl,
+                        OutputFlushKind.Complete,
+                        fallbackLoggers: _nonSpectreLoggerFactory.CreateLoggers(
+                            OutputLoggerCategories.Pipeline))
+                    .ConfigureAwait(false);
+            }
         }
     }
 

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -54,6 +54,11 @@ internal interface IModuleOutputBuffer
     bool HasOutput { get; }
 
     /// <summary>
+    /// Gets a value indicating whether a structured event needs another provider delivery attempt.
+    /// </summary>
+    bool HasStructuredDeliveryRetries => false;
+
+    /// <summary>
     /// Gets a value indicating whether the owning module has completed.
     /// </summary>
     bool IsComplete { get; }

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -77,6 +77,7 @@ internal interface IModuleOutputBuffer
     /// <param name="logger">The logger for structured log output.</param>
     /// <param name="loggerControl">Coordinates log rendering with direct console writes.</param>
     /// <param name="flushKind">Whether this is an incremental or complete flush.</param>
+    /// <param name="fallbackLoggers">Non-Spectre loggers that receive structured events during direct fallback.</param>
     /// <param name="cancellationToken">Cancellation token for the flush operation.</param>
     /// <returns>A task that completes when buffered output has been rendered.</returns>
     Task FlushToAsync(
@@ -85,5 +86,6 @@ internal interface IModuleOutputBuffer
         ILogger logger,
         ISpectreConsoleLoggerControl loggerControl,
         OutputFlushKind flushKind,
+        IReadOnlyList<ILogger>? fallbackLoggers = null,
         CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
+++ b/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
@@ -1,5 +1,4 @@
 using System.Collections.Concurrent;
-using System.Reflection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -129,81 +128,6 @@ internal sealed class NonSpectreLoggerFactory(
                 // composite logger would also invoke providers that already succeeded.
                 throw new ProviderDeliveryException([], [deliveryException]);
             }
-        }
-    }
-
-    private sealed class NonOwningLoggerProvider(ILoggerProvider inner) : ILoggerProvider
-    {
-        public ILogger CreateLogger(string categoryName) => inner.CreateLogger(categoryName);
-
-        public void Dispose()
-        {
-        }
-    }
-
-    private sealed class ProviderFilterOptionsMonitor(
-        IOptionsMonitor<LoggerFilterOptions> inner,
-        Type providerType) : IOptionsMonitor<LoggerFilterOptions>
-    {
-        private static readonly string WrapperProviderName =
-            typeof(NonOwningLoggerProvider).FullName!;
-
-        private readonly string? _providerAlias =
-            providerType.GetCustomAttribute<ProviderAliasAttribute>()?.Alias;
-
-        private readonly string _providerName = providerType.FullName ?? providerType.Name;
-
-        public LoggerFilterOptions CurrentValue => Translate(inner.CurrentValue);
-
-        public LoggerFilterOptions Get(string? name) => Translate(inner.Get(name));
-
-        public IDisposable? OnChange(Action<LoggerFilterOptions, string?> listener) =>
-            inner.OnChange((options, name) => listener(Translate(options), name));
-
-        private LoggerFilterOptions Translate(LoggerFilterOptions source)
-        {
-            var translated = new LoggerFilterOptions
-            {
-                CaptureScopes = source.CaptureScopes,
-                MinLevel = source.MinLevel,
-            };
-
-            foreach (var rule in source.Rules)
-            {
-                translated.Rules.Add(Translate(rule));
-            }
-
-            return translated;
-        }
-
-        private LoggerFilterRule Translate(LoggerFilterRule rule)
-        {
-            var originalFilter = rule.Filter;
-            var translatedProviderName = string.Equals(
-                                             rule.ProviderName,
-                                             _providerName,
-                                             StringComparison.OrdinalIgnoreCase)
-                                         || (_providerAlias is not null && string.Equals(
-                                             rule.ProviderName,
-                                             _providerAlias,
-                                             StringComparison.OrdinalIgnoreCase))
-                ? WrapperProviderName
-                : rule.ProviderName;
-            if (translatedProviderName == rule.ProviderName && originalFilter is null)
-            {
-                return rule;
-            }
-
-            return new LoggerFilterRule(
-                translatedProviderName,
-                rule.CategoryName,
-                rule.LogLevel,
-                originalFilter is null
-                    ? null
-                    : (_, categoryName, logLevel) => originalFilter(
-                        _providerName,
-                        categoryName,
-                        logLevel));
         }
     }
 }

--- a/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
+++ b/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
+using System.Reflection;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace ModularPipelines.Console;
 
@@ -9,27 +11,54 @@ internal interface INonSpectreLoggerFactory
 }
 
 internal sealed class NonSpectreLoggerFactory(
-    ILoggerFactory loggerFactory,
-    ISpectreLoggerSuppression suppression) : INonSpectreLoggerFactory
+    ILoggerProviderRegistry providerRegistry,
+    IOptionsMonitor<LoggerFilterOptions> filterOptions) : INonSpectreLoggerFactory, IDisposable
 {
     private readonly ConcurrentDictionary<string, IReadOnlyList<ILogger>> _loggers = new();
+    private readonly ConcurrentDictionary<ILoggerProvider, LoggerFactory> _providerFactories =
+        new(ReferenceEqualityComparer.Instance);
 
     public IReadOnlyList<ILogger> CreateLoggers(string categoryName)
     {
         return _loggers.GetOrAdd(
             categoryName,
-            name => [new SpectreSuppressingLogger(loggerFactory.CreateLogger(name), suppression)]);
+            name => [new DynamicProviderLogger(this, name)]);
     }
 
-    private sealed class SpectreSuppressingLogger(
-        ILogger inner,
-        ISpectreLoggerSuppression suppression) : ILogger
+    public void Dispose()
+    {
+        foreach (var factory in _providerFactories.Values)
+        {
+            factory.Dispose();
+        }
+    }
+
+    private static bool IsSpectreProvider(ILoggerProvider provider) =>
+        provider is SuppressibleSpectreLoggerProvider
+        || provider.GetType().FullName is SpectreLoggerSuppressionRegistration.SpectreProviderTypeName;
+
+    private IReadOnlyList<ILogger> GetProviderLoggers(string categoryName) =>
+    [
+        .. providerRegistry.Providers
+            .Where(static provider => !IsSpectreProvider(provider))
+            .Select(provider => _providerFactories
+                .GetOrAdd(
+                    provider,
+                    value => new LoggerFactory(
+                        [new NonOwningLoggerProvider(value)],
+                        new ProviderFilterOptionsMonitor(filterOptions, value.GetType())))
+                .CreateLogger(categoryName)),
+    ];
+
+    private sealed class DynamicProviderLogger(
+        NonSpectreLoggerFactory owner,
+        string categoryName) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state)
-            where TState : notnull
-            => inner.BeginScope(state);
+            where TState : notnull => null;
 
-        public bool IsEnabled(LogLevel logLevel) => inner.IsEnabled(logLevel);
+        public bool IsEnabled(LogLevel logLevel) =>
+            owner.GetProviderLoggers(categoryName).Any(logger => logger.IsEnabled(logLevel));
 
         public void Log<TState>(
             LogLevel logLevel,
@@ -38,8 +67,103 @@ internal sealed class NonSpectreLoggerFactory(
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
-            using var scope = suppression.BeginSuppression();
-            inner.Log(logLevel, eventId, state, exception, formatter);
+            List<ILogger>? failedLoggers = null;
+            List<Exception>? exceptions = null;
+            foreach (var logger in owner.GetProviderLoggers(categoryName))
+            {
+                try
+                {
+                    logger.Log(logLevel, eventId, state, exception, formatter);
+                }
+                catch (Exception deliveryException)
+                {
+                    (failedLoggers ??= []).Add(logger);
+                    (exceptions ??= []).Add(deliveryException);
+                }
+            }
+
+            if (failedLoggers is not null)
+            {
+                throw new ProviderDeliveryException(failedLoggers, exceptions!);
+            }
         }
     }
+
+    private sealed class NonOwningLoggerProvider(ILoggerProvider inner) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => inner.CreateLogger(categoryName);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class ProviderFilterOptionsMonitor(
+        IOptionsMonitor<LoggerFilterOptions> inner,
+        Type providerType) : IOptionsMonitor<LoggerFilterOptions>
+    {
+        private static readonly string WrapperProviderName =
+            typeof(NonOwningLoggerProvider).FullName!;
+
+        private readonly string? _providerAlias =
+            providerType.GetCustomAttribute<ProviderAliasAttribute>()?.Alias;
+
+        private readonly string _providerName = providerType.FullName ?? providerType.Name;
+
+        public LoggerFilterOptions CurrentValue => Translate(inner.CurrentValue);
+
+        public LoggerFilterOptions Get(string? name) => Translate(inner.Get(name));
+
+        public IDisposable? OnChange(Action<LoggerFilterOptions, string?> listener) =>
+            inner.OnChange((options, name) => listener(Translate(options), name));
+
+        private LoggerFilterOptions Translate(LoggerFilterOptions source)
+        {
+            var translated = new LoggerFilterOptions
+            {
+                CaptureScopes = source.CaptureScopes,
+                MinLevel = source.MinLevel,
+            };
+
+            foreach (var rule in source.Rules)
+            {
+                translated.Rules.Add(Translate(rule));
+            }
+
+            return translated;
+        }
+
+        private LoggerFilterRule Translate(LoggerFilterRule rule)
+        {
+            var originalFilter = rule.Filter;
+            var translatedProviderName = rule.ProviderName == _providerName
+                                         || (_providerAlias is not null
+                                             && rule.ProviderName == _providerAlias)
+                ? WrapperProviderName
+                : rule.ProviderName;
+            if (translatedProviderName == rule.ProviderName && originalFilter is null)
+            {
+                return rule;
+            }
+
+            return new LoggerFilterRule(
+                translatedProviderName,
+                rule.CategoryName,
+                rule.LogLevel,
+                originalFilter is null
+                    ? null
+                    : (_, categoryName, logLevel) => originalFilter(
+                        _providerName,
+                        categoryName,
+                        logLevel));
+        }
+    }
+}
+
+internal sealed class ProviderDeliveryException(
+    IReadOnlyList<ILogger> failedLoggers,
+    IReadOnlyList<Exception> exceptions)
+    : AggregateException("One or more non-console loggers rejected buffered output.", exceptions)
+{
+    public IReadOnlyList<ILogger> FailedLoggers { get; } = failedLoggers;
 }

--- a/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
+++ b/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
@@ -105,7 +105,7 @@ internal sealed class NonSpectreLoggerFactory(
         string? providerName,
         string categoryName)
     {
-        if (rule.ProviderName is not null && rule.ProviderName != providerName)
+        if (!ProviderMatches(rule.ProviderName, providerName))
         {
             return false;
         }
@@ -120,28 +120,32 @@ internal sealed class NonSpectreLoggerFactory(
             return true;
         }
 
-        if (current.ProviderName is not null && rule.ProviderName is null)
+        if (IsLessSpecificProvider(rule, current))
         {
             return false;
         }
 
-        if (current.ProviderName is null && rule.ProviderName is not null)
+        if (IsMoreSpecificProvider(rule, current))
         {
             return true;
         }
 
-        if (current.CategoryName is null)
-        {
-            return true;
-        }
-
-        if (rule.CategoryName is null)
-        {
-            return false;
-        }
-
-        return current.CategoryName.Length <= rule.CategoryName.Length;
+        return IsAtLeastAsSpecificCategory(rule, current);
     }
+
+    private static bool ProviderMatches(string? ruleProviderName, string? providerName)
+        => ruleProviderName is null || ruleProviderName == providerName;
+
+    private static bool IsLessSpecificProvider(LoggerFilterRule rule, LoggerFilterRule current)
+        => current.ProviderName is not null && rule.ProviderName is null;
+
+    private static bool IsMoreSpecificProvider(LoggerFilterRule rule, LoggerFilterRule current)
+        => current.ProviderName is null && rule.ProviderName is not null;
+
+    private static bool IsAtLeastAsSpecificCategory(LoggerFilterRule rule, LoggerFilterRule current)
+        => current.CategoryName is null
+           || (rule.CategoryName is not null
+               && current.CategoryName.Length <= rule.CategoryName.Length);
 
     private static bool CategoryMatches(string? ruleCategory, string categoryName)
     {

--- a/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
+++ b/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
@@ -1,7 +1,5 @@
 using System.Collections.Concurrent;
-using System.Reflection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace ModularPipelines.Console;
 
@@ -11,57 +9,27 @@ internal interface INonSpectreLoggerFactory
 }
 
 internal sealed class NonSpectreLoggerFactory(
-    IEnumerable<ILoggerProvider> providers,
-    IOptionsMonitor<LoggerFilterOptions> filterOptions) : INonSpectreLoggerFactory
+    ILoggerFactory loggerFactory,
+    ISpectreLoggerSuppression suppression) : INonSpectreLoggerFactory
 {
-    private const string SpectreProviderTypeName = "MEL.Spectre.Provider.SpectreConsoleLoggerProvider";
     private readonly ConcurrentDictionary<string, IReadOnlyList<ILogger>> _loggers = new();
-    private readonly ILoggerProvider[] _providers =
-    [
-        .. providers.Where(static provider =>
-            provider.GetType().FullName is not SpectreProviderTypeName),
-    ];
 
     public IReadOnlyList<ILogger> CreateLoggers(string categoryName)
     {
-        return _loggers.GetOrAdd(categoryName, CreateLoggersCore);
+        return _loggers.GetOrAdd(
+            categoryName,
+            name => [new SpectreSuppressingLogger(loggerFactory.CreateLogger(name), suppression)]);
     }
 
-    private IReadOnlyList<ILogger> CreateLoggersCore(string categoryName)
-    {
-        return
-        [
-            .. _providers.Select(provider => new FilteredProviderLogger(
-                provider.CreateLogger(categoryName),
-                provider.GetType(),
-                categoryName,
-                filterOptions)),
-        ];
-    }
-
-    private sealed class FilteredProviderLogger(
+    private sealed class SpectreSuppressingLogger(
         ILogger inner,
-        Type providerType,
-        string categoryName,
-        IOptionsMonitor<LoggerFilterOptions> filterOptions) : ILogger
+        ISpectreLoggerSuppression suppression) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state)
             where TState : notnull
             => inner.BeginScope(state);
 
-        public bool IsEnabled(LogLevel logLevel)
-        {
-            var options = filterOptions.CurrentValue;
-            var rule = SelectRule(options, providerType, categoryName);
-            var minimumLevel = rule is null ? options.MinLevel : rule.LogLevel;
-            if (minimumLevel is { } level && logLevel < level)
-            {
-                return false;
-            }
-
-            return (rule?.Filter?.Invoke(providerType.FullName, categoryName, logLevel) ?? true)
-                   && inner.IsEnabled(logLevel);
-        }
+        public bool IsEnabled(LogLevel logLevel) => inner.IsEnabled(logLevel);
 
         public void Log<TState>(
             LogLevel logLevel,
@@ -70,99 +38,8 @@ internal sealed class NonSpectreLoggerFactory(
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
-            if (IsEnabled(logLevel))
-            {
-                inner.Log(logLevel, eventId, state, exception, formatter);
-            }
+            using var scope = suppression.BeginSuppression();
+            inner.Log(logLevel, eventId, state, exception, formatter);
         }
-    }
-
-    private static LoggerFilterRule? SelectRule(
-        LoggerFilterOptions options,
-        Type providerType,
-        string categoryName)
-    {
-        var providerName = providerType.FullName;
-        var providerAlias = providerType.GetCustomAttribute<ProviderAliasAttribute>()?.Alias;
-        LoggerFilterRule? current = null;
-
-        foreach (var rule in options.Rules)
-        {
-            if (IsBetter(rule, current, providerName, categoryName)
-                || (!string.IsNullOrEmpty(providerAlias)
-                    && IsBetter(rule, current, providerAlias, categoryName)))
-            {
-                current = rule;
-            }
-        }
-
-        return current;
-    }
-
-    private static bool IsBetter(
-        LoggerFilterRule rule,
-        LoggerFilterRule? current,
-        string? providerName,
-        string categoryName)
-    {
-        if (!ProviderMatches(rule.ProviderName, providerName))
-        {
-            return false;
-        }
-
-        if (!CategoryMatches(rule.CategoryName, categoryName))
-        {
-            return false;
-        }
-
-        if (current is null)
-        {
-            return true;
-        }
-
-        if (IsLessSpecificProvider(rule, current))
-        {
-            return false;
-        }
-
-        if (IsMoreSpecificProvider(rule, current))
-        {
-            return true;
-        }
-
-        return IsAtLeastAsSpecificCategory(rule, current);
-    }
-
-    private static bool ProviderMatches(string? ruleProviderName, string? providerName)
-        => ruleProviderName is null || ruleProviderName == providerName;
-
-    private static bool IsLessSpecificProvider(LoggerFilterRule rule, LoggerFilterRule current)
-        => current.ProviderName is not null && rule.ProviderName is null;
-
-    private static bool IsMoreSpecificProvider(LoggerFilterRule rule, LoggerFilterRule current)
-        => current.ProviderName is null && rule.ProviderName is not null;
-
-    private static bool IsAtLeastAsSpecificCategory(LoggerFilterRule rule, LoggerFilterRule current)
-        => current.CategoryName is null
-           || (rule.CategoryName is not null
-               && current.CategoryName.Length <= rule.CategoryName.Length);
-
-    private static bool CategoryMatches(string? ruleCategory, string categoryName)
-    {
-        if (ruleCategory is null)
-        {
-            return true;
-        }
-
-        var wildcardIndex = ruleCategory.IndexOf('*');
-        if (wildcardIndex >= 0 && ruleCategory.IndexOf('*', wildcardIndex + 1) >= 0)
-        {
-            throw new InvalidOperationException("Logger filter categories cannot contain more than one wildcard.");
-        }
-
-        var prefix = wildcardIndex < 0 ? ruleCategory : ruleCategory[..wildcardIndex];
-        var suffix = wildcardIndex < 0 ? string.Empty : ruleCategory[(wildcardIndex + 1)..];
-        return categoryName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-               && categoryName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
+++ b/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
@@ -179,9 +179,14 @@ internal sealed class NonSpectreLoggerFactory(
         private LoggerFilterRule Translate(LoggerFilterRule rule)
         {
             var originalFilter = rule.Filter;
-            var translatedProviderName = rule.ProviderName == _providerName
-                                         || (_providerAlias is not null
-                                             && rule.ProviderName == _providerAlias)
+            var translatedProviderName = string.Equals(
+                                             rule.ProviderName,
+                                             _providerName,
+                                             StringComparison.OrdinalIgnoreCase)
+                                         || (_providerAlias is not null && string.Equals(
+                                             rule.ProviderName,
+                                             _providerAlias,
+                                             StringComparison.OrdinalIgnoreCase))
                 ? WrapperProviderName
                 : rule.ProviderName;
             if (translatedProviderName == rule.ProviderName && originalFilter is null)

--- a/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
+++ b/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
@@ -115,7 +115,20 @@ internal sealed class NonSpectreLoggerFactory(
             Func<TState, Exception?, string> formatter)
         {
             using var scope = suppression.BeginSuppression();
-            inner.Log(logLevel, eventId, state, exception, formatter);
+            try
+            {
+                inner.Log(logLevel, eventId, state, exception, formatter);
+            }
+            catch (ProviderDeliveryException)
+            {
+                throw;
+            }
+            catch (Exception deliveryException)
+            {
+                // ILoggerFactory does not expose the provider that failed. Retrying its
+                // composite logger would also invoke providers that already succeeded.
+                throw new ProviderDeliveryException([], [deliveryException]);
+            }
         }
     }
 

--- a/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
+++ b/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
@@ -11,18 +11,27 @@ internal interface INonSpectreLoggerFactory
 }
 
 internal sealed class NonSpectreLoggerFactory(
+    ILoggerFactory loggerFactory,
     ILoggerProviderRegistry providerRegistry,
-    IOptionsMonitor<LoggerFilterOptions> filterOptions) : INonSpectreLoggerFactory, IDisposable
+    IOptionsMonitor<LoggerFilterOptions> filterOptions,
+    ISpectreLoggerSuppression suppression) : INonSpectreLoggerFactory, IDisposable
 {
     private readonly ConcurrentDictionary<string, IReadOnlyList<ILogger>> _loggers = new();
     private readonly ConcurrentDictionary<ILoggerProvider, LoggerFactory> _providerFactories =
         new(ReferenceEqualityComparer.Instance);
 
+    // A later user registration can replace ILoggerFactory while leaving the core registry registered.
+    // In that case only the effective factory knows which providers should receive the event.
+    private readonly bool _isEffectiveFactoryTracked =
+        ReferenceEquals(loggerFactory, providerRegistry);
+
     public IReadOnlyList<ILogger> CreateLoggers(string categoryName)
     {
         return _loggers.GetOrAdd(
             categoryName,
-            name => [new DynamicProviderLogger(this, name)]);
+            name => _isEffectiveFactoryTracked
+                ? [new DynamicProviderLogger(this, name)]
+                : [new SpectreSuppressingLogger(loggerFactory.CreateLogger(name), suppression)]);
     }
 
     public void Dispose()
@@ -86,6 +95,27 @@ internal sealed class NonSpectreLoggerFactory(
             {
                 throw new ProviderDeliveryException(failedLoggers, exceptions!);
             }
+        }
+    }
+
+    private sealed class SpectreSuppressingLogger(
+        ILogger inner,
+        ISpectreLoggerSuppression suppression) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => inner.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) => inner.IsEnabled(logLevel);
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            using var scope = suppression.BeginSuppression();
+            inner.Log(logLevel, eventId, state, exception, formatter);
         }
     }
 

--- a/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
+++ b/src/ModularPipelines/Console/INonSpectreLoggerFactory.cs
@@ -1,0 +1,164 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ModularPipelines.Console;
+
+internal interface INonSpectreLoggerFactory
+{
+    IReadOnlyList<ILogger> CreateLoggers(string categoryName);
+}
+
+internal sealed class NonSpectreLoggerFactory(
+    IEnumerable<ILoggerProvider> providers,
+    IOptionsMonitor<LoggerFilterOptions> filterOptions) : INonSpectreLoggerFactory
+{
+    private const string SpectreProviderTypeName = "MEL.Spectre.Provider.SpectreConsoleLoggerProvider";
+    private readonly ConcurrentDictionary<string, IReadOnlyList<ILogger>> _loggers = new();
+    private readonly ILoggerProvider[] _providers =
+    [
+        .. providers.Where(static provider =>
+            provider.GetType().FullName is not SpectreProviderTypeName),
+    ];
+
+    public IReadOnlyList<ILogger> CreateLoggers(string categoryName)
+    {
+        return _loggers.GetOrAdd(categoryName, CreateLoggersCore);
+    }
+
+    private IReadOnlyList<ILogger> CreateLoggersCore(string categoryName)
+    {
+        return
+        [
+            .. _providers.Select(provider => new FilteredProviderLogger(
+                provider.CreateLogger(categoryName),
+                provider.GetType(),
+                categoryName,
+                filterOptions)),
+        ];
+    }
+
+    private sealed class FilteredProviderLogger(
+        ILogger inner,
+        Type providerType,
+        string categoryName,
+        IOptionsMonitor<LoggerFilterOptions> filterOptions) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => inner.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            var options = filterOptions.CurrentValue;
+            var rule = SelectRule(options, providerType, categoryName);
+            var minimumLevel = rule is null ? options.MinLevel : rule.LogLevel;
+            if (minimumLevel is { } level && logLevel < level)
+            {
+                return false;
+            }
+
+            return (rule?.Filter?.Invoke(providerType.FullName, categoryName, logLevel) ?? true)
+                   && inner.IsEnabled(logLevel);
+        }
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (IsEnabled(logLevel))
+            {
+                inner.Log(logLevel, eventId, state, exception, formatter);
+            }
+        }
+    }
+
+    private static LoggerFilterRule? SelectRule(
+        LoggerFilterOptions options,
+        Type providerType,
+        string categoryName)
+    {
+        var providerName = providerType.FullName;
+        var providerAlias = providerType.GetCustomAttribute<ProviderAliasAttribute>()?.Alias;
+        LoggerFilterRule? current = null;
+
+        foreach (var rule in options.Rules)
+        {
+            if (IsBetter(rule, current, providerName, categoryName)
+                || (!string.IsNullOrEmpty(providerAlias)
+                    && IsBetter(rule, current, providerAlias, categoryName)))
+            {
+                current = rule;
+            }
+        }
+
+        return current;
+    }
+
+    private static bool IsBetter(
+        LoggerFilterRule rule,
+        LoggerFilterRule? current,
+        string? providerName,
+        string categoryName)
+    {
+        if (rule.ProviderName is not null && rule.ProviderName != providerName)
+        {
+            return false;
+        }
+
+        if (!CategoryMatches(rule.CategoryName, categoryName))
+        {
+            return false;
+        }
+
+        if (current is null)
+        {
+            return true;
+        }
+
+        if (current.ProviderName is not null && rule.ProviderName is null)
+        {
+            return false;
+        }
+
+        if (current.ProviderName is null && rule.ProviderName is not null)
+        {
+            return true;
+        }
+
+        if (current.CategoryName is null)
+        {
+            return true;
+        }
+
+        if (rule.CategoryName is null)
+        {
+            return false;
+        }
+
+        return current.CategoryName.Length <= rule.CategoryName.Length;
+    }
+
+    private static bool CategoryMatches(string? ruleCategory, string categoryName)
+    {
+        if (ruleCategory is null)
+        {
+            return true;
+        }
+
+        var wildcardIndex = ruleCategory.IndexOf('*');
+        if (wildcardIndex >= 0 && ruleCategory.IndexOf('*', wildcardIndex + 1) >= 0)
+        {
+            throw new InvalidOperationException("Logger filter categories cannot contain more than one wildcard.");
+        }
+
+        var prefix = wildcardIndex < 0 ? ruleCategory : ruleCategory[..wildcardIndex];
+        var suffix = wildcardIndex < 0 ? string.Empty : ruleCategory[(wildcardIndex + 1)..];
+        return categoryName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+               && categoryName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/ModularPipelines/Console/ISpectreLoggerFilter.cs
+++ b/src/ModularPipelines/Console/ISpectreLoggerFilter.cs
@@ -13,18 +13,23 @@ internal sealed class SpectreLoggerFilter : ISpectreLoggerFilter, IDisposable
 {
     private readonly ConcurrentDictionary<string, ILogger> _loggers = new();
     private readonly LoggerFactory _loggerFactory;
+    private readonly bool _isEffectiveFactoryTracked;
 
     public SpectreLoggerFilter(
         SuppressibleSpectreLoggerProvider provider,
-        IOptionsMonitor<LoggerFilterOptions> filterOptions)
+        IOptionsMonitor<LoggerFilterOptions> filterOptions,
+        ILoggerFactory loggerFactory,
+        ILoggerProviderRegistry providerRegistry)
     {
+        _isEffectiveFactoryTracked = ReferenceEquals(loggerFactory, providerRegistry);
         _loggerFactory = new LoggerFactory(
             [new NonOwningLoggerProvider(provider)],
             new ProviderFilterOptionsMonitor(filterOptions, provider.GetType()));
     }
 
     public bool IsEnabled(string categoryName, LogLevel logLevel) =>
-        _loggers.GetOrAdd(categoryName, _loggerFactory.CreateLogger).IsEnabled(logLevel);
+        _isEffectiveFactoryTracked
+        && _loggers.GetOrAdd(categoryName, _loggerFactory.CreateLogger).IsEnabled(logLevel);
 
     public void Dispose() => _loggerFactory.Dispose();
 }

--- a/src/ModularPipelines/Console/ISpectreLoggerFilter.cs
+++ b/src/ModularPipelines/Console/ISpectreLoggerFilter.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ModularPipelines.Console;
+
+internal interface ISpectreLoggerFilter
+{
+    bool IsEnabled(string categoryName, LogLevel logLevel);
+}
+
+internal sealed class SpectreLoggerFilter : ISpectreLoggerFilter, IDisposable
+{
+    private readonly ConcurrentDictionary<string, ILogger> _loggers = new();
+    private readonly LoggerFactory _loggerFactory;
+
+    public SpectreLoggerFilter(
+        SuppressibleSpectreLoggerProvider provider,
+        IOptionsMonitor<LoggerFilterOptions> filterOptions)
+    {
+        _loggerFactory = new LoggerFactory(
+            [new NonOwningLoggerProvider(provider)],
+            new ProviderFilterOptionsMonitor(filterOptions, provider.GetType()));
+    }
+
+    public bool IsEnabled(string categoryName, LogLevel logLevel) =>
+        _loggers.GetOrAdd(categoryName, _loggerFactory.CreateLogger).IsEnabled(logLevel);
+
+    public void Dispose() => _loggerFactory.Dispose();
+}

--- a/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
+++ b/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
@@ -165,6 +165,55 @@ internal static class SpectreLoggerSuppressionRegistration
             serviceProvider.GetRequiredService<SuppressibleSpectreLoggerProvider>());
         services.AddSingleton<ISpectreConsoleLoggerControl>(serviceProvider =>
             serviceProvider.GetRequiredService<SuppressibleSpectreLoggerProvider>());
+        services.MakeLoggerFactoryTrackProviders();
+    }
+
+    private static void MakeLoggerFactoryTrackProviders(this IServiceCollection services)
+    {
+        var factoryDescriptor = services.LastOrDefault(static service =>
+            service.ServiceType == typeof(ILoggerFactory));
+        if (factoryDescriptor is null)
+        {
+            throw new InvalidOperationException("The logger factory is not registered.");
+        }
+
+        services.Remove(factoryDescriptor);
+        services.AddSingleton(serviceProvider =>
+        {
+            var inner = CreateLoggerFactory(serviceProvider, factoryDescriptor);
+            return new ProviderTrackingLoggerFactory(
+                inner,
+                serviceProvider.GetServices<ILoggerProvider>(),
+                disposeInner: factoryDescriptor.ImplementationInstance is null);
+        });
+        services.AddSingleton<ILoggerFactory>(serviceProvider =>
+            serviceProvider.GetRequiredService<ProviderTrackingLoggerFactory>());
+        services.AddSingleton<ILoggerProviderRegistry>(serviceProvider =>
+            serviceProvider.GetRequiredService<ProviderTrackingLoggerFactory>());
+    }
+
+    private static ILoggerFactory CreateLoggerFactory(
+        IServiceProvider serviceProvider,
+        ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationInstance is ILoggerFactory instance)
+        {
+            return instance;
+        }
+
+        if (descriptor.ImplementationFactory is not null)
+        {
+            return (ILoggerFactory) descriptor.ImplementationFactory(serviceProvider);
+        }
+
+        if (descriptor.ImplementationType is not null)
+        {
+            return (ILoggerFactory) ActivatorUtilities.CreateInstance(
+                serviceProvider,
+                descriptor.ImplementationType);
+        }
+
+        throw new InvalidOperationException("The logger factory registration is unsupported.");
     }
 }
 

--- a/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
+++ b/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
@@ -181,11 +181,17 @@ internal sealed class SpectreLoggerFilterOptionsPostConfigure
                 continue;
             }
 
+            var originalFilter = rule.Filter;
             options.Rules[index] = new LoggerFilterRule(
                 typeof(SuppressibleSpectreLoggerProvider).FullName,
                 rule.CategoryName,
                 rule.LogLevel,
-                rule.Filter);
+                originalFilter is null
+                    ? null
+                    : (_, categoryName, logLevel) => originalFilter(
+                        SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
+                        categoryName,
+                        logLevel));
         }
     }
 }

--- a/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
+++ b/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
@@ -166,6 +166,7 @@ internal static class SpectreLoggerSuppressionRegistration
             serviceProvider.GetRequiredService<SuppressibleSpectreLoggerProvider>());
         services.AddSingleton<ISpectreConsoleLoggerControl>(serviceProvider =>
             serviceProvider.GetRequiredService<SuppressibleSpectreLoggerProvider>());
+        services.AddSingleton<ISpectreLoggerFilter, SpectreLoggerFilter>();
         services.MakeLoggerFactoryTrackProviders();
     }
 

--- a/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
+++ b/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
@@ -2,6 +2,7 @@ using MEL.Spectre;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace ModularPipelines.Console;
 
@@ -119,7 +120,7 @@ internal sealed class SuppressibleSpectreLoggerProvider(
 
 internal static class SpectreLoggerSuppressionRegistration
 {
-    private const string SpectreProviderTypeName = "MEL.Spectre.Provider.SpectreConsoleLoggerProvider";
+    internal const string SpectreProviderTypeName = "MEL.Spectre.Provider.SpectreConsoleLoggerProvider";
 
     public static void MakeSpectreLoggerSuppressible(this IServiceCollection services)
     {
@@ -141,6 +142,10 @@ internal static class SpectreLoggerSuppressionRegistration
         services.Remove(providerDescriptor);
         services.Remove(controlDescriptor);
         services.TryAddSingleton<ISpectreLoggerSuppression, SpectreLoggerSuppression>();
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<
+                IPostConfigureOptions<LoggerFilterOptions>,
+                SpectreLoggerFilterOptionsPostConfigure>());
         services.AddSingleton(serviceProvider =>
         {
             var provider = (ILoggerProvider) ActivatorUtilities.CreateInstance(
@@ -160,5 +165,27 @@ internal static class SpectreLoggerSuppressionRegistration
             serviceProvider.GetRequiredService<SuppressibleSpectreLoggerProvider>());
         services.AddSingleton<ISpectreConsoleLoggerControl>(serviceProvider =>
             serviceProvider.GetRequiredService<SuppressibleSpectreLoggerProvider>());
+    }
+}
+
+internal sealed class SpectreLoggerFilterOptionsPostConfigure
+    : IPostConfigureOptions<LoggerFilterOptions>
+{
+    public void PostConfigure(string? name, LoggerFilterOptions options)
+    {
+        for (var index = 0; index < options.Rules.Count; index++)
+        {
+            var rule = options.Rules[index];
+            if (rule.ProviderName is not SpectreLoggerSuppressionRegistration.SpectreProviderTypeName)
+            {
+                continue;
+            }
+
+            options.Rules[index] = new LoggerFilterRule(
+                typeof(SuppressibleSpectreLoggerProvider).FullName,
+                rule.CategoryName,
+                rule.LogLevel,
+                rule.Filter);
+        }
     }
 }

--- a/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
+++ b/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
@@ -1,0 +1,164 @@
+using MEL.Spectre;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+
+namespace ModularPipelines.Console;
+
+internal interface ISpectreLoggerSuppression
+{
+    bool IsSuppressed { get; }
+
+    IDisposable BeginSuppression();
+}
+
+internal sealed class SpectreLoggerSuppression : ISpectreLoggerSuppression
+{
+    private readonly AsyncLocal<int> _suppressionDepth = new();
+
+    public bool IsSuppressed => _suppressionDepth.Value > 0;
+
+    public IDisposable BeginSuppression()
+    {
+        _suppressionDepth.Value++;
+        return new SuppressionScope(this);
+    }
+
+    private sealed class SuppressionScope(SpectreLoggerSuppression owner) : IDisposable
+    {
+        private bool _isDisposed;
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            owner._suppressionDepth.Value--;
+            _isDisposed = true;
+        }
+    }
+}
+
+[ProviderAlias("SpectreConsole")]
+internal sealed class SuppressibleSpectreLoggerProvider(
+    ILoggerProvider inner,
+    ISpectreConsoleLoggerControl control,
+    ISpectreLoggerSuppression suppression)
+    : ILoggerProvider, ISupportExternalScope, ISpectreConsoleLoggerControl, IAsyncDisposable
+{
+    private int _isDisposed;
+
+    public object SynchronizationLock => control.SynchronizationLock;
+
+    public ILogger CreateLogger(string categoryName) =>
+        new SuppressibleSpectreLogger(inner.CreateLogger(categoryName), suppression);
+
+    public Task FlushAsync(CancellationToken cancellationToken = default) =>
+        control.FlushAsync(cancellationToken);
+
+    public void SetScopeProvider(IExternalScopeProvider scopeProvider)
+    {
+        if (inner is ISupportExternalScope supportExternalScope)
+        {
+            supportExternalScope.SetScopeProvider(scopeProvider);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) == 0)
+        {
+            inner.Dispose();
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) != 0)
+        {
+            return;
+        }
+
+        if (inner is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        }
+        else
+        {
+            inner.Dispose();
+        }
+    }
+
+    private sealed class SuppressibleSpectreLogger(
+        ILogger inner,
+        ISpectreLoggerSuppression suppression) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => inner.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) =>
+            !suppression.IsSuppressed && inner.IsEnabled(logLevel);
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (!suppression.IsSuppressed)
+            {
+                inner.Log(logLevel, eventId, state, exception, formatter);
+            }
+        }
+    }
+}
+
+internal static class SpectreLoggerSuppressionRegistration
+{
+    private const string SpectreProviderTypeName = "MEL.Spectre.Provider.SpectreConsoleLoggerProvider";
+
+    public static void MakeSpectreLoggerSuppressible(this IServiceCollection services)
+    {
+        var providerDescriptor = services.LastOrDefault(static service =>
+            service.ServiceType == typeof(ILoggerProvider)
+            && service.ImplementationType?.FullName is SpectreProviderTypeName);
+        if (providerDescriptor?.ImplementationType is not { } providerType)
+        {
+            throw new InvalidOperationException("The MEL.Spectre logger provider is not registered.");
+        }
+
+        var controlDescriptor = services.LastOrDefault(static service =>
+            service.ServiceType == typeof(ISpectreConsoleLoggerControl));
+        if (controlDescriptor?.ImplementationType is not { } controlType)
+        {
+            throw new InvalidOperationException("The MEL.Spectre logger control is not registered.");
+        }
+
+        services.Remove(providerDescriptor);
+        services.Remove(controlDescriptor);
+        services.TryAddSingleton<ISpectreLoggerSuppression, SpectreLoggerSuppression>();
+        services.AddSingleton(serviceProvider =>
+        {
+            var provider = (ILoggerProvider) ActivatorUtilities.CreateInstance(
+                serviceProvider,
+                providerType);
+            ILoggerProvider[] controlProviders = [provider];
+            var control = (ISpectreConsoleLoggerControl) ActivatorUtilities.CreateInstance(
+                serviceProvider,
+                controlType,
+                (object) controlProviders);
+            return new SuppressibleSpectreLoggerProvider(
+                provider,
+                control,
+                serviceProvider.GetRequiredService<ISpectreLoggerSuppression>());
+        });
+        services.AddSingleton<ILoggerProvider>(serviceProvider =>
+            serviceProvider.GetRequiredService<SuppressibleSpectreLoggerProvider>());
+        services.AddSingleton<ISpectreConsoleLoggerControl>(serviceProvider =>
+            serviceProvider.GetRequiredService<SuppressibleSpectreLoggerProvider>());
+    }
+}

--- a/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
+++ b/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
@@ -42,7 +42,7 @@ internal sealed class SpectreLoggerSuppression : ISpectreLoggerSuppression
     }
 }
 
-[ProviderAlias("SpectreConsole")]
+[ProviderAlias(SpectreLoggerSuppressionRegistration.SpectreProviderAlias)]
 internal sealed class SuppressibleSpectreLoggerProvider(
     ILoggerProvider inner,
     ISpectreConsoleLoggerControl control,
@@ -120,6 +120,7 @@ internal sealed class SuppressibleSpectreLoggerProvider(
 
 internal static class SpectreLoggerSuppressionRegistration
 {
+    internal const string SpectreProviderAlias = "SpectreConsole";
     internal const string SpectreProviderTypeName = "MEL.Spectre.Provider.SpectreConsoleLoggerProvider";
 
     public static void MakeSpectreLoggerSuppressible(this IServiceCollection services)
@@ -225,20 +226,33 @@ internal sealed class SpectreLoggerFilterOptionsPostConfigure
         for (var index = 0; index < options.Rules.Count; index++)
         {
             var rule = options.Rules[index];
-            if (rule.ProviderName is not SpectreLoggerSuppressionRegistration.SpectreProviderTypeName)
+            if (rule.ProviderName is not null
+                && rule.ProviderName is not SpectreLoggerSuppressionRegistration.SpectreProviderAlias
+                && rule.ProviderName is not SpectreLoggerSuppressionRegistration.SpectreProviderTypeName)
             {
                 continue;
             }
 
             var originalFilter = rule.Filter;
+            var translatedProviderName =
+                rule.ProviderName is SpectreLoggerSuppressionRegistration.SpectreProviderTypeName
+                    ? typeof(SuppressibleSpectreLoggerProvider).FullName
+                    : rule.ProviderName;
+            if (translatedProviderName == rule.ProviderName && originalFilter is null)
+            {
+                continue;
+            }
+
             options.Rules[index] = new LoggerFilterRule(
-                typeof(SuppressibleSpectreLoggerProvider).FullName,
+                translatedProviderName,
                 rule.CategoryName,
                 rule.LogLevel,
                 originalFilter is null
                     ? null
-                    : (_, categoryName, logLevel) => originalFilter(
-                        SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
+                    : (providerName, categoryName, logLevel) => originalFilter(
+                        providerName == typeof(SuppressibleSpectreLoggerProvider).FullName
+                            ? SpectreLoggerSuppressionRegistration.SpectreProviderTypeName
+                            : providerName,
                         categoryName,
                         logLevel));
         }

--- a/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
+++ b/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
@@ -226,35 +226,55 @@ internal sealed class SpectreLoggerFilterOptionsPostConfigure
         for (var index = 0; index < options.Rules.Count; index++)
         {
             var rule = options.Rules[index];
-            if (rule.ProviderName is not null
-                && rule.ProviderName is not SpectreLoggerSuppressionRegistration.SpectreProviderAlias
-                && rule.ProviderName is not SpectreLoggerSuppressionRegistration.SpectreProviderTypeName)
+            var translatedRule = TranslateRule(rule);
+            if (!ReferenceEquals(translatedRule, rule))
             {
-                continue;
+                options.Rules[index] = translatedRule;
             }
-
-            var originalFilter = rule.Filter;
-            var translatedProviderName =
-                rule.ProviderName is SpectreLoggerSuppressionRegistration.SpectreProviderTypeName
-                    ? typeof(SuppressibleSpectreLoggerProvider).FullName
-                    : rule.ProviderName;
-            if (translatedProviderName == rule.ProviderName && originalFilter is null)
-            {
-                continue;
-            }
-
-            options.Rules[index] = new LoggerFilterRule(
-                translatedProviderName,
-                rule.CategoryName,
-                rule.LogLevel,
-                originalFilter is null
-                    ? null
-                    : (providerName, categoryName, logLevel) => originalFilter(
-                        providerName == typeof(SuppressibleSpectreLoggerProvider).FullName
-                            ? SpectreLoggerSuppressionRegistration.SpectreProviderTypeName
-                            : providerName,
-                        categoryName,
-                        logLevel));
         }
+    }
+
+    private static LoggerFilterRule TranslateRule(LoggerFilterRule rule)
+    {
+        if (!TargetsSpectreProvider(rule.ProviderName))
+        {
+            return rule;
+        }
+
+        var providerName = rule.ProviderName is SpectreLoggerSuppressionRegistration.SpectreProviderTypeName
+            ? typeof(SuppressibleSpectreLoggerProvider).FullName
+            : rule.ProviderName;
+        var filter = TranslateFilter(rule.Filter);
+        if (providerName == rule.ProviderName && ReferenceEquals(filter, rule.Filter))
+        {
+            return rule;
+        }
+
+        return new LoggerFilterRule(
+            providerName,
+            rule.CategoryName,
+            rule.LogLevel,
+            filter);
+    }
+
+    private static bool TargetsSpectreProvider(string? providerName) =>
+        providerName is null
+        or SpectreLoggerSuppressionRegistration.SpectreProviderAlias
+        or SpectreLoggerSuppressionRegistration.SpectreProviderTypeName;
+
+    private static Func<string?, string?, LogLevel, bool>? TranslateFilter(
+        Func<string?, string?, LogLevel, bool>? filter)
+    {
+        if (filter is null)
+        {
+            return null;
+        }
+
+        return (providerName, categoryName, logLevel) => filter(
+            providerName == typeof(SuppressibleSpectreLoggerProvider).FullName
+                ? SpectreLoggerSuppressionRegistration.SpectreProviderTypeName
+                : providerName,
+            categoryName,
+            logLevel);
     }
 }

--- a/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
+++ b/src/ModularPipelines/Console/ISpectreLoggerSuppression.cs
@@ -241,7 +241,10 @@ internal sealed class SpectreLoggerFilterOptionsPostConfigure
             return rule;
         }
 
-        var providerName = rule.ProviderName is SpectreLoggerSuppressionRegistration.SpectreProviderTypeName
+        var providerName = string.Equals(
+            rule.ProviderName,
+            SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
+            StringComparison.OrdinalIgnoreCase)
             ? typeof(SuppressibleSpectreLoggerProvider).FullName
             : rule.ProviderName;
         var filter = TranslateFilter(rule.Filter);
@@ -259,8 +262,14 @@ internal sealed class SpectreLoggerFilterOptionsPostConfigure
 
     private static bool TargetsSpectreProvider(string? providerName) =>
         providerName is null
-        or SpectreLoggerSuppressionRegistration.SpectreProviderAlias
-        or SpectreLoggerSuppressionRegistration.SpectreProviderTypeName;
+        || string.Equals(
+            providerName,
+            SpectreLoggerSuppressionRegistration.SpectreProviderAlias,
+            StringComparison.OrdinalIgnoreCase)
+        || string.Equals(
+            providerName,
+            SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
+            StringComparison.OrdinalIgnoreCase);
 
     private static Func<string?, string?, LogLevel, bool>? TranslateFilter(
         Func<string?, string?, LogLevel, bool>? filter)

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -29,7 +29,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private static readonly TimeSpan DefaultSynchronizationLockTimeout = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan SynchronizationLockPollInterval = TimeSpan.FromMilliseconds(50);
     private readonly List<BufferedOutput> _outputs = [];
-    private readonly List<IBufferedLogEvent> _structuredDeliveryRetries = [];
+    private readonly List<StructuredDeliveryRetry> _structuredDeliveryRetries = [];
     private readonly Lock _lock = new();
     private readonly string _moduleName;
     private readonly DateTime _startTimeUtc;
@@ -195,14 +195,13 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         var directConsole = GetDirectConsole(console);
         var effectiveFallbackLoggers = fallbackLoggers ?? [];
-        var failedStructuredDeliveries = new List<IBufferedLogEvent>();
+        var failedStructuredDeliveries = new List<StructuredDeliveryRetry>();
         var renderedCount = 0;
 
         try
         {
             RetryStructuredDeliveries(
                 structuredDeliveryRetries,
-                effectiveFallbackLoggers,
                 failedStructuredDeliveries,
                 console,
                 cancellationToken);
@@ -276,7 +275,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private bool TryTakeOutputs(
         OutputFlushKind flushKind,
         out List<BufferedOutput> outputs,
-        out List<IBufferedLogEvent> structuredDeliveryRetries,
+        out List<StructuredDeliveryRetry> structuredDeliveryRetries,
         out bool shouldRenderOutputGroup,
         out Exception? exception)
     {
@@ -326,7 +325,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         OutputFlushKind flushKind,
         List<BufferedOutput> outputs,
         IReadOnlyList<ILogger> fallbackLoggers,
-        List<IBufferedLogEvent> failedStructuredDeliveries,
+        List<StructuredDeliveryRetry> failedStructuredDeliveries,
         ref int renderedCount,
         CancellationToken cancellationToken)
     {
@@ -371,7 +370,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         OutputFlushKind flushKind,
         List<BufferedOutput> outputs,
         IReadOnlyList<ILogger> fallbackLoggers,
-        List<IBufferedLogEvent> failedStructuredDeliveries,
+        List<StructuredDeliveryRetry> failedStructuredDeliveries,
         bool writeStructuredLogsDirectly,
         ref int renderedCount,
         CancellationToken cancellationToken)
@@ -429,7 +428,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         ILogger logger,
         List<BufferedOutput> outputs,
         IReadOnlyList<ILogger> fallbackLoggers,
-        List<IBufferedLogEvent> failedStructuredDeliveries,
+        List<StructuredDeliveryRetry> failedStructuredDeliveries,
         bool writeStructuredLogsDirectly,
         ref int renderedCount,
         CancellationToken cancellationToken)
@@ -446,9 +445,14 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             {
                 if (writeStructuredLogsDirectly)
                 {
-                    if (!WriteToFallbackLoggers(logEvent, fallbackLoggers, console))
+                    var failedLoggers = WriteToFallbackLoggers(
+                        logEvent,
+                        fallbackLoggers,
+                        console);
+                    if (failedLoggers.Count > 0)
                     {
-                        failedStructuredDeliveries.Add(logEvent);
+                        failedStructuredDeliveries.Add(
+                            new StructuredDeliveryRetry(logEvent, failedLoggers));
                     }
 
                     WriteDirect(directConsole, console, logEvent.FormatMessageWithLevel());
@@ -521,33 +525,38 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         return false;
     }
 
-    private static bool WriteToFallbackLoggers(
+    private static IReadOnlyList<ILogger> WriteToFallbackLoggers(
         IBufferedLogEvent logEvent,
         IReadOnlyList<ILogger> fallbackLoggers,
         TextWriter console)
     {
-        var delivered = true;
+        List<ILogger>? failedLoggers = null;
         foreach (var fallbackLogger in fallbackLoggers)
         {
             try
             {
                 logEvent.WriteTo(fallbackLogger);
             }
+            catch (ProviderDeliveryException exception)
+            {
+                (failedLoggers ??= []).AddRange(exception.FailedLoggers);
+                console.WriteLine(
+                    $"A non-console logger failed while handling buffered output: {exception.Message}");
+            }
             catch (Exception exception)
             {
-                delivered = false;
+                (failedLoggers ??= []).Add(fallbackLogger);
                 console.WriteLine(
                     $"A non-console logger failed while handling buffered output: {exception.Message}");
             }
         }
 
-        return delivered;
+        return failedLoggers ?? [];
     }
 
     private static void RetryStructuredDeliveries(
-        List<IBufferedLogEvent> structuredDeliveryRetries,
-        IReadOnlyList<ILogger> fallbackLoggers,
-        List<IBufferedLogEvent> failedStructuredDeliveries,
+        List<StructuredDeliveryRetry> structuredDeliveryRetries,
+        List<StructuredDeliveryRetry> failedStructuredDeliveries,
         TextWriter console,
         CancellationToken cancellationToken)
     {
@@ -559,8 +568,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 cancellationToken.ThrowIfCancellationRequested();
             }
 
-            var logEvent = structuredDeliveryRetries[index];
-            if (!WriteToFallbackLoggers(logEvent, fallbackLoggers, console))
+            var retry = structuredDeliveryRetries[index];
+            if (WriteToFallbackLoggers(retry.LogEvent, retry.Loggers, console).Count > 0)
             {
                 console.WriteLine(
                     "Structured delivery was abandoned after 2 failed attempts; the direct console copy was retained.");
@@ -569,7 +578,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     private void RestoreStructuredDeliveryRetries(
-        List<IBufferedLogEvent> structuredDeliveryRetries)
+        List<StructuredDeliveryRetry> structuredDeliveryRetries)
     {
         if (structuredDeliveryRetries.Count == 0)
         {
@@ -581,6 +590,10 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             _structuredDeliveryRetries.InsertRange(0, structuredDeliveryRetries);
         }
     }
+
+    private readonly record struct StructuredDeliveryRetry(
+        IBufferedLogEvent LogEvent,
+        IReadOnlyList<ILogger> Loggers);
 
     private void RestoreUnrenderedOutputs(List<BufferedOutput> outputs, int renderedCount)
     {

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -35,6 +35,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly DateTime _startTimeUtc;
     private readonly int _outputFlushThreshold;
     private readonly TimeSpan _synchronizationLockTimeout;
+    private readonly Func<LogLevel, bool> _isSpectreEnabled;
     private readonly Action<IModuleOutputBuffer>? _requestIncrementalFlush;
     private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = [];
     private Exception? _exception;
@@ -54,17 +55,20 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="outputFlushThreshold">The output count that triggers an incremental flush, or zero to disable threshold flushing.</param>
     /// <param name="requestIncrementalFlush">Callback that requests an incremental flush.</param>
     /// <param name="synchronizationLockTimeout">Maximum time to wait for the Spectre logger synchronization lock.</param>
+    /// <param name="isSpectreEnabled">Determines whether Spectre would render a structured event level.</param>
     public ModuleOutputBuffer(
         Type moduleType,
         int outputFlushThreshold = 0,
         Action<IModuleOutputBuffer>? requestIncrementalFlush = null,
-        TimeSpan? synchronizationLockTimeout = null)
+        TimeSpan? synchronizationLockTimeout = null,
+        Func<LogLevel, bool>? isSpectreEnabled = null)
         : this(
             moduleType.Name,
             moduleType,
             outputFlushThreshold,
             requestIncrementalFlush,
-            synchronizationLockTimeout)
+            synchronizationLockTimeout,
+            isSpectreEnabled)
     {
     }
 
@@ -77,12 +81,14 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="outputFlushThreshold">The output count that triggers an incremental flush, or zero to disable threshold flushing.</param>
     /// <param name="requestIncrementalFlush">Callback that requests an incremental flush.</param>
     /// <param name="synchronizationLockTimeout">Maximum time to wait for the Spectre logger synchronization lock.</param>
+    /// <param name="isSpectreEnabled">Determines whether Spectre would render a structured event level.</param>
     internal ModuleOutputBuffer(
         string name,
         Type moduleType,
         int outputFlushThreshold = 0,
         Action<IModuleOutputBuffer>? requestIncrementalFlush = null,
-        TimeSpan? synchronizationLockTimeout = null)
+        TimeSpan? synchronizationLockTimeout = null,
+        Func<LogLevel, bool>? isSpectreEnabled = null)
     {
         ModuleType = moduleType;
         _moduleName = name;
@@ -90,6 +96,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         _outputFlushThreshold = outputFlushThreshold;
         _requestIncrementalFlush = requestIncrementalFlush;
         _synchronizationLockTimeout = synchronizationLockTimeout ?? DefaultSynchronizationLockTimeout;
+        _isSpectreEnabled = isSpectreEnabled ?? (static _ => true);
     }
 
     /// <inheritdoc />
@@ -422,7 +429,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
     }
 
-    private static void RenderBufferedOutputs(
+    private void RenderBufferedOutputs(
         TextWriter console,
         IAnsiConsole directConsole,
         ILogger logger,
@@ -455,10 +462,13 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                             new StructuredDeliveryRetry(logEvent, failedLoggers));
                     }
 
-                    WriteDirect(directConsole, console, logEvent.FormatMessageWithLevel());
-                    if (logEvent.FormatException() is { } formattedException)
+                    if (_isSpectreEnabled(logEvent.Level))
                     {
-                        console.WriteLine(formattedException);
+                        WriteDirect(directConsole, console, logEvent.FormatMessageWithLevel());
+                        if (logEvent.FormatException() is { } formattedException)
+                        {
+                            console.WriteLine(formattedException);
+                        }
                     }
                 }
                 else
@@ -693,6 +703,8 @@ internal readonly struct BufferedOutput
 /// </summary>
 internal interface IBufferedLogEvent
 {
+    LogLevel Level { get; }
+
     void WriteTo(ILogger logger);
 
     string FormatMessageWithLevel();
@@ -712,6 +724,8 @@ internal sealed class BufferedLogEvent<TState>(
     Func<TState, Exception?, string> formatter,
     ISecretObfuscator secretObfuscator) : IBufferedLogEvent
 {
+    public LogLevel Level => level;
+
     public void WriteTo(ILogger logger)
     {
         logger.Log(

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -29,6 +29,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private static readonly TimeSpan DefaultSynchronizationLockTimeout = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan SynchronizationLockPollInterval = TimeSpan.FromMilliseconds(50);
     private readonly List<BufferedOutput> _outputs = [];
+    private readonly List<IBufferedLogEvent> _structuredDeliveryRetries = [];
     private readonly Lock _lock = new();
     private readonly string _moduleName;
     private readonly DateTime _startTimeUtc;
@@ -119,7 +120,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             lock (_lock)
             {
-                return _outputs.Count > 0;
+                return _outputs.Count > 0 || _structuredDeliveryRetries.Count > 0;
             }
         }
     }
@@ -144,6 +145,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             lock (_lock)
             {
                 return _outputs.Count > 0
+                       || _structuredDeliveryRetries.Count > 0
                        || _isIncrementalFlushInProgress
                        || _hasRenderedIncrementalOutput;
             }
@@ -169,28 +171,46 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         IReadOnlyList<ILogger>? fallbackLoggers = null,
         CancellationToken cancellationToken = default)
     {
-        if (!TryTakeOutputs(flushKind, out var outputs, out var exception))
+        if (!TryTakeOutputs(
+                flushKind,
+                out var outputs,
+                out var structuredDeliveryRetries,
+                out var shouldRenderOutputGroup,
+                out var exception))
         {
             return Task.CompletedTask;
         }
 
         var directConsole = GetDirectConsole(console);
+        var effectiveFallbackLoggers = fallbackLoggers ?? [];
+        var failedStructuredDeliveries = new List<IBufferedLogEvent>();
         var renderedCount = 0;
 
         try
         {
-            RenderOutputs(
+            RetryStructuredDeliveries(
+                structuredDeliveryRetries,
+                effectiveFallbackLoggers,
+                failedStructuredDeliveries,
                 console,
-                directConsole,
-                formatter,
-                logger,
-                loggerControl.SynchronizationLock,
-                exception,
-                flushKind,
-                outputs,
-                fallbackLoggers ?? [],
-                ref renderedCount,
                 cancellationToken);
+
+            if (shouldRenderOutputGroup)
+            {
+                RenderOutputs(
+                    console,
+                    directConsole,
+                    formatter,
+                    logger,
+                    loggerControl.SynchronizationLock,
+                    exception,
+                    flushKind,
+                    outputs,
+                    effectiveFallbackLoggers,
+                    failedStructuredDeliveries,
+                    ref renderedCount,
+                    cancellationToken);
+            }
         }
         catch
         {
@@ -201,6 +221,10 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
             RestoreUnrenderedOutputs(outputs, renderedCount);
             throw;
+        }
+        finally
+        {
+            RestoreStructuredDeliveryRetries(failedStructuredDeliveries);
         }
 
         RecordRenderedOutput(flushKind, renderedCount);
@@ -240,6 +264,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private bool TryTakeOutputs(
         OutputFlushKind flushKind,
         out List<BufferedOutput> outputs,
+        out List<IBufferedLogEvent> structuredDeliveryRetries,
+        out bool shouldRenderOutputGroup,
         out Exception? exception)
     {
         lock (_lock)
@@ -247,20 +273,30 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             if (flushKind is OutputFlushKind.Incremental && _isComplete)
             {
                 outputs = null!;
+                structuredDeliveryRetries = null!;
+                shouldRenderOutputGroup = false;
                 exception = null;
                 return false;
             }
 
             if (_outputs.Count == 0
+                && _structuredDeliveryRetries.Count == 0
                 && (flushKind is OutputFlushKind.Incremental || !_hasRenderedIncrementalOutput))
             {
                 outputs = null!;
+                structuredDeliveryRetries = null!;
+                shouldRenderOutputGroup = false;
                 exception = null;
                 return false;
             }
 
             outputs = [.. _outputs];
+            structuredDeliveryRetries = [.. _structuredDeliveryRetries];
+            shouldRenderOutputGroup = _outputs.Count > 0
+                                      || (flushKind is OutputFlushKind.Complete
+                                          && _hasRenderedIncrementalOutput);
             _outputs.Clear();
+            _structuredDeliveryRetries.Clear();
             _thresholdFlushRequested = false;
             _isIncrementalFlushInProgress = flushKind is OutputFlushKind.Incremental;
             exception = _exception;
@@ -278,6 +314,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         OutputFlushKind flushKind,
         List<BufferedOutput> outputs,
         IReadOnlyList<ILogger> fallbackLoggers,
+        List<IBufferedLogEvent> failedStructuredDeliveries,
         ref int renderedCount,
         CancellationToken cancellationToken)
     {
@@ -299,6 +336,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 flushKind,
                 outputs,
                 fallbackLoggers,
+                failedStructuredDeliveries,
                 writeStructuredLogsDirectly: !lockTaken,
                 ref renderedCount,
                 cancellationToken);
@@ -321,6 +359,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         OutputFlushKind flushKind,
         List<BufferedOutput> outputs,
         IReadOnlyList<ILogger> fallbackLoggers,
+        List<IBufferedLogEvent> failedStructuredDeliveries,
         bool writeStructuredLogsDirectly,
         ref int renderedCount,
         CancellationToken cancellationToken)
@@ -349,6 +388,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 logger,
                 outputs,
                 fallbackLoggers,
+                failedStructuredDeliveries,
                 writeStructuredLogsDirectly,
                 ref renderedCount,
                 cancellationToken);
@@ -377,6 +417,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         ILogger logger,
         List<BufferedOutput> outputs,
         IReadOnlyList<ILogger> fallbackLoggers,
+        List<IBufferedLogEvent> failedStructuredDeliveries,
         bool writeStructuredLogsDirectly,
         ref int renderedCount,
         CancellationToken cancellationToken)
@@ -393,7 +434,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             {
                 if (writeStructuredLogsDirectly)
                 {
-                    WriteToFallbackLoggers(logEvent, fallbackLoggers, console);
+                    if (!WriteToFallbackLoggers(logEvent, fallbackLoggers, console))
+                    {
+                        failedStructuredDeliveries.Add(logEvent);
+                    }
+
                     WriteDirect(directConsole, console, logEvent.FormatMessageWithLevel());
                     if (logEvent.FormatException() is { } formattedException)
                     {
@@ -464,11 +509,12 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         return false;
     }
 
-    private static void WriteToFallbackLoggers(
+    private static bool WriteToFallbackLoggers(
         IBufferedLogEvent logEvent,
         IReadOnlyList<ILogger> fallbackLoggers,
         TextWriter console)
     {
+        var delivered = true;
         foreach (var fallbackLogger in fallbackLoggers)
         {
             try
@@ -477,9 +523,49 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             }
             catch (Exception exception)
             {
+                delivered = false;
                 console.WriteLine(
                     $"A non-console logger failed while handling buffered output: {exception.Message}");
             }
+        }
+
+        return delivered;
+    }
+
+    private static void RetryStructuredDeliveries(
+        List<IBufferedLogEvent> structuredDeliveryRetries,
+        IReadOnlyList<ILogger> fallbackLoggers,
+        List<IBufferedLogEvent> failedStructuredDeliveries,
+        TextWriter console,
+        CancellationToken cancellationToken)
+    {
+        for (var index = 0; index < structuredDeliveryRetries.Count; index++)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                failedStructuredDeliveries.AddRange(structuredDeliveryRetries.Skip(index));
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            var logEvent = structuredDeliveryRetries[index];
+            if (!WriteToFallbackLoggers(logEvent, fallbackLoggers, console))
+            {
+                failedStructuredDeliveries.Add(logEvent);
+            }
+        }
+    }
+
+    private void RestoreStructuredDeliveryRetries(
+        List<IBufferedLogEvent> structuredDeliveryRetries)
+    {
+        if (structuredDeliveryRetries.Count == 0)
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            _structuredDeliveryRetries.InsertRange(0, structuredDeliveryRetries);
         }
     }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -394,7 +394,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 if (writeStructuredLogsDirectly)
                 {
                     WriteToFallbackLoggers(logEvent, fallbackLoggers, console);
-                    WriteDirect(directConsole, console, logEvent.FormatMessage());
+                    WriteDirect(directConsole, console, logEvent.FormatMessageWithLevel());
                     if (logEvent.FormatException() is { } formattedException)
                     {
                         console.WriteLine(formattedException);
@@ -583,7 +583,7 @@ internal interface IBufferedLogEvent
 {
     void WriteTo(ILogger logger);
 
-    string FormatMessage();
+    string FormatMessageWithLevel();
 
     string? FormatException();
 }
@@ -610,7 +610,7 @@ internal sealed class BufferedLogEvent<TState>(
             Format);
     }
 
-    public string FormatMessage() => Format(obfuscatedState, exception);
+    public string FormatMessageWithLevel() => $"[{FormatLevel(level)}] {Format(obfuscatedState, exception)}";
 
     public string? FormatException()
         => exception is null
@@ -622,4 +622,16 @@ internal sealed class BufferedLogEvent<TState>(
         var formatted = formatter(originalState, logException);
         return secretObfuscator.Obfuscate(formatted, null) ?? string.Empty;
     }
+
+    private static string FormatLevel(LogLevel logLevel) =>
+        logLevel switch
+        {
+            LogLevel.Trace => "TRCE",
+            LogLevel.Debug => "DBUG",
+            LogLevel.Information => "INFO",
+            LogLevel.Warning => "WARN",
+            LogLevel.Error => "ERRO",
+            LogLevel.Critical => "CRIT",
+            _ => "NONE",
+        };
 }

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -166,6 +166,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         ILogger logger,
         ISpectreConsoleLoggerControl loggerControl,
         OutputFlushKind flushKind,
+        IReadOnlyList<ILogger>? fallbackLoggers = null,
         CancellationToken cancellationToken = default)
     {
         if (!TryTakeOutputs(flushKind, out var outputs, out var exception))
@@ -187,6 +188,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 exception,
                 flushKind,
                 outputs,
+                fallbackLoggers ?? [],
                 ref renderedCount,
                 cancellationToken);
         }
@@ -275,6 +277,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         Exception? exception,
         OutputFlushKind flushKind,
         List<BufferedOutput> outputs,
+        IReadOnlyList<ILogger> fallbackLoggers,
         ref int renderedCount,
         CancellationToken cancellationToken)
     {
@@ -295,6 +298,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 exception,
                 flushKind,
                 outputs,
+                fallbackLoggers,
                 writeStructuredLogsDirectly: !lockTaken,
                 ref renderedCount,
                 cancellationToken);
@@ -316,6 +320,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         Exception? exception,
         OutputFlushKind flushKind,
         List<BufferedOutput> outputs,
+        IReadOnlyList<ILogger> fallbackLoggers,
         bool writeStructuredLogsDirectly,
         ref int renderedCount,
         CancellationToken cancellationToken)
@@ -343,6 +348,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 directConsole,
                 logger,
                 outputs,
+                fallbackLoggers,
                 writeStructuredLogsDirectly,
                 ref renderedCount,
                 cancellationToken);
@@ -370,6 +376,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         IAnsiConsole directConsole,
         ILogger logger,
         List<BufferedOutput> outputs,
+        IReadOnlyList<ILogger> fallbackLoggers,
         bool writeStructuredLogsDirectly,
         ref int renderedCount,
         CancellationToken cancellationToken)
@@ -386,7 +393,12 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             {
                 if (writeStructuredLogsDirectly)
                 {
+                    WriteToFallbackLoggers(logEvent, fallbackLoggers, console);
                     WriteDirect(directConsole, console, logEvent.FormatMessage());
+                    if (logEvent.FormatException() is { } formattedException)
+                    {
+                        console.WriteLine(formattedException);
+                    }
                 }
                 else
                 {
@@ -432,6 +444,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         while (stopwatch.Elapsed < _synchronizationLockTimeout)
         {
             var remaining = _synchronizationLockTimeout - stopwatch.Elapsed;
+            if (remaining <= TimeSpan.Zero)
+            {
+                return false;
+            }
+
             var wait = remaining < SynchronizationLockPollInterval
                 ? remaining
                 : SynchronizationLockPollInterval;
@@ -445,6 +462,25 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
 
         return false;
+    }
+
+    private static void WriteToFallbackLoggers(
+        IBufferedLogEvent logEvent,
+        IReadOnlyList<ILogger> fallbackLoggers,
+        TextWriter console)
+    {
+        foreach (var fallbackLogger in fallbackLoggers)
+        {
+            try
+            {
+                logEvent.WriteTo(fallbackLogger);
+            }
+            catch (Exception exception)
+            {
+                console.WriteLine(
+                    $"A non-console logger failed while handling buffered output: {exception.Message}");
+            }
+        }
     }
 
     private void RestoreUnrenderedOutputs(List<BufferedOutput> outputs, int renderedCount)
@@ -548,6 +584,8 @@ internal interface IBufferedLogEvent
     void WriteTo(ILogger logger);
 
     string FormatMessage();
+
+    string? FormatException();
 }
 
 /// <summary>
@@ -573,6 +611,11 @@ internal sealed class BufferedLogEvent<TState>(
     }
 
     public string FormatMessage() => Format(obfuscatedState, exception);
+
+    public string? FormatException()
+        => exception is null
+            ? null
+            : secretObfuscator.Obfuscate(exception.ToString(), null);
 
     private string Format(object state, Exception? logException)
     {

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using MEL.Spectre;
@@ -25,13 +26,16 @@ namespace ModularPipelines.Console;
 [ExcludeFromCodeCoverage]
 internal class ModuleOutputBuffer : IModuleOutputBuffer
 {
-    private readonly List<BufferedOutput> _outputs = new();
-    private readonly object _lock = new();
+    private static readonly TimeSpan DefaultSynchronizationLockTimeout = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan SynchronizationLockPollInterval = TimeSpan.FromMilliseconds(50);
+    private readonly List<BufferedOutput> _outputs = [];
+    private readonly Lock _lock = new();
     private readonly string _moduleName;
     private readonly DateTime _startTimeUtc;
     private readonly int _outputFlushThreshold;
+    private readonly TimeSpan _synchronizationLockTimeout;
     private readonly Action<IModuleOutputBuffer>? _requestIncrementalFlush;
-    private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = new();
+    private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = [];
     private Exception? _exception;
     private bool _isComplete;
     private bool _isIncrementalFlushInProgress;
@@ -48,11 +52,18 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="moduleType">The module type.</param>
     /// <param name="outputFlushThreshold">The output count that triggers an incremental flush, or zero to disable threshold flushing.</param>
     /// <param name="requestIncrementalFlush">Callback that requests an incremental flush.</param>
+    /// <param name="synchronizationLockTimeout">Maximum time to wait for the Spectre logger synchronization lock.</param>
     public ModuleOutputBuffer(
         Type moduleType,
         int outputFlushThreshold = 0,
-        Action<IModuleOutputBuffer>? requestIncrementalFlush = null)
-        : this(moduleType.Name, moduleType, outputFlushThreshold, requestIncrementalFlush)
+        Action<IModuleOutputBuffer>? requestIncrementalFlush = null,
+        TimeSpan? synchronizationLockTimeout = null)
+        : this(
+            moduleType.Name,
+            moduleType,
+            outputFlushThreshold,
+            requestIncrementalFlush,
+            synchronizationLockTimeout)
     {
     }
 
@@ -64,17 +75,20 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="moduleType">Placeholder type.</param>
     /// <param name="outputFlushThreshold">The output count that triggers an incremental flush, or zero to disable threshold flushing.</param>
     /// <param name="requestIncrementalFlush">Callback that requests an incremental flush.</param>
+    /// <param name="synchronizationLockTimeout">Maximum time to wait for the Spectre logger synchronization lock.</param>
     internal ModuleOutputBuffer(
         string name,
         Type moduleType,
         int outputFlushThreshold = 0,
-        Action<IModuleOutputBuffer>? requestIncrementalFlush = null)
+        Action<IModuleOutputBuffer>? requestIncrementalFlush = null,
+        TimeSpan? synchronizationLockTimeout = null)
     {
         ModuleType = moduleType;
         _moduleName = name;
         _startTimeUtc = DateTime.UtcNow;
         _outputFlushThreshold = outputFlushThreshold;
         _requestIncrementalFlush = requestIncrementalFlush;
+        _synchronizationLockTimeout = synchronizationLockTimeout ?? DefaultSynchronizationLockTimeout;
     }
 
     /// <inheritdoc />
@@ -243,7 +257,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 return false;
             }
 
-            outputs = new List<BufferedOutput>(_outputs);
+            outputs = [.. _outputs];
             _outputs.Clear();
             _thresholdFlushRequested = false;
             _isIncrementalFlushInProgress = flushKind is OutputFlushKind.Incremental;
@@ -264,7 +278,13 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         ref int renderedCount,
         CancellationToken cancellationToken)
     {
-        EnterSynchronizationLock(synchronizationLock, cancellationToken);
+        var lockTaken = TryEnterSynchronizationLock(synchronizationLock, cancellationToken);
+        if (!lockTaken)
+        {
+            console.WriteLine(
+                $"Timed out waiting for the console logger lock for {_moduleName}; writing buffered output directly.");
+        }
+
         try
         {
             RenderOutputGroup(
@@ -275,12 +295,16 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 exception,
                 flushKind,
                 outputs,
+                writeStructuredLogsDirectly: !lockTaken,
                 ref renderedCount,
                 cancellationToken);
         }
         finally
         {
-            Monitor.Exit(synchronizationLock);
+            if (lockTaken)
+            {
+                Monitor.Exit(synchronizationLock);
+            }
         }
     }
 
@@ -292,6 +316,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         Exception? exception,
         OutputFlushKind flushKind,
         List<BufferedOutput> outputs,
+        bool writeStructuredLogsDirectly,
         ref int renderedCount,
         CancellationToken cancellationToken)
     {
@@ -318,6 +343,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 directConsole,
                 logger,
                 outputs,
+                writeStructuredLogsDirectly,
                 ref renderedCount,
                 cancellationToken);
 
@@ -344,6 +370,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         IAnsiConsole directConsole,
         ILogger logger,
         List<BufferedOutput> outputs,
+        bool writeStructuredLogsDirectly,
         ref int renderedCount,
         CancellationToken cancellationToken)
     {
@@ -357,9 +384,16 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             }
             else if (output.LogEvent is { } logEvent)
             {
-                // Synchronous MEL.Spectre rendering preserves this buffer's position
-                // while other providers (for example file logging) still receive the event.
-                logEvent.WriteTo(logger);
+                if (writeStructuredLogsDirectly)
+                {
+                    WriteDirect(directConsole, console, logEvent.FormatMessage());
+                }
+                else
+                {
+                    // Synchronous MEL.Spectre rendering preserves this buffer's position
+                    // while other providers (for example file logging) still receive the event.
+                    logEvent.WriteTo(logger);
+                }
             }
 
             // Advance only after the sink returns successfully. A sink that accepts
@@ -388,15 +422,29 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
     }
 
-    private static void EnterSynchronizationLock(
+    private bool TryEnterSynchronizationLock(
         object synchronizationLock,
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        while (!Monitor.TryEnter(synchronizationLock, millisecondsTimeout: 50))
+        var stopwatch = Stopwatch.StartNew();
+
+        while (stopwatch.Elapsed < _synchronizationLockTimeout)
         {
+            var remaining = _synchronizationLockTimeout - stopwatch.Elapsed;
+            var wait = remaining < SynchronizationLockPollInterval
+                ? remaining
+                : SynchronizationLockPollInterval;
+
+            if (Monitor.TryEnter(synchronizationLock, wait))
+            {
+                return true;
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
         }
+
+        return false;
     }
 
     private void RestoreUnrenderedOutputs(List<BufferedOutput> outputs, int renderedCount)
@@ -498,52 +546,37 @@ internal readonly struct BufferedOutput
 internal interface IBufferedLogEvent
 {
     void WriteTo(ILogger logger);
+
+    string FormatMessage();
 }
 
 /// <summary>
 /// Holds generic structured log state and its original formatter for deferred output.
 /// </summary>
-internal sealed class BufferedLogEvent<TState> : IBufferedLogEvent
+internal sealed class BufferedLogEvent<TState>(
+    LogLevel level,
+    EventId eventId,
+    TState originalState,
+    object obfuscatedState,
+    Exception? exception,
+    Func<TState, Exception?, string> formatter,
+    ISecretObfuscator secretObfuscator) : IBufferedLogEvent
 {
-    private readonly LogLevel _level;
-    private readonly EventId _eventId;
-    private readonly TState _originalState;
-    private readonly object _obfuscatedState;
-    private readonly Exception? _exception;
-    private readonly Func<TState, Exception?, string> _formatter;
-    private readonly ISecretObfuscator _secretObfuscator;
-
-    public BufferedLogEvent(
-        LogLevel level,
-        EventId eventId,
-        TState originalState,
-        object obfuscatedState,
-        Exception? exception,
-        Func<TState, Exception?, string> formatter,
-        ISecretObfuscator secretObfuscator)
-    {
-        _level = level;
-        _eventId = eventId;
-        _originalState = originalState;
-        _obfuscatedState = obfuscatedState;
-        _exception = exception;
-        _formatter = formatter;
-        _secretObfuscator = secretObfuscator;
-    }
-
     public void WriteTo(ILogger logger)
     {
         logger.Log(
-            _level,
-            _eventId,
-            _obfuscatedState,
-            _exception,
+            level,
+            eventId,
+            obfuscatedState,
+            exception,
             Format);
     }
 
-    private string Format(object state, Exception? exception)
+    public string FormatMessage() => Format(obfuscatedState, exception);
+
+    private string Format(object state, Exception? logException)
     {
-        var formatted = _formatter(_originalState, exception);
-        return _secretObfuscator.Obfuscate(formatted, null) ?? string.Empty;
+        var formatted = formatter(originalState, logException);
+        return secretObfuscator.Obfuscate(formatted, null) ?? string.Empty;
     }
 }

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -126,6 +126,18 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     /// <inheritdoc />
+    public bool HasStructuredDeliveryRetries
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _structuredDeliveryRetries.Count > 0;
+            }
+        }
+    }
+
+    /// <inheritdoc />
     public bool IsComplete
     {
         get
@@ -550,7 +562,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             var logEvent = structuredDeliveryRetries[index];
             if (!WriteToFallbackLoggers(logEvent, fallbackLoggers, console))
             {
-                failedStructuredDeliveries.Add(logEvent);
+                console.WriteLine(
+                    "Structured delivery was abandoned after 2 failed attempts; the direct console copy was retained.");
             }
         }
     }

--- a/src/ModularPipelines/Console/NonOwningLoggerProvider.cs
+++ b/src/ModularPipelines/Console/NonOwningLoggerProvider.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Logging;
+
+namespace ModularPipelines.Console;
+
+internal sealed class NonOwningLoggerProvider(ILoggerProvider inner) : ILoggerProvider
+{
+    public ILogger CreateLogger(string categoryName) => inner.CreateLogger(categoryName);
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -377,6 +377,22 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         OutputFlushKind flushKind,
         CancellationToken cancellationToken)
     {
+        await FlushBufferOnceAsync(buffer, formatter, flushKind, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (flushKind is OutputFlushKind.Complete && buffer.HasStructuredDeliveryRetries)
+        {
+            await FlushBufferOnceAsync(buffer, formatter, flushKind, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private async Task FlushBufferOnceAsync(
+        IModuleOutputBuffer buffer,
+        IBuildSystemFormatter formatter,
+        OutputFlushKind flushKind,
+        CancellationToken cancellationToken)
+    {
         var moduleLogger = GetModuleLogger(buffer.ModuleType);
 
         using var directWrite = CoordinatedTextWriter.BeginDirectWrite();
@@ -393,13 +409,15 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     }
 
     private static string GetCategoryName(Type moduleType)
-        => moduleType.FullName ?? moduleType.Name;
+        => moduleType == typeof(void)
+            ? OutputLoggerCategories.Pipeline
+            : moduleType.FullName ?? moduleType.Name;
 
     private ILogger GetModuleLogger(Type moduleType)
     {
         if (moduleType == typeof(void))
         {
-            return _loggerFactory.CreateLogger(moduleType);
+            return _loggerFactory.CreateLogger(OutputLoggerCategories.Pipeline);
         }
 
         var loggerType = typeof(ILogger<>).MakeGenericType(moduleType);

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -17,6 +17,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
     private readonly ILogger _logger;
     private readonly TextWriter _console;
     private readonly ISpectreConsoleLoggerControl _loggerControl;
+    private readonly INonSpectreLoggerFactory _nonSpectreLoggerFactory;
 
     private readonly object _queueLock = new();
     private readonly Queue<PendingFlush> _pendingQueue = new();
@@ -42,12 +43,15 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         IBuildSystemFormatterProvider formatterProvider,
         ILoggerFactory loggerFactory,
         IServiceProvider serviceProvider,
-        ISpectreConsoleLoggerControl loggerControl)
+        ISpectreConsoleLoggerControl loggerControl,
+        INonSpectreLoggerFactory nonSpectreLoggerFactory)
     {
         _formatterProvider = formatterProvider ?? throw new ArgumentNullException(nameof(formatterProvider));
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         _loggerControl = loggerControl ?? throw new ArgumentNullException(nameof(loggerControl));
+        _nonSpectreLoggerFactory = nonSpectreLoggerFactory
+                                   ?? throw new ArgumentNullException(nameof(nonSpectreLoggerFactory));
         _logger = loggerFactory.CreateLogger<OutputCoordinator>();
         _console = System.Console.Out;
     }
@@ -377,9 +381,19 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
         using var directWrite = CoordinatedTextWriter.BeginDirectWrite();
         await buffer
-            .FlushToAsync(_console, formatter, moduleLogger, _loggerControl, flushKind, cancellationToken)
+            .FlushToAsync(
+                _console,
+                formatter,
+                moduleLogger,
+                _loggerControl,
+                flushKind,
+                _nonSpectreLoggerFactory.CreateLoggers(GetCategoryName(buffer.ModuleType)),
+                cancellationToken)
             .ConfigureAwait(false);
     }
+
+    private static string GetCategoryName(Type moduleType)
+        => moduleType.FullName ?? moduleType.Name;
 
     private ILogger GetModuleLogger(Type moduleType)
     {

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -403,15 +403,11 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                 moduleLogger,
                 _loggerControl,
                 flushKind,
-                _nonSpectreLoggerFactory.CreateLoggers(GetCategoryName(buffer.ModuleType)),
+                _nonSpectreLoggerFactory.CreateLoggers(
+                    OutputLoggerCategories.ForModule(buffer.ModuleType)),
                 cancellationToken)
             .ConfigureAwait(false);
     }
-
-    private static string GetCategoryName(Type moduleType)
-        => moduleType == typeof(void)
-            ? OutputLoggerCategories.Pipeline
-            : moduleType.FullName ?? moduleType.Name;
 
     private ILogger GetModuleLogger(Type moduleType)
     {

--- a/src/ModularPipelines/Console/OutputLoggerCategories.cs
+++ b/src/ModularPipelines/Console/OutputLoggerCategories.cs
@@ -1,0 +1,6 @@
+namespace ModularPipelines.Console;
+
+internal static class OutputLoggerCategories
+{
+    public const string Pipeline = "ModularPipelines.Output";
+}

--- a/src/ModularPipelines/Console/OutputLoggerCategories.cs
+++ b/src/ModularPipelines/Console/OutputLoggerCategories.cs
@@ -3,4 +3,9 @@ namespace ModularPipelines.Console;
 internal static class OutputLoggerCategories
 {
     public const string Pipeline = "ModularPipelines.Output";
+
+    public static string ForModule(Type moduleType) =>
+        moduleType == typeof(void)
+            ? Pipeline
+            : moduleType.FullName ?? moduleType.Name;
 }

--- a/src/ModularPipelines/Console/OutputLoggerCategories.cs
+++ b/src/ModularPipelines/Console/OutputLoggerCategories.cs
@@ -1,11 +1,55 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
 namespace ModularPipelines.Console;
 
 internal static class OutputLoggerCategories
 {
     public const string Pipeline = "ModularPipelines.Output";
 
+    private static readonly ConcurrentDictionary<Type, string> ModuleCategories = [];
+    private static readonly CategoryNameLoggerFactory CategoryNameFactory = new();
+
     public static string ForModule(Type moduleType) =>
         moduleType == typeof(void)
             ? Pipeline
-            : moduleType.FullName ?? moduleType.Name;
+            : ModuleCategories.GetOrAdd(moduleType, GetCategoryName);
+
+    private static string GetCategoryName(Type moduleType)
+    {
+        var logger = (CategoryNameLogger) CategoryNameFactory.CreateLogger(moduleType);
+        return logger.CategoryName;
+    }
+
+    private sealed class CategoryNameLoggerFactory : ILoggerFactory
+    {
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName) => new CategoryNameLogger(categoryName);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class CategoryNameLogger(string categoryName) : ILogger
+    {
+        public string CategoryName { get; } = categoryName;
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => false;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+        }
+    }
 }

--- a/src/ModularPipelines/Console/ProviderFilterOptionsMonitor.cs
+++ b/src/ModularPipelines/Console/ProviderFilterOptionsMonitor.cs
@@ -1,0 +1,71 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ModularPipelines.Console;
+
+internal sealed class ProviderFilterOptionsMonitor(
+    IOptionsMonitor<LoggerFilterOptions> inner,
+    Type providerType) : IOptionsMonitor<LoggerFilterOptions>
+{
+    private static readonly string WrapperProviderName =
+        typeof(NonOwningLoggerProvider).FullName!;
+
+    private readonly string? _providerAlias =
+        providerType.GetCustomAttribute<ProviderAliasAttribute>()?.Alias;
+
+    private readonly string _providerName = providerType.FullName ?? providerType.Name;
+
+    public LoggerFilterOptions CurrentValue => Translate(inner.CurrentValue);
+
+    public LoggerFilterOptions Get(string? name) => Translate(inner.Get(name));
+
+    public IDisposable? OnChange(Action<LoggerFilterOptions, string?> listener) =>
+        inner.OnChange((options, name) => listener(Translate(options), name));
+
+    private LoggerFilterOptions Translate(LoggerFilterOptions source)
+    {
+        var translated = new LoggerFilterOptions
+        {
+            CaptureScopes = source.CaptureScopes,
+            MinLevel = source.MinLevel,
+        };
+
+        foreach (var rule in source.Rules)
+        {
+            translated.Rules.Add(Translate(rule));
+        }
+
+        return translated;
+    }
+
+    private LoggerFilterRule Translate(LoggerFilterRule rule)
+    {
+        var originalFilter = rule.Filter;
+        var translatedProviderName = string.Equals(
+                                         rule.ProviderName,
+                                         _providerName,
+                                         StringComparison.OrdinalIgnoreCase)
+                                     || (_providerAlias is not null && string.Equals(
+                                         rule.ProviderName,
+                                         _providerAlias,
+                                         StringComparison.OrdinalIgnoreCase))
+            ? WrapperProviderName
+            : rule.ProviderName;
+        if (translatedProviderName == rule.ProviderName && originalFilter is null)
+        {
+            return rule;
+        }
+
+        return new LoggerFilterRule(
+            translatedProviderName,
+            rule.CategoryName,
+            rule.LogLevel,
+            originalFilter is null
+                ? null
+                : (_, categoryName, logLevel) => originalFilter(
+                    _providerName,
+                    categoryName,
+                    logLevel));
+    }
+}

--- a/src/ModularPipelines/Console/ProviderTrackingLoggerFactory.cs
+++ b/src/ModularPipelines/Console/ProviderTrackingLoggerFactory.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging;
+
+namespace ModularPipelines.Console;
+
+internal sealed class ProviderTrackingLoggerFactory(
+    ILoggerFactory inner,
+    IEnumerable<ILoggerProvider> providers,
+    bool disposeInner = true) : ILoggerFactory, ILoggerProviderRegistry
+{
+    private readonly Lock _lock = new();
+    private readonly List<ILoggerProvider> _providers = [.. providers];
+    private int _isDisposed;
+
+    public IReadOnlyList<ILoggerProvider> Providers
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return [.. _providers];
+            }
+        }
+    }
+
+    public void AddProvider(ILoggerProvider provider)
+    {
+        lock (_lock)
+        {
+            inner.AddProvider(provider);
+            _providers.Add(provider);
+        }
+    }
+
+    public ILogger CreateLogger(string categoryName) => inner.CreateLogger(categoryName);
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _isDisposed, 1) == 0 && disposeInner)
+        {
+            inner.Dispose();
+        }
+    }
+}
+
+internal interface ILoggerProviderRegistry
+{
+    IReadOnlyList<ILoggerProvider> Providers { get; }
+}

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -191,6 +191,7 @@ internal static class DependencyInjectionSetup
             .AddSingleton<IProgressDisplay>(sp => sp.GetRequiredService<Console.ConsoleCoordinator>())
 
             // Output coordinator - manages immediate output during live display
+            .AddSingleton<Console.INonSpectreLoggerFactory, Console.NonSpectreLoggerFactory>()
             .AddSingleton<Console.OutputCoordinator>()
             .AddSingleton<Console.IOutputCoordinator>(sp => sp.GetRequiredService<Console.OutputCoordinator>())
 

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -62,6 +62,27 @@ internal static class DependencyInjectionSetup
         RegisterDistributedServices(services);
     }
 
+    internal static void ConfigureSpectreConsoleLogger(SpectreConsoleLoggerOptions config) =>
+        ConfigureSpectreConsoleLogger(config, DelegatingAnsiConsole.Instance);
+
+    internal static void ConfigureSpectreConsoleLogger(
+        SpectreConsoleLoggerOptions config,
+        IAnsiConsole console)
+    {
+        // Console width and CI capabilities are configured by ConsoleCoordinator.
+        config.Console = console;
+        config.Template = "[{Level:u4}] {Message}";
+        config.ExceptionFormats = ExceptionFormats.Default;
+        config.AllowMarkupInMessageTemplate = true;
+        config.Theme = new SpectreTheme()
+            .WithPlaceholders(placeholders =>
+            {
+                placeholders.ForName("CommandOutput", Style.Plain);
+                placeholders.ForName("CommandError", Style.Plain);
+            });
+        config.WriteMode = WriteMode.Synchronous;
+    }
+
     /// <summary>
     /// Registers external integrations and bundled services:
     /// options configuration, logging provider, HTTP clients, initializers, and mediator.
@@ -90,27 +111,6 @@ internal static class DependencyInjectionSetup
             .AddInitializers()
             .AddServiceCollection()
             .AddMediator();
-    }
-
-    internal static void ConfigureSpectreConsoleLogger(SpectreConsoleLoggerOptions config) =>
-        ConfigureSpectreConsoleLogger(config, DelegatingAnsiConsole.Instance);
-
-    internal static void ConfigureSpectreConsoleLogger(
-        SpectreConsoleLoggerOptions config,
-        IAnsiConsole console)
-    {
-        // Console width and CI capabilities are configured by ConsoleCoordinator.
-        config.Console = console;
-        config.Template = "[{Level:u4}] {Message}";
-        config.ExceptionFormats = ExceptionFormats.Default;
-        config.AllowMarkupInMessageTemplate = true;
-        config.Theme = new SpectreTheme()
-            .WithPlaceholders(placeholders =>
-            {
-                placeholders.ForName("CommandOutput", Style.Plain);
-                placeholders.ForName("CommandError", Style.Plain);
-            });
-        config.WriteMode = WriteMode.Synchronous;
     }
 
     /// <summary>
@@ -159,6 +159,7 @@ internal static class DependencyInjectionSetup
             .AddScoped<IInstallersContext, InstallersContext>()
             .AddScoped<INetworkContext, NetworkContext>()
             .AddScoped<ISecurityContext, SecurityContext>()
+
             // Register Services domain context
             .AddScoped<IServicesContext, ServicesContext>()
             .AddScoped<ModularPipelines.Http.IHttpLogger, ModularPipelines.Http.HttpLogger>()
@@ -228,6 +229,7 @@ internal static class DependencyInjectionSetup
     {
         services.TryAddSingleton<IFileSystemProvider>(SystemFileSystemProvider.Instance);
         services
+
             // Module activator - sets AsyncLocal context before module construction
             .AddSingleton<IModuleActivator, ModuleActivator>()
             .AddSingleton<IPipelineContextProvider, ModuleContextProvider>()

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -105,6 +105,7 @@ internal static class DependencyInjectionSetup
                     .AddFilter("System", LogLevel.Warning);
 
                 builder.AddSpectreConsole(ConfigureSpectreConsoleLogger);
+                builder.Services.MakeSpectreLoggerSuppressible();
             })
             .AddHttpClient()
             .AddLoggingHttpClients()

--- a/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
@@ -1,4 +1,5 @@
 using MEL.Spectre;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
@@ -162,6 +163,10 @@ public class ConsoleCoordinatorTests
         nonSpectreLoggerFactory
             .Setup(factory => factory.CreateLoggers(It.IsAny<string>()))
             .Returns([]);
+        var spectreLoggerFilter = new Mock<ISpectreLoggerFilter>();
+        spectreLoggerFilter
+            .Setup(filter => filter.IsEnabled(It.IsAny<string>(), It.IsAny<LogLevel>()))
+            .Returns(true);
 
         return new ConsoleCoordinator(
             Mock.Of<IBuildSystemFormatterProvider>(),
@@ -174,6 +179,7 @@ public class ConsoleCoordinatorTests
             Mock.Of<IServiceProvider>(),
             outputCoordinator,
             Mock.Of<ISpectreConsoleLoggerControl>(),
-            nonSpectreLoggerFactory.Object);
+            nonSpectreLoggerFactory.Object,
+            spectreLoggerFilter.Object);
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
@@ -158,6 +158,10 @@ public class ConsoleCoordinatorTests
         secretObfuscator
             .Setup(obfuscator => obfuscator.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
             .Returns((string? value, object? _) => value ?? string.Empty);
+        var nonSpectreLoggerFactory = new Mock<INonSpectreLoggerFactory>();
+        nonSpectreLoggerFactory
+            .Setup(factory => factory.CreateLoggers(It.IsAny<string>()))
+            .Returns([]);
 
         return new ConsoleCoordinator(
             Mock.Of<IBuildSystemFormatterProvider>(),
@@ -169,6 +173,7 @@ public class ConsoleCoordinatorTests
             Mock.Of<IBuildSystemDetector>(),
             Mock.Of<IServiceProvider>(),
             outputCoordinator,
-            Mock.Of<ISpectreConsoleLoggerControl>());
+            Mock.Of<ISpectreConsoleLoggerControl>(),
+            nonSpectreLoggerFactory.Object);
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -475,17 +475,70 @@ public class ModuleOutputBufferTests
         await Assert.That(buffer.HasOutput).IsTrue();
     }
 
-    private static ModuleOutputBuffer CreateBufferWithStructuredLog()
+    [Test]
+    public async Task Flush_LockTimeout_WritesBufferedOutputDirectly()
     {
-        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = CreateBufferWithStructuredLog(
+            TimeSpan.FromMilliseconds(50),
+            "structured secret",
+            new RedactingSecretObfuscator());
+        buffer.WriteLine("direct output");
+        var lockAcquired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lockHolder = Task.Run(() =>
+        {
+            lock (loggerControl.SynchronizationLock)
+            {
+                lockAcquired.TrySetResult();
+                releaseLock.Task.GetAwaiter().GetResult();
+            }
+        });
+
+        await lockAcquired.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        try
+        {
+            var flush = Task.Run(() => buffer.FlushToAsync(
+                writer,
+                new GitHubActionsFormatter(),
+                loggerControl,
+                loggerControl,
+                OutputFlushKind.Complete));
+
+            await flush.WaitAsync(TimeSpan.FromSeconds(2));
+        }
+        finally
+        {
+            releaseLock.TrySetResult();
+            await lockHolder;
+        }
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("Timed out waiting for the console logger lock");
+        await Assert.That(output).Contains("structured ***");
+        await Assert.That(output).DoesNotContain("structured secret");
+        await Assert.That(output).Contains("direct output");
+        await Assert.That(loggerControl.LogCallCount).IsEqualTo(0);
+        await Assert.That(buffer.HasOutput).IsFalse();
+    }
+
+    private static ModuleOutputBuffer CreateBufferWithStructuredLog(
+        TimeSpan? synchronizationLockTimeout = null,
+        string message = "structured log",
+        ISecretObfuscator? secretObfuscator = null)
+    {
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            synchronizationLockTimeout: synchronizationLockTimeout);
         buffer.AddLogEvent(new BufferedLogEvent<string>(
             LogLevel.Information,
             default,
-            "structured log",
-            "structured log",
+            message,
+            message,
             null,
             static (state, _) => state,
-            new PassthroughSecretObfuscator()));
+            secretObfuscator ?? new PassthroughSecretObfuscator()));
         return buffer;
     }
 
@@ -499,6 +552,12 @@ public class ModuleOutputBufferTests
         public string Obfuscate(string? input, object? optionsObject) => input ?? string.Empty;
     }
 
+    private sealed class RedactingSecretObfuscator : ISecretObfuscator
+    {
+        public string Obfuscate(string? input, object? optionsObject)
+            => input?.Replace("secret", "***", StringComparison.Ordinal) ?? string.Empty;
+    }
+
     private sealed class SynchronousLoggerControl(TextWriter writer) : ILogger, ISpectreConsoleLoggerControl
     {
         public object SynchronizationLock { get; } = new();
@@ -508,6 +567,8 @@ public class ModuleOutputBufferTests
         public Exception? LogException { get; set; }
 
         public Exception? LogExceptionAfterWrite { get; set; }
+
+        public int LogCallCount { get; private set; }
 
         public IDisposable? BeginScope<TState>(TState state)
             where TState : notnull
@@ -522,6 +583,8 @@ public class ModuleOutputBufferTests
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
+            LogCallCount++;
+
             if (LogException is not null)
             {
                 throw LogException;

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -486,7 +486,8 @@ public class ModuleOutputBufferTests
             TimeSpan.FromMilliseconds(50),
             "structured secret",
             new RedactingSecretObfuscator(),
-            logException);
+            logException,
+            LogLevel.Warning);
         buffer.WriteLine("direct output");
         var lockAcquired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -521,7 +522,7 @@ public class ModuleOutputBufferTests
 
         var output = writer.ToString();
         await Assert.That(output).Contains("Timed out waiting for the console logger lock");
-        await Assert.That(output).Contains("structured ***");
+        await Assert.That(output).Contains("[WARN] structured ***");
         await Assert.That(output).DoesNotContain("structured secret");
         await Assert.That(output).Contains(nameof(InvalidOperationException));
         await Assert.That(output).Contains("structured failure");
@@ -536,13 +537,14 @@ public class ModuleOutputBufferTests
         TimeSpan? synchronizationLockTimeout = null,
         string message = "structured log",
         ISecretObfuscator? secretObfuscator = null,
-        Exception? exception = null)
+        Exception? exception = null,
+        LogLevel logLevel = LogLevel.Information)
     {
         var buffer = new ModuleOutputBuffer(
             typeof(ModuleOutputBufferTests),
             synchronizationLockTimeout: synchronizationLockTimeout);
         buffer.AddLogEvent(new BufferedLogEvent<string>(
-            LogLevel.Information,
+            logLevel,
             default,
             message,
             message,

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -330,7 +330,7 @@ public class ModuleOutputBufferTests
                 loggerControl,
                 loggerControl,
                 OutputFlushKind.Complete,
-                cancellationTokenSource.Token));
+                cancellationToken: cancellationTokenSource.Token));
 
         await Assert.That(buffer.HasOutput).IsTrue();
     }
@@ -352,7 +352,7 @@ public class ModuleOutputBufferTests
                 loggerControl,
                 loggerControl,
                 OutputFlushKind.Complete,
-                cancellationTokenSource.Token));
+                cancellationToken: cancellationTokenSource.Token));
 
         var cancelledOutput = writer.ToString();
         await Assert.That(cancelledOutput.IndexOf("::endgroup::", StringComparison.Ordinal))
@@ -464,7 +464,7 @@ public class ModuleOutputBufferTests
                     loggerControl,
                     loggerControl,
                     OutputFlushKind.Complete,
-                    cancellationTokenSource.Token));
+                    cancellationToken: cancellationTokenSource.Token));
         }
         finally
         {
@@ -480,10 +480,13 @@ public class ModuleOutputBufferTests
     {
         var writer = new StringWriter();
         var loggerControl = new SynchronousLoggerControl(writer);
+        var fallbackLogger = new RecordingLogger();
+        var logException = new InvalidOperationException("structured failure");
         var buffer = CreateBufferWithStructuredLog(
             TimeSpan.FromMilliseconds(50),
             "structured secret",
-            new RedactingSecretObfuscator());
+            new RedactingSecretObfuscator(),
+            logException);
         buffer.WriteLine("direct output");
         var lockAcquired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -504,7 +507,9 @@ public class ModuleOutputBufferTests
                 new GitHubActionsFormatter(),
                 loggerControl,
                 loggerControl,
-                OutputFlushKind.Complete));
+                OutputFlushKind.Complete,
+                [fallbackLogger],
+                CancellationToken.None));
 
             await flush.WaitAsync(TimeSpan.FromSeconds(2));
         }
@@ -518,15 +523,20 @@ public class ModuleOutputBufferTests
         await Assert.That(output).Contains("Timed out waiting for the console logger lock");
         await Assert.That(output).Contains("structured ***");
         await Assert.That(output).DoesNotContain("structured secret");
+        await Assert.That(output).Contains(nameof(InvalidOperationException));
+        await Assert.That(output).Contains("structured failure");
         await Assert.That(output).Contains("direct output");
         await Assert.That(loggerControl.LogCallCount).IsEqualTo(0);
+        await Assert.That(fallbackLogger.Entries).HasSingleItem();
+        await Assert.That(fallbackLogger.Entries[0].Exception).IsSameReferenceAs(logException);
         await Assert.That(buffer.HasOutput).IsFalse();
     }
 
     private static ModuleOutputBuffer CreateBufferWithStructuredLog(
         TimeSpan? synchronizationLockTimeout = null,
         string message = "structured log",
-        ISecretObfuscator? secretObfuscator = null)
+        ISecretObfuscator? secretObfuscator = null,
+        Exception? exception = null)
     {
         var buffer = new ModuleOutputBuffer(
             typeof(ModuleOutputBufferTests),
@@ -536,7 +546,7 @@ public class ModuleOutputBufferTests
             default,
             message,
             message,
-            null,
+            exception,
             static (state, _) => state,
             secretObfuscator ?? new PassthroughSecretObfuscator()));
         return buffer;
@@ -556,6 +566,27 @@ public class ModuleOutputBufferTests
     {
         public string Obfuscate(string? input, object? optionsObject)
             => input?.Replace("secret", "***", StringComparison.Ordinal) ?? string.Empty;
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<(string Message, Exception? Exception)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((formatter(state, exception), exception));
+        }
     }
 
     private sealed class SynchronousLoggerControl(TextWriter writer) : ILogger, ISpectreConsoleLoggerControl

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -534,6 +534,54 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task Flush_LockTimeout_Respects_Spectre_Filter()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var fallbackLogger = new RecordingLogger();
+        var buffer = CreateBufferWithStructuredLog(
+            TimeSpan.FromMilliseconds(50),
+            "filtered structured log",
+            isSpectreEnabled: static _ => false);
+        buffer.WriteLine("direct output");
+        var lockAcquired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lockHolder = Task.Run(() =>
+        {
+            lock (loggerControl.SynchronizationLock)
+            {
+                lockAcquired.TrySetResult();
+                releaseLock.Task.GetAwaiter().GetResult();
+            }
+        });
+
+        await lockAcquired.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        try
+        {
+            await buffer.FlushToAsync(
+                writer,
+                new GitHubActionsFormatter(),
+                loggerControl,
+                loggerControl,
+                OutputFlushKind.Complete,
+                [fallbackLogger],
+                CancellationToken.None);
+        }
+        finally
+        {
+            releaseLock.TrySetResult();
+            await lockHolder;
+        }
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("Timed out waiting for the console logger lock");
+        await Assert.That(output).Contains("direct output");
+        await Assert.That(output).DoesNotContain("filtered structured log");
+        await Assert.That(fallbackLogger.Entries).HasSingleItem();
+        await Assert.That(buffer.HasOutput).IsFalse();
+    }
+
+    [Test]
     public async Task Flush_LockTimeout_RetriesFailedProviderWithoutRepeatingConsoleOutput()
     {
         var writer = new StringWriter();
@@ -603,11 +651,13 @@ public class ModuleOutputBufferTests
         string message = "structured log",
         ISecretObfuscator? secretObfuscator = null,
         Exception? exception = null,
-        LogLevel logLevel = LogLevel.Information)
+        LogLevel logLevel = LogLevel.Information,
+        Func<LogLevel, bool>? isSpectreEnabled = null)
     {
         var buffer = new ModuleOutputBuffer(
             typeof(ModuleOutputBufferTests),
-            synchronizationLockTimeout: synchronizationLockTimeout);
+            synchronizationLockTimeout: synchronizationLockTimeout,
+            isSpectreEnabled: isSpectreEnabled);
         buffer.AddLogEvent(new BufferedLogEvent<string>(
             logLevel,
             default,

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -538,6 +538,7 @@ public class ModuleOutputBufferTests
     {
         var writer = new StringWriter();
         var loggerControl = new SynchronousLoggerControl(writer);
+        var successfulLogger = new RecordingLogger();
         var fallbackLogger = new RecordingLogger
         {
             LogException = new InvalidOperationException("provider rejected event"),
@@ -565,7 +566,7 @@ public class ModuleOutputBufferTests
                 loggerControl,
                 loggerControl,
                 OutputFlushKind.Complete,
-                [fallbackLogger],
+                [successfulLogger, fallbackLogger],
                 CancellationToken.None);
         }
         finally
@@ -575,6 +576,7 @@ public class ModuleOutputBufferTests
         }
 
         await Assert.That(buffer.HasOutput).IsTrue();
+        await Assert.That(successfulLogger.Entries).HasSingleItem();
         await Assert.That(fallbackLogger.Entries).IsEmpty();
         await Assert.That(CountOccurrences(writer.ToString(), "[INFO] retry structured log"))
             .IsEqualTo(1);
@@ -586,10 +588,11 @@ public class ModuleOutputBufferTests
             loggerControl,
             loggerControl,
             OutputFlushKind.Complete,
-            [fallbackLogger],
+            [successfulLogger, fallbackLogger],
             CancellationToken.None);
 
         await Assert.That(buffer.HasOutput).IsFalse();
+        await Assert.That(successfulLogger.Entries).HasSingleItem();
         await Assert.That(fallbackLogger.Entries).HasSingleItem();
         await Assert.That(CountOccurrences(writer.ToString(), "[INFO] retry structured log"))
             .IsEqualTo(1);

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -533,6 +533,68 @@ public class ModuleOutputBufferTests
         await Assert.That(buffer.HasOutput).IsFalse();
     }
 
+    [Test]
+    public async Task Flush_LockTimeout_RetriesFailedProviderWithoutRepeatingConsoleOutput()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var fallbackLogger = new RecordingLogger
+        {
+            LogException = new InvalidOperationException("provider rejected event"),
+        };
+        var buffer = CreateBufferWithStructuredLog(
+            TimeSpan.FromMilliseconds(50),
+            "retry structured log");
+        var lockAcquired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var lockHolder = Task.Run(() =>
+        {
+            lock (loggerControl.SynchronizationLock)
+            {
+                lockAcquired.TrySetResult();
+                releaseLock.Task.GetAwaiter().GetResult();
+            }
+        });
+
+        await lockAcquired.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        try
+        {
+            await buffer.FlushToAsync(
+                writer,
+                new GitHubActionsFormatter(),
+                loggerControl,
+                loggerControl,
+                OutputFlushKind.Complete,
+                [fallbackLogger],
+                CancellationToken.None);
+        }
+        finally
+        {
+            releaseLock.TrySetResult();
+            await lockHolder;
+        }
+
+        await Assert.That(buffer.HasOutput).IsTrue();
+        await Assert.That(fallbackLogger.Entries).IsEmpty();
+        await Assert.That(CountOccurrences(writer.ToString(), "[INFO] retry structured log"))
+            .IsEqualTo(1);
+
+        fallbackLogger.LogException = null;
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete,
+            [fallbackLogger],
+            CancellationToken.None);
+
+        await Assert.That(buffer.HasOutput).IsFalse();
+        await Assert.That(fallbackLogger.Entries).HasSingleItem();
+        await Assert.That(CountOccurrences(writer.ToString(), "[INFO] retry structured log"))
+            .IsEqualTo(1);
+    }
+
     private static ModuleOutputBuffer CreateBufferWithStructuredLog(
         TimeSpan? synchronizationLockTimeout = null,
         string message = "structured log",
@@ -574,6 +636,8 @@ public class ModuleOutputBufferTests
     {
         public List<(string Message, Exception? Exception)> Entries { get; } = [];
 
+        public Exception? LogException { get; set; }
+
         public IDisposable? BeginScope<TState>(TState state)
             where TState : notnull
             => null;
@@ -587,6 +651,11 @@ public class ModuleOutputBufferTests
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
+            if (LogException is not null)
+            {
+                throw LogException;
+            }
+
             Entries.Add((formatter(state, exception), exception));
         }
     }

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -183,6 +183,48 @@ public class NonSpectreLoggerFactoryTests
         }
     }
 
+    [Test]
+    public async Task Filter_PostConfigure_Preserves_Identity_For_Global_And_Alias_Filters()
+    {
+        var filteredProviderNames = new List<string?>();
+        Func<string?, string?, LogLevel, bool> filter = (providerName, _, _) =>
+        {
+            filteredProviderNames.Add(providerName);
+            return true;
+        };
+        var options = new LoggerFilterOptions();
+        options.Rules.Add(new LoggerFilterRule(
+            null,
+            "Global",
+            LogLevel.Information,
+            filter));
+        options.Rules.Add(new LoggerFilterRule(
+            SpectreLoggerSuppressionRegistration.SpectreProviderAlias,
+            "Alias",
+            LogLevel.Warning,
+            filter));
+
+        new SpectreLoggerFilterOptionsPostConfigure().PostConfigure(null, options);
+
+        var wrapperProviderName = typeof(SuppressibleSpectreLoggerProvider).FullName;
+        options.Rules[0].Filter!(wrapperProviderName, "Global", LogLevel.Information);
+        options.Rules[1].Filter!(wrapperProviderName, "Alias", LogLevel.Warning);
+        options.Rules[0].Filter!("Other.Provider", "Global", LogLevel.Information);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(options.Rules[0].ProviderName).IsNull();
+            await Assert.That(options.Rules[1].ProviderName)
+                .IsEqualTo(SpectreLoggerSuppressionRegistration.SpectreProviderAlias);
+            await Assert.That(filteredProviderNames).IsEquivalentTo(
+            [
+                SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
+                SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
+                "Other.Provider",
+            ]);
+        }
+    }
+
     private static NonSpectreLoggerFactory CreateFactory(
         ILoggerProvider provider,
         LoggerFilterOptions options)

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -122,6 +122,31 @@ public class NonSpectreLoggerFactoryTests
     }
 
     [Test]
+    public async Task CreateLoggers_Does_Not_Retry_Opaque_Replacement_Factory()
+    {
+        var successfulProvider = new RecordingLoggerProvider();
+        var failingProvider = new RecordingLoggerProvider
+        {
+            LogException = new InvalidOperationException("provider rejected event"),
+        };
+        var suppression = new SpectreLoggerSuppression();
+        using var effectiveFactory = new LoggerFactory([successfulProvider, failingProvider]);
+        using var factory = new NonSpectreLoggerFactory(
+            effectiveFactory,
+            new TestProviderRegistry([]),
+            CreateOptionsMonitor(new LoggerFilterOptions()),
+            suppression);
+        var logger = factory.CreateLoggers("Category").Single();
+
+        var exception = Assert.Throws<ProviderDeliveryException>(
+            () => logger.LogWarning("delivered"));
+
+        await Assert.That(successfulProvider.Entries).HasSingleItem();
+        await Assert.That(failingProvider.Entries).IsEmpty();
+        await Assert.That(exception.FailedLoggers).IsEmpty();
+    }
+
+    [Test]
     public async Task CreateLoggers_ReportsOnlyFailedProviderForRetry()
     {
         var successfulProvider = new RecordingLoggerProvider();

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -96,6 +96,42 @@ public class NonSpectreLoggerFactoryTests
         await Assert.That(control.SynchronizationLock).IsNotNull();
     }
 
+    [Test]
+    public async Task Filter_PostConfigure_Translates_Full_Provider_Name_In_Place()
+    {
+        Func<string?, string?, LogLevel, bool> filter = (_, _, _) => true;
+        var options = new LoggerFilterOptions();
+        options.Rules.Add(new LoggerFilterRule(
+            "Other.Provider",
+            "Before",
+            LogLevel.Trace,
+            null));
+        options.Rules.Add(new LoggerFilterRule(
+            SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
+            "Category",
+            LogLevel.Warning,
+            filter));
+        options.Rules.Add(new LoggerFilterRule(
+            "Other.Provider",
+            "After",
+            LogLevel.Critical,
+            null));
+
+        new SpectreLoggerFilterOptionsPostConfigure().PostConfigure(null, options);
+
+        var translatedRule = options.Rules[1];
+        using (Assert.Multiple())
+        {
+            await Assert.That(options.Rules[0].CategoryName).IsEqualTo("Before");
+            await Assert.That(translatedRule.ProviderName)
+                .IsEqualTo(typeof(SuppressibleSpectreLoggerProvider).FullName);
+            await Assert.That(translatedRule.CategoryName).IsEqualTo("Category");
+            await Assert.That(translatedRule.LogLevel).IsEqualTo(LogLevel.Warning);
+            await Assert.That(translatedRule.Filter).IsSameReferenceAs(filter);
+            await Assert.That(options.Rules[2].CategoryName).IsEqualTo("After");
+        }
+    }
+
     private static NonSpectreLoggerFactory CreateFactory(ILoggerFactory loggerFactory)
     {
         return new NonSpectreLoggerFactory(loggerFactory, new SpectreLoggerSuppression());

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -210,18 +210,19 @@ public class NonSpectreLoggerFactoryTests
         options.Rules[0].Filter!(wrapperProviderName, "Global", LogLevel.Information);
         options.Rules[1].Filter!(wrapperProviderName, "Alias", LogLevel.Warning);
         options.Rules[0].Filter!("Other.Provider", "Global", LogLevel.Information);
+        string?[] expectedProviderNames =
+        [
+            SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
+            SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
+            "Other.Provider",
+        ];
 
         using (Assert.Multiple())
         {
             await Assert.That(options.Rules[0].ProviderName).IsNull();
             await Assert.That(options.Rules[1].ProviderName)
                 .IsEqualTo(SpectreLoggerSuppressionRegistration.SpectreProviderAlias);
-            await Assert.That(filteredProviderNames).IsEquivalentTo(
-            [
-                SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
-                SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
-                "Other.Provider",
-            ]);
+            await Assert.That(filteredProviderNames).IsEquivalentTo(expectedProviderNames);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -22,8 +22,8 @@ public class NonSpectreLoggerFactoryTests
             "Allowed",
             LogLevel.Warning,
             null));
-        using var loggerFactory = CreateLoggerFactory(provider, options);
-        var logger = CreateFactory(loggerFactory).CreateLoggers("Allowed.Category").Single();
+        using var factory = CreateFactory(provider, options);
+        var logger = factory.CreateLoggers("Allowed.Category").Single();
 
         logger.LogInformation("filtered");
         logger.LogWarning("delivered");
@@ -36,6 +36,7 @@ public class NonSpectreLoggerFactoryTests
     public async Task CreateLoggers_Rule_With_No_Minimum_Overrides_Global_Minimum()
     {
         var provider = new RecordingLoggerProvider();
+        string? filteredProviderName = null;
         var options = new LoggerFilterOptions
         {
             MinLevel = LogLevel.Error,
@@ -44,14 +45,20 @@ public class NonSpectreLoggerFactoryTests
             "Recording",
             "Allowed",
             null,
-            (_, _, _) => true));
-        using var loggerFactory = CreateLoggerFactory(provider, options);
-        var logger = CreateFactory(loggerFactory).CreateLoggers("Allowed.Category").Single();
+            (providerName, _, _) =>
+            {
+                filteredProviderName = providerName;
+                return true;
+            }));
+        using var factory = CreateFactory(provider, options);
+        var logger = factory.CreateLoggers("Allowed.Category").Single();
 
         logger.LogInformation("delivered");
 
         await Assert.That(provider.Entries).HasSingleItem();
         await Assert.That(provider.Entries[0]).IsEqualTo((LogLevel.Information, "delivered"));
+        await Assert.That(filteredProviderName)
+            .IsEqualTo(typeof(RecordingLoggerProvider).FullName);
     }
 
     [Test]
@@ -65,17 +72,50 @@ public class NonSpectreLoggerFactoryTests
                 spectreProvider,
                 Mock.Of<ISpectreConsoleLoggerControl>(),
                 suppression);
-        using var loggerFactory = new LoggerFactory([suppressibleSpectreProvider]);
-        var logger = new NonSpectreLoggerFactory(loggerFactory, suppression)
+        var loggerFactory = new LoggerFactory([suppressibleSpectreProvider]);
+        using var trackingFactory = new ProviderTrackingLoggerFactory(
+            loggerFactory,
+            [suppressibleSpectreProvider]);
+        using var factory = new NonSpectreLoggerFactory(
+            trackingFactory,
+            CreateOptionsMonitor(new LoggerFilterOptions()));
+        var logger = factory
             .CreateLoggers("Category")
             .Single();
 
-        loggerFactory.AddProvider(dynamicProvider);
+        trackingFactory.AddProvider(dynamicProvider);
         logger.LogWarning("delivered");
 
         await Assert.That(spectreProvider.Entries).IsEmpty();
         await Assert.That(dynamicProvider.Entries).HasSingleItem();
         await Assert.That(dynamicProvider.Entries[0]).IsEqualTo((LogLevel.Warning, "delivered"));
+    }
+
+    [Test]
+    public async Task CreateLoggers_ReportsOnlyFailedProviderForRetry()
+    {
+        var successfulProvider = new RecordingLoggerProvider();
+        var failingProvider = new RecordingLoggerProvider
+        {
+            LogException = new InvalidOperationException("provider rejected event"),
+        };
+        using var factory = new NonSpectreLoggerFactory(
+            new TestProviderRegistry([successfulProvider, failingProvider]),
+            CreateOptionsMonitor(new LoggerFilterOptions()));
+        var logger = factory.CreateLoggers("Category").Single();
+
+        var exception = Assert.Throws<ProviderDeliveryException>(
+            () => logger.LogWarning("delivered"));
+
+        await Assert.That(successfulProvider.Entries).HasSingleItem();
+        await Assert.That(failingProvider.Entries).IsEmpty();
+        await Assert.That(exception.FailedLoggers).HasSingleItem();
+
+        failingProvider.LogException = null;
+        exception.FailedLoggers.Single().LogWarning("delivered");
+
+        await Assert.That(successfulProvider.Entries).HasSingleItem();
+        await Assert.That(failingProvider.Entries).HasSingleItem();
     }
 
     [Test]
@@ -143,21 +183,31 @@ public class NonSpectreLoggerFactoryTests
         }
     }
 
-    private static NonSpectreLoggerFactory CreateFactory(ILoggerFactory loggerFactory)
+    private static NonSpectreLoggerFactory CreateFactory(
+        ILoggerProvider provider,
+        LoggerFilterOptions options)
     {
-        return new NonSpectreLoggerFactory(loggerFactory, new SpectreLoggerSuppression());
+        return new NonSpectreLoggerFactory(
+            new TestProviderRegistry([provider]),
+            CreateOptionsMonitor(options));
     }
 
-    private static LoggerFactory CreateLoggerFactory(
-        ILoggerProvider provider,
+    private static IOptionsMonitor<LoggerFilterOptions> CreateOptionsMonitor(
         LoggerFilterOptions options)
     {
         var monitor = new Mock<IOptionsMonitor<LoggerFilterOptions>>();
         monitor.SetupGet(x => x.CurrentValue).Returns(options);
+        monitor.Setup(x => x.Get(It.IsAny<string?>())).Returns(options);
         monitor
             .Setup(x => x.OnChange(It.IsAny<Action<LoggerFilterOptions, string?>>()))
             .Returns(Mock.Of<IDisposable>());
-        return new LoggerFactory([provider], monitor.Object);
+        return monitor.Object;
+    }
+
+    private sealed class TestProviderRegistry(
+        IReadOnlyList<ILoggerProvider> providers) : ILoggerProviderRegistry
+    {
+        public IReadOnlyList<ILoggerProvider> Providers { get; } = providers;
     }
 
     [ProviderAlias("Recording")]
@@ -165,7 +215,9 @@ public class NonSpectreLoggerFactoryTests
     {
         public List<(LogLevel LogLevel, string Message)> Entries { get; } = [];
 
-        public ILogger CreateLogger(string categoryName) => new RecordingLogger(Entries);
+        public Exception? LogException { get; set; }
+
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(this);
 
         public void Dispose()
         {
@@ -173,7 +225,7 @@ public class NonSpectreLoggerFactoryTests
     }
 
     private sealed class RecordingLogger(
-        List<(LogLevel LogLevel, string Message)> entries) : ILogger
+        RecordingLoggerProvider provider) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state)
             where TState : notnull
@@ -188,7 +240,12 @@ public class NonSpectreLoggerFactoryTests
             Exception? exception,
             Func<TState, Exception?, string> formatter)
         {
-            entries.Add((logLevel, formatter(state, exception)));
+            if (provider.LogException is not null)
+            {
+                throw provider.LogException;
+            }
+
+            provider.Entries.Add((logLevel, formatter(state, exception)));
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ModularPipelines.Console;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Console;
+
+public class NonSpectreLoggerFactoryTests
+{
+    [Test]
+    public async Task CreateLoggers_Applies_Provider_And_Category_Rules()
+    {
+        var provider = new RecordingLoggerProvider();
+        var options = new LoggerFilterOptions
+        {
+            MinLevel = LogLevel.Error,
+        };
+        options.Rules.Add(new LoggerFilterRule(
+            "Recording",
+            "Allowed",
+            LogLevel.Warning,
+            null));
+        var logger = CreateFactory(provider, options).CreateLoggers("Allowed.Category").Single();
+
+        logger.LogInformation("filtered");
+        logger.LogWarning("delivered");
+
+        await Assert.That(provider.Entries).HasSingleItem();
+        await Assert.That(provider.Entries[0]).IsEqualTo((LogLevel.Warning, "delivered"));
+    }
+
+    [Test]
+    public async Task CreateLoggers_Rule_With_No_Minimum_Overrides_Global_Minimum()
+    {
+        var provider = new RecordingLoggerProvider();
+        var options = new LoggerFilterOptions
+        {
+            MinLevel = LogLevel.Error,
+        };
+        options.Rules.Add(new LoggerFilterRule(
+            "Recording",
+            "Allowed",
+            null,
+            (_, _, _) => true));
+        var logger = CreateFactory(provider, options).CreateLoggers("Allowed.Category").Single();
+
+        logger.LogInformation("delivered");
+
+        await Assert.That(provider.Entries).HasSingleItem();
+        await Assert.That(provider.Entries[0]).IsEqualTo((LogLevel.Information, "delivered"));
+    }
+
+    private static NonSpectreLoggerFactory CreateFactory(
+        ILoggerProvider provider,
+        LoggerFilterOptions options)
+    {
+        var monitor = new Mock<IOptionsMonitor<LoggerFilterOptions>>();
+        monitor.SetupGet(x => x.CurrentValue).Returns(options);
+        return new NonSpectreLoggerFactory([provider], monitor.Object);
+    }
+
+    [ProviderAlias("Recording")]
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        public List<(LogLevel LogLevel, string Message)> Entries { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => new RecordingLogger(Entries);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class RecordingLogger(
+        List<(LogLevel LogLevel, string Message)> entries) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+            => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            entries.Add((logLevel, formatter(state, exception)));
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -122,6 +122,25 @@ public class NonSpectreLoggerFactoryTests
     }
 
     [Test]
+    public async Task SpectreFilter_Disables_Orphaned_Provider_For_Replacement_Factory()
+    {
+        var suppression = new SpectreLoggerSuppression();
+        using var provider = new SuppressibleSpectreLoggerProvider(
+            new RecordingLoggerProvider(),
+            Mock.Of<ISpectreConsoleLoggerControl>(),
+            suppression);
+        var registry = new TestProviderRegistry([]);
+        using var replacementFactory = new LoggerFactory();
+        using var filter = new SpectreLoggerFilter(
+            provider,
+            CreateOptionsMonitor(new LoggerFilterOptions()),
+            replacementFactory,
+            registry);
+
+        await Assert.That(filter.IsEnabled("Category", LogLevel.Warning)).IsFalse();
+    }
+
+    [Test]
     public async Task CreateLoggers_Does_Not_Retry_Opaque_Replacement_Factory()
     {
         var successfulProvider = new RecordingLoggerProvider();
@@ -213,9 +232,12 @@ public class NonSpectreLoggerFactoryTests
             new RecordingLoggerProvider(),
             Mock.Of<ISpectreConsoleLoggerControl>(),
             suppression);
+        var registry = new TestProviderRegistry([]);
         using var filter = new SpectreLoggerFilter(
             provider,
-            CreateOptionsMonitor(options));
+            CreateOptionsMonitor(options),
+            registry,
+            registry);
 
         var informationEnabled = filter.IsEnabled(
             "Filtered.Category",

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -18,7 +18,7 @@ public class NonSpectreLoggerFactoryTests
             MinLevel = LogLevel.Error,
         };
         options.Rules.Add(new LoggerFilterRule(
-            "Recording",
+            "recording",
             "Allowed",
             LogLevel.Warning,
             null));
@@ -42,7 +42,7 @@ public class NonSpectreLoggerFactoryTests
             MinLevel = LogLevel.Error,
         };
         options.Rules.Add(new LoggerFilterRule(
-            "Recording",
+            typeof(RecordingLoggerProvider).FullName!.ToLowerInvariant(),
             "Allowed",
             null,
             (providerName, _, _) =>
@@ -210,7 +210,7 @@ public class NonSpectreLoggerFactoryTests
             LogLevel.Trace,
             null));
         options.Rules.Add(new LoggerFilterRule(
-            SpectreLoggerSuppressionRegistration.SpectreProviderTypeName,
+            SpectreLoggerSuppressionRegistration.SpectreProviderTypeName.ToLowerInvariant(),
             "Category",
             LogLevel.Warning,
             filter));
@@ -257,7 +257,7 @@ public class NonSpectreLoggerFactoryTests
             LogLevel.Information,
             filter));
         options.Rules.Add(new LoggerFilterRule(
-            SpectreLoggerSuppressionRegistration.SpectreProviderAlias,
+            SpectreLoggerSuppressionRegistration.SpectreProviderAlias.ToLowerInvariant(),
             "Alias",
             LogLevel.Warning,
             filter));
@@ -279,7 +279,7 @@ public class NonSpectreLoggerFactoryTests
         {
             await Assert.That(options.Rules[0].ProviderName).IsNull();
             await Assert.That(options.Rules[1].ProviderName)
-                .IsEqualTo(SpectreLoggerSuppressionRegistration.SpectreProviderAlias);
+                .IsEqualTo(SpectreLoggerSuppressionRegistration.SpectreProviderAlias.ToLowerInvariant());
             await Assert.That(filteredProviderNames).IsEquivalentTo(expectedProviderNames);
         }
     }

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -99,7 +99,12 @@ public class NonSpectreLoggerFactoryTests
     [Test]
     public async Task Filter_PostConfigure_Translates_Full_Provider_Name_In_Place()
     {
-        Func<string?, string?, LogLevel, bool> filter = (_, _, _) => true;
+        string? filteredProviderName = null;
+        Func<string?, string?, LogLevel, bool> filter = (providerName, _, _) =>
+        {
+            filteredProviderName = providerName;
+            return true;
+        };
         var options = new LoggerFilterOptions();
         options.Rules.Add(new LoggerFilterRule(
             "Other.Provider",
@@ -120,6 +125,10 @@ public class NonSpectreLoggerFactoryTests
         new SpectreLoggerFilterOptionsPostConfigure().PostConfigure(null, options);
 
         var translatedRule = options.Rules[1];
+        var filterResult = translatedRule.Filter!(
+            translatedRule.ProviderName,
+            translatedRule.CategoryName,
+            translatedRule.LogLevel!.Value);
         using (Assert.Multiple())
         {
             await Assert.That(options.Rules[0].CategoryName).IsEqualTo("Before");
@@ -127,7 +136,9 @@ public class NonSpectreLoggerFactoryTests
                 .IsEqualTo(typeof(SuppressibleSpectreLoggerProvider).FullName);
             await Assert.That(translatedRule.CategoryName).IsEqualTo("Category");
             await Assert.That(translatedRule.LogLevel).IsEqualTo(LogLevel.Warning);
-            await Assert.That(translatedRule.Filter).IsSameReferenceAs(filter);
+            await Assert.That(filterResult).IsTrue();
+            await Assert.That(filteredProviderName)
+                .IsEqualTo(SpectreLoggerSuppressionRegistration.SpectreProviderTypeName);
             await Assert.That(options.Rules[2].CategoryName).IsEqualTo("After");
         }
     }

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -189,9 +189,46 @@ public class NonSpectreLoggerFactoryTests
 
         var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
         var control = serviceProvider.GetRequiredService<ISpectreConsoleLoggerControl>();
+        var spectreFilter = serviceProvider.GetRequiredService<ISpectreLoggerFilter>();
 
         await Assert.That(loggerFactory).IsNotNull();
         await Assert.That(control.SynchronizationLock).IsNotNull();
+        await Assert.That(spectreFilter).IsNotNull();
+    }
+
+    [Test]
+    public async Task SpectreFilter_Applies_Configured_Provider_And_Category_Rules()
+    {
+        var options = new LoggerFilterOptions
+        {
+            MinLevel = LogLevel.Trace,
+        };
+        options.Rules.Add(new LoggerFilterRule(
+            SpectreLoggerSuppressionRegistration.SpectreProviderAlias,
+            "Filtered.Category",
+            LogLevel.Warning,
+            null));
+        var suppression = new SpectreLoggerSuppression();
+        using var provider = new SuppressibleSpectreLoggerProvider(
+            new RecordingLoggerProvider(),
+            Mock.Of<ISpectreConsoleLoggerControl>(),
+            suppression);
+        using var filter = new SpectreLoggerFilter(
+            provider,
+            CreateOptionsMonitor(options));
+
+        var informationEnabled = filter.IsEnabled(
+            "Filtered.Category",
+            LogLevel.Information);
+        var warningEnabled = filter.IsEnabled(
+            "Filtered.Category",
+            LogLevel.Warning);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(informationEnabled).IsFalse();
+            await Assert.That(warningEnabled).IsTrue();
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -78,7 +78,9 @@ public class NonSpectreLoggerFactoryTests
             [suppressibleSpectreProvider]);
         using var factory = new NonSpectreLoggerFactory(
             trackingFactory,
-            CreateOptionsMonitor(new LoggerFilterOptions()));
+            trackingFactory,
+            CreateOptionsMonitor(new LoggerFilterOptions()),
+            suppression);
         var logger = factory
             .CreateLoggers("Category")
             .Single();
@@ -92,6 +94,34 @@ public class NonSpectreLoggerFactoryTests
     }
 
     [Test]
+    public async Task CreateLoggers_Uses_Effective_Replacement_Logger_Factory()
+    {
+        var effectiveProvider = new RecordingLoggerProvider();
+        var excludedProvider = new RecordingLoggerProvider();
+        var spectreProvider = new RecordingLoggerProvider();
+        var suppression = new SpectreLoggerSuppression();
+        using var suppressibleSpectreProvider =
+            new SuppressibleSpectreLoggerProvider(
+                spectreProvider,
+                Mock.Of<ISpectreConsoleLoggerControl>(),
+                suppression);
+        using var effectiveFactory = new LoggerFactory(
+            [suppressibleSpectreProvider, effectiveProvider]);
+        using var factory = new NonSpectreLoggerFactory(
+            effectiveFactory,
+            new TestProviderRegistry([suppressibleSpectreProvider, excludedProvider]),
+            CreateOptionsMonitor(new LoggerFilterOptions()),
+            suppression);
+        var logger = factory.CreateLoggers("Category").Single();
+
+        logger.LogWarning("delivered");
+
+        await Assert.That(spectreProvider.Entries).IsEmpty();
+        await Assert.That(effectiveProvider.Entries).HasSingleItem();
+        await Assert.That(excludedProvider.Entries).IsEmpty();
+    }
+
+    [Test]
     public async Task CreateLoggers_ReportsOnlyFailedProviderForRetry()
     {
         var successfulProvider = new RecordingLoggerProvider();
@@ -99,9 +129,12 @@ public class NonSpectreLoggerFactoryTests
         {
             LogException = new InvalidOperationException("provider rejected event"),
         };
+        var registry = new TestProviderRegistry([successfulProvider, failingProvider]);
         using var factory = new NonSpectreLoggerFactory(
-            new TestProviderRegistry([successfulProvider, failingProvider]),
-            CreateOptionsMonitor(new LoggerFilterOptions()));
+            registry,
+            registry,
+            CreateOptionsMonitor(new LoggerFilterOptions()),
+            new SpectreLoggerSuppression());
         var logger = factory.CreateLoggers("Category").Single();
 
         var exception = Assert.Throws<ProviderDeliveryException>(
@@ -230,9 +263,12 @@ public class NonSpectreLoggerFactoryTests
         ILoggerProvider provider,
         LoggerFilterOptions options)
     {
+        var registry = new TestProviderRegistry([provider]);
         return new NonSpectreLoggerFactory(
-            new TestProviderRegistry([provider]),
-            CreateOptionsMonitor(options));
+            registry,
+            registry,
+            CreateOptionsMonitor(options),
+            new SpectreLoggerSuppression());
     }
 
     private static IOptionsMonitor<LoggerFilterOptions> CreateOptionsMonitor(
@@ -248,9 +284,19 @@ public class NonSpectreLoggerFactoryTests
     }
 
     private sealed class TestProviderRegistry(
-        IReadOnlyList<ILoggerProvider> providers) : ILoggerProviderRegistry
+        IReadOnlyList<ILoggerProvider> providers) : ILoggerFactory, ILoggerProviderRegistry
     {
         public IReadOnlyList<ILoggerProvider> Providers { get; } = providers;
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName) => Mock.Of<ILogger>();
+
+        public void Dispose()
+        {
+        }
     }
 
     [ProviderAlias("Recording")]

--- a/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/NonSpectreLoggerFactoryTests.cs
@@ -1,3 +1,5 @@
+using MEL.Spectre;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Console;
@@ -20,7 +22,8 @@ public class NonSpectreLoggerFactoryTests
             "Allowed",
             LogLevel.Warning,
             null));
-        var logger = CreateFactory(provider, options).CreateLoggers("Allowed.Category").Single();
+        using var loggerFactory = CreateLoggerFactory(provider, options);
+        var logger = CreateFactory(loggerFactory).CreateLoggers("Allowed.Category").Single();
 
         logger.LogInformation("filtered");
         logger.LogWarning("delivered");
@@ -42,7 +45,8 @@ public class NonSpectreLoggerFactoryTests
             "Allowed",
             null,
             (_, _, _) => true));
-        var logger = CreateFactory(provider, options).CreateLoggers("Allowed.Category").Single();
+        using var loggerFactory = CreateLoggerFactory(provider, options);
+        var logger = CreateFactory(loggerFactory).CreateLoggers("Allowed.Category").Single();
 
         logger.LogInformation("delivered");
 
@@ -50,13 +54,63 @@ public class NonSpectreLoggerFactoryTests
         await Assert.That(provider.Entries[0]).IsEqualTo((LogLevel.Information, "delivered"));
     }
 
-    private static NonSpectreLoggerFactory CreateFactory(
+    [Test]
+    public async Task CreateLoggers_Includes_Provider_Added_After_Logger_Creation()
+    {
+        var spectreProvider = new RecordingLoggerProvider();
+        var dynamicProvider = new RecordingLoggerProvider();
+        var suppression = new SpectreLoggerSuppression();
+        using var suppressibleSpectreProvider =
+            new SuppressibleSpectreLoggerProvider(
+                spectreProvider,
+                Mock.Of<ISpectreConsoleLoggerControl>(),
+                suppression);
+        using var loggerFactory = new LoggerFactory([suppressibleSpectreProvider]);
+        var logger = new NonSpectreLoggerFactory(loggerFactory, suppression)
+            .CreateLoggers("Category")
+            .Single();
+
+        loggerFactory.AddProvider(dynamicProvider);
+        logger.LogWarning("delivered");
+
+        await Assert.That(spectreProvider.Entries).IsEmpty();
+        await Assert.That(dynamicProvider.Entries).HasSingleItem();
+        await Assert.That(dynamicProvider.Entries[0]).IsEqualTo((LogLevel.Warning, "delivered"));
+    }
+
+    [Test]
+    public async Task Registration_Resolves_Logger_Factory_And_Control()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(builder =>
+        {
+            builder.AddSpectreConsole();
+            builder.Services.MakeSpectreLoggerSuppressible();
+        });
+        await using var serviceProvider = services.BuildServiceProvider();
+
+        var loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
+        var control = serviceProvider.GetRequiredService<ISpectreConsoleLoggerControl>();
+
+        await Assert.That(loggerFactory).IsNotNull();
+        await Assert.That(control.SynchronizationLock).IsNotNull();
+    }
+
+    private static NonSpectreLoggerFactory CreateFactory(ILoggerFactory loggerFactory)
+    {
+        return new NonSpectreLoggerFactory(loggerFactory, new SpectreLoggerSuppression());
+    }
+
+    private static LoggerFactory CreateLoggerFactory(
         ILoggerProvider provider,
         LoggerFilterOptions options)
     {
         var monitor = new Mock<IOptionsMonitor<LoggerFilterOptions>>();
         monitor.SetupGet(x => x.CurrentValue).Returns(options);
-        return new NonSpectreLoggerFactory([provider], monitor.Object);
+        monitor
+            .Setup(x => x.OnChange(It.IsAny<Action<LoggerFilterOptions, string?>>()))
+            .Returns(Mock.Of<IDisposable>());
+        return new LoggerFactory([provider], monitor.Object);
     }
 
     [ProviderAlias("Recording")]

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -215,6 +215,75 @@ public class OutputCoordinatorTests
     }
 
     [Test]
+    public async Task UnattributedFlush_UsesPipelineLoggerCategory()
+    {
+        var buffer = new Mock<IModuleOutputBuffer>();
+        buffer.SetupGet(x => x.ModuleType).Returns(typeof(void));
+        buffer.SetupGet(x => x.HasOutput).Returns(true);
+        buffer
+            .Setup(x => x.FlushToAsync(
+                It.IsAny<TextWriter>(),
+                It.IsAny<IBuildSystemFormatter>(),
+                It.IsAny<ILogger>(),
+                It.IsAny<ISpectreConsoleLoggerControl>(),
+                OutputFlushKind.Incremental,
+                It.IsAny<IReadOnlyList<ILogger>?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var loggerFactory = new Mock<ILoggerFactory>();
+        loggerFactory
+            .Setup(x => x.CreateLogger(It.IsAny<string>()))
+            .Returns(Mock.Of<ILogger>());
+        var nonSpectreLoggerFactory = new Mock<INonSpectreLoggerFactory>();
+        nonSpectreLoggerFactory
+            .Setup(x => x.CreateLoggers(It.IsAny<string>()))
+            .Returns([]);
+        var coordinator = CreateCoordinator(
+            loggerFactory.Object,
+            nonSpectreLoggerFactory: nonSpectreLoggerFactory.Object);
+
+        await coordinator.EnqueueAndFlushAsync(buffer.Object, OutputFlushKind.Incremental);
+
+        loggerFactory.Verify(
+            x => x.CreateLogger(OutputLoggerCategories.Pipeline),
+            Times.Once);
+        nonSpectreLoggerFactory.Verify(
+            x => x.CreateLoggers(OutputLoggerCategories.Pipeline),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task Completion_RetriesStructuredProviderDeliveryOnce()
+    {
+        var buffer = new Mock<IModuleOutputBuffer>();
+        buffer.SetupGet(x => x.ModuleType).Returns(typeof(OutputCoordinatorTests));
+        buffer.SetupGet(x => x.NeedsCompletionFlush).Returns(true);
+        buffer.SetupGet(x => x.HasStructuredDeliveryRetries).Returns(true);
+        buffer
+            .Setup(x => x.FlushToAsync(
+                It.IsAny<TextWriter>(),
+                It.IsAny<IBuildSystemFormatter>(),
+                It.IsAny<ILogger>(),
+                It.IsAny<ISpectreConsoleLoggerControl>(),
+                OutputFlushKind.Complete,
+                It.IsAny<IReadOnlyList<ILogger>?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
+
+        await coordinator.OnModuleCompletedAsync(buffer.Object, buffer.Object.ModuleType);
+
+        buffer.Verify(x => x.FlushToAsync(
+            It.IsAny<TextWriter>(),
+            It.IsAny<IBuildSystemFormatter>(),
+            It.IsAny<ILogger>(),
+            It.IsAny<ISpectreConsoleLoggerControl>(),
+            OutputFlushKind.Complete,
+            It.IsAny<IReadOnlyList<ILogger>?>(),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Test]
     public async Task Completion_IsQueuedWhileIncrementalFlushOwnsOutput()
     {
         var buffer = new BlockingIncrementalOutputBuffer();
@@ -418,7 +487,8 @@ public class OutputCoordinatorTests
 
     private static OutputCoordinator CreateCoordinator(
         ILoggerFactory loggerFactory,
-        IBuildSystemFormatterProvider? formatterProvider = null)
+        IBuildSystemFormatterProvider? formatterProvider = null,
+        INonSpectreLoggerFactory? nonSpectreLoggerFactory = null)
     {
         if (formatterProvider is null)
         {
@@ -430,17 +500,21 @@ public class OutputCoordinatorTests
         var serviceProvider = new Mock<IServiceProvider>();
         var loggerControl = new Mock<ISpectreConsoleLoggerControl>();
         loggerControl.SetupGet(x => x.SynchronizationLock).Returns(new object());
-        var nonSpectreLoggerFactory = new Mock<INonSpectreLoggerFactory>();
-        nonSpectreLoggerFactory
-            .Setup(factory => factory.CreateLoggers(It.IsAny<string>()))
-            .Returns([]);
+        if (nonSpectreLoggerFactory is null)
+        {
+            var nonSpectreLoggerFactoryMock = new Mock<INonSpectreLoggerFactory>();
+            nonSpectreLoggerFactoryMock
+                .Setup(factory => factory.CreateLoggers(It.IsAny<string>()))
+                .Returns([]);
+            nonSpectreLoggerFactory = nonSpectreLoggerFactoryMock.Object;
+        }
 
         return new OutputCoordinator(
             formatterProvider,
             loggerFactory,
             serviceProvider.Object,
             loggerControl.Object,
-            nonSpectreLoggerFactory.Object);
+            nonSpectreLoggerFactory);
     }
 
     private sealed class ConsoleWritingLoggerFactory(TextWriter writer) : ILoggerFactory

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -126,6 +126,7 @@ public class OutputCoordinatorTests
             It.IsAny<ILogger>(),
             It.IsAny<ISpectreConsoleLoggerControl>(),
             It.IsAny<OutputFlushKind>(),
+            It.IsAny<IReadOnlyList<ILogger>?>(),
             It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -158,6 +159,7 @@ public class OutputCoordinatorTests
                 It.IsAny<ILogger>(),
                 It.IsAny<ISpectreConsoleLoggerControl>(),
                 OutputFlushKind.Incremental,
+                It.IsAny<IReadOnlyList<ILogger>?>(),
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
@@ -170,6 +172,7 @@ public class OutputCoordinatorTests
             It.IsAny<ILogger>(),
             It.IsAny<ISpectreConsoleLoggerControl>(),
             OutputFlushKind.Incremental,
+            It.IsAny<IReadOnlyList<ILogger>?>(),
             It.IsAny<CancellationToken>()), Times.Once);
         buffer.Verify(x => x.FlushToAsync(
             It.IsAny<TextWriter>(),
@@ -177,6 +180,7 @@ public class OutputCoordinatorTests
             It.IsAny<ILogger>(),
             It.IsAny<ISpectreConsoleLoggerControl>(),
             OutputFlushKind.Complete,
+            It.IsAny<IReadOnlyList<ILogger>?>(),
             It.IsAny<CancellationToken>()), Times.Never);
     }
 
@@ -193,6 +197,7 @@ public class OutputCoordinatorTests
                 It.IsAny<ILogger>(),
                 It.IsAny<ISpectreConsoleLoggerControl>(),
                 OutputFlushKind.Incremental,
+                It.IsAny<IReadOnlyList<ILogger>?>(),
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
         var coordinator = CreateCoordinator(new ConsoleWritingLoggerFactory(TextWriter.Null));
@@ -205,6 +210,7 @@ public class OutputCoordinatorTests
             It.IsAny<ILogger>(),
             It.IsAny<ISpectreConsoleLoggerControl>(),
             OutputFlushKind.Incremental,
+            It.IsAny<IReadOnlyList<ILogger>?>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -424,12 +430,17 @@ public class OutputCoordinatorTests
         var serviceProvider = new Mock<IServiceProvider>();
         var loggerControl = new Mock<ISpectreConsoleLoggerControl>();
         loggerControl.SetupGet(x => x.SynchronizationLock).Returns(new object());
+        var nonSpectreLoggerFactory = new Mock<INonSpectreLoggerFactory>();
+        nonSpectreLoggerFactory
+            .Setup(factory => factory.CreateLoggers(It.IsAny<string>()))
+            .Returns([]);
 
         return new OutputCoordinator(
             formatterProvider,
             loggerFactory,
             serviceProvider.Object,
-            loggerControl.Object);
+            loggerControl.Object,
+            nonSpectreLoggerFactory.Object);
     }
 
     private sealed class ConsoleWritingLoggerFactory(TextWriter writer) : ILoggerFactory
@@ -499,6 +510,7 @@ public class OutputCoordinatorTests
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
             OutputFlushKind flushKind,
+            IReadOnlyList<ILogger>? fallbackLoggers = null,
             CancellationToken cancellationToken = default)
         {
             FlushCount++;
@@ -544,6 +556,7 @@ public class OutputCoordinatorTests
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
             OutputFlushKind flushKind,
+            IReadOnlyList<ILogger>? fallbackLoggers = null,
             CancellationToken cancellationToken = default)
         {
             FlushCount++;
@@ -590,6 +603,7 @@ public class OutputCoordinatorTests
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
             OutputFlushKind flushKind,
+            IReadOnlyList<ILogger>? fallbackLoggers = null,
             CancellationToken cancellationToken = default)
         {
             FlushStarted.TrySetResult();
@@ -638,6 +652,7 @@ public class OutputCoordinatorTests
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
             OutputFlushKind flushKind,
+            IReadOnlyList<ILogger>? fallbackLoggers = null,
             CancellationToken cancellationToken = default)
         {
             if (flushKind is OutputFlushKind.Complete)
@@ -692,6 +707,7 @@ public class OutputCoordinatorTests
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
             OutputFlushKind flushKind,
+            IReadOnlyList<ILogger>? fallbackLoggers = null,
             CancellationToken cancellationToken = default)
         {
             FlushStarted.TrySetResult();
@@ -732,6 +748,7 @@ public class OutputCoordinatorTests
             ILogger logger,
             ISpectreConsoleLoggerControl loggerControl,
             OutputFlushKind flushKind,
+            IReadOnlyList<ILogger>? fallbackLoggers = null,
             CancellationToken cancellationToken = default)
         {
             DeliveryCount++;

--- a/test/ModularPipelines.UnitTests/Console/OutputLoggerCategoriesTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputLoggerCategoriesTests.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Console;
+
+namespace ModularPipelines.UnitTests.Console;
+
+public class OutputLoggerCategoriesTests
+{
+    [Test]
+    public async Task Module_Category_Matches_ILogger_Type_Category()
+    {
+        var provider = new CategoryRecordingLoggerProvider();
+        using var loggerFactory = new LoggerFactory([provider]);
+        var moduleType = typeof(NestedGenericModule<string>);
+
+        _ = loggerFactory.CreateLogger(moduleType);
+
+        await Assert.That(OutputLoggerCategories.ForModule(moduleType))
+            .IsEqualTo(provider.CategoryName);
+    }
+
+    private sealed class NestedGenericModule<T>;
+
+    private sealed class CategoryRecordingLoggerProvider : ILoggerProvider
+    {
+        public string? CategoryName { get; private set; }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            CategoryName = categoryName;
+            return Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Console/ProgressSessionTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ProgressSessionTests.cs
@@ -39,6 +39,10 @@ public class ProgressSessionTests
         secretObfuscator
             .Setup(obfuscator => obfuscator.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
             .Returns((string? value, object? _) => value ?? string.Empty);
+        var nonSpectreLoggerFactory = new Mock<INonSpectreLoggerFactory>();
+        nonSpectreLoggerFactory
+            .Setup(factory => factory.CreateLoggers(It.IsAny<string>()))
+            .Returns([]);
 
         return new ConsoleCoordinator(
             Mock.Of<IBuildSystemFormatterProvider>(),
@@ -50,6 +54,7 @@ public class ProgressSessionTests
             Mock.Of<IBuildSystemDetector>(),
             Mock.Of<IServiceProvider>(),
             outputCoordinator,
-            Mock.Of<ISpectreConsoleLoggerControl>());
+            Mock.Of<ISpectreConsoleLoggerControl>(),
+            nonSpectreLoggerFactory.Object);
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ProgressSessionTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ProgressSessionTests.cs
@@ -1,4 +1,5 @@
 using MEL.Spectre;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
@@ -43,6 +44,10 @@ public class ProgressSessionTests
         nonSpectreLoggerFactory
             .Setup(factory => factory.CreateLoggers(It.IsAny<string>()))
             .Returns([]);
+        var spectreLoggerFilter = new Mock<ISpectreLoggerFilter>();
+        spectreLoggerFilter
+            .Setup(filter => filter.IsEnabled(It.IsAny<string>(), It.IsAny<LogLevel>()))
+            .Returns(true);
 
         return new ConsoleCoordinator(
             Mock.Of<IBuildSystemFormatterProvider>(),
@@ -55,6 +60,7 @@ public class ProgressSessionTests
             Mock.Of<IServiceProvider>(),
             outputCoordinator,
             Mock.Of<ISpectreConsoleLoggerControl>(),
-            nonSpectreLoggerFactory.Object);
+            nonSpectreLoggerFactory.Object,
+            spectreLoggerFilter.Object);
     }
 }


### PR DESCRIPTION
## Summary
- bound MEL.Spectre synchronization-lock acquisition to one second
- fall back to the captured console for direct and structured output instead of dropping it
- preserve secret masking and emit a timeout diagnostic
- add a held-lock regression test

## Validation
- ModuleOutputBufferTests: 18/18 passed
- changed-file analyzers: clean at info severity
- ModularPipelines.sln Release build: 0 errors

Closes #3270