### PR TITLE
Narrow source generator semantic analysis

### DIFF
--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -24,17 +24,25 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var metadata = context.SyntaxProvider
+        var typeMetadata = context.SyntaxProvider
             .CreateSyntaxProvider(
-                static (node, _) => node is ClassDeclarationSyntax
-                    || (node is RecordDeclarationSyntax record
-                        && !record.ClassOrStructKeyword.IsKind(SyntaxKind.StructKeyword)),
+                static (node, _) => IsTypeCandidate(node),
                 static (generatorContext, _) => GetTypeMetadata(generatorContext))
             .Where(static item => item is not null)
             .Select(static (item, _) => item!);
 
-        context.RegisterSourceOutput(metadata.Collect(), static (sourceContext, items) =>
+        var secretMetadata = context.SyntaxProvider
+            .ForAttributeWithMetadataName(
+                SecretValueAttributeFullName,
+                static (_, _) => true,
+                static (generatorContext, _) => GetTypeMetadata(generatorContext))
+            .Where(static item => item is not null)
+            .Select(static (item, _) => item!);
+
+        var metadata = typeMetadata.Collect().Combine(secretMetadata.Collect());
+        context.RegisterSourceOutput(metadata, static (sourceContext, itemGroups) =>
         {
+            var items = itemGroups.Left.AddRange(itemGroups.Right);
             if (items.Length > 0)
             {
                 sourceContext.AddSource("ModularPipelines.RuntimeMetadata.g.cs", Generate(items));
@@ -42,20 +50,42 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         });
     }
 
+    internal static bool IsTypeCandidate(SyntaxNode node)
+    {
+        return node is ClassDeclarationSyntax { BaseList.Types.Count: > 0 }
+            || (node is RecordDeclarationSyntax record
+                && !record.ClassOrStructKeyword.IsKind(SyntaxKind.StructKeyword)
+                && (record.BaseList is { Types.Count: > 0 }
+                    || record.ParameterList?.Parameters.Any(
+                        static parameter => parameter.AttributeLists.Count > 0) == true));
+    }
+
     private static TypeMetadata? GetTypeMetadata(GeneratorSyntaxContext context)
     {
-        if (context.SemanticModel.GetDeclaredSymbol(context.Node) is not INamedTypeSymbol type
+        return GetTypeMetadata(
+            context.SemanticModel.GetDeclaredSymbol(context.Node) as INamedTypeSymbol,
+            context.SemanticModel.Compilation);
+    }
+
+    private static TypeMetadata? GetTypeMetadata(GeneratorAttributeSyntaxContext context)
+    {
+        return GetTypeMetadata(context.TargetSymbol.ContainingType, context.SemanticModel.Compilation);
+    }
+
+    private static TypeMetadata? GetTypeMetadata(INamedTypeSymbol? type, Compilation compilation)
+    {
+        if (type is null
             || type.IsGenericType
-            || !IsTypeAccessible(type, context.SemanticModel.Compilation.Assembly))
+            || !IsTypeAccessible(type, compilation.Assembly))
         {
             return null;
         }
 
         var isCommandOptions = InheritsFrom(type, CommandLineToolOptionsFullName);
         var commandMetadata = isCommandOptions
-            ? GetCommandProperties(type, context.SemanticModel.Compilation.Assembly)
+            ? GetCommandProperties(type, compilation.Assembly)
             : PropertyCollection.Empty;
-        var secretMetadata = GetSecretProperties(type, context.SemanticModel.Compilation.Assembly);
+        var secretMetadata = GetSecretProperties(type, compilation.Assembly);
 
         if (!isCommandOptions && !secretMetadata.HasAttributes)
         {

--- a/src/ModularPipelines.SourceGenerator/ModularPipelines.SourceGenerator.csproj
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelines.SourceGenerator.csproj
@@ -9,6 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>ModularPipelines.Development.Analyzers.UnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
@@ -21,10 +21,7 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
     {
         var modules = context.SyntaxProvider
             .CreateSyntaxProvider(
-                static (node, _) => node is TypeDeclarationSyntax
-                {
-                    BaseList.Types.Count: > 0,
-                },
+                static (node, _) => IsTypeCandidate(node),
                 static (generatorContext, _) => GetModuleMetadata(generatorContext))
             .Where(static metadata => metadata is not null)
             .Select(static (metadata, _) => metadata!);
@@ -38,6 +35,13 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
                     Generate(metadata));
             }
         });
+    }
+
+    internal static bool IsTypeCandidate(SyntaxNode node)
+    {
+        return node is ClassDeclarationSyntax { BaseList.Types.Count: > 0 }
+            || (node is RecordDeclarationSyntax { BaseList.Types.Count: > 0 } record
+                && !record.ClassOrStructKeyword.IsKind(SyntaxKind.StructKeyword));
     }
 
     private static ModuleEventMetadata? GetModuleMetadata(GeneratorSyntaxContext context)

--- a/test/ModularPipelines.Development.Analyzers.UnitTests/IncrementalGeneratorCachingTests.cs
+++ b/test/ModularPipelines.Development.Analyzers.UnitTests/IncrementalGeneratorCachingTests.cs
@@ -76,6 +76,109 @@ public class IncrementalGeneratorCachingTests
         await AssertOutputIsCachedAfterTriviaChange(new ModuleEventMetadataGenerator(), source);
     }
 
+    [Test]
+    public async Task Command_Metadata_Only_Performs_Semantic_Analysis_For_Syntax_Candidates()
+    {
+        const string source = """
+                              namespace ModularPipelines.Options
+                              {
+                                  public abstract class CommandLineToolOptions;
+                              }
+
+                              namespace ModularPipelines.Attributes
+                              {
+                                  [System.AttributeUsage(System.AttributeTargets.Property)]
+                                  public sealed class SecretValueAttribute : System.Attribute;
+                              }
+
+                              namespace Consumer
+                              {
+                                  public class CommandTarget : ModularPipelines.Options.CommandLineToolOptions;
+
+                                  public class SecretTarget
+                                  {
+                                      [ModularPipelines.Attributes.SecretValue]
+                                      public string? Value { get; init; }
+                                  }
+
+                                  public record SecretRecord(
+                                      [property: ModularPipelines.Attributes.SecretValue] string Value);
+
+                                  public class PlainClass;
+                                  public record PlainRecord;
+                                  public struct PlainStruct;
+                                  public interface IPlainInterface;
+                              }
+                              """;
+
+        var result = RunGenerator(new CommandOptionsGenerator(), source);
+        var candidateCount = CSharpSyntaxTree.ParseText(source)
+            .GetRoot()
+            .DescendantNodes()
+            .Count(CommandOptionsGenerator.IsTypeCandidate);
+        var generatedSource = result.GeneratedSources.Single().SourceText.ToString();
+
+        await Assert.That(candidateCount).IsEqualTo(3);
+        await Assert.That(generatedSource).Contains("SecretTarget");
+        await Assert.That(generatedSource).Contains("SecretRecord");
+    }
+
+    [Test]
+    public async Task Module_Event_Metadata_Only_Performs_Semantic_Analysis_For_Class_Candidates()
+    {
+        const string source = """
+                              namespace ModularPipelines.Modules
+                              {
+                                  public abstract class Module<T>;
+                              }
+
+                              namespace Consumer
+                              {
+                                  public sealed class SampleAttribute : System.Attribute;
+                                  public class ModuleTarget : ModularPipelines.Modules.Module<string>;
+                                  public class NotAModule : System.IDisposable
+                                  {
+                                      public void Dispose() { }
+                                  }
+
+                                  public interface IPlainInterface : System.IDisposable;
+                                  public struct PlainStruct : System.IDisposable
+                                  {
+                                      public void Dispose() { }
+                                  }
+
+                                  public class PlainClass;
+                                  public record PlainRecord;
+                              }
+                              """;
+
+        var result = RunGenerator(new ModuleEventMetadataGenerator(), source);
+        var candidateCount = CSharpSyntaxTree.ParseText(source)
+            .GetRoot()
+            .DescendantNodes()
+            .Count(ModuleEventMetadataGenerator.IsTypeCandidate);
+
+        await Assert.That(candidateCount).IsEqualTo(3);
+        await Assert.That(result.GeneratedSources).IsNotEmpty();
+    }
+
+    private static GeneratorRunResult RunGenerator(
+        IIncrementalGenerator generator,
+        string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var compilation = CSharpCompilation.Create(
+            "GeneratorCandidateTests",
+            [syntaxTree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        GeneratorDriver driver = CSharpGeneratorDriver.Create([generator.AsSourceGenerator()]);
+
+        driver = driver.RunGenerators(compilation);
+
+        return driver.GetRunResult().Results.Single();
+    }
+
     private static async Task AssertOutputIsCachedAfterTriviaChange(
         IIncrementalGenerator generator,
         string source)


### PR DESCRIPTION
## Summary
- restrict command and module metadata semantic analysis to cheap syntax candidates
- discover ordinary `[SecretValue]` properties with `ForAttributeWithMetadataName`
- preserve positional-record secret metadata with an attributed-parameter syntax fallback
- add candidate-count and generated-output regression coverage

## Validation
- Development analyzer tests: 29 passed
- Source generator tests: 4 passed
- Generated runtime metadata tests: 14 passed
- `ModularPipelines.sln` Release build: 0 errors (existing warnings remain)

Closes #3304