### PR TITLE
Cache module lookup results

### DIFF
--- a/src/ModularPipelines/Context/ModuleLookup.cs
+++ b/src/ModularPipelines/Context/ModuleLookup.cs
@@ -1,0 +1,79 @@
+using System.Collections.Concurrent;
+using ModularPipelines.Exceptions;
+using ModularPipelines.Helpers;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Context;
+
+internal sealed class ModuleLookup
+{
+    private readonly ConcurrentDictionary<Type, IReadOnlyList<IModule>> _assignableModules = new();
+    private readonly IReadOnlyDictionary<Type, IReadOnlyList<IModule>> _ambiguousConcreteModules;
+    private readonly IReadOnlyDictionary<Type, IModule> _concreteModules;
+    private readonly IReadOnlyList<IModule> _modules;
+
+    public ModuleLookup(IEnumerable<IModule> registeredModules)
+    {
+        _modules =
+        [
+            .. registeredModules.Distinct<IModule>(ReferenceEqualityComparer.Instance),
+        ];
+
+        var modulesByConcreteType = _modules
+            .GroupBy(x => x.GetType())
+            .ToDictionary(
+                x => x.Key,
+                x => (IReadOnlyList<IModule>) [.. x]);
+
+        _concreteModules = modulesByConcreteType
+            .Where(x => x.Value.Count == 1)
+            .ToDictionary(x => x.Key, x => x.Value[0]);
+        _ambiguousConcreteModules = modulesByConcreteType
+            .Where(x => x.Value.Count > 1)
+            .ToDictionary(x => x.Key, x => x.Value);
+    }
+
+    public IModule? GetAssignable(Type type)
+    {
+        if (type.IsSealed)
+        {
+            return GetExact(type);
+        }
+
+        var matches = _assignableModules.GetOrAdd(
+            type,
+            requestedType => [.. _modules.Where(requestedType.IsInstanceOfType)]);
+
+        return GetSingleMatch(type, matches);
+    }
+
+    public IModule? GetExact(Type type)
+    {
+        ThrowIfAmbiguous(type, _ambiguousConcreteModules);
+        return _concreteModules.GetValueOrDefault(type);
+    }
+
+    private static IModule? GetSingleMatch(Type requestedType, IReadOnlyList<IModule> matches)
+    {
+        if (matches.Count > 1)
+        {
+            throw new AmbiguousModuleException(
+                requestedType,
+                [.. matches.Select(x => x.GetType())]);
+        }
+
+        return matches.Count == 1 ? matches[0] : null;
+    }
+
+    private static void ThrowIfAmbiguous(
+        Type requestedType,
+        IReadOnlyDictionary<Type, IReadOnlyList<IModule>> ambiguousModules)
+    {
+        if (ambiguousModules.TryGetValue(requestedType, out var matches))
+        {
+            throw new AmbiguousModuleException(
+                requestedType,
+                [.. matches.Select(x => x.GetType())]);
+        }
+    }
+}

--- a/src/ModularPipelines/Context/PipelineContext.cs
+++ b/src/ModularPipelines/Context/PipelineContext.cs
@@ -1,8 +1,5 @@
-using System.Collections.Concurrent;
-using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context.Domains;
 using ModularPipelines.Engine;
-using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Modules;
@@ -19,7 +16,7 @@ namespace ModularPipelines.Context;
 internal class PipelineContext : IPipelineContext, IInternalPipelineContext
 {
     private readonly IInternalModuleLoggerProvider _moduleLoggerProvider;
-    private readonly Lazy<ModuleLookup> _moduleLookup;
+    private readonly ModuleLookup _moduleLookup;
 
     /// <summary>
     /// Cached logger instance for this context.
@@ -72,7 +69,7 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
     /// Initialises a new instance of the <see cref="PipelineContext"/> class.
     /// </summary>
     public PipelineContext(
-        IServiceProvider serviceProvider,
+        ModuleLookup moduleLookup,
         IDependencyCollisionDetector dependencyCollisionDetector,
         IModuleResultRepository moduleResultRepository,
         IInternalModuleLoggerProvider moduleLoggerProvider,
@@ -87,9 +84,7 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
         IServicesContext services,
         ISummaryLogger summary)
     {
-        _moduleLookup = new Lazy<ModuleLookup>(
-            () => ModuleLookup.Create(serviceProvider.GetServices<IModule>()),
-            LazyThreadSafetyMode.ExecutionAndPublication);
+        _moduleLookup = moduleLookup;
         _moduleLoggerProvider = moduleLoggerProvider;
         DependencyCollisionDetector = dependencyCollisionDetector;
         ModuleResultRepository = moduleResultRepository;
@@ -110,95 +105,11 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
     public TModule? GetModule<TModule>()
         where TModule : class, IModule
     {
-        return (TModule?) _moduleLookup.Value.GetAssignable(typeof(TModule));
+        return (TModule?) _moduleLookup.GetAssignable(typeof(TModule));
     }
 
     public IModule? GetModule(Type type)
     {
-        return _moduleLookup.Value.GetExact(type);
-    }
-
-    private sealed class ModuleLookup
-    {
-        private readonly ConcurrentDictionary<Type, IReadOnlyList<IModule>> _assignableModules = new();
-        private readonly IReadOnlyDictionary<Type, IReadOnlyList<IModule>> _ambiguousConcreteModules;
-        private readonly IReadOnlyDictionary<Type, IModule> _concreteModules;
-        private readonly IReadOnlyList<IModule> _modules;
-
-        private ModuleLookup(
-            IReadOnlyList<IModule> modules,
-            IReadOnlyDictionary<Type, IModule> concreteModules,
-            IReadOnlyDictionary<Type, IReadOnlyList<IModule>> ambiguousConcreteModules)
-        {
-            _modules = modules;
-            _concreteModules = concreteModules;
-            _ambiguousConcreteModules = ambiguousConcreteModules;
-        }
-
-        public static ModuleLookup Create(IEnumerable<IModule> registeredModules)
-        {
-            var modules = registeredModules
-                .Distinct<IModule>(ReferenceEqualityComparer.Instance)
-                .ToArray();
-
-            var modulesByConcreteType = modules
-                .GroupBy(x => x.GetType())
-                .ToDictionary(
-                    x => x.Key,
-                    x => (IReadOnlyList<IModule>) x.ToArray());
-
-            return new ModuleLookup(
-                modules,
-                modulesByConcreteType
-                    .Where(x => x.Value.Count == 1)
-                    .ToDictionary(x => x.Key, x => x.Value[0]),
-                modulesByConcreteType
-                    .Where(x => x.Value.Count > 1)
-                    .ToDictionary(x => x.Key, x => x.Value));
-        }
-
-        public IModule? GetAssignable(Type type)
-        {
-            if (_concreteModules.ContainsKey(type) || _ambiguousConcreteModules.ContainsKey(type))
-            {
-                return GetExact(type);
-            }
-
-            var matches = _assignableModules.GetOrAdd(
-                type,
-                requestedType => _modules.Where(requestedType.IsInstanceOfType).ToArray());
-
-            return GetSingleMatch(type, matches);
-        }
-
-        public IModule? GetExact(Type type)
-        {
-            ThrowIfAmbiguous(type, _ambiguousConcreteModules);
-            return _concreteModules.GetValueOrDefault(type);
-        }
-
-        private static IModule? GetSingleMatch(Type requestedType, IReadOnlyList<IModule> matches)
-        {
-            if (matches.Count > 1)
-            {
-                throw new AmbiguousModuleException(
-                    requestedType,
-                    matches.Select(x => x.GetType()).ToArray());
-            }
-
-            return matches.Count == 1 ? matches[0] : null;
-        }
-
-        private static void ThrowIfAmbiguous(
-            Type requestedType,
-            IReadOnlyDictionary<Type, IReadOnlyList<IModule>> ambiguousModules)
-        {
-            if (ambiguousModules.TryGetValue(requestedType, out var matches))
-            {
-                throw new AmbiguousModuleException(
-                    requestedType,
-                    matches.Select(x => x.GetType()).ToArray());
-            }
-        }
+        return _moduleLookup.GetExact(type);
     }
 }

--- a/src/ModularPipelines/Context/PipelineContext.cs
+++ b/src/ModularPipelines/Context/PipelineContext.cs
@@ -66,7 +66,7 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
     }
 
     /// <summary>
-    /// Initialises a new instance of the <see cref="PipelineContext"/> class.
+    /// Initializes a new instance of the <see cref="PipelineContext"/> class.
     /// </summary>
     public PipelineContext(
         ModuleLookup moduleLookup,

--- a/src/ModularPipelines/Context/PipelineContext.cs
+++ b/src/ModularPipelines/Context/PipelineContext.cs
@@ -66,7 +66,7 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PipelineContext"/> class.
+    /// Initialises a new instance of the <see cref="PipelineContext"/> class.
     /// </summary>
     public PipelineContext(
         ModuleLookup moduleLookup,

--- a/src/ModularPipelines/Context/PipelineContext.cs
+++ b/src/ModularPipelines/Context/PipelineContext.cs
@@ -1,6 +1,8 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context.Domains;
 using ModularPipelines.Engine;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Modules;
@@ -17,7 +19,7 @@ namespace ModularPipelines.Context;
 internal class PipelineContext : IPipelineContext, IInternalPipelineContext
 {
     private readonly IInternalModuleLoggerProvider _moduleLoggerProvider;
-    private readonly IServiceProvider _serviceProvider;
+    private readonly Lazy<ModuleLookup> _moduleLookup;
 
     /// <summary>
     /// Cached logger instance for this context.
@@ -67,7 +69,7 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PipelineContext"/> class.
+    /// Initialises a new instance of the <see cref="PipelineContext"/> class.
     /// </summary>
     public PipelineContext(
         IServiceProvider serviceProvider,
@@ -85,7 +87,9 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
         IServicesContext services,
         ISummaryLogger summary)
     {
-        _serviceProvider = serviceProvider;
+        _moduleLookup = new Lazy<ModuleLookup>(
+            () => ModuleLookup.Create(serviceProvider.GetServices<IModule>()),
+            LazyThreadSafetyMode.ExecutionAndPublication);
         _moduleLoggerProvider = moduleLoggerProvider;
         DependencyCollisionDetector = dependencyCollisionDetector;
         ModuleResultRepository = moduleResultRepository;
@@ -106,15 +110,95 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
     public TModule? GetModule<TModule>()
         where TModule : class, IModule
     {
-        return GetDistinctModules().OfType<TModule>().SingleOrDefault();
+        return (TModule?) _moduleLookup.Value.GetAssignable(typeof(TModule));
     }
 
     public IModule? GetModule(Type type)
     {
-        return GetDistinctModules().SingleOrDefault(module => module.GetType() == type);
+        return _moduleLookup.Value.GetExact(type);
     }
 
-    private IEnumerable<IModule> GetDistinctModules() =>
-        _serviceProvider.GetServices<IModule>()
-            .Distinct<IModule>(ReferenceEqualityComparer.Instance);
+    private sealed class ModuleLookup
+    {
+        private readonly ConcurrentDictionary<Type, IReadOnlyList<IModule>> _assignableModules = new();
+        private readonly IReadOnlyDictionary<Type, IReadOnlyList<IModule>> _ambiguousConcreteModules;
+        private readonly IReadOnlyDictionary<Type, IModule> _concreteModules;
+        private readonly IReadOnlyList<IModule> _modules;
+
+        private ModuleLookup(
+            IReadOnlyList<IModule> modules,
+            IReadOnlyDictionary<Type, IModule> concreteModules,
+            IReadOnlyDictionary<Type, IReadOnlyList<IModule>> ambiguousConcreteModules)
+        {
+            _modules = modules;
+            _concreteModules = concreteModules;
+            _ambiguousConcreteModules = ambiguousConcreteModules;
+        }
+
+        public static ModuleLookup Create(IEnumerable<IModule> registeredModules)
+        {
+            var modules = registeredModules
+                .Distinct<IModule>(ReferenceEqualityComparer.Instance)
+                .ToArray();
+
+            var modulesByConcreteType = modules
+                .GroupBy(x => x.GetType())
+                .ToDictionary(
+                    x => x.Key,
+                    x => (IReadOnlyList<IModule>) x.ToArray());
+
+            return new ModuleLookup(
+                modules,
+                modulesByConcreteType
+                    .Where(x => x.Value.Count == 1)
+                    .ToDictionary(x => x.Key, x => x.Value[0]),
+                modulesByConcreteType
+                    .Where(x => x.Value.Count > 1)
+                    .ToDictionary(x => x.Key, x => x.Value));
+        }
+
+        public IModule? GetAssignable(Type type)
+        {
+            if (_concreteModules.ContainsKey(type) || _ambiguousConcreteModules.ContainsKey(type))
+            {
+                return GetExact(type);
+            }
+
+            var matches = _assignableModules.GetOrAdd(
+                type,
+                requestedType => _modules.Where(requestedType.IsInstanceOfType).ToArray());
+
+            return GetSingleMatch(type, matches);
+        }
+
+        public IModule? GetExact(Type type)
+        {
+            ThrowIfAmbiguous(type, _ambiguousConcreteModules);
+            return _concreteModules.GetValueOrDefault(type);
+        }
+
+        private static IModule? GetSingleMatch(Type requestedType, IReadOnlyList<IModule> matches)
+        {
+            if (matches.Count > 1)
+            {
+                throw new AmbiguousModuleException(
+                    requestedType,
+                    matches.Select(x => x.GetType()).ToArray());
+            }
+
+            return matches.Count == 1 ? matches[0] : null;
+        }
+
+        private static void ThrowIfAmbiguous(
+            Type requestedType,
+            IReadOnlyDictionary<Type, IReadOnlyList<IModule>> ambiguousModules)
+        {
+            if (ambiguousModules.TryGetValue(requestedType, out var matches))
+            {
+                throw new AmbiguousModuleException(
+                    requestedType,
+                    matches.Select(x => x.GetType()).ToArray());
+            }
+        }
+    }
 }

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -62,6 +62,27 @@ internal static class DependencyInjectionSetup
         RegisterDistributedServices(services);
     }
 
+    internal static void ConfigureSpectreConsoleLogger(SpectreConsoleLoggerOptions config) =>
+        ConfigureSpectreConsoleLogger(config, DelegatingAnsiConsole.Instance);
+
+    internal static void ConfigureSpectreConsoleLogger(
+        SpectreConsoleLoggerOptions config,
+        IAnsiConsole console)
+    {
+        // Console width and CI capabilities are configured by ConsoleCoordinator.
+        config.Console = console;
+        config.Template = "[{Level:u4}] {Message}";
+        config.ExceptionFormats = ExceptionFormats.Default;
+        config.AllowMarkupInMessageTemplate = true;
+        config.Theme = new SpectreTheme()
+            .WithPlaceholders(placeholders =>
+            {
+                placeholders.ForName("CommandOutput", Style.Plain);
+                placeholders.ForName("CommandError", Style.Plain);
+            });
+        config.WriteMode = WriteMode.Synchronous;
+    }
+
     /// <summary>
     /// Registers external integrations and bundled services:
     /// options configuration, logging provider, HTTP clients, initializers, and mediator.
@@ -92,27 +113,6 @@ internal static class DependencyInjectionSetup
             .AddMediator();
     }
 
-    internal static void ConfigureSpectreConsoleLogger(SpectreConsoleLoggerOptions config) =>
-        ConfigureSpectreConsoleLogger(config, DelegatingAnsiConsole.Instance);
-
-    internal static void ConfigureSpectreConsoleLogger(
-        SpectreConsoleLoggerOptions config,
-        IAnsiConsole console)
-    {
-        // Console width and CI capabilities are configured by ConsoleCoordinator.
-        config.Console = console;
-        config.Template = "[{Level:u4}] {Message}";
-        config.ExceptionFormats = ExceptionFormats.Default;
-        config.AllowMarkupInMessageTemplate = true;
-        config.Theme = new SpectreTheme()
-            .WithPlaceholders(placeholders =>
-            {
-                placeholders.ForName("CommandOutput", Style.Plain);
-                placeholders.ForName("CommandError", Style.Plain);
-            });
-        config.WriteMode = WriteMode.Synchronous;
-    }
-
     /// <summary>
     /// Registers scoped services injected into IModuleContext:
     /// HTTP, command execution, installers, shell environments, and context-specific services.
@@ -120,6 +120,7 @@ internal static class DependencyInjectionSetup
     private static void RegisterPipelineContextServices(IServiceCollection services)
     {
         services
+            .AddSingleton<ModuleLookup>()
             .AddScoped<PipelineContext>()
             .AddScoped<IPipelineContext>(sp => sp.GetRequiredService<PipelineContext>())
             .AddScoped<ModuleLoggerProvider>()
@@ -159,6 +160,7 @@ internal static class DependencyInjectionSetup
             .AddScoped<IInstallersContext, InstallersContext>()
             .AddScoped<INetworkContext, NetworkContext>()
             .AddScoped<ISecurityContext, SecurityContext>()
+
             // Register Services domain context
             .AddScoped<IServicesContext, ServicesContext>()
             .AddScoped<ModularPipelines.Http.IHttpLogger, ModularPipelines.Http.HttpLogger>()
@@ -227,6 +229,7 @@ internal static class DependencyInjectionSetup
     {
         services.TryAddSingleton<IFileSystemProvider>(SystemFileSystemProvider.Instance);
         services
+
             // Module activator - sets AsyncLocal context before module construction
             .AddSingleton<IModuleActivator, ModuleActivator>()
             .AddSingleton<IPipelineContextProvider, ModuleContextProvider>()

--- a/src/ModularPipelines/Exceptions/AmbiguousModuleException.cs
+++ b/src/ModularPipelines/Exceptions/AmbiguousModuleException.cs
@@ -1,0 +1,44 @@
+namespace ModularPipelines.Exceptions;
+
+/// <summary>
+/// Thrown when a module lookup matches more than one registered module.
+/// </summary>
+/// <remarks>
+/// Request a concrete module type when multiple registered modules inherit from or implement
+/// the requested type.
+/// </remarks>
+/// <seealso cref="PipelineException"/>
+public class AmbiguousModuleException : PipelineException
+{
+    /// <summary>
+    /// Initialises a new instance of the <see cref="AmbiguousModuleException"/> class.
+    /// </summary>
+    /// <param name="requestedType">The module type requested by the lookup.</param>
+    /// <param name="matchingModuleTypes">The registered module types matched by the lookup.</param>
+    public AmbiguousModuleException(Type requestedType, IReadOnlyList<Type> matchingModuleTypes)
+        : base(CreateMessage(requestedType, matchingModuleTypes))
+    {
+        RequestedType = requestedType;
+        MatchingModuleTypes = matchingModuleTypes;
+    }
+
+    /// <summary>
+    /// Gets the module type requested by the lookup.
+    /// </summary>
+    public Type RequestedType { get; }
+
+    /// <summary>
+    /// Gets the registered module types matched by the lookup.
+    /// </summary>
+    public IReadOnlyList<Type> MatchingModuleTypes { get; }
+
+    private static string CreateMessage(Type requestedType, IReadOnlyList<Type> matchingModuleTypes)
+    {
+        var matches = string.Join(
+            ", ",
+            matchingModuleTypes.Select(x => $"'{x.FullName ?? x.Name}'"));
+
+        return $"Module lookup for '{requestedType.FullName ?? requestedType.Name}' matched multiple registered modules: " +
+               $"{matches}. Request a concrete module type.";
+    }
+}

--- a/src/ModularPipelines/Exceptions/PipelineException.cs
+++ b/src/ModularPipelines/Exceptions/PipelineException.cs
@@ -43,14 +43,14 @@ namespace ModularPipelines.Exceptions;
 public class PipelineException : Exception
 {
     /// <summary>
-    /// Initialises a new instance of the <see cref="PipelineException"/> class.
+    /// Initializes a new instance of the <see cref="PipelineException"/> class.
     /// </summary>
     public PipelineException()
     {
     }
 
     /// <summary>
-    /// Initialises a new instance of the <see cref="PipelineException"/> class with a specified error message.
+    /// Initializes a new instance of the <see cref="PipelineException"/> class with a specified error message.
     /// </summary>
     /// <param name="message">The message that describes the error.</param>
     public PipelineException(string? message) : base(message)
@@ -58,7 +58,7 @@ public class PipelineException : Exception
     }
 
     /// <summary>
-    /// Initialises a new instance of the <see cref="PipelineException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+    /// Initializes a new instance of the <see cref="PipelineException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
     /// </summary>
     /// <param name="message">The message that describes the error.</param>
     /// <param name="innerException">The exception that is the cause of the current exception.</param>

--- a/src/ModularPipelines/Exceptions/PipelineException.cs
+++ b/src/ModularPipelines/Exceptions/PipelineException.cs
@@ -43,14 +43,14 @@ namespace ModularPipelines.Exceptions;
 public class PipelineException : Exception
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="PipelineException"/> class.
+    /// Initialises a new instance of the <see cref="PipelineException"/> class.
     /// </summary>
     public PipelineException()
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PipelineException"/> class with a specified error message.
+    /// Initialises a new instance of the <see cref="PipelineException"/> class with a specified error message.
     /// </summary>
     /// <param name="message">The message that describes the error.</param>
     public PipelineException(string? message) : base(message)
@@ -58,7 +58,7 @@ public class PipelineException : Exception
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PipelineException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+    /// Initialises a new instance of the <see cref="PipelineException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
     /// </summary>
     /// <param name="message">The message that describes the error.</param>
     /// <param name="innerException">The exception that is the cause of the current exception.</param>

--- a/src/ModularPipelines/Exceptions/PipelineException.cs
+++ b/src/ModularPipelines/Exceptions/PipelineException.cs
@@ -11,6 +11,7 @@ namespace ModularPipelines.Exceptions;
 /// <para><b>Exception Hierarchy:</b></para>
 /// <list type="bullet">
 /// <item><see cref="PipelineException"/> - Base exception for all pipeline errors</item>
+/// <item><see cref="AmbiguousModuleException"/> - Module lookup matched multiple registrations</item>
 /// <item><see cref="CommandException"/> - CLI command execution failures</item>
 /// <item><see cref="CircularDependencyException"/> - Circular module dependency detected</item>
 /// <item><see cref="DependencyCollisionException"/> - Module dependency conflicts</item>
@@ -42,14 +43,14 @@ namespace ModularPipelines.Exceptions;
 public class PipelineException : Exception
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="PipelineException"/> class.
+    /// Initialises a new instance of the <see cref="PipelineException"/> class.
     /// </summary>
     public PipelineException()
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PipelineException"/> class with a specified error message.
+    /// Initialises a new instance of the <see cref="PipelineException"/> class with a specified error message.
     /// </summary>
     /// <param name="message">The message that describes the error.</param>
     public PipelineException(string? message) : base(message)
@@ -57,7 +58,7 @@ public class PipelineException : Exception
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="PipelineException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+    /// Initialises a new instance of the <see cref="PipelineException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
     /// </summary>
     /// <param name="message">The message that describes the error.</param>
     /// <param name="innerException">The exception that is the cause of the current exception.</param>

--- a/test/ModularPipelines.UnitTests/Context/PipelineContextModuleLookupTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/PipelineContextModuleLookupTests.cs
@@ -1,5 +1,7 @@
+using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains;
+using ModularPipelines.DependencyInjection;
 using ModularPipelines.Engine;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers;
@@ -13,29 +15,31 @@ namespace ModularPipelines.UnitTests.Context;
 public class PipelineContextModuleLookupTests
 {
     [Test]
-    public async Task GetModule_BuildsModuleLookupOnlyOnce()
+    public async Task ModuleLookup_IsSharedAcrossScopes()
     {
         var module = new FirstLookupModule();
-        var resolutionCount = 0;
-        var serviceProvider = CreateServiceProvider([module], () => resolutionCount++);
-        using var engineCancellationToken = new EngineCancellationToken(Mock.Of<IPrimaryExceptionContainer>());
-        var context = CreateContext(serviceProvider, engineCancellationToken);
+        var services = new ServiceCollection();
+        DependencyInjectionSetup.Initialize(services);
+        services.AddSingleton<IModule>(module);
+        await using var serviceProvider = services.BuildServiceProvider();
+        using var firstScope = serviceProvider.CreateScope();
+        using var secondScope = serviceProvider.CreateScope();
 
-        var firstResult = context.GetModule<FirstLookupModule>();
-        var secondResult = context.GetModule<FirstLookupModule>();
+        var firstLookup = firstScope.ServiceProvider.GetRequiredService<ModuleLookup>();
+        var secondLookup = secondScope.ServiceProvider.GetRequiredService<ModuleLookup>();
 
-        await Assert.That(firstResult).IsSameReferenceAs(module);
-        await Assert.That(secondResult).IsSameReferenceAs(module);
-        await Assert.That(resolutionCount).IsEqualTo(1);
+        await Assert.That(secondLookup).IsSameReferenceAs(firstLookup);
+        await Assert.That(firstLookup.GetAssignable(typeof(FirstLookupModule)))
+            .IsSameReferenceAs(module);
     }
 
     [Test]
     public async Task GetModule_ReturnsOnlyAssignableModule()
     {
         var module = new FirstLookupModule();
-        var serviceProvider = CreateServiceProvider([module]);
+        var moduleLookup = CreateModuleLookup([module]);
         using var engineCancellationToken = new EngineCancellationToken(Mock.Of<IPrimaryExceptionContainer>());
-        var context = CreateContext(serviceProvider, engineCancellationToken);
+        var context = CreateContext(moduleLookup, engineCancellationToken);
 
         var result = context.GetModule<LookupModule>();
 
@@ -45,9 +49,9 @@ public class PipelineContextModuleLookupTests
     [Test]
     public async Task GetModuleByType_RequiresExactModuleType()
     {
-        var serviceProvider = CreateServiceProvider([new FirstLookupModule()]);
+        var moduleLookup = CreateModuleLookup([new FirstLookupModule()]);
         using var engineCancellationToken = new EngineCancellationToken(Mock.Of<IPrimaryExceptionContainer>());
-        var context = CreateContext(serviceProvider, engineCancellationToken);
+        var context = CreateContext(moduleLookup, engineCancellationToken);
 
         var result = context.GetModule(typeof(LookupModule));
 
@@ -57,9 +61,9 @@ public class PipelineContextModuleLookupTests
     [Test]
     public async Task GetModule_WhenMultipleModulesMatch_ThrowsDescriptivePipelineException()
     {
-        var serviceProvider = CreateServiceProvider([new FirstLookupModule(), new SecondLookupModule()]);
+        var moduleLookup = CreateModuleLookup([new FirstLookupModule(), new SecondLookupModule()]);
         using var engineCancellationToken = new EngineCancellationToken(Mock.Of<IPrimaryExceptionContainer>());
-        var context = CreateContext(serviceProvider, engineCancellationToken);
+        var context = CreateContext(moduleLookup, engineCancellationToken);
 
         var exception = Assert.Throws<AmbiguousModuleException>(() => context.GetModule<LookupModule>());
 
@@ -71,28 +75,31 @@ public class PipelineContextModuleLookupTests
             .IsEquivalentTo([typeof(FirstLookupModule), typeof(SecondLookupModule)]);
     }
 
-    private static Mock<IServiceProvider> CreateServiceProvider(
-        IReadOnlyList<IModule> modules,
-        Action? onResolve = null)
+    [Test]
+    public async Task GetModule_WhenConcreteBaseAndDerivedModulesMatch_ThrowsDescriptivePipelineException()
     {
-        var serviceProvider = new Mock<IServiceProvider>();
-        serviceProvider
-            .Setup(x => x.GetService(typeof(IEnumerable<IModule>)))
-            .Returns(() =>
-            {
-                onResolve?.Invoke();
-                return modules;
-            });
+        var moduleLookup = CreateModuleLookup(
+            [new ConcreteBaseLookupModule(), new DerivedConcreteLookupModule()]);
+        using var engineCancellationToken = new EngineCancellationToken(Mock.Of<IPrimaryExceptionContainer>());
+        var context = CreateContext(moduleLookup, engineCancellationToken);
 
-        return serviceProvider;
+        var exception = Assert.Throws<AmbiguousModuleException>(
+            () => context.GetModule<ConcreteBaseLookupModule>());
+
+        await Assert.That(exception.RequestedType).IsEqualTo(typeof(ConcreteBaseLookupModule));
+        await Assert.That(exception.MatchingModuleTypes)
+            .IsEquivalentTo([typeof(ConcreteBaseLookupModule), typeof(DerivedConcreteLookupModule)]);
     }
 
+    private static ModuleLookup CreateModuleLookup(IReadOnlyList<IModule> modules) =>
+        new(modules);
+
     private static PipelineContext CreateContext(
-        Mock<IServiceProvider> serviceProvider,
+        ModuleLookup moduleLookup,
         EngineCancellationToken engineCancellationToken)
     {
         return new PipelineContext(
-            serviceProvider.Object,
+            moduleLookup,
             Mock.Of<IDependencyCollisionDetector>(),
             Mock.Of<IModuleResultRepository>(),
             Mock.Of<IInternalModuleLoggerProvider>(),
@@ -125,4 +132,14 @@ public class PipelineContextModuleLookupTests
             CancellationToken cancellationToken)
             => Task.FromResult<string?>(nameof(SecondLookupModule));
     }
+
+    private class ConcreteBaseLookupModule : LookupModule
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult<string?>(nameof(ConcreteBaseLookupModule));
+    }
+
+    private sealed class DerivedConcreteLookupModule : ConcreteBaseLookupModule;
 }

--- a/test/ModularPipelines.UnitTests/Context/PipelineContextModuleLookupTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/PipelineContextModuleLookupTests.cs
@@ -1,0 +1,128 @@
+using ModularPipelines.Context;
+using ModularPipelines.Context.Domains;
+using ModularPipelines.Engine;
+using ModularPipelines.Exceptions;
+using ModularPipelines.Helpers;
+using ModularPipelines.Logging;
+using ModularPipelines.Modules;
+using Moq;
+using EngineCancellationToken = ModularPipelines.Engine.EngineCancellationToken;
+
+namespace ModularPipelines.UnitTests.Context;
+
+public class PipelineContextModuleLookupTests
+{
+    [Test]
+    public async Task GetModule_BuildsModuleLookupOnlyOnce()
+    {
+        var module = new FirstLookupModule();
+        var resolutionCount = 0;
+        var serviceProvider = CreateServiceProvider([module], () => resolutionCount++);
+        using var engineCancellationToken = new EngineCancellationToken(Mock.Of<IPrimaryExceptionContainer>());
+        var context = CreateContext(serviceProvider, engineCancellationToken);
+
+        var firstResult = context.GetModule<FirstLookupModule>();
+        var secondResult = context.GetModule<FirstLookupModule>();
+
+        await Assert.That(firstResult).IsSameReferenceAs(module);
+        await Assert.That(secondResult).IsSameReferenceAs(module);
+        await Assert.That(resolutionCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task GetModule_ReturnsOnlyAssignableModule()
+    {
+        var module = new FirstLookupModule();
+        var serviceProvider = CreateServiceProvider([module]);
+        using var engineCancellationToken = new EngineCancellationToken(Mock.Of<IPrimaryExceptionContainer>());
+        var context = CreateContext(serviceProvider, engineCancellationToken);
+
+        var result = context.GetModule<LookupModule>();
+
+        await Assert.That(result).IsSameReferenceAs(module);
+    }
+
+    [Test]
+    public async Task GetModuleByType_RequiresExactModuleType()
+    {
+        var serviceProvider = CreateServiceProvider([new FirstLookupModule()]);
+        using var engineCancellationToken = new EngineCancellationToken(Mock.Of<IPrimaryExceptionContainer>());
+        var context = CreateContext(serviceProvider, engineCancellationToken);
+
+        var result = context.GetModule(typeof(LookupModule));
+
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task GetModule_WhenMultipleModulesMatch_ThrowsDescriptivePipelineException()
+    {
+        var serviceProvider = CreateServiceProvider([new FirstLookupModule(), new SecondLookupModule()]);
+        using var engineCancellationToken = new EngineCancellationToken(Mock.Of<IPrimaryExceptionContainer>());
+        var context = CreateContext(serviceProvider, engineCancellationToken);
+
+        var exception = Assert.Throws<AmbiguousModuleException>(() => context.GetModule<LookupModule>());
+
+        await Assert.That(exception.Message).Contains(nameof(LookupModule));
+        await Assert.That(exception.Message).Contains(nameof(FirstLookupModule));
+        await Assert.That(exception.Message).Contains(nameof(SecondLookupModule));
+        await Assert.That(exception.RequestedType).IsEqualTo(typeof(LookupModule));
+        await Assert.That(exception.MatchingModuleTypes)
+            .IsEquivalentTo([typeof(FirstLookupModule), typeof(SecondLookupModule)]);
+    }
+
+    private static Mock<IServiceProvider> CreateServiceProvider(
+        IReadOnlyList<IModule> modules,
+        Action? onResolve = null)
+    {
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider
+            .Setup(x => x.GetService(typeof(IEnumerable<IModule>)))
+            .Returns(() =>
+            {
+                onResolve?.Invoke();
+                return modules;
+            });
+
+        return serviceProvider;
+    }
+
+    private static PipelineContext CreateContext(
+        Mock<IServiceProvider> serviceProvider,
+        EngineCancellationToken engineCancellationToken)
+    {
+        return new PipelineContext(
+            serviceProvider.Object,
+            Mock.Of<IDependencyCollisionDetector>(),
+            Mock.Of<IModuleResultRepository>(),
+            Mock.Of<IInternalModuleLoggerProvider>(),
+            engineCancellationToken,
+            Mock.Of<IShellContext>(),
+            Mock.Of<IFilesContext>(),
+            Mock.Of<IDataContext>(),
+            Mock.Of<IEnvironmentDomainContext>(),
+            Mock.Of<IInstallersContext>(),
+            Mock.Of<INetworkContext>(),
+            Mock.Of<ISecurityContext>(),
+            Mock.Of<IServicesContext>(),
+            Mock.Of<ISummaryLogger>());
+    }
+
+    private abstract class LookupModule : Module<string>;
+
+    private sealed class FirstLookupModule : LookupModule
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult<string?>(nameof(FirstLookupModule));
+    }
+
+    private sealed class SecondLookupModule : LookupModule
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult<string?>(nameof(SecondLookupModule));
+    }
+}


### PR DESCRIPTION
## Summary
- build the concrete module dictionary once per scoped pipeline context
- cache base and interface lookup matches after first use
- throw `AmbiguousModuleException` with requested and matching types
- preserve exact-type behavior for the non-generic lookup

## Test plan
- [x] focused `PipelineContextModuleLookupTests` (4 passed)
- [x] `ModularPipelines.sln` Release build (0 errors)
- [x] targeted `dotnet format` for touched core and test files
- [ ] full `ModularPipelines.UnitTests` run exceeded the agent guard's 2 GB process-tree limit at 2067 MB; CI will run the broader suite

Closes #3282
