### PR TITLE
Hide raw HTTP clients from pipeline context

### DIFF
--- a/src/ModularPipelines.Slack/Slack.cs
+++ b/src/ModularPipelines.Slack/Slack.cs
@@ -1,5 +1,5 @@
+using System.Text;
 using ModularPipelines.Context.Domains.Network;
-using ModularPipelines.Http;
 using ModularPipelines.Slack.Options;
 using Slack.Webhooks;
 
@@ -18,8 +18,14 @@ internal class Slack : ISlack
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var slackClient = new SlackClient(options.WebHookUri.AbsoluteUri, httpClient: _http.GetLoggingHttpClient());
+        using var request = new HttpRequestMessage(HttpMethod.Post, options.WebHookUri)
+        {
+            Content = new StringContent(
+                SlackClient.SerializeObject(options.SlackMessage),
+                Encoding.UTF8,
+                "application/json"),
+        };
 
-        await slackClient.PostAsync(options.SlackMessage);
+        using var response = await _http.SendAsync(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/ModularPipelines/Context/Domains/Network/IHttpContext.cs
+++ b/src/ModularPipelines/Context/Domains/Network/IHttpContext.cs
@@ -1,4 +1,3 @@
-using ModularPipelines.Http;
 using ModularPipelines.Options;
 
 namespace ModularPipelines.Context.Domains.Network;
@@ -12,15 +11,4 @@ public interface IHttpContext
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     Task<HttpResponseMessage> SendAsync(HttpOptions httpOptions, CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Gets the default, non-logging HTTP client.
-    /// </summary>
-    HttpClient HttpClient { get; }
-
-    /// <summary>
-    /// Gets a logging HTTP client.
-    /// </summary>
-    /// <returns>A logging HTTP client.</returns>
-    HttpClient GetLoggingHttpClient(HttpLoggingType loggingType = HttpLoggingType.Request | HttpLoggingType.Response | HttpLoggingType.StatusCode | HttpLoggingType.Duration);
 }

--- a/src/ModularPipelines/Http/Http.cs
+++ b/src/ModularPipelines/Http/Http.cs
@@ -9,20 +9,17 @@ namespace ModularPipelines.Http;
 
 internal class Http : IHttpContext
 {
-    public HttpClient HttpClient { get; }
-
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IModuleLoggerProvider _moduleLoggerProvider;
     private readonly IHttpLogger _httpLogger;
     private readonly IOptions<PipelineOptions> _pipelineOptions;
 
-    public Http(HttpClient defaultHttpClient,
+    public Http(
         IHttpClientFactory httpClientFactory,
         IModuleLoggerProvider moduleLoggerProvider,
         IHttpLogger httpLogger,
         IOptions<PipelineOptions> pipelineOptions)
     {
-        HttpClient = defaultHttpClient;
         _httpClientFactory = httpClientFactory;
         _moduleLoggerProvider = moduleLoggerProvider;
         _httpLogger = httpLogger;
@@ -51,7 +48,7 @@ internal class Http : IHttpContext
             return await SendAndWrapLogging(httpOptions, effectiveCancellationToken).ConfigureAwait(false);
         }
 
-        var httpClient = GetLoggingHttpClient(httpOptions.LoggingType);
+        var httpClient = GetHttpClient(httpOptions.LoggingType);
 
         var response = await httpClient.SendAsync(httpOptions.HttpRequestMessage, effectiveCancellationToken).ConfigureAwait(false);
 
@@ -63,7 +60,7 @@ internal class Http : IHttpContext
         return await response.EnsureSuccessStatusCodeWithContentAsync(effectiveCancellationToken).ConfigureAwait(false);
     }
 
-    public HttpClient GetLoggingHttpClient(HttpLoggingType loggingType)
+    private HttpClient GetHttpClient(HttpLoggingType loggingType)
     {
         var clientName = HttpClientNames.GetClientName(loggingType);
         return _httpClientFactory.CreateClient(clientName);

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Context.Domains.Network;
@@ -12,6 +13,22 @@ namespace ModularPipelines.UnitTests.Context;
 
 public class HttpTests : TestBase
 {
+    [Test]
+    public async Task PublicApi_DoesNotExposeRawHttpClients()
+    {
+        var rawClientMembers = typeof(IHttpContext)
+            .GetMembers()
+            .Where(member => member switch
+            {
+                PropertyInfo property => property.PropertyType == typeof(HttpClient),
+                MethodInfo method => method.ReturnType == typeof(HttpClient),
+                _ => false,
+            })
+            .Select(member => member.Name);
+
+        await Assert.That(rawClientMembers).IsEmpty();
+    }
+
     [Test]
     public async Task Can_Send_Request_With_String_To_Request_Implicit_Conversion()
     {
@@ -83,7 +100,7 @@ public class HttpTests : TestBase
     [Test]
     [Arguments(true)]
     [Arguments(false)]
-    public async Task Assert_LoggingHttpClient_Logs_As_Expected(bool customHttpClient)
+    public async Task Assert_SendAsync_Logs_As_Expected(bool customHttpClient)
     {
         var file = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".txt");
 
@@ -98,9 +115,7 @@ public class HttpTests : TestBase
 
         if (!customHttpClient)
         {
-            var loggingClient = result.T.GetLoggingHttpClient();
-
-            await loggingClient.GetAsync(new Uri("https://thomhurst.github.io/TUnit"));
+            await result.T.SendAsync(new Uri("https://thomhurst.github.io/TUnit"));
         }
         else
         {


### PR DESCRIPTION
## Summary
- remove the raw HttpClient property and GetLoggingHttpClient method from IHttpContext
- keep factory-managed clients internal to the SendAsync implementation
- route Slack webhook requests through IHttpContext.SendAsync
- add a public-surface regression test and retain HTTP logging coverage

## Validation
- 6 HttpTests passed
- ModularPipelines.Slack solution build: 0 warnings, 0 errors
- changed-file analyzer warning gates passed

Closes #3301