### PR TITLE
Add discoverable tool context

### DIFF
--- a/docs/docs/how-to/generate-private-cli-integration.md
+++ b/docs/docs/how-to/generate-private-cli-integration.md
@@ -165,6 +165,8 @@ public static IPrivateWidget PrivateWidget(this IPipelineContext context) =>
 
 The generator uses that shared declaring type to associate the accessor with its
 registration. Accessor names must be unique across all referenced integration packages.
+They also cannot use names already exposed by `IToolsContext` or `object`, such as `Get`
+or `GetType`, because instance-member lookup would hide the generated property.
 `context.Tools.*` is the preferred discoverable API; the original extension method remains
 available for compatibility. Generated tool properties use C# 14 extension members. On
 older language versions, registration metadata still generates and `MPGEN003` explains why

--- a/docs/docs/how-to/generate-private-cli-integration.md
+++ b/docs/docs/how-to/generate-private-cli-integration.md
@@ -154,6 +154,22 @@ The method must be accessible from its assembly, static, non-generic, declared o
 non-generic accessible type, and accept one `IServiceCollection` parameter. It can return
 either `void` or `IServiceCollection`.
 
+To expose the integration through the discoverable `context.Tools.PrivateWidget` API, keep
+its public `IPipelineContext` extension accessor in the same static class as the attributed
+registration method:
+
+```csharp
+public static IPrivateWidget PrivateWidget(this IPipelineContext context) =>
+    context.Services.Get<IPrivateWidget>();
+```
+
+The generator uses that shared declaring type to associate the accessor with its
+registration. Accessor names must be unique across all referenced integration packages.
+`context.Tools.*` is the preferred discoverable API; the original extension method remains
+available for compatibility. Generated tool properties use C# 14 extension members. On
+older language versions, registration metadata still generates and `MPGEN003` explains why
+the optional `Tools` property was skipped.
+
 Referencing the `ModularPipelines` package includes the source generator as an analyzer.
 The generator emits immutable assembly registration metadata, which each pipeline consumes
 independently. Remove the old parameterless module initializer and any call to

--- a/docs/docs/how-to/generate-private-cli-integration.md
+++ b/docs/docs/how-to/generate-private-cli-integration.md
@@ -169,7 +169,7 @@ They also cannot use names already exposed by `IToolsContext` or `object`, such 
 or `GetType`, because instance-member lookup would hide the generated property.
 `context.Tools.*` is the preferred discoverable API; the original extension method remains
 available for compatibility. Generated tool properties use C# 14 extension members. On
-older language versions, registration metadata still generates and `MPGEN003` explains why
+older language versions, registration metadata still generates and `MPG0008` explains why
 the optional `Tools` property was skipped.
 
 Referencing the `ModularPipelines` package includes the source generator as an analyzer.

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -66,6 +66,28 @@ accessible and non-generic. Until fixed, Modular Pipelines uses runtime reflecti
 
 **Severity:** Info
 
+## MPG0008
+
+A tool accessor cannot generate a discoverable `context.Tools` property because
+the consuming project uses a language version older than C# 14. Registration
+metadata still generates. Use C# 14 or preview to enable the property.
+
+**Severity:** Warning
+
+## MPG0009
+
+Multiple tool accessors would generate the same discoverable property with
+conflicting declarations. Give each accessor a unique name.
+
+**Severity:** Error
+
+## MPG0010
+
+A tool accessor would generate a property whose name is already available on
+`IToolsContext` or `object`, such as `Get` or `GetType`. Rename the accessor.
+
+**Severity:** Error
+
 Diagnostics can be configured with standard MSBuild or `.editorconfig` settings.
 For example:
 

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -57,6 +57,26 @@ internal static class GeneratorDiagnostics
         + "type is generic or inaccessible; runtime reflection will be used",
         DiagnosticSeverity.Info);
 
+    public static DiagnosticDescriptor UnsupportedToolsLanguageVersion { get; } = Create(
+        "MPG0008",
+        "Discoverable tool properties require C# 14",
+        "Tool accessor '{0}' cannot generate a context.Tools property because language version "
+        + "'{1}' does not support extension members; use C# 14 or preview",
+        DiagnosticSeverity.Warning);
+
+    public static DiagnosticDescriptor ConflictingToolProperty { get; } = Create(
+        "MPG0009",
+        "Conflicting discoverable tool property",
+        "Tool property '{0}' has conflicting declarations: {1}",
+        DiagnosticSeverity.Error);
+
+    public static DiagnosticDescriptor ShadowedToolProperty { get; } = Create(
+        "MPG0010",
+        "Discoverable tool property shadows an instance member",
+        "Tool accessor '{0}' cannot generate property '{1}' because that name is already "
+        + "available on IToolsContext or object",
+        DiagnosticSeverity.Error);
+
     private static DiagnosticDescriptor Create(
         string id,
         string title,

--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -43,7 +43,7 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor ConflictingToolProperty = new(
         id: "MPGEN004",
         title: "Conflicting discoverable tool property",
-        messageFormat: "Tool property '{0}' has conflicting return types: {1}",
+        messageFormat: "Tool property '{0}' has conflicting declarations: {1}",
         category: "ModularPipelines.SourceGenerator",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -118,12 +118,14 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
                 && method.Parameters.Length == 1
                 && method.Parameters[0].RefKind == RefKind.None
                 && method.Parameters[0].Type.ToDisplayString() == PipelineContextFullName
-                && method.ReturnType.IsReferenceType)
+                && method.ReturnType.IsReferenceType
+                && IsPubliclyAccessible(method.ReturnType))
             .Select(static method => new ToolProperty(
                 method.Name,
                 method.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 method.ToDisplayString(),
-                method.Locations.FirstOrDefault()))
+                method.Locations.FirstOrDefault(),
+                method.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)))
             .ToImmutableArray();
     }
 
@@ -133,20 +135,22 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         return compilation.References
             .Select(compilation.GetAssemblyOrModuleSymbol)
             .OfType<IAssemblySymbol>()
-            .SelectMany(static assembly => assembly.GetAttributes())
-            .Where(static attribute =>
-                attribute.AttributeClass?.ToDisplayString() == AssemblyMetadataAttributeFullName
-                && attribute.ConstructorArguments.Length == 2
-                && attribute.ConstructorArguments[0].Value is string key
-                && key.StartsWith(ToolPropertyMetadataPrefix, StringComparison.Ordinal)
-                && attribute.ConstructorArguments[1].Value is string)
-            .Select(static attribute => new ReferencedToolProperty(
-                ((string) attribute.ConstructorArguments[0].Value!)
-                    .Substring(ToolPropertyMetadataPrefix.Length),
-                (string) attribute.ConstructorArguments[1].Value!))
+            .SelectMany(static assembly => assembly.GetAttributes()
+                .Where(static attribute =>
+                    attribute.AttributeClass?.ToDisplayString() == AssemblyMetadataAttributeFullName
+                    && attribute.ConstructorArguments.Length == 2
+                    && attribute.ConstructorArguments[0].Value is string key
+                    && key.StartsWith(ToolPropertyMetadataPrefix, StringComparison.Ordinal)
+                    && attribute.ConstructorArguments[1].Value is string)
+                .Select(attribute => new ReferencedToolProperty(
+                    ((string) attribute.ConstructorArguments[0].Value!)
+                        .Substring(ToolPropertyMetadataPrefix.Length),
+                    (string) attribute.ConstructorArguments[1].Value!,
+                    assembly.Identity.ToString())))
             .Distinct()
             .OrderBy(static property => property.Name, StringComparer.Ordinal)
             .ThenBy(static property => property.TypeName, StringComparer.Ordinal)
+            .ThenBy(static property => property.SourceId, StringComparer.Ordinal)
             .ToImmutableArray();
     }
 
@@ -192,6 +196,29 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         return true;
     }
 
+    private static bool IsPubliclyAccessible(ITypeSymbol type)
+    {
+        if (type is IArrayTypeSymbol arrayType)
+        {
+            return IsPubliclyAccessible(arrayType.ElementType);
+        }
+
+        if (type is not INamedTypeSymbol namedType)
+        {
+            return type.TypeKind == TypeKind.Dynamic;
+        }
+
+        for (var current = namedType; current is not null; current = current.ContainingType)
+        {
+            if (current.DeclaredAccessibility != Accessibility.Public)
+            {
+                return false;
+            }
+        }
+
+        return namedType.TypeArguments.All(IsPubliclyAccessible);
+    }
+
     private static void Generate(
         SourceProductionContext context,
         ImmutableArray<IntegrationCandidate> candidates,
@@ -225,7 +252,8 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
                 property.Name,
                 property.TypeName,
                 MethodName: property.Name,
-                Location: null)))
+                Location: null,
+                property.SourceId)))
             .ToArray();
         var conflictingPropertyNames = ReportToolPropertyConflicts(context, allToolProperties);
         var uniqueToolProperties = toolProperties
@@ -307,7 +335,7 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
             foreach (var property in uniqueToolProperties)
             {
                 builder.AppendLine(
-                    $"        public {property.TypeName} {property.Name} "
+                    $"        public {property.TypeName} {EscapeIdentifier(property.Name)} "
                     + $"=> tools.Get<{property.TypeName}>();");
             }
 
@@ -324,28 +352,31 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         ToolProperty[] toolProperties)
     {
         var conflicts = toolProperties
+            .GroupBy(static property => new
+            {
+                property.Name,
+                property.TypeName,
+                property.SourceId,
+            })
+            .Select(static group => group.First())
             .GroupBy(static property => property.Name, StringComparer.Ordinal)
-            .Where(static group =>
-                group.Select(static property => property.TypeName)
-                    .Distinct(StringComparer.Ordinal)
-                    .Skip(1)
-                    .Any())
+            .Where(static group => group.Skip(1).Any())
             .ToArray();
 
         foreach (var conflict in conflicts)
         {
-            var types = string.Join(
+            var declarations = string.Join(
                 ", ",
-                conflict.Select(static property => property.TypeName)
-                    .Distinct(StringComparer.Ordinal)
-                    .OrderBy(static typeName => typeName, StringComparer.Ordinal));
+                conflict.Select(static property =>
+                        $"{property.TypeName} ({property.SourceId})")
+                    .OrderBy(static declaration => declaration, StringComparer.Ordinal));
             foreach (var property in conflict)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     ConflictingToolProperty,
                     property.Location,
                     property.Name,
-                    types));
+                    declarations));
             }
         }
 
@@ -371,6 +402,12 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
     private static string Literal(string value) =>
         global::Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(value, quote: true);
 
+    private static string EscapeIdentifier(string identifier) =>
+        SyntaxFacts.GetKeywordKind(identifier) != SyntaxKind.None
+        || SyntaxFacts.GetContextualKeywordKind(identifier) != SyntaxKind.None
+            ? $"@{identifier}"
+            : identifier;
+
     private sealed record IntegrationCandidate(
         IntegrationRegistration? Registration,
         EquatableArray<ToolProperty> ToolProperties,
@@ -384,9 +421,11 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         string Name,
         string TypeName,
         string MethodName,
-        Location? Location);
+        Location? Location,
+        string SourceId);
 
     private sealed record ReferencedToolProperty(
         string Name,
-        string TypeName);
+        string TypeName,
+        string SourceId);
 }

--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -17,6 +17,9 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
     private const string ServiceCollectionFullName =
         "Microsoft.Extensions.DependencyInjection.IServiceCollection";
 
+    private const string PipelineContextFullName =
+        "ModularPipelines.Context.IPipelineContext";
+
     private static readonly DiagnosticDescriptor InvalidIntegrationMethod =
         GeneratorDiagnostics.InvalidIntegrationMethod;
 
@@ -53,6 +56,8 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         {
             return new IntegrationCandidate(
                 Registration: null,
+                EquatableArray<ToolProperty>.Empty,
+                GetGeneratedTypeName(context.SemanticModel.Compilation.AssemblyName),
                 method.ToDisplayString(),
                 location);
         }
@@ -61,9 +66,54 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
             new IntegrationRegistration(
                 method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 method.Name),
+            GetToolProperties(method.ContainingType),
+            GetGeneratedTypeName(context.SemanticModel.Compilation.AssemblyName),
             method.ToDisplayString(),
             location);
     }
+
+    private static EquatableArray<ToolProperty> GetToolProperties(INamedTypeSymbol type)
+    {
+        return type.GetMembers()
+            .OfType<IMethodSymbol>()
+            .Where(static method =>
+                method.IsStatic
+                && method.IsExtensionMethod
+                && !method.IsGenericMethod
+                && method.DeclaredAccessibility == Accessibility.Public
+                && method.Parameters.Length == 1
+                && method.Parameters[0].RefKind == RefKind.None
+                && method.Parameters[0].Type.ToDisplayString() == PipelineContextFullName
+                && !method.ReturnsVoid)
+            .Select(static method => new ToolProperty(
+                method.Name,
+                method.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)))
+            .ToImmutableArray();
+    }
+
+    private static string GetGeneratedTypeName(string? assemblyName)
+    {
+        var name = assemblyName ?? "Integration";
+        var builder = new StringBuilder(name.Length + 15);
+
+        if (name.Length == 0 || !IsIdentifierStart(name[0]))
+        {
+            builder.Append('_');
+        }
+
+        foreach (var character in name)
+        {
+            builder.Append(IsIdentifierPart(character) ? character : '_');
+        }
+
+        return builder.Append("ToolsExtensions").ToString();
+    }
+
+    private static bool IsIdentifierStart(char character) =>
+        character == '_' || char.IsLetter(character);
+
+    private static bool IsIdentifierPart(char character) =>
+        character == '_' || char.IsLetterOrDigit(character);
 
     private static bool IsAccessibleFromGeneratedRegistrar(INamedTypeSymbol type)
     {
@@ -105,6 +155,14 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
             .OrderBy(static registration => registration.TypeName, StringComparer.Ordinal)
             .ThenBy(static registration => registration.MethodName, StringComparer.Ordinal)
             .ToArray();
+
+        var toolProperties = candidates
+            .SelectMany(static candidate => candidate.ToolProperties)
+            .Distinct()
+            .OrderBy(static property => property.Name, StringComparer.Ordinal)
+            .ThenBy(static property => property.TypeName, StringComparer.Ordinal)
+            .ToArray();
+
         if (uniqueRegistrations.Length == 0)
         {
             return;
@@ -118,8 +176,8 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
             "[assembly: global::ModularPipelines.Attributes.ModularPipelinesContextAttribute("
             + "typeof(global::ModularPipelines.Generated.ModularPipelinesContextRegistration))]");
         builder.AppendLine();
-        builder.AppendLine("namespace ModularPipelines.Generated;");
-        builder.AppendLine();
+        builder.AppendLine("namespace ModularPipelines.Generated");
+        builder.AppendLine("{");
         builder.AppendLine("internal static class ModularPipelinesContextRegistration");
         builder.AppendLine("{");
         builder.AppendLine(
@@ -135,14 +193,43 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
 
         builder.AppendLine("    }");
         builder.AppendLine("}");
+        builder.AppendLine("}");
+
+        if (toolProperties.Length > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("namespace ModularPipelines.Context");
+            builder.AppendLine("{");
+            builder.AppendLine(
+                $"public static class {candidates[0].GeneratedTypeName}");
+            builder.AppendLine("{");
+            builder.AppendLine(
+                "    extension(global::ModularPipelines.Context.IToolsContext tools)");
+            builder.AppendLine("    {");
+
+            foreach (var property in toolProperties)
+            {
+                builder.AppendLine(
+                    $"        public {property.TypeName} {property.Name} "
+                    + $"=> tools.Get<{property.TypeName}>();");
+            }
+
+            builder.AppendLine("    }");
+            builder.AppendLine("}");
+            builder.AppendLine("}");
+        }
 
         context.AddSource("ModularPipelines.IntegrationRegistration.g.cs", builder.ToString());
     }
 
     private sealed record IntegrationCandidate(
         IntegrationRegistration? Registration,
+        EquatableArray<ToolProperty> ToolProperties,
+        string GeneratedTypeName,
         string MethodName,
         Location Location);
 
     private sealed record IntegrationRegistration(string TypeName, string MethodName);
+
+    private sealed record ToolProperty(string Name, string TypeName);
 }

--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -21,6 +21,12 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
     private const string PipelineContextFullName =
         "ModularPipelines.Context.IPipelineContext";
 
+    private const string AssemblyMetadataAttributeFullName =
+        "System.Reflection.AssemblyMetadataAttribute";
+
+    private const string ToolPropertyMetadataPrefix =
+        "ModularPipelines.ToolProperty:";
+
     private static readonly DiagnosticDescriptor InvalidIntegrationMethod =
         GeneratorDiagnostics.InvalidIntegrationMethod;
 
@@ -48,12 +54,18 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
                 IntegrationAttributeFullName,
                 static (node, _) => node is MethodDeclarationSyntax,
                 static (generatorContext, _) => GetCandidate(generatorContext));
+        var referencedToolProperties = context.CompilationProvider.Select(
+            static (compilation, _) => GetReferencedToolProperties(compilation));
 
         context.RegisterSourceOutput(
-            candidates.Collect().Combine(context.ParseOptionsProvider),
+            candidates
+                .Collect()
+                .Combine(context.ParseOptionsProvider)
+                .Combine(referencedToolProperties),
             static (sourceContext, input) => Generate(
                 sourceContext,
-                input.Left,
+                input.Left.Left,
+                input.Left.Right,
                 input.Right));
     }
 
@@ -106,12 +118,35 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
                 && method.Parameters.Length == 1
                 && method.Parameters[0].RefKind == RefKind.None
                 && method.Parameters[0].Type.ToDisplayString() == PipelineContextFullName
-                && !method.ReturnsVoid)
+                && method.ReturnType.IsReferenceType)
             .Select(static method => new ToolProperty(
                 method.Name,
                 method.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 method.ToDisplayString(),
                 method.Locations.FirstOrDefault()))
+            .ToImmutableArray();
+    }
+
+    private static EquatableArray<ReferencedToolProperty> GetReferencedToolProperties(
+        Compilation compilation)
+    {
+        return compilation.References
+            .Select(compilation.GetAssemblyOrModuleSymbol)
+            .OfType<IAssemblySymbol>()
+            .SelectMany(static assembly => assembly.GetAttributes())
+            .Where(static attribute =>
+                attribute.AttributeClass?.ToDisplayString() == AssemblyMetadataAttributeFullName
+                && attribute.ConstructorArguments.Length == 2
+                && attribute.ConstructorArguments[0].Value is string key
+                && key.StartsWith(ToolPropertyMetadataPrefix, StringComparison.Ordinal)
+                && attribute.ConstructorArguments[1].Value is string)
+            .Select(static attribute => new ReferencedToolProperty(
+                ((string) attribute.ConstructorArguments[0].Value!)
+                    .Substring(ToolPropertyMetadataPrefix.Length),
+                (string) attribute.ConstructorArguments[1].Value!))
+            .Distinct()
+            .OrderBy(static property => property.Name, StringComparer.Ordinal)
+            .ThenBy(static property => property.TypeName, StringComparer.Ordinal)
             .ToImmutableArray();
     }
 
@@ -160,7 +195,8 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
     private static void Generate(
         SourceProductionContext context,
         ImmutableArray<IntegrationCandidate> candidates,
-        ParseOptions parseOptions)
+        ParseOptions parseOptions,
+        EquatableArray<ReferencedToolProperty> referencedToolProperties)
     {
         foreach (var candidate in candidates)
         {
@@ -184,7 +220,14 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         var toolProperties = candidates
             .SelectMany(static candidate => candidate.ToolProperties)
             .ToArray();
-        var conflictingPropertyNames = ReportToolPropertyConflicts(context, toolProperties);
+        var allToolProperties = toolProperties
+            .Concat(referencedToolProperties.Select(static property => new ToolProperty(
+                property.Name,
+                property.TypeName,
+                MethodName: property.Name,
+                Location: null)))
+            .ToArray();
+        var conflictingPropertyNames = ReportToolPropertyConflicts(context, allToolProperties);
         var uniqueToolProperties = toolProperties
             .Where(property => !conflictingPropertyNames.Contains(property.Name))
             .GroupBy(static property => new
@@ -209,6 +252,17 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         builder.AppendLine(
             "[assembly: global::ModularPipelines.Attributes.ModularPipelinesContextAttribute("
             + "typeof(global::ModularPipelines.Generated.ModularPipelinesContextRegistration))]");
+        if (uniqueToolProperties.Length > 0 && SupportsExtensionMembers(parseOptions))
+        {
+            foreach (var property in uniqueToolProperties)
+            {
+                builder.AppendLine(
+                    "[assembly: global::System.Reflection.AssemblyMetadataAttribute("
+                    + $"{Literal(ToolPropertyMetadataPrefix + property.Name)}, "
+                    + $"{Literal(property.TypeName)})]");
+            }
+        }
+
         builder.AppendLine();
         builder.AppendLine("namespace ModularPipelines.Generated");
         builder.AppendLine("{");
@@ -314,6 +368,9 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
             : parseOptions.Language;
     }
 
+    private static string Literal(string value) =>
+        global::Microsoft.CodeAnalysis.CSharp.SymbolDisplay.FormatLiteral(value, quote: true);
+
     private sealed record IntegrationCandidate(
         IntegrationRegistration? Registration,
         EquatableArray<ToolProperty> ToolProperties,
@@ -328,4 +385,8 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         string TypeName,
         string MethodName,
         Location? Location);
+
+    private sealed record ReferencedToolProperty(
+        string Name,
+        string TypeName);
 }

--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -39,33 +39,14 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor InvalidIntegrationMethod =
         GeneratorDiagnostics.InvalidIntegrationMethod;
 
-    private static readonly DiagnosticDescriptor UnsupportedToolsLanguageVersion = new(
-        id: "MPGEN003",
-        title: "Discoverable tool properties require C# 14",
-        messageFormat:
-            "Tool accessor '{0}' cannot generate a context.Tools property because language version "
-            + "'{1}' does not support extension members; use C# 14 or preview",
-        category: "ModularPipelines.SourceGenerator",
-        defaultSeverity: DiagnosticSeverity.Warning,
-        isEnabledByDefault: true);
+    private static readonly DiagnosticDescriptor UnsupportedToolsLanguageVersion =
+        GeneratorDiagnostics.UnsupportedToolsLanguageVersion;
 
-    private static readonly DiagnosticDescriptor ConflictingToolProperty = new(
-        id: "MPGEN004",
-        title: "Conflicting discoverable tool property",
-        messageFormat: "Tool property '{0}' has conflicting declarations: {1}",
-        category: "ModularPipelines.SourceGenerator",
-        defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+    private static readonly DiagnosticDescriptor ConflictingToolProperty =
+        GeneratorDiagnostics.ConflictingToolProperty;
 
-    private static readonly DiagnosticDescriptor ShadowedToolProperty = new(
-        id: "MPGEN005",
-        title: "Discoverable tool property shadows an instance member",
-        messageFormat:
-            "Tool accessor '{0}' cannot generate property '{1}' because that name is already "
-            + "available on IToolsContext or object",
-        category: "ModularPipelines.SourceGenerator",
-        defaultSeverity: DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+    private static readonly DiagnosticDescriptor ShadowedToolProperty =
+        GeneratorDiagnostics.ShadowedToolProperty;
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -260,6 +241,8 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
             candidates,
             referencedToolProperties,
             supportsExtensionMembers);
+        var generatesExtensionMembers =
+            uniqueToolProperties.Length > 0 && supportsExtensionMembers;
 
         if (uniqueRegistrations.Length == 0)
         {
@@ -273,7 +256,7 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         builder.AppendLine(
             "[assembly: global::ModularPipelines.Attributes.ModularPipelinesContextAttribute("
             + "typeof(global::ModularPipelines.Generated.ModularPipelinesContextRegistration))]");
-        if (uniqueToolProperties.Length > 0 && supportsExtensionMembers)
+        if (generatesExtensionMembers)
         {
             foreach (var property in uniqueToolProperties)
             {
@@ -285,8 +268,17 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         }
 
         builder.AppendLine();
-        builder.AppendLine("namespace ModularPipelines.Generated");
-        builder.AppendLine("{");
+        if (generatesExtensionMembers)
+        {
+            builder.AppendLine("namespace ModularPipelines.Generated");
+            builder.AppendLine("{");
+        }
+        else
+        {
+            builder.AppendLine("namespace ModularPipelines.Generated;");
+        }
+
+        builder.AppendLine();
         builder.AppendLine("internal static class ModularPipelinesContextRegistration");
         builder.AppendLine("{");
         builder.AppendLine(
@@ -302,7 +294,10 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
 
         builder.AppendLine("    }");
         builder.AppendLine("}");
-        builder.AppendLine("}");
+        if (generatesExtensionMembers)
+        {
+            builder.AppendLine("}");
+        }
 
         if (uniqueToolProperties.Length > 0 && !supportsExtensionMembers)
         {

--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ModularPipelines.SourceGenerator;
@@ -23,6 +24,24 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor InvalidIntegrationMethod =
         GeneratorDiagnostics.InvalidIntegrationMethod;
 
+    private static readonly DiagnosticDescriptor UnsupportedToolsLanguageVersion = new(
+        id: "MPGEN003",
+        title: "Discoverable tool properties require C# 14",
+        messageFormat:
+            "Tool accessor '{0}' cannot generate a context.Tools property because language version "
+            + "'{1}' does not support extension members; use C# 14 or preview",
+        category: "ModularPipelines.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor ConflictingToolProperty = new(
+        id: "MPGEN004",
+        title: "Conflicting discoverable tool property",
+        messageFormat: "Tool property '{0}' has conflicting return types: {1}",
+        category: "ModularPipelines.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var candidates = context.SyntaxProvider.ForAttributeWithMetadataName(
@@ -31,8 +50,11 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
                 static (generatorContext, _) => GetCandidate(generatorContext));
 
         context.RegisterSourceOutput(
-            candidates.Collect(),
-            static (sourceContext, items) => Generate(sourceContext, items));
+            candidates.Collect().Combine(context.ParseOptionsProvider),
+            static (sourceContext, input) => Generate(
+                sourceContext,
+                input.Left,
+                input.Right));
     }
 
     private static IntegrationCandidate GetCandidate(
@@ -87,7 +109,9 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
                 && !method.ReturnsVoid)
             .Select(static method => new ToolProperty(
                 method.Name,
-                method.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)))
+                method.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                method.ToDisplayString(),
+                method.Locations.FirstOrDefault()))
             .ToImmutableArray();
     }
 
@@ -135,7 +159,8 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
 
     private static void Generate(
         SourceProductionContext context,
-        ImmutableArray<IntegrationCandidate> candidates)
+        ImmutableArray<IntegrationCandidate> candidates,
+        ParseOptions parseOptions)
     {
         foreach (var candidate in candidates)
         {
@@ -158,7 +183,16 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
 
         var toolProperties = candidates
             .SelectMany(static candidate => candidate.ToolProperties)
-            .Distinct()
+            .ToArray();
+        var conflictingPropertyNames = ReportToolPropertyConflicts(context, toolProperties);
+        var uniqueToolProperties = toolProperties
+            .Where(property => !conflictingPropertyNames.Contains(property.Name))
+            .GroupBy(static property => new
+            {
+                property.Name,
+                property.TypeName,
+            })
+            .Select(static group => group.First())
             .OrderBy(static property => property.Name, StringComparer.Ordinal)
             .ThenBy(static property => property.TypeName, StringComparer.Ordinal)
             .ToArray();
@@ -195,7 +229,16 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         builder.AppendLine("}");
         builder.AppendLine("}");
 
-        if (toolProperties.Length > 0)
+        if (uniqueToolProperties.Length > 0 && !SupportsExtensionMembers(parseOptions))
+        {
+            var firstProperty = uniqueToolProperties[0];
+            context.ReportDiagnostic(Diagnostic.Create(
+                UnsupportedToolsLanguageVersion,
+                firstProperty.Location,
+                firstProperty.MethodName,
+                GetLanguageVersionDisplay(parseOptions)));
+        }
+        else if (uniqueToolProperties.Length > 0)
         {
             builder.AppendLine();
             builder.AppendLine("namespace ModularPipelines.Context");
@@ -207,7 +250,7 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
                 "    extension(global::ModularPipelines.Context.IToolsContext tools)");
             builder.AppendLine("    {");
 
-            foreach (var property in toolProperties)
+            foreach (var property in uniqueToolProperties)
             {
                 builder.AppendLine(
                     $"        public {property.TypeName} {property.Name} "
@@ -222,6 +265,55 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         context.AddSource("ModularPipelines.IntegrationRegistration.g.cs", builder.ToString());
     }
 
+    private static ImmutableHashSet<string> ReportToolPropertyConflicts(
+        SourceProductionContext context,
+        ToolProperty[] toolProperties)
+    {
+        var conflicts = toolProperties
+            .GroupBy(static property => property.Name, StringComparer.Ordinal)
+            .Where(static group =>
+                group.Select(static property => property.TypeName)
+                    .Distinct(StringComparer.Ordinal)
+                    .Skip(1)
+                    .Any())
+            .ToArray();
+
+        foreach (var conflict in conflicts)
+        {
+            var types = string.Join(
+                ", ",
+                conflict.Select(static property => property.TypeName)
+                    .Distinct(StringComparer.Ordinal)
+                    .OrderBy(static typeName => typeName, StringComparer.Ordinal));
+            foreach (var property in conflict)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    ConflictingToolProperty,
+                    property.Location,
+                    property.Name,
+                    types));
+            }
+        }
+
+        return conflicts
+            .Select(static group => group.Key)
+            .ToImmutableHashSet(StringComparer.Ordinal);
+    }
+
+    private static bool SupportsExtensionMembers(ParseOptions parseOptions)
+    {
+        return parseOptions is CSharpParseOptions csharpParseOptions
+            && (int) LanguageVersionFacts.MapSpecifiedToEffectiveVersion(
+                csharpParseOptions.SpecifiedLanguageVersion) >= 1400;
+    }
+
+    private static string GetLanguageVersionDisplay(ParseOptions parseOptions)
+    {
+        return parseOptions is CSharpParseOptions csharpParseOptions
+            ? csharpParseOptions.SpecifiedLanguageVersion.ToDisplayString()
+            : parseOptions.Language;
+    }
+
     private sealed record IntegrationCandidate(
         IntegrationRegistration? Registration,
         EquatableArray<ToolProperty> ToolProperties,
@@ -231,5 +323,9 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
 
     private sealed record IntegrationRegistration(string TypeName, string MethodName);
 
-    private sealed record ToolProperty(string Name, string TypeName);
+    private sealed record ToolProperty(
+        string Name,
+        string TypeName,
+        string MethodName,
+        Location? Location);
 }

--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -27,6 +27,15 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
     private const string ToolPropertyMetadataPrefix =
         "ModularPipelines.ToolProperty:";
 
+    private static readonly ImmutableHashSet<string> ShadowedToolPropertyNames =
+    [
+        "Equals",
+        "Get",
+        "GetHashCode",
+        "GetType",
+        "ToString",
+    ];
+
     private static readonly DiagnosticDescriptor InvalidIntegrationMethod =
         GeneratorDiagnostics.InvalidIntegrationMethod;
 
@@ -44,6 +53,16 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         id: "MPGEN004",
         title: "Conflicting discoverable tool property",
         messageFormat: "Tool property '{0}' has conflicting declarations: {1}",
+        category: "ModularPipelines.SourceGenerator",
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor ShadowedToolProperty = new(
+        id: "MPGEN005",
+        title: "Discoverable tool property shadows an instance member",
+        messageFormat:
+            "Tool accessor '{0}' cannot generate property '{1}' because that name is already "
+            + "available on IToolsContext or object",
         category: "ModularPipelines.SourceGenerator",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true);
@@ -247,6 +266,26 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         var toolProperties = candidates
             .SelectMany(static candidate => candidate.ToolProperties)
             .ToArray();
+        var supportsExtensionMembers = SupportsExtensionMembers(parseOptions);
+        if (supportsExtensionMembers)
+        {
+            foreach (var property in toolProperties.Where(
+                         static property => ShadowedToolPropertyNames.Contains(property.Name)))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    ShadowedToolProperty,
+                    property.Location,
+                    property.MethodName,
+                    property.Name));
+            }
+
+            toolProperties =
+            [
+                .. toolProperties.Where(
+                    static property => !ShadowedToolPropertyNames.Contains(property.Name)),
+            ];
+        }
+
         var allToolProperties = toolProperties
             .Concat(referencedToolProperties.Select(static property => new ToolProperty(
                 property.Name,
@@ -255,7 +294,9 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
                 Location: null,
                 property.SourceId)))
             .ToArray();
-        var conflictingPropertyNames = ReportToolPropertyConflicts(context, allToolProperties);
+        var conflictingPropertyNames = supportsExtensionMembers
+            ? ReportToolPropertyConflicts(context, allToolProperties)
+            : [];
         var uniqueToolProperties = toolProperties
             .Where(property => !conflictingPropertyNames.Contains(property.Name))
             .GroupBy(static property => new
@@ -280,7 +321,7 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         builder.AppendLine(
             "[assembly: global::ModularPipelines.Attributes.ModularPipelinesContextAttribute("
             + "typeof(global::ModularPipelines.Generated.ModularPipelinesContextRegistration))]");
-        if (uniqueToolProperties.Length > 0 && SupportsExtensionMembers(parseOptions))
+        if (uniqueToolProperties.Length > 0 && supportsExtensionMembers)
         {
             foreach (var property in uniqueToolProperties)
             {
@@ -311,7 +352,7 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         builder.AppendLine("}");
         builder.AppendLine("}");
 
-        if (uniqueToolProperties.Length > 0 && !SupportsExtensionMembers(parseOptions))
+        if (uniqueToolProperties.Length > 0 && !supportsExtensionMembers)
         {
             var firstProperty = uniqueToolProperties[0];
             context.ReportDiagnostic(Diagnostic.Create(

--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -244,16 +244,7 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         ParseOptions parseOptions,
         EquatableArray<ReferencedToolProperty> referencedToolProperties)
     {
-        foreach (var candidate in candidates)
-        {
-            if (candidate.Registration is null)
-            {
-                context.ReportDiagnostic(Diagnostic.Create(
-                    InvalidIntegrationMethod,
-                    candidate.Location,
-                    candidate.MethodName));
-            }
-        }
+        ReportInvalidIntegrationMethods(context, candidates);
 
         var uniqueRegistrations = candidates
             .Select(static candidate => candidate.Registration)
@@ -263,51 +254,12 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
             .ThenBy(static registration => registration.MethodName, StringComparer.Ordinal)
             .ToArray();
 
-        var toolProperties = candidates
-            .SelectMany(static candidate => candidate.ToolProperties)
-            .ToArray();
         var supportsExtensionMembers = SupportsExtensionMembers(parseOptions);
-        if (supportsExtensionMembers)
-        {
-            foreach (var property in toolProperties.Where(
-                         static property => ShadowedToolPropertyNames.Contains(property.Name)))
-            {
-                context.ReportDiagnostic(Diagnostic.Create(
-                    ShadowedToolProperty,
-                    property.Location,
-                    property.MethodName,
-                    property.Name));
-            }
-
-            toolProperties =
-            [
-                .. toolProperties.Where(
-                    static property => !ShadowedToolPropertyNames.Contains(property.Name)),
-            ];
-        }
-
-        var allToolProperties = toolProperties
-            .Concat(referencedToolProperties.Select(static property => new ToolProperty(
-                property.Name,
-                property.TypeName,
-                MethodName: property.Name,
-                Location: null,
-                property.SourceId)))
-            .ToArray();
-        var conflictingPropertyNames = supportsExtensionMembers
-            ? ReportToolPropertyConflicts(context, allToolProperties)
-            : [];
-        var uniqueToolProperties = toolProperties
-            .Where(property => !conflictingPropertyNames.Contains(property.Name))
-            .GroupBy(static property => new
-            {
-                property.Name,
-                property.TypeName,
-            })
-            .Select(static group => group.First())
-            .OrderBy(static property => property.Name, StringComparer.Ordinal)
-            .ThenBy(static property => property.TypeName, StringComparer.Ordinal)
-            .ToArray();
+        var uniqueToolProperties = GetUniqueToolProperties(
+            context,
+            candidates,
+            referencedToolProperties,
+            supportsExtensionMembers);
 
         if (uniqueRegistrations.Length == 0)
         {
@@ -386,6 +338,81 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         }
 
         context.AddSource("ModularPipelines.IntegrationRegistration.g.cs", builder.ToString());
+    }
+
+    private static void ReportInvalidIntegrationMethods(
+        SourceProductionContext context,
+        ImmutableArray<IntegrationCandidate> candidates)
+    {
+        foreach (var candidate in candidates.Where(
+                     static candidate => candidate.Registration is null))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                InvalidIntegrationMethod,
+                candidate.Location,
+                candidate.MethodName));
+        }
+    }
+
+    private static ToolProperty[] GetUniqueToolProperties(
+        SourceProductionContext context,
+        ImmutableArray<IntegrationCandidate> candidates,
+        EquatableArray<ReferencedToolProperty> referencedToolProperties,
+        bool supportsExtensionMembers)
+    {
+        var toolProperties = candidates
+            .SelectMany(static candidate => candidate.ToolProperties)
+            .ToArray();
+        if (supportsExtensionMembers)
+        {
+            ReportShadowedToolProperties(context, toolProperties);
+            toolProperties =
+            [
+                .. toolProperties.Where(
+                    static property => !ShadowedToolPropertyNames.Contains(property.Name)),
+            ];
+        }
+
+        var allToolProperties = toolProperties
+            .Concat(referencedToolProperties.Select(static property => new ToolProperty(
+                property.Name,
+                property.TypeName,
+                MethodName: property.Name,
+                Location: null,
+                property.SourceId)))
+            .ToArray();
+        var conflictingPropertyNames = supportsExtensionMembers
+            ? ReportToolPropertyConflicts(context, allToolProperties)
+            : [];
+
+        return
+        [
+            .. toolProperties
+                .Where(property => !conflictingPropertyNames.Contains(property.Name))
+                .GroupBy(static property => new
+                {
+                    property.Name,
+                    property.TypeName,
+                })
+                .Select(static group => group.First())
+                .OrderBy(static property => property.Name, StringComparer.Ordinal)
+                .ThenBy(static property => property.TypeName, StringComparer.Ordinal),
+        ];
+    }
+
+    private static void ReportShadowedToolProperties(
+        SourceProductionContext context,
+        ToolProperty[] toolProperties)
+    {
+        foreach (var property in toolProperties.Where(
+                     static property => ShadowedToolPropertyNames.Contains(property.Name)))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                ShadowedToolProperty,
+                property.Location,
+                property.MethodName,
+                property.Name));
+        }
     }
 
     private static ImmutableHashSet<string> ReportToolPropertyConflicts(

--- a/src/ModularPipelines/Context/IPipelineContext.cs
+++ b/src/ModularPipelines/Context/IPipelineContext.cs
@@ -20,58 +20,64 @@ namespace ModularPipelines.Context;
 /// <item><term>Network</term><description>HTTP and downloads</description></item>
 /// <item><term>Security</term><description>Certificates and hashing</description></item>
 /// <item><term>Services</term><description>DI and configuration</description></item>
+/// <item><term>Tools</term><description>Installed tool integrations</description></item>
 /// <item><term>Summary</term><description>Pipeline summary logging (displayed after completion)</description></item>
 /// </list>
 /// </remarks>
 public interface IPipelineContext
 {
     /// <summary>
-    /// Logger for the current context. Thread-safe.
+    /// Gets the logger for the current context. Thread-safe.
     /// </summary>
     IModuleLogger Logger { get; }
 
     /// <summary>
-    /// Command execution capabilities.
+    /// Gets the command execution capabilities.
     /// </summary>
     Domains.IShellContext Shell { get; }
 
     /// <summary>
-    /// File system operations.
+    /// Gets the file system operations.
     /// </summary>
     IFilesContext Files { get; }
 
     /// <summary>
-    /// Serialization and encoding.
+    /// Gets the serialization and encoding capabilities.
     /// </summary>
     IDataContext Data { get; }
 
     /// <summary>
-    /// Environment and system information.
+    /// Gets the environment and system information.
     /// </summary>
     IEnvironmentDomainContext Environment { get; }
 
     /// <summary>
-    /// Software installation.
+    /// Gets the software installation capabilities.
     /// </summary>
     IInstallersContext Installers { get; }
 
     /// <summary>
-    /// HTTP and download operations.
+    /// Gets the HTTP and download operations.
     /// </summary>
     INetworkContext Network { get; }
 
     /// <summary>
-    /// Security operations.
+    /// Gets the security operations.
     /// </summary>
     ISecurityContext Security { get; }
 
     /// <summary>
-    /// Dependency injection and configuration.
+    /// Gets the dependency injection and configuration capabilities.
     /// </summary>
     IServicesContext Services { get; }
 
     /// <summary>
-    /// Summary logger for messages displayed after pipeline completion.
+    /// Gets the installed tool integrations.
+    /// </summary>
+    IToolsContext Tools { get; }
+
+    /// <summary>
+    /// Gets the summary logger for messages displayed after pipeline completion.
     /// </summary>
     /// <remarks>
     /// <para>

--- a/src/ModularPipelines/Context/IToolsContext.cs
+++ b/src/ModularPipelines/Context/IToolsContext.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel;
+
+namespace ModularPipelines.Context;
+
+/// <summary>
+/// Provides discoverable access to installed tool integrations.
+/// </summary>
+public interface IToolsContext
+{
+    /// <summary>
+    /// Resolves a tool integration from the pipeline service provider.
+    /// </summary>
+    /// <typeparam name="T">The tool integration type.</typeparam>
+    /// <returns>The registered tool integration.</returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    T Get<T>()
+        where T : class;
+}

--- a/src/ModularPipelines/Context/ModuleContext.cs
+++ b/src/ModularPipelines/Context/ModuleContext.cs
@@ -130,6 +130,9 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
     public IServicesContext Services => _pipelineContext.Services;
 
     /// <inheritdoc />
+    public IToolsContext Tools => _pipelineContext.Tools;
+
+    /// <inheritdoc />
     public ISummaryLogger Summary => _pipelineContext.Summary;
 
     #endregion

--- a/src/ModularPipelines/Context/ModuleHookContext.cs
+++ b/src/ModularPipelines/Context/ModuleHookContext.cs
@@ -113,6 +113,9 @@ internal class ModuleHookContext : IModuleHookContext
     public IServicesContext Services => _pipelineContext.Services;
 
     /// <inheritdoc />
+    public IToolsContext Tools => _pipelineContext.Tools;
+
+    /// <inheritdoc />
     public ISummaryLogger Summary => _pipelineContext.Summary;
 
     #endregion

--- a/src/ModularPipelines/Context/PipelineContext.cs
+++ b/src/ModularPipelines/Context/PipelineContext.cs
@@ -51,6 +51,9 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
     public IServicesContext Services { get; }
 
     /// <inheritdoc />
+    public IToolsContext Tools { get; }
+
+    /// <inheritdoc />
     public ISummaryLogger Summary { get; }
 
     // Internal properties for IInternalPipelineContext
@@ -99,6 +102,7 @@ internal class PipelineContext : IPipelineContext, IInternalPipelineContext
         Network = network;
         Security = security;
         Services = services;
+        Tools = new ToolsContext(services);
         Summary = summary;
     }
 

--- a/src/ModularPipelines/Context/ToolsContext.cs
+++ b/src/ModularPipelines/Context/ToolsContext.cs
@@ -1,0 +1,9 @@
+using ModularPipelines.Context.Domains;
+
+namespace ModularPipelines.Context;
+
+internal sealed class ToolsContext(IServicesContext services) : IToolsContext
+{
+    public T Get<T>()
+        where T : class => services.Get<T>();
+}

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
@@ -113,6 +113,37 @@ public class ModularPipelinesIntegrationGeneratorTests
             await Assert.That(result.Diagnostics).IsEmpty();
             await Assert.That(generatedSource)
                 .Contains("public global::IGit Git => tools.Get<global::IGit>();");
+            await Assert.That(generatedSource)
+                .Contains("\"ModularPipelines.ToolProperty:Git\", \"global::IGit\"");
+        }
+    }
+
+    [Test]
+    public async Task Value_Type_Accessor_Does_Not_Generate_Tool_Property()
+    {
+        var result = RunGenerator("""
+            using ModularPipelines.Attributes;
+            using ModularPipelines.Context;
+            using Microsoft.Extensions.DependencyInjection;
+
+            public static class AvailabilityIntegration
+            {
+                [ModularPipelinesIntegration]
+                public static void Register(IServiceCollection services)
+                {
+                }
+
+                public static bool IsAvailable(this IPipelineContext context) => true;
+            }
+            """);
+
+        var generatedSource = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics).IsEmpty();
+            await Assert.That(generatedSource).DoesNotContain("IsAvailable");
+            await Assert.That(generatedSource).DoesNotContain("tools.Get<bool>");
         }
     }
 
@@ -206,6 +237,41 @@ public class ModularPipelinesIntegrationGeneratorTests
     }
 
     [Test]
+    public async Task Conflicting_Referenced_Tool_Accessors_Report_Diagnostics()
+    {
+        var firstIntegration = CreateMetadataReference(
+            "FirstIntegration",
+            """
+            [assembly: System.Reflection.AssemblyMetadata(
+                "ModularPipelines.ToolProperty:Git",
+                "global::FirstIntegration.IGit")]
+            """);
+        var secondIntegration = CreateMetadataReference(
+            "SecondIntegration",
+            """
+            [assembly: System.Reflection.AssemblyMetadata(
+                "ModularPipelines.ToolProperty:Git",
+                "global::SecondIntegration.IGit")]
+            """);
+
+        var result = RunGenerator(
+            source: string.Empty,
+            additionalReferences: [firstIntegration, secondIntegration]);
+        var diagnostics = result.Diagnostics
+            .Where(static diagnostic => diagnostic.Id == "MPGEN004")
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(diagnostics).Count().IsEqualTo(2);
+            await Assert.That(diagnostics.Select(static diagnostic => diagnostic.Severity))
+                .IsEquivalentTo([DiagnosticSeverity.Error, DiagnosticSeverity.Error]);
+            await Assert.That(diagnostics[0].GetMessage()).Contains("Git");
+            await Assert.That(result.GeneratedTrees).IsEmpty();
+        }
+    }
+
+    [Test]
     public async Task File_Local_Integration_Type_Reports_Diagnostic()
     {
         var result = GeneratorTestHarness.Run(new ModularPipelinesIntegrationGenerator(), TestInfrastructure, """
@@ -281,7 +347,8 @@ public class ModularPipelinesIntegrationGeneratorTests
 
     private static GeneratorDriverRunResult RunGenerator(
         string source,
-        LanguageVersion languageVersion = LanguageVersion.Preview)
+        LanguageVersion languageVersion = LanguageVersion.Preview,
+        IReadOnlyList<MetadataReference>? additionalReferences = null)
     {
         var parseOptions = new CSharpParseOptions(languageVersion);
         var infrastructureSyntaxTree = CSharpSyntaxTree.ParseText(
@@ -290,7 +357,8 @@ public class ModularPipelinesIntegrationGeneratorTests
         var sourceSyntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
         var references = ((string) AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
             .Split(Path.PathSeparator)
-            .Select(static path => MetadataReference.CreateFromFile(path));
+            .Select(static path => MetadataReference.CreateFromFile(path))
+            .Concat(additionalReferences ?? []);
         var compilation = CSharpCompilation.Create(
             "GeneratorTests",
             [infrastructureSyntaxTree, sourceSyntaxTree],
@@ -314,5 +382,31 @@ public class ModularPipelinesIntegrationGeneratorTests
             out _);
 
         return driver.GetRunResult();
+    }
+
+    private static MetadataReference CreateMetadataReference(
+        string assemblyName,
+        string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var references = ((string) AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(static path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+        if (!emitResult.Success)
+        {
+            throw new InvalidOperationException(string.Join(
+                Environment.NewLine,
+                emitResult.Diagnostics));
+        }
+
+        return MetadataReference.CreateFromImage(stream.ToArray());
     }
 }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
@@ -185,6 +185,50 @@ public class ModularPipelinesIntegrationGeneratorTests
     }
 
     [Test]
+    public async Task Referenced_Conflicts_On_Older_Language_Version_Are_Ignored()
+    {
+        var firstIntegration = CreateMetadataReference(
+            "FirstIntegration",
+            """
+            [assembly: System.Reflection.AssemblyMetadata(
+                "ModularPipelines.ToolProperty:Git",
+                "global::FirstIntegration.IGit")]
+            """);
+        var secondIntegration = CreateMetadataReference(
+            "SecondIntegration",
+            """
+            [assembly: System.Reflection.AssemblyMetadata(
+                "ModularPipelines.ToolProperty:Git",
+                "global::SecondIntegration.IGit")]
+            """);
+
+        var result = RunGenerator(
+            """
+            using ModularPipelines.Attributes;
+            using Microsoft.Extensions.DependencyInjection;
+
+            public static class ConsumerIntegration
+            {
+                [ModularPipelinesIntegration]
+                public static void Register(IServiceCollection services)
+                {
+                }
+            }
+            """,
+            LanguageVersion.CSharp13,
+            [firstIntegration, secondIntegration]);
+        var generatedSource = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics).IsEmpty();
+            await Assert.That(generatedSource)
+                .Contains("global::ConsumerIntegration.Register(services);");
+            await Assert.That(generatedSource).DoesNotContain("extension(");
+        }
+    }
+
+    [Test]
     public async Task Conflicting_Tool_Accessors_Report_Diagnostics()
     {
         var result = RunGenerator("""
@@ -374,6 +418,47 @@ public class ModularPipelinesIntegrationGeneratorTests
     }
 
     [Test]
+    public async Task Instance_Member_Tool_Names_Report_Diagnostics()
+    {
+        var result = RunGenerator("""
+            using ModularPipelines.Attributes;
+            using ModularPipelines.Context;
+            using Microsoft.Extensions.DependencyInjection;
+
+            public interface ITool
+            {
+            }
+
+            public static class ToolIntegration
+            {
+                [ModularPipelinesIntegration]
+                public static void Register(IServiceCollection services)
+                {
+                }
+
+                public static ITool Get(this IPipelineContext context) => throw null!;
+
+                public static ITool GetType(this IPipelineContext context) => throw null!;
+            }
+            """);
+
+        var diagnostics = result.Diagnostics
+            .Where(static diagnostic => diagnostic.Id == "MPGEN005")
+            .ToArray();
+        var generatedSource = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(diagnostics).Count().IsEqualTo(2);
+            await Assert.That(diagnostics.Select(static diagnostic => diagnostic.Severity))
+                .IsEquivalentTo([DiagnosticSeverity.Error, DiagnosticSeverity.Error]);
+            await Assert.That(diagnostics[0].GetMessage()).Contains("IToolsContext or object");
+            await Assert.That(diagnostics[1].GetMessage()).Contains("IToolsContext or object");
+            await Assert.That(generatedSource).DoesNotContain("public global::ITool Get");
+        }
+    }
+
+    [Test]
     public async Task File_Local_Integration_Type_Reports_Diagnostic()
     {
         var result = GeneratorTestHarness.Run(new ModularPipelinesIntegrationGenerator(), TestInfrastructure, """
@@ -486,7 +571,7 @@ public class ModularPipelinesIntegrationGeneratorTests
         return driver.GetRunResult();
     }
 
-    private static MetadataReference CreateMetadataReference(
+    private static PortableExecutableReference CreateMetadataReference(
         string assemblyName,
         string source)
     {

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
@@ -117,6 +117,95 @@ public class ModularPipelinesIntegrationGeneratorTests
     }
 
     [Test]
+    public async Task Tool_Accessor_On_Older_Language_Version_Reports_Diagnostic()
+    {
+        var result = RunGenerator("""
+            using ModularPipelines.Attributes;
+            using ModularPipelines.Context;
+            using Microsoft.Extensions.DependencyInjection;
+
+            public interface IGit
+            {
+            }
+
+            public static class GitIntegration
+            {
+                [ModularPipelinesIntegration]
+                public static void Register(IServiceCollection services)
+                {
+                }
+
+                public static IGit Git(this IPipelineContext context) => throw null!;
+            }
+            """, LanguageVersion.CSharp13);
+
+        var diagnostic = result.Diagnostics.Single();
+        var generatedSource = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(diagnostic.Id).IsEqualTo("MPGEN003");
+            await Assert.That(diagnostic.Severity).IsEqualTo(DiagnosticSeverity.Warning);
+            await Assert.That(diagnostic.GetMessage()).Contains("C# 14");
+            await Assert.That(generatedSource).DoesNotContain("extension(");
+            await Assert.That(generatedSource)
+                .Contains("global::GitIntegration.Register(services);");
+        }
+    }
+
+    [Test]
+    public async Task Conflicting_Tool_Accessors_Report_Diagnostics()
+    {
+        var result = RunGenerator("""
+            using ModularPipelines.Attributes;
+            using ModularPipelines.Context;
+            using Microsoft.Extensions.DependencyInjection;
+
+            public interface IGit
+            {
+            }
+
+            public interface IAlternateGit
+            {
+            }
+
+            public static class GitIntegration
+            {
+                [ModularPipelinesIntegration]
+                public static void Register(IServiceCollection services)
+                {
+                }
+
+                public static IGit Git(this IPipelineContext context) => throw null!;
+            }
+
+            public static class AlternateGitIntegration
+            {
+                [ModularPipelinesIntegration]
+                public static void Register(IServiceCollection services)
+                {
+                }
+
+                public static IAlternateGit Git(this IPipelineContext context) => throw null!;
+            }
+            """);
+
+        var diagnostics = result.Diagnostics
+            .Where(static diagnostic => diagnostic.Id == "MPGEN004")
+            .ToArray();
+        var generatedSource = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(diagnostics).Count().IsEqualTo(2);
+            await Assert.That(diagnostics.Select(static diagnostic => diagnostic.Severity))
+                .IsEquivalentTo([DiagnosticSeverity.Error, DiagnosticSeverity.Error]);
+            await Assert.That(diagnostics[0].GetMessage()).Contains("Git");
+            await Assert.That(generatedSource).DoesNotContain("tools.Get");
+        }
+    }
+
+    [Test]
     public async Task File_Local_Integration_Type_Reports_Diagnostic()
     {
         var result = GeneratorTestHarness.Run(new ModularPipelinesIntegrationGenerator(), TestInfrastructure, """
@@ -188,5 +277,42 @@ public class ModularPipelinesIntegrationGeneratorTests
             """);
 
         await Assert.That(GeneratorTestHarness.HasCachedOutput(result)).IsTrue();
+    }
+
+    private static GeneratorDriverRunResult RunGenerator(
+        string source,
+        LanguageVersion languageVersion = LanguageVersion.Preview)
+    {
+        var parseOptions = new CSharpParseOptions(languageVersion);
+        var infrastructureSyntaxTree = CSharpSyntaxTree.ParseText(
+            TestInfrastructure,
+            parseOptions);
+        var sourceSyntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
+        var references = ((string) AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+            .Split(Path.PathSeparator)
+            .Select(static path => MetadataReference.CreateFromFile(path));
+        var compilation = CSharpCompilation.Create(
+            "GeneratorTests",
+            [infrastructureSyntaxTree, sourceSyntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var compilationErrors = compilation.GetDiagnostics()
+            .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+        if (compilationErrors.Length > 0)
+        {
+            throw new InvalidOperationException(string.Join(Environment.NewLine, compilationErrors));
+        }
+
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(
+            [new ModularPipelinesIntegrationGenerator().AsSourceGenerator()],
+            parseOptions: parseOptions);
+
+        driver = driver.RunGeneratorsAndUpdateCompilation(
+            compilation,
+            out _,
+            out _);
+
+        return driver.GetRunResult();
     }
 }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace ModularPipelines.SourceGenerator.UnitTests;
 
@@ -175,7 +176,7 @@ public class ModularPipelinesIntegrationGeneratorTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(diagnostic.Id).IsEqualTo("MPGEN003");
+            await Assert.That(diagnostic.Id).IsEqualTo("MPG0008");
             await Assert.That(diagnostic.Severity).IsEqualTo(DiagnosticSeverity.Warning);
             await Assert.That(diagnostic.GetMessage()).Contains("C# 14");
             await Assert.That(generatedSource).DoesNotContain("extension(");
@@ -266,7 +267,7 @@ public class ModularPipelinesIntegrationGeneratorTests
             """);
 
         var diagnostics = result.Diagnostics
-            .Where(static diagnostic => diagnostic.Id == "MPGEN004")
+            .Where(static diagnostic => diagnostic.Id == "MPG0009")
             .ToArray();
         var generatedSource = result.GeneratedTrees.Single().GetText().ToString();
 
@@ -302,7 +303,7 @@ public class ModularPipelinesIntegrationGeneratorTests
             source: string.Empty,
             additionalReferences: [firstIntegration, secondIntegration]);
         var diagnostics = result.Diagnostics
-            .Where(static diagnostic => diagnostic.Id == "MPGEN004")
+            .Where(static diagnostic => diagnostic.Id == "MPG0009")
             .ToArray();
 
         using (Assert.Multiple())
@@ -337,7 +338,7 @@ public class ModularPipelinesIntegrationGeneratorTests
             source: string.Empty,
             additionalReferences: [firstIntegration, secondIntegration]);
         var diagnostics = result.Diagnostics
-            .Where(static diagnostic => diagnostic.Id == "MPGEN004")
+            .Where(static diagnostic => diagnostic.Id == "MPG0009")
             .ToArray();
 
         using (Assert.Multiple())
@@ -443,7 +444,7 @@ public class ModularPipelinesIntegrationGeneratorTests
             """);
 
         var diagnostics = result.Diagnostics
-            .Where(static diagnostic => diagnostic.Id == "MPGEN005")
+            .Where(static diagnostic => diagnostic.Id == "MPG0010")
             .ToArray();
         var generatedSource = result.GeneratedTrees.Single().GetText().ToString();
 

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
@@ -19,6 +19,18 @@ public class ModularPipelinesIntegrationGeneratorTests
             {
             }
         }
+
+        namespace ModularPipelines.Context
+        {
+            public interface IPipelineContext
+            {
+            }
+
+            public interface IToolsContext
+            {
+                T Get<T>() where T : class;
+            }
+        }
         """;
 
     [Test]
@@ -69,6 +81,39 @@ public class ModularPipelinesIntegrationGeneratorTests
         await SnapshotVerifier.VerifyAsync(
             "ModularPipelinesIntegrationGenerator.ValidIntegration",
             result.GeneratedTrees.Single().GetText().ToString());
+    }
+
+    [Test]
+    public async Task Tool_Accessor_Generates_Discoverable_Extension_Property()
+    {
+        var result = RunGenerator("""
+            using ModularPipelines.Attributes;
+            using ModularPipelines.Context;
+            using Microsoft.Extensions.DependencyInjection;
+
+            public interface IGit
+            {
+            }
+
+            public static class GitIntegration
+            {
+                [ModularPipelinesIntegration]
+                public static void Register(IServiceCollection services)
+                {
+                }
+
+                public static IGit Git(this IPipelineContext context) => throw null!;
+            }
+            """);
+
+        var generatedSource = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics).IsEmpty();
+            await Assert.That(generatedSource)
+                .Contains("public global::IGit Git => tools.Get<global::IGit>();");
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
@@ -272,6 +272,108 @@ public class ModularPipelinesIntegrationGeneratorTests
     }
 
     [Test]
+    public async Task Identical_Referenced_Tool_Accessors_Report_Diagnostics()
+    {
+        var firstIntegration = CreateMetadataReference(
+            "FirstIntegration",
+            """
+            [assembly: System.Reflection.AssemblyMetadata(
+                "ModularPipelines.ToolProperty:Git",
+                "global::Shared.IGit")]
+            """);
+        var secondIntegration = CreateMetadataReference(
+            "SecondIntegration",
+            """
+            [assembly: System.Reflection.AssemblyMetadata(
+                "ModularPipelines.ToolProperty:Git",
+                "global::Shared.IGit")]
+            """);
+
+        var result = RunGenerator(
+            source: string.Empty,
+            additionalReferences: [firstIntegration, secondIntegration]);
+        var diagnostics = result.Diagnostics
+            .Where(static diagnostic => diagnostic.Id == "MPGEN004")
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(diagnostics).Count().IsEqualTo(2);
+            await Assert.That(diagnostics[0].GetMessage()).Contains("FirstIntegration");
+            await Assert.That(diagnostics[0].GetMessage()).Contains("SecondIntegration");
+            await Assert.That(result.GeneratedTrees).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task Inaccessible_Tool_Return_Type_Does_Not_Generate_Property()
+    {
+        var result = RunGenerator("""
+            using ModularPipelines.Attributes;
+            using ModularPipelines.Context;
+            using Microsoft.Extensions.DependencyInjection;
+
+            internal interface IHiddenTool
+            {
+            }
+
+            internal static class HiddenIntegration
+            {
+                [ModularPipelinesIntegration]
+                public static void Register(IServiceCollection services)
+                {
+                }
+
+                public static IHiddenTool Hidden(this IPipelineContext context) => throw null!;
+            }
+            """);
+
+        var generatedSource = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics).IsEmpty();
+            await Assert.That(generatedSource).DoesNotContain("ToolProperty:Hidden");
+            await Assert.That(generatedSource).DoesNotContain("tools.Get<global::IHiddenTool>");
+        }
+    }
+
+    [Test]
+    public async Task Keyword_Tool_Accessor_Generates_Escaped_Property()
+    {
+        var result = RunGenerator("""
+            using ModularPipelines.Attributes;
+            using ModularPipelines.Context;
+            using Microsoft.Extensions.DependencyInjection;
+
+            public interface IClassTool
+            {
+            }
+
+            public static class ClassIntegration
+            {
+                [ModularPipelinesIntegration]
+                public static void Register(IServiceCollection services)
+                {
+                }
+
+                public static IClassTool @class(this IPipelineContext context) => throw null!;
+            }
+            """);
+
+        var generatedSource = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics).IsEmpty();
+            await Assert.That(generatedSource)
+                .Contains("public global::IClassTool @class => tools.Get<global::IClassTool>();");
+            await Assert.That(generatedSource)
+                .Contains("\"ModularPipelines.ToolProperty:class\", \"global::IClassTool\"");
+        }
+    }
+
+    [Test]
     public async Task File_Local_Integration_Type_Reports_Diagnostic()
     {
         var result = GeneratorTestHarness.Run(new ModularPipelinesIntegrationGenerator(), TestInfrastructure, """

--- a/test/ModularPipelines.UnitTests/Context/ContextHierarchyTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextHierarchyTests.cs
@@ -78,6 +78,12 @@ public class ContextHierarchyTests
             .Because("IPipelineContext should have Services property");
         await Assert.That(servicesProperty!.PropertyType).IsEqualTo(typeof(IServicesContext))
             .Because("Services should be of type IServicesContext");
+
+        var toolsProperty = contextType.GetProperty("Tools");
+        await Assert.That(toolsProperty).IsNotNull()
+            .Because("IPipelineContext should have Tools property");
+        await Assert.That(toolsProperty!.PropertyType).IsEqualTo(typeof(IToolsContext))
+            .Because("Tools should be of type IToolsContext");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Helpers/CmdTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CmdTests.cs
@@ -1,4 +1,3 @@
-using ModularPipelines.Cmd.Extensions;
 using ModularPipelines.Context;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -15,7 +14,7 @@ public class CmdTests : TestBase
     {
         protected internal override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            return await context.Cmd().ScriptAsync(new("echo Foo bar!"), cancellationToken: cancellationToken);
+            return await context.Tools.Cmd.ScriptAsync(new("echo Foo bar!"), cancellationToken: cancellationToken);
         }
     }
 


### PR DESCRIPTION
Closes #3296

## Summary
- add context.Tools as the discoverable integration root
- generate C# 14 extension properties for every registered tool accessor
- verify context.Tools.Cmd works without a tool-specific extension namespace

## Validation
- ModularPipelines.SourceGenerator.UnitTests: 8 passed
- ContextHierarchyTests: 6 passed
- CmdTests: 2 passed
- ModularPipelines.sln Release build: 0 errors
- changed-file analyzer format gates: passed