### PR TITLE
Unify command builder abstraction

### DIFF
--- a/src/ModularPipelines.DotNet/Builders/DotNetBuildBuilder.cs
+++ b/src/ModularPipelines.DotNet/Builders/DotNetBuildBuilder.cs
@@ -1,8 +1,7 @@
+using ModularPipelines.Builders;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.DotNet.Options;
-using ModularPipelines.Models;
-using ModularPipelines.Options;
 using KeyValue = ModularPipelines.Models.KeyValue;
 
 namespace ModularPipelines.DotNet.Builders;
@@ -10,31 +9,23 @@ namespace ModularPipelines.DotNet.Builders;
 /// <summary>
 /// Fluent builder implementation for dotnet build command.
 /// </summary>
-public class DotNetBuildBuilder : IDotNetBuildBuilder
+public class DotNetBuildBuilder : CommandBuilderBase<IDotNetBuildBuilder, DotNetBuildOptions>, IDotNetBuildBuilder
 {
-    private readonly ICommandContext _command;
-    private DotNetBuildOptions _toolOptions;
-    private CommandExecutionOptions _executionOptions = new();
-
     /// <summary>
-    /// Initializes a new instance of the <see cref="DotNetBuildBuilder"/> class.
+    /// Initialises a new instance of the <see cref="DotNetBuildBuilder"/> class.
     /// </summary>
     /// <param name="command">The command interface for execution.</param>
-    public DotNetBuildBuilder(ICommandContext command)
+    public DotNetBuildBuilder(ICommandContext command) : base(command)
     {
-        _command = command;
-        _toolOptions = new DotNetBuildOptions();
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DotNetBuildBuilder"/> class with initial options.
+    /// Initialises a new instance of the <see cref="DotNetBuildBuilder"/> class.
     /// </summary>
     /// <param name="command">The command interface for execution.</param>
     /// <param name="options">The initial build options.</param>
-    public DotNetBuildBuilder(ICommandContext command, DotNetBuildOptions options)
+    public DotNetBuildBuilder(ICommandContext command, DotNetBuildOptions options) : base(command, options)
     {
-        _command = command;
-        _toolOptions = options;
     }
 
     #region Tool-Specific Options
@@ -42,112 +33,112 @@ public class DotNetBuildBuilder : IDotNetBuildBuilder
     /// <inheritdoc />
     public IDotNetBuildBuilder ForProject(string projectPath)
     {
-        _toolOptions = _toolOptions with { ProjectSolution = projectPath };
+        ToolOptions = ToolOptions with { ProjectSolution = projectPath };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithFramework(string framework)
     {
-        _toolOptions = _toolOptions with { Framework = framework };
+        ToolOptions = ToolOptions with { Framework = framework };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithConfiguration(string configuration)
     {
-        _toolOptions = _toolOptions with { Configuration = configuration };
+        ToolOptions = ToolOptions with { Configuration = configuration };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithRuntime(string runtime)
     {
-        _toolOptions = _toolOptions with { Runtime = runtime };
+        ToolOptions = ToolOptions with { Runtime = runtime };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithOutput(string outputPath)
     {
-        _toolOptions = _toolOptions with { Output = outputPath };
+        ToolOptions = ToolOptions with { Output = outputPath };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithArtifactsPath(string artifactsPath)
     {
-        _toolOptions = _toolOptions with { ArtifactsPath = artifactsPath };
+        ToolOptions = ToolOptions with { ArtifactsPath = artifactsPath };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithVersionSuffix(string versionSuffix)
     {
-        _toolOptions = _toolOptions with { VersionSuffix = versionSuffix };
+        ToolOptions = ToolOptions with { VersionSuffix = versionSuffix };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithNoRestore(bool noRestore = true)
     {
-        _toolOptions = _toolOptions with { NoRestore = noRestore };
+        ToolOptions = ToolOptions with { NoRestore = noRestore };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithNoIncremental(bool noIncremental = true)
     {
-        _toolOptions = _toolOptions with { NoIncremental = noIncremental };
+        ToolOptions = ToolOptions with { NoIncremental = noIncremental };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithNoDependencies(bool noDependencies = true)
     {
-        _toolOptions = _toolOptions with { NoDependencies = noDependencies };
+        ToolOptions = ToolOptions with { NoDependencies = noDependencies };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithNoLogo(bool noLogo = true)
     {
-        _toolOptions = _toolOptions with { NoLogo = noLogo };
+        ToolOptions = ToolOptions with { NoLogo = noLogo };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithInteractive(bool interactive = true)
     {
-        _toolOptions = _toolOptions with { Interactive = interactive };
+        ToolOptions = ToolOptions with { Interactive = interactive };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithArch(string arch)
     {
-        _toolOptions = _toolOptions with { Arch = arch };
+        ToolOptions = ToolOptions with { Arch = arch };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithOs(string os)
     {
-        _toolOptions = _toolOptions with { Os = os };
+        ToolOptions = ToolOptions with { Os = os };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithNoSelfContained(bool noSelfContained = true)
     {
-        _toolOptions = _toolOptions with { NoSelfContained = noSelfContained };
+        ToolOptions = ToolOptions with { NoSelfContained = noSelfContained };
         return this;
     }
 
     /// <inheritdoc />
     public IDotNetBuildBuilder WithDisableBuildServers(bool disableBuildServers = true)
     {
-        _toolOptions = _toolOptions with { DisableBuildServers = disableBuildServers };
+        ToolOptions = ToolOptions with { DisableBuildServers = disableBuildServers };
         return this;
     }
 
@@ -161,82 +152,10 @@ public class DotNetBuildBuilder : IDotNetBuildBuilder
     /// <inheritdoc />
     public IDotNetBuildBuilder WithProperty(string name, string value)
     {
-        var properties = _toolOptions.Properties?.ToList() ?? [];
+        var properties = ToolOptions.Properties?.ToList() ?? [];
         properties.Add(new KeyValue(name, value));
-        _toolOptions = _toolOptions with { Properties = properties };
+        ToolOptions = ToolOptions with { Properties = properties };
         return this;
-    }
-
-    #endregion
-
-    #region Execution Options
-
-    /// <inheritdoc />
-    public IDotNetBuildBuilder WithWorkingDirectory(string directory)
-    {
-        _executionOptions = _executionOptions with { WorkingDirectory = directory };
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IDotNetBuildBuilder WithTimeout(TimeSpan timeout)
-    {
-        _executionOptions = _executionOptions with { ExecutionTimeout = timeout };
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IDotNetBuildBuilder WithEnvironmentVariable(string key, string value)
-    {
-        var vars = _executionOptions.EnvironmentVariables?.ToDictionary(k => k.Key, v => v.Value)
-            ?? new Dictionary<string, string?>();
-        vars[key] = value;
-        _executionOptions = _executionOptions with { EnvironmentVariables = vars };
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IDotNetBuildBuilder WithEnvironmentVariables(IDictionary<string, string?> variables)
-    {
-        var vars = _executionOptions.EnvironmentVariables?.ToDictionary(k => k.Key, v => v.Value)
-            ?? new Dictionary<string, string?>();
-        foreach (var kvp in variables)
-        {
-            vars[kvp.Key] = kvp.Value;
-        }
-
-        _executionOptions = _executionOptions with { EnvironmentVariables = vars };
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IDotNetBuildBuilder WithThrowOnError(bool throwOnError = true)
-    {
-        _executionOptions = _executionOptions with { ThrowOnNonZeroExitCode = throwOnError };
-        return this;
-    }
-
-    /// <inheritdoc />
-    public IDotNetBuildBuilder WithLogging(CommandLoggingOptions options)
-    {
-        _executionOptions = _executionOptions with { LogSettings = options };
-        return this;
-    }
-
-    #endregion
-
-    #region Terminal Operations
-
-    /// <inheritdoc />
-    public virtual async Task<CommandResult> ExecuteAsync(CancellationToken cancellationToken = default)
-    {
-        return await _command.ExecuteCommandLineTool(_toolOptions, _executionOptions, cancellationToken);
-    }
-
-    /// <inheritdoc />
-    public (DotNetBuildOptions ToolOptions, CommandExecutionOptions ExecutionOptions) ToOptions()
-    {
-        return (_toolOptions, _executionOptions);
     }
 
     #endregion

--- a/src/ModularPipelines.DotNet/Builders/IDotNetBuildBuilder.cs
+++ b/src/ModularPipelines.DotNet/Builders/IDotNetBuildBuilder.cs
@@ -1,6 +1,5 @@
+using ModularPipelines.Builders;
 using ModularPipelines.DotNet.Options;
-using ModularPipelines.Models;
-using ModularPipelines.Options;
 
 namespace ModularPipelines.DotNet.Builders;
 
@@ -8,7 +7,7 @@ namespace ModularPipelines.DotNet.Builders;
 /// Fluent builder interface for dotnet build command.
 /// Provides a discoverable, chainable API for configuring build options.
 /// </summary>
-public interface IDotNetBuildBuilder
+public interface IDotNetBuildBuilder : ICommandBuilder<IDotNetBuildBuilder, DotNetBuildOptions>
 {
     #region Tool-Specific Options
 
@@ -139,71 +138,6 @@ public interface IDotNetBuildBuilder
     /// <param name="value">The property value.</param>
     /// <returns>The builder instance for chaining.</returns>
     IDotNetBuildBuilder WithProperty(string name, string value);
-
-    #endregion
-
-    #region Execution Options
-
-    /// <summary>
-    /// Sets the working directory for command execution.
-    /// </summary>
-    /// <param name="directory">The working directory path.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    IDotNetBuildBuilder WithWorkingDirectory(string directory);
-
-    /// <summary>
-    /// Sets the execution timeout.
-    /// </summary>
-    /// <param name="timeout">The timeout duration.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    IDotNetBuildBuilder WithTimeout(TimeSpan timeout);
-
-    /// <summary>
-    /// Sets an environment variable for the command.
-    /// </summary>
-    /// <param name="key">The environment variable name.</param>
-    /// <param name="value">The environment variable value.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    IDotNetBuildBuilder WithEnvironmentVariable(string key, string value);
-
-    /// <summary>
-    /// Sets multiple environment variables.
-    /// </summary>
-    /// <param name="variables">A dictionary of environment variables.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    IDotNetBuildBuilder WithEnvironmentVariables(IDictionary<string, string?> variables);
-
-    /// <summary>
-    /// Configures whether to throw on non-zero exit code.
-    /// </summary>
-    /// <param name="throwOnError">Whether to throw on error. Defaults to true.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    IDotNetBuildBuilder WithThrowOnError(bool throwOnError = true);
-
-    /// <summary>
-    /// Configures logging options for the command.
-    /// </summary>
-    /// <param name="options">The logging options.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    IDotNetBuildBuilder WithLogging(CommandLoggingOptions options);
-
-    #endregion
-
-    #region Terminal Operations
-
-    /// <summary>
-    /// Executes the build command with the configured options.
-    /// </summary>
-    /// <param name="cancellationToken">Optional cancellation token.</param>
-    /// <returns>A task representing the command result.</returns>
-    Task<CommandResult> ExecuteAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Returns the built options without executing.
-    /// Useful for inspection, testing, or hybrid usage patterns.
-    /// </summary>
-    /// <returns>A tuple containing the tool options and execution options.</returns>
-    (DotNetBuildOptions ToolOptions, CommandExecutionOptions ExecutionOptions) ToOptions();
 
     #endregion
 }

--- a/src/ModularPipelines/Builders/CommandBuilderBase.cs
+++ b/src/ModularPipelines/Builders/CommandBuilderBase.cs
@@ -8,10 +8,10 @@ namespace ModularPipelines.Builders;
 /// <summary>
 /// Base implementation for command builders providing common execution options handling.
 /// </summary>
-/// <typeparam name="TBuilder">The concrete builder type for fluent chaining.</typeparam>
+/// <typeparam name="TBuilder">The builder self type used for fluent chaining.</typeparam>
 /// <typeparam name="TOptions">The tool options type.</typeparam>
 public abstract class CommandBuilderBase<TBuilder, TOptions> : ICommandBuilder<TBuilder, TOptions>
-    where TBuilder : CommandBuilderBase<TBuilder, TOptions>
+    where TBuilder : class, ICommandBuilder<TBuilder, TOptions>
     where TOptions : CommandLineToolOptions, new()
 {
     private readonly ICommandContext _command;
@@ -19,7 +19,7 @@ public abstract class CommandBuilderBase<TBuilder, TOptions> : ICommandBuilder<T
     private CommandExecutionOptions _executionOptions = new();
 
     /// <summary>
-    /// Initializes a new instance of the builder with default options.
+    /// Initialises a new instance of the <see cref="CommandBuilderBase{TBuilder, TOptions}"/> class.
     /// </summary>
     /// <param name="command">The command interface for execution.</param>
     protected CommandBuilderBase(ICommandContext command)
@@ -29,7 +29,7 @@ public abstract class CommandBuilderBase<TBuilder, TOptions> : ICommandBuilder<T
     }
 
     /// <summary>
-    /// Initializes a new instance of the builder with initial options.
+    /// Initialises a new instance of the <see cref="CommandBuilderBase{TBuilder, TOptions}"/> class.
     /// </summary>
     /// <param name="command">The command interface for execution.</param>
     /// <param name="initialOptions">The initial tool options.</param>
@@ -42,7 +42,8 @@ public abstract class CommandBuilderBase<TBuilder, TOptions> : ICommandBuilder<T
     /// <summary>
     /// Gets the builder instance as the concrete type for fluent chaining.
     /// </summary>
-    protected TBuilder Self => (TBuilder) this;
+    protected TBuilder Self => this as TBuilder
+        ?? throw new InvalidOperationException($"{GetType().Name} must implement {typeof(TBuilder).Name}.");
 
     /// <summary>
     /// Gets or sets the tool-specific options being built.
@@ -80,7 +81,7 @@ public abstract class CommandBuilderBase<TBuilder, TOptions> : ICommandBuilder<T
     public TBuilder WithEnvironmentVariable(string key, string value)
     {
         var vars = _executionOptions.EnvironmentVariables?.ToDictionary(k => k.Key, v => v.Value)
-            ?? new Dictionary<string, string?>();
+            ?? [];
         vars[key] = value;
         _executionOptions = _executionOptions with { EnvironmentVariables = vars };
         return Self;
@@ -90,7 +91,7 @@ public abstract class CommandBuilderBase<TBuilder, TOptions> : ICommandBuilder<T
     public TBuilder WithEnvironmentVariables(IDictionary<string, string?> variables)
     {
         var vars = _executionOptions.EnvironmentVariables?.ToDictionary(k => k.Key, v => v.Value)
-            ?? new Dictionary<string, string?>();
+            ?? [];
         foreach (var kvp in variables)
         {
             vars[kvp.Key] = kvp.Value;
@@ -135,33 +136,6 @@ public abstract class CommandBuilderBase<TBuilder, TOptions> : ICommandBuilder<T
         configure(options);
         return WithLogging(options);
     }
-
-    /// <inheritdoc />
-    ICommandBuilder ICommandBuilder.WithWorkingDirectory(string directory) => WithWorkingDirectory(directory);
-
-    /// <inheritdoc />
-    ICommandBuilder ICommandBuilder.WithTimeout(TimeSpan timeout) => WithTimeout(timeout);
-
-    /// <inheritdoc />
-    ICommandBuilder ICommandBuilder.WithEnvironmentVariable(string key, string value) => WithEnvironmentVariable(key, value);
-
-    /// <inheritdoc />
-    ICommandBuilder ICommandBuilder.WithEnvironmentVariables(IDictionary<string, string?> variables) => WithEnvironmentVariables(variables);
-
-    /// <inheritdoc />
-    ICommandBuilder ICommandBuilder.WithSudo(bool sudo) => WithSudo(sudo);
-
-    /// <inheritdoc />
-    ICommandBuilder ICommandBuilder.WithThrowOnError(bool throwOnError) => WithThrowOnError(throwOnError);
-
-    /// <inheritdoc />
-    ICommandBuilder ICommandBuilder.WithGracefulShutdownTimeout(TimeSpan timeout) => WithGracefulShutdownTimeout(timeout);
-
-    /// <inheritdoc />
-    ICommandBuilder ICommandBuilder.WithLogging(CommandLoggingOptions options) => WithLogging(options);
-
-    /// <inheritdoc />
-    ICommandBuilder ICommandBuilder.WithLogging(Action<CommandLoggingOptions> configure) => WithLogging(configure);
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ExecuteAsync(CancellationToken cancellationToken = default)

--- a/src/ModularPipelines/Builders/ICommandBuilder.cs
+++ b/src/ModularPipelines/Builders/ICommandBuilder.cs
@@ -4,81 +4,11 @@ using ModularPipelines.Options;
 namespace ModularPipelines.Builders;
 
 /// <summary>
-/// Base interface for all command builders providing execution options.
-/// </summary>
-public interface ICommandBuilder
-{
-    /// <summary>
-    /// Sets the working directory for command execution.
-    /// </summary>
-    /// <param name="directory">The working directory path.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    ICommandBuilder WithWorkingDirectory(string directory);
-
-    /// <summary>
-    /// Sets the execution timeout.
-    /// </summary>
-    /// <param name="timeout">The timeout duration.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    ICommandBuilder WithTimeout(TimeSpan timeout);
-
-    /// <summary>
-    /// Sets an environment variable for the command.
-    /// </summary>
-    /// <param name="key">The environment variable name.</param>
-    /// <param name="value">The environment variable value.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    ICommandBuilder WithEnvironmentVariable(string key, string value);
-
-    /// <summary>
-    /// Sets multiple environment variables.
-    /// </summary>
-    /// <param name="variables">A dictionary of environment variables.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    ICommandBuilder WithEnvironmentVariables(IDictionary<string, string?> variables);
-
-    /// <summary>
-    /// Configures the command to run with sudo.
-    /// </summary>
-    /// <param name="sudo">Whether to use sudo. Defaults to true.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    ICommandBuilder WithSudo(bool sudo = true);
-
-    /// <summary>
-    /// Configures whether to throw on non-zero exit code.
-    /// </summary>
-    /// <param name="throwOnError">Whether to throw on error. Defaults to true.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    ICommandBuilder WithThrowOnError(bool throwOnError = true);
-
-    /// <summary>
-    /// Sets the graceful shutdown timeout.
-    /// </summary>
-    /// <param name="timeout">The graceful shutdown timeout duration.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    ICommandBuilder WithGracefulShutdownTimeout(TimeSpan timeout);
-
-    /// <summary>
-    /// Configures logging options for the command.
-    /// </summary>
-    /// <param name="options">The logging options.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    ICommandBuilder WithLogging(CommandLoggingOptions options);
-
-    /// <summary>
-    /// Configures logging options using a builder action.
-    /// </summary>
-    /// <param name="configure">An action to configure the logging options.</param>
-    /// <returns>The builder instance for chaining.</returns>
-    ICommandBuilder WithLogging(Action<CommandLoggingOptions> configure);
-}
-
-/// <summary>
 /// Typed command builder with tool-specific options.
 /// </summary>
-/// <typeparam name="TBuilder">The concrete builder type for fluent chaining.</typeparam>
+/// <typeparam name="TBuilder">The builder self type used for fluent chaining.</typeparam>
 /// <typeparam name="TOptions">The tool options type.</typeparam>
-public interface ICommandBuilder<TBuilder, TOptions> : ICommandBuilder
+public interface ICommandBuilder<TBuilder, TOptions>
     where TBuilder : ICommandBuilder<TBuilder, TOptions>
     where TOptions : CommandLineToolOptions
 {
@@ -101,14 +31,14 @@ public interface ICommandBuilder<TBuilder, TOptions> : ICommandBuilder
     /// </summary>
     /// <param name="directory">The working directory path.</param>
     /// <returns>The builder instance for chaining.</returns>
-    new TBuilder WithWorkingDirectory(string directory);
+    TBuilder WithWorkingDirectory(string directory);
 
     /// <summary>
     /// Sets the execution timeout.
     /// </summary>
     /// <param name="timeout">The timeout duration.</param>
     /// <returns>The builder instance for chaining.</returns>
-    new TBuilder WithTimeout(TimeSpan timeout);
+    TBuilder WithTimeout(TimeSpan timeout);
 
     /// <summary>
     /// Sets an environment variable for the command.
@@ -116,47 +46,47 @@ public interface ICommandBuilder<TBuilder, TOptions> : ICommandBuilder
     /// <param name="key">The environment variable name.</param>
     /// <param name="value">The environment variable value.</param>
     /// <returns>The builder instance for chaining.</returns>
-    new TBuilder WithEnvironmentVariable(string key, string value);
+    TBuilder WithEnvironmentVariable(string key, string value);
 
     /// <summary>
     /// Sets multiple environment variables.
     /// </summary>
     /// <param name="variables">A dictionary of environment variables.</param>
     /// <returns>The builder instance for chaining.</returns>
-    new TBuilder WithEnvironmentVariables(IDictionary<string, string?> variables);
+    TBuilder WithEnvironmentVariables(IDictionary<string, string?> variables);
 
     /// <summary>
     /// Configures the command to run with sudo.
     /// </summary>
     /// <param name="sudo">Whether to use sudo. Defaults to true.</param>
     /// <returns>The builder instance for chaining.</returns>
-    new TBuilder WithSudo(bool sudo = true);
+    TBuilder WithSudo(bool sudo = true);
 
     /// <summary>
     /// Configures whether to throw on non-zero exit code.
     /// </summary>
     /// <param name="throwOnError">Whether to throw on error. Defaults to true.</param>
     /// <returns>The builder instance for chaining.</returns>
-    new TBuilder WithThrowOnError(bool throwOnError = true);
+    TBuilder WithThrowOnError(bool throwOnError = true);
 
     /// <summary>
     /// Sets the graceful shutdown timeout.
     /// </summary>
     /// <param name="timeout">The graceful shutdown timeout duration.</param>
     /// <returns>The builder instance for chaining.</returns>
-    new TBuilder WithGracefulShutdownTimeout(TimeSpan timeout);
+    TBuilder WithGracefulShutdownTimeout(TimeSpan timeout);
 
     /// <summary>
     /// Configures logging options for the command.
     /// </summary>
     /// <param name="options">The logging options.</param>
     /// <returns>The builder instance for chaining.</returns>
-    new TBuilder WithLogging(CommandLoggingOptions options);
+    TBuilder WithLogging(CommandLoggingOptions options);
 
     /// <summary>
     /// Configures logging options using a builder action.
     /// </summary>
     /// <param name="configure">An action to configure the logging options.</param>
     /// <returns>The builder instance for chaining.</returns>
-    new TBuilder WithLogging(Action<CommandLoggingOptions> configure);
+    TBuilder WithLogging(Action<CommandLoggingOptions> configure);
 }

--- a/src/ModularPipelines/Context/ICommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/ICommandLineBuilder.cs
@@ -8,7 +8,7 @@ namespace ModularPipelines.Context;
 /// This is a pure transformation with no side effects.
 /// </summary>
 /// <remarks>
-/// This interface is distinct from <see cref="Builders.ICommandBuilder"/> which is a fluent
+/// This interface is distinct from <see cref="Builders.ICommandBuilder{TBuilder, TOptions}"/> which is a fluent
 /// builder pattern for configuring and executing commands. This interface is specifically
 /// for transforming <see cref="CommandLineToolOptions"/> into a <see cref="CommandLine"/> model.
 /// </remarks>

--- a/src/ModularPipelines/Models/CommandLine.cs
+++ b/src/ModularPipelines/Models/CommandLine.cs
@@ -2,22 +2,22 @@ namespace ModularPipelines.Models;
 
 /// <summary>
 /// Represents a fully-built command line ready for execution.
-/// This is the output of ICommandBuilder and input to ICommandExecutor.
+/// This is the output of the internal command-line builder and input to ICommandExecutor.
 /// </summary>
 public record CommandLine
 {
     /// <summary>
-    /// The CLI tool to execute (e.g., "git", "docker").
+    /// Gets the CLI tool to execute (e.g., "git", "docker").
     /// </summary>
     public string Tool { get; }
 
     /// <summary>
-    /// The command arguments.
+    /// Gets the command arguments.
     /// </summary>
     public IReadOnlyList<string> Arguments { get; }
 
     /// <summary>
-    /// Initializes a new instance with the specified tool and arguments.
+    /// Initialises a new instance of the <see cref="CommandLine"/> class.
     /// Creates a defensive copy to ensure immutability.
     /// </summary>
     /// <param name="tool">The CLI tool to execute.</param>
@@ -31,6 +31,7 @@ public record CommandLine
     /// <summary>
     /// Returns the command line as a string suitable for display.
     /// </summary>
+    /// <returns>The command line as a display string.</returns>
     public override string ToString()
     {
         return Arguments.Count == 0

--- a/test/ModularPipelines.UnitTests/Builders/CommandBuilderBaseTests.cs
+++ b/test/ModularPipelines.UnitTests/Builders/CommandBuilderBaseTests.cs
@@ -460,22 +460,21 @@ public class CommandBuilderBaseTests : TestBase
 
     #endregion
 
-    #region Non-Generic Interface Tests
+    #region Generic Interface Tests
 
     [Test]
-    public async Task NonGenericInterface_CanBeUsedForChaining()
+    public async Task GenericInterface_CanBeUsedForChaining()
     {
         var mockCommand = new Mock<ICommandContext>();
         var builder = new TestToolBuilder(mockCommand.Object);
 
-        // Use via non-generic interface
-        ICommandBuilder nonGenericBuilder = builder;
-        nonGenericBuilder
+        ICommandBuilder<TestToolBuilder, TestToolOptions> genericBuilder = builder;
+        var chainedBuilder = genericBuilder
             .WithWorkingDirectory("/test")
             .WithTimeout(TimeSpan.FromMinutes(1));
 
-        // The underlying builder should still have the options set
         var (_, execOptions) = builder.ToOptions();
+        await Assert.That(chainedBuilder).IsSameReferenceAs(builder);
         await Assert.That(execOptions.WorkingDirectory).IsEqualTo("/test");
         await Assert.That(execOptions.ExecutionTimeout).IsEqualTo(TimeSpan.FromMinutes(1));
     }

--- a/test/ModularPipelines.UnitTests/Builders/DotNetBuildBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Builders/DotNetBuildBuilderTests.cs
@@ -1,5 +1,6 @@
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
+using ModularPipelines.Builders;
 using ModularPipelines.DotNet.Builders;
 using ModularPipelines.DotNet.Options;
 using ModularPipelines.Models;
@@ -33,6 +34,40 @@ public class DotNetBuildBuilderTests : TestBase
     }
 
     #region Tool-Specific Options Tests
+
+    [Test]
+    public async Task Interface_InheritsGenericCommandBuilderWithoutRedeclaringBaseMembers()
+    {
+        var interfaces = typeof(IDotNetBuildBuilder).GetInterfaces();
+        var declaredMethods = typeof(IDotNetBuildBuilder).GetMethods(
+            System.Reflection.BindingFlags.Public |
+            System.Reflection.BindingFlags.Instance |
+            System.Reflection.BindingFlags.DeclaredOnly);
+
+        await Assert.That(interfaces).Contains(typeof(ICommandBuilder<IDotNetBuildBuilder, DotNetBuildOptions>));
+        await Assert.That(declaredMethods.Select(x => x.Name)).DoesNotContain(nameof(IDotNetBuildBuilder.WithWorkingDirectory));
+        await Assert.That(declaredMethods.Select(x => x.Name)).DoesNotContain(nameof(IDotNetBuildBuilder.ExecuteAsync));
+        await Assert.That(typeof(ICommandBuilder<,>).Assembly.GetType("ModularPipelines.Builders.ICommandBuilder")).IsNull();
+    }
+
+    [Test]
+    public async Task Interface_BaseMethodsPreserveToolSpecificChaining()
+    {
+#pragma warning disable CA1859 // Intentionally exercise fluent chaining through the public interface.
+        IDotNetBuildBuilder builder = new DotNetBuildBuilder(CreateMockCommand().Object);
+#pragma warning restore CA1859
+
+        var chainedBuilder = builder
+            .WithSudo()
+            .WithGracefulShutdownTimeout(TimeSpan.FromSeconds(5))
+            .WithNoLogo();
+
+        var (toolOptions, executionOptions) = chainedBuilder.ToOptions();
+        await Assert.That(chainedBuilder).IsSameReferenceAs(builder);
+        await Assert.That(toolOptions.NoLogo).IsTrue();
+        await Assert.That(executionOptions.Sudo).IsTrue();
+        await Assert.That(executionOptions.GracefulShutdownTimeout).IsEqualTo(TimeSpan.FromSeconds(5));
+    }
 
     [Test]
     public async Task ForProject_SetsProjectPath()


### PR DESCRIPTION
Closes #3295

## Summary
- remove the non-generic `ICommandBuilder` surface and its shadowing bridge implementations
- make `IDotNetBuildBuilder` inherit `ICommandBuilder<IDotNetBuildBuilder, DotNetBuildOptions>`
- move DotNet execution behavior onto `CommandBuilderBase` and keep fluent tool-specific chaining
- add regression coverage for the generic-only API and inherited builder operations

## Breaking change
Consumers using the non-generic `ICommandBuilder` must use the typed `ICommandBuilder<TBuilder, TOptions>` abstraction.

## Validation
- `CommandBuilderBaseTests`: 23 passed
- `DotNetBuildBuilderTests`: 22 passed
- core Release build: 0 errors (repository baseline warnings remain)
- DotNet solution Release build: 0 errors (repository baseline warnings remain)
- targeted `dotnet format --verify-no-changes --severity info`: passed
- `git diff --check`: passed