### PR TITLE
Remove redundant dependency APIs

### DIFF
--- a/docs/docs/migrating-to-v3.md
+++ b/docs/docs/migrating-to-v3.md
@@ -962,8 +962,6 @@ public class MyModule : Module<string>
         // Conditional dependency
         deps.DependsOnIf<ProductionModule>(Environment.IsProduction);
 
-        // Lazy dependency (evaluated later)
-        deps.DependsOnLazy<HeavyModule>();
     }
 
     protected override async Task<string?> ExecuteAsync(

--- a/docs/docs/migrating-to-v3.md
+++ b/docs/docs/migrating-to-v3.md
@@ -961,7 +961,6 @@ public class MyModule : Module<string>
 
         // Conditional dependency
         deps.DependsOnIf<ProductionModule>(Environment.IsProduction);
-
     }
 
     protected override async Task<string?> ExecuteAsync(
@@ -971,6 +970,13 @@ public class MyModule : Module<string>
     }
 }
 ```
+
+Two redundant dependency APIs have been removed:
+
+- Replace `DependsOnLazy<TModule>()` with `DependsOnOptional<TModule>()`. The removed API was only an optional-dependency marker; it did not defer module execution.
+- Replace `DependsOnIf<TModule>(Func<bool>)` with `DependsOnIf<TModule>(bool)` by evaluating the predicate before the call, for example `deps.DependsOnIf<HeavyModule>(ShouldRunHeavyProcessing())`.
+
+The same replacements apply to the overloads that accept a module `Type`.
 
 ### New Dependency Attributes
 

--- a/docs/versioned_docs/version-3.x/migrating-to-v3.md
+++ b/docs/versioned_docs/version-3.x/migrating-to-v3.md
@@ -959,7 +959,6 @@ public class MyModule : Module<string>
 
         // Conditional dependency
         deps.DependsOnIf<ProductionModule>(Environment.IsProduction);
-
     }
 
     protected override async Task<string?> ExecuteAsync(
@@ -969,6 +968,13 @@ public class MyModule : Module<string>
     }
 }
 ```
+
+Two redundant dependency APIs have been removed:
+
+- Replace `DependsOnLazy<TModule>()` with `DependsOnOptional<TModule>()`. The removed API was only an optional-dependency marker; it did not defer module execution.
+- Replace `DependsOnIf<TModule>(Func<bool>)` with `DependsOnIf<TModule>(bool)` by evaluating the predicate before the call, for example `deps.DependsOnIf<HeavyModule>(ShouldRunHeavyProcessing())`.
+
+The same replacements apply to the overloads that accept a module `Type`.
 
 ### New Dependency Attributes
 

--- a/docs/versioned_docs/version-3.x/migrating-to-v3.md
+++ b/docs/versioned_docs/version-3.x/migrating-to-v3.md
@@ -960,8 +960,6 @@ public class MyModule : Module<string>
         // Conditional dependency
         deps.DependsOnIf<ProductionModule>(Environment.IsProduction);
 
-        // Lazy dependency (evaluated later)
-        deps.DependsOnLazy<HeavyModule>();
     }
 
     protected override async Task<string?> ExecuteAsync(

--- a/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
@@ -286,54 +286,11 @@ public sealed class ModuleConfigurationBuilder
         => condition ? DependsOn<TModule>() : this;
 
     /// <summary>
-    /// Adds a required dependency when the supplied predicate returns true.
-    /// </summary>
-    /// <returns>This builder instance for method chaining.</returns>
-    public ModuleConfigurationBuilder DependsOnIf<TModule>(Func<bool> predicate)
-        where TModule : IModule
-    {
-        ArgumentNullException.ThrowIfNull(predicate);
-        return DependsOnIf<TModule>(predicate());
-    }
-
-    /// <summary>
     /// Adds a required dependency when the supplied condition is true.
     /// </summary>
     /// <returns>This builder instance for method chaining.</returns>
     public ModuleConfigurationBuilder DependsOnIf(Type moduleType, bool condition)
         => condition ? DependsOn(moduleType) : this;
-
-    /// <summary>
-    /// Adds a required dependency when the supplied predicate returns true.
-    /// </summary>
-    /// <returns>This builder instance for method chaining.</returns>
-    public ModuleConfigurationBuilder DependsOnIf(Type moduleType, Func<bool> predicate)
-    {
-        ArgumentNullException.ThrowIfNull(predicate);
-        return DependsOnIf(moduleType, predicate());
-    }
-
-    /// <summary>
-    /// Adds a lazy optional dependency.
-    /// </summary>
-    /// <returns>This builder instance for method chaining.</returns>
-    public ModuleConfigurationBuilder DependsOnLazy<TModule>()
-        where TModule : IModule
-    {
-        _dependencies.Add(DeclaredDependency.Lazy(typeof(TModule)));
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a lazy optional dependency.
-    /// </summary>
-    /// <returns>This builder instance for method chaining.</returns>
-    public ModuleConfigurationBuilder DependsOnLazy(Type moduleType)
-    {
-        ValidateModuleType(moduleType);
-        _dependencies.Add(DeclaredDependency.Lazy(moduleType));
-        return this;
-    }
 
     #endregion
 

--- a/src/ModularPipelines/Enums/DependencyType.cs
+++ b/src/ModularPipelines/Enums/DependencyType.cs
@@ -19,13 +19,6 @@ public enum DependencyType
     Optional = 1,
 
     /// <summary>
-    /// Lazy dependency. Behaves the same as <see cref="Optional"/> for dependency resolution purposes -
-    /// the dependency is optional and will not fail if not registered. This is a semantic marker to
-    /// indicate intent that the dependency may be awaited on-demand rather than required upfront.
-    /// </summary>
-    Lazy = 2,
-
-    /// <summary>
     /// Conditional dependency. Used when a dependency is added based on a runtime condition via
     /// <see cref="Modules.IDependencyDeclaration.DependsOnIf{TModule}(bool)"/>. For dependency resolution,
     /// this behaves as a required dependency (will fail if condition is true and dependency is not registered).

--- a/src/ModularPipelines/Models/DeclaredDependency.cs
+++ b/src/ModularPipelines/Models/DeclaredDependency.cs
@@ -16,18 +16,21 @@ public readonly record struct DeclaredDependency(
     /// <summary>
     /// Creates a required dependency.
     /// </summary>
+    /// <returns>A required dependency declaration.</returns>
     public static DeclaredDependency Required(Type type) =>
         new(type, Enums.DependencyType.Required, false);
 
     /// <summary>
     /// Creates an optional dependency.
     /// </summary>
+    /// <returns>An optional dependency declaration.</returns>
     public static DeclaredDependency Optional(Type type) =>
         new(type, Enums.DependencyType.Optional, true);
 
     /// <summary>
     /// Creates a conditional dependency.
     /// </summary>
+    /// <returns>A conditional dependency declaration.</returns>
     public static DeclaredDependency Conditional(Type type) =>
         new(type, Enums.DependencyType.Conditional, false);
 }

--- a/src/ModularPipelines/Models/DeclaredDependency.cs
+++ b/src/ModularPipelines/Models/DeclaredDependency.cs
@@ -6,7 +6,7 @@ namespace ModularPipelines.Models;
 /// Represents a dependency declared programmatically via <see cref="Modules.IDependencyDeclaration"/>.
 /// </summary>
 /// <param name="ModuleType">The type of the module being depended on.</param>
-/// <param name="Kind">The kind of dependency (Required, Optional, Lazy, Conditional).</param>
+/// <param name="Kind">The kind of dependency (Required, Optional, Conditional).</param>
 /// <param name="IsOptional">Whether this dependency is optional (module runs even if dependency is not registered or skipped).</param>
 public readonly record struct DeclaredDependency(
     Type ModuleType,
@@ -24,12 +24,6 @@ public readonly record struct DeclaredDependency(
     /// </summary>
     public static DeclaredDependency Optional(Type type) =>
         new(type, Enums.DependencyType.Optional, true);
-
-    /// <summary>
-    /// Creates a lazy dependency.
-    /// </summary>
-    public static DeclaredDependency Lazy(Type type) =>
-        new(type, Enums.DependencyType.Lazy, true);
 
     /// <summary>
     /// Creates a conditional dependency.

--- a/src/ModularPipelines/Modules/DependencyDeclaration.cs
+++ b/src/ModularPipelines/Modules/DependencyDeclaration.cs
@@ -58,13 +58,6 @@ internal sealed class DependencyDeclaration : IDependencyDeclaration
     }
 
     /// <inheritdoc />
-    public IDependencyDeclaration DependsOnIf<TModule>(Func<bool> predicate) where TModule : IModule
-    {
-        ArgumentNullException.ThrowIfNull(predicate);
-        return DependsOnIf(typeof(TModule), predicate());
-    }
-
-    /// <inheritdoc />
     public IDependencyDeclaration DependsOnIf(Type moduleType, bool condition)
     {
         if (!condition)
@@ -74,27 +67,6 @@ internal sealed class DependencyDeclaration : IDependencyDeclaration
 
         ValidateModuleType(moduleType);
         _dependencies.Add(DeclaredDependency.Conditional(moduleType));
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IDependencyDeclaration DependsOnIf(Type moduleType, Func<bool> predicate)
-    {
-        ArgumentNullException.ThrowIfNull(predicate);
-        return DependsOnIf(moduleType, predicate());
-    }
-
-    /// <inheritdoc />
-    public IDependencyDeclaration DependsOnLazy<TModule>() where TModule : IModule
-    {
-        return DependsOnLazy(typeof(TModule));
-    }
-
-    /// <inheritdoc />
-    public IDependencyDeclaration DependsOnLazy(Type moduleType)
-    {
-        ValidateModuleType(moduleType);
-        _dependencies.Add(DeclaredDependency.Lazy(moduleType));
         return this;
     }
 

--- a/src/ModularPipelines/Modules/DependencyDeclaration.cs
+++ b/src/ModularPipelines/Modules/DependencyDeclaration.cs
@@ -24,7 +24,8 @@ internal sealed class DependencyDeclaration : IDependencyDeclaration
     public IReadOnlyList<DeclaredDependency> Dependencies => _dependencies;
 
     /// <inheritdoc />
-    public IDependencyDeclaration DependsOn<TModule>() where TModule : IModule
+    public IDependencyDeclaration DependsOn<TModule>()
+        where TModule : IModule
     {
         return DependsOn(typeof(TModule));
     }
@@ -38,7 +39,8 @@ internal sealed class DependencyDeclaration : IDependencyDeclaration
     }
 
     /// <inheritdoc />
-    public IDependencyDeclaration DependsOnOptional<TModule>() where TModule : IModule
+    public IDependencyDeclaration DependsOnOptional<TModule>()
+        where TModule : IModule
     {
         return DependsOnOptional(typeof(TModule));
     }
@@ -52,7 +54,8 @@ internal sealed class DependencyDeclaration : IDependencyDeclaration
     }
 
     /// <inheritdoc />
-    public IDependencyDeclaration DependsOnIf<TModule>(bool condition) where TModule : IModule
+    public IDependencyDeclaration DependsOnIf<TModule>(bool condition)
+        where TModule : IModule
     {
         return DependsOnIf(typeof(TModule), condition);
     }

--- a/src/ModularPipelines/Modules/IDependencyDeclaration.cs
+++ b/src/ModularPipelines/Modules/IDependencyDeclaration.cs
@@ -24,13 +24,13 @@ namespace ModularPipelines.Modules;
 ///         // Optional dependency (doesn't fail if not registered)
 ///         deps.DependsOnOptional&lt;CachingModule&gt;();
 ///
-///         // Conditional dependency
+///         // Evaluate the condition before declaring a required dependency
 ///         if (Environment.IsProduction)
 ///         {
 ///             deps.DependsOn&lt;PerformanceMonitoringModule&gt;();
 ///         }
 ///
-///         // Conditional dependency
+///         // Declare a dependency only when the supplied value is true
 ///         deps.DependsOnIf&lt;HeavyProcessingModule&gt;(ShouldRunHeavyProcessing);
 ///     }
 /// }
@@ -46,7 +46,8 @@ public interface IDependencyDeclaration
     /// <exception cref="Exceptions.ModuleNotRegisteredException">
     /// Thrown during pipeline execution if the dependency is not registered.
     /// </exception>
-    IDependencyDeclaration DependsOn<TModule>() where TModule : IModule;
+    IDependencyDeclaration DependsOn<TModule>()
+        where TModule : IModule;
 
     /// <summary>
     /// Declares a required dependency on the specified module type.
@@ -67,7 +68,8 @@ public interface IDependencyDeclaration
     /// </summary>
     /// <typeparam name="TModule">The type of module to depend on.</typeparam>
     /// <returns>This instance for method chaining.</returns>
-    IDependencyDeclaration DependsOnOptional<TModule>() where TModule : IModule;
+    IDependencyDeclaration DependsOnOptional<TModule>()
+        where TModule : IModule;
 
     /// <summary>
     /// Declares an optional dependency on the specified module type.
@@ -89,7 +91,8 @@ public interface IDependencyDeclaration
     /// <remarks>
     /// If the condition is false, the dependency is not added at all.
     /// </remarks>
-    IDependencyDeclaration DependsOnIf<TModule>(bool condition) where TModule : IModule;
+    IDependencyDeclaration DependsOnIf<TModule>(bool condition)
+        where TModule : IModule;
 
     /// <summary>
     /// Declares a conditional dependency that is only active if the condition is true.

--- a/src/ModularPipelines/Modules/IDependencyDeclaration.cs
+++ b/src/ModularPipelines/Modules/IDependencyDeclaration.cs
@@ -30,8 +30,8 @@ namespace ModularPipelines.Modules;
 ///             deps.DependsOn&lt;PerformanceMonitoringModule&gt;();
 ///         }
 ///
-///         // Conditional with predicate
-///         deps.DependsOnIf&lt;HeavyProcessingModule&gt;(() =&gt; ShouldRunHeavyProcessing);
+///         // Conditional dependency
+///         deps.DependsOnIf&lt;HeavyProcessingModule&gt;(ShouldRunHeavyProcessing);
 ///     }
 /// }
 /// </code>
@@ -92,18 +92,6 @@ public interface IDependencyDeclaration
     IDependencyDeclaration DependsOnIf<TModule>(bool condition) where TModule : IModule;
 
     /// <summary>
-    /// Declares a conditional dependency that is only active if the predicate returns true.
-    /// </summary>
-    /// <typeparam name="TModule">The type of module to depend on.</typeparam>
-    /// <param name="predicate">The predicate that determines whether the dependency is active.</param>
-    /// <returns>This instance for method chaining.</returns>
-    /// <remarks>
-    /// The predicate is evaluated immediately when this method is called.
-    /// If it returns false, the dependency is not added at all.
-    /// </remarks>
-    IDependencyDeclaration DependsOnIf<TModule>(Func<bool> predicate) where TModule : IModule;
-
-    /// <summary>
     /// Declares a conditional dependency that is only active if the condition is true.
     /// </summary>
     /// <param name="moduleType">The type of module to depend on.</param>
@@ -113,55 +101,4 @@ public interface IDependencyDeclaration
     /// Thrown if the type does not implement <see cref="IModule"/>.
     /// </exception>
     IDependencyDeclaration DependsOnIf(Type moduleType, bool condition);
-
-    /// <summary>
-    /// Declares a conditional dependency that is only active if the predicate returns true.
-    /// </summary>
-    /// <param name="moduleType">The type of module to depend on.</param>
-    /// <param name="predicate">The predicate that determines whether the dependency is active.</param>
-    /// <returns>This instance for method chaining.</returns>
-    /// <exception cref="ArgumentException">
-    /// Thrown if the type does not implement <see cref="IModule"/>.
-    /// </exception>
-    IDependencyDeclaration DependsOnIf(Type moduleType, Func<bool> predicate);
-
-    /// <summary>
-    /// Declares a lazy dependency - an optional dependency intended to be awaited on-demand.
-    /// </summary>
-    /// <typeparam name="TModule">The type of module to depend on.</typeparam>
-    /// <returns>This instance for method chaining.</returns>
-    /// <remarks>
-    /// <para>
-    /// Lazy dependencies behave the same as <see cref="DependsOnOptional{TModule}"/> for
-    /// dependency resolution purposes - the dependency is optional and will not fail if not
-    /// registered. This is a semantic marker to indicate intent that the dependency may be
-    /// awaited on-demand rather than required upfront.
-    /// </para>
-    /// <para>
-    /// <strong>Important:</strong> The lazy module will still execute during normal pipeline
-    /// scheduling if it is registered. It does NOT defer execution until explicitly awaited.
-    /// The "lazy" designation indicates the dependency relationship is optional and the result
-    /// may be consumed on-demand, but does not affect when the module runs.
-    /// </para>
-    /// <para>
-    /// Use this to express intent for optional processing that may or may not be awaited.
-    /// </para>
-    /// </remarks>
-    IDependencyDeclaration DependsOnLazy<TModule>() where TModule : IModule;
-
-    /// <summary>
-    /// Declares a lazy dependency - an optional dependency intended to be awaited on-demand.
-    /// </summary>
-    /// <param name="moduleType">The type of module to depend on.</param>
-    /// <returns>This instance for method chaining.</returns>
-    /// <remarks>
-    /// <para>
-    /// Lazy dependencies behave the same as <see cref="DependsOnOptional(Type)"/> for
-    /// dependency resolution purposes. See <see cref="DependsOnLazy{TModule}"/> for full details.
-    /// </para>
-    /// </remarks>
-    /// <exception cref="ArgumentException">
-    /// Thrown if the type does not implement <see cref="IModule"/>.
-    /// </exception>
-    IDependencyDeclaration DependsOnLazy(Type moduleType);
 }

--- a/src/ModularPipelines/Modules/Module.cs
+++ b/src/ModularPipelines/Modules/Module.cs
@@ -151,7 +151,6 @@ public abstract class Module<T> : IModule, ITaggedModule
     ///     deps.DependsOn&lt;RequiredModule&gt;();
     ///     deps.DependsOnOptional&lt;OptionalModule&gt;();
     ///     deps.DependsOnIf&lt;ConditionalModule&gt;(SomeCondition);
-    ///     deps.DependsOnLazy&lt;HeavyModule&gt;();
     /// }
     /// </code>
     /// </example>

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigureTests.cs
@@ -76,10 +76,10 @@ public class ModuleConfigureTests
     }
 
     [ModularPipelines.Attributes.DependsOn<TestModule>]
-    private class RequiredAndLazyDependencyModule : Module<string>
+    private class RequiredAndOptionalDependencyModule : Module<string>
     {
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOnLazy<TestModule>()
+            .DependsOnOptional<TestModule>()
             .Build();
 
         protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -160,7 +160,7 @@ public class ModuleConfigureTests
     [Test]
     public async Task Module_Configuration_Uses_Strictest_Duplicate_Dependency()
     {
-        var dependency = ((IModule) new RequiredAndLazyDependencyModule()).Configuration.Dependencies.Single();
+        var dependency = ((IModule) new RequiredAndOptionalDependencyModule()).Configuration.Dependencies.Single();
 
         await Assert.That(dependency.Kind).IsEqualTo(DependencyType.Required);
         await Assert.That(dependency.IsOptional).IsFalse();

--- a/test/ModularPipelines.UnitTests/Dependencies/DependencyApiSurfaceTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/DependencyApiSurfaceTests.cs
@@ -1,0 +1,38 @@
+using ModularPipelines.Configuration;
+using ModularPipelines.Enums;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.UnitTests.Dependencies;
+
+public class DependencyApiSurfaceTests
+{
+    [Test]
+    public async Task Redundant_Dependency_APIs_Are_Not_Exposed()
+    {
+        var dependencyApiTypes = new[]
+        {
+            typeof(IDependencyDeclaration),
+            typeof(DependencyDeclaration),
+            typeof(ModuleConfigurationBuilder),
+        };
+        var lazyMethods = dependencyApiTypes
+            .SelectMany(static type => type.GetMethods())
+            .Where(static method => method.Name == "DependsOnLazy")
+            .ToArray();
+        var predicateOverloads = dependencyApiTypes
+            .SelectMany(static type => type.GetMethods())
+            .Where(static method => method.Name == "DependsOnIf")
+            .Where(static method => method.GetParameters()
+                .Any(static parameter => parameter.ParameterType == typeof(Func<bool>)))
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(lazyMethods).IsEmpty();
+            await Assert.That(predicateOverloads).IsEmpty();
+            await Assert.That(Enum.GetNames<DependencyType>()).DoesNotContain("Lazy");
+            await Assert.That(typeof(DeclaredDependency).GetMethod("Lazy")).IsNull();
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Dependencies/DynamicDependencyDeclarationTests.cs
+++ b/test/ModularPipelines.UnitTests/Dependencies/DynamicDependencyDeclarationTests.cs
@@ -33,14 +33,6 @@ public class DynamicDependencyDeclarationTests : TestBase
     }
 
     /// <summary>
-    /// A module for testing lazy dependencies.
-    /// </summary>
-    private class LazyModule : SimpleTestModule<string>
-    {
-        protected override string Result => "lazy";
-    }
-
-    /// <summary>
     /// A module for testing conditional dependencies.
     /// </summary>
     private class ConditionalModule : SimpleTestModule<string>
@@ -117,42 +109,6 @@ public class DynamicDependencyDeclarationTests : TestBase
     }
 
     /// <summary>
-    /// A module that declares a conditional dependency using a predicate.
-    /// </summary>
-    private class ModuleWithPredicateConditionalDependency : Module<string>
-    {
-        public static bool ShouldDependOnConditional { get; set; } = true;
-
-        protected override void DeclareDependencies(IDependencyDeclaration deps)
-        {
-            deps.DependsOnIf<ConditionalModule>(() => ShouldDependOnConditional);
-        }
-
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-        {
-            await Task.Yield();
-            return "predicate-conditional";
-        }
-    }
-
-    /// <summary>
-    /// A module that declares a lazy dependency.
-    /// </summary>
-    private class ModuleWithLazyDependency : Module<string>
-    {
-        protected override void DeclareDependencies(IDependencyDeclaration deps)
-        {
-            deps.DependsOnLazy<LazyModule>();
-        }
-
-        protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-        {
-            await Task.Yield();
-            return "lazy-dep";
-        }
-    }
-
-    /// <summary>
     /// A module that combines both attribute and programmatic dependencies.
     /// </summary>
     [ModularPipelines.Attributes.DependsOn<BaseModule>]
@@ -178,8 +134,7 @@ public class DynamicDependencyDeclarationTests : TestBase
         protected override void DeclareDependencies(IDependencyDeclaration deps)
         {
             deps.DependsOn<BaseModule>()
-                .DependsOnOptional<OptionalDependencyModule>()
-                .DependsOnLazy<LazyModule>();
+                .DependsOnOptional<OptionalDependencyModule>();
         }
 
         protected internal override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -317,58 +272,6 @@ public class DynamicDependencyDeclarationTests : TestBase
         await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
     }
 
-    [Test]
-    [TUnit.Core.NotInParallel(Order = 1)]
-    public async Task Conditional_Predicate_Dependency_Works_When_Predicate_Returns_True()
-    {
-        ModuleWithPredicateConditionalDependency.ShouldDependOnConditional = true;
-
-        var pipelineSummary = await TestPipelineHostBuilder.Create()
-            .AddModule<ConditionalModule>()
-            .AddModule<ModuleWithPredicateConditionalDependency>()
-            .ExecutePipelineAsync();
-
-        await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
-    }
-
-    [Test]
-    [TUnit.Core.NotInParallel(Order = 2)]
-    public async Task Conditional_Predicate_Dependency_Not_Added_When_Predicate_Returns_False()
-    {
-        ModuleWithPredicateConditionalDependency.ShouldDependOnConditional = false;
-
-        var pipelineSummary = await TestPipelineHostBuilder.Create()
-            .AddModule<ModuleWithPredicateConditionalDependency>()
-            .ExecutePipelineAsync();
-
-        await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
-    }
-
-    #endregion
-
-    #region Lazy Dependency Tests
-
-    [Test]
-    public async Task Lazy_Dependency_Does_Not_Fail_When_Not_Registered()
-    {
-        var pipelineSummary = await TestPipelineHostBuilder.Create()
-            .AddModule<ModuleWithLazyDependency>()
-            .ExecutePipelineAsync();
-
-        await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
-    }
-
-    [Test]
-    public async Task Lazy_Dependency_Works_When_Registered()
-    {
-        var pipelineSummary = await TestPipelineHostBuilder.Create()
-            .AddModule<LazyModule>()
-            .AddModule<ModuleWithLazyDependency>()
-            .ExecutePipelineAsync();
-
-        await Assert.That(pipelineSummary.Status).IsEqualTo(Status.Successful);
-    }
-
     #endregion
 
     #region Combined Dependency Tests
@@ -402,7 +305,6 @@ public class DynamicDependencyDeclarationTests : TestBase
         var pipelineSummary = await TestPipelineHostBuilder.Create()
             .AddModule<BaseModule>()
             .AddModule<OptionalDependencyModule>()
-            .AddModule<LazyModule>()
             .AddModule<ModuleWithChainedDependencies>()
             .ExecutePipelineAsync();
 
@@ -455,16 +357,6 @@ public class DynamicDependencyDeclarationTests : TestBase
     }
 
     [Test]
-    public async Task DependencyDeclaration_DependsOnLazy_Returns_Same_Instance_For_Chaining()
-    {
-        var declaration = new DependencyDeclaration();
-
-        var result = declaration.DependsOnLazy<BaseModule>();
-
-        await Assert.That(result).IsSameReferenceAs(declaration);
-    }
-
-    [Test]
     public async Task DependencyDeclaration_Throws_For_Non_Module_Type()
     {
         var declaration = new DependencyDeclaration();
@@ -497,19 +389,6 @@ public class DynamicDependencyDeclarationTests : TestBase
 
         await Assert.That(deps).Count().IsEqualTo(1);
         await Assert.That(deps[0].Kind).IsEqualTo(DependencyType.Optional);
-        await Assert.That(deps[0].IsOptional).IsTrue();
-    }
-
-    [Test]
-    public async Task DependencyDeclaration_Lazy_Has_Correct_DependencyType()
-    {
-        var declaration = new DependencyDeclaration();
-        declaration.DependsOnLazy<BaseModule>();
-
-        var deps = declaration.Dependencies;
-
-        await Assert.That(deps).Count().IsEqualTo(1);
-        await Assert.That(deps[0].Kind).IsEqualTo(DependencyType.Lazy);
         await Assert.That(deps[0].IsOptional).IsTrue();
     }
 


### PR DESCRIPTION
## Summary
- remove no-op `DependsOnLazy` APIs and `DependencyType.Lazy`
- remove eagerly evaluated `DependsOnIf(Func<bool>)` overloads
- update dependency tests and current/versioned migration docs

## Tests
- `DependencyApiSurfaceTests` (1 passed)
- `DynamicDependencyDeclarationTests` (20 passed)
- `ModuleConfigureTests` (6 passed)
- `npm run build --prefix docs`
- guarded `dotnet build ModularPipelines.sln -c Release --no-restore` (0 errors)

## Breaking change
Removes `DependsOnLazy`, `DependsOnIf(Func<bool>)`, `DependencyType.Lazy`, and `DeclaredDependency.Lazy`. Use `DependsOnOptional` or evaluate the condition before calling `DependsOnIf(bool)`.

Closes #3284