### PR TITLE
Make SkipDecision immutable

### DIFF
--- a/src/ModularPipelines/Models/SkipDecision.cs
+++ b/src/ModularPipelines/Models/SkipDecision.cs
@@ -3,11 +3,20 @@ using System.Text.Json.Serialization;
 
 namespace ModularPipelines.Models;
 
+/// <summary>
+/// Represents the result of evaluating whether a module should be skipped.
+/// </summary>
 public sealed record SkipDecision
 {
+    /// <summary>
+    /// Gets a value indicating whether the module should be skipped.
+    /// </summary>
     [JsonInclude]
-    public bool ShouldSkip { get; private set; }
+    public bool ShouldSkip { get; private init; }
 
+    /// <summary>
+    /// Gets the reason the module should be skipped, or <see langword="null"/> when no reason was provided.
+    /// </summary>
     [JsonInclude]
     public string? Reason { get; private init; }
 
@@ -22,21 +31,36 @@ public sealed record SkipDecision
         ShouldSkip = shouldSkip;
     }
 
+    /// <summary>
+    /// Gets a decision that allows the module to run.
+    /// </summary>
     public static readonly SkipDecision DoNotSkip = new(false);
 
+    /// <summary>
+    /// Creates a decision that skips the module.
+    /// </summary>
+    /// <param name="reason">The reason for skipping the module, or <see langword="null"/> when unspecified.</param>
+    /// <returns>A decision that skips the module.</returns>
     public static SkipDecision Skip(string? reason) => new(true)
     {
         Reason = reason,
     };
 
+    /// <summary>
+    /// Creates a skip decision from a boolean condition.
+    /// </summary>
+    /// <param name="shouldSkip"><see langword="true"/> to skip the module; otherwise, <see langword="false"/>.</param>
+    /// <param name="reason">The reason for skipping, used only when <paramref name="shouldSkip"/> is <see langword="true"/>.</param>
+    /// <returns>A decision matching <paramref name="shouldSkip"/>.</returns>
     public static SkipDecision Of(bool shouldSkip, string? reason) => new(shouldSkip)
     {
         Reason = shouldSkip ? reason : null,
     };
 
+    /// <summary>
+    /// Converts a boolean condition to a skip decision.
+    /// </summary>
+    /// <param name="shouldSkip"><see langword="true"/> to skip the module; otherwise, <see langword="false"/>.</param>
+    /// <returns>A decision matching <paramref name="shouldSkip"/>.</returns>
     public static implicit operator SkipDecision(bool shouldSkip) => shouldSkip ? Skip(null) : DoNotSkip;
-
-    public static implicit operator SkipDecision(string reason) => Skip(reason);
-
-    public static implicit operator Task<SkipDecision>(SkipDecision skipDecision) => Task.FromResult(skipDecision);
 }

--- a/test/ModularPipelines.UnitTests/Models/SkipDecisionTests.cs
+++ b/test/ModularPipelines.UnitTests/Models/SkipDecisionTests.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
 using ModularPipelines.Models;
 
 namespace ModularPipelines.UnitTests.Models;
@@ -17,15 +19,39 @@ public class SkipDecisionTests
     }
 
     [Test]
-    public async Task String_Implicit_Cast()
+    public async Task ImplicitConversions_OnlyExposeBooleanToSkipDecision()
     {
-        SkipDecision skipDecision = "Foo!";
+        var conversions = typeof(SkipDecision)
+            .GetMethods()
+            .Where(method => method.Name == "op_Implicit")
+            .Select(method =>
+                $"{method.GetParameters().Single().ParameterType.FullName}->{method.ReturnType.FullName}")
+            .ToArray();
 
-        using (Assert.Multiple())
-        {
-            await Assert.That(skipDecision.ShouldSkip).IsTrue();
-            await Assert.That(skipDecision.Reason).IsEqualTo("Foo!");
-        }
+        await Assert.That(conversions).IsEquivalentTo(
+            [$"{typeof(bool).FullName}->{typeof(SkipDecision).FullName}"]);
+    }
+
+    [Test]
+    public async Task ShouldSkip_IsInitOnly()
+    {
+        var setter = typeof(SkipDecision)
+            .GetProperty(nameof(SkipDecision.ShouldSkip))!
+            .SetMethod!;
+
+        await Assert.That(setter.ReturnParameter.GetRequiredCustomModifiers())
+            .Contains(typeof(IsExternalInit));
+    }
+
+    [Test]
+    public async Task JsonRoundTrip_PreservesDecision()
+    {
+        var expected = SkipDecision.Skip("Serialized reason");
+
+        var json = JsonSerializer.Serialize(expected);
+        var actual = JsonSerializer.Deserialize<SkipDecision>(json);
+
+        await Assert.That(actual).IsEqualTo(expected);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- remove implicit `string -> SkipDecision` and `SkipDecision -> Task<SkipDecision>` conversions while retaining the intentional boolean conversion
- make `ShouldSkip` private-init-only so decisions cannot mutate after construction
- document the complete public `SkipDecision` API
- cover conversion surface, init metadata, factories, and JSON round-trip behavior

## Breaking change
Call `SkipDecision.Skip(reason)` explicitly and use `Task.FromResult(decision)` where a task is required.

## Test plan
- [x] 9 focused `SkipDecisionTests`
- [x] `ModularPipelines.sln` Release build (0 errors)
- [x] whitespace format verification

Closes #3289
