### PR TITLE
Mark unwired matrix API experimental

### DIFF
--- a/docs/docs/distributed/capabilities.md
+++ b/docs/docs/distributed/capabilities.md
@@ -88,24 +88,6 @@ public class LinuxDockerModule : Module<string>
 
 Modules without `[RequiresCapability]` can run on any worker. They have no routing restrictions.
 
-## MatrixTarget Attribute
-
-The `[MatrixTarget]` attribute is designed for modules that need to run once per target value — for example, building for multiple operating systems or configurations.
-
-```csharp
-[MatrixTarget("windows", "linux", "macos")]
-public class PlatformBuildModule : Module<string>
-{
-    protected override async Task<string?> ExecuteAsync(
-        IModuleContext context, CancellationToken cancellationToken)
-    {
-        return "built";
-    }
-}
-```
-
-When the master encounters a matrix module, it expands it into one assignment per target. Each expanded instance gets a capability requirement matching its target value, so `"windows"` is sent to a worker with the `"windows"` capability, `"linux"` to a Linux worker, and so on.
-
 ## Capability Matching Rules
 
 The matching logic is straightforward:

--- a/src/ModularPipelines/Context/IModuleContext.cs
+++ b/src/ModularPipelines/Context/IModuleContext.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
@@ -181,10 +182,14 @@ public interface IModuleContext : IPipelineContext
         where TModule : class, IModule;
 
     /// <summary>
-    /// Gets the matrix target value for this module instance, if it was expanded via <see cref="Attributes.MatrixTargetAttribute"/>.
-    /// Returns <c>null</c> if this is not an expanded matrix module instance.
+    /// Gets the matrix target value reserved for future distributed matrix execution.
     /// </summary>
+    /// <remarks>
+    /// Matrix module expansion is not yet connected to the distributed executor.
+    /// This method currently returns <c>null</c>.
+    /// </remarks>
     /// <returns>The matrix target string, or <c>null</c>.</returns>
+    [Experimental("MPDIST001")]
     string? GetMatrixTarget();
 
     /// <summary>

--- a/test/ModularPipelines.UnitTests/Context/ContextHierarchyTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextHierarchyTests.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains;
 using ModularPipelines.Logging;
@@ -102,6 +104,16 @@ public class ContextHierarchyTests
         var getModuleIfRegisteredMethods = moduleContextType.GetMethods().Where(m => m.Name == "GetModuleIfRegistered").ToArray();
         await Assert.That(getModuleIfRegisteredMethods.Length).IsGreaterThanOrEqualTo(1)
             .Because("IModuleContext should have GetModuleIfRegistered method(s)");
+    }
+
+    [Test]
+    public async Task MatrixTargetApi_ShouldBeExperimentalUntilExecutionIsWired()
+    {
+        var method = typeof(IModuleContext).GetMethod("GetMatrixTarget");
+        var experimental = method?.GetCustomAttribute<ExperimentalAttribute>();
+
+        await Assert.That(experimental).IsNotNull();
+        await Assert.That(experimental!.DiagnosticId).IsEqualTo("MPDIST001");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- mark `IModuleContext.GetMatrixTarget()` experimental with diagnostic `MPDIST001`
- document that distributed matrix expansion is not yet connected and currently returns `null`
- remove documentation claiming matrix modules are expanded and routed today
- add a reflection contract test for the experimental marker

## Validation
- `ModularPipelines.sln` Release build: passed (0 warnings, 0 errors)
- focused unit test: passed (1/1)
- touched-file formatter verification: passed
- full unit project attempt exceeded the required 2 GB agent guard before tests; limits were not raised

Closes #3276