### PR TITLE
Drive CLI generation from the generator catalog

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -7,14 +7,6 @@ on:
   workflow_dispatch:
     inputs:
       # Specify which tools to run (comma-separated). Leave empty to run all tools.
-      # Linux tools: helm, kubectl, kustomize, docker, trivy, hadolint, podman, buildah, skopeo
-      # Cloud CLIs: az, gcloud, aws
-      # Infrastructure: terraform, pulumi, packer, vault, ansible, flyway, liquibase
-      # Development: dotnet, go, cargo, mvn, gradle, yarn, pnpm, gh, git, brew
-      # Kubernetes/GitOps: eksctl, argocd, flux, kind, minikube
-      # Security/Quality: sonar-scanner, snyk, shellcheck, cosign, syft, grype
-      # Other: newman, nbgv, jq, yq, pip
-      # Windows-only: choco, winget
       tools:
         description: 'Tools to run (comma-separated, empty = all). Example: helm,kubectl,docker'
         required: false
@@ -42,75 +34,62 @@ jobs:
         shell: pwsh
         run: tools/ModularPipelines.OptionsGenerator/scripts/Test-StageGeneratedChanges.ps1
 
+  tool-catalog:
+    needs: validate-generation-safety
+    runs-on: ubuntu-latest
+    outputs:
+      linux: ${{ steps.catalog.outputs.linux }}
+      windows: ${{ steps.catalog.outputs.windows }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-dotnet@v6.0.0
+        with:
+          dotnet-version: 10.0.x
+      - name: Build generator
+        run: >-
+          dotnet build
+          tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.csproj
+          -c Release
+      - name: Create generation matrices
+        id: catalog
+        run: |
+          dotnet run --no-build \
+            --project tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ModularPipelines.OptionsGenerator.csproj \
+            -c Release -- \
+            --list-tools --json > "$RUNNER_TEMP/tool-catalog.json"
+
+          create_matrix() {
+            jq -c --arg platform "$1" \
+              '{include: [.[] | select(.generationPlatform == $platform) | {
+                tool: .toolName,
+                package: .packageName,
+                prefix: .namespacePrefix,
+                outputDirectory: .outputDirectory
+              }]}' \
+              "$RUNNER_TEMP/tool-catalog.json"
+          }
+
+          LINUX_MATRIX="$(create_matrix linux)"
+          WINDOWS_MATRIX="$(create_matrix windows)"
+          jq -e '.include | length > 0' <<< "$LINUX_MATRIX"
+          jq -e '.include | length > 0' <<< "$WINDOWS_MATRIX"
+          echo "linux=$LINUX_MATRIX" >> "$GITHUB_OUTPUT"
+          echo "windows=$WINDOWS_MATRIX" >> "$GITHUB_OUTPUT"
+
   # Generate options for each tool in parallel (Linux)
   generate:
-    needs: validate-generation-safety
+    needs:
+      - validate-generation-safety
+      - tool-catalog
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     strategy:
       fail-fast: false
-      matrix:
-        tool:
-          # Kubernetes/Container ecosystem
-          - helm
-          - kubectl
-          - kustomize
-          - docker
-          - trivy
-          - hadolint
-          - podman
-          - buildah
-          - skopeo
-          # Cloud CLIs
-          - az
-          - gcloud
-          - aws
-          # Infrastructure/DevOps
-          - terraform
-          - pulumi
-          - packer
-          - vault
-          - ansible
-          - flyway
-          - liquibase
-          # Development tools
-          - dotnet
-          - go
-          - cargo
-          - mvn
-          - gradle
-          - git
-          - brew
-          # Node.js ecosystem
-          - yarn
-          - pnpm
-          # GitHub CLI
-          - gh
-          # Kubernetes/GitOps
-          - eksctl
-          - argocd
-          - flux
-          - kind
-          - minikube
-          # Code quality/Security
-          - sonar-scanner
-          - snyk
-          - shellcheck
-          # Supply chain security
-          - cosign
-          - syft
-          - grype
-          # Testing
-          - newman
-          # Versioning
-          - nbgv
-          # Data processing
-          - jq
-          - yq
-          # Python
-          - pip
+      matrix: ${{ fromJSON(needs.tool-catalog.outputs.linux) }}
 
     steps:
       - name: Check if tool should run
@@ -170,75 +149,9 @@ jobs:
         id: package
         if: steps.should-run.outputs.run == 'true'
         run: |
-          # Map tool to package directory and namespace prefix
-          declare -A TOOL_MAP=(
-            # Kubernetes/Container ecosystem
-            ["helm"]="ModularPipelines.Helm:Helm"
-            ["kubectl"]="ModularPipelines.Kubernetes:Kubernetes"
-            ["kustomize"]="ModularPipelines.Kubernetes:Kustomize"
-            ["docker"]="ModularPipelines.Docker:Docker"
-            ["trivy"]="ModularPipelines.Trivy:Trivy"
-            ["hadolint"]="ModularPipelines.Hadolint:Hadolint"
-            ["podman"]="ModularPipelines.Podman:Podman"
-            ["buildah"]="ModularPipelines.Buildah:Buildah"
-            ["skopeo"]="ModularPipelines.Skopeo:Skopeo"
-            # Cloud CLIs
-            ["az"]="ModularPipelines.Azure:Az"
-            ["gcloud"]="ModularPipelines.Google:Gcloud"
-            ["aws"]="ModularPipelines.AmazonWebServices:Aws"
-            # Infrastructure/DevOps
-            ["terraform"]="ModularPipelines.Terraform:Terraform"
-            ["pulumi"]="ModularPipelines.Pulumi:Pulumi"
-            ["packer"]="ModularPipelines.Packer:Packer"
-            ["vault"]="ModularPipelines.Vault:Vault"
-            ["ansible"]="ModularPipelines.Ansible:Ansible"
-            ["flyway"]="ModularPipelines.Flyway:Flyway"
-            ["liquibase"]="ModularPipelines.Liquibase:Liquibase"
-            # Development tools
-            ["dotnet"]="ModularPipelines.DotNet:DotNet"
-            ["go"]="ModularPipelines.Go:Go"
-            ["cargo"]="ModularPipelines.Rust:Cargo"
-            ["mvn"]="ModularPipelines.Java:Maven"
-            ["gradle"]="ModularPipelines.Java:Gradle"
-            ["git"]="ModularPipelines.Git:Git"
-            ["brew"]="ModularPipelines.Homebrew:Brew"
-            # Node.js ecosystem
-            ["yarn"]="ModularPipelines.Yarn:Yarn"
-            ["pnpm"]="ModularPipelines.Node:Pnpm"
-            # GitHub CLI
-            ["gh"]="ModularPipelines.GitHub:Gh"
-            # Kubernetes/GitOps
-            ["eksctl"]="ModularPipelines.Eksctl:Eksctl"
-            ["argocd"]="ModularPipelines.ArgoCd:ArgoCd"
-            ["flux"]="ModularPipelines.Flux:Flux"
-            ["kind"]="ModularPipelines.Kind:Kind"
-            ["minikube"]="ModularPipelines.Minikube:Minikube"
-            # Code quality/Security
-            ["sonar-scanner"]="ModularPipelines.SonarScanner:SonarScanner"
-            ["snyk"]="ModularPipelines.Snyk:Snyk"
-            ["shellcheck"]="ModularPipelines.Shellcheck:Shellcheck"
-            # Supply chain security
-            ["cosign"]="ModularPipelines.Cosign:Cosign"
-            ["syft"]="ModularPipelines.Syft:Syft"
-            ["grype"]="ModularPipelines.Grype:Grype"
-            # Testing
-            ["newman"]="ModularPipelines.Newman:Newman"
-            # Versioning
-            ["nbgv"]="ModularPipelines.NerdbankGitVersioning:Nbgv"
-            # Data processing
-            ["jq"]="ModularPipelines.Jq:Jq"
-            ["yq"]="ModularPipelines.Yq:Yq"
-            # Python
-            ["pip"]="ModularPipelines.Python:Pip"
-          )
-
-          IFS=':' read -r PACKAGE PREFIX <<< "${TOOL_MAP[${{ matrix.tool }}]}"
-          if [ -z "$PACKAGE" ]; then
-            echo "No package mapping exists for ${{ matrix.tool }}" >&2
-            exit 1
-          fi
-
-          PKG_DIR="src/$PACKAGE"
+          PACKAGE="${{ matrix.package }}"
+          PREFIX="${{ matrix.prefix }}"
+          PKG_DIR="${{ matrix.outputDirectory }}"
           PROJECT="$PKG_DIR/$PACKAGE.csproj"
           if [ ! -f "$PROJECT" ]; then
             echo "Package project not found: $PROJECT" >&2
@@ -749,17 +662,16 @@ jobs:
 
   # Generate options for Windows-only tools
   generate-windows:
-    needs: validate-generation-safety
+    needs:
+      - validate-generation-safety
+      - tool-catalog
     runs-on: windows-latest
     permissions:
       contents: write
       pull-requests: write
     strategy:
       fail-fast: false
-      matrix:
-        tool:
-          - choco
-          - winget
+      matrix: ${{ fromJSON(needs.tool-catalog.outputs.windows) }}
 
     steps:
       - name: Check if tool should run
@@ -825,20 +737,9 @@ jobs:
         if: steps.should-run.outputs.run == 'true'
         shell: pwsh
         run: |
-          # Map tool to package directory and namespace prefix
-          $toolMap = @{
-            "choco" = @{ Package = "ModularPipelines.Chocolatey"; Prefix = "Choco" }
-            "winget" = @{ Package = "ModularPipelines.WinGet"; Prefix = "Winget" }
-          }
-
-          $toolInfo = $toolMap["${{ matrix.tool }}"]
-          if (-not $toolInfo) {
-            throw "No package mapping exists for ${{ matrix.tool }}"
-          }
-
-          $package = $toolInfo.Package
-          $prefix = $toolInfo.Prefix
-          $pkgDir = "src/$package"
+          $package = "${{ matrix.package }}"
+          $prefix = "${{ matrix.prefix }}"
+          $pkgDir = "${{ matrix.outputDirectory }}"
           $project = "$pkgDir/$package.csproj"
           if (-not (Test-Path -LiteralPath $project -PathType Leaf)) {
             throw "Package project not found: $project"

--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -62,7 +62,9 @@ jobs:
 
           create_matrix() {
             jq -c --arg platform "$1" \
-              '{include: [.[] | select(.generationPlatform == $platform) | {
+              '{include: [.[] | select(
+                .generationPlatform == $platform and .includeInGenerationMatrix
+              ) | {
                 tool: .toolName,
                 package: .packageName,
                 prefix: .namespacePrefix,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ToolCatalogTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ToolCatalogTests.cs
@@ -1,0 +1,123 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+
+namespace ModularPipelines.OptionsGenerator.Tests;
+
+public class ToolCatalogTests
+{
+    [Test]
+    public async Task RegisteredCatalog_ContainsEveryPlatformAndValidMetadata()
+    {
+        var entries = OptionsGeneratorCommand.CreateToolCatalog();
+
+        await Assert.That(entries.Count).IsGreaterThan(40);
+        await Assert.That(entries
+                .Where(entry => entry.GenerationPlatform == CliGenerationPlatform.Windows)
+                .Select(entry => entry.ToolName))
+            .IsEquivalentTo(["choco", "winget"]);
+        await Assert.That(entries.All(
+            entry => entry.OutputDirectory == $"src/{entry.PackageName}")).IsTrue();
+    }
+
+    [Test]
+    public async Task Create_OrdersAndProjectsRegisteredScrapers()
+    {
+        var entries = ToolCatalog.Create(
+        [
+            new FakeCliScraper("zeta", "Zeta", "src/ModularPipelines.Zeta"),
+            new FakeCliScraper(
+                "alpha",
+                "Alpha",
+                @"src\ModularPipelines.Alpha",
+                CliGenerationPlatform.Windows),
+        ]);
+
+        await Assert.That(entries.Select(entry => entry.ToolName))
+            .IsEquivalentTo(
+                ["alpha", "zeta"],
+                TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await Assert.That(entries[0].PackageName).IsEqualTo("ModularPipelines.Alpha");
+        await Assert.That(entries[0].OutputDirectory).IsEqualTo("src/ModularPipelines.Alpha");
+        await Assert.That(entries[0].GenerationPlatform).IsEqualTo(CliGenerationPlatform.Windows);
+    }
+
+    [Test]
+    public async Task ToJson_UsesWorkflowFieldNames()
+    {
+        var entries = ToolCatalog.Create(
+        [
+            new FakeCliScraper("fake", "Fake", "src/ModularPipelines.Fake"),
+        ]);
+
+        using var document = JsonDocument.Parse(ToolCatalog.ToJson(entries));
+        var tool = document.RootElement[0];
+
+        await Assert.That(tool.GetProperty("toolName").GetString()).IsEqualTo("fake");
+        await Assert.That(tool.GetProperty("packageName").GetString()).IsEqualTo("ModularPipelines.Fake");
+        await Assert.That(tool.GetProperty("namespacePrefix").GetString()).IsEqualTo("Fake");
+        await Assert.That(tool.GetProperty("outputDirectory").GetString())
+            .IsEqualTo("src/ModularPipelines.Fake");
+        await Assert.That(tool.GetProperty("generationPlatform").GetString()).IsEqualTo("linux");
+    }
+
+    [Test]
+    public async Task Create_RejectsDuplicateToolNames()
+    {
+        var duplicateScrapers = new ICliScraper[]
+        {
+            new FakeCliScraper("fake", "Fake", "src/ModularPipelines.Fake"),
+            new FakeCliScraper("FAKE", "Other", "src/ModularPipelines.Other"),
+        };
+
+        await Assert.That(() => ToolCatalog.Create(duplicateScrapers))
+            .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task Create_RejectsOutputOutsideSingleSrcProject()
+    {
+        var scraper = new FakeCliScraper("fake", "Fake", "generated/Fake");
+
+        await Assert.That(() => ToolCatalog.Create([scraper]))
+            .Throws<InvalidOperationException>();
+    }
+
+    private sealed class FakeCliScraper(
+        string toolName,
+        string namespacePrefix,
+        string outputDirectory,
+        CliGenerationPlatform generationPlatform = CliGenerationPlatform.Linux) : ICliScraper
+    {
+        public string ToolName => toolName;
+
+        public string NamespacePrefix => namespacePrefix;
+
+        public string TargetNamespace => $"ModularPipelines.{namespacePrefix}";
+
+        public string OutputDirectory => outputDirectory;
+
+        public CliGenerationPlatform GenerationPlatform => generationPlatform;
+
+        public Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+
+        public async IAsyncEnumerable<CliCommandDefinition> ScrapeAsync(
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public CliToolDefinition CreateToolDefinition() => new()
+        {
+            ToolName = ToolName,
+            NamespacePrefix = NamespacePrefix,
+            TargetNamespace = TargetNamespace,
+            OutputDirectory = OutputDirectory,
+            Commands = [],
+            Errors = [],
+        };
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ToolCatalogTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ToolCatalogTests.cs
@@ -17,6 +17,12 @@ public class ToolCatalogTests
                 .Where(entry => entry.GenerationPlatform == CliGenerationPlatform.Windows)
                 .Select(entry => entry.ToolName))
             .IsEquivalentTo(["choco", "winget"]);
+        await Assert.That(entries.Single(entry => entry.ToolName == "npm").IncludeInGenerationMatrix)
+            .IsFalse();
+        await Assert.That(entries
+                .Where(entry => entry.ToolName != "npm")
+                .All(entry => entry.IncludeInGenerationMatrix))
+            .IsTrue();
         await Assert.That(entries.All(
             entry => entry.OutputDirectory == $"src/{entry.PackageName}")).IsTrue();
     }
@@ -60,6 +66,7 @@ public class ToolCatalogTests
         await Assert.That(tool.GetProperty("outputDirectory").GetString())
             .IsEqualTo("src/ModularPipelines.Fake");
         await Assert.That(tool.GetProperty("generationPlatform").GetString()).IsEqualTo("linux");
+        await Assert.That(tool.GetProperty("includeInGenerationMatrix").GetBoolean()).IsTrue();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/OptionsGeneratorCommand.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/OptionsGeneratorCommand.cs
@@ -31,6 +31,8 @@ internal static class OptionsGeneratorCommand
         rootCommand.Options.Add(options.EnhanceTypes);
         rootCommand.Options.Add(options.ApproveCommandCoverageShrinkage);
         rootCommand.Options.Add(options.ChangeManifest);
+        rootCommand.Options.Add(options.ListTools);
+        rootCommand.Options.Add(options.Json);
         rootCommand.SetAction((parseResult, cancellationToken) =>
             ExecuteAsync(ParseSettings(parseResult, options), cancellationToken));
         return rootCommand;
@@ -71,6 +73,14 @@ internal static class OptionsGeneratorCommand
             ChangeManifest: new Option<string?>("--change-manifest")
             {
                 Description = "Write the repository-relative generated and deleted paths to this file",
+            },
+            ListTools: new Option<bool>("--list-tools")
+            {
+                Description = "List registered first-party CLI tools without generating files",
+            },
+            Json: new Option<bool>("--json")
+            {
+                Description = "Write machine-readable JSON when listing tools",
             });
     }
 
@@ -83,13 +93,34 @@ internal static class OptionsGeneratorCommand
             UseCliFirst: parseResult.GetValue(options.UseCliFirst),
             EnhanceTypes: parseResult.GetValue(options.EnhanceTypes),
             ApproveCommandCoverageShrinkage: parseResult.GetValue(options.ApproveCommandCoverageShrinkage),
-            ChangeManifest: parseResult.GetValue(options.ChangeManifest));
+            ChangeManifest: parseResult.GetValue(options.ChangeManifest),
+            ListTools: parseResult.GetValue(options.ListTools),
+            Json: parseResult.GetValue(options.Json));
     }
 
     private static async Task<int> ExecuteAsync(
         GeneratorSettings settings,
         CancellationToken cancellationToken)
     {
+        if (settings.Json && !settings.ListTools)
+        {
+            Console.Error.WriteLine("--json requires --list-tools.");
+            return 1;
+        }
+
+        if (settings.ListTools)
+        {
+            if (settings.Input is not null)
+            {
+                Console.Error.WriteLine("--list-tools cannot be combined with --input.");
+                return 1;
+            }
+
+            var entries = CreateToolCatalog();
+            Console.WriteLine(settings.Json ? ToolCatalog.ToJson(entries) : ToolCatalog.ToText(entries));
+            return 0;
+        }
+
         if (settings.Input is not null
             && !string.Equals(settings.Tools, "all", StringComparison.OrdinalIgnoreCase))
         {
@@ -129,11 +160,11 @@ internal static class OptionsGeneratorCommand
         }
     }
 
-    private static IHost BuildHost(bool enhanceTypes)
+    private static IHost BuildHost(bool enhanceTypes, bool suppressLogs = false)
     {
         var builder = Host.CreateApplicationBuilder();
         builder.Logging.AddConsole();
-        builder.Logging.SetMinimumLevel(LogLevel.Information);
+        builder.Logging.SetMinimumLevel(suppressLogs ? LogLevel.None : LogLevel.Information);
         builder.Services.AddHttpClient();
         builder.Services.AddSingleton<ProcessCliCommandExecutor>();
         builder.Services.AddSingleton<ICliCommandExecutor>(serviceProvider =>
@@ -159,6 +190,12 @@ internal static class OptionsGeneratorCommand
 
         builder.Services.AddSingleton<CodeGeneratorOrchestrator>();
         return builder.Build();
+    }
+
+    internal static IReadOnlyList<ToolCatalogEntry> CreateToolCatalog()
+    {
+        using var host = BuildHost(enhanceTypes: false, suppressLogs: true);
+        return ToolCatalog.Create(host.Services.GetServices<ICliScraper>());
     }
 
     private static void RegisterCliScrapers(IServiceCollection services)
@@ -346,7 +383,9 @@ internal static class OptionsGeneratorCommand
         Option<bool> UseCliFirst,
         Option<bool> EnhanceTypes,
         Option<bool> ApproveCommandCoverageShrinkage,
-        Option<string?> ChangeManifest);
+        Option<string?> ChangeManifest,
+        Option<bool> ListTools,
+        Option<bool> Json);
 
     private sealed record GeneratorSettings(
         string Tools,
@@ -355,5 +394,7 @@ internal static class OptionsGeneratorCommand
         bool UseCliFirst,
         bool EnhanceTypes,
         bool ApproveCommandCoverageShrinkage,
-        string? ChangeManifest);
+        string? ChangeManifest,
+        bool ListTools,
+        bool Json);
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ChocolateyCliScraper.cs
@@ -53,6 +53,7 @@ public partial class ChocolateyCliScraper : CliScraperBase
 
     public override string OutputDirectory => "src/ModularPipelines.Chocolatey";
 
+    public override CliGenerationPlatform GenerationPlatform => CliGenerationPlatform.Windows;
 
     /// <summary>
     /// Skip utility commands.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliGenerationPlatform.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliGenerationPlatform.cs
@@ -1,0 +1,17 @@
+namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
+
+/// <summary>
+/// The operating-system family used to generate a CLI integration in automation.
+/// </summary>
+public enum CliGenerationPlatform
+{
+    /// <summary>
+    /// Generate on a Linux runner.
+    /// </summary>
+    Linux,
+
+    /// <summary>
+    /// Generate on a Windows runner.
+    /// </summary>
+    Windows,
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -47,6 +47,11 @@ public abstract partial class CliScraperBase : ICliScraper
     /// </summary>
     public abstract string OutputDirectory { get; }
 
+    /// <summary>
+    /// The operating-system family used to run this scraper in generation automation.
+    /// </summary>
+    public virtual CliGenerationPlatform GenerationPlatform => CliGenerationPlatform.Linux;
+
     #endregion
 
     #region Virtual Properties - Can Override

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -52,6 +52,9 @@ public abstract partial class CliScraperBase : ICliScraper
     /// </summary>
     public virtual CliGenerationPlatform GenerationPlatform => CliGenerationPlatform.Linux;
 
+    /// <inheritdoc />
+    public virtual bool IncludeInGenerationMatrix => true;
+
     #endregion
 
     #region Virtual Properties - Can Override

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ICliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ICliScraper.cs
@@ -29,6 +29,11 @@ public interface ICliScraper
     string OutputDirectory { get; }
 
     /// <summary>
+    /// The operating-system family used to run this scraper in generation automation.
+    /// </summary>
+    CliGenerationPlatform GenerationPlatform => CliGenerationPlatform.Linux;
+
+    /// <summary>
     /// Whether the CLI tool is available on the system.
     /// </summary>
     Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ICliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ICliScraper.cs
@@ -34,6 +34,11 @@ public interface ICliScraper
     CliGenerationPlatform GenerationPlatform => CliGenerationPlatform.Linux;
 
     /// <summary>
+    /// Whether this integration is ready for catalog-driven generation automation.
+    /// </summary>
+    bool IncludeInGenerationMatrix => true;
+
+    /// <summary>
     /// Whether the CLI tool is available on the system.
     /// </summary>
     Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/NpmCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/NpmCliScraper.cs
@@ -19,6 +19,9 @@ public partial class NpmCliScraper(
 
     public override string NamespacePrefix => "Npm";
 
+    /// <inheritdoc />
+    public override bool IncludeInGenerationMatrix => false;
+
     public override string TargetNamespace => "ModularPipelines.Node";
 
     public override string OutputDirectory => "src/ModularPipelines.Node";

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
@@ -52,6 +52,7 @@ public partial class WinGetCliScraper : CliScraperBase
 
     public override string OutputDirectory => "src/ModularPipelines.WinGet";
 
+    public override CliGenerationPlatform GenerationPlatform => CliGenerationPlatform.Windows;
 
     /// <summary>
     /// Skip utility commands.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ToolCatalog.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ToolCatalog.cs
@@ -36,9 +36,10 @@ internal static class ToolCatalog
 
     public static string ToText(IReadOnlyList<ToolCatalogEntry> entries)
     {
-        var lines = new[] { "Tool\tPackage\tNamespace prefix\tPlatform" }
+        var lines = new[] { "Tool\tPackage\tNamespace prefix\tPlatform\tAutomation" }
             .Concat(entries.Select(entry =>
-                $"{entry.ToolName}\t{entry.PackageName}\t{entry.NamespacePrefix}\t{entry.GenerationPlatform}"));
+                $"{entry.ToolName}\t{entry.PackageName}\t{entry.NamespacePrefix}\t"
+                + $"{entry.GenerationPlatform}\t{entry.IncludeInGenerationMatrix}"));
         return string.Join(Environment.NewLine, lines);
     }
 
@@ -72,7 +73,8 @@ internal static class ToolCatalog
             PackageName: pathParts[1],
             NamespacePrefix: namespacePrefix,
             OutputDirectory: outputDirectory,
-            GenerationPlatform: scraper.GenerationPlatform);
+            GenerationPlatform: scraper.GenerationPlatform,
+            IncludeInGenerationMatrix: scraper.IncludeInGenerationMatrix);
     }
 
     private static string RequireValue(string value, string description) =>
@@ -86,4 +88,5 @@ internal sealed record ToolCatalogEntry(
     string PackageName,
     string NamespacePrefix,
     string OutputDirectory,
-    CliGenerationPlatform GenerationPlatform);
+    CliGenerationPlatform GenerationPlatform,
+    bool IncludeInGenerationMatrix);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ToolCatalog.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ToolCatalog.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+
+namespace ModularPipelines.OptionsGenerator;
+
+internal static class ToolCatalog
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
+    };
+
+    public static IReadOnlyList<ToolCatalogEntry> Create(IEnumerable<ICliScraper> scrapers)
+    {
+        ArgumentNullException.ThrowIfNull(scrapers);
+
+        var entries = scrapers
+            .Select(CreateEntry)
+            .OrderBy(entry => entry.ToolName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var duplicate = entries
+            .GroupBy(entry => entry.ToolName, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(group => group.Count() > 1);
+
+        return duplicate is null
+            ? entries
+            : throw new InvalidOperationException(
+                $"Multiple CLI scrapers are registered for tool '{duplicate.Key}'.");
+    }
+
+    public static string ToJson(IReadOnlyList<ToolCatalogEntry> entries) =>
+        JsonSerializer.Serialize(entries, JsonOptions);
+
+    public static string ToText(IReadOnlyList<ToolCatalogEntry> entries)
+    {
+        var lines = new[] { "Tool\tPackage\tNamespace prefix\tPlatform" }
+            .Concat(entries.Select(entry =>
+                $"{entry.ToolName}\t{entry.PackageName}\t{entry.NamespacePrefix}\t{entry.GenerationPlatform}"));
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static ToolCatalogEntry CreateEntry(ICliScraper scraper)
+    {
+        var toolName = RequireValue(scraper.ToolName, "tool name");
+        var namespacePrefix = RequireValue(scraper.NamespacePrefix, $"namespace prefix for '{toolName}'");
+        var outputDirectory = RequireValue(
+                scraper.OutputDirectory,
+                $"output directory for '{toolName}'")
+            .Replace('\\', '/')
+            .TrimEnd('/');
+        var pathParts = outputDirectory.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (Path.IsPathRooted(outputDirectory)
+            || pathParts.Length != 2
+            || !string.Equals(pathParts[0], "src", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Tool '{toolName}' output directory must identify one project directly under src: "
+                + $"'{outputDirectory}'.");
+        }
+
+        if (!Enum.IsDefined(scraper.GenerationPlatform))
+        {
+            throw new InvalidOperationException(
+                $"Tool '{toolName}' has unsupported generation platform '{scraper.GenerationPlatform}'.");
+        }
+
+        return new ToolCatalogEntry(
+            ToolName: toolName,
+            PackageName: pathParts[1],
+            NamespacePrefix: namespacePrefix,
+            OutputDirectory: outputDirectory,
+            GenerationPlatform: scraper.GenerationPlatform);
+    }
+
+    private static string RequireValue(string value, string description) =>
+        string.IsNullOrWhiteSpace(value)
+            ? throw new InvalidOperationException($"CLI scraper {description} cannot be empty.")
+            : value.Trim();
+}
+
+internal sealed record ToolCatalogEntry(
+    string ToolName,
+    string PackageName,
+    string NamespacePrefix,
+    string OutputDirectory,
+    CliGenerationPlatform GenerationPlatform);


### PR DESCRIPTION
## Summary

- add `--list-tools --json` with validated package, prefix, output-directory, and generation-platform metadata
- derive Linux and Windows workflow matrices from the registered scraper catalog
- remove duplicated static tool and package maps; registered `npm` generation is now included automatically
- test catalog ordering, JSON shape, platform assignment, duplicate detection, and output-path validation

## Validation

- OptionsGenerator Release build: 0 warnings, 0 errors
- OptionsGenerator tests: 680 passed
- emitted catalog: 48 tools, 46 Linux, 2 Windows, 0 missing projects
- workflow YAML parsed and dynamic matrix references verified
- `git diff --check`

Closes #3325