### PR TITLE
Require complete CommandResult data

### DIFF
--- a/src/ModularPipelines/Models/CommandResult.cs
+++ b/src/ModularPipelines/Models/CommandResult.cs
@@ -9,12 +9,13 @@ public record CommandResult
     /// <summary>
     /// Gets the command that was executed.
     /// </summary>
-    public string CommandInput { get; }
+    public required string CommandInput { get; init; }
 
-    public IReadOnlyDictionary<string, string?> EnvironmentVariables { get; }
+    public required IReadOnlyDictionary<string, string?> EnvironmentVariables { get; init; }
 
-    public string WorkingDirectory { get; }
+    public required string WorkingDirectory { get; init; }
 
+    [SetsRequiredMembers]
     public CommandResult(
         string commandInput,
         string workingDirectory,
@@ -38,18 +39,23 @@ public record CommandResult
         ExitCode = exitCode;
     }
 
-#if NET7_0_OR_GREATER
-    [SetsRequiredMembersAttribute]
-#endif
-#pragma warning disable CS8618
+    [SetsRequiredMembers]
     internal CommandResult(Command command)
-#pragma warning restore CS8618
     {
+        var completedAt = DateTimeOffset.UtcNow;
+
         CommandInput = command.ToString();
         WorkingDirectory = command.WorkingDirPath;
         EnvironmentVariables = GetPublicEnvironmentVariables(command);
+        StandardOutput = string.Empty;
+        StandardError = string.Empty;
+        ExitCode = 0;
+        StartTime = completedAt;
+        EndTime = completedAt;
+        Duration = TimeSpan.Zero;
     }
 
+    [SetsRequiredMembers]
     internal CommandResult(Command command, CliWrap.CommandResult commandResult, string standardOutput, string standardError)
     {
         CommandInput = command.ToString();
@@ -78,30 +84,30 @@ public record CommandResult
     /// <summary>
     /// Gets standard output data produced by the underlying process.
     /// </summary>
-    public string StandardOutput { get; }
+    public required string StandardOutput { get; init; }
 
     /// <summary>
     /// Gets standard error data produced by the underlying process.
     /// </summary>
-    public string StandardError { get; }
+    public required string StandardError { get; init; }
 
     /// <summary>
     /// Gets exit code set by the underlying process.
     /// </summary>
-    public int ExitCode { get; }
+    public required int ExitCode { get; init; }
 
     /// <summary>
     /// Gets time at which the command started executing.
     /// </summary>
-    public DateTimeOffset StartTime { get; }
+    public required DateTimeOffset StartTime { get; init; }
 
     /// <summary>
     /// Gets time at which the command finished executing.
     /// </summary>
-    public DateTimeOffset EndTime { get; }
+    public required DateTimeOffset EndTime { get; init; }
 
     /// <summary>
     /// Gets total duration of the command execution.
     /// </summary>
-    public TimeSpan Duration { get; }
+    public required TimeSpan Duration { get; init; }
 }

--- a/test/ModularPipelines.UnitTests/Models/CommandResultTests.cs
+++ b/test/ModularPipelines.UnitTests/Models/CommandResultTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using CliWrap;
+using CommandResult = ModularPipelines.Models.CommandResult;
+
+namespace ModularPipelines.UnitTests.Models;
+
+public class CommandResultTests
+{
+    [Test]
+    public async Task Public_Result_Data_Is_Required()
+    {
+        var nonRequiredProperties = typeof(CommandResult)
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(static property => property.GetCustomAttribute<RequiredMemberAttribute>() is null)
+            .Select(static property => property.Name)
+            .ToArray();
+
+        await Assert.That(nonRequiredProperties).IsEmpty();
+    }
+
+    [Test]
+    public async Task Dry_Run_Result_Contains_Completed_Result_Data()
+    {
+        var result = new CommandResult(Cli.Wrap("tool"));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.StandardOutput).IsEqualTo(string.Empty);
+            await Assert.That(result.StandardError).IsEqualTo(string.Empty);
+            await Assert.That(result.ExitCode).IsEqualTo(0);
+            await Assert.That(result.StartTime).IsNotEqualTo(default(DateTimeOffset));
+            await Assert.That(result.EndTime).IsEqualTo(result.StartTime);
+            await Assert.That(result.Duration).IsEqualTo(TimeSpan.Zero);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make every `CommandResult` data property a required init-only member
- annotate constructors that fully initialize the required contract
- remove the CS8618 suppression
- return valid empty output and zero-duration timing data for dry runs
- cover required metadata and dry-run invariants

## Validation
- CommandResult tests: 2 passed
- CommandException tests: 1 passed
- CommandBuilderBase tests: 23 passed
- `ModularPipelines.sln` Release build: 0 errors (existing warnings remain)

## Breaking change
`CommandResult` properties now expose a required init-only contract.

Closes #3278