### PR TITLE
Reshape module retry configuration

### DIFF
--- a/docs/docs/how-to/defining-modules.md
+++ b/docs/docs/how-to/defining-modules.md
@@ -64,7 +64,7 @@ public class MyModule : Module<FileInfo>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
         .WithTimeout(TimeSpan.FromMinutes(5))
-        .WithRetryCount(3)
+        .WithRetry(3)
         .WithSkipWhen(_ => !File.Exists("important.json")
             ? SkipDecision.Skip("important.json does not exist")
             : SkipDecision.DoNotSkip)
@@ -90,8 +90,8 @@ public class MyModule : Module<FileInfo>
 | Method | Description |
 |--------|-------------|
 | `.WithTimeout(TimeSpan)` | Maximum execution time before module is cancelled |
-| `.WithRetryCount(int)` | Number of retry attempts on failure |
-| `.WithRetryPolicy(IAsyncPolicy)` | Custom Polly retry policy |
+| `.WithRetry(int, TimeSpan?, Func<Exception, bool>?)` | Retry attempts, jittered base delay, and optional exception filter |
+| `.Advanced.WithRetryPolicy(IAsyncPolicy)` | Custom Polly policy for advanced scenarios |
 | `.WithSkipWhen(...)` | Condition to skip the module |
 | `.WithIgnoreFailures()` | Don't fail the pipeline if this module fails |
 | `.WithIgnoreFailuresWhen(...)` | Conditionally ignore failures |

--- a/docs/docs/how-to/ignoring-failures.md
+++ b/docs/docs/how-to/ignoring-failures.md
@@ -74,7 +74,7 @@ Ignoring failures can be combined with other module behaviors:
 public class ResilientModule : Module<CommandResult>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-        .WithRetryCount(3)  // Try 3 times first
+        .WithRetry(3)  // Try 3 times first
         .WithIgnoreFailuresWhen((ctx, ex) => ex is HttpRequestException)  // Then ignore HTTP errors
         .WithAlwaysRun()  // Run even if dependencies failed
         .Build();

--- a/docs/docs/how-to/retry-policy.md
+++ b/docs/docs/how-to/retry-policy.md
@@ -5,19 +5,21 @@ sidebar_position: 6
 
 # Retry Policies
 
-When creating modules, you can set a retry policy per module using the `Configure()` method. The retry policy uses Polly, so if you've used Polly before you should be familiar with how to use it.
+When creating modules, you can configure retries per module using the `Configure()` method.
+The standard API supports exponential backoff, jitter, and exception filtering without exposing
+the underlying resilience library.
 
 ## Using ModuleConfiguration
 
-### Simple Retry Count
+### Simple Retries
 
-The easiest way to add retries is with `WithRetryCount()`:
+The easiest way to add retries is with `WithRetry()`:
 
 ```csharp
 public class MyModule : Module<CommandResult>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-        .WithRetryCount(3)  // Retry up to 3 times with exponential backoff
+        .WithRetry(3)  // Retry up to 3 times with exponential backoff and jitter
         .Build();
 
     protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -27,14 +29,28 @@ public class MyModule : Module<CommandResult>
 }
 ```
 
-### Custom Polly Policy
+The default base delay is 100 milliseconds. Each retry uses equal jitter between half and all of
+its exponential-backoff ceiling. You can set a different base delay and limit retries to selected
+exceptions:
 
-For more control, you can provide a custom Polly policy:
+```csharp
+protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    .WithRetry(
+        count: 5,
+        baseDelay: TimeSpan.FromSeconds(1),
+        shouldRetry: exception => exception is HttpRequestException)
+    .Build();
+```
+
+### Advanced Polly Policy
+
+For policy features outside the standard API, use the explicit `.Advanced` surface:
 
 ```csharp
 public class MyModule : Module<CommandResult>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        .Advanced
         .WithRetryPolicy(
             Policy.Handle<HttpRequestException>()
                 .WaitAndRetryAsync(5, i => TimeSpan.FromSeconds(i * i)))
@@ -55,6 +71,7 @@ If you need access to the pipeline context when building your policy:
 public class MyModule : Module<CommandResult>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+        .Advanced
         .WithRetryPolicy(ctx =>
         {
             var retryCount = ctx.Environment.IsCI ? 5 : 2;
@@ -73,7 +90,7 @@ Retry policies can be combined with other module behaviors:
 public class ResilientModule : Module<CommandResult>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-        .WithRetryCount(3)
+        .WithRetry(3)
         .WithTimeout(TimeSpan.FromMinutes(10))
         .WithIgnoreFailures()  // Don't fail the pipeline even after all retries
         .Build();

--- a/docs/docs/how-to/timeouts.md
+++ b/docs/docs/how-to/timeouts.md
@@ -41,7 +41,7 @@ public class ResilientModule : Module<CommandResult>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
         .WithTimeout(TimeSpan.FromMinutes(5))
-        .WithRetryCount(3)  // Retry if timeout or other failure occurs
+        .WithRetry(3)  // Retry if timeout or other failure occurs
         .WithIgnoreFailures()  // Don't fail the pipeline if module times out
         .Build();
 

--- a/docs/docs/migrating-to-v3.md
+++ b/docs/docs/migrating-to-v3.md
@@ -218,7 +218,7 @@ public class MyModule : Module<string>
 {
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
         .WithTimeout(TimeSpan.FromMinutes(5))
-        .WithRetryCount(3)
+        .WithRetry(3)
         .WithSkipWhen(async ctx => (await ctx.Git().Information.GetInfoAsync())?.BranchName != "main"
             ? SkipDecision.Skip("Only runs on main branch")
             : SkipDecision.DoNotSkip)
@@ -240,7 +240,7 @@ public class MyModule : Module<string>
 | V2 Override | V3 Configure() Method |
 |-------------|----------------------|
 | `TimeSpan Timeout` property | `.WithTimeout(TimeSpan)` |
-| `AsyncRetryPolicy<T?> RetryPolicy` property | `.WithRetryCount(int)` or `.WithRetryPolicy(IAsyncPolicy)` |
+| `AsyncRetryPolicy<T?> RetryPolicy` property | `.WithRetry(int, ...)` or `.Advanced.WithRetryPolicy(IAsyncPolicy)` |
 | `Task<SkipDecision> ShouldSkip()` method | `.WithSkipWhen(...)` |
 | `Task<bool> ShouldIgnoreFailures()` method | `.WithIgnoreFailures()` or `.WithIgnoreFailuresWhen(...)` |
 | `ModuleRunType.AlwaysRun` | `.WithAlwaysRun()` |
@@ -867,7 +867,7 @@ The following have been removed in V3:
 | `ShouldIgnoreFailures()` method | `Configure().WithIgnoreFailures()` |
 | `ModuleRunType` property | `Configure().WithAlwaysRun()` |
 | `Timeout` property | `Configure().WithTimeout()` |
-| `RetryPolicy` property | `Configure().WithRetryCount()` or `.WithRetryPolicy()` |
+| `RetryPolicy` property | `Configure().WithRetry()` or `.Advanced.WithRetryPolicy()` |
 | `GetModule<T>()` on module | `context.GetModule<TModule>()` |
 
 ## New Features in V3
@@ -1190,7 +1190,7 @@ public class DeployModule : Module<bool>
 | `ShouldSkip()` override | `Configure().WithSkipWhen()` | Fluent builder |
 | `ShouldIgnoreFailures()` override | `Configure().WithIgnoreFailures()` | Fluent builder |
 | `Timeout` property override | `Configure().WithTimeout()` | Fluent builder |
-| `RetryPolicy` property override | `Configure().WithRetryCount()` | Fluent builder |
+| `RetryPolicy` property override | `Configure().WithRetry()` | Fluent builder |
 | `ModuleRunType` override | `Configure().WithAlwaysRun()` | Fluent builder |
 | `OnBeforeExecute()` override | `OnBeforeExecuteAsync()` | Override the module virtual |
 | `OnAfterExecute()` override | `OnAfterExecuteAsync()` | Override the module virtual |
@@ -1271,7 +1271,7 @@ This section provides structured data optimized for AI assistants helping with c
   new: "Configure().WithTimeout(TimeSpan)"
 
 - old: "protected override AsyncRetryPolicy<T?> RetryPolicy => ..."
-  new: "Configure().WithRetryCount(int)"
+  new: "Configure().WithRetry(int)"
 
 - old: "protected internal override Task<SkipDecision> ShouldSkip(...)"
   new: "Configure().WithSkipWhen(Func<IModuleContext, SkipDecision>)"
@@ -1369,7 +1369,7 @@ This section provides structured data optimized for AI assistants helping with c
 | `CS0117: 'ModuleResult' does not contain 'Exception'` | Property renamed | Change `.Exception` to `.ExceptionOrDefault` |
 | `CS0115: 'ShouldSkip': no suitable method found to override` | Method removed | Use `Configure().WithSkipWhen()` instead |
 | `CS0115: 'Timeout': no suitable method found to override` | Property removed | Use `Configure().WithTimeout()` instead |
-| `CS0115: 'RetryPolicy': no suitable method found to override` | Property removed | Use `Configure().WithRetryCount()` instead |
+| `CS0115: 'RetryPolicy': no suitable method found to override` | Property removed | Use `Configure().WithRetry()` instead |
 | `CS1061: 'DotNetBuildOptions' does not contain 'WorkingDirectory'` | Property moved | Pass `CommandExecutionOptions` as second parameter |
 | `CS1061: 'DotNetBuildOptions' does not contain 'LogInput'` | Property moved | Use `CommandExecutionOptions.LogSettings` with `CommandLoggingOptions` |
 | `CS0246: 'CommandLoggingOptions' could not be found` | Missing using | Add `using ModularPipelines.Options;` |
@@ -1498,7 +1498,7 @@ await context.DotNet().Build(
 
 ### Keywords for Search
 
-ModularPipelines, V3 migration, PipelineHostBuilder, Pipeline.CreateBuilder, IPipelineContext, IModuleContext, GetModule, ModuleResult, ValueOrDefault, ExceptionOrDefault, IsSuccess, IsFailure, IsSkipped, ModuleConfiguration, Configure, WithTimeout, WithRetryCount, WithSkipWhen, WithIgnoreFailures, WithAlwaysRun, CommandExecutionOptions, WorkingDirectory, EnvironmentVariables, Module, SyncModule, None struct, ExecuteAsync, Execute, SubModule, context.SubModule, CommandLoggingOptions, CommandLogVerbosity, context.Shell.Command, context.Shell.Bash, context.Shell.PowerShell, DotNetNewOptions, DotNetPackOptions, GitTagOptions, TemplateShortName, property initializer, constructor removed, token parameter
+ModularPipelines, V3 migration, PipelineHostBuilder, Pipeline.CreateBuilder, IPipelineContext, IModuleContext, GetModule, ModuleResult, ValueOrDefault, ExceptionOrDefault, IsSuccess, IsFailure, IsSkipped, ModuleConfiguration, Configure, WithTimeout, WithRetry, WithSkipWhen, WithIgnoreFailures, WithAlwaysRun, CommandExecutionOptions, WorkingDirectory, EnvironmentVariables, Module non-generic, SyncModule, None struct, ExecuteModuleAsync, ExecuteModule, SubModule, context.SubModule, CommandLoggingOptions, CommandLogVerbosity, context.Shell.Command, context.Shell.Bash, context.Shell.PowerShell, DotNetNewOptions, DotNetPackOptions, GitTagOptions, TemplateShortName, property initializer, constructor removed, token parameter
 
 ## Getting Help
 

--- a/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
+++ b/src/ModularPipelines.Build/Modules/UnitTests/RunUnitTestModule.cs
@@ -35,6 +35,7 @@ public abstract partial class RunUnitTestModule(IOptions<PipelineSettings> pipel
 
     protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
         .WithSkipWhen(GetSkipDecision)
+        .Advanced
         .WithRetryPolicy(Policy.Handle<Exception>().RetryAsync(0))
         .Build();
 

--- a/src/ModularPipelines/Configuration/AdvancedModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/AdvancedModuleConfigurationBuilder.cs
@@ -1,0 +1,39 @@
+using ModularPipelines.Context;
+using Polly;
+
+namespace ModularPipelines.Configuration;
+
+/// <summary>
+/// Provides advanced module configuration that depends on third-party policy abstractions.
+/// </summary>
+public sealed class AdvancedModuleConfigurationBuilder
+{
+    private readonly ModuleConfigurationBuilder _builder;
+
+    internal AdvancedModuleConfigurationBuilder(ModuleConfigurationBuilder builder)
+    {
+        _builder = builder;
+    }
+
+    /// <summary>
+    /// Sets a custom Polly async policy for module execution.
+    /// </summary>
+    /// <param name="policy">The Polly async policy to execute around the module.</param>
+    /// <returns>The parent module configuration builder.</returns>
+    public ModuleConfigurationBuilder WithRetryPolicy(IAsyncPolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+        return _builder.SetAdvancedRetryPolicy(_ => policy);
+    }
+
+    /// <summary>
+    /// Sets a factory that creates a custom Polly async policy from the module context.
+    /// </summary>
+    /// <param name="factory">The policy factory.</param>
+    /// <returns>The parent module configuration builder.</returns>
+    public ModuleConfigurationBuilder WithRetryPolicy(Func<IModuleContext, IAsyncPolicy> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        return _builder.SetAdvancedRetryPolicy(factory);
+    }
+}

--- a/src/ModularPipelines/Configuration/ModuleConfiguration.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfiguration.cs
@@ -39,7 +39,7 @@ public sealed class ModuleConfiguration
     /// <code>
     /// var config = ModuleConfiguration.Create()
     ///     .WithTimeout(TimeSpan.FromMinutes(5))
-    ///     .WithRetryCount(3)
+    ///     .WithRetry(3)
     ///     .Build();
     /// </code>
     /// </example>
@@ -63,15 +63,6 @@ public sealed class ModuleConfiguration
     /// or null if no timeout is configured.
     /// </value>
     public TimeSpan? Timeout { get; init; }
-
-    /// <summary>
-    /// Gets the factory function that creates a retry policy for module execution.
-    /// </summary>
-    /// <value>
-    /// A function that takes an <see cref="IModuleContext"/> and returns an <see cref="IAsyncPolicy"/>,
-    /// or null if no retry policy is configured.
-    /// </value>
-    public Func<IModuleContext, IAsyncPolicy>? RetryPolicyFactory { get; init; }
 
     /// <summary>
     /// Gets the condition that determines whether a failure should be ignored.
@@ -122,4 +113,14 @@ public sealed class ModuleConfiguration
     /// Gets dependencies declared through fluent configuration or attributes.
     /// </summary>
     internal IReadOnlyList<DeclaredDependency> Dependencies { get; init; } = [];
+
+    /// <summary>
+    /// Gets the standard retry configuration for module execution.
+    /// </summary>
+    internal ModuleRetryConfiguration? RetryConfiguration { get; init; }
+
+    /// <summary>
+    /// Gets the advanced policy factory for module execution.
+    /// </summary>
+    internal Func<IModuleContext, IAsyncPolicy>? AdvancedRetryPolicyFactory { get; init; }
 }

--- a/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
@@ -34,7 +34,8 @@ internal static class ModuleConfigurationAttributeAdapter
         {
             SkipCondition = configured.SkipCondition,
             Timeout = configured.Timeout,
-            RetryPolicyFactory = configured.RetryPolicyFactory,
+            RetryConfiguration = configured.RetryConfiguration,
+            AdvancedRetryPolicyFactory = configured.AdvancedRetryPolicyFactory,
             IgnoreFailuresCondition = configured.IgnoreFailuresCondition,
             AlwaysRun = configured.AlwaysRun,
             ParallelConstraintKeys = configured.ParallelConstraintKeys

--- a/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
@@ -356,6 +356,13 @@ public sealed class ModuleConfigurationBuilder
         };
     }
 
+    internal ModuleConfigurationBuilder SetAdvancedRetryPolicy(Func<IModuleContext, IAsyncPolicy> factory)
+    {
+        _advancedRetryPolicyFactory = factory;
+        _retryConfiguration = null;
+        return this;
+    }
+
     private Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>? ComposeSkipConditions()
     {
         if (_skipConditions.Count == 0)
@@ -384,13 +391,6 @@ public sealed class ModuleConfigurationBuilder
 
             return SkipDecision.Skip(reasons is null ? null : string.Join("; ", reasons));
         };
-    }
-
-    internal ModuleConfigurationBuilder SetAdvancedRetryPolicy(Func<IModuleContext, IAsyncPolicy> factory)
-    {
-        _advancedRetryPolicyFactory = factory;
-        _retryConfiguration = null;
-        return this;
     }
 
     private static void ValidateModuleType(Type moduleType)

--- a/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
@@ -27,7 +27,7 @@ namespace ModularPipelines.Configuration;
 ///         ? SkipDecision.Skip("Configured skip condition returned true")
 ///         : SkipDecision.DoNotSkip)
 ///     .WithTimeout(TimeSpan.FromMinutes(5))
-///     .WithRetryCount(3)
+///     .WithRetry(3)
 ///     .WithIgnoreFailures()
 ///     .WithAlwaysRun()
 ///     .Build();
@@ -39,13 +39,19 @@ public sealed class ModuleConfigurationBuilder
     private readonly List<DeclaredDependency> _dependencies = [];
     private readonly List<Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>> _skipConditions = [];
     private TimeSpan? _timeout;
-    private Func<IModuleContext, IAsyncPolicy>? _retryPolicyFactory;
+    private ModuleRetryConfiguration? _retryConfiguration;
+    private Func<IModuleContext, IAsyncPolicy>? _advancedRetryPolicyFactory;
     private Func<IModuleContext, Exception, Task<bool>>? _ignoreFailuresCondition;
     private bool _alwaysRun;
     private string[]? _parallelConstraintKeys;
     private ModulePriority? _priority;
     private ExecutionType? _executionType;
     private string? _category;
+
+    /// <summary>
+    /// Gets advanced configuration APIs that expose third-party policy abstractions.
+    /// </summary>
+    public AdvancedModuleConfigurationBuilder Advanced => new(this);
 
     #region WithSkipWhen Overloads
 
@@ -244,43 +250,34 @@ public sealed class ModuleConfigurationBuilder
 
     #endregion
 
-    #region WithRetryPolicy Overloads
+    #region WithRetry
 
     /// <summary>
-    /// Sets a retry policy for module execution.
+    /// Configures retries with exponential backoff and jitter.
     /// </summary>
-    /// <param name="policy">The Polly async policy to use for retries.</param>
-    /// <returns>This builder instance for method chaining.</returns>
-    public ModuleConfigurationBuilder WithRetryPolicy(IAsyncPolicy policy)
-    {
-        _retryPolicyFactory = _ => policy;
-        return this;
-    }
-
-    /// <summary>
-    /// Sets a retry policy factory that creates the policy based on the module context.
-    /// </summary>
-    /// <param name="factory">A factory function that creates a Polly async policy using the module context.</param>
-    /// <returns>This builder instance for method chaining.</returns>
-    public ModuleConfigurationBuilder WithRetryPolicy(Func<IModuleContext, IAsyncPolicy> factory)
-    {
-        _retryPolicyFactory = factory;
-        return this;
-    }
-
-    /// <summary>
-    /// Sets a simple retry count using an exponential backoff strategy.
-    /// </summary>
-    /// <param name="count">The number of retry attempts.</param>
+    /// <param name="count">The number of retry attempts after the initial execution.</param>
+    /// <param name="baseDelay">The first exponential-backoff ceiling. Defaults to 100 milliseconds.</param>
+    /// <param name="shouldRetry">An optional predicate that selects retryable exceptions.</param>
     /// <returns>This builder instance for method chaining.</returns>
     /// <remarks>
-    /// This creates a retry policy with exponential backoff where each retry waits
-    /// (attempt^2 * 100) milliseconds before the next attempt.
+    /// Each delay uses equal jitter between half and all of its exponential-backoff ceiling.
+    /// A null <paramref name="shouldRetry"/> retries every exception handled by the retry engine.
     /// </remarks>
-    public ModuleConfigurationBuilder WithRetryCount(int count)
+    public ModuleConfigurationBuilder WithRetry(
+        int count,
+        TimeSpan? baseDelay = null,
+        Func<Exception, bool>? shouldRetry = null)
     {
-        _retryPolicyFactory = _ => Policy.Handle<Exception>()
-            .WaitAndRetryAsync(count, attempt => TimeSpan.FromMilliseconds(attempt * attempt * 100));
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        var retryBaseDelay = baseDelay ?? ModuleRetryConfiguration.DefaultBaseDelay;
+        if (retryBaseDelay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(baseDelay), baseDelay, "The retry base delay cannot be negative.");
+        }
+
+        _retryConfiguration = new ModuleRetryConfiguration(count, retryBaseDelay, shouldRetry);
+        _advancedRetryPolicyFactory = null;
         return this;
     }
 
@@ -346,7 +343,8 @@ public sealed class ModuleConfigurationBuilder
         {
             SkipCondition = ComposeSkipConditions(),
             Timeout = _timeout,
-            RetryPolicyFactory = _retryPolicyFactory,
+            RetryConfiguration = _retryConfiguration,
+            AdvancedRetryPolicyFactory = _advancedRetryPolicyFactory,
             IgnoreFailuresCondition = _ignoreFailuresCondition,
             AlwaysRun = _alwaysRun,
             ParallelConstraintKeys = _parallelConstraintKeys,
@@ -386,6 +384,13 @@ public sealed class ModuleConfigurationBuilder
 
             return SkipDecision.Skip(reasons is null ? null : string.Join("; ", reasons));
         };
+    }
+
+    internal ModuleConfigurationBuilder SetAdvancedRetryPolicy(Func<IModuleContext, IAsyncPolicy> factory)
+    {
+        _advancedRetryPolicyFactory = factory;
+        _retryConfiguration = null;
+        return this;
     }
 
     private static void ValidateModuleType(Type moduleType)

--- a/src/ModularPipelines/Configuration/ModuleRetryConfiguration.cs
+++ b/src/ModularPipelines/Configuration/ModuleRetryConfiguration.cs
@@ -1,0 +1,9 @@
+namespace ModularPipelines.Configuration;
+
+internal sealed record ModuleRetryConfiguration(
+    int Count,
+    TimeSpan BaseDelay,
+    Func<Exception, bool>? ShouldRetry)
+{
+    internal static TimeSpan DefaultBaseDelay { get; } = TimeSpan.FromMilliseconds(100);
+}

--- a/src/ModularPipelines/Configuration/ModuleRetryPolicyFactory.cs
+++ b/src/ModularPipelines/Configuration/ModuleRetryPolicyFactory.cs
@@ -1,0 +1,44 @@
+using Polly;
+
+namespace ModularPipelines.Configuration;
+
+internal static class ModuleRetryPolicyFactory
+{
+    internal static IAsyncPolicy Create(ModuleRetryConfiguration configuration)
+    {
+        var policyBuilder = configuration.ShouldRetry is null
+            ? Policy.Handle<Exception>()
+            : Policy.Handle<Exception>(configuration.ShouldRetry);
+
+        return policyBuilder.WaitAndRetryAsync(
+            configuration.Count,
+            retryAttempt => CalculateDelay(
+                retryAttempt,
+                configuration.BaseDelay,
+                Random.Shared.NextDouble()));
+    }
+
+    internal static TimeSpan CalculateDelay(
+        int retryAttempt,
+        TimeSpan baseDelay,
+        double jitterFactor)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(retryAttempt, 1);
+        if (baseDelay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(baseDelay), baseDelay, "The retry base delay cannot be negative.");
+        }
+
+        if (jitterFactor is < 0 or > 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(jitterFactor));
+        }
+
+        var exponentialTicks = baseDelay.Ticks * Math.Pow(2, retryAttempt - 1);
+        var maximumTicks = Math.Min(exponentialTicks, TimeSpan.MaxValue.Ticks);
+        var minimumTicks = maximumTicks / 2;
+        var jitteredTicks = minimumTicks + ((maximumTicks - minimumTicks) * jitterFactor);
+
+        return TimeSpan.FromTicks((long) jitteredTicks);
+    }
+}

--- a/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
@@ -55,7 +55,7 @@ internal class DistributedWorkPublisher(
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfig(
                 TimeoutSeconds: config.Timeout is not null ? (int?) config.Timeout.Value.TotalSeconds : null,
-                RetryCount: 0, // Retry policies are Polly IAsyncPolicy factories, not portable across processes
+                RetryCount: config.RetryConfiguration?.Count ?? 0,
                 AlwaysRun: config.AlwaysRun
             ),
             DependencyResults: dependencyResults

--- a/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedWorkPublisher.cs
@@ -47,6 +47,7 @@ internal class DistributedWorkPublisher(
 
         var dependencyResults = GatherDependencyResults(module);
 
+        // Distributed workers do not yet consume portable retry configuration.
         return new ModuleAssignment(
             ModuleTypeName: moduleType.FullName!,
             ResultTypeName: resultTypeName,
@@ -55,7 +56,7 @@ internal class DistributedWorkPublisher(
             AssignedAt: DateTimeOffset.UtcNow,
             Configuration: new ModuleAssignmentConfig(
                 TimeoutSeconds: config.Timeout is not null ? (int?) config.Timeout.Value.TotalSeconds : null,
-                RetryCount: config.RetryConfiguration?.Count ?? 0,
+                RetryCount: 0,
                 AlwaysRun: config.AlwaysRun
             ),
             DependencyResults: dependencyResults

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -313,17 +313,24 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         ModuleConfiguration config,
         IModuleContext moduleContext)
     {
-        if (config.RetryPolicyFactory != null)
+        if (config.AdvancedRetryPolicyFactory != null)
         {
-            return config.RetryPolicyFactory(moduleContext);
+            return config.AdvancedRetryPolicyFactory(moduleContext);
+        }
+
+        if (config.RetryConfiguration != null)
+        {
+            return ModuleRetryPolicyFactory.Create(config.RetryConfiguration);
         }
 
         // Check if default retry count is configured
         var defaultRetryCount = moduleContext.Services.Options.DefaultRetryCount;
         if (defaultRetryCount > 0)
         {
-            return Policy.Handle<Exception>()
-                .WaitAndRetryAsync(defaultRetryCount, i => TimeSpan.FromMilliseconds(i * i * 100));
+            return ModuleRetryPolicyFactory.Create(new ModuleRetryConfiguration(
+                defaultRetryCount,
+                ModuleRetryConfiguration.DefaultBaseDelay,
+                ShouldRetry: null));
         }
 
         return null;

--- a/src/ModularPipelines/Modules/Module.cs
+++ b/src/ModularPipelines/Modules/Module.cs
@@ -21,7 +21,7 @@ namespace ModularPipelines.Modules;
 /// <list type="bullet">
 /// <item><see cref="ModuleConfigurationBuilder.WithSkipWhen(System.Func{IModuleContext, SkipDecision})"/> - Define skip conditions</item>
 /// <item><see cref="ModuleConfigurationBuilder.WithTimeout"/> - Set execution timeout</item>
-/// <item><see cref="ModuleConfigurationBuilder.WithRetryCount"/> - Configure retry policy</item>
+/// <item><see cref="ModuleConfigurationBuilder.WithRetry"/> - Configure retries</item>
 /// <item><see cref="ModuleConfigurationBuilder.WithIgnoreFailures()"/> - Handle failures gracefully</item>
 /// <item><see cref="ModuleConfigurationBuilder.WithAlwaysRun"/> - Run even when pipeline fails</item>
 /// <item><see cref="ModuleConfigurationBuilder.WithPriority"/> - Set scheduling priority</item>
@@ -95,7 +95,7 @@ public abstract class Module<T> : IModule, ITaggedModule
     /// <code>
     /// protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
     ///     .WithTimeout(TimeSpan.FromMinutes(5))
-    ///     .WithRetryCount(3)
+    ///     .WithRetry(3)
     ///     .WithAlwaysRun()
     ///     .Build();
     /// </code>

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -41,7 +41,7 @@ namespace ModularPipelines.Options;
 /// <para>
 /// <strong>Module Behaviors:</strong>
 /// Module-level configuration uses <see cref="Configuration.ModuleConfiguration"/>. A module with
-/// <see cref="Configuration.ModuleConfigurationBuilder.WithRetryCount"/> configured will use its custom retry policy instead of
+/// <see cref="Configuration.ModuleConfigurationBuilder.WithRetry"/> configured will use its custom retry policy instead of
 /// <see cref="DefaultRetryCount"/>. Modules without configuration fall back to global settings.
 /// </para>
 /// </remarks>
@@ -111,10 +111,10 @@ public record PipelineOptions
     /// <remarks>
     /// <para>
     /// <strong>Configuration Precedence:</strong>
-    /// This is a global default that applies when a module does not have a custom retry policy configured via <see cref="Configuration.ModuleConfigurationBuilder.WithRetryCount"/>.
+    /// This is a global default that applies when a module does not have custom retries configured via <see cref="Configuration.ModuleConfigurationBuilder.WithRetry"/>.
     /// </para>
     /// <list type="bullet">
-    /// <item>If a module has a retry policy configured via <see cref="Configuration.ModuleConfigurationBuilder.WithRetryCount"/>, that takes precedence</item>
+    /// <item>If a module has retries configured via <see cref="Configuration.ModuleConfigurationBuilder.WithRetry"/>, that takes precedence</item>
     /// <item>Otherwise, this global <see cref="DefaultRetryCount"/> is used</item>
     /// <item>If this value is 0 (default), no retries are attempted</item>
     /// </list>

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
@@ -35,11 +35,15 @@ public class ModuleConfigurationTests
     }
 
     [Test]
-    public async Task Default_RetryPolicyFactory_IsNull()
+    public async Task Default_RetryConfiguration_IsNull()
     {
         var config = ModuleConfiguration.Default;
 
-        await Assert.That(config.RetryPolicyFactory).IsNull();
+        using (Assert.Multiple())
+        {
+            await Assert.That(config.RetryConfiguration).IsNull();
+            await Assert.That(config.AdvancedRetryPolicyFactory).IsNull();
+        }
     }
 
     [Test]
@@ -230,50 +234,121 @@ public class ModuleConfigurationTests
 
     #endregion
 
-    #region WithRetryPolicy Tests
+    #region WithRetry Tests
 
     [Test]
-    public async Task WithRetryPolicy_Direct_SetsRetryPolicyFactory()
+    public async Task WithRetry_UsesDefaultBaseDelay()
+    {
+        var config = ModuleConfiguration.Create()
+            .WithRetry(3)
+            .Build();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(config.RetryConfiguration).IsNotNull();
+            await Assert.That(config.RetryConfiguration!.Count).IsEqualTo(3);
+            await Assert.That(config.RetryConfiguration.BaseDelay).IsEqualTo(TimeSpan.FromMilliseconds(100));
+            await Assert.That(config.RetryConfiguration.ShouldRetry).IsNull();
+            await Assert.That(config.AdvancedRetryPolicyFactory).IsNull();
+        }
+    }
+
+    [Test]
+    public async Task WithRetry_StoresBaseDelayAndExceptionFilter()
+    {
+        var baseDelay = TimeSpan.FromSeconds(2);
+        Func<Exception, bool> shouldRetry = exception => exception is TimeoutException;
+
+        var config = ModuleConfiguration.Create()
+            .WithRetry(5, baseDelay, shouldRetry)
+            .Build();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(config.RetryConfiguration).IsNotNull();
+            await Assert.That(config.RetryConfiguration!.Count).IsEqualTo(5);
+            await Assert.That(config.RetryConfiguration.BaseDelay).IsEqualTo(baseDelay);
+            await Assert.That(config.RetryConfiguration.ShouldRetry).IsSameReferenceAs(shouldRetry);
+        }
+    }
+
+    [Test]
+    public async Task WithRetry_RejectsNegativeValues()
+    {
+        var countException = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ModuleConfiguration.Create().WithRetry(-1));
+        var delayException = Assert.Throws<ArgumentOutOfRangeException>(
+            () => ModuleConfiguration.Create().WithRetry(1, TimeSpan.FromMilliseconds(-1)));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(countException.ParamName).IsEqualTo("count");
+            await Assert.That(delayException.ParamName).IsEqualTo("baseDelay");
+        }
+    }
+
+    [Test]
+    public async Task Advanced_WithRetryPolicy_Direct_SetsAdvancedRetryPolicyFactory()
     {
         var policy = Policy.NoOpAsync();
 
         var config = ModuleConfiguration.Create()
+            .Advanced
             .WithRetryPolicy(policy)
             .Build();
 
-        await Assert.That(config.RetryPolicyFactory).IsNotNull();
+        await Assert.That(config.AdvancedRetryPolicyFactory).IsNotNull();
 
         var context = Mock.Of<IModuleContext>();
-        var result = config.RetryPolicyFactory!(context);
+        var result = config.AdvancedRetryPolicyFactory!(context);
 
         await Assert.That(result).IsEqualTo(policy);
     }
 
     [Test]
-    public async Task WithRetryPolicy_Factory_SetsRetryPolicyFactory()
+    public async Task Advanced_WithRetryPolicy_Factory_SetsAdvancedRetryPolicyFactory()
     {
         var policy = Policy.NoOpAsync();
 
         var config = ModuleConfiguration.Create()
-            .WithRetryPolicy(ctx => policy)
+            .Advanced
+            .WithRetryPolicy(_ => policy)
             .Build();
 
-        await Assert.That(config.RetryPolicyFactory).IsNotNull();
+        await Assert.That(config.AdvancedRetryPolicyFactory).IsNotNull();
 
         var context = Mock.Of<IModuleContext>();
-        var result = config.RetryPolicyFactory!(context);
+        var result = config.AdvancedRetryPolicyFactory!(context);
 
         await Assert.That(result).IsEqualTo(policy);
     }
 
     [Test]
-    public async Task WithRetryCount_SetsRetryPolicyFactory()
+    public async Task StandardConfigurationSurface_DoesNotExposePollyTypes()
     {
-        var config = ModuleConfiguration.Create()
-            .WithRetryCount(3)
-            .Build();
+        var publicSurfaceTypes = typeof(ModuleConfigurationBuilder)
+            .GetMethods()
+            .SelectMany(method => method.GetParameters()
+                .Select(parameter => parameter.ParameterType)
+                .Append(method.ReturnType))
+            .Concat(typeof(ModuleConfiguration)
+                .GetProperties()
+                .Select(property => property.PropertyType));
 
-        await Assert.That(config.RetryPolicyFactory).IsNotNull();
+        await Assert.That(publicSurfaceTypes.Any(ContainsPollyType)).IsFalse();
+    }
+
+    [Test]
+    [Arguments(0, 100)]
+    [Arguments(1, 200)]
+    public async Task RetryDelayCalculator_AddsBoundedJitter(double jitterFactor, int expectedMilliseconds)
+    {
+        var delay = ModuleRetryPolicyFactory.CalculateDelay(
+            retryAttempt: 2,
+            baseDelay: TimeSpan.FromMilliseconds(100),
+            jitterFactor);
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.FromMilliseconds(expectedMilliseconds));
     }
 
     #endregion
@@ -378,12 +453,10 @@ public class ModuleConfigurationTests
     [Test]
     public async Task Builder_FluentChaining_AllMethodsChain()
     {
-        var policy = Policy.NoOpAsync();
-
         var config = ModuleConfiguration.Create()
             .WithSkipWhen(_ => false)
             .WithTimeout(TimeSpan.FromMinutes(1))
-            .WithRetryPolicy(policy)
+            .WithRetry(3)
             .WithIgnoreFailures()
             .WithAlwaysRun()
             .WithNotInParallel("shared")
@@ -398,7 +471,7 @@ public class ModuleConfigurationTests
         {
             await Assert.That((object?) config.SkipCondition).IsNotNull();
             await Assert.That(config.Timeout).IsEqualTo(TimeSpan.FromMinutes(1));
-            await Assert.That(config.RetryPolicyFactory).IsNotNull();
+            await Assert.That(config.RetryConfiguration).IsNotNull();
             await Assert.That(config.IgnoreFailuresCondition).IsNotNull();
             await Assert.That(config.AlwaysRun).IsTrue();
             await Assert.That(config.ParallelConstraintKeys).IsEquivalentTo(new[] { "shared" });
@@ -411,4 +484,8 @@ public class ModuleConfigurationTests
     }
 
     #endregion
+
+    private static bool ContainsPollyType(Type type) =>
+        type.Namespace?.StartsWith("Polly", StringComparison.Ordinal) == true
+        || type.GetGenericArguments().Any(ContainsPollyType);
 }

--- a/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
@@ -69,11 +69,55 @@ public class RetryTests : TestBase
         }
     }
 
+    private sealed class RetryableTestException : Exception
+    {
+    }
+
+    private class FailedModuleWithFilteredRetries : Module<bool>
+    {
+        internal int ExecutionCount;
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithRetry(
+                DefaultRetryCount,
+                TimeSpan.Zero,
+                exception => exception is RetryableTestException)
+            .Build();
+
+        protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            ExecutionCount++;
+
+            return ExecutionCount == ExpectedExecutionCountAfterRetries
+                ? Task.FromResult(true)
+                : Task.FromException<bool>(new RetryableTestException());
+        }
+    }
+
+    private class FailedModuleWithRejectedRetry : Module<bool>
+    {
+        internal int ExecutionCount;
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithRetry(
+                DefaultRetryCount,
+                TimeSpan.Zero,
+                exception => exception is RetryableTestException)
+            .Build();
+
+        protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            ExecutionCount++;
+            return Task.FromException<bool>(new InvalidOperationException());
+        }
+    }
+
     private class FailedModuleWithCustomRetryPolicy : Module<string>
     {
         internal int ExecutionCount;
 
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .Advanced
             .WithRetryPolicy(Policy
                 .Handle<Exception>()
                 .WaitAndRetryAsync(DefaultRetryCount, _ => TimeSpan.Zero))
@@ -99,6 +143,7 @@ public class RetryTests : TestBase
 
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
             .WithTimeout(TimeSpan.FromMilliseconds(ModuleTimeoutMs))
+            .Advanced
             .WithRetryPolicy(Policy
                 .Handle<Exception>()
                 .WaitAndRetryAsync(DefaultRetryCount, _ => TimeSpan.FromMilliseconds(RetryDelayMs)))
@@ -190,6 +235,39 @@ public class RetryTests : TestBase
             await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedExecutionCountAfterRetries);
             await Assert.That(result.ExceptionOrDefault).IsNull();
         }
+    }
+
+    [Test]
+    public async Task When_Error_Matches_Filter_Then_Retry()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<FailedModuleWithFilteredRetries>()
+            .BuildAsync();
+
+        await host.RunAsync();
+
+        var module = host.Services.GetServices<IModule>().OfType<FailedModuleWithFilteredRetries>().Single();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+        var result = resultRegistry.GetResult(typeof(FailedModuleWithFilteredRetries))!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedExecutionCountAfterRetries);
+            await Assert.That(result.ExceptionOrDefault).IsNull();
+        }
+    }
+
+    [Test]
+    public async Task When_Error_DoesNotMatch_Filter_Then_DoNotRetry()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<FailedModuleWithRejectedRetry>()
+            .BuildAsync();
+
+        await Assert.ThrowsAsync<ModuleFailedException>(() => host.RunAsync());
+
+        var module = host.Services.GetServices<IModule>().OfType<FailedModuleWithRejectedRetry>().Single();
+        await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedSingleExecutionCount);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/SubModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/SubModuleTests.cs
@@ -170,6 +170,7 @@ public class SubModuleTests : TestBase
         public int _threeCount;
 
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .Advanced
             .WithRetryPolicy(Policy.Handle<Exception>().RetryAsync(3))
             .Build();
 
@@ -207,6 +208,7 @@ public class SubModuleTests : TestBase
         public int _threeCount;
 
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .Advanced
             .WithRetryPolicy(Policy.Handle<Exception>().RetryAsync(3))
             .Build();
 

--- a/test/ModularPipelines.UnitTests/Modules/SyncModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/SyncModuleTests.cs
@@ -389,7 +389,7 @@ public class SyncModuleTests : TestBase
         public int ExecutionCount { get; private set; }
 
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .WithRetryCount(3)
+            .WithRetry(3, TimeSpan.Zero)
             .Build();
 
         protected override string? Execute(IModuleContext context, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- replace WithRetryCount with WithRetry(count, baseDelay, shouldRetry)
- add equal-jitter exponential backoff and exception filtering
- move custom Polly policies behind .Advanced and remove Polly from the standard configuration surface
- update runtime wiring, call sites, tests, and current docs

## Test plan
- [x] focused ModuleConfigurationTests (30 passed)
- [x] focused RetryTests (8 passed)
- [x] warning-level changed-file analyzer gate
- [x] core Release build (0 warnings, 0 errors)
- [x] Docusaurus production build

Closes #3288
