### PR TITLE
Detect indirect module dependency cycles

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConflictingDependsOnAttributeUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConflictingDependsOnAttributeUnitTests.cs
@@ -35,6 +35,53 @@ public class Module1 : Module<List<string>>
 {SimpleModuleBody}
 ";
 
+    private const string IndirectCycleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[{{|#0:DependsOn<Module2>|}}]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+
+[{{|#1:DependsOn<Module3>|}}]
+public class Module2 : Module<List<string>>
+{SimpleModuleBody}
+
+[{{|#2:DependsOn<Module1>|}}]
+public class Module3 : Module<List<string>>
+{SimpleModuleBody}
+";
+
+    private const string NonGenericIndirectCycleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[{{|#0:DependsOn(typeof(Module2))|}}]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+
+[{{|#1:DependsOn(typeof(Module3))|}}]
+public class Module2 : Module<List<string>>
+{SimpleModuleBody}
+
+[{{|#2:DependsOn(typeof(Module1))|}}]
+public class Module3 : Module<List<string>>
+{SimpleModuleBody}
+";
+
+    private const string AcyclicChainSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[DependsOn<Module2>]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+
+[DependsOn<Module3>]
+public class Module2 : Module<List<string>>
+{SimpleModuleBody}
+
+public class Module3 : Module<List<string>>
+{SimpleModuleBody}
+";
+
     private const string GoodModuleSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -68,6 +115,52 @@ public class Module2 : Module<List<string>>
             .WithArguments("Module1", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleSource2, expected);
+    }
+
+    [TestMethod]
+    public async Task AnalyzerIsTriggered_When_Indirect_Cycle_Exists()
+    {
+        var expected1 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Module2", "Module1");
+
+        var expected2 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(1)
+            .WithArguments("Module3", "Module2");
+
+        var expected3 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(2)
+            .WithArguments("Module1", "Module3");
+
+        await VerifyCS.VerifyAnalyzerAsync(IndirectCycleSource, expected1, expected2, expected3);
+    }
+
+    [TestMethod]
+    public async Task AnalyzerIsTriggered_When_NonGeneric_Indirect_Cycle_Exists()
+    {
+        var expected1 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Module2", "Module1");
+
+        var expected2 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(1)
+            .WithArguments("Module3", "Module2");
+
+        var expected3 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(2)
+            .WithArguments("Module1", "Module3");
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            NonGenericIndirectCycleSource,
+            expected1,
+            expected2,
+            expected3);
+    }
+
+    [TestMethod]
+    public async Task AnalyzerIsNotTriggered_When_Indirect_Dependency_Chain_Is_Acyclic()
+    {
+        await VerifyCS.VerifyAnalyzerAsync(AcyclicChainSource);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConflictingDependsOnAttributeUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConflictingDependsOnAttributeUnitTests.cs
@@ -1,4 +1,7 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using ModularPipelines.Context;
 using System.Text;
 using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpAnalyzerVerifier<ModularPipelines.Analyzers.ConflictingDependsOnAttributeAnalyzer>;
 
@@ -127,6 +130,22 @@ public class Module1<T> : Module<List<string>>
 {SimpleModuleBody}
 
 [{{|#1:DependsOn<Module1<int>>|}}]
+public class Module2 : Module<List<string>>
+{SimpleModuleBody}
+";
+
+    private const string GeneratedCycleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[{{|#0:DependsOn<Module2>|}}]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
+    private const string GeneratedDependencySource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[DependsOn<Module1>]
 public class Module2 : Module<List<string>>
 {SimpleModuleBody}
 ";
@@ -264,6 +283,31 @@ public class Module2 : Module<List<string>>
     }
 
     [TestMethod]
+    public async Task AnalyzerIsTriggered_When_Cycle_Uses_Generated_Dependency()
+    {
+        var expected = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Module2", "Module1");
+        var test = new GeneratedDependencyAnalyzerTest
+        {
+            TestCode = GeneratedCycleSource,
+            ReferenceAssemblies = Net.Net100,
+            TestState =
+            {
+                AdditionalReferences = { typeof(IModuleContext).Assembly.Location },
+            },
+        };
+
+        test.TestState.GeneratedSources.Add((
+            typeof(GeneratedDependencySourceGenerator),
+            "GeneratedDependency.g.cs",
+            SourceText.From(GeneratedDependencySource, Encoding.UTF8)));
+        test.ExpectedDiagnostics.Add(expected);
+
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    [TestMethod]
     public async Task AnalyzerHandlesLongDependencyChainsIteratively()
     {
         await VerifyCS.VerifyAnalyzerAsync(CreateLongDependencyChain(5_000));
@@ -304,5 +348,25 @@ public class Module2 : Module<List<string>>
         source.AppendLine("}");
 
         return source.ToString();
+    }
+
+    private sealed class GeneratedDependencyAnalyzerTest : VerifyCS.Test
+    {
+        protected override IEnumerable<Type> GetSourceGenerators()
+        {
+            return [typeof(GeneratedDependencySourceGenerator)];
+        }
+    }
+
+    public sealed class GeneratedDependencySourceGenerator : ISourceGenerator
+    {
+        public void Initialize(GeneratorInitializationContext context)
+        {
+        }
+
+        public void Execute(GeneratorExecutionContext context)
+        {
+            context.AddSource("GeneratedDependency.g.cs", GeneratedDependencySource);
+        }
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConflictingDependsOnAttributeUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConflictingDependsOnAttributeUnitTests.cs
@@ -82,6 +82,22 @@ public class Module3 : Module<List<string>>
 {SimpleModuleBody}
 ";
 
+    private const string InheritedInterfaceCycleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[DependsOn<Module2>]
+public interface IModule1Dependencies
+{{
+}}
+
+public class Module1 : Module<List<string>>, IModule1Dependencies
+{SimpleModuleBody}
+
+[{{|#0:DependsOn<Module1>|}}]
+public class Module2 : Module<List<string>>
+{SimpleModuleBody}
+";
+
     private const string GoodModuleSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -161,6 +177,16 @@ public class Module2 : Module<List<string>>
     public async Task AnalyzerIsNotTriggered_When_Indirect_Dependency_Chain_Is_Acyclic()
     {
         await VerifyCS.VerifyAnalyzerAsync(AcyclicChainSource);
+    }
+
+    [TestMethod]
+    public async Task AnalyzerIsTriggered_When_Cycle_Uses_Inherited_Interface_Dependency()
+    {
+        var expected = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Module1", "Module2");
+
+        await VerifyCS.VerifyAnalyzerAsync(InheritedInterfaceCycleSource, expected);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConflictingDependsOnAttributeUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConflictingDependsOnAttributeUnitTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text;
 using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpAnalyzerVerifier<ModularPipelines.Analyzers.ConflictingDependsOnAttributeAnalyzer>;
 
 namespace ModularPipelines.Analyzers.Test;
@@ -85,7 +86,7 @@ public class Module3 : Module<List<string>>
     private const string InheritedInterfaceCycleSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
-[DependsOn<Module2>]
+    [{{|#0:DependsOn<Module2>|}}]
 public interface IModule1Dependencies
 {{
 }}
@@ -93,7 +94,39 @@ public interface IModule1Dependencies
 public class Module1 : Module<List<string>>, IModule1Dependencies
 {SimpleModuleBody}
 
-[{{|#0:DependsOn<Module1>|}}]
+[{{|#1:DependsOn<Module1>|}}]
+public class Module2 : Module<List<string>>
+{SimpleModuleBody}
+";
+
+    private const string InheritedBaseCycleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[{{|#0:DependsOn<Module2>|}}]
+public abstract class Module1Base : Module<List<string>>
+{{
+}}
+
+public class Module1 : Module1Base
+{SimpleModuleBody}
+
+[{{|#1:DependsOn<Module1>|}}]
+public abstract class Module2Base : Module<List<string>>
+{{
+}}
+
+public class Module2 : Module2Base
+{SimpleModuleBody}
+";
+
+    private const string ConstructedGenericCycleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[{{|#0:DependsOn<Module2>|}}]
+public class Module1<T> : Module<List<string>>
+{SimpleModuleBody}
+
+[{{|#1:DependsOn<Module1<int>>|}}]
 public class Module2 : Module<List<string>>
 {SimpleModuleBody}
 ";
@@ -182,16 +215,94 @@ public class Module2 : Module<List<string>>
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_Cycle_Uses_Inherited_Interface_Dependency()
     {
-        var expected = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+        var expected1 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
             .WithLocation(0)
+            .WithArguments("Module2", "Module1");
+
+        var expected2 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(1)
             .WithArguments("Module1", "Module2");
 
-        await VerifyCS.VerifyAnalyzerAsync(InheritedInterfaceCycleSource, expected);
+        await VerifyCS.VerifyAnalyzerAsync(
+            InheritedInterfaceCycleSource,
+            expected1,
+            expected2);
+    }
+
+    [TestMethod]
+    public async Task AnalyzerIsTriggered_When_All_Cycle_Edges_Are_Inherited()
+    {
+        var expected1 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Module2", "Module1");
+
+        var expected2 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(1)
+            .WithArguments("Module1", "Module2");
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            InheritedBaseCycleSource,
+            expected1,
+            expected2);
+    }
+
+    [TestMethod]
+    public async Task AnalyzerIsTriggered_When_Cycle_Uses_Constructed_Generic()
+    {
+        var expected1 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Module2", "Module1<T>");
+
+        var expected2 = VerifyCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithLocation(1)
+            .WithArguments("Module1<int>", "Module2");
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            ConstructedGenericCycleSource,
+            expected1,
+            expected2);
+    }
+
+    [TestMethod]
+    public async Task AnalyzerHandlesLongDependencyChainsIteratively()
+    {
+        await VerifyCS.VerifyAnalyzerAsync(CreateLongDependencyChain(5_000));
     }
 
     [TestMethod]
     public async Task AnalyzerIsNotTriggered_When_No_Conflicting_Dependencies()
     {
         await VerifyCS.VerifyAnalyzerAsync(GoodModuleSource);
+    }
+
+    private static string CreateLongDependencyChain(int length)
+    {
+        var source = new StringBuilder(
+            TestSourceConstants.StandardModuleHeaderWithLogging);
+        source.AppendLine("""
+                          public abstract class ChainModule : Module<List<string>>
+                          {
+                              protected override Task<List<string>?> ExecuteAsync(
+                                  IModuleContext context,
+                                  CancellationToken cancellationToken)
+                              {
+                                  return Task.FromResult<List<string>?>([]);
+                              }
+                          }
+                          """);
+
+        for (var index = 0; index < length - 1; index++)
+        {
+            source.AppendLine($"[DependsOn<Chain{index + 1}>]");
+            source.AppendLine($"public class Chain{index} : ChainModule");
+            source.AppendLine("{");
+            source.AppendLine("}");
+        }
+
+        source.AppendLine($"public class Chain{length - 1} : ChainModule");
+        source.AppendLine("{");
+        source.AppendLine("}");
+
+        return source.ToString();
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
@@ -27,7 +27,7 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
         context.EnableConcurrentExecution();
 
         context.RegisterCompilationStartAction(startContext =>

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
@@ -29,49 +30,50 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
 
-        context.RegisterSyntaxNodeAction(AnalyzeConflictingDependsOnAttributes, SyntaxKind.Attribute);
+        context.RegisterCompilationStartAction(startContext =>
+        {
+            var edges = new ConcurrentBag<DependencyEdge>();
+
+            startContext.RegisterSyntaxNodeAction(
+                syntaxContext => CollectDependencyEdge(syntaxContext, edges),
+                SyntaxKind.Attribute);
+            startContext.RegisterCompilationEndAction(
+                compilationContext => ReportCircularDependencies(compilationContext, edges));
+        });
     }
 
-    private void AnalyzeConflictingDependsOnAttributes(SyntaxNodeAnalysisContext context)
+    private static void CollectDependencyEdge(
+        SyntaxNodeAnalysisContext context,
+        ConcurrentBag<DependencyEdge> edges)
     {
-        if (!IsDependsOn(context, out var namedTypeSymbol))
+        if (!TryGetDependencyType(context, out var dependencyType) ||
+            dependencyType is null)
         {
             return;
         }
 
-        if (!namedTypeSymbol!.IsGenericType ||
-            namedTypeSymbol.TypeArguments.FirstOrDefault() is not INamedTypeSymbol namedArgumentTypeSymbol)
+        var typeDeclaration = context.Node.FirstAncestorOrSelf<TypeDeclarationSyntax>();
+        var dependentType = typeDeclaration is null
+            ? null
+            : context.SemanticModel.GetDeclaredSymbol(
+                typeDeclaration,
+                context.CancellationToken);
+
+        if (dependentType is null)
         {
             return;
         }
 
-        var typeContainingAttribute = context.GetClassThatNodeIsIn();
-
-        if (typeContainingAttribute is null)
-        {
-            return;
-        }
-
-        var allAttributesOnDependentType = namedArgumentTypeSymbol.GetAllAttributesIncludingBaseAndInterfaces();
-
-        ReportDiagnostics(context, allAttributesOnDependentType, typeContainingAttribute, namedArgumentTypeSymbol);
+        edges.Add(new DependencyEdge(dependentType, dependencyType, context.Node.GetLocation()));
     }
 
-    private static bool IsDependsOn(SyntaxNodeAnalysisContext context, out INamedTypeSymbol? namedTypeSymbol)
+    private static bool TryGetDependencyType(
+        SyntaxNodeAnalysisContext context,
+        out INamedTypeSymbol? dependencyType)
     {
-        namedTypeSymbol = null;
+        dependencyType = null;
 
         if (context.Node is not AttributeSyntax attributeSyntax)
-        {
-            return false;
-        }
-
-        if (attributeSyntax.Name is not GenericNameSyntax genericNameSyntax)
-        {
-            return false;
-        }
-
-        if (genericNameSyntax.Identifier.ValueText is not AnalyzerConstants.TypeNames.DependsOn)
         {
             return false;
         }
@@ -83,56 +85,160 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        namedTypeSymbol = methodSymbol.ContainingType;
+        var attributeType = methodSymbol.ContainingType;
 
-        if (!IsDependsOnAttributeType(namedTypeSymbol, context.Compilation))
+        if (!attributeType.IsDependsOnAttribute(context.Compilation))
         {
             return false;
         }
 
-        return true;
+        dependencyType = attributeType.GetDependsOnTypeArgument(
+            attributeSyntax,
+            context.SemanticModel) as INamedTypeSymbol;
+
+        return dependencyType is not null;
     }
 
-    /// <summary>
-    /// Checks if the given type symbol is the DependsOnAttribute type (generic or non-generic).
-    /// Uses proper symbol comparison instead of string comparison.
-    /// </summary>
-    private static bool IsDependsOnAttributeType(INamedTypeSymbol typeSymbol, Compilation compilation)
+    private static void ReportCircularDependencies(
+        CompilationAnalysisContext context,
+        ConcurrentBag<DependencyEdge> collectedEdges)
     {
-        // Get the non-generic DependsOnAttribute type
-        var dependsOnAttributeType = compilation.GetTypeByMetadataName("ModularPipelines.Attributes.DependsOnAttribute");
-        if (dependsOnAttributeType is null)
+        var edges = collectedEdges
+            .OrderBy(edge => edge.Location.SourceTree?.FilePath, StringComparer.Ordinal)
+            .ThenBy(edge => edge.Location.SourceSpan.Start)
+            .ToArray();
+
+        if (edges.Length == 0)
         {
-            return false;
+            return;
         }
 
-        // For generic types, compare the original definition
-        var typeToCompare = typeSymbol.IsGenericType
-            ? typeSymbol.OriginalDefinition
-            : typeSymbol;
+        var graph = BuildGraph(edges);
 
-        // Check if it's the non-generic version
-        if (SymbolEqualityComparer.Default.Equals(typeToCompare, dependsOnAttributeType))
+        foreach (var edge in edges)
         {
-            return true;
-        }
+            context.CancellationToken.ThrowIfCancellationRequested();
 
-        // Get and check the generic version (DependsOnAttribute`1)
-        var genericDependsOnAttributeType = compilation.GetTypeByMetadataName("ModularPipelines.Attributes.DependsOnAttribute`1");
-        return genericDependsOnAttributeType is not null &&
-               SymbolEqualityComparer.Default.Equals(typeToCompare, genericDependsOnAttributeType);
+            if (!CanReach(
+                    edge.DependencyType,
+                    edge.DependentType,
+                    graph,
+                    context.CancellationToken))
+            {
+                continue;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                Rule,
+                edge.Location,
+                edge.DependencyType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                edge.DependentType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+        }
     }
 
-    private static void ReportDiagnostics(SyntaxNodeAnalysisContext context, IEnumerable<AttributeData> allAttributesOnDependentType,
-        INamedTypeSymbol typeContainingAttribute, INamedTypeSymbol namedArgumentTypeSymbol)
+    private static Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> BuildGraph(
+        IEnumerable<DependencyEdge> edges)
     {
-        foreach (var conflictingDependencyAttribute in allAttributesOnDependentType.Where(x =>
-                     x.IsDependsOnAttributeFor(context.Compilation, typeContainingAttribute)))
+        var graph = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(
+            SymbolEqualityComparer.Default);
+
+        foreach (var edge in edges)
         {
-            context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation(),
-                namedArgumentTypeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                conflictingDependencyAttribute.AttributeClass?.TypeArguments.First()
-                    .ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+            if (!graph.TryGetValue(edge.DependentType, out var dependencies))
+            {
+                dependencies = [];
+                graph.Add(edge.DependentType, dependencies);
+            }
+
+            dependencies.Add(edge.DependencyType);
         }
+
+        return graph;
+    }
+
+    private static bool CanReach(
+        INamedTypeSymbol start,
+        INamedTypeSymbol target,
+        IReadOnlyDictionary<INamedTypeSymbol, List<INamedTypeSymbol>> graph,
+        CancellationToken cancellationToken)
+    {
+        var pending = new Stack<INamedTypeSymbol>();
+        var visited = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        pending.Push(start);
+
+        while (pending.Count > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var current = pending.Pop();
+
+            if (SymbolEqualityComparer.Default.Equals(current, target))
+            {
+                return true;
+            }
+
+            if (!visited.Add(current))
+            {
+                continue;
+            }
+
+            foreach (var dependency in GetDependencies(current, graph))
+            {
+                pending.Push(dependency);
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> GetDependencies(
+        INamedTypeSymbol type,
+        IReadOnlyDictionary<INamedTypeSymbol, List<INamedTypeSymbol>> graph)
+    {
+        if (graph.TryGetValue(type, out var directDependencies))
+        {
+            foreach (var dependency in directDependencies)
+            {
+                yield return dependency;
+            }
+        }
+
+        foreach (var interfaceType in type.AllInterfaces)
+        {
+            if (!graph.TryGetValue(interfaceType, out var interfaceDependencies))
+            {
+                continue;
+            }
+
+            foreach (var dependency in interfaceDependencies)
+            {
+                yield return dependency;
+            }
+        }
+
+        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (!graph.TryGetValue(baseType, out var baseDependencies))
+            {
+                continue;
+            }
+
+            foreach (var dependency in baseDependencies)
+            {
+                yield return dependency;
+            }
+        }
+    }
+
+    private sealed class DependencyEdge(
+        INamedTypeSymbol dependentType,
+        INamedTypeSymbol dependencyType,
+        Location location)
+    {
+        public INamedTypeSymbol DependentType { get; } = dependentType;
+
+        public INamedTypeSymbol DependencyType { get; } = dependencyType;
+
+        public Location Location { get; } = location;
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
@@ -113,17 +113,16 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var graph = BuildGraph(edges);
+        var graph = BuildEffectiveGraph(edges);
+        var components = FindStronglyConnectedComponents(
+            graph,
+            context.CancellationToken);
 
         foreach (var edge in edges)
         {
             context.CancellationToken.ThrowIfCancellationRequested();
 
-            if (!CanReach(
-                    edge.DependencyType,
-                    edge.DependentType,
-                    graph,
-                    context.CancellationToken))
+            if (components[edge.DependentType] != components[edge.DependencyType])
             {
                 continue;
             }
@@ -136,59 +135,104 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> BuildGraph(
+    private static Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> BuildEffectiveGraph(
         IEnumerable<DependencyEdge> edges)
     {
-        var graph = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(
+        var directGraph = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(
             SymbolEqualityComparer.Default);
+        var nodes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
 
         foreach (var edge in edges)
         {
-            if (!graph.TryGetValue(edge.DependentType, out var dependencies))
+            nodes.Add(edge.DependentType);
+            nodes.Add(edge.DependencyType);
+
+            if (!directGraph.TryGetValue(edge.DependentType, out var dependencies))
             {
                 dependencies = [];
-                graph.Add(edge.DependentType, dependencies);
+                directGraph.Add(edge.DependentType, dependencies);
             }
 
             dependencies.Add(edge.DependencyType);
         }
 
-        return graph;
+        var effectiveGraph = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(
+            SymbolEqualityComparer.Default);
+
+        foreach (var node in nodes)
+        {
+            effectiveGraph[node] = GetDependencies(node, directGraph)
+                .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)
+                .ToList();
+        }
+
+        return effectiveGraph;
     }
 
-    private static bool CanReach(
-        INamedTypeSymbol start,
-        INamedTypeSymbol target,
+    private static Dictionary<INamedTypeSymbol, int> FindStronglyConnectedComponents(
         IReadOnlyDictionary<INamedTypeSymbol, List<INamedTypeSymbol>> graph,
         CancellationToken cancellationToken)
     {
-        var pending = new Stack<INamedTypeSymbol>();
-        var visited = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-        pending.Push(start);
+        var nextIndex = 0;
+        var nextComponent = 0;
+        var indices = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
+        var lowLinks = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
+        var stack = new Stack<INamedTypeSymbol>();
+        var onStack = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var components = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
 
-        while (pending.Count > 0)
+        foreach (var node in graph.Keys)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var current = pending.Pop();
-
-            if (SymbolEqualityComparer.Default.Equals(current, target))
+            if (!indices.ContainsKey(node))
             {
-                return true;
-            }
-
-            if (!visited.Add(current))
-            {
-                continue;
-            }
-
-            foreach (var dependency in GetDependencies(current, graph))
-            {
-                pending.Push(dependency);
+                Visit(node);
             }
         }
 
-        return false;
+        return components;
+
+        void Visit(INamedTypeSymbol node)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            indices[node] = nextIndex;
+            lowLinks[node] = nextIndex;
+            nextIndex++;
+            stack.Push(node);
+            onStack.Add(node);
+
+            foreach (var dependency in graph[node])
+            {
+                if (!indices.ContainsKey(dependency))
+                {
+                    Visit(dependency);
+                    lowLinks[node] = Math.Min(lowLinks[node], lowLinks[dependency]);
+                }
+                else if (onStack.Contains(dependency))
+                {
+                    lowLinks[node] = Math.Min(lowLinks[node], indices[dependency]);
+                }
+            }
+
+            if (lowLinks[node] != indices[node])
+            {
+                return;
+            }
+
+            INamedTypeSymbol componentNode;
+
+            do
+            {
+                componentNode = stack.Pop();
+                onStack.Remove(componentNode);
+                components[componentNode] = nextComponent;
+            }
+            while (!SymbolEqualityComparer.Default.Equals(componentNode, node));
+
+            nextComponent++;
+        }
     }
 
     private static IEnumerable<INamedTypeSymbol> GetDependencies(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
@@ -113,9 +113,13 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var graph = BuildEffectiveGraph(edges);
+        var graphs = BuildDependencyGraphs(edges);
         var components = FindStronglyConnectedComponents(
-            graph,
+            graphs.Effective,
+            context.CancellationToken);
+        var cyclicEffectiveDependents = FindCyclicEffectiveDependents(
+            graphs,
+            components,
             context.CancellationToken);
 
         foreach (var edge in edges)
@@ -124,24 +128,13 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
 
             var dependencyType = Normalize(edge.DependencyType);
             var declarationType = Normalize(edge.DependentType);
-            var effectiveDependentType =
-                components[declarationType] == components[dependencyType]
-                    ? declarationType
-                    : graph.Keys
-                        .Where(type => !SymbolEqualityComparer.Default.Equals(
-                            type,
-                            declarationType))
-                        .Where(type => ReceivesAttributesFrom(type, declarationType))
-                        .Where(type => graph[type].Contains(
-                            dependencyType,
-                            SymbolEqualityComparer.Default))
-                        .Where(type => components[type] == components[dependencyType])
-                        .OrderBy(
-                            type => type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                            StringComparer.Ordinal)
-                        .FirstOrDefault();
 
-            if (effectiveDependentType is null)
+            if (!cyclicEffectiveDependents.TryGetValue(
+                    declarationType,
+                    out var cyclicDependencies)
+                || !cyclicDependencies.TryGetValue(
+                    dependencyType,
+                    out var effectiveDependentType))
             {
                 continue;
             }
@@ -154,7 +147,7 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> BuildEffectiveGraph(
+    private static DependencyGraphs BuildDependencyGraphs(
         IEnumerable<DependencyEdge> edges)
     {
         var directGraph = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(
@@ -190,7 +183,89 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
             ];
         }
 
-        return effectiveGraph;
+        return new DependencyGraphs(directGraph, effectiveGraph);
+    }
+
+    private static Dictionary<
+        INamedTypeSymbol,
+        Dictionary<INamedTypeSymbol, INamedTypeSymbol>> FindCyclicEffectiveDependents(
+        DependencyGraphs graphs,
+        IReadOnlyDictionary<INamedTypeSymbol, int> components,
+        CancellationToken cancellationToken)
+    {
+        var result = new Dictionary<
+            INamedTypeSymbol,
+            Dictionary<INamedTypeSymbol, INamedTypeSymbol>>(
+            SymbolEqualityComparer.Default);
+        var receivers = graphs.Effective.Keys
+            .OrderBy(
+                type => type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                StringComparer.Ordinal);
+
+        foreach (var receiver in receivers)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            foreach (var declaration in GetAttributeDeclarations(
+                         receiver,
+                         graphs.Direct))
+            {
+                foreach (var dependency in graphs.Direct[declaration])
+                {
+                    if (components[receiver] != components[dependency])
+                    {
+                        continue;
+                    }
+
+                    if (!result.TryGetValue(declaration, out var cyclicDependencies))
+                    {
+                        cyclicDependencies =
+                            new Dictionary<INamedTypeSymbol, INamedTypeSymbol>(
+                                SymbolEqualityComparer.Default);
+                        result.Add(declaration, cyclicDependencies);
+                    }
+
+                    if (!cyclicDependencies.ContainsKey(dependency))
+                    {
+                        cyclicDependencies.Add(dependency, receiver);
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> GetAttributeDeclarations(
+        INamedTypeSymbol type,
+        IReadOnlyDictionary<INamedTypeSymbol, List<INamedTypeSymbol>> directGraph)
+    {
+        var yielded = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        if (directGraph.ContainsKey(type) && yielded.Add(type))
+        {
+            yield return type;
+        }
+
+        foreach (var interfaceType in type.AllInterfaces)
+        {
+            var declaration = Normalize(interfaceType);
+
+            if (directGraph.ContainsKey(declaration) && yielded.Add(declaration))
+            {
+                yield return declaration;
+            }
+        }
+
+        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            var declaration = Normalize(baseType);
+
+            if (directGraph.ContainsKey(declaration) && yielded.Add(declaration))
+            {
+                yield return declaration;
+            }
+        }
     }
 
     private static Dictionary<INamedTypeSymbol, int> FindStronglyConnectedComponents(
@@ -337,36 +412,6 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool ReceivesAttributesFrom(
-        INamedTypeSymbol type,
-        INamedTypeSymbol declarationType)
-    {
-        if (SymbolEqualityComparer.Default.Equals(type, declarationType))
-        {
-            return true;
-        }
-
-        if (type.AllInterfaces.Any(interfaceType =>
-                SymbolEqualityComparer.Default.Equals(
-                    Normalize(interfaceType),
-                    declarationType)))
-        {
-            return true;
-        }
-
-        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
-        {
-            if (SymbolEqualityComparer.Default.Equals(
-                    Normalize(baseType),
-                    declarationType))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     private static INamedTypeSymbol Normalize(INamedTypeSymbol type)
     {
         return type.OriginalDefinition;
@@ -382,5 +427,14 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
         public INamedTypeSymbol DependencyType { get; } = dependencyType;
 
         public Location Location { get; } = location;
+    }
+
+    private sealed class DependencyGraphs(
+        Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> direct,
+        Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> effective)
+    {
+        public Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> Direct { get; } = direct;
+
+        public Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> Effective { get; } = effective;
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
@@ -22,7 +22,7 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
         nameof(Resources.ConflictingDependsOnAttributeAnalyzerDescription));
 
     /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -122,7 +122,26 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
         {
             context.CancellationToken.ThrowIfCancellationRequested();
 
-            if (components[edge.DependentType] != components[edge.DependencyType])
+            var dependencyType = Normalize(edge.DependencyType);
+            var declarationType = Normalize(edge.DependentType);
+            var effectiveDependentType =
+                components[declarationType] == components[dependencyType]
+                    ? declarationType
+                    : graph.Keys
+                        .Where(type => !SymbolEqualityComparer.Default.Equals(
+                            type,
+                            declarationType))
+                        .Where(type => ReceivesAttributesFrom(type, declarationType))
+                        .Where(type => graph[type].Contains(
+                            dependencyType,
+                            SymbolEqualityComparer.Default))
+                        .Where(type => components[type] == components[dependencyType])
+                        .OrderBy(
+                            type => type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                            StringComparer.Ordinal)
+                        .FirstOrDefault();
+
+            if (effectiveDependentType is null)
             {
                 continue;
             }
@@ -131,7 +150,7 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
                 Rule,
                 edge.Location,
                 edge.DependencyType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
-                edge.DependentType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+                effectiveDependentType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
         }
     }
 
@@ -144,16 +163,19 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
 
         foreach (var edge in edges)
         {
-            nodes.Add(edge.DependentType);
-            nodes.Add(edge.DependencyType);
+            var dependentType = Normalize(edge.DependentType);
+            var dependencyType = Normalize(edge.DependencyType);
 
-            if (!directGraph.TryGetValue(edge.DependentType, out var dependencies))
+            nodes.Add(dependentType);
+            nodes.Add(dependencyType);
+
+            if (!directGraph.TryGetValue(dependentType, out var dependencies))
             {
                 dependencies = [];
-                directGraph.Add(edge.DependentType, dependencies);
+                directGraph.Add(dependentType, dependencies);
             }
 
-            dependencies.Add(edge.DependencyType);
+            dependencies.Add(dependencyType);
         }
 
         var effectiveGraph = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(
@@ -161,9 +183,11 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
 
         foreach (var node in nodes)
         {
-            effectiveGraph[node] = GetDependencies(node, directGraph)
-                .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)
-                .ToList();
+            effectiveGraph[node] =
+            [
+                .. GetDependencies(node, directGraph)
+                    .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default),
+            ];
         }
 
         return effectiveGraph;
@@ -173,71 +197,106 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
         IReadOnlyDictionary<INamedTypeSymbol, List<INamedTypeSymbol>> graph,
         CancellationToken cancellationToken)
     {
-        var nextIndex = 0;
-        var nextComponent = 0;
-        var indices = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
-        var lowLinks = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
-        var stack = new Stack<INamedTypeSymbol>();
-        var onStack = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
-        var components = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
+        var visited = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var finishOrder = new List<INamedTypeSymbol>(graph.Count);
 
         foreach (var node in graph.Keys)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!indices.ContainsKey(node))
+            if (visited.Contains(node))
             {
-                Visit(node);
+                continue;
+            }
+
+            var traversal = new Stack<(INamedTypeSymbol Node, bool IsExpanded)>();
+            traversal.Push((node, false));
+
+            while (traversal.Count > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var (current, isExpanded) = traversal.Pop();
+
+                if (isExpanded)
+                {
+                    finishOrder.Add(current);
+                    continue;
+                }
+
+                if (!visited.Add(current))
+                {
+                    continue;
+                }
+
+                traversal.Push((current, true));
+
+                foreach (var dependency in graph[current])
+                {
+                    if (!visited.Contains(dependency))
+                    {
+                        traversal.Push((dependency, false));
+                    }
+                }
             }
         }
 
-        return components;
+        var reverseGraph = graph.Keys.ToDictionary(
+            node => node,
+            _ => new List<INamedTypeSymbol>(),
+            SymbolEqualityComparer.Default);
 
-        void Visit(INamedTypeSymbol node)
+        foreach (var entry in graph)
+        {
+            foreach (var dependency in entry.Value)
+            {
+                reverseGraph[dependency].Add(entry.Key);
+            }
+        }
+
+        var components = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
+        var nextComponent = 0;
+
+        for (var index = finishOrder.Count - 1; index >= 0; index--)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            indices[node] = nextIndex;
-            lowLinks[node] = nextIndex;
-            nextIndex++;
-            stack.Push(node);
-            onStack.Add(node);
+            var node = finishOrder[index];
 
-            foreach (var dependency in graph[node])
+            if (components.ContainsKey(node))
             {
-                if (!indices.ContainsKey(dependency))
+                continue;
+            }
+
+            var traversal = new Stack<INamedTypeSymbol>();
+            traversal.Push(node);
+            components[node] = nextComponent;
+
+            while (traversal.Count > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var current = traversal.Pop();
+
+                foreach (var dependent in reverseGraph[current])
                 {
-                    Visit(dependency);
-                    lowLinks[node] = Math.Min(lowLinks[node], lowLinks[dependency]);
+                    if (!components.ContainsKey(dependent))
+                    {
+                        components.Add(dependent, nextComponent);
+                        traversal.Push(dependent);
+                    }
                 }
-                else if (onStack.Contains(dependency))
-                {
-                    lowLinks[node] = Math.Min(lowLinks[node], indices[dependency]);
-                }
             }
 
-            if (lowLinks[node] != indices[node])
-            {
-                return;
-            }
-
-            INamedTypeSymbol componentNode;
-
-            do
-            {
-                componentNode = stack.Pop();
-                onStack.Remove(componentNode);
-                components[componentNode] = nextComponent;
-            }
-            while (!SymbolEqualityComparer.Default.Equals(componentNode, node));
-
-            nextComponent++;
+            nextComponent += 1;
         }
+
+        return components;
     }
 
     private static IEnumerable<INamedTypeSymbol> GetDependencies(
         INamedTypeSymbol type,
-        IReadOnlyDictionary<INamedTypeSymbol, List<INamedTypeSymbol>> graph)
+        Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> graph)
     {
         if (graph.TryGetValue(type, out var directDependencies))
         {
@@ -249,7 +308,9 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
 
         foreach (var interfaceType in type.AllInterfaces)
         {
-            if (!graph.TryGetValue(interfaceType, out var interfaceDependencies))
+            if (!graph.TryGetValue(
+                    Normalize(interfaceType),
+                    out var interfaceDependencies))
             {
                 continue;
             }
@@ -262,7 +323,9 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
 
         for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
         {
-            if (!graph.TryGetValue(baseType, out var baseDependencies))
+            if (!graph.TryGetValue(
+                    Normalize(baseType),
+                    out var baseDependencies))
             {
                 continue;
             }
@@ -272,6 +335,41 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
                 yield return dependency;
             }
         }
+    }
+
+    private static bool ReceivesAttributesFrom(
+        INamedTypeSymbol type,
+        INamedTypeSymbol declarationType)
+    {
+        if (SymbolEqualityComparer.Default.Equals(type, declarationType))
+        {
+            return true;
+        }
+
+        if (type.AllInterfaces.Any(interfaceType =>
+                SymbolEqualityComparer.Default.Equals(
+                    Normalize(interfaceType),
+                    declarationType)))
+        {
+            return true;
+        }
+
+        for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(
+                    Normalize(baseType),
+                    declarationType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static INamedTypeSymbol Normalize(INamedTypeSymbol type)
+    {
+        return type.OriginalDefinition;
     }
 
     private sealed class DependencyEdge(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ConflictingDependsOnAttributeAnalyzer.cs
@@ -190,7 +190,7 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
         INamedTypeSymbol,
         Dictionary<INamedTypeSymbol, INamedTypeSymbol>> FindCyclicEffectiveDependents(
         DependencyGraphs graphs,
-        IReadOnlyDictionary<INamedTypeSymbol, int> components,
+        Dictionary<INamedTypeSymbol, int> components,
         CancellationToken cancellationToken)
     {
         var result = new Dictionary<
@@ -238,7 +238,7 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
 
     private static IEnumerable<INamedTypeSymbol> GetAttributeDeclarations(
         INamedTypeSymbol type,
-        IReadOnlyDictionary<INamedTypeSymbol, List<INamedTypeSymbol>> directGraph)
+        Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> directGraph)
     {
         var yielded = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
 
@@ -269,6 +269,16 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
     }
 
     private static Dictionary<INamedTypeSymbol, int> FindStronglyConnectedComponents(
+        IReadOnlyDictionary<INamedTypeSymbol, List<INamedTypeSymbol>> graph,
+        CancellationToken cancellationToken)
+    {
+        var finishOrder = CreateFinishOrder(graph, cancellationToken);
+        var reverseGraph = CreateReverseGraph(graph);
+
+        return AssignComponents(finishOrder, reverseGraph, cancellationToken);
+    }
+
+    private static List<INamedTypeSymbol> CreateFinishOrder(
         IReadOnlyDictionary<INamedTypeSymbol, List<INamedTypeSymbol>> graph,
         CancellationToken cancellationToken)
     {
@@ -316,10 +326,19 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        var reverseGraph = graph.Keys.ToDictionary(
-            node => node,
-            _ => new List<INamedTypeSymbol>(),
+        return finishOrder;
+    }
+
+    private static Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> CreateReverseGraph(
+        IReadOnlyDictionary<INamedTypeSymbol, List<INamedTypeSymbol>> graph)
+    {
+        var reverseGraph = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>(
             SymbolEqualityComparer.Default);
+
+        foreach (var node in graph.Keys)
+        {
+            reverseGraph.Add(node, []);
+        }
 
         foreach (var entry in graph)
         {
@@ -329,6 +348,14 @@ public class ConflictingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
             }
         }
 
+        return reverseGraph;
+    }
+
+    private static Dictionary<INamedTypeSymbol, int> AssignComponents(
+        List<INamedTypeSymbol> finishOrder,
+        Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> reverseGraph,
+        CancellationToken cancellationToken)
+    {
         var components = new Dictionary<INamedTypeSymbol, int>(SymbolEqualityComparer.Default);
         var nextComponent = 0;
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Resources.Designer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Resources.Designer.cs
@@ -87,7 +87,7 @@ namespace ModularPipelines.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} Depends on {1} and {1} Depends on {0}..
+        ///   Looks up a localized string similar to A dependency edge participates in a circular module dependency..
         /// </summary>
         internal static string ConflictingDependsOnAttributeAnalyzerDescription {
             get {
@@ -96,7 +96,7 @@ namespace ModularPipelines.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} Depends on {1} and {1} Depends on {0}.
+        ///   Looks up a localized string similar to Dependency edge {1} -&gt; {0} participates in a circular dependency.
         /// </summary>
         internal static string ConflictingDependsOnAttributeAnalyzerMessageFormat {
             get {
@@ -105,7 +105,7 @@ namespace ModularPipelines.Analyzers {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Conflicting DependsOn Attributes.
+        ///   Looks up a localized string similar to Circular dependency detected.
         /// </summary>
         internal static string ConflictingDependsOnAttributeAnalyzerTitle {
             get {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Resources.resx
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Resources.resx
@@ -154,13 +154,13 @@
     <value>Use of Console detected</value>
   </data>
   <data name="ConflictingDependsOnAttributeAnalyzerTitle" xml:space="preserve">
-    <value>Conflicting DependsOn Attributes</value>
+    <value>Circular dependency detected</value>
   </data>
   <data name="ConflictingDependsOnAttributeAnalyzerMessageFormat" xml:space="preserve">
-    <value>{0} Depends on {1} and {1} Depends on {0}</value>
+    <value>Dependency edge {1} -&gt; {0} participates in a circular dependency</value>
   </data>
   <data name="ConflictingDependsOnAttributeAnalyzerDescription" xml:space="preserve">
-    <value>{0} Depends on {1} and {1} Depends on {0}.</value>
+    <value>A dependency edge participates in a circular module dependency.</value>
   </data>
   <data name="AsyncModuleAnalyzerTitle" xml:space="preserve">
     <value>Module should be async</value>


### PR DESCRIPTION
## Summary
- collect DependsOn edges for the complete compilation
- use cancellation-aware iterative graph traversal to detect cycles of any length
- support generic and non-generic dependency attributes across type declarations
- report each participating edge with a cycle-specific diagnostic message

## Validation
- 56 analyzer tests passed
- ModularPipelines.Analyzers.sln Release build: 0 warnings, 0 errors
- changed-file analyzer warning gate passed

Closes #3313