### PR TITLE
Add code fixes for remaining analyzer rules

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
@@ -33,7 +33,7 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
         if (awaitExpression?.Parent is not ExpressionStatementSyntax expressionStatement
             || expressionStatement.ContainsDirectives
             || IsInsideLoop(expressionStatement)
-            || IsGotoTarget(expressionStatement))
+            || IsInsideBackwardGotoCycle(expressionStatement))
         {
             return;
         }
@@ -56,29 +56,44 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
                 or ForEachVariableStatementSyntax);
     }
 
-    private static bool IsGotoTarget(ExpressionStatementSyntax statement)
+    private static bool IsInsideBackwardGotoCycle(ExpressionStatementSyntax statement)
     {
-        var labeledStatement = statement
-            .AncestorsAndSelf()
+        var callable = GetEnclosingCallable(statement);
+        var scope = callable ?? statement.SyntaxTree.GetRoot();
+        var labels = scope.DescendantNodes()
             .OfType<LabeledStatementSyntax>()
-            .FirstOrDefault();
-        if (labeledStatement is null)
-        {
-            return false;
-        }
+            .Where(label => IsInSameCallable(label, callable))
+            .Where(label => label.SpanStart <= statement.SpanStart)
+            .ToArray();
 
-        var callable = statement.Ancestors().FirstOrDefault(static ancestor =>
+        return scope.DescendantNodes()
+            .OfType<GotoStatementSyntax>()
+            .Where(gotoStatement =>
+                IsInSameCallable(gotoStatement, callable)
+                && gotoStatement.SpanStart > statement.SpanStart)
+            .Any(gotoStatement =>
+                gotoStatement.Expression is IdentifierNameSyntax identifier
+                && labels.Any(label =>
+                    label.Identifier.ValueText == identifier.Identifier.ValueText));
+    }
+
+    private static bool IsInSameCallable(SyntaxNode node, SyntaxNode? callable)
+    {
+        var enclosingCallable = GetEnclosingCallable(node);
+        return enclosingCallable is null
+            ? callable is null
+            : callable is not null
+              && enclosingCallable.RawKind == callable.RawKind
+              && enclosingCallable.Span == callable.Span;
+    }
+
+    private static SyntaxNode? GetEnclosingCallable(SyntaxNode node)
+    {
+        return node.Ancestors().FirstOrDefault(static ancestor =>
             ancestor is BaseMethodDeclarationSyntax
                 or AccessorDeclarationSyntax
                 or LocalFunctionStatementSyntax
                 or AnonymousFunctionExpressionSyntax);
-        var scope = callable ?? statement.SyntaxTree.GetRoot();
-
-        return scope.DescendantNodes()
-            .OfType<GotoStatementSyntax>()
-            .Any(gotoStatement =>
-                gotoStatement.Expression is IdentifierNameSyntax identifier
-                && identifier.Identifier.ValueText == labeledStatement.Identifier.ValueText);
     }
 
     private static async Task<Document> RemoveAwaitAsync(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
@@ -17,7 +17,7 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
 {
     /// <inheritdoc/>
     public override ImmutableArray<string> FixableDiagnosticIds =>
-        ImmutableArray.Create(AwaitThisAnalyzer.DiagnosticId);
+        [AwaitThisAnalyzer.DiagnosticId];
 
     /// <inheritdoc/>
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
@@ -30,7 +30,8 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
         var awaitExpression = root?.FindNode(diagnostic.Location.SourceSpan)
             .FirstAncestorOrSelf<AwaitExpressionSyntax>();
 
-        if (awaitExpression?.Parent is not ExpressionStatementSyntax expressionStatement)
+        if (awaitExpression?.Parent is not ExpressionStatementSyntax expressionStatement
+            || expressionStatement.ContainsDirectives)
         {
             return;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
@@ -65,6 +65,7 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
             .Where(label => IsInSameCallable(label, callable))
             .Where(label => label.SpanStart <= statement.SpanStart)
             .ToArray();
+        var containingSwitch = statement.FirstAncestorOrSelf<SwitchStatementSyntax>();
 
         return scope.DescendantNodes()
             .OfType<GotoStatementSyntax>()
@@ -72,9 +73,15 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
                 IsInSameCallable(gotoStatement, callable)
                 && gotoStatement.SpanStart > statement.SpanStart)
             .Any(gotoStatement =>
-                gotoStatement.Expression is IdentifierNameSyntax identifier
-                && labels.Any(label =>
-                    label.Identifier.ValueText == identifier.Identifier.ValueText));
+                (gotoStatement.Expression is IdentifierNameSyntax identifier
+                 && labels.Any(label =>
+                     label.Identifier.ValueText == identifier.Identifier.ValueText))
+                || (containingSwitch is not null
+                    && gotoStatement.Kind() is
+                        SyntaxKind.GotoCaseStatement or SyntaxKind.GotoDefaultStatement
+                    && ReferenceEquals(
+                        gotoStatement.FirstAncestorOrSelf<SwitchStatementSyntax>(),
+                        containingSwitch)));
     }
 
     private static bool IsInSameCallable(SyntaxNode node, SyntaxNode? callable)

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
@@ -4,7 +4,9 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
 
 namespace ModularPipelines.Analyzers;
 
@@ -47,7 +49,13 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
         CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var newRoot = root?.RemoveNode(expressionStatement, SyntaxRemoveOptions.KeepNoTrivia);
+        var newRoot = expressionStatement.Parent is BlockSyntax or SwitchSectionSyntax
+            ? root?.RemoveNode(expressionStatement, SyntaxRemoveOptions.KeepNoTrivia)
+            : root?.ReplaceNode(
+                expressionStatement,
+                SyntaxFactory.EmptyStatement()
+                    .WithTriviaFrom(expressionStatement)
+                    .WithAdditionalAnnotations(Formatter.Annotation));
         return newRoot is null ? document : document.WithSyntaxRoot(newRoot);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
@@ -1,0 +1,53 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ModularPipelines.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AwaitThisCodeFixProvider))]
+[Shared]
+[ExcludeFromCodeCoverage]
+public sealed class AwaitThisCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(AwaitThisAnalyzer.DiagnosticId);
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var diagnostic = context.Diagnostics.First();
+        var awaitExpression = root?.FindNode(diagnostic.Location.SourceSpan)
+            .FirstAncestorOrSelf<AwaitExpressionSyntax>();
+
+        if (awaitExpression?.Parent is not ExpressionStatementSyntax expressionStatement)
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                CodeFixResources.AwaitThisCodeFixTitle,
+                cancellationToken => RemoveAwaitAsync(context.Document, expressionStatement, cancellationToken),
+                nameof(CodeFixResources.AwaitThisCodeFixTitle)),
+            diagnostic);
+    }
+
+    private static async Task<Document> RemoveAwaitAsync(
+        Document document,
+        ExpressionStatementSyntax expressionStatement,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var newRoot = root?.RemoveNode(expressionStatement, SyntaxRemoveOptions.KeepNoTrivia);
+        return newRoot is null ? document : document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
@@ -31,7 +31,8 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
             .FirstAncestorOrSelf<AwaitExpressionSyntax>();
 
         if (awaitExpression?.Parent is not ExpressionStatementSyntax expressionStatement
-            || expressionStatement.ContainsDirectives)
+            || expressionStatement.ContainsDirectives
+            || IsDirectLoopBody(expressionStatement))
         {
             return;
         }
@@ -42,6 +43,15 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
                 cancellationToken => RemoveAwaitAsync(context.Document, expressionStatement, cancellationToken),
                 nameof(CodeFixResources.AwaitThisCodeFixTitle)),
             diagnostic);
+    }
+
+    private static bool IsDirectLoopBody(ExpressionStatementSyntax statement)
+    {
+        return statement.Parent is WhileStatementSyntax
+            or DoStatementSyntax
+            or ForStatementSyntax
+            or ForEachStatementSyntax
+            or ForEachVariableStatementSyntax;
     }
 
     private static async Task<Document> RemoveAwaitAsync(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
@@ -50,13 +50,36 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
         CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-        var newRoot = expressionStatement.Parent is BlockSyntax or SwitchSectionSyntax
-            ? root?.RemoveNode(expressionStatement, SyntaxRemoveOptions.KeepNoTrivia)
-            : root?.ReplaceNode(
+        if (root is null)
+        {
+            return document;
+        }
+
+        if (expressionStatement.Parent is not (BlockSyntax or SwitchSectionSyntax))
+        {
+            return document.WithSyntaxRoot(root.ReplaceNode(
                 expressionStatement,
                 SyntaxFactory.EmptyStatement()
                     .WithTriviaFrom(expressionStatement)
-                    .WithAdditionalAnnotations(Formatter.Annotation));
-        return newRoot is null ? document : document.WithSyntaxRoot(newRoot);
+                    .WithAdditionalAnnotations(Formatter.Annotation)));
+        }
+
+        var newRoot = root.RemoveNode(
+            expressionStatement,
+            SyntaxRemoveOptions.KeepExteriorTrivia);
+        if (newRoot is null)
+        {
+            return document;
+        }
+
+        var nextNode = newRoot.FindToken(expressionStatement.SpanStart).Parent;
+        if (nextNode is not null)
+        {
+            newRoot = newRoot.ReplaceNode(
+                nextNode,
+                nextNode.WithAdditionalAnnotations(Formatter.Annotation));
+        }
+
+        return document.WithSyntaxRoot(newRoot);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using ModularPipelines.Analyzers.Extensions;
 
 namespace ModularPipelines.Analyzers;
 
@@ -32,6 +33,7 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
 
         if (awaitExpression?.Parent is not ExpressionStatementSyntax expressionStatement
             || expressionStatement.ContainsDirectives
+            || GetEnclosingCallable(expressionStatement)?.ContainsConditionalDirectives() == true
             || IsInsideLoop(expressionStatement)
             || IsInsideBackwardGotoCycle(expressionStatement))
         {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
@@ -32,7 +32,7 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
 
         if (awaitExpression?.Parent is not ExpressionStatementSyntax expressionStatement
             || expressionStatement.ContainsDirectives
-            || IsDirectLoopBody(expressionStatement))
+            || IsInsideLoop(expressionStatement))
         {
             return;
         }
@@ -45,13 +45,14 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
             diagnostic);
     }
 
-    private static bool IsDirectLoopBody(ExpressionStatementSyntax statement)
+    private static bool IsInsideLoop(ExpressionStatementSyntax statement)
     {
-        return statement.Parent is WhileStatementSyntax
-            or DoStatementSyntax
-            or ForStatementSyntax
-            or ForEachStatementSyntax
-            or ForEachVariableStatementSyntax;
+        return statement.Ancestors().Any(ancestor =>
+            ancestor is WhileStatementSyntax
+                or DoStatementSyntax
+                or ForStatementSyntax
+                or ForEachStatementSyntax
+                or ForEachVariableStatementSyntax);
     }
 
     private static async Task<Document> RemoveAwaitAsync(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AwaitThisCodeFixProvider.cs
@@ -32,7 +32,8 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
 
         if (awaitExpression?.Parent is not ExpressionStatementSyntax expressionStatement
             || expressionStatement.ContainsDirectives
-            || IsInsideLoop(expressionStatement))
+            || IsInsideLoop(expressionStatement)
+            || IsGotoTarget(expressionStatement))
         {
             return;
         }
@@ -53,6 +54,31 @@ public sealed class AwaitThisCodeFixProvider : CodeFixProvider
                 or ForStatementSyntax
                 or ForEachStatementSyntax
                 or ForEachVariableStatementSyntax);
+    }
+
+    private static bool IsGotoTarget(ExpressionStatementSyntax statement)
+    {
+        var labeledStatement = statement
+            .AncestorsAndSelf()
+            .OfType<LabeledStatementSyntax>()
+            .FirstOrDefault();
+        if (labeledStatement is null)
+        {
+            return false;
+        }
+
+        var callable = statement.Ancestors().FirstOrDefault(static ancestor =>
+            ancestor is BaseMethodDeclarationSyntax
+                or AccessorDeclarationSyntax
+                or LocalFunctionStatementSyntax
+                or AnonymousFunctionExpressionSyntax);
+        var scope = callable ?? statement.SyntaxTree.GetRoot();
+
+        return scope.DescendantNodes()
+            .OfType<GotoStatementSyntax>()
+            .Any(gotoStatement =>
+                gotoStatement.Expression is IdentifierNameSyntax identifier
+                && identifier.Identifier.ValueText == labeledStatement.Identifier.ValueText);
     }
 
     private static async Task<Document> RemoveAwaitAsync(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/CodeFixResources.Designer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/CodeFixResources.Designer.cs
@@ -103,5 +103,41 @@ namespace ModularPipelines.Analyzers {
                 return ResourceManager.GetString("ConflictingDependsOnAttributeCodeFixTitle", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Remove self-await.
+        /// </summary>
+        internal static string AwaitThisCodeFixTitle {
+            get {
+                return ResourceManager.GetString("AwaitThisCodeFixTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Use the module context logger.
+        /// </summary>
+        internal static string ConsoleUseCodeFixTitle {
+            get {
+                return ResourceManager.GetString("ConsoleUseCodeFixTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Remove logger parameter; use context.Logger.
+        /// </summary>
+        internal static string LoggerInConstructorCodeFixTitle {
+            get {
+                return ResourceManager.GetString("LoggerInConstructorCodeFixTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Make field readonly.
+        /// </summary>
+        internal static string StatefulModuleCodeFixTitle {
+            get {
+                return ResourceManager.GetString("StatefulModuleCodeFixTitle", resourceCulture);
+            }
+        }
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/CodeFixResources.resx
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/CodeFixResources.resx
@@ -136,4 +136,20 @@
     <value>Remove DependsOn Attribute</value>
     <comment>The title of the code fix to remove a conflicting DependsOn attribute.</comment>
   </data>
+  <data name="AwaitThisCodeFixTitle" xml:space="preserve">
+    <value>Remove self-await</value>
+    <comment>The title of the code fix to remove a standalone await this statement.</comment>
+  </data>
+  <data name="ConsoleUseCodeFixTitle" xml:space="preserve">
+    <value>Use the module context logger</value>
+    <comment>The title of the code fix to replace supported Console writes with context.Logger.</comment>
+  </data>
+  <data name="LoggerInConstructorCodeFixTitle" xml:space="preserve">
+    <value>Remove logger parameter; use context.Logger</value>
+    <comment>The title of the code fix to remove an unused logger constructor parameter.</comment>
+  </data>
+  <data name="StatefulModuleCodeFixTitle" xml:space="preserve">
+    <value>Make field readonly</value>
+    <comment>The title of the code fix to make an eligible module field readonly.</comment>
+  </data>
 </root>

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
@@ -44,7 +44,8 @@ public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
         // Find the attribute syntax identified by the diagnostic.
         var attributeSyntax = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<AttributeSyntax>().FirstOrDefault();
 
-        if (attributeSyntax is null)
+        if (attributeSyntax?.Parent is not AttributeListSyntax attributeList
+            || attributeList.ContainsDirectives)
         {
             return;
         }
@@ -64,10 +65,7 @@ public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
         var documentRoot = (await document.GetSyntaxRootAsync(cancellationToken))!;
 
         // Get the attribute list that contains this attribute
-        if (attributeSyntax.Parent is not AttributeListSyntax attributeList)
-        {
-            return document;
-        }
+        var attributeList = (AttributeListSyntax) attributeSyntax.Parent!;
 
         SyntaxNode newRoot;
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
@@ -109,6 +109,7 @@ public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
                 .FirstOrDefault())
             .Where(static attribute => attribute?.Parent is AttributeListSyntax { ContainsDirectives: false })
             .Cast<AttributeSyntax>()
+            .Distinct()
             .GroupBy(static attribute => (AttributeListSyntax) attribute.Parent!)
             .OrderByDescending(static group => group.Key.SpanStart);
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ModularPipelines.Analyzers;
@@ -72,7 +73,12 @@ public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
         // If this is the only attribute in the list, remove the entire attribute list
         if (attributeList.Attributes.Count == 1)
         {
-            newRoot = documentRoot.RemoveNode(attributeList, SyntaxRemoveOptions.KeepLeadingTrivia)!;
+            var removalOptions = attributeList.GetTrailingTrivia().Any(static trivia =>
+                !trivia.IsKind(SyntaxKind.WhitespaceTrivia)
+                && !trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                ? SyntaxRemoveOptions.KeepExteriorTrivia
+                : SyntaxRemoveOptions.KeepLeadingTrivia;
+            newRoot = documentRoot.RemoveNode(attributeList, removalOptions)!;
         }
         else
         {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
@@ -72,7 +72,7 @@ public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
         // If this is the only attribute in the list, remove the entire attribute list
         if (attributeList.Attributes.Count == 1)
         {
-            newRoot = documentRoot.RemoveNode(attributeList, SyntaxRemoveOptions.KeepTrailingTrivia)!;
+            newRoot = documentRoot.RemoveNode(attributeList, SyntaxRemoveOptions.KeepLeadingTrivia)!;
         }
         else
         {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
@@ -15,10 +15,12 @@ namespace ModularPipelines.Analyzers;
 public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
 {
     /// <inheritdoc/>
-    public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
+    public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+    [
         ConflictingDependsOnAttributeAnalyzer.DiagnosticId,
         InvalidDependsOnTypeAnalyzer.DiagnosticId,
-        SelfDependencyAnalyzer.DiagnosticId);
+        SelfDependencyAnalyzer.DiagnosticId,
+    ];
 
     /// <inheritdoc/>
     public sealed override FixAllProvider GetFixAllProvider()
@@ -62,8 +64,7 @@ public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
         var documentRoot = (await document.GetSyntaxRootAsync(cancellationToken))!;
 
         // Get the attribute list that contains this attribute
-        var attributeList = attributeSyntax.Parent as AttributeListSyntax;
-        if (attributeList is null)
+        if (attributeSyntax.Parent is not AttributeListSyntax attributeList)
         {
             return document;
         }
@@ -82,10 +83,10 @@ public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
         }
         else
         {
-            // Otherwise, just remove this attribute from the list
-            var newAttributes = attributeList.Attributes.Remove(attributeSyntax);
-            var newAttributeList = attributeList.WithAttributes(newAttributes);
-            newRoot = documentRoot.ReplaceNode(attributeList, newAttributeList);
+            // Let Roslyn remove the adjacent separator and transfer the attribute's trivia.
+            newRoot = documentRoot.RemoveNode(
+                attributeSyntax,
+                SyntaxRemoveOptions.KeepExteriorTrivia)!;
         }
 
         return document.WithSyntaxRoot(newRoot);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 
 namespace ModularPipelines.Analyzers;
 
@@ -14,6 +15,9 @@ namespace ModularPipelines.Analyzers;
 [ExcludeFromCodeCoverage]
 public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
 {
+    private static readonly FixAllProvider DocumentFixAllProvider =
+        FixAllProvider.Create(FixAllInDocumentAsync);
+
     /// <inheritdoc/>
     public sealed override ImmutableArray<string> FixableDiagnosticIds =>
     [
@@ -25,7 +29,7 @@ public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
     /// <inheritdoc/>
     public sealed override FixAllProvider GetFixAllProvider()
     {
-        return WellKnownFixAllProviders.BatchFixer;
+        return DocumentFixAllProvider;
     }
 
     /// <inheritdoc/>
@@ -72,11 +76,7 @@ public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
         // If this is the only attribute in the list, remove the entire attribute list
         if (attributeList.Attributes.Count == 1)
         {
-            var removalOptions = attributeList.GetTrailingTrivia().Any(static trivia =>
-                !trivia.IsKind(SyntaxKind.WhitespaceTrivia)
-                && !trivia.IsKind(SyntaxKind.EndOfLineTrivia))
-                ? SyntaxRemoveOptions.KeepExteriorTrivia
-                : SyntaxRemoveOptions.KeepLeadingTrivia;
+            var removalOptions = GetAttributeListRemovalOptions(attributeList);
             newRoot = documentRoot.RemoveNode(attributeList, removalOptions)!;
         }
         else
@@ -88,5 +88,56 @@ public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
         }
 
         return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static async Task<Document?> FixAllInDocumentAsync(
+        FixAllContext context,
+        Document document,
+        ImmutableArray<Diagnostic> diagnostics)
+    {
+        var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return null;
+        }
+
+        var attributeGroups = diagnostics
+            .Select(diagnostic => root.FindToken(diagnostic.Location.SourceSpan.Start)
+                .Parent?
+                .AncestorsAndSelf()
+                .OfType<AttributeSyntax>()
+                .FirstOrDefault())
+            .Where(static attribute => attribute?.Parent is AttributeListSyntax { ContainsDirectives: false })
+            .Cast<AttributeSyntax>()
+            .GroupBy(static attribute => (AttributeListSyntax) attribute.Parent!)
+            .OrderByDescending(static group => group.Key.SpanStart);
+
+        var editor = new SyntaxEditor(root, document.Project.Solution.Workspace.Services);
+        foreach (var group in attributeGroups)
+        {
+            var attributeList = group.Key;
+            if (group.Count() == attributeList.Attributes.Count)
+            {
+                var removalOptions = GetAttributeListRemovalOptions(attributeList);
+                editor.RemoveNode(attributeList, removalOptions);
+                continue;
+            }
+
+            var updatedList = attributeList.RemoveNodes(
+                group,
+                SyntaxRemoveOptions.KeepExteriorTrivia)!;
+            editor.ReplaceNode(attributeList, updatedList);
+        }
+
+        return document.WithSyntaxRoot(editor.GetChangedRoot());
+    }
+
+    private static SyntaxRemoveOptions GetAttributeListRemovalOptions(AttributeListSyntax attributeList)
+    {
+        return attributeList.GetTrailingTrivia().Any(static trivia =>
+            !trivia.IsKind(SyntaxKind.WhitespaceTrivia)
+            && !trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            ? SyntaxRemoveOptions.KeepExteriorTrivia
+            : SyntaxRemoveOptions.KeepLeadingTrivia;
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConflictingDependsOnAttributeCodeFixProvider.cs
@@ -14,7 +14,10 @@ namespace ModularPipelines.Analyzers;
 public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
 {
     /// <inheritdoc/>
-    public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(ConflictingDependsOnAttributeAnalyzer.DiagnosticId);
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
+        ConflictingDependsOnAttributeAnalyzer.DiagnosticId,
+        InvalidDependsOnTypeAnalyzer.DiagnosticId,
+        SelfDependencyAnalyzer.DiagnosticId);
 
     /// <inheritdoc/>
     public sealed override FixAllProvider GetFixAllProvider()
@@ -69,7 +72,7 @@ public class ConflictingDependsOnAttributeCodeFixProvider : CodeFixProvider
         // If this is the only attribute in the list, remove the entire attribute list
         if (attributeList.Attributes.Count == 1)
         {
-            newRoot = documentRoot.RemoveNode(attributeList, SyntaxRemoveOptions.KeepNoTrivia)!;
+            newRoot = documentRoot.RemoveNode(attributeList, SyntaxRemoveOptions.KeepTrailingTrivia)!;
         }
         else
         {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -1,0 +1,143 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using ModularPipelines.Analyzers.Extensions;
+
+namespace ModularPipelines.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ConsoleUseCodeFixProvider))]
+[Shared]
+[ExcludeFromCodeCoverage]
+public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
+{
+    private static readonly ImmutableHashSet<string> SupportedMethodNames =
+        ImmutableHashSet.Create("Write", "WriteLine", "WriteAsync", "WriteLineAsync");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(ConsoleUseAnalyzer.DiagnosticId);
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        var diagnostic = context.Diagnostics.First();
+        var invocation = root?.FindNode(diagnostic.Location.SourceSpan)
+            .FirstAncestorOrSelf<InvocationExpressionSyntax>();
+
+        if (invocation is null
+            || semanticModel?.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method
+            || !SupportedMethodNames.Contains(method.Name)
+            || !CanReplaceStatement(invocation)
+            || !HasSupportedArguments(invocation, semanticModel, context.CancellationToken)
+            || FindModuleContextParameter(invocation, semanticModel, context.CancellationToken) is not { } contextParameter)
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                CodeFixResources.ConsoleUseCodeFixTitle,
+                cancellationToken => ReplaceWithLoggerAsync(
+                    context.Document,
+                    invocation,
+                    contextParameter.Identifier.ValueText,
+                    cancellationToken),
+                nameof(CodeFixResources.ConsoleUseCodeFixTitle)),
+            diagnostic);
+    }
+
+    private static bool CanReplaceStatement(InvocationExpressionSyntax invocation)
+    {
+        return invocation.Parent is ExpressionStatementSyntax
+               || invocation.Parent is AwaitExpressionSyntax { Parent: ExpressionStatementSyntax };
+    }
+
+    private static bool HasSupportedArguments(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var firstArgument = invocation.ArgumentList.Arguments.FirstOrDefault();
+        return invocation.ArgumentList.Arguments.Count <= 1
+               && (firstArgument is null
+               || semanticModel.GetTypeInfo(firstArgument.Expression, cancellationToken).ConvertedType?.SpecialType
+               == SpecialType.System_String);
+    }
+
+    private static ParameterSyntax? FindModuleContextParameter(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var moduleContextType = semanticModel.Compilation.GetTypeByMetadataName(
+            "ModularPipelines.Context.IModuleContext");
+        var method = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+
+        return moduleContextType is null
+            ? null
+            : method?.ParameterList.Parameters.FirstOrDefault(parameter =>
+                SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetTypeInfo(parameter.Type!, cancellationToken).Type,
+                    moduleContextType));
+    }
+
+    private static async Task<Document> ReplaceWithLoggerAsync(
+        Document document,
+        InvocationExpressionSyntax invocation,
+        string contextParameterName,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return document;
+        }
+
+        var logMethod = invocation.Expression.ToString().Contains("Console.Error.", StringComparison.Ordinal)
+            ? "LogError"
+            : "LogInformation";
+        var arguments = invocation.ArgumentList.Arguments.Count == 0
+            ? SyntaxFactory.SingletonSeparatedList(
+                SyntaxFactory.Argument(
+                    SyntaxFactory.LiteralExpression(
+                        SyntaxKind.StringLiteralExpression,
+                        SyntaxFactory.Literal(string.Empty))))
+            : invocation.ArgumentList.Arguments;
+        var loggerInvocation = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.ParseExpression($"{contextParameterName}.Logger.{logMethod}"),
+                SyntaxFactory.ArgumentList(arguments))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+
+        SyntaxNode oldNode;
+        SyntaxNode newNode;
+
+        if (invocation.Parent is AwaitExpressionSyntax awaitExpression
+            && awaitExpression.Parent is ExpressionStatementSyntax awaitStatement)
+        {
+            oldNode = awaitStatement;
+            newNode = SyntaxFactory.ExpressionStatement(loggerInvocation)
+                .WithTriviaFrom(oldNode)
+                .WithAdditionalAnnotations(Formatter.Annotation);
+        }
+        else
+        {
+            oldNode = invocation;
+            newNode = loggerInvocation.WithTriviaFrom(invocation);
+        }
+
+        var newRoot = root.ReplaceNode(oldNode, newNode)
+            .AddUsing("Microsoft.Extensions.Logging");
+        return document.WithSyntaxRoot(newRoot);
+    }
+}

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -17,7 +17,7 @@ namespace ModularPipelines.Analyzers;
 public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
 {
     private static readonly ImmutableHashSet<string> SupportedMethodNames =
-        ["Write", "WriteLine", "WriteAsync", "WriteLineAsync"];
+        ["WriteLine", "WriteLineAsync"];
 
     /// <inheritdoc/>
     public override ImmutableArray<string> FixableDiagnosticIds =>

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -47,6 +47,17 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
             return;
         }
 
+        var isConsoleError = IsConsoleError(invocation, semanticModel, context.CancellationToken);
+        if (!await BindsToLoggerExtensionsAsync(
+                context.Document,
+                invocation,
+                contextParameter.Identifier,
+                isConsoleError,
+                context.CancellationToken).ConfigureAwait(false))
+        {
+            return;
+        }
+
         context.RegisterCodeFix(
             CodeAction.Create(
                 CodeFixResources.ConsoleUseCodeFixTitle,
@@ -54,7 +65,7 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
                     context.Document,
                     invocation,
                     contextParameter.Identifier,
-                    IsConsoleError(invocation, semanticModel, context.CancellationToken),
+                    isConsoleError,
                     cancellationToken),
                 nameof(CodeFixResources.ConsoleUseCodeFixTitle)),
             diagnostic);
@@ -105,6 +116,46 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
                && SymbolEqualityComparer.Default.Equals(property.ContainingType, consoleType);
     }
 
+    private static async Task<bool> BindsToLoggerExtensionsAsync(
+        Document document,
+        InvocationExpressionSyntax invocation,
+        SyntaxToken contextParameterIdentifier,
+        bool isConsoleError,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return false;
+        }
+
+        var annotation = new SyntaxAnnotation();
+        var newRoot = ReplaceWithLogger(
+            root,
+            invocation,
+            contextParameterIdentifier,
+            isConsoleError,
+            annotation);
+        var newDocument = document.WithSyntaxRoot(newRoot);
+        var semanticModel = await newDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var boundRoot = await newDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var loggerInvocation = boundRoot?.GetAnnotatedNodes(annotation)
+            .OfType<InvocationExpressionSyntax>()
+            .SingleOrDefault();
+        if (loggerInvocation is null)
+        {
+            return false;
+        }
+
+        var method = semanticModel?.GetSymbolInfo(loggerInvocation, cancellationToken).Symbol as IMethodSymbol;
+        var loggerExtensions = semanticModel?.Compilation.GetTypeByMetadataName(
+            "Microsoft.Extensions.Logging.LoggerExtensions");
+
+        return SymbolEqualityComparer.Default.Equals(
+            method?.ReducedFrom?.ContainingType ?? method?.ContainingType,
+            loggerExtensions);
+    }
+
     private static async Task<Document> ReplaceWithLoggerAsync(
         Document document,
         InvocationExpressionSyntax invocation,
@@ -118,6 +169,21 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
             return document;
         }
 
+        return document.WithSyntaxRoot(
+            ReplaceWithLogger(
+                root,
+                invocation,
+                contextParameterIdentifier,
+                isConsoleError));
+    }
+
+    private static SyntaxNode ReplaceWithLogger(
+        SyntaxNode root,
+        InvocationExpressionSyntax invocation,
+        SyntaxToken contextParameterIdentifier,
+        bool isConsoleError,
+        SyntaxAnnotation? annotation = null)
+    {
         var logMethod = isConsoleError ? "LogError" : "LogInformation";
         var arguments = CreateLoggerArguments(invocation.ArgumentList);
         var contextLogger = SyntaxFactory.MemberAccessExpression(
@@ -131,6 +197,10 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
                     SyntaxFactory.IdentifierName(logMethod)),
                 SyntaxFactory.ArgumentList(arguments))
             .WithAdditionalAnnotations(Formatter.Annotation);
+        if (annotation is not null)
+        {
+            loggerInvocation = loggerInvocation.WithAdditionalAnnotations(annotation);
+        }
 
         SyntaxNode oldNode;
         SyntaxNode newNode;
@@ -149,9 +219,8 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
             newNode = loggerInvocation.WithTriviaFrom(invocation);
         }
 
-        var newRoot = root.ReplaceNode(oldNode, newNode)
+        return root.ReplaceNode(oldNode, newNode)
             .AddUsing("Microsoft.Extensions.Logging");
-        return document.WithSyntaxRoot(newRoot);
     }
 
     private static SeparatedSyntaxList<ArgumentSyntax> CreateLoggerArguments(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -55,7 +55,6 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
                     invocation,
                     contextParameter.Identifier,
                     IsConsoleError(invocation, semanticModel, context.CancellationToken),
-                    MessageCanBeNull(invocation, semanticModel, context.CancellationToken),
                     cancellationToken),
                 nameof(CodeFixResources.ConsoleUseCodeFixTitle)),
             diagnostic);
@@ -106,23 +105,11 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
                && SymbolEqualityComparer.Default.Equals(property.ContainingType, consoleType);
     }
 
-    private static bool MessageCanBeNull(
-        InvocationExpressionSyntax invocation,
-        SemanticModel semanticModel,
-        CancellationToken cancellationToken)
-    {
-        var arguments = invocation.ArgumentList.Arguments;
-        return arguments.Count == 1
-               && semanticModel.GetTypeInfo(arguments[0].Expression, cancellationToken)
-                   .ConvertedNullability.FlowState != NullableFlowState.NotNull;
-    }
-
     private static async Task<Document> ReplaceWithLoggerAsync(
         Document document,
         InvocationExpressionSyntax invocation,
         SyntaxToken contextParameterIdentifier,
         bool isConsoleError,
-        bool messageCanBeNull,
         CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -132,9 +119,7 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
         }
 
         var logMethod = isConsoleError ? "LogError" : "LogInformation";
-        var arguments = CreateLoggerArguments(
-            invocation.ArgumentList,
-            messageCanBeNull);
+        var arguments = CreateLoggerArguments(invocation.ArgumentList);
         var contextLogger = SyntaxFactory.MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
             SyntaxFactory.IdentifierName(contextParameterIdentifier.WithoutTrivia()),
@@ -170,8 +155,7 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
     }
 
     private static SeparatedSyntaxList<ArgumentSyntax> CreateLoggerArguments(
-        ArgumentListSyntax argumentList,
-        bool messageCanBeNull)
+        ArgumentListSyntax argumentList)
     {
         var arguments = argumentList.Arguments;
         if (arguments.Count == 0)
@@ -193,20 +177,17 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
         }
 
         var argument = arguments[0].WithLeadingTrivia(default(SyntaxTriviaList));
-        if (messageCanBeNull)
-        {
-            var parenthesizedMessage = SyntaxFactory.ParenthesizedExpression(
-                argument.Expression.WithoutTrivia());
-            argument = argument.WithExpression(
-                    SyntaxFactory.BinaryExpression(
-                        SyntaxKind.CoalesceExpression,
-                        parenthesizedMessage,
-                        SyntaxFactory.MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)),
-                            SyntaxFactory.IdentifierName(nameof(string.Empty)))))
-                .WithTriviaFrom(argument);
-        }
+        var parenthesizedMessage = SyntaxFactory.ParenthesizedExpression(
+            argument.Expression.WithoutTrivia());
+        argument = argument.WithExpression(
+                SyntaxFactory.BinaryExpression(
+                    SyntaxKind.CoalesceExpression,
+                    parenthesizedMessage,
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)),
+                        SyntaxFactory.IdentifierName(nameof(string.Empty)))))
+            .WithTriviaFrom(argument);
 
         return SyntaxFactory.SeparatedList<ArgumentSyntax>(
         [

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -51,7 +51,8 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
                 cancellationToken => ReplaceWithLoggerAsync(
                     context.Document,
                     invocation,
-                    contextParameter.Identifier.ValueText,
+                    contextParameter.Identifier,
+                    IsConsoleError(invocation, semanticModel, context.CancellationToken),
                     cancellationToken),
                 nameof(CodeFixResources.ConsoleUseCodeFixTitle)),
             diagnostic);
@@ -108,10 +109,28 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
         };
     }
 
+    private static bool IsConsoleError(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax methodAccess
+            || semanticModel.GetSymbolInfo(methodAccess.Expression, cancellationToken).Symbol
+                is not IPropertySymbol property)
+        {
+            return false;
+        }
+
+        var consoleType = semanticModel.Compilation.GetTypeByMetadataName("System.Console");
+        return property.Name == nameof(Console.Error)
+               && SymbolEqualityComparer.Default.Equals(property.ContainingType, consoleType);
+    }
+
     private static async Task<Document> ReplaceWithLoggerAsync(
         Document document,
         InvocationExpressionSyntax invocation,
-        string contextParameterName,
+        SyntaxToken contextParameterIdentifier,
+        bool isConsoleError,
         CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -120,9 +139,7 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
             return document;
         }
 
-        var logMethod = invocation.Expression.ToString().Contains("Console.Error.", StringComparison.Ordinal)
-            ? "LogError"
-            : "LogInformation";
+        var logMethod = isConsoleError ? "LogError" : "LogInformation";
         var arguments = invocation.ArgumentList.Arguments.Count == 0
             ? SyntaxFactory.SingletonSeparatedList(
                 SyntaxFactory.Argument(
@@ -130,8 +147,15 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
                         SyntaxKind.StringLiteralExpression,
                         SyntaxFactory.Literal(string.Empty))))
             : invocation.ArgumentList.Arguments;
+        var contextLogger = SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            SyntaxFactory.IdentifierName(contextParameterIdentifier.WithoutTrivia()),
+            SyntaxFactory.IdentifierName("Logger"));
         var loggerInvocation = SyntaxFactory.InvocationExpression(
-                SyntaxFactory.ParseExpression($"{contextParameterName}.Logger.{logMethod}"),
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    contextLogger,
+                    SyntaxFactory.IdentifierName(logMethod)),
                 SyntaxFactory.ArgumentList(arguments))
             .WithAdditionalAnnotations(Formatter.Annotation);
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -73,6 +73,11 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
         CancellationToken cancellationToken)
     {
         var arguments = invocation.ArgumentList.Arguments;
+        if (invocation.ArgumentList.ContainsDirectives)
+        {
+            return false;
+        }
+
         if (arguments.Count != 1)
         {
             return arguments.Count == 0;
@@ -128,7 +133,7 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
 
         var logMethod = isConsoleError ? "LogError" : "LogInformation";
         var arguments = CreateLoggerArguments(
-            invocation.ArgumentList.Arguments,
+            invocation.ArgumentList,
             messageCanBeNull);
         var contextLogger = SyntaxFactory.MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
@@ -165,37 +170,52 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
     }
 
     private static SeparatedSyntaxList<ArgumentSyntax> CreateLoggerArguments(
-        SeparatedSyntaxList<ArgumentSyntax> arguments,
+        ArgumentListSyntax argumentList,
         bool messageCanBeNull)
     {
+        var arguments = argumentList.Arguments;
         if (arguments.Count == 0)
         {
             return SyntaxFactory.SingletonSeparatedList(
                 SyntaxFactory.Argument(
                     SyntaxFactory.LiteralExpression(
                         SyntaxKind.StringLiteralExpression,
-                        SyntaxFactory.Literal(string.Empty))));
+                        SyntaxFactory.Literal(string.Empty)))
+                    .WithLeadingTrivia(argumentList.OpenParenToken.TrailingTrivia));
         }
 
-        var argument = arguments[0];
+        var messageTrivia = argumentList.OpenParenToken.TrailingTrivia.AddRange(
+            arguments[0].GetLeadingTrivia());
+        if (messageTrivia.Count == 0
+            || !messageTrivia[0].IsKind(SyntaxKind.WhitespaceTrivia))
+        {
+            messageTrivia = messageTrivia.Insert(0, SyntaxFactory.Space);
+        }
+
+        var argument = arguments[0].WithLeadingTrivia(default(SyntaxTriviaList));
         if (messageCanBeNull)
         {
+            var parenthesizedMessage = SyntaxFactory.ParenthesizedExpression(
+                argument.Expression.WithoutTrivia());
             argument = argument.WithExpression(
-                SyntaxFactory.BinaryExpression(
-                    SyntaxKind.CoalesceExpression,
-                    SyntaxFactory.ParenthesizedExpression(argument.Expression.WithoutTrivia()),
-                    SyntaxFactory.MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)),
-                        SyntaxFactory.IdentifierName(nameof(string.Empty)))));
+                    SyntaxFactory.BinaryExpression(
+                        SyntaxKind.CoalesceExpression,
+                        parenthesizedMessage,
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)),
+                            SyntaxFactory.IdentifierName(nameof(string.Empty)))))
+                .WithTriviaFrom(argument);
         }
 
-        return SyntaxFactory.SeparatedList(
+        return SyntaxFactory.SeparatedList<ArgumentSyntax>(
         [
             SyntaxFactory.Argument(
                 SyntaxFactory.LiteralExpression(
                     SyntaxKind.StringLiteralExpression,
                     SyntaxFactory.Literal("{Message}"))),
+            SyntaxFactory.Token(SyntaxKind.CommaToken)
+                .WithTrailingTrivia(messageTrivia),
             argument,
         ]);
     }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -158,15 +158,9 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
         }
 
         var logMethod = isConsoleError ? "LogError" : "LogInformation";
-        var arguments = invocation.ArgumentList.Arguments.Count == 0
-            ? SyntaxFactory.SingletonSeparatedList(
-                SyntaxFactory.Argument(
-                    SyntaxFactory.LiteralExpression(
-                        SyntaxKind.StringLiteralExpression,
-                        SyntaxFactory.Literal(string.Empty))))
-            : CoalesceNullableMessage(
-                invocation.ArgumentList.Arguments,
-                messageCanBeNull);
+        var arguments = CreateLoggerArguments(
+            invocation.ArgumentList.Arguments,
+            messageCanBeNull);
         var contextLogger = SyntaxFactory.MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
             SyntaxFactory.IdentifierName(contextParameterIdentifier.WithoutTrivia()),
@@ -201,24 +195,39 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
         return document.WithSyntaxRoot(newRoot);
     }
 
-    private static SeparatedSyntaxList<ArgumentSyntax> CoalesceNullableMessage(
+    private static SeparatedSyntaxList<ArgumentSyntax> CreateLoggerArguments(
         SeparatedSyntaxList<ArgumentSyntax> arguments,
         bool messageCanBeNull)
     {
-        if (!messageCanBeNull)
+        if (arguments.Count == 0)
         {
-            return arguments;
+            return SyntaxFactory.SingletonSeparatedList(
+                SyntaxFactory.Argument(
+                    SyntaxFactory.LiteralExpression(
+                        SyntaxKind.StringLiteralExpression,
+                        SyntaxFactory.Literal(string.Empty))));
         }
 
         var argument = arguments[0];
-        var coalescedMessage = SyntaxFactory.BinaryExpression(
-            SyntaxKind.CoalesceExpression,
-            SyntaxFactory.ParenthesizedExpression(argument.Expression.WithoutTrivia()),
-            SyntaxFactory.MemberAccessExpression(
-                SyntaxKind.SimpleMemberAccessExpression,
-                SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)),
-                SyntaxFactory.IdentifierName(nameof(string.Empty))));
-        return SyntaxFactory.SingletonSeparatedList(
-            argument.WithExpression(coalescedMessage));
+        if (messageCanBeNull)
+        {
+            argument = argument.WithExpression(
+                SyntaxFactory.BinaryExpression(
+                    SyntaxKind.CoalesceExpression,
+                    SyntaxFactory.ParenthesizedExpression(argument.Expression.WithoutTrivia()),
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)),
+                        SyntaxFactory.IdentifierName(nameof(string.Empty)))));
+        }
+
+        return SyntaxFactory.SeparatedList(
+        [
+            SyntaxFactory.Argument(
+                SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal("{Message}"))),
+            argument,
+        ]);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Analyzers;
 public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
 {
     private static readonly ImmutableHashSet<string> SupportedMethodNames =
-        ImmutableHashSet.Create("Write", "WriteLine", "WriteAsync", "WriteLineAsync");
+        ["Write", "WriteLine", "WriteAsync", "WriteLineAsync"];
 
     /// <inheritdoc/>
     public override ImmutableArray<string> FixableDiagnosticIds =>
-        ImmutableArray.Create(ConsoleUseAnalyzer.DiagnosticId);
+        [ConsoleUseAnalyzer.DiagnosticId];
 
     /// <inheritdoc/>
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
@@ -69,11 +69,16 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        var firstArgument = invocation.ArgumentList.Arguments.FirstOrDefault();
-        return invocation.ArgumentList.Arguments.Count <= 1
-               && (firstArgument is null
-               || semanticModel.GetTypeInfo(firstArgument.Expression, cancellationToken).ConvertedType?.SpecialType
-               == SpecialType.System_String);
+        var arguments = invocation.ArgumentList.Arguments;
+        if (arguments.Count != 1)
+        {
+            return arguments.Count == 0;
+        }
+
+        var argument = arguments[0];
+        return argument.NameColon is null
+               && semanticModel.GetTypeInfo(argument.Expression, cancellationToken).ConvertedType?.SpecialType
+               == SpecialType.System_String;
     }
 
     private static ParameterSyntax? FindModuleContextParameter(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -73,7 +73,7 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
         CancellationToken cancellationToken)
     {
         var arguments = invocation.ArgumentList.Arguments;
-        if (invocation.ArgumentList.ContainsDirectives)
+        if (invocation.ContainsDirectives)
         {
             return false;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -85,11 +85,27 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
         var method = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
 
         return moduleContextType is null
+               || method is null
+               || invocation.Ancestors()
+                   .TakeWhile(node => node != method)
+                   .Any(IsStaticCallable)
             ? null
-            : method?.ParameterList.Parameters.FirstOrDefault(parameter =>
+            : method.ParameterList.Parameters.FirstOrDefault(parameter =>
                 SymbolEqualityComparer.Default.Equals(
                     semanticModel.GetTypeInfo(parameter.Type!, cancellationToken).Type,
                     moduleContextType));
+    }
+
+    private static bool IsStaticCallable(SyntaxNode node)
+    {
+        return node switch
+        {
+            LocalFunctionStatementSyntax localFunction =>
+                localFunction.Modifiers.Any(SyntaxKind.StaticKeyword),
+            AnonymousFunctionExpressionSyntax anonymousFunction =>
+                anonymousFunction.Modifiers.Any(SyntaxKind.StaticKeyword),
+            _ => false,
+        };
     }
 
     private static async Task<Document> ReplaceWithLoggerAsync(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -40,7 +40,9 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
             || !SupportedMethodNames.Contains(method.Name)
             || !CanReplaceStatement(invocation)
             || !HasSupportedArguments(invocation, semanticModel, context.CancellationToken)
-            || FindModuleContextParameter(invocation, semanticModel, context.CancellationToken) is not { } contextParameter)
+            || invocation.FindVisibleModuleContextParameter(
+                semanticModel,
+                context.CancellationToken) is not { } contextParameter)
         {
             return;
         }
@@ -80,39 +82,6 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
         return argument.NameColon is null
                && semanticModel.GetTypeInfo(argument.Expression, cancellationToken).ConvertedType?.SpecialType
                == SpecialType.System_String;
-    }
-
-    private static ParameterSyntax? FindModuleContextParameter(
-        InvocationExpressionSyntax invocation,
-        SemanticModel semanticModel,
-        CancellationToken cancellationToken)
-    {
-        var moduleContextType = semanticModel.Compilation.GetTypeByMetadataName(
-            "ModularPipelines.Context.IModuleContext");
-        var method = invocation.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-
-        return moduleContextType is null
-               || method is null
-               || invocation.Ancestors()
-                   .TakeWhile(node => node != method)
-                   .Any(IsStaticCallable)
-            ? null
-            : method.ParameterList.Parameters.FirstOrDefault(parameter =>
-                SymbolEqualityComparer.Default.Equals(
-                    semanticModel.GetTypeInfo(parameter.Type!, cancellationToken).Type,
-                    moduleContextType));
-    }
-
-    private static bool IsStaticCallable(SyntaxNode node)
-    {
-        return node switch
-        {
-            LocalFunctionStatementSyntax localFunction =>
-                localFunction.Modifiers.Any(SyntaxKind.StaticKeyword),
-            AnonymousFunctionExpressionSyntax anonymousFunction =>
-                anonymousFunction.Modifiers.Any(SyntaxKind.StaticKeyword),
-            _ => false,
-        };
     }
 
     private static bool IsConsoleError(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/ConsoleUseCodeFixProvider.cs
@@ -53,6 +53,7 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
                     invocation,
                     contextParameter.Identifier,
                     IsConsoleError(invocation, semanticModel, context.CancellationToken),
+                    MessageCanBeNull(invocation, semanticModel, context.CancellationToken),
                     cancellationToken),
                 nameof(CodeFixResources.ConsoleUseCodeFixTitle)),
             diagnostic);
@@ -131,11 +132,23 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
                && SymbolEqualityComparer.Default.Equals(property.ContainingType, consoleType);
     }
 
+    private static bool MessageCanBeNull(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var arguments = invocation.ArgumentList.Arguments;
+        return arguments.Count == 1
+               && semanticModel.GetTypeInfo(arguments[0].Expression, cancellationToken)
+                   .ConvertedNullability.FlowState != NullableFlowState.NotNull;
+    }
+
     private static async Task<Document> ReplaceWithLoggerAsync(
         Document document,
         InvocationExpressionSyntax invocation,
         SyntaxToken contextParameterIdentifier,
         bool isConsoleError,
+        bool messageCanBeNull,
         CancellationToken cancellationToken)
     {
         var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
@@ -151,7 +164,9 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
                     SyntaxFactory.LiteralExpression(
                         SyntaxKind.StringLiteralExpression,
                         SyntaxFactory.Literal(string.Empty))))
-            : invocation.ArgumentList.Arguments;
+            : CoalesceNullableMessage(
+                invocation.ArgumentList.Arguments,
+                messageCanBeNull);
         var contextLogger = SyntaxFactory.MemberAccessExpression(
             SyntaxKind.SimpleMemberAccessExpression,
             SyntaxFactory.IdentifierName(contextParameterIdentifier.WithoutTrivia()),
@@ -184,5 +199,26 @@ public sealed class ConsoleUseCodeFixProvider : CodeFixProvider
         var newRoot = root.ReplaceNode(oldNode, newNode)
             .AddUsing("Microsoft.Extensions.Logging");
         return document.WithSyntaxRoot(newRoot);
+    }
+
+    private static SeparatedSyntaxList<ArgumentSyntax> CoalesceNullableMessage(
+        SeparatedSyntaxList<ArgumentSyntax> arguments,
+        bool messageCanBeNull)
+    {
+        if (!messageCanBeNull)
+        {
+            return arguments;
+        }
+
+        var argument = arguments[0];
+        var coalescedMessage = SyntaxFactory.BinaryExpression(
+            SyntaxKind.CoalesceExpression,
+            SyntaxFactory.ParenthesizedExpression(argument.Expression.WithoutTrivia()),
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword)),
+                SyntaxFactory.IdentifierName(nameof(string.Empty))));
+        return SyntaxFactory.SingletonSeparatedList(
+            argument.WithExpression(coalescedMessage));
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
@@ -10,15 +10,20 @@ internal static class SyntaxNodeExtensions
 {
     public static SyntaxNode AddUsings(this SyntaxNode documentRoot)
     {
+        return documentRoot.AddUsing("ModularPipelines.Attributes");
+    }
+
+    public static SyntaxNode AddUsing(this SyntaxNode documentRoot, string namespaceName)
+    {
         var compilationUnitSyntax = (CompilationUnitSyntax) documentRoot;
 
-        if (compilationUnitSyntax.Usings.Any(x => x.Name?.ToFullString() == "ModularPipelines.Attributes"))
+        if (compilationUnitSyntax.Usings.Any(x => x.Name?.ToFullString() == namespaceName))
         {
             return documentRoot;
         }
 
         compilationUnitSyntax = compilationUnitSyntax.AddUsings(
-            SyntaxFactory.UsingDirective(SyntaxFactory.ParseName("ModularPipelines.Attributes")));
+            SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName)));
 
         return compilationUnitSyntax;
     }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
@@ -17,7 +17,8 @@ internal static class SyntaxNodeExtensions
     {
         var compilationUnitSyntax = (CompilationUnitSyntax) documentRoot;
 
-        if (compilationUnitSyntax.Usings.Any(x => x.Name?.ToFullString() == namespaceName))
+        if (compilationUnitSyntax.Usings.Any(x =>
+                x.Alias is null && x.Name?.ToFullString() == namespaceName))
         {
             return documentRoot;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
@@ -18,15 +18,37 @@ internal static class SyntaxNodeExtensions
         var compilationUnitSyntax = (CompilationUnitSyntax) documentRoot;
 
         if (compilationUnitSyntax.Usings.Any(x =>
-                x.Alias is null && x.Name?.ToFullString() == namespaceName))
+                x.Alias is null
+                && !x.ContainsConditionalDirectives()
+                && x.Name?.ToFullString() == namespaceName))
         {
             return documentRoot;
         }
 
-        compilationUnitSyntax = compilationUnitSyntax.AddUsings(
-            SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceName)));
+        var usingDirective = SyntaxFactory.UsingDirective(
+            SyntaxFactory.ParseName(namespaceName));
+        var conditionalMatch = compilationUnitSyntax.Usings
+            .FirstOrDefault(item =>
+                item.Alias is null
+                && item.Name?.ToFullString() == namespaceName);
+        compilationUnitSyntax = conditionalMatch is null
+            ? compilationUnitSyntax.AddUsings(usingDirective)
+            : compilationUnitSyntax.WithUsings(
+                compilationUnitSyntax.Usings.Insert(
+                    compilationUnitSyntax.Usings.IndexOf(conditionalMatch),
+                    usingDirective));
 
         return compilationUnitSyntax;
+    }
+
+    public static bool ContainsConditionalDirectives(this SyntaxNode node)
+    {
+        return node.DescendantTrivia(descendIntoTrivia: true)
+            .Any(static trivia => trivia.Kind() is
+                SyntaxKind.IfDirectiveTrivia
+                or SyntaxKind.ElifDirectiveTrivia
+                or SyntaxKind.ElseDirectiveTrivia
+                or SyntaxKind.EndIfDirectiveTrivia);
     }
 
     public static ParameterSyntax? FindVisibleModuleContextParameter(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
@@ -27,4 +27,52 @@ internal static class SyntaxNodeExtensions
 
         return compilationUnitSyntax;
     }
+
+    public static ParameterSyntax? FindVisibleModuleContextParameter(
+        this SyntaxNode node,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var moduleContextType = semanticModel.Compilation.GetTypeByMetadataName(
+            "ModularPipelines.Context.IModuleContext");
+        var method = node.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+        if (moduleContextType is null
+            || method is null
+            || node.Ancestors()
+                .TakeWhile(ancestor => ancestor != method)
+                .Any(IsStaticCallable))
+        {
+            return null;
+        }
+
+        var parameter = method.ParameterList.Parameters.FirstOrDefault(candidate =>
+            SymbolEqualityComparer.Default.Equals(
+                semanticModel.GetTypeInfo(candidate.Type!, cancellationToken).Type,
+                moduleContextType));
+        if (parameter is null
+            || semanticModel.GetDeclaredSymbol(parameter, cancellationToken) is not { } parameterSymbol)
+        {
+            return null;
+        }
+
+        var visibleSymbol = semanticModel.GetSpeculativeSymbolInfo(
+            node.SpanStart,
+            SyntaxFactory.IdentifierName(parameter.Identifier.WithoutTrivia()),
+            SpeculativeBindingOption.BindAsExpression).Symbol;
+        return SymbolEqualityComparer.Default.Equals(visibleSymbol, parameterSymbol)
+            ? parameter
+            : null;
+    }
+
+    private static bool IsStaticCallable(SyntaxNode node)
+    {
+        return node switch
+        {
+            LocalFunctionStatementSyntax localFunction =>
+                localFunction.Modifiers.Any(SyntaxKind.StaticKeyword),
+            AnonymousFunctionExpressionSyntax anonymousFunction =>
+                anonymousFunction.Modifiers.Any(SyntaxKind.StaticKeyword),
+            _ => false,
+        };
+    }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -331,14 +331,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var remainingStatements = constructor.Body?.Statements.Count - (assignmentStatement is null ? 0 : 1);
-        var removeConstructor = constructor.ParameterList.Parameters.Count == 1
-                                && remainingStatements == 0
-                                && constructor.Initializer is null
-                                && constructor.AttributeLists.Count == 0
-                                && !constructor.ContainsDirectives
-                                && constructor.Modifiers.Any(SyntaxKind.PublicKeyword)
-                                && IsOnlyInstanceConstructor(constructor);
+        var removeConstructor = CanRemoveConstructor(constructor, assignmentStatement);
 
         foreach (var replacement in loggerReplacements)
         {
@@ -376,6 +369,21 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         }
 
         return editor.GetChangedDocument();
+    }
+
+    private static bool CanRemoveConstructor(
+        ConstructorDeclarationSyntax constructor,
+        ExpressionStatementSyntax? assignmentStatement)
+    {
+        var removedStatementCount = assignmentStatement is null ? 0 : 1;
+        var remainingStatements = constructor.Body?.Statements.Count - removedStatementCount;
+        return constructor.ParameterList.Parameters.Count == 1
+               && remainingStatements == 0
+               && constructor.Initializer is null
+               && constructor.AttributeLists.Count == 0
+               && !constructor.ContainsDirectives
+               && constructor.Modifiers.Any(SyntaxKind.PublicKeyword)
+               && IsOnlyInstanceConstructor(constructor);
     }
 
     private static bool IsOnlyInstanceConstructor(ConstructorDeclarationSyntax constructor)

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -18,7 +18,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
 {
     /// <inheritdoc/>
     public override ImmutableArray<string> FixableDiagnosticIds =>
-        ImmutableArray.Create(LoggerInConstructorAnalyzer.DiagnosticId);
+        [LoggerInConstructorAnalyzer.DiagnosticId];
 
     /// <inheritdoc/>
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
@@ -76,7 +76,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
     {
         fieldDeclaration = null;
         assignmentStatement = null;
-        loggerReplacements = ImmutableArray<LoggerReplacement>.Empty;
+        loggerReplacements = [];
 
         if (containingType.Modifiers.Any(SyntaxKind.PartialKeyword))
         {
@@ -85,12 +85,13 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
 
         var constructorSymbol = semanticModel.GetDeclaredSymbol(constructor, cancellationToken);
         if (constructorSymbol is not null
-            && containingType.DescendantNodes()
-                .OfType<ConstructorInitializerSyntax>()
-                .Where(initializer => initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.ThisKeyword))
-                .Any(initializer => SymbolEqualityComparer.Default.Equals(
-                    semanticModel.GetSymbolInfo(initializer, cancellationToken).Symbol,
-                    constructorSymbol)))
+            && (containingType.DescendantNodes()
+                    .OfType<ConstructorInitializerSyntax>()
+                    .Where(initializer => initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.ThisKeyword))
+                    .Any(initializer => SymbolEqualityComparer.Default.Equals(
+                        semanticModel.GetSymbolInfo(initializer, cancellationToken).Symbol,
+                        constructorSymbol))
+                || WouldDuplicateConstructor(constructorSymbol, parameter)))
         {
             return false;
         }
@@ -130,6 +131,40 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         fieldDeclaration = loggerStorage.FieldDeclaration;
         assignmentStatement = loggerStorage.AssignmentStatement;
         loggerReplacements = replacements.Value;
+        return true;
+    }
+
+    private static bool WouldDuplicateConstructor(
+        IMethodSymbol constructor,
+        IParameterSymbol removedParameter)
+    {
+        var remainingParameters = constructor.Parameters
+            .Where(parameter => !SymbolEqualityComparer.Default.Equals(parameter, removedParameter))
+            .ToArray();
+
+        return constructor.ContainingType.InstanceConstructors
+            .Where(other => !SymbolEqualityComparer.Default.Equals(other, constructor))
+            .Any(other => HaveSameSignature(remainingParameters, other.Parameters));
+    }
+
+    private static bool HaveSameSignature(
+        IParameterSymbol[] first,
+        IReadOnlyList<IParameterSymbol> second)
+    {
+        if (first.Length != second.Count)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < first.Length; index++)
+        {
+            if (!SymbolEqualityComparer.Default.Equals(first[index].Type, second[index].Type)
+                || (first[index].RefKind == RefKind.None) != (second[index].RefKind == RefKind.None))
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 
@@ -212,12 +247,14 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        return containingType.DescendantNodes()
-            .OfType<IdentifierNameSyntax>()
-            .Where(identifier => SymbolEqualityComparer.Default.Equals(
-                semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol,
-                symbol))
-            .ToImmutableArray();
+        return
+        [
+            .. containingType.DescendantNodes()
+                .OfType<IdentifierNameSyntax>()
+                .Where(identifier => SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol,
+                    symbol)),
+        ];
     }
 
     private static ExpressionSyntax GetLoggerExpression(IdentifierNameSyntax fieldReference)

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -127,7 +127,9 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             return false;
         }
 
-        if (loggerStorage.AssignmentStatement.Parent != constructor.Body)
+        if (loggerStorage.AssignmentStatement.Parent != constructor.Body
+            || loggerStorage.FieldDeclaration.ContainsDirectives
+            || loggerStorage.AssignmentStatement.ContainsDirectives)
         {
             return false;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -216,7 +216,8 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         var fieldDeclaration = fieldVariable?.Parent?.Parent as FieldDeclarationSyntax;
 
         return fieldVariable?.Initializer is null
-               && fieldDeclaration?.Declaration.Variables.Count == 1
+               && fieldDeclaration is { AttributeLists.Count: 0 }
+               && fieldDeclaration.Declaration.Variables.Count == 1
             ? new LoggerStorage(field, fieldDeclaration, assignmentStatement, assignment)
             : null;
     }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -242,10 +242,14 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             var nodeToReplace = GetLoggerExpression(fieldReference);
             if (nodeToReplace.Parent is not MemberAccessExpressionSyntax { Expression: var expression }
                 || expression != nodeToReplace
-                || !CanReplaceLoggerReceiver(nodeToReplace, semanticModel, cancellationToken)
                 || nodeToReplace.FindVisibleModuleContextParameter(
                     semanticModel,
-                    cancellationToken) is not { } contextParameter)
+                    cancellationToken) is not { } contextParameter
+                || !CanReplaceLoggerReceiver(
+                    nodeToReplace,
+                    contextParameter.Identifier,
+                    semanticModel,
+                    cancellationToken))
             {
                 return null;
             }
@@ -258,6 +262,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
 
     private static bool CanReplaceLoggerReceiver(
         ExpressionSyntax loggerExpression,
+        SyntaxToken contextParameterIdentifier,
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
@@ -279,11 +284,36 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         var contextLoggerType = semanticModel.Compilation.GetTypeByMetadataName(
             "ModularPipelines.Logging.IModuleLogger");
 
-        return requiredReceiverType is not null
-               && contextLoggerType is not null
-               && semanticModel.Compilation
-                   .ClassifyCommonConversion(contextLoggerType, requiredReceiverType)
-                   .IsImplicit;
+        if (requiredReceiverType is null
+            || contextLoggerType is null
+            || !semanticModel.Compilation
+                .ClassifyCommonConversion(contextLoggerType, requiredReceiverType)
+                .IsImplicit)
+        {
+            return false;
+        }
+
+        ExpressionSyntax expressionToBind =
+            memberAccess.Parent is InvocationExpressionSyntax invocation
+            && invocation.Expression == memberAccess
+                ? invocation
+                : memberAccess;
+        var contextLogger = SyntaxFactory.MemberAccessExpression(
+            SyntaxKind.SimpleMemberAccessExpression,
+            SyntaxFactory.IdentifierName(contextParameterIdentifier.WithoutTrivia()),
+            SyntaxFactory.IdentifierName("Logger"));
+        var rewrittenExpression = expressionToBind.ReplaceNode(
+            loggerExpression,
+            contextLogger);
+        var originalSymbol = semanticModel.GetSymbolInfo(
+            expressionToBind,
+            cancellationToken).Symbol;
+        var rewrittenSymbol = semanticModel.GetSpeculativeSymbolInfo(
+            expressionToBind.SpanStart,
+            rewrittenExpression,
+            SpeculativeBindingOption.BindAsExpression).Symbol;
+
+        return SymbolEqualityComparer.Default.Equals(originalSymbol, rewrittenSymbol);
     }
 
     private static bool IsLogger(ITypeSymbol type)

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -300,7 +300,8 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         var removeConstructor = constructor.ParameterList.Parameters.Count == 1
                                 && remainingStatements == 0
                                 && constructor.Initializer is null
-                                && constructor.Modifiers.Any(SyntaxKind.PublicKeyword);
+                                && constructor.Modifiers.Any(SyntaxKind.PublicKeyword)
+                                && IsOnlyInstanceConstructor(constructor);
 
         foreach (var replacement in loggerReplacements)
         {
@@ -338,6 +339,15 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         }
 
         return editor.GetChangedDocument();
+    }
+
+    private static bool IsOnlyInstanceConstructor(ConstructorDeclarationSyntax constructor)
+    {
+        return constructor.Parent is TypeDeclarationSyntax containingType
+               && !containingType.Members
+                   .OfType<ConstructorDeclarationSyntax>()
+                   .Any(other => other != constructor
+                                 && !other.Modifiers.Any(SyntaxKind.StaticKeyword));
     }
 
     private sealed class LoggerReplacement(SyntaxNode node, SyntaxToken contextParameterIdentifier)

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -97,7 +97,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
                 .Any(initializer => SymbolEqualityComparer.Default.Equals(
                     semanticModel.GetSymbolInfo(initializer, cancellationToken).Symbol,
                     constructorSymbol))
-            || WouldDuplicateConstructor(constructorSymbol, parameter))
+            || WouldOverlapSiblingConstructor(constructorSymbol, parameter))
         {
             return false;
         }
@@ -120,6 +120,11 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             semanticModel,
             cancellationToken);
         if (loggerStorage is null)
+        {
+            return false;
+        }
+
+        if (loggerStorage.AssignmentStatement.Parent != constructor.Body)
         {
             return false;
         }
@@ -153,38 +158,32 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         return references.Any(static reference => reference.Locations.Any());
     }
 
-    private static bool WouldDuplicateConstructor(
+    private static bool WouldOverlapSiblingConstructor(
         IMethodSymbol constructor,
         IParameterSymbol removedParameter)
     {
         var remainingParameters = constructor.Parameters
             .Where(parameter => !SymbolEqualityComparer.Default.Equals(parameter, removedParameter))
             .ToArray();
+        var remainingArity = GetCallableArity(remainingParameters);
 
         return constructor.ContainingType.InstanceConstructors
             .Where(other => !SymbolEqualityComparer.Default.Equals(other, constructor))
-            .Any(other => HaveSameSignature(remainingParameters, other.Parameters));
+            .Select(static other => GetCallableArity(other.Parameters))
+            .Any(otherArity =>
+                remainingArity.Minimum <= otherArity.Maximum
+                && otherArity.Minimum <= remainingArity.Maximum);
     }
 
-    private static bool HaveSameSignature(
-        IParameterSymbol[] first,
-        IReadOnlyList<IParameterSymbol> second)
+    private static (int Minimum, int Maximum) GetCallableArity(
+        IReadOnlyList<IParameterSymbol> parameters)
     {
-        if (first.Length != second.Count)
-        {
-            return false;
-        }
-
-        for (var index = 0; index < first.Length; index++)
-        {
-            if (!SymbolEqualityComparer.Default.Equals(first[index].Type, second[index].Type)
-                || (first[index].RefKind == RefKind.None) != (second[index].RefKind == RefKind.None))
-            {
-                return false;
-            }
-        }
-
-        return true;
+        var minimum = parameters.Count(static parameter =>
+            !parameter.IsOptional && !parameter.IsParams);
+        var maximum = parameters.Any(static parameter => parameter.IsParams)
+            ? int.MaxValue
+            : parameters.Count;
+        return (minimum, maximum);
     }
 
     private static LoggerStorage? GetLoggerStorage(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -63,6 +63,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             .FirstAncestorOrSelf<ParameterSyntax>();
 
         if (parameter is null
+            || parameter.AttributeLists.Count != 0
             || parameter.FirstAncestorOrSelf<ConstructorDeclarationSyntax>() is not { } constructor
             || constructor.ParameterList.ContainsDirectives
             || parameter.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -18,42 +18,25 @@ namespace ModularPipelines.Analyzers;
 [ExcludeFromCodeCoverage]
 public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
 {
+    private static readonly FixAllProvider DocumentFixAllProvider =
+        FixAllProvider.Create(FixAllInDocumentAsync);
+
     /// <inheritdoc/>
     public override ImmutableArray<string> FixableDiagnosticIds =>
         [LoggerInConstructorAnalyzer.DiagnosticId];
 
     /// <inheritdoc/>
-    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+    public override FixAllProvider GetFixAllProvider() => DocumentFixAllProvider;
 
     /// <inheritdoc/>
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
-        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
         var diagnostic = context.Diagnostics.First();
-        var parameter = root?.FindNode(diagnostic.Location.SourceSpan)
-            .FirstAncestorOrSelf<ParameterSyntax>();
-
-        if (parameter is null
-            || parameter.FirstAncestorOrSelf<ConstructorDeclarationSyntax>() is not { } constructor
-            || constructor.ParameterList.ContainsDirectives
-            || parameter.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
-            || semanticModel?.GetDeclaredSymbol(parameter, context.CancellationToken) is not IParameterSymbol parameterSymbol
-            || semanticModel.GetDeclaredSymbol(constructor, context.CancellationToken) is not IMethodSymbol constructorSymbol
-            || await HasExplicitReferencesAsync(
-                constructorSymbol,
-                context.Document.Project.Solution,
-                context.CancellationToken).ConfigureAwait(false)
-            || !TryCreateFix(
-                containingType,
-                constructor,
-                constructorSymbol,
-                parameterSymbol,
-                semanticModel,
-                context.CancellationToken,
-                out var fieldDeclaration,
-                out var assignmentStatement,
-                out var loggerReplacements))
+        var fix = await TryCreateFixAsync(
+            context.Document,
+            diagnostic,
+            context.CancellationToken).ConfigureAwait(false);
+        if (fix is null)
         {
             return;
         }
@@ -63,14 +46,78 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
                 CodeFixResources.LoggerInConstructorCodeFixTitle,
                 cancellationToken => ReplaceWithContextLoggerAsync(
                     context.Document,
-                    constructor,
-                    parameter,
-                    fieldDeclaration,
-                    assignmentStatement,
-                    loggerReplacements,
+                    [fix],
                     cancellationToken),
                 nameof(CodeFixResources.LoggerInConstructorCodeFixTitle)),
             diagnostic);
+    }
+
+    private static async Task<LoggerFix?> TryCreateFixAsync(
+        Document document,
+        Diagnostic diagnostic,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        var parameter = root?.FindNode(diagnostic.Location.SourceSpan)
+            .FirstAncestorOrSelf<ParameterSyntax>();
+
+        if (parameter is null
+            || parameter.FirstAncestorOrSelf<ConstructorDeclarationSyntax>() is not { } constructor
+            || constructor.ParameterList.ContainsDirectives
+            || parameter.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
+            || semanticModel?.GetDeclaredSymbol(parameter, cancellationToken) is not IParameterSymbol parameterSymbol
+            || semanticModel.GetDeclaredSymbol(constructor, cancellationToken) is not IMethodSymbol constructorSymbol
+            || await HasExplicitReferencesAsync(
+                constructorSymbol,
+                document.Project.Solution,
+                cancellationToken).ConfigureAwait(false)
+            || !TryCreateFix(
+                containingType,
+                constructor,
+                constructorSymbol,
+                parameterSymbol,
+                semanticModel,
+                cancellationToken,
+                out var fieldDeclaration,
+                out var assignmentStatement,
+                out var loggerReplacements))
+        {
+            return null;
+        }
+
+        return new LoggerFix(
+            constructor,
+            constructorSymbol,
+            parameter,
+            parameterSymbol,
+            fieldDeclaration,
+            assignmentStatement,
+            loggerReplacements);
+    }
+
+    private static async Task<Document?> FixAllInDocumentAsync(
+        FixAllContext context,
+        Document document,
+        ImmutableArray<Diagnostic> diagnostics)
+    {
+        var fixes = ImmutableArray.CreateBuilder<LoggerFix>();
+        foreach (var diagnostic in diagnostics)
+        {
+            var fix = await TryCreateFixAsync(
+                document,
+                diagnostic,
+                context.CancellationToken).ConfigureAwait(false);
+            if (fix is not null)
+            {
+                fixes.Add(fix);
+            }
+        }
+
+        return await ReplaceWithContextLoggerAsync(
+            document,
+            fixes.ToImmutable(),
+            context.CancellationToken).ConfigureAwait(false);
     }
 
     private static bool TryCreateFix(
@@ -167,8 +214,16 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         IMethodSymbol constructor,
         IParameterSymbol removedParameter)
     {
+        return WouldOverlapSiblingConstructor(constructor, [removedParameter]);
+    }
+
+    private static bool WouldOverlapSiblingConstructor(
+        IMethodSymbol constructor,
+        IReadOnlyCollection<IParameterSymbol> removedParameters)
+    {
         var remainingParameters = constructor.Parameters
-            .Where(parameter => !SymbolEqualityComparer.Default.Equals(parameter, removedParameter))
+            .Where(parameter => !removedParameters.Any(removedParameter =>
+                SymbolEqualityComparer.Default.Equals(parameter, removedParameter)))
             .ToArray();
         var (remainingMinimum, remainingMaximum) = GetCallableArity(remainingParameters);
 
@@ -360,17 +415,13 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
 
     private static async Task<Document> ReplaceWithContextLoggerAsync(
         Document document,
-        ConstructorDeclarationSyntax constructor,
-        ParameterSyntax parameter,
-        FieldDeclarationSyntax? fieldDeclaration,
-        ExpressionStatementSyntax? assignmentStatement,
-        ImmutableArray<LoggerReplacement> loggerReplacements,
+        ImmutableArray<LoggerFix> fixes,
         CancellationToken cancellationToken)
     {
         var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-        var removeConstructor = CanRemoveConstructor(constructor, assignmentStatement);
+        var applicableFixes = GetApplicableFixes(fixes);
 
-        foreach (var replacement in loggerReplacements)
+        foreach (var replacement in applicableFixes.SelectMany(static fix => fix.LoggerReplacements))
         {
             editor.ReplaceNode(
                 replacement.Node,
@@ -383,38 +434,90 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
                     .WithAdditionalAnnotations(Formatter.Annotation));
         }
 
-        if (fieldDeclaration is not null)
+        foreach (var fieldDeclaration in applicableFixes
+                     .Select(static fix => fix.FieldDeclaration)
+                     .OfType<FieldDeclarationSyntax>()
+                     .Distinct())
         {
             editor.RemoveNode(fieldDeclaration);
         }
 
-        if (assignmentStatement is not null && !removeConstructor)
+        foreach (var constructorFixes in applicableFixes.GroupBy(static fix => fix.Constructor))
         {
-            editor.RemoveNode(assignmentStatement);
-        }
+            var constructor = constructorFixes.Key;
+            var parameters = constructorFixes
+                .Select(static fix => fix.Parameter)
+                .ToImmutableHashSet();
+            var assignmentStatements = constructorFixes
+                .Select(static fix => fix.AssignmentStatement)
+                .OfType<ExpressionStatementSyntax>()
+                .ToImmutableHashSet();
+            var removeConstructor = CanRemoveConstructor(
+                constructor,
+                parameters,
+                assignmentStatements);
 
-        if (removeConstructor)
-        {
-            editor.RemoveNode(constructor);
-        }
-        else
-        {
+            if (removeConstructor)
+            {
+                editor.RemoveNode(constructor);
+                continue;
+            }
+
+            foreach (var assignmentStatement in assignmentStatements)
+            {
+                editor.RemoveNode(assignmentStatement);
+            }
+
+            var remainingParameters = constructor.ParameterList.Parameters;
+            foreach (var parameter in parameters)
+            {
+                remainingParameters = remainingParameters.Remove(parameter);
+            }
+
             editor.ReplaceNode(
                 constructor.ParameterList,
-                constructor.ParameterList.WithParameters(
-                    constructor.ParameterList.Parameters.Remove(parameter)));
+                constructor.ParameterList
+                    .WithParameters(remainingParameters)
+                    .WithAdditionalAnnotations(Formatter.Annotation));
         }
 
         return editor.GetChangedDocument();
     }
 
+    private static ImmutableArray<LoggerFix> GetApplicableFixes(
+        ImmutableArray<LoggerFix> fixes)
+    {
+        var applicableFixes = ImmutableArray.CreateBuilder<LoggerFix>();
+        foreach (var constructorFixes in fixes.GroupBy(static fix => fix.Constructor))
+        {
+            var selectedFixes = new List<LoggerFix>();
+            foreach (var fix in constructorFixes)
+            {
+                var removedParameters = selectedFixes
+                    .Select(static selectedFix => selectedFix.ParameterSymbol)
+                    .Append(fix.ParameterSymbol)
+                    .ToArray();
+                if (!WouldOverlapSiblingConstructor(
+                        fix.ConstructorSymbol,
+                        removedParameters))
+                {
+                    selectedFixes.Add(fix);
+                }
+            }
+
+            applicableFixes.AddRange(selectedFixes);
+        }
+
+        return applicableFixes.ToImmutable();
+    }
+
     private static bool CanRemoveConstructor(
         ConstructorDeclarationSyntax constructor,
-        ExpressionStatementSyntax? assignmentStatement)
+        IReadOnlyCollection<ParameterSyntax> parameters,
+        IReadOnlyCollection<ExpressionStatementSyntax> assignmentStatements)
     {
-        var removedStatementCount = assignmentStatement is null ? 0 : 1;
-        var remainingStatements = constructor.Body?.Statements.Count - removedStatementCount;
-        return constructor.ParameterList.Parameters.Count == 1
+        var remainingStatements = constructor.Body?.Statements.Count - assignmentStatements.Count;
+        return constructor.ParameterList.Parameters.Count == parameters.Count
                && remainingStatements == 0
                && constructor.Initializer is null
                && constructor.AttributeLists.Count == 0
@@ -439,6 +542,30 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         public SyntaxNode Node { get; } = node;
 
         public SyntaxToken ContextParameterIdentifier { get; } = contextParameterIdentifier;
+    }
+
+    private sealed class LoggerFix(
+        ConstructorDeclarationSyntax constructor,
+        IMethodSymbol constructorSymbol,
+        ParameterSyntax parameter,
+        IParameterSymbol parameterSymbol,
+        FieldDeclarationSyntax? fieldDeclaration,
+        ExpressionStatementSyntax? assignmentStatement,
+        ImmutableArray<LoggerReplacement> loggerReplacements)
+    {
+        public ConstructorDeclarationSyntax Constructor { get; } = constructor;
+
+        public IMethodSymbol ConstructorSymbol { get; } = constructorSymbol;
+
+        public ParameterSyntax Parameter { get; } = parameter;
+
+        public IParameterSymbol ParameterSymbol { get; } = parameterSymbol;
+
+        public FieldDeclarationSyntax? FieldDeclaration { get; } = fieldDeclaration;
+
+        public ExpressionStatementSyntax? AssignmentStatement { get; } = assignmentStatement;
+
+        public ImmutableArray<LoggerReplacement> LoggerReplacements { get; } = loggerReplacements;
     }
 
     private sealed class LoggerStorage(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -257,6 +257,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             || assignment.Parent is not ExpressionStatementSyntax assignmentStatement
             || assignment.Right != parameterReference
             || semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol is not IFieldSymbol field
+            || !IsCurrentInstanceFieldReference(assignment.Left)
             || field.DeclaredAccessibility != Accessibility.Private
             || !IsLogger(field.Type))
         {
@@ -275,6 +276,15 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
                && fieldDeclaration.Declaration.Variables.Count == 1
             ? new LoggerStorage(field, fieldDeclaration, assignmentStatement, assignment)
             : null;
+    }
+
+    private static bool IsCurrentInstanceFieldReference(ExpressionSyntax expression)
+    {
+        return expression is IdentifierNameSyntax
+            or MemberAccessExpressionSyntax
+        {
+            Expression: ThisExpressionSyntax,
+        };
     }
 
     private static ImmutableArray<LoggerReplacement>? CreateLoggerReplacements(
@@ -513,8 +523,8 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
 
     private static bool CanRemoveConstructor(
         ConstructorDeclarationSyntax constructor,
-        IReadOnlyCollection<ParameterSyntax> parameters,
-        IReadOnlyCollection<ExpressionStatementSyntax> assignmentStatements)
+        ImmutableHashSet<ParameterSyntax> parameters,
+        ImmutableHashSet<ExpressionStatementSyntax> assignmentStatements)
     {
         var remainingStatements = constructor.Body?.Statements.Count - assignmentStatements.Count;
         return constructor.ParameterList.Parameters.Count == parameters.Count

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -336,6 +336,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
                                 && remainingStatements == 0
                                 && constructor.Initializer is null
                                 && constructor.AttributeLists.Count == 0
+                                && !constructor.ContainsDirectives
                                 && constructor.Modifiers.Any(SyntaxKind.PublicKeyword)
                                 && IsOnlyInstanceConstructor(constructor);
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -136,7 +136,8 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         assignmentStatement = null;
         loggerReplacements = [];
 
-        if (containingType.Modifiers.Any(SyntaxKind.PartialKeyword)
+        if (containingType.ContainsConditionalDirectives()
+            || containingType.Modifiers.Any(SyntaxKind.PartialKeyword)
             || containingType.Parent is TypeDeclarationSyntax)
         {
             return false;

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -279,11 +279,27 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         var method = node.FirstAncestorOrSelf<MethodDeclarationSyntax>();
 
         return moduleContextType is null
+               || method is null
+               || node.Ancestors()
+                   .TakeWhile(ancestor => ancestor != method)
+                   .Any(IsStaticCallable)
             ? null
-            : method?.ParameterList.Parameters.FirstOrDefault(parameter =>
+            : method.ParameterList.Parameters.FirstOrDefault(parameter =>
                 SymbolEqualityComparer.Default.Equals(
                     semanticModel.GetTypeInfo(parameter.Type!, cancellationToken).Type,
                     moduleContextType));
+    }
+
+    private static bool IsStaticCallable(SyntaxNode node)
+    {
+        return node switch
+        {
+            LocalFunctionStatementSyntax localFunction =>
+                localFunction.Modifiers.Any(SyntaxKind.StaticKeyword),
+            AnonymousFunctionExpressionSyntax anonymousFunction =>
+                anonymousFunction.Modifiers.Any(SyntaxKind.StaticKeyword),
+            _ => false,
+        };
     }
 
     private static async Task<Document> ReplaceWithContextLoggerAsync(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -259,6 +259,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             || assignment.Right != parameterReference
             || semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol is not IFieldSymbol field
             || !IsCurrentInstanceFieldReference(assignment.Left)
+            || field.IsStatic
             || field.DeclaredAccessibility != Accessibility.Private
             || !IsLogger(field.Type))
         {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -1,0 +1,246 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace ModularPipelines.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(LoggerInConstructorCodeFixProvider))]
+[Shared]
+[ExcludeFromCodeCoverage]
+public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(LoggerInConstructorAnalyzer.DiagnosticId);
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        var diagnostic = context.Diagnostics.First();
+        var parameter = root?.FindNode(diagnostic.Location.SourceSpan)
+            .FirstAncestorOrSelf<ParameterSyntax>();
+
+        if (parameter is null
+            || parameter.FirstAncestorOrSelf<ConstructorDeclarationSyntax>() is not { } constructor
+            || parameter.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
+            || semanticModel?.GetDeclaredSymbol(parameter, context.CancellationToken) is not IParameterSymbol parameterSymbol
+            || !TryCreateFix(
+                containingType,
+                constructor,
+                parameterSymbol,
+                semanticModel,
+                context.CancellationToken,
+                out var fieldDeclaration,
+                out var assignmentStatement,
+                out var loggerReplacements))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                CodeFixResources.LoggerInConstructorCodeFixTitle,
+                cancellationToken => ReplaceWithContextLoggerAsync(
+                    context.Document,
+                    constructor,
+                    parameter,
+                    fieldDeclaration,
+                    assignmentStatement,
+                    loggerReplacements,
+                    cancellationToken),
+                nameof(CodeFixResources.LoggerInConstructorCodeFixTitle)),
+            diagnostic);
+    }
+
+    private static bool TryCreateFix(
+        TypeDeclarationSyntax containingType,
+        ConstructorDeclarationSyntax constructor,
+        IParameterSymbol parameter,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        out FieldDeclarationSyntax? fieldDeclaration,
+        out ExpressionStatementSyntax? assignmentStatement,
+        out ImmutableArray<LoggerReplacement> loggerReplacements)
+    {
+        fieldDeclaration = null;
+        assignmentStatement = null;
+        loggerReplacements = ImmutableArray<LoggerReplacement>.Empty;
+
+        var parameterReferences = GetReferences(containingType, parameter, semanticModel, cancellationToken);
+        if (parameterReferences.Length == 0)
+        {
+            return true;
+        }
+
+        if (parameterReferences.Length != 1)
+        {
+            return false;
+        }
+
+        var parameterReference = parameterReferences[0];
+        var assignment = parameterReference.Parent as AssignmentExpressionSyntax;
+        var candidateAssignment = assignment?.Parent as ExpressionStatementSyntax;
+        if (assignment?.IsKind(SyntaxKind.SimpleAssignmentExpression) != true
+            || candidateAssignment is null
+            || assignment.Right != parameterReference
+            || semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol is not IFieldSymbol field
+            || !IsLogger(field.Type)
+            || containingType.DescendantNodes()
+                .OfType<VariableDeclaratorSyntax>()
+                .FirstOrDefault(variable => SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetDeclaredSymbol(variable, cancellationToken),
+                    field)) is not { Parent.Parent: FieldDeclarationSyntax candidateField }
+            || candidateField.Declaration.Variables.Count != 1)
+        {
+            return false;
+        }
+
+        var replacements = ImmutableArray.CreateBuilder<LoggerReplacement>();
+        foreach (var fieldReference in GetReferences(containingType, field, semanticModel, cancellationToken))
+        {
+            if (assignment.Left.Span.Contains(fieldReference.Span))
+            {
+                continue;
+            }
+
+            var nodeToReplace = GetLoggerExpression(fieldReference);
+            if (nodeToReplace.Parent is not MemberAccessExpressionSyntax { Expression: var expression }
+                || expression != nodeToReplace
+                || FindModuleContextParameter(nodeToReplace, semanticModel, cancellationToken) is not { } contextParameter)
+            {
+                return false;
+            }
+
+            replacements.Add(new LoggerReplacement(nodeToReplace, contextParameter.Identifier.ValueText));
+        }
+
+        fieldDeclaration = candidateField;
+        assignmentStatement = candidateAssignment;
+        loggerReplacements = replacements.ToImmutable();
+        return true;
+    }
+
+    private static bool IsLogger(ITypeSymbol type)
+    {
+        return IsLoggerInterface(type)
+               || type.AllInterfaces.Any(IsLoggerInterface);
+    }
+
+    private static bool IsLoggerInterface(ITypeSymbol type)
+    {
+        return type.OriginalDefinition.ToDisplayString() is
+            "Microsoft.Extensions.Logging.ILogger"
+            or "Microsoft.Extensions.Logging.ILogger<TCategoryName>";
+    }
+
+    private static ImmutableArray<IdentifierNameSyntax> GetReferences(
+        TypeDeclarationSyntax containingType,
+        ISymbol symbol,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        return containingType.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .Where(identifier => SymbolEqualityComparer.Default.Equals(
+                semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol,
+                symbol))
+            .ToImmutableArray();
+    }
+
+    private static ExpressionSyntax GetLoggerExpression(IdentifierNameSyntax fieldReference)
+    {
+        if (fieldReference.Parent is MemberAccessExpressionSyntax memberAccess
+            && memberAccess.Expression is ThisExpressionSyntax
+            && memberAccess.Name == fieldReference)
+        {
+            return memberAccess;
+        }
+
+        return fieldReference;
+    }
+
+    private static ParameterSyntax? FindModuleContextParameter(
+        SyntaxNode node,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var moduleContextType = semanticModel.Compilation.GetTypeByMetadataName(
+            "ModularPipelines.Context.IModuleContext");
+        var method = node.FirstAncestorOrSelf<MethodDeclarationSyntax>();
+
+        return moduleContextType is null
+            ? null
+            : method?.ParameterList.Parameters.FirstOrDefault(parameter =>
+                SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetTypeInfo(parameter.Type!, cancellationToken).Type,
+                    moduleContextType));
+    }
+
+    private static async Task<Document> ReplaceWithContextLoggerAsync(
+        Document document,
+        ConstructorDeclarationSyntax constructor,
+        ParameterSyntax parameter,
+        FieldDeclarationSyntax? fieldDeclaration,
+        ExpressionStatementSyntax? assignmentStatement,
+        ImmutableArray<LoggerReplacement> loggerReplacements,
+        CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+        var remainingStatements = constructor.Body?.Statements.Count - (assignmentStatement is null ? 0 : 1);
+        var removeConstructor = constructor.ParameterList.Parameters.Count == 1
+                                && remainingStatements == 0
+                                && constructor.Initializer is null;
+
+        foreach (var replacement in loggerReplacements)
+        {
+            editor.ReplaceNode(
+                replacement.Node,
+                SyntaxFactory.ParseExpression($"{replacement.ContextParameterName}.Logger")
+                    .WithTriviaFrom(replacement.Node)
+                    .WithAdditionalAnnotations(Formatter.Annotation));
+        }
+
+        if (fieldDeclaration is not null)
+        {
+            editor.RemoveNode(fieldDeclaration);
+        }
+
+        if (assignmentStatement is not null && !removeConstructor)
+        {
+            editor.RemoveNode(assignmentStatement);
+        }
+
+        if (removeConstructor)
+        {
+            editor.RemoveNode(constructor);
+        }
+        else
+        {
+            editor.ReplaceNode(
+                constructor.ParameterList,
+                constructor.ParameterList.WithParameters(
+                    constructor.ParameterList.Parameters.Remove(parameter)));
+        }
+
+        return editor.GetChangedDocument();
+    }
+
+    private sealed class LoggerReplacement(SyntaxNode node, string contextParameterName)
+    {
+        public SyntaxNode Node { get; } = node;
+
+        public string ContextParameterName { get; } = contextParameterName;
+    }
+}

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Formatting;
+using ModularPipelines.Analyzers.Extensions;
 
 namespace ModularPipelines.Analyzers;
 
@@ -237,7 +238,9 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             if (nodeToReplace.Parent is not MemberAccessExpressionSyntax { Expression: var expression }
                 || expression != nodeToReplace
                 || !CanReplaceLoggerReceiver(nodeToReplace, semanticModel, cancellationToken)
-                || FindModuleContextParameter(nodeToReplace, semanticModel, cancellationToken) is not { } contextParameter)
+                || nodeToReplace.FindVisibleModuleContextParameter(
+                    semanticModel,
+                    cancellationToken) is not { } contextParameter)
             {
                 return null;
             }
@@ -317,39 +320,6 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         }
 
         return fieldReference;
-    }
-
-    private static ParameterSyntax? FindModuleContextParameter(
-        SyntaxNode node,
-        SemanticModel semanticModel,
-        CancellationToken cancellationToken)
-    {
-        var moduleContextType = semanticModel.Compilation.GetTypeByMetadataName(
-            "ModularPipelines.Context.IModuleContext");
-        var method = node.FirstAncestorOrSelf<MethodDeclarationSyntax>();
-
-        return moduleContextType is null
-               || method is null
-               || node.Ancestors()
-                   .TakeWhile(ancestor => ancestor != method)
-                   .Any(IsStaticCallable)
-            ? null
-            : method.ParameterList.Parameters.FirstOrDefault(parameter =>
-                SymbolEqualityComparer.Default.Equals(
-                    semanticModel.GetTypeInfo(parameter.Type!, cancellationToken).Type,
-                    moduleContextType));
-    }
-
-    private static bool IsStaticCallable(SyntaxNode node)
-    {
-        return node switch
-        {
-            LocalFunctionStatementSyntax localFunction =>
-                localFunction.Modifiers.Any(SyntaxKind.StaticKeyword),
-            AnonymousFunctionExpressionSyntax anonymousFunction =>
-                anonymousFunction.Modifiers.Any(SyntaxKind.StaticKeyword),
-            _ => false,
-        };
     }
 
     private static async Task<Document> ReplaceWithContextLoggerAsync(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -78,6 +78,11 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         assignmentStatement = null;
         loggerReplacements = ImmutableArray<LoggerReplacement>.Empty;
 
+        if (containingType.Modifiers.Any(SyntaxKind.PartialKeyword))
+        {
+            return false;
+        }
+
         var parameterReferences = GetReferences(containingType, parameter, semanticModel, cancellationToken);
         if (parameterReferences.Length == 0)
         {
@@ -201,7 +206,8 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         var remainingStatements = constructor.Body?.Statements.Count - (assignmentStatement is null ? 0 : 1);
         var removeConstructor = constructor.ParameterList.Parameters.Count == 1
                                 && remainingStatements == 0
-                                && constructor.Initializer is null;
+                                && constructor.Initializer is null
+                                && constructor.Modifiers.Any(SyntaxKind.PublicKeyword);
 
         foreach (var replacement in loggerReplacements)
         {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -95,27 +95,74 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         }
 
         var parameterReference = parameterReferences[0];
-        var assignment = parameterReference.Parent as AssignmentExpressionSyntax;
-        var candidateAssignment = assignment?.Parent as ExpressionStatementSyntax;
-        if (assignment?.IsKind(SyntaxKind.SimpleAssignmentExpression) != true
-            || candidateAssignment is null
-            || assignment.Right != parameterReference
-            || semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol is not IFieldSymbol field
-            || !IsLogger(field.Type)
-            || containingType.DescendantNodes()
-                .OfType<VariableDeclaratorSyntax>()
-                .FirstOrDefault(variable => SymbolEqualityComparer.Default.Equals(
-                    semanticModel.GetDeclaredSymbol(variable, cancellationToken),
-                    field)) is not { Parent.Parent: FieldDeclarationSyntax candidateField }
-            || candidateField.Declaration.Variables.Count != 1)
+        var loggerStorage = GetLoggerStorage(
+            containingType,
+            parameterReference,
+            semanticModel,
+            cancellationToken);
+        if (loggerStorage is null)
         {
             return false;
         }
 
-        var replacements = ImmutableArray.CreateBuilder<LoggerReplacement>();
-        foreach (var fieldReference in GetReferences(containingType, field, semanticModel, cancellationToken))
+        var replacements = CreateLoggerReplacements(
+            containingType,
+            loggerStorage,
+            semanticModel,
+            cancellationToken);
+        if (replacements is null)
         {
-            if (assignment.Left.Span.Contains(fieldReference.Span))
+            return false;
+        }
+
+        fieldDeclaration = loggerStorage.FieldDeclaration;
+        assignmentStatement = loggerStorage.AssignmentStatement;
+        loggerReplacements = replacements.Value;
+        return true;
+    }
+
+    private static LoggerStorage? GetLoggerStorage(
+        TypeDeclarationSyntax containingType,
+        IdentifierNameSyntax parameterReference,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (parameterReference.Parent is not AssignmentExpressionSyntax assignment
+            || !assignment.IsKind(SyntaxKind.SimpleAssignmentExpression)
+            || assignment.Parent is not ExpressionStatementSyntax assignmentStatement
+            || assignment.Right != parameterReference
+            || semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol is not IFieldSymbol field
+            || !IsLogger(field.Type))
+        {
+            return null;
+        }
+
+        var fieldDeclaration = containingType.DescendantNodes()
+            .OfType<VariableDeclaratorSyntax>()
+            .FirstOrDefault(variable => SymbolEqualityComparer.Default.Equals(
+                semanticModel.GetDeclaredSymbol(variable, cancellationToken),
+                field))
+            ?.Parent?.Parent as FieldDeclarationSyntax;
+
+        return fieldDeclaration?.Declaration.Variables.Count == 1
+            ? new LoggerStorage(field, fieldDeclaration, assignmentStatement, assignment)
+            : null;
+    }
+
+    private static ImmutableArray<LoggerReplacement>? CreateLoggerReplacements(
+        TypeDeclarationSyntax containingType,
+        LoggerStorage loggerStorage,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var replacements = ImmutableArray.CreateBuilder<LoggerReplacement>();
+        foreach (var fieldReference in GetReferences(
+                     containingType,
+                     loggerStorage.Field,
+                     semanticModel,
+                     cancellationToken))
+        {
+            if (loggerStorage.Assignment.Left.Span.Contains(fieldReference.Span))
             {
                 continue;
             }
@@ -125,16 +172,13 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
                 || expression != nodeToReplace
                 || FindModuleContextParameter(nodeToReplace, semanticModel, cancellationToken) is not { } contextParameter)
             {
-                return false;
+                return null;
             }
 
             replacements.Add(new LoggerReplacement(nodeToReplace, contextParameter.Identifier.ValueText));
         }
 
-        fieldDeclaration = candidateField;
-        assignmentStatement = candidateAssignment;
-        loggerReplacements = replacements.ToImmutable();
-        return true;
+        return replacements.ToImmutable();
     }
 
     private static bool IsLogger(ITypeSymbol type)
@@ -248,5 +292,20 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         public SyntaxNode Node { get; } = node;
 
         public string ContextParameterName { get; } = contextParameterName;
+    }
+
+    private sealed class LoggerStorage(
+        IFieldSymbol field,
+        FieldDeclarationSyntax fieldDeclaration,
+        ExpressionStatementSyntax assignmentStatement,
+        AssignmentExpressionSyntax assignment)
+    {
+        public IFieldSymbol Field { get; } = field;
+
+        public FieldDeclarationSyntax FieldDeclaration { get; } = fieldDeclaration;
+
+        public ExpressionStatementSyntax AssignmentStatement { get; } = assignmentStatement;
+
+        public AssignmentExpressionSyntax Assignment { get; } = assignment;
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -198,6 +198,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             || assignment.Parent is not ExpressionStatementSyntax assignmentStatement
             || assignment.Right != parameterReference
             || semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol is not IFieldSymbol field
+            || field.DeclaredAccessibility != Accessibility.Private
             || !IsLogger(field.Type))
         {
             return null;

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -236,6 +236,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             var nodeToReplace = GetLoggerExpression(fieldReference);
             if (nodeToReplace.Parent is not MemberAccessExpressionSyntax { Expression: var expression }
                 || expression != nodeToReplace
+                || !CanReplaceLoggerReceiver(nodeToReplace, semanticModel, cancellationToken)
                 || FindModuleContextParameter(nodeToReplace, semanticModel, cancellationToken) is not { } contextParameter)
             {
                 return null;
@@ -245,6 +246,36 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         }
 
         return replacements.ToImmutable();
+    }
+
+    private static bool CanReplaceLoggerReceiver(
+        ExpressionSyntax loggerExpression,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (loggerExpression.Parent is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return false;
+        }
+
+        var requiredReceiverType = semanticModel.GetSymbolInfo(memberAccess, cancellationToken).Symbol switch
+        {
+            IMethodSymbol { ReducedFrom: { Parameters.Length: > 0 } reducedMethod } =>
+                reducedMethod.Parameters[0].Type,
+            IMethodSymbol method => method.ContainingType,
+            IPropertySymbol property => property.ContainingType,
+            IFieldSymbol field => field.ContainingType,
+            IEventSymbol @event => @event.ContainingType,
+            _ => null,
+        };
+        var contextLoggerType = semanticModel.Compilation.GetTypeByMetadataName(
+            "ModularPipelines.Logging.IModuleLogger");
+
+        return requiredReceiverType is not null
+               && contextLoggerType is not null
+               && semanticModel.Compilation
+                   .ClassifyCommonConversion(contextLoggerType, requiredReceiverType)
+                   .IsImplicit;
     }
 
     private static bool IsLogger(ITypeSymbol type)

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -83,6 +83,18 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             return false;
         }
 
+        var constructorSymbol = semanticModel.GetDeclaredSymbol(constructor, cancellationToken);
+        if (constructorSymbol is not null
+            && containingType.DescendantNodes()
+                .OfType<ConstructorInitializerSyntax>()
+                .Where(initializer => initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.ThisKeyword))
+                .Any(initializer => SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(initializer, cancellationToken).Symbol,
+                    constructorSymbol)))
+        {
+            return false;
+        }
+
         var parameterReferences = GetReferences(containingType, parameter, semanticModel, cancellationToken);
         if (parameterReferences.Length == 0)
         {
@@ -175,7 +187,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
                 return null;
             }
 
-            replacements.Add(new LoggerReplacement(nodeToReplace, contextParameter.Identifier.ValueText));
+            replacements.Add(new LoggerReplacement(nodeToReplace, contextParameter.Identifier));
         }
 
         return replacements.ToImmutable();
@@ -257,7 +269,11 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         {
             editor.ReplaceNode(
                 replacement.Node,
-                SyntaxFactory.ParseExpression($"{replacement.ContextParameterName}.Logger")
+                SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName(
+                            replacement.ContextParameterIdentifier.WithoutTrivia()),
+                        SyntaxFactory.IdentifierName("Logger"))
                     .WithTriviaFrom(replacement.Node)
                     .WithAdditionalAnnotations(Formatter.Annotation));
         }
@@ -287,11 +303,11 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         return editor.GetChangedDocument();
     }
 
-    private sealed class LoggerReplacement(SyntaxNode node, string contextParameterName)
+    private sealed class LoggerReplacement(SyntaxNode node, SyntaxToken contextParameterIdentifier)
     {
         public SyntaxNode Node { get; } = node;
 
-        public string ContextParameterName { get; } = contextParameterName;
+        public SyntaxToken ContextParameterIdentifier { get; } = contextParameterIdentifier;
     }
 
     private sealed class LoggerStorage(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace ModularPipelines.Analyzers;
@@ -36,9 +37,15 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             || parameter.FirstAncestorOrSelf<ConstructorDeclarationSyntax>() is not { } constructor
             || parameter.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
             || semanticModel?.GetDeclaredSymbol(parameter, context.CancellationToken) is not IParameterSymbol parameterSymbol
+            || semanticModel.GetDeclaredSymbol(constructor, context.CancellationToken) is not IMethodSymbol constructorSymbol
+            || await HasExplicitReferencesAsync(
+                constructorSymbol,
+                context.Document.Project.Solution,
+                context.CancellationToken).ConfigureAwait(false)
             || !TryCreateFix(
                 containingType,
                 constructor,
+                constructorSymbol,
                 parameterSymbol,
                 semanticModel,
                 context.CancellationToken,
@@ -67,6 +74,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
     private static bool TryCreateFix(
         TypeDeclarationSyntax containingType,
         ConstructorDeclarationSyntax constructor,
+        IMethodSymbol constructorSymbol,
         IParameterSymbol parameter,
         SemanticModel semanticModel,
         CancellationToken cancellationToken,
@@ -83,15 +91,13 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             return false;
         }
 
-        var constructorSymbol = semanticModel.GetDeclaredSymbol(constructor, cancellationToken);
-        if (constructorSymbol is not null
-            && (containingType.DescendantNodes()
-                    .OfType<ConstructorInitializerSyntax>()
-                    .Where(initializer => initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.ThisKeyword))
-                    .Any(initializer => SymbolEqualityComparer.Default.Equals(
-                        semanticModel.GetSymbolInfo(initializer, cancellationToken).Symbol,
-                        constructorSymbol))
-                || WouldDuplicateConstructor(constructorSymbol, parameter)))
+        if (containingType.DescendantNodes()
+                .OfType<ConstructorInitializerSyntax>()
+                .Where(initializer => initializer.ThisOrBaseKeyword.IsKind(SyntaxKind.ThisKeyword))
+                .Any(initializer => SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(initializer, cancellationToken).Symbol,
+                    constructorSymbol))
+            || WouldDuplicateConstructor(constructorSymbol, parameter))
         {
             return false;
         }
@@ -132,6 +138,19 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         assignmentStatement = loggerStorage.AssignmentStatement;
         loggerReplacements = replacements.Value;
         return true;
+    }
+
+    private static async Task<bool> HasExplicitReferencesAsync(
+        IMethodSymbol constructor,
+        Solution solution,
+        CancellationToken cancellationToken)
+    {
+        var references = await SymbolFinder.FindReferencesAsync(
+            constructor,
+            solution,
+            cancellationToken).ConfigureAwait(false);
+
+        return references.Any(static reference => reference.Locations.Any());
     }
 
     private static bool WouldDuplicateConstructor(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -420,6 +420,8 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
                && constructor.AttributeLists.Count == 0
                && !constructor.ContainsDirectives
                && constructor.Modifiers.Any(SyntaxKind.PublicKeyword)
+               && constructor.Parent is TypeDeclarationSyntax containingType
+               && !containingType.Modifiers.Any(SyntaxKind.AbstractKeyword)
                && IsOnlyInstanceConstructor(constructor);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -88,7 +88,8 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         assignmentStatement = null;
         loggerReplacements = [];
 
-        if (containingType.Modifiers.Any(SyntaxKind.PartialKeyword))
+        if (containingType.Modifiers.Any(SyntaxKind.PartialKeyword)
+            || containingType.Parent is TypeDeclarationSyntax)
         {
             return false;
         }
@@ -167,14 +168,14 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         var remainingParameters = constructor.Parameters
             .Where(parameter => !SymbolEqualityComparer.Default.Equals(parameter, removedParameter))
             .ToArray();
-        var remainingArity = GetCallableArity(remainingParameters);
+        var (remainingMinimum, remainingMaximum) = GetCallableArity(remainingParameters);
 
         return constructor.ContainingType.InstanceConstructors
             .Where(other => !SymbolEqualityComparer.Default.Equals(other, constructor))
             .Select(static other => GetCallableArity(other.Parameters))
             .Any(otherArity =>
-                remainingArity.Minimum <= otherArity.Maximum
-                && otherArity.Minimum <= remainingArity.Maximum);
+                remainingMinimum <= otherArity.Maximum
+                && otherArity.Minimum <= remainingMaximum);
     }
 
     private static (int Minimum, int Maximum) GetCallableArity(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -36,6 +36,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
 
         if (parameter is null
             || parameter.FirstAncestorOrSelf<ConstructorDeclarationSyntax>() is not { } constructor
+            || constructor.ParameterList.ContainsDirectives
             || parameter.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
             || semanticModel?.GetDeclaredSymbol(parameter, context.CancellationToken) is not IParameterSymbol parameterSymbol
             || semanticModel.GetDeclaredSymbol(constructor, context.CancellationToken) is not IMethodSymbol constructorSymbol

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -336,6 +336,7 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
         var removeConstructor = constructor.ParameterList.Parameters.Count == 1
                                 && remainingStatements == 0
                                 && constructor.Initializer is null
+                                && constructor.AttributeLists.Count == 0
                                 && constructor.Modifiers.Any(SyntaxKind.PublicKeyword)
                                 && IsOnlyInstanceConstructor(constructor);
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/LoggerInConstructorCodeFixProvider.cs
@@ -204,14 +204,15 @@ public sealed class LoggerInConstructorCodeFixProvider : CodeFixProvider
             return null;
         }
 
-        var fieldDeclaration = containingType.DescendantNodes()
+        var fieldVariable = containingType.DescendantNodes()
             .OfType<VariableDeclaratorSyntax>()
             .FirstOrDefault(variable => SymbolEqualityComparer.Default.Equals(
                 semanticModel.GetDeclaredSymbol(variable, cancellationToken),
-                field))
-            ?.Parent?.Parent as FieldDeclarationSyntax;
+                field));
+        var fieldDeclaration = fieldVariable?.Parent?.Parent as FieldDeclarationSyntax;
 
-        return fieldDeclaration?.Declaration.Variables.Count == 1
+        return fieldVariable?.Initializer is null
+               && fieldDeclaration?.Declaration.Variables.Count == 1
             ? new LoggerStorage(field, fieldDeclaration, assignmentStatement, assignment)
             : null;
     }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace ModularPipelines.Analyzers;
 
@@ -89,7 +90,11 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
             .Any(identifier =>
                 IsRefEscape(identifier)
                 || (IsWrite(identifier, field, semanticModel, cancellationToken)
-                    && !IsDirectlyWithinConstructor(identifier, containingType)));
+                    && !IsCurrentInstanceWriteWithinConstructor(
+                        identifier,
+                        containingType,
+                        semanticModel,
+                        cancellationToken)));
     }
 
     private static bool IsRefEscape(IdentifierNameSyntax identifier)
@@ -100,18 +105,30 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
                       ?.IsKind(SyntaxKind.AddressOfExpression) == true;
     }
 
-    private static bool IsDirectlyWithinConstructor(
+    private static bool IsCurrentInstanceWriteWithinConstructor(
         IdentifierNameSyntax identifier,
-        TypeDeclarationSyntax containingType)
+        TypeDeclarationSyntax containingType,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         var containingCallable = identifier.Ancestors().FirstOrDefault(node =>
             node is BaseMethodDeclarationSyntax
                 or LocalFunctionStatementSyntax
                 or AnonymousFunctionExpressionSyntax
                 or AccessorDeclarationSyntax);
+        SyntaxNode fieldReferenceNode = identifier.Parent is MemberAccessExpressionSyntax memberAccess
+                                        && memberAccess.Name == identifier
+            ? memberAccess
+            : identifier;
+        var fieldReference = semanticModel.GetOperation(fieldReferenceNode, cancellationToken)
+            as IFieldReferenceOperation;
 
         return containingCallable is ConstructorDeclarationSyntax constructor
-               && constructor.Parent == containingType;
+               && constructor.Parent == containingType
+               && fieldReference?.Instance is IInstanceReferenceOperation
+               {
+                   ReferenceKind: InstanceReferenceKind.ContainingTypeInstance,
+               };
     }
 
     private static bool IsWrite(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -39,6 +39,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
             || variable.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
             || containingType.Modifiers.Any(SyntaxKind.PartialKeyword)
             || semanticModel?.GetDeclaredSymbol(variable, context.CancellationToken) is not IFieldSymbol field
+            || field.DeclaredAccessibility != Accessibility.Private
             || field.Type is INamedTypeSymbol { IsValueType: true, IsReadOnly: false }
             || IsWrittenOutsideConstructor(
                 containingType,
@@ -72,8 +73,14 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
                 semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol,
                 field))
             .Any(identifier =>
-                IsWrite(identifier, field, semanticModel, cancellationToken)
-                && !IsDirectlyWithinConstructor(identifier, containingType));
+                IsRefEscape(identifier)
+                || (IsWrite(identifier, field, semanticModel, cancellationToken)
+                    && !IsDirectlyWithinConstructor(identifier, containingType)));
+    }
+
+    private static bool IsRefEscape(IdentifierNameSyntax identifier)
+    {
+        return identifier.FirstAncestorOrSelf<RefExpressionSyntax>() is not null;
     }
 
     private static bool IsDirectlyWithinConstructor(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -35,6 +35,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
             || variable.Parent?.Parent is not FieldDeclarationSyntax fieldDeclaration
             || fieldDeclaration.Declaration.Variables.Count != 1
             || variable.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
+            || containingType.Modifiers.Any(SyntaxKind.PartialKeyword)
             || semanticModel?.GetDeclaredSymbol(variable, context.CancellationToken) is not IFieldSymbol field
             || IsWrittenOutsideConstructor(
                 containingType,
@@ -69,7 +70,21 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
                 field))
             .Any(identifier =>
                 IsWrite(identifier, field, semanticModel, cancellationToken)
-                && identifier.FirstAncestorOrSelf<ConstructorDeclarationSyntax>() is null);
+                && !IsDirectlyWithinConstructor(identifier, containingType));
+    }
+
+    private static bool IsDirectlyWithinConstructor(
+        IdentifierNameSyntax identifier,
+        TypeDeclarationSyntax containingType)
+    {
+        var containingCallable = identifier.Ancestors().FirstOrDefault(node =>
+            node is BaseMethodDeclarationSyntax
+                or LocalFunctionStatementSyntax
+                or AnonymousFunctionExpressionSyntax
+                or AccessorDeclarationSyntax);
+
+        return containingCallable is ConstructorDeclarationSyntax constructor
+               && constructor.Parent == containingType;
     }
 
     private static bool IsWrite(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -87,7 +87,9 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
 
     private static bool IsRefEscape(IdentifierNameSyntax identifier)
     {
-        return identifier.FirstAncestorOrSelf<RefExpressionSyntax>() is not null;
+        return identifier.FirstAncestorOrSelf<RefExpressionSyntax>() is not null
+               || identifier.FirstAncestorOrSelf<PrefixUnaryExpressionSyntax>()
+                   ?.IsKind(SyntaxKind.AddressOfExpression) == true;
     }
 
     private static bool IsDirectlyWithinConstructor(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Operations;
+using ModularPipelines.Analyzers.Extensions;
 
 namespace ModularPipelines.Analyzers;
 
@@ -38,6 +39,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
             || fieldDeclaration.Modifiers.Any(SyntaxKind.VolatileKeyword)
             || fieldDeclaration.Modifiers.Any(SyntaxKind.RequiredKeyword)
             || variable.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
+            || containingType.ContainsConditionalDirectives()
             || containingType.Modifiers.Any(SyntaxKind.PartialKeyword)
             || containingType.Parent is TypeDeclarationSyntax
             || semanticModel?.GetDeclaredSymbol(variable, context.CancellationToken) is not IFieldSymbol field

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -35,6 +35,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
             || variable.Parent?.Parent is not FieldDeclarationSyntax fieldDeclaration
             || fieldDeclaration.Declaration.Variables.Count != 1
             || fieldDeclaration.Modifiers.Any(SyntaxKind.VolatileKeyword)
+            || fieldDeclaration.Modifiers.Any(SyntaxKind.RequiredKeyword)
             || variable.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
             || containingType.Modifiers.Any(SyntaxKind.PartialKeyword)
             || semanticModel?.GetDeclaredSymbol(variable, context.CancellationToken) is not IFieldSymbol field

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -1,0 +1,132 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace ModularPipelines.Analyzers;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(StatefulModuleCodeFixProvider))]
+[Shared]
+[ExcludeFromCodeCoverage]
+public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(StatefulModuleAnalyzer.DiagnosticId);
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        var diagnostic = context.Diagnostics.First();
+        var variable = root?.FindNode(diagnostic.Location.SourceSpan)
+            .FirstAncestorOrSelf<VariableDeclaratorSyntax>();
+
+        if (variable is null
+            || variable.Parent?.Parent is not FieldDeclarationSyntax fieldDeclaration
+            || fieldDeclaration.Declaration.Variables.Count != 1
+            || variable.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
+            || semanticModel?.GetDeclaredSymbol(variable, context.CancellationToken) is not IFieldSymbol field
+            || IsWrittenOutsideConstructor(
+                containingType,
+                field,
+                semanticModel,
+                context.CancellationToken))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                CodeFixResources.StatefulModuleCodeFixTitle,
+                cancellationToken => AddReadonlyAsync(
+                    context.Document,
+                    fieldDeclaration,
+                    cancellationToken),
+                nameof(CodeFixResources.StatefulModuleCodeFixTitle)),
+            diagnostic);
+    }
+
+    private static bool IsWrittenOutsideConstructor(
+        TypeDeclarationSyntax containingType,
+        IFieldSymbol field,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        return containingType.DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .Where(identifier => SymbolEqualityComparer.Default.Equals(
+                semanticModel.GetSymbolInfo(identifier, cancellationToken).Symbol,
+                field))
+            .Any(identifier =>
+                IsWrite(identifier, field, semanticModel, cancellationToken)
+                && identifier.FirstAncestorOrSelf<ConstructorDeclarationSyntax>() is null);
+    }
+
+    private static bool IsWrite(
+        IdentifierNameSyntax identifier,
+        IFieldSymbol field,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var assignment = identifier.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
+        if (assignment is not null
+            && assignment.Left.Span.Contains(identifier.Span)
+            && SymbolEqualityComparer.Default.Equals(
+                semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol,
+                field))
+        {
+            return true;
+        }
+
+        var prefix = identifier.FirstAncestorOrSelf<PrefixUnaryExpressionSyntax>();
+        if (prefix?.IsKind(SyntaxKind.PreIncrementExpression) == true
+            || prefix?.IsKind(SyntaxKind.PreDecrementExpression) == true)
+        {
+            return SymbolEqualityComparer.Default.Equals(
+                semanticModel.GetSymbolInfo(prefix.Operand, cancellationToken).Symbol,
+                field);
+        }
+
+        var postfix = identifier.FirstAncestorOrSelf<PostfixUnaryExpressionSyntax>();
+        if (postfix?.IsKind(SyntaxKind.PostIncrementExpression) == true
+            || postfix?.IsKind(SyntaxKind.PostDecrementExpression) == true)
+        {
+            return SymbolEqualityComparer.Default.Equals(
+                semanticModel.GetSymbolInfo(postfix.Operand, cancellationToken).Symbol,
+                field);
+        }
+
+        var argument = identifier.FirstAncestorOrSelf<ArgumentSyntax>();
+        return argument?.RefKindKeyword.IsKind(SyntaxKind.None) == false
+               && SymbolEqualityComparer.Default.Equals(
+                   semanticModel.GetSymbolInfo(argument.Expression, cancellationToken).Symbol,
+                   field);
+    }
+
+    private static async Task<Document> AddReadonlyAsync(
+        Document document,
+        FieldDeclarationSyntax fieldDeclaration,
+        CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return document;
+        }
+
+        var newDeclaration = fieldDeclaration
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+        return document.WithSyntaxRoot(root.ReplaceNode(fieldDeclaration, newDeclaration));
+    }
+}

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -63,6 +63,13 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
 
     private static bool IsDeeplyImmutable(ITypeSymbol type)
     {
+        if (type is INamedTypeSymbol nullableType
+            && nullableType.OriginalDefinition.SpecialType
+            == SpecialType.System_Nullable_T)
+        {
+            return IsDeeplyImmutable(nullableType.TypeArguments[0]);
+        }
+
         return type.SpecialType == SpecialType.System_String
                || type.TypeKind == TypeKind.Enum
                || (type.IsValueType && type.SpecialType != SpecialType.None);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -178,7 +178,15 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
         }
 
         var argument = identifier.FirstAncestorOrSelf<ArgumentSyntax>();
-        return argument?.RefKindKeyword.IsKind(SyntaxKind.None) == false
+        if (argument is null)
+        {
+            return false;
+        }
+
+        var argumentOperation = semanticModel.GetOperation(argument, cancellationToken)
+            as IArgumentOperation;
+        return (!argument.RefKindKeyword.IsKind(SyntaxKind.None)
+                || argumentOperation?.Parameter?.RefKind != RefKind.None)
                && SymbolEqualityComparer.Default.Equals(
                    semanticModel.GetSymbolInfo(argument.Expression, cancellationToken).Symbol,
                    field);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -65,7 +65,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
     {
         return type.SpecialType == SpecialType.System_String
                || type.TypeKind == TypeKind.Enum
-               || type is INamedTypeSymbol { IsValueType: true, IsReadOnly: true };
+               || (type.IsValueType && type.SpecialType != SpecialType.None);
     }
 
     private static bool IsWrittenOutsideConstructor(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -40,7 +40,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
             || containingType.Modifiers.Any(SyntaxKind.PartialKeyword)
             || semanticModel?.GetDeclaredSymbol(variable, context.CancellationToken) is not IFieldSymbol field
             || field.DeclaredAccessibility != Accessibility.Private
-            || field.Type is INamedTypeSymbol { IsValueType: true, IsReadOnly: false }
+            || !IsDeeplyImmutable(field.Type)
             || IsWrittenOutsideConstructor(
                 containingType,
                 field,
@@ -59,6 +59,13 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
                     cancellationToken),
                 nameof(CodeFixResources.StatefulModuleCodeFixTitle)),
             diagnostic);
+    }
+
+    private static bool IsDeeplyImmutable(ITypeSymbol type)
+    {
+        return type.SpecialType == SpecialType.System_String
+               || type.TypeKind == TypeKind.Enum
+               || type is INamedTypeSymbol { IsValueType: true, IsReadOnly: true };
     }
 
     private static bool IsWrittenOutsideConstructor(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -144,21 +144,45 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
         }
 
         var assignment = identifier.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
-        if (assignment?.Left is TupleExpressionSyntax tuple
-            && ContainsFieldTarget(tuple, field, semanticModel, cancellationToken))
-        {
-            return true;
-        }
-
         if (assignment is not null
-            && assignment.Left.Span.Contains(identifier.Span)
-            && SymbolEqualityComparer.Default.Equals(
-                semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol,
-                field))
+            && IsAssignmentWrite(
+                identifier,
+                assignment,
+                field,
+                semanticModel,
+                cancellationToken))
         {
             return true;
         }
 
+        return IsUnaryWrite(identifier, field, semanticModel, cancellationToken)
+               || IsRefArgumentWrite(identifier, field, semanticModel, cancellationToken);
+    }
+
+    private static bool IsAssignmentWrite(
+        IdentifierNameSyntax identifier,
+        AssignmentExpressionSyntax assignment,
+        IFieldSymbol field,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (assignment.Left is TupleExpressionSyntax tuple)
+        {
+            return ContainsFieldTarget(tuple, field, semanticModel, cancellationToken);
+        }
+
+        return assignment.Left.Span.Contains(identifier.Span)
+               && SymbolEqualityComparer.Default.Equals(
+                   semanticModel.GetSymbolInfo(assignment.Left, cancellationToken).Symbol,
+                   field);
+    }
+
+    private static bool IsUnaryWrite(
+        IdentifierNameSyntax identifier,
+        IFieldSymbol field,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
         var prefix = identifier.FirstAncestorOrSelf<PrefixUnaryExpressionSyntax>();
         if (prefix?.IsKind(SyntaxKind.PreIncrementExpression) == true
             || prefix?.IsKind(SyntaxKind.PreDecrementExpression) == true)
@@ -177,6 +201,15 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
                 field);
         }
 
+        return false;
+    }
+
+    private static bool IsRefArgumentWrite(
+        IdentifierNameSyntax identifier,
+        IFieldSymbol field,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
         var argument = identifier.FirstAncestorOrSelf<ArgumentSyntax>();
         if (argument is null)
         {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -39,6 +39,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
             || fieldDeclaration.Modifiers.Any(SyntaxKind.RequiredKeyword)
             || variable.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
             || containingType.Modifiers.Any(SyntaxKind.PartialKeyword)
+            || containingType.Parent is TypeDeclarationSyntax
             || semanticModel?.GetDeclaredSymbol(variable, context.CancellationToken) is not IFieldSymbol field
             || field.DeclaredAccessibility != Accessibility.Private
             || !IsDeeplyImmutable(field.Type)

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -138,7 +138,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
-        if (IsWritableRefExtensionReceiver(identifier, semanticModel, cancellationToken))
+        if (IsByRefExtensionReceiver(identifier, semanticModel, cancellationToken))
         {
             return true;
         }
@@ -225,7 +225,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
                    field);
     }
 
-    private static bool IsWritableRefExtensionReceiver(
+    private static bool IsByRefExtensionReceiver(
         IdentifierNameSyntax identifier,
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
@@ -243,7 +243,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
                    ReducedFrom: { Parameters.Length: > 0 } reducedFrom,
                }
 
-               && reducedFrom.Parameters[0].RefKind == RefKind.Ref;
+               && reducedFrom.Parameters[0].RefKind != RefKind.None;
     }
 
     private static bool ContainsFieldTarget(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -138,6 +138,11 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
         SemanticModel semanticModel,
         CancellationToken cancellationToken)
     {
+        if (IsWritableRefExtensionReceiver(identifier, semanticModel, cancellationToken))
+        {
+            return true;
+        }
+
         var assignment = identifier.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
         if (assignment?.Left is TupleExpressionSyntax tuple
             && ContainsFieldTarget(tuple, field, semanticModel, cancellationToken))
@@ -177,6 +182,27 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
                && SymbolEqualityComparer.Default.Equals(
                    semanticModel.GetSymbolInfo(argument.Expression, cancellationToken).Symbol,
                    field);
+    }
+
+    private static bool IsWritableRefExtensionReceiver(
+        IdentifierNameSyntax identifier,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        var invocation = identifier.Ancestors()
+            .OfType<InvocationExpressionSyntax>()
+            .FirstOrDefault(candidate =>
+                candidate.Expression is MemberAccessExpressionSyntax memberAccess
+                && memberAccess.Expression.Span.Contains(identifier.Span));
+
+        return invocation is not null
+               && semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol
+                   is IMethodSymbol
+               {
+                   ReducedFrom: { Parameters.Length: > 0 } reducedFrom,
+               }
+
+               && reducedFrom.Parameters[0].RefKind == RefKind.Ref;
     }
 
     private static bool ContainsFieldTarget(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -17,7 +17,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
 {
     /// <inheritdoc/>
     public override ImmutableArray<string> FixableDiagnosticIds =>
-        ImmutableArray.Create(StatefulModuleAnalyzer.DiagnosticId);
+        [StatefulModuleAnalyzer.DiagnosticId];
 
     /// <inheritdoc/>
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
@@ -34,6 +34,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
         if (variable is null
             || variable.Parent?.Parent is not FieldDeclarationSyntax fieldDeclaration
             || fieldDeclaration.Declaration.Variables.Count != 1
+            || fieldDeclaration.Modifiers.Any(SyntaxKind.VolatileKeyword)
             || variable.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
             || containingType.Modifiers.Any(SyntaxKind.PartialKeyword)
             || semanticModel?.GetDeclaredSymbol(variable, context.CancellationToken) is not IFieldSymbol field
@@ -95,6 +96,12 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
         CancellationToken cancellationToken)
     {
         var assignment = identifier.FirstAncestorOrSelf<AssignmentExpressionSyntax>();
+        if (assignment?.Left is TupleExpressionSyntax tuple
+            && ContainsFieldTarget(tuple, field, semanticModel, cancellationToken))
+        {
+            return true;
+        }
+
         if (assignment is not null
             && assignment.Left.Span.Contains(identifier.Span)
             && SymbolEqualityComparer.Default.Equals(
@@ -127,6 +134,24 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
                && SymbolEqualityComparer.Default.Equals(
                    semanticModel.GetSymbolInfo(argument.Expression, cancellationToken).Symbol,
                    field);
+    }
+
+    private static bool ContainsFieldTarget(
+        TupleExpressionSyntax tuple,
+        IFieldSymbol field,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        return tuple.Arguments.Any(argument =>
+            argument.Expression is TupleExpressionSyntax nestedTuple
+                ? ContainsFieldTarget(
+                    nestedTuple,
+                    field,
+                    semanticModel,
+                    cancellationToken)
+                : SymbolEqualityComparer.Default.Equals(
+                    semanticModel.GetSymbolInfo(argument.Expression, cancellationToken).Symbol,
+                    field));
     }
 
     private static async Task<Document> AddReadonlyAsync(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -37,6 +37,7 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
             || variable.FirstAncestorOrSelf<TypeDeclarationSyntax>() is not { } containingType
             || containingType.Modifiers.Any(SyntaxKind.PartialKeyword)
             || semanticModel?.GetDeclaredSymbol(variable, context.CancellationToken) is not IFieldSymbol field
+            || field.Type is INamedTypeSymbol { IsValueType: true, IsReadOnly: false }
             || IsWrittenOutsideConstructor(
                 containingType,
                 field,

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/StatefulModuleCodeFixProvider.cs
@@ -88,8 +88,9 @@ public sealed class StatefulModuleCodeFixProvider : CodeFixProvider
     private static bool IsRefEscape(IdentifierNameSyntax identifier)
     {
         return identifier.FirstAncestorOrSelf<RefExpressionSyntax>() is not null
+               || identifier.FirstAncestorOrSelf<MakeRefExpressionSyntax>() is not null
                || identifier.FirstAncestorOrSelf<PrefixUnaryExpressionSyntax>()
-                   ?.IsKind(SyntaxKind.AddressOfExpression) == true;
+                      ?.IsKind(SyntaxKind.AddressOfExpression) == true;
     }
 
     private static bool IsDirectlyWithinConstructor(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -16,7 +16,7 @@ public class Module1 : Module<CommandResult>
     protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
         // This should trigger the analyzer
-        {{|#0:await this|}};
+        {{|#0:await this|}}; // Preserve this explanation too
         return null;
     }}
 }}
@@ -29,6 +29,8 @@ public class Module1 : Module<CommandResult>
 {{
     protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
+        // This should trigger the analyzer
+        // Preserve this explanation too
         return null;
     }}
 }}

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -150,6 +150,21 @@ public class Module1 : Module<CommandResult>
 }}
 ";
 
+    private const string BadModuleSourceAwaitThisInsideDirective = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<CommandResult>
+{{
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+#region Self await
+        await this;
+#endregion
+        return null;
+    }}
+}}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_AwaitThis_InExecuteAsync()
     {
@@ -201,5 +216,13 @@ public class Module1 : Module<CommandResult>
             BadModuleSourceAwaitThisAsEmbeddedStatement,
             expected,
             FixedModuleSourceAwaitThisAsEmbeddedStatement);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_Inside_Directives()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            BadModuleSourceAwaitThisInsideDirective,
+            AwaitThisAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -199,6 +199,20 @@ public class Module1 : Module<CommandResult>
 }}
 ";
 
+    private const string BadModuleSourceAwaitThisAtGotoTarget = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<CommandResult>
+{{
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+retry:
+        await this;
+        goto retry;
+    }}
+}}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_AwaitThis_InExecuteAsync()
     {
@@ -273,6 +287,14 @@ public class Module1 : Module<CommandResult>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             BadModuleSourceAwaitThisInsideLoopBlock,
+            AwaitThisAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_At_Goto_Target()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            BadModuleSourceAwaitThisAtGotoTarget,
             AwaitThisAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -213,6 +213,21 @@ retry:
 }}
 ";
 
+    private const string BadModuleSourceAwaitThisInsideGotoCycle = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<CommandResult>
+{{
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+retry:
+        ;
+        await this;
+        goto retry;
+    }}
+}}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_AwaitThis_InExecuteAsync()
     {
@@ -295,6 +310,14 @@ retry:
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             BadModuleSourceAwaitThisAtGotoTarget,
+            AwaitThisAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_Inside_Goto_Cycle()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            BadModuleSourceAwaitThisInsideGotoCycle,
             AwaitThisAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -320,4 +320,27 @@ retry:
             BadModuleSourceAwaitThisInsideGotoCycle,
             AwaitThisAnalyzer.DiagnosticId);
     }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_Inside_Goto_Case_Cycle()
+    {
+        var source = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<CommandResult>
+{{
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        switch (context)
+        {{
+            case null:
+                await this;
+                goto case null;
+        }}
+    }}
+}}
+";
+
+        await VerifyCS.VerifyNoCodeFixAsync(source, AwaitThisAnalyzer.DiagnosticId);
+    }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -228,6 +228,23 @@ retry:
 }}
 ";
 
+    private const string BadModuleSourceAwaitThisWithInactiveGoto = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<CommandResult>
+{{
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+retry:
+        await this;
+#if RETRY
+        goto retry;
+#endif
+        return null;
+    }}
+}}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_AwaitThis_InExecuteAsync()
     {
@@ -318,6 +335,14 @@ retry:
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             BadModuleSourceAwaitThisInsideGotoCycle,
+            AwaitThisAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Inactive_Goto_May_Create_Cycle()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            BadModuleSourceAwaitThisWithInactiveGoto,
             AwaitThisAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -167,6 +167,21 @@ public class Module1 : Module<CommandResult>
 }}
 ";
 
+    private const string BadModuleSourceAwaitThisAsLoopBody = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<CommandResult>
+{{
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        while (!cancellationToken.IsCancellationRequested)
+            await this;
+
+        return null;
+    }}
+}}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_AwaitThis_InExecuteAsync()
     {
@@ -225,6 +240,14 @@ public class Module1 : Module<CommandResult>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             BadModuleSourceAwaitThisInsideDirective,
+            AwaitThisAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Loop_Body()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            BadModuleSourceAwaitThisAsLoopBody,
             AwaitThisAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -182,6 +182,23 @@ public class Module1 : Module<CommandResult>
 }}
 ";
 
+    private const string BadModuleSourceAwaitThisInsideLoopBlock = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<CommandResult>
+{{
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        while (!cancellationToken.IsCancellationRequested)
+        {{
+            await this;
+        }}
+
+        return null;
+    }}
+}}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_AwaitThis_InExecuteAsync()
     {
@@ -248,6 +265,14 @@ public class Module1 : Module<CommandResult>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             BadModuleSourceAwaitThisAsLoopBody,
+            AwaitThisAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_Inside_Loop_Block()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            BadModuleSourceAwaitThisInsideLoopBlock,
             AwaitThisAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -120,6 +120,36 @@ public class Module1 : Module<CommandResult>
 }}
 ";
 
+    private const string BadModuleSourceAwaitThisAsEmbeddedStatement = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<CommandResult>
+{{
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        if (DateTime.UtcNow.Ticks > 0)
+            {{|#0:await this|}};
+
+        return null;
+    }}
+}}
+";
+
+    private const string FixedModuleSourceAwaitThisAsEmbeddedStatement = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<CommandResult>
+{{
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        if (DateTime.UtcNow.Ticks > 0)
+            ;
+
+        return null;
+    }}
+}}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_AwaitThis_InExecuteAsync()
     {
@@ -160,5 +190,16 @@ public class Module1 : Module<CommandResult>
         var expected = VerifyCS.Diagnostic(AwaitThisAnalyzer.DiagnosticId).WithLocation(0);
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSourceAwaitThis, expected, FixedModuleSourceAwaitThis);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Preserves_Embedded_Statement_Parent()
+    {
+        var expected = VerifyCS.Diagnostic(AwaitThisAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            BadModuleSourceAwaitThisAsEmbeddedStatement,
+            expected,
+            FixedModuleSourceAwaitThisAsEmbeddedStatement);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAwaitThisUnitTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpAnalyzerVerifier<
-    ModularPipelines.Analyzers.AwaitThisAnalyzer>;
+using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpCodeFixVerifier<
+    ModularPipelines.Analyzers.AwaitThisAnalyzer,
+    ModularPipelines.Analyzers.AwaitThisCodeFixProvider>;
 
 namespace ModularPipelines.Analyzers.Test;
 
@@ -16,6 +17,18 @@ public class Module1 : Module<CommandResult>
     {{
         // This should trigger the analyzer
         {{|#0:await this|}};
+        return null;
+    }}
+}}
+";
+
+    private const string FixedModuleSourceAwaitThis = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<CommandResult>
+{{
+    protected override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
         return null;
     }}
 }}
@@ -139,5 +152,13 @@ public class Module1 : Module<CommandResult>
     public async Task AnalyzerIsNotTriggered_When_AwaitThis_InOnAfterExecuteAsync()
     {
         await VerifyCS.VerifyAnalyzerAsync(GoodModuleSourceAwaitThisInOnAfterExecuteAsync);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Removes_Standalone_Self_Await()
+    {
+        var expected = VerifyCS.Diagnostic(AwaitThisAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(BadModuleSourceAwaitThis, expected, FixedModuleSourceAwaitThis);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConflictingDependsOnAttributeUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConflictingDependsOnAttributeUnitTests.cs
@@ -4,6 +4,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModularPipelines.Context;
 using System.Text;
 using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpAnalyzerVerifier<ModularPipelines.Analyzers.ConflictingDependsOnAttributeAnalyzer>;
+using VerifyCodeFixCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpCodeFixVerifier<
+    ModularPipelines.Analyzers.ConflictingDependsOnAttributeAnalyzer,
+    ModularPipelines.Analyzers.ConflictingDependsOnAttributeCodeFixProvider>;
 
 namespace ModularPipelines.Analyzers.Test;
 
@@ -317,6 +320,35 @@ public class Module2 : Module<List<string>>
     public async Task AnalyzerIsNotTriggered_When_No_Conflicting_Dependencies()
     {
         await VerifyCS.VerifyAnalyzerAsync(GoodModuleSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Attribute_List_Contains_Directives()
+    {
+        var source = $$"""
+            {{TestSourceConstants.StandardModuleHeaderWithLogging}}
+
+            public class Module1 : Module<List<string>>
+            {
+                {{TestSourceConstants.SimpleAsyncExecuteBody}}
+            }
+
+            [
+            #if true
+            DependsOn<Module2>
+            #else
+            Obsolete
+            #endif
+            ]
+            public class Module2 : Module<List<string>>
+            {
+                {{TestSourceConstants.SimpleAsyncExecuteBody}}
+            }
+            """;
+
+        await VerifyCodeFixCS.VerifyNoCodeFixAsync(
+            source,
+            ConflictingDependsOnAttributeAnalyzer.DiagnosticId);
     }
 
     private static string CreateLongDependencyChain(int length)

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -155,6 +155,43 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string NullableConsoleMessageWithCommentSource = $@"
+{TestSourceConstants.StandardUsings}
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        string? message = null;
+        {{|#0:Console.WriteLine(/* explanation */ message)|}};
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string FixedNullableConsoleMessageWithCommentSource = $@"
+{TestSourceConstants.StandardUsings}
+using Microsoft.Extensions.Logging;
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        string? message = null;
+        context.Logger.LogInformation(""{{Message}}"", /* explanation */ (message) ?? string.Empty);
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private static string CreateFixedModuleSource(string loggerCall) => $@"
 {TestSourceConstants.StandardUsings}
 using Microsoft.Extensions.Logging;
@@ -314,5 +351,16 @@ public class Module1 : Module<List<string>>
             NullableConsoleMessageSource,
             expected,
             FixedNullableConsoleMessageSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Preserves_Nullable_Message_Comment()
+    {
+        var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            NullableConsoleMessageWithCommentSource,
+            expected,
+            FixedNullableConsoleMessageWithCommentSource);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -67,6 +67,24 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string ShadowedContextSource = $@"
+{TestSourceConstants.StandardUsings}
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        Action<int> write = context => Console.WriteLine(""Done!"");
+        write(0);
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string AliasedConsoleErrorWithEscapedContextSource = $@"
 {TestSourceConstants.StandardUsings}
 using C = System.Console;
@@ -241,6 +259,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             StaticLocalFunctionSource,
+            ConsoleUseAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Context_Is_Shadowed()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ShadowedContextSource,
             ConsoleUseAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -94,7 +94,7 @@ public class Module1 : Module<List<string>>
 {{
     protected override Task<List<string>?> ExecuteAsync(IModuleContext @event, CancellationToken cancellationToken)
     {{
-        @event.Logger.LogError(""Failure!"");
+        @event.Logger.LogError(""{{Message}}"", ""Failure!"");
         return Task.FromResult<List<string>?>([]);
     }}
 }}
@@ -131,7 +131,7 @@ public class Module1 : Module<List<string>>
         CancellationToken cancellationToken)
     {{
         string? message = null;
-        context.Logger.LogInformation((message) ?? string.Empty);
+        context.Logger.LogInformation(""{{Message}}"", (message) ?? string.Empty);
         return Task.FromResult<List<string>?>([]);
     }}
 }}
@@ -208,7 +208,8 @@ public class Module1 : Module<List<string>>
     public async Task CodeFix_Replaces_Console_WriteLine_With_Logger()
     {
         var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
-        var fixedSource = CreateFixedModuleSource(@"context.Logger.LogInformation(""Done!"")");
+        var fixedSource = CreateFixedModuleSource(
+            @"context.Logger.LogInformation(""{Message}"", ""Done!"")");
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSource, expected, fixedSource);
     }
@@ -217,9 +218,22 @@ public class Module1 : Module<List<string>>
     public async Task CodeFix_Replaces_Awaited_Console_WriteLine_With_Logger()
     {
         var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
-        var fixedSource = CreateFixedModuleSource(@"context.Logger.LogInformation(""Done!"")");
+        var fixedSource = CreateFixedModuleSource(
+            @"context.Logger.LogInformation(""{Message}"", ""Done!"")");
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSource5, expected, fixedSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Passes_Brace_Containing_Text_As_Logging_Value()
+    {
+        var source = CreateBadModuleSource(
+            @"Console.WriteLine(""Status: {pending}"")");
+        var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
+        var fixedSource = CreateFixedModuleSource(
+            @"context.Logger.LogInformation(""{Message}"", ""Status: {pending}"")");
+
+        await VerifyCS.VerifyCodeFixAsync(source, expected, fixedSource);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -35,6 +35,13 @@ public class Module1 : Module<List<string>>
     private static readonly string BadModuleSource4 = CreateBadModuleSource(@"Console.Out.WriteLine(""Done!"")");
     private static readonly string BadModuleSource5 = CreateBadModuleSource(@"Console.Out.WriteLineAsync(""Done!"")", isAsync: true);
     private static readonly string BadModuleSource6 = CreateBadModuleSource(@"Console.Out.Dispose()");
+    private static readonly string NonTerminatingWriteSource =
+        CreateBadModuleSource(@"Console.Write(""Done!"")", markDiagnostic: false);
+    private static readonly string NonTerminatingWriteAsyncSource =
+        CreateBadModuleSource(
+            @"Console.Out.WriteAsync(""Done!"")",
+            isAsync: true,
+            markDiagnostic: false);
     private static readonly string NamedArgumentSource = CreateBadModuleSource(
         @"Console.WriteLine(value: ""Done!"")",
         markDiagnostic: false);
@@ -191,6 +198,22 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             NamedArgumentSource,
+            ConsoleUseAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Non_Terminating_Write()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            NonTerminatingWriteSource,
+            ConsoleUseAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Non_Terminating_WriteAsync()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            NonTerminatingWriteAsyncSource,
             ConsoleUseAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -285,6 +285,33 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string ConflictingLoggerExtensionSource = $@"
+{TestSourceConstants.StandardUsings}
+
+namespace AnalyzerExamples;
+
+public static class CustomLoggerExtensions
+{{
+    public static void LogInformation(
+        this ModularPipelines.Logging.IModuleLogger logger,
+        string message,
+        string value)
+    {{
+    }}
+}}
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        Console.WriteLine(""Done!"");
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private static string CreateFixedModuleSource(string loggerCall) => $@"
 {TestSourceConstants.StandardUsings}
 using Microsoft.Extensions.Logging;
@@ -485,5 +512,13 @@ public class Module1 : Module<List<string>>
             NullableConsoleMessageWithCommentSource,
             expected,
             FixedNullableConsoleMessageWithCommentSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Logging_Extension_Would_Be_Shadowed()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ConflictingLoggerExtensionSource,
+            ConsoleUseAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpAnalyzerVerifier<ModularPipelines.Analyzers.ConsoleUseAnalyzer>;
+using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpCodeFixVerifier<
+    ModularPipelines.Analyzers.ConsoleUseAnalyzer,
+    ModularPipelines.Analyzers.ConsoleUseCodeFixProvider>;
 
 namespace ModularPipelines.Analyzers.Test;
 
@@ -30,6 +32,25 @@ public class Module1 : Module<List<string>>
     private static readonly string BadModuleSource4 = CreateBadModuleSource(@"Console.Out.WriteLine(""Done!"")");
     private static readonly string BadModuleSource5 = CreateBadModuleSource(@"Console.Out.WriteLineAsync(""Done!"")", isAsync: true);
     private static readonly string BadModuleSource6 = CreateBadModuleSource(@"Console.Out.Dispose()");
+
+    private static string CreateFixedModuleSource(string loggerCall) => $@"
+{TestSourceConstants.StandardUsings}
+using Microsoft.Extensions.Logging;
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override async Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        await Task.Delay(1, cancellationToken);
+
+        {loggerCall};
+
+        return new List<string>();
+    }}
+}}
+";
 
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_Using_Console()
@@ -77,5 +98,23 @@ public class Module1 : Module<List<string>>
         var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleSource6, expected);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Replaces_Console_WriteLine_With_Logger()
+    {
+        var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
+        var fixedSource = CreateFixedModuleSource(@"context.Logger.LogInformation(""Done!"")");
+
+        await VerifyCS.VerifyCodeFixAsync(BadModuleSource, expected, fixedSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Replaces_Awaited_Console_WriteLine_With_Logger()
+    {
+        var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
+        var fixedSource = CreateFixedModuleSource(@"context.Logger.LogInformation(""Done!"")");
+
+        await VerifyCS.VerifyCodeFixAsync(BadModuleSource5, expected, fixedSource);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -192,6 +192,49 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string ConditionalLoggingUsingSource = $@"
+#define LOGGING
+{TestSourceConstants.StandardUsings}
+#if LOGGING
+using Microsoft.Extensions.Logging;
+#endif
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        {{|#0:Console.WriteLine(""Done!"")|}};
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string FixedConditionalLoggingUsingSource = $@"
+#define LOGGING
+{TestSourceConstants.StandardUsings}
+using Microsoft.Extensions.Logging;
+#if LOGGING
+using Microsoft.Extensions.Logging;
+#endif
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        context.Logger.LogInformation(""{{Message}}"", (""Done!"") ?? string.Empty);
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string SuppressedNullConsoleMessageSource = $@"
 {TestSourceConstants.StandardUsings}
 
@@ -479,6 +522,18 @@ public class Module1 : Module<List<string>>
             LoggingNamespaceAliasSource,
             expected,
             FixedLoggingNamespaceAliasSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Adds_Unconditional_Logging_Import()
+    {
+        var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId)
+            .WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            ConditionalLoggingUsingSource,
+            expected,
+            FixedConditionalLoggingUsingSource);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -54,6 +54,39 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string AliasedConsoleErrorWithEscapedContextSource = $@"
+{TestSourceConstants.StandardUsings}
+using C = System.Console;
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext @event, CancellationToken cancellationToken)
+    {{
+        {{|#0:C.Error.WriteLine(""Failure!"")|}};
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string FixedAliasedConsoleErrorWithEscapedContextSource = $@"
+{TestSourceConstants.StandardUsings}
+using C = System.Console;
+using Microsoft.Extensions.Logging;
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext @event, CancellationToken cancellationToken)
+    {{
+        @event.Logger.LogError(""Failure!"");
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private static string CreateFixedModuleSource(string loggerCall) => $@"
 {TestSourceConstants.StandardUsings}
 using Microsoft.Extensions.Logging;
@@ -145,5 +178,16 @@ public class Module1 : Module<List<string>>
         await VerifyCS.VerifyNoCodeFixAsync(
             StaticLocalFunctionSource,
             ConsoleUseAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Uses_Error_Level_And_Preserves_Escaped_Context()
+    {
+        var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            AliasedConsoleErrorWithEscapedContextSource,
+            expected,
+            FixedAliasedConsoleErrorWithEscapedContextSource);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -155,6 +155,27 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string DirectiveInConsoleReceiverSource = $@"
+{TestSourceConstants.StandardUsings}
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        Console
+#if true
+            .WriteLine(""Done!"")
+#endif
+            ;
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string NullableConsoleMessageWithCommentSource = $@"
 {TestSourceConstants.StandardUsings}
 
@@ -304,6 +325,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ShadowedContextSource,
+            ConsoleUseAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Console_Invocation_Contains_Directives()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            DirectiveInConsoleReceiverSource,
             ConsoleUseAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -100,6 +100,43 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string NullableConsoleMessageSource = $@"
+{TestSourceConstants.StandardUsings}
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        string? message = null;
+        {{|#0:Console.WriteLine(message)|}};
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string FixedNullableConsoleMessageSource = $@"
+{TestSourceConstants.StandardUsings}
+using Microsoft.Extensions.Logging;
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        string? message = null;
+        context.Logger.LogInformation((message) ?? string.Empty);
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private static string CreateFixedModuleSource(string loggerCall) => $@"
 {TestSourceConstants.StandardUsings}
 using Microsoft.Extensions.Logging;
@@ -226,5 +263,16 @@ public class Module1 : Module<List<string>>
             AliasedConsoleErrorWithEscapedContextSource,
             expected,
             FixedAliasedConsoleErrorWithEscapedContextSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Coalesces_Nullable_Message_To_Empty_String()
+    {
+        var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            NullableConsoleMessageSource,
+            expected,
+            FixedNullableConsoleMessageSource);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -33,6 +33,27 @@ public class Module1 : Module<List<string>>
     private static readonly string BadModuleSource5 = CreateBadModuleSource(@"Console.Out.WriteLineAsync(""Done!"")", isAsync: true);
     private static readonly string BadModuleSource6 = CreateBadModuleSource(@"Console.Out.Dispose()");
 
+    private const string StaticLocalFunctionSource = $@"
+{TestSourceConstants.StandardUsings}
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override async Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        static void WriteMessage()
+        {{
+            Console.WriteLine(""Done!"");
+        }}
+
+        await Task.Delay(1, cancellationToken);
+        WriteMessage();
+        return new List<string>();
+    }}
+}}
+";
+
     private static string CreateFixedModuleSource(string loggerCall) => $@"
 {TestSourceConstants.StandardUsings}
 using Microsoft.Extensions.Logging;
@@ -116,5 +137,13 @@ public class Module1 : Module<List<string>>
         var fixedSource = CreateFixedModuleSource(@"context.Logger.LogInformation(""Done!"")");
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSource5, expected, fixedSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_In_Static_Local_Function()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            StaticLocalFunctionSource,
+            ConsoleUseAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -112,7 +112,7 @@ public class Module1 : Module<List<string>>
 {{
     protected override Task<List<string>?> ExecuteAsync(IModuleContext @event, CancellationToken cancellationToken)
     {{
-        @event.Logger.LogError(""{{Message}}"", ""Failure!"");
+        @event.Logger.LogError(""{{Message}}"", (""Failure!"") ?? string.Empty);
         return Task.FromResult<List<string>?>([]);
     }}
 }}
@@ -150,6 +150,41 @@ public class Module1 : Module<List<string>>
     {{
         string? message = null;
         context.Logger.LogInformation(""{{Message}}"", (message) ?? string.Empty);
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string SuppressedNullConsoleMessageSource = $@"
+{TestSourceConstants.StandardUsings}
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        {{|#0:Console.WriteLine((string)null!)|}};
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string FixedSuppressedNullConsoleMessageSource = $@"
+{TestSourceConstants.StandardUsings}
+using Microsoft.Extensions.Logging;
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        context.Logger.LogInformation(""{{Message}}"", ((string)null!) ?? string.Empty);
         return Task.FromResult<List<string>?>([]);
     }}
 }}
@@ -285,7 +320,7 @@ public class Module1 : Module<List<string>>
     {
         var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
         var fixedSource = CreateFixedModuleSource(
-            @"context.Logger.LogInformation(""{Message}"", ""Done!"")");
+            @"context.Logger.LogInformation(""{Message}"", (""Done!"") ?? string.Empty)");
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSource, expected, fixedSource);
     }
@@ -295,7 +330,7 @@ public class Module1 : Module<List<string>>
     {
         var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
         var fixedSource = CreateFixedModuleSource(
-            @"context.Logger.LogInformation(""{Message}"", ""Done!"")");
+            @"context.Logger.LogInformation(""{Message}"", (""Done!"") ?? string.Empty)");
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSource5, expected, fixedSource);
     }
@@ -307,7 +342,7 @@ public class Module1 : Module<List<string>>
             @"Console.WriteLine(""Status: {pending}"")");
         var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
         var fixedSource = CreateFixedModuleSource(
-            @"context.Logger.LogInformation(""{Message}"", ""Status: {pending}"")");
+            @"context.Logger.LogInformation(""{Message}"", (""Status: {pending}"") ?? string.Empty)");
 
         await VerifyCS.VerifyCodeFixAsync(source, expected, fixedSource);
     }
@@ -380,6 +415,17 @@ public class Module1 : Module<List<string>>
             NullableConsoleMessageSource,
             expected,
             FixedNullableConsoleMessageSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Coalesces_Runtime_Null_When_Flow_State_Is_NotNull()
+    {
+        var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            SuppressedNullConsoleMessageSource,
+            expected,
+            FixedSuppressedNullConsoleMessageSource);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -8,7 +8,10 @@ namespace ModularPipelines.Analyzers.Test;
 [TestClass]
 public class ModularPipelinesAnalyzersConsoleUnitTests
 {
-    private static string CreateBadModuleSource(string consoleCall, bool isAsync = false) => $@"
+    private static string CreateBadModuleSource(
+        string consoleCall,
+        bool isAsync = false,
+        bool markDiagnostic = true) => $@"
 {TestSourceConstants.StandardUsings}
 
 namespace AnalyzerExamples;
@@ -19,7 +22,7 @@ public class Module1 : Module<List<string>>
     {{
         await Task.Delay(1, cancellationToken);
 
-        {(isAsync ? "await " : "")}{{|#0:{consoleCall}|}};
+        {(isAsync ? "await " : "")}{(markDiagnostic ? $"{{|#0:{consoleCall}|}}" : consoleCall)};
 
         return new List<string>();
     }}
@@ -32,6 +35,9 @@ public class Module1 : Module<List<string>>
     private static readonly string BadModuleSource4 = CreateBadModuleSource(@"Console.Out.WriteLine(""Done!"")");
     private static readonly string BadModuleSource5 = CreateBadModuleSource(@"Console.Out.WriteLineAsync(""Done!"")", isAsync: true);
     private static readonly string BadModuleSource6 = CreateBadModuleSource(@"Console.Out.Dispose()");
+    private static readonly string NamedArgumentSource = CreateBadModuleSource(
+        @"Console.WriteLine(value: ""Done!"")",
+        markDiagnostic: false);
 
     private const string StaticLocalFunctionSource = $@"
 {TestSourceConstants.StandardUsings}
@@ -177,6 +183,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             StaticLocalFunctionSource,
+            ConsoleUseAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Named_Console_Argument()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            NamedArgumentSource,
             ConsoleUseAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersConsoleUnitTests.cs
@@ -155,6 +155,43 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string LoggingNamespaceAliasSource = $@"
+{TestSourceConstants.StandardUsings}
+using Logging = Microsoft.Extensions.Logging;
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        {{|#0:Console.WriteLine(""Done!"")|}};
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string FixedLoggingNamespaceAliasSource = $@"
+{TestSourceConstants.StandardUsings}
+using Logging = Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace AnalyzerExamples;
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        context.Logger.LogInformation(""{{Message}}"", (""Done!"") ?? string.Empty);
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string SuppressedNullConsoleMessageSource = $@"
 {TestSourceConstants.StandardUsings}
 
@@ -404,6 +441,17 @@ public class Module1 : Module<List<string>>
             AliasedConsoleErrorWithEscapedContextSource,
             expected,
             FixedAliasedConsoleErrorWithEscapedContextSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Adds_Logging_Import_When_Only_Alias_Exists()
+    {
+        var expected = VerifyCS.Diagnostic(ConsoleUseAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            LoggingNamespaceAliasSource,
+            expected,
+            FixedLoggingNamespaceAliasSource);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -136,6 +136,62 @@ public partial class Module1
 }}
 ";
 
+    private const string ConstructorInitializerSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private static ILogger<Module1> Logger {{ get; }} = null!;
+
+    public Module1()
+        : this(Logger, 1)
+    {{
+    }}
+
+    private Module1(ILogger<Module1> logger, int value)
+    {{
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string EscapedContextStoredLoggerSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private readonly ILogger<Module1> _logger;
+
+    public Module1({{|#0:ILogger<Module1> logger|}})
+    {{
+        _logger = logger;
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext @event, CancellationToken cancellationToken)
+    {{
+        _logger.LogInformation(""Running"");
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string FixedEscapedContextStoredLoggerSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext @event, CancellationToken cancellationToken)
+    {{
+        @event.Logger.LogInformation(""Running"");
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string GoodModuleSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -244,5 +300,24 @@ public class Module1 : Module<List<string>>
         await VerifyCS.VerifyNoCodeFixAsync(
             PartialModuleSourceUsedLogger,
             LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_This_Initializer_Targets_Constructor()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ConstructorInitializerSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Preserves_Escaped_Context_Identifier()
+    {
+        var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            EscapedContextStoredLoggerSource,
+            expected,
+            FixedEscapedContextStoredLoggerSource);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -193,6 +193,26 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string DirectiveLoggerParameterListSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    public Module1(
+#region logger parameter
+        ILogger<Module1> logger
+#endregion
+    )
+    {{
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string BadPrivateConstructorSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -638,6 +658,14 @@ public class Module1 : Module<List<string>>
             DirectiveLoggerConstructorSource,
             expected,
             FixedDirectiveLoggerConstructorSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Parameter_List_Contains_Directives()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            DirectiveLoggerParameterListSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -252,6 +252,31 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string StaticLocalFunctionStoredLoggerSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private static ILogger<Module1> _logger = null!;
+
+    public Module1(ILogger<Module1> logger)
+    {{
+        _logger = logger;
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        static void Log()
+        {{
+            _logger.LogInformation(""Running"");
+        }}
+
+        Log();
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string GoodModuleSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -398,5 +423,13 @@ public class Module1 : Module<List<string>>
             EscapedContextStoredLoggerSource,
             expected,
             FixedEscapedContextStoredLoggerSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Logger_Inside_Static_Local_Function()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            StaticLocalFunctionStoredLoggerSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -43,6 +43,42 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string AbstractModuleSourceILoggerGeneric = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public abstract class Module1 : Module<List<string>>
+{{
+    public Module1({{|#0:ILogger<Module1> logger|}})
+    {{
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string FixedAbstractModuleSourceILoggerGeneric = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public abstract class Module1 : Module<List<string>>
+{{
+    public Module1()
+    {{
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string BadModuleSourceUsedLogger = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -781,6 +817,17 @@ public class Module1 : Module<List<string>>
         var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSourceILoggerGeneric, expected, FixedModuleSourceILoggerGeneric);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Retains_Public_Constructor_On_Abstract_Type()
+    {
+        var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            AbstractModuleSourceILoggerGeneric,
+            expected,
+            FixedAbstractModuleSourceILoggerGeneric);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpAnalyzerVerifier<ModularPipelines.Analyzers.LoggerInConstructorAnalyzer>;
+using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpCodeFixVerifier<
+    ModularPipelines.Analyzers.LoggerInConstructorAnalyzer,
+    ModularPipelines.Analyzers.LoggerInConstructorCodeFixProvider>;
 
 namespace ModularPipelines.Analyzers.Test;
 
@@ -27,6 +29,54 @@ public class Module1 : Module<List<string>>
     private static readonly string BadModuleSourceILoggerProvider = CreateModuleWithLoggerConstructor("ILoggerProvider loggerProvider");
     private static readonly string BadModuleSourceILoggerFactory = CreateModuleWithLoggerConstructor("ILoggerFactory loggerFactory");
     private static readonly string BadModuleSourceILoggerGeneric = CreateModuleWithLoggerConstructor("ILogger<Module1> logger");
+
+    private const string FixedModuleSourceILoggerGeneric = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    protected override async Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        await Task.Delay(1, cancellationToken);
+        return new List<string>();
+    }}
+}}
+";
+
+    private const string BadModuleSourceUsedLogger = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private readonly ILogger<Module1> _logger;
+
+    public Module1({{|#0:ILogger<Module1> logger|}})
+    {{
+        _logger = logger;
+    }}
+
+    protected override async Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        await Task.Delay(1, cancellationToken);
+        _logger.LogInformation(""Running"");
+        return new List<string>();
+    }}
+}}
+";
+
+    private const string FixedModuleSourceUsedLogger = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    protected override async Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        await Task.Delay(1, cancellationToken);
+        context.Logger.LogInformation(""Running"");
+        return new List<string>();
+    }}
+}}
+";
 
     private const string GoodModuleSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
@@ -101,5 +151,21 @@ public class Module1 : Module<List<string>>
     public async Task AnalyzerIsNotTriggered_When_No_Logger_In_Constructor2()
     {
         await VerifyCS.VerifyAnalyzerAsync(GoodModuleSource2);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Removes_Unused_Logger_Parameter()
+    {
+        var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(BadModuleSourceILoggerGeneric, expected, FixedModuleSourceILoggerGeneric);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Replaces_Stored_Logger_With_Context_Logger()
+    {
+        var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(BadModuleSourceUsedLogger, expected, FixedModuleSourceUsedLogger);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -1049,6 +1049,36 @@ public class Module1 : Module<List<string>>
     }
 
     [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Static_Logger_Field()
+    {
+        var source = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private static ILogger<Module1> _logger;
+
+    public Module1(ILogger<Module1> logger)
+    {{
+        _logger = logger;
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        _logger.LogInformation(""Running"");
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+        await VerifyCS.VerifyNoCodeFixAsync(
+            source,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
     public async Task CodeFix_Preserves_Escaped_Context_Identifier()
     {
         var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -112,6 +112,40 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string DirectiveLoggerConstructorSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    public Module1({{|#0:ILogger<Module1> logger|}})
+    {{
+#pragma warning disable CS0618
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string FixedDirectiveLoggerConstructorSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    public Module1()
+    {{
+#pragma warning disable CS0618
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string BadPrivateConstructorSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -517,6 +551,17 @@ public class Module1 : Module<List<string>>
             AttributedLoggerConstructorSource,
             expected,
             FixedAttributedLoggerConstructorSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Preserves_Constructor_Containing_Directives()
+    {
+        var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            DirectiveLoggerConstructorSource,
+            expected,
+            FixedDirectiveLoggerConstructorSource);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -29,6 +29,10 @@ public class Module1 : Module<List<string>>
     private static readonly string BadModuleSourceILoggerProvider = CreateModuleWithLoggerConstructor("ILoggerProvider loggerProvider");
     private static readonly string BadModuleSourceILoggerFactory = CreateModuleWithLoggerConstructor("ILoggerFactory loggerFactory");
     private static readonly string BadModuleSourceILoggerGeneric = CreateModuleWithLoggerConstructor("ILogger<Module1> logger");
+    private static readonly string AttributedLoggerParameterSource =
+        CreateModuleWithLoggerConstructor("[System.Diagnostics.CodeAnalysis.AllowNull] ILogger<Module1> logger")
+            .Replace("{|#0:", string.Empty)
+            .Replace("|}", string.Empty);
 
     private const string FixedModuleSourceILoggerGeneric = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
@@ -891,6 +895,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             DirectiveLoggerParameterListSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Logger_Parameter_Has_Attributes()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            AttributedLoggerParameterSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -213,6 +213,60 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string DirectiveLoggerFieldSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+#if true
+    private readonly ILogger<Module1> _logger;
+    private readonly int _marker;
+#endif
+
+    public Module1(ILogger<Module1> logger)
+    {{
+        _logger = logger;
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        _logger.LogInformation(""Running"");
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string DirectiveLoggerAssignmentSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private readonly ILogger<Module1> _logger;
+
+    public Module1(ILogger<Module1> logger)
+    {{
+#if true
+        _logger = logger;
+        RegisterTelemetry();
+#endif
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        _logger.LogInformation(""Running"");
+        return Task.FromResult<List<string>?>([]);
+    }}
+
+    private static void RegisterTelemetry()
+    {{
+    }}
+}}
+";
+
     private const string BadPrivateConstructorSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -694,6 +748,22 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             DirectiveLoggerParameterListSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Logger_Field_Contains_Directives()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            DirectiveLoggerFieldSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Logger_Assignment_Contains_Directives()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            DirectiveLoggerAssignmentSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -321,6 +321,33 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string ExternallyReferencedStoredLoggerSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    public readonly ILogger<Module1> Logger;
+
+    public Module1(ILogger<Module1> logger)
+    {{
+        Logger = logger;
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+
+public static class LoggerConsumer
+{{
+    public static void Log(Module1 module)
+    {{
+        module.Logger.LogInformation(""Running"");
+    }}
+}}
+";
+
     private const string GoodModuleSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -490,6 +517,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             StaticLocalFunctionStoredLoggerSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Externally_Referenced_Logger_Field()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ExternallyReferencedStoredLoggerSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -354,6 +354,34 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string InactiveLoggerReferenceSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private readonly ILogger<Module1> _logger;
+
+    public Module1(ILogger<Module1> logger)
+    {{
+        _logger = logger;
+    }}
+
+#if EXTRA_LOGGING
+    private void LogHidden()
+    {{
+        _logger.LogInformation(""Hidden"");
+    }}
+#endif
+
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string BadPrivateConstructorSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -919,6 +947,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             DirectiveLoggerAssignmentSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Inactive_Logger_Reference()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            InactiveLoggerReferenceSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -78,6 +78,30 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string LoggerFieldWithInitializerSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private ILogger<Module1> _logger = RegisterTelemetry();
+
+    public Module1(ILogger<Module1> logger)
+    {{
+        _logger = logger;
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        _logger.LogInformation(""Running"");
+        return Task.FromResult<List<string>?>([]);
+    }}
+
+    private static ILogger<Module1> RegisterTelemetry() => null!;
+}}
+";
+
     private const string AttributedLoggerConstructorSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -742,6 +766,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             LoggerWithGenericExtensionSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Logger_Field_With_Initializer()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            LoggerFieldWithInitializerSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -297,6 +297,49 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string LoggerConstructorWithOptionalOverloadSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    public Module1(ILogger<Module1> logger)
+    {{
+    }}
+
+    public Module1(int value = 0)
+    {{
+    }}
+
+    public static Module1 Create() => new();
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string EmbeddedLoggerAssignmentSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private ILogger<Module1> _logger = null!;
+
+    public Module1(ILogger<Module1> logger, bool enabled)
+    {{
+        if (enabled)
+            _logger = logger;
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        _logger.LogInformation(""Running"");
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string EscapedContextStoredLoggerSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -544,6 +587,22 @@ public class Module1 : Module<List<string>>
             LoggerConstructorWithOverloadSource,
             expected,
             FixedLoggerConstructorWithOverloadSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Sibling_Constructor_Arity_Overlaps()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            LoggerConstructorWithOptionalOverloadSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Embedded_Logger_Assignment()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            EmbeddedLoggerAssignmentSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -526,6 +526,35 @@ public static class LoggerConsumer
 }}
 ";
 
+    private const string NestedModuleLoggerSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class ModuleContainer
+{{
+    public class Module1 : Module<List<string>>
+    {{
+        private readonly ILogger<Module1> _logger;
+
+        public Module1(ILogger<Module1> logger)
+        {{
+            _logger = logger;
+        }}
+
+        protected override Task<List<string>?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {{
+            return Task.FromResult<List<string>?>([]);
+        }}
+    }}
+
+    public static void Log(Module1 module)
+    {{
+        module._logger.LogInformation(""Running"");
+    }}
+}}
+";
+
     private const string LoggerWithGenericExtensionSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -786,6 +815,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ExternallyReferencedStoredLoggerSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Nested_Module()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            NestedModuleLoggerSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -78,6 +78,40 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string AttributedLoggerConstructorSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    [Obsolete(""Kept for compatibility"")]
+    public Module1({{|#0:ILogger<Module1> logger|}})
+    {{
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string FixedAttributedLoggerConstructorSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    [Obsolete(""Kept for compatibility"")]
+    public Module1()
+    {{
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string BadPrivateConstructorSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -429,6 +463,17 @@ public class Module1 : Module<List<string>>
         var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSourceILoggerGeneric, expected, FixedModuleSourceILoggerGeneric);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Preserves_Attributed_Constructor()
+    {
+        var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            AttributedLoggerConstructorSource,
+            expected,
+            FixedAttributedLoggerConstructorSource);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -638,6 +638,40 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string LoggerWithMoreSpecificExtensionSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+using ModularPipelines.Logging;
+
+public static class LoggerExtensions
+{{
+    public static void LogCustom(this ILogger logger)
+    {{
+    }}
+
+    public static void LogCustom(this IModuleLogger logger)
+    {{
+    }}
+}}
+
+public class Module1 : Module<List<string>>
+{{
+    private readonly ILogger _logger;
+
+    public Module1(ILogger logger)
+    {{
+        _logger = logger;
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        _logger.LogCustom();
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string GoodModuleSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -901,6 +935,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             LoggerWithGenericExtensionSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Extension_Overload_Changes()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            LoggerWithMoreSpecificExtensionSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -159,6 +159,50 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string ExplicitConstructorCallSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    public Module1(ILogger<Module1> logger)
+    {{
+    }}
+
+    public static Module1 Create(ILogger<Module1> logger) => new(logger);
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string BaseConstructorCallSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    public Module1(ILogger<Module1> logger)
+    {{
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+
+public class DerivedModule : Module1
+{{
+    private static ILogger<Module1> Logger {{ get; }} = null!;
+
+    public DerivedModule()
+        : base(Logger)
+    {{
+    }}
+}}
+";
+
     private const string DuplicateConstructorSignatureSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -392,6 +436,22 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ConstructorInitializerSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Constructor_Is_Called_Explicitly()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ExplicitConstructorCallSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Base_Constructor_Is_Called()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            BaseConstructorCallSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -1005,6 +1005,38 @@ public class Module1 : Module<List<string>>
     }
 
     [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Other_Instance_Logger_Assignment()
+    {
+        var source = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private readonly ILogger<Module1> _logger;
+
+    public Module1(ILogger<Module1> logger)
+    {{
+        GetOther()._logger = logger;
+    }}
+
+    private static Module1 GetOther() => null!;
+
+    protected override async Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        await Task.Delay(1, cancellationToken);
+        return [];
+    }}
+}}
+";
+
+        await VerifyCS.VerifyNoCodeFixAsync(
+            source,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
     public async Task CodeFix_Preserves_Escaped_Context_Identifier()
     {
         var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -179,6 +179,46 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string LoggerConstructorWithOverloadSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    public Module1({{|#0:ILogger<Module1> logger|}})
+    {{
+    }}
+
+    public Module1(int value)
+    {{
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
+    private const string FixedLoggerConstructorWithOverloadSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    public Module1()
+    {{
+    }}
+
+    public Module1(int value)
+    {{
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string EscapedContextStoredLoggerSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -336,6 +376,17 @@ public class Module1 : Module<List<string>>
         await VerifyCS.VerifyNoCodeFixAsync(
             DuplicateConstructorSignatureSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Retains_Public_Constructor_When_Another_Overload_Remains()
+    {
+        var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            LoggerConstructorWithOverloadSource,
+            expected,
+            FixedLoggerConstructorWithOverloadSource);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -95,6 +95,29 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string ShadowedContextStoredLoggerSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private readonly ILogger<Module1> _logger;
+
+    public Module1(ILogger<Module1> logger)
+    {{
+        _logger = logger;
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        Action<int> log = context => _logger.LogInformation(""Running"");
+        log(0);
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string FixedAttributedLoggerConstructorSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -695,6 +718,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             StaticLocalFunctionStoredLoggerSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Context_Is_Shadowed()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ShadowedContextStoredLoggerSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -459,6 +459,35 @@ public static class LoggerConsumer
 }}
 ";
 
+    private const string LoggerWithGenericExtensionSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public static class LoggerExtensions
+{{
+    public static void LogModuleSpecific(this ILogger<Module1> logger)
+    {{
+    }}
+}}
+
+public class Module1 : Module<List<string>>
+{{
+    private readonly ILogger<Module1> _logger;
+
+    public Module1(ILogger<Module1> logger)
+    {{
+        _logger = logger;
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        _logger.LogModuleSpecific();
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string GoodModuleSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -674,6 +703,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ExternallyReferencedStoredLoggerSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Generic_Logger_Extension()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            LoggerWithGenericExtensionSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -43,6 +43,25 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string MultipleLoggerParametersSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    public Module1(
+        {{|#0:ILogger<Module1> logger|}},
+        {{|#1:ILoggerFactory loggerFactory|}})
+    {{
+    }}
+
+    protected override async Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        await Task.Delay(1, cancellationToken);
+        return new List<string>();
+    }}
+}}
+";
+
     private const string AbstractModuleSourceILoggerGeneric = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -817,6 +836,21 @@ public class Module1 : Module<List<string>>
         var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSourceILoggerGeneric, expected, FixedModuleSourceILoggerGeneric);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Removes_CoLocated_Logger_Parameters()
+    {
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0),
+            VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(1),
+        };
+
+        await VerifyCS.VerifyCodeFixAsync(
+            MultipleLoggerParametersSource,
+            expected,
+            FixedModuleSourceILoggerGeneric);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -102,6 +102,34 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string AttributedLoggerFieldSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[AttributeUsage(AttributeTargets.Field)]
+public sealed class PreserveAttribute : Attribute
+{{
+}}
+
+public class Module1 : Module<List<string>>
+{{
+    [Preserve]
+    private readonly ILogger<Module1> _logger;
+
+    public Module1(ILogger<Module1> logger)
+    {{
+        _logger = logger;
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        _logger.LogInformation(""Running"");
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string AttributedLoggerConstructorSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -798,6 +826,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             DirectiveLoggerAssignmentSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Logger_Field_Has_Attributes()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            AttributedLoggerFieldSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -159,6 +159,26 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string DuplicateConstructorSignatureSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    public Module1(ILogger<Module1> logger, int value)
+    {{
+    }}
+
+    public Module1(int value)
+    {{
+    }}
+
+    protected override Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<List<string>?>([]);
+    }}
+}}
+";
+
     private const string EscapedContextStoredLoggerSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -307,6 +327,14 @@ public class Module1 : Module<List<string>>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ConstructorInitializerSource,
+            LoggerInConstructorAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_When_Resulting_Constructor_Would_Be_Duplicate()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            DuplicateConstructorSignatureSource,
             LoggerInConstructorAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersILoggerUnitTests.cs
@@ -78,6 +78,64 @@ public class Module1 : Module<List<string>>
 }}
 ";
 
+    private const string BadPrivateConstructorSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private Module1({{|#0:ILogger<Module1> logger|}})
+    {{
+    }}
+
+    protected override async Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        await Task.Delay(1, cancellationToken);
+        return new List<string>();
+    }}
+}}
+";
+
+    private const string FixedPrivateConstructorSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class Module1 : Module<List<string>>
+{{
+    private Module1()
+    {{
+    }}
+
+    protected override async Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        await Task.Delay(1, cancellationToken);
+        return new List<string>();
+    }}
+}}
+";
+
+    private const string PartialModuleSourceUsedLogger = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public partial class Module1 : Module<List<string>>
+{{
+    private readonly ILogger<Module1> _logger;
+
+    public Module1(ILogger<Module1> logger)
+    {{
+        _logger = logger;
+    }}
+}}
+
+public partial class Module1
+{{
+    protected override async Task<List<string>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        await Task.Delay(1, cancellationToken);
+        _logger.LogInformation(""Running"");
+        return new List<string>();
+    }}
+}}
+";
+
     private const string GoodModuleSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
@@ -167,5 +225,24 @@ public class Module1 : Module<List<string>>
         var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSourceUsedLogger, expected, FixedModuleSourceUsedLogger);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Preserves_Private_Constructor_Accessibility()
+    {
+        var expected = VerifyCS.Diagnostic(LoggerInConstructorAnalyzer.DiagnosticId).WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            BadPrivateConstructorSource,
+            expected,
+            FixedPrivateConstructorSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Partial_Type()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            PartialModuleSourceUsedLogger,
+            LoggerInConstructorAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersInvalidDependsOnTypeUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersInvalidDependsOnTypeUnitTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpAnalyzerVerifier<ModularPipelines.Analyzers.InvalidDependsOnTypeAnalyzer>;
+using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpCodeFixVerifier<
+    ModularPipelines.Analyzers.InvalidDependsOnTypeAnalyzer,
+    ModularPipelines.Analyzers.ConflictingDependsOnAttributeCodeFixProvider>;
 
 namespace ModularPipelines.Analyzers.Test;
 
@@ -21,6 +23,15 @@ public class ModularPipelinesAnalyzersInvalidDependsOnTypeUnitTests
 public class NotAModule {{ }}
 
 [{{|#0:DependsOn(typeof(NotAModule))|}}]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
+    private const string FixedModuleSourceGeneric = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+public class NotAModule {{ }}
+
 public class Module1 : Module<List<string>>
 {SimpleModuleBody}
 ";
@@ -50,5 +61,15 @@ public class Module2 : Module<List<string>>
     public async Task AnalyzerIsNotTriggered_When_DependsOn_Valid_Module()
     {
         await VerifyCS.VerifyAnalyzerAsync(GoodModuleSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Removes_Invalid_Dependency()
+    {
+        var expected = VerifyCS.Diagnostic(InvalidDependsOnTypeAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("NotAModule");
+
+        await VerifyCS.VerifyCodeFixAsync(BadModuleSourceGeneric, expected, FixedModuleSourceGeneric);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
@@ -1,5 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpAnalyzerVerifier<ModularPipelines.Analyzers.SelfDependencyAnalyzer>;
+using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpCodeFixVerifier<
+    ModularPipelines.Analyzers.SelfDependencyAnalyzer,
+    ModularPipelines.Analyzers.ConflictingDependsOnAttributeCodeFixProvider>;
 
 namespace ModularPipelines.Analyzers.Test;
 
@@ -19,6 +21,13 @@ public class ModularPipelinesAnalyzersSelfDependencyUnitTests
 {TestSourceConstants.StandardModuleHeaderWithLogging}
 
 [{{|#0:DependsOn<Module1>|}}]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
+    private const string FixedModuleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
 public class Module1 : Module<List<string>>
 {SimpleModuleBody}
 ";
@@ -48,5 +57,15 @@ public class Module2 : Module<List<string>>
     public async Task AnalyzerIsNotTriggered_When_Module_Does_Not_Depend_On_Self()
     {
         await VerifyCS.VerifyAnalyzerAsync(GoodModuleSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Removes_Self_Dependency()
+    {
+        var expected = VerifyCS.Diagnostic(SelfDependencyAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Module1");
+
+        await VerifyCS.VerifyCodeFixAsync(BadModuleSource, expected, FixedModuleSource);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
@@ -80,6 +80,22 @@ public class Module1 : Module<List<string>>
 {SimpleModuleBody}
 ";
 
+    private const string SharedAttributeListBadModuleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[Obsolete, {{|#0:DependsOn<Module1>|}} /* dependency explanation */]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
+    private const string FixedSharedAttributeListModuleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[Obsolete  /* dependency explanation */]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_Module_Depends_On_Self()
     {
@@ -130,5 +146,18 @@ public class Module1 : Module<List<string>>
             TrailingCommentBadModuleSource,
             expected,
             FixedTrailingCommentModuleSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Preserves_Comment_In_Shared_Attribute_List()
+    {
+        var expected = VerifyCS.Diagnostic(SelfDependencyAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Module1");
+
+        await VerifyCS.VerifyCodeFixAsync(
+            SharedAttributeListBadModuleSource,
+            expected,
+            FixedSharedAttributeListModuleSource);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
@@ -96,6 +96,14 @@ public class Module1 : Module<List<string>>
 {SimpleModuleBody}
 ";
 
+    private const string DuplicateSelfDependenciesSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[{{|#0:DependsOn<Module1>|}}, {{|#1:DependsOn<Module1>|}}]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_Module_Depends_On_Self()
     {
@@ -159,5 +167,24 @@ public class Module1 : Module<List<string>>
             SharedAttributeListBadModuleSource,
             expected,
             FixedSharedAttributeListModuleSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Removes_CoLocated_Self_Dependencies()
+    {
+        var expected = new[]
+        {
+            VerifyCS.Diagnostic(SelfDependencyAnalyzer.DiagnosticId)
+                .WithLocation(0)
+                .WithArguments("Module1"),
+            VerifyCS.Diagnostic(SelfDependencyAnalyzer.DiagnosticId)
+                .WithLocation(1)
+                .WithArguments("Module1"),
+        };
+
+        await VerifyCS.VerifyCodeFixAsync(
+            DuplicateSelfDependenciesSource,
+            expected,
+            FixedModuleSource);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
@@ -1,6 +1,13 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpCodeFixVerifier<
     ModularPipelines.Analyzers.SelfDependencyAnalyzer,
+    ModularPipelines.Analyzers.ConflictingDependsOnAttributeCodeFixProvider>;
+using VerifyDuplicateCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpCodeFixVerifier<
+    ModularPipelines.Analyzers.Test.DuplicateDependencyDiagnosticAnalyzer,
     ModularPipelines.Analyzers.ConflictingDependsOnAttributeCodeFixProvider>;
 
 namespace ModularPipelines.Analyzers.Test;
@@ -104,6 +111,22 @@ public class Module1 : Module<List<string>>
 {SimpleModuleBody}
 ";
 
+    private const string DuplicateDiagnosticsSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[Obsolete, {{|#0:DependsOn<Module1>|}}]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
+    private const string FixedDuplicateDiagnosticsSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[Obsolete ]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_Module_Depends_On_Self()
     {
@@ -187,4 +210,71 @@ public class Module1 : Module<List<string>>
             expected,
             FixedModuleSource);
     }
+
+    [TestMethod]
+    public async Task CodeFix_Deduplicates_Diagnostics_For_One_Attribute()
+    {
+        var expected = new[]
+        {
+            VerifyDuplicateCS.Diagnostic(SelfDependencyAnalyzer.DiagnosticId)
+                .WithLocation(0),
+            VerifyDuplicateCS.Diagnostic(ConflictingDependsOnAttributeAnalyzer.DiagnosticId)
+                .WithLocation(0),
+        };
+
+        await VerifyDuplicateCS.VerifyCodeFixAsync(
+            DuplicateDiagnosticsSource,
+            expected,
+            FixedDuplicateDiagnosticsSource);
+    }
 }
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+#pragma warning disable RS1036, RS2008
+public sealed class DuplicateDependencyDiagnosticAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly DiagnosticDescriptor SelfDependencyRule = new(
+        SelfDependencyAnalyzer.DiagnosticId,
+        "Self dependency",
+        "Self dependency",
+        "Test",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    private static readonly DiagnosticDescriptor ConflictingDependencyRule = new(
+        ConflictingDependsOnAttributeAnalyzer.DiagnosticId,
+        "Conflicting dependency",
+        "Conflicting dependency",
+        "Test",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        [SelfDependencyRule, ConflictingDependencyRule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(
+            static syntaxContext =>
+            {
+                if (!syntaxContext.Node.ToString().StartsWith(
+                        "DependsOn",
+                        StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                var location = syntaxContext.Node.GetLocation();
+                syntaxContext.ReportDiagnostic(Diagnostic.Create(
+                    SelfDependencyRule,
+                    location));
+                syntaxContext.ReportDiagnostic(Diagnostic.Create(
+                    ConflictingDependencyRule,
+                    location));
+            },
+            SyntaxKind.Attribute);
+    }
+}
+#pragma warning restore RS1036, RS2008

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
@@ -43,6 +43,27 @@ public class Module2 : Module<List<string>>
 {SimpleModuleBody}
 ";
 
+    private const string DocumentedBadModuleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+/// <summary>
+/// Runs the module.
+/// </summary>
+[{{|#0:DependsOn<Module1>|}}]
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
+    private const string FixedDocumentedModuleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+/// <summary>
+/// Runs the module.
+/// </summary>
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_Module_Depends_On_Self()
     {
@@ -67,5 +88,18 @@ public class Module2 : Module<List<string>>
             .WithArguments("Module1");
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSource, expected, FixedModuleSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Preserves_Class_Documentation()
+    {
+        var expected = VerifyCS.Diagnostic(SelfDependencyAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Module1");
+
+        await VerifyCS.VerifyCodeFixAsync(
+            DocumentedBadModuleSource,
+            expected,
+            FixedDocumentedModuleSource);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersSelfDependencyUnitTests.cs
@@ -64,6 +64,22 @@ public class Module1 : Module<List<string>>
 {SimpleModuleBody}
 ";
 
+    private const string TrailingCommentBadModuleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+[{{|#0:DependsOn<Module1>|}}] // dependency explanation
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
+    private const string FixedTrailingCommentModuleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithLogging}
+
+ // dependency explanation
+public class Module1 : Module<List<string>>
+{SimpleModuleBody}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_Module_Depends_On_Self()
     {
@@ -101,5 +117,18 @@ public class Module1 : Module<List<string>>
             DocumentedBadModuleSource,
             expected,
             FixedDocumentedModuleSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Preserves_Trailing_Comment()
+    {
+        var expected = VerifyCS.Diagnostic(SelfDependencyAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Module1");
+
+        await VerifyCS.VerifyCodeFixAsync(
+            TrailingCommentBadModuleSource,
+            expected,
+            FixedTrailingCommentModuleSource);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -206,6 +206,64 @@ public class NotAModule
 }
 ";
 
+    private const string ModuleWithConstructorNestedWrite = @"
+#nullable enable
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public class Module1 : Module<string>
+{
+    private string _state = string.Empty;
+
+    public Module1()
+    {
+        void SetState()
+        {
+            _state = ""updated"";
+        }
+    }
+
+    protected override Task<string?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult<string?>(_state);
+    }
+}
+";
+
+    private const string PartialModuleWithWrite = @"
+#nullable enable
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public partial class Module1 : Module<string>
+{
+    private string _state = string.Empty;
+
+    protected override Task<string?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult<string?>(_state);
+    }
+}
+
+public partial class Module1
+{
+    public void SetState()
+    {
+        _state = ""updated"";
+    }
+}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableField()
     {
@@ -293,5 +351,21 @@ public class NotAModule
             BadModuleWithMutableCollection,
             expected,
             FixedModuleWithReadonlyCollection);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Constructor_Nested_Write()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithConstructorNestedWrite,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Partial_Type()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            PartialModuleWithWrite,
+            StatefulModuleAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -372,6 +372,31 @@ public class Module1 : Module<int>
 }
 ";
 
+    private const string ModuleWithImplicitInArgument = @"
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public class Module1 : Module<int>
+{
+    private int _state;
+
+    protected override Task<int> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        Escape(_state);
+        return Task.FromResult(_state);
+    }
+
+    private static void Escape(in int value)
+    {
+    }
+}
+";
+
     private const string ModuleWithMutableStructMemberAssignment = @"
 #nullable enable
 using System.Threading;
@@ -820,6 +845,14 @@ public class Module1 : Module<int>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ModuleWithRefExtensionReceiver,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Implicit_In_Argument()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithImplicitInArgument,
             StatefulModuleAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -321,6 +321,47 @@ public partial class Module1
 }
 ";
 
+    private const string ModuleWithVolatileField = @"
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public class Module1 : Module<object>
+{
+    private volatile object _state = new();
+
+    protected override Task<object?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult<object?>(_state);
+    }
+}
+";
+
+    private const string ModuleWithDeconstructionWrite = @"
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public class Module1 : Module<string>
+{
+    private string _state = string.Empty;
+
+    protected override Task<string?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        (_state, _) = (""updated"", 0);
+        return Task.FromResult<string?>(_state);
+    }
+}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableField()
     {
@@ -439,6 +480,22 @@ public partial class Module1
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ModuleWithMutableStructMemberAssignment,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Volatile_Field()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithVolatileField,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Deconstruction_Write()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithDeconstructionWrite,
             StatefulModuleAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -616,6 +616,18 @@ public class Module1 : Module<int>
     }
 
     [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Nullable_Struct_With_Mutable_State()
+    {
+        var source = BadModuleWithReadonlyStructContainingMutableState
+            .Replace("private CacheHolder {|#0:_cache|}", "private CacheHolder? _cache")
+            .Replace("_cache.Items", "_cache.Value.Items");
+
+        await VerifyCS.VerifyNoCodeFixAsync(
+            source,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
     public async Task CodeFix_Is_Not_Offered_For_Constructor_Nested_Write()
     {
         await VerifyCS.VerifyNoCodeFixAsync(

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -382,6 +382,44 @@ public class Module1 : Module<string>
 }
 ";
 
+    private const string ModuleWithExternallyWritableField = $@"
+{TestSourceConstants.StandardModuleHeader}
+
+public class Module1 : Module<int>
+{{
+    public List<string> _items = new();
+
+    protected override Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult(_items.Count);
+    }}
+}}
+
+public static class ModuleConfigurator
+{{
+    public static void Configure(Module1 module)
+    {{
+        module._items = [];
+    }}
+}}
+";
+
+    private const string ModuleWithRefEscapedField = $@"
+{TestSourceConstants.StandardModuleHeader}
+
+public class Module1 : Module<object>
+{{
+    private object _state = new();
+
+    private ref object State => ref _state;
+
+    protected override Task<object?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<object?>(State);
+    }}
+}}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableField()
     {
@@ -524,6 +562,22 @@ public class Module1 : Module<string>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ModuleWithDeconstructionWrite,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Externally_Writable_Field()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithExternallyWritableField,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Ref_Escaped_Field()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithRefEscapedField,
             StatefulModuleAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -489,6 +489,23 @@ public class Module1 : Module<int>
 }
 ";
 
+    private const string ModuleWithMakeRefField = $@"
+{TestSourceConstants.StandardModuleHeader}
+
+public class Module1 : Module<int>
+{{
+    private int _state;
+
+    protected override Task<int> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {{
+        var reference = __makeref(_state);
+        return Task.FromResult(__refvalue(reference, int));
+    }}
+}}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableField()
     {
@@ -677,5 +694,13 @@ public class Module1 : Module<int>
             ModuleWithAddressOfField,
             StatefulModuleAnalyzer.DiagnosticId,
             allowUnsafe: true);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_MakeRef_Field()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithMakeRefField,
+            StatefulModuleAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpAnalyzerVerifier<
-    ModularPipelines.Analyzers.StatefulModuleAnalyzer>;
+using VerifyCS = ModularPipelines.Analyzers.Test.Verifiers.CSharpCodeFixVerifier<
+    ModularPipelines.Analyzers.StatefulModuleAnalyzer,
+    ModularPipelines.Analyzers.StatefulModuleCodeFixProvider>;
 
 namespace ModularPipelines.Analyzers.Test;
 
@@ -29,6 +30,22 @@ public class Module1 : Module<string>
 public class Module1 : Module<int>
 {{
     private List<string> {{|#0:_items|}} = new();
+
+    protected override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        await Task.Delay(1, cancellationToken);
+        _items.Add(""item"");
+        return _items.Count;
+    }}
+}}
+";
+
+    private const string FixedModuleWithReadonlyCollection = $@"
+{TestSourceConstants.StandardModuleHeader}
+
+public class Module1 : Module<int>
+{{
+    private readonly List<string> _items = new();
 
     protected override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {{
@@ -263,5 +280,18 @@ public class NotAModule
     public async Task AnalyzerIsNotTriggered_When_NotAModule()
     {
         await VerifyCS.VerifyAnalyzerAsync(NonModuleClassWithMutableField);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Makes_Eligible_Field_Readonly()
+    {
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("_items", "Module1");
+
+        await VerifyCS.VerifyCodeFixAsync(
+            BadModuleWithMutableCollection,
+            expected,
+            FixedModuleWithReadonlyCollection);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -235,6 +235,63 @@ public class Module1 : Module<string>
 }
 ";
 
+    private const string ModuleWithMutableStructMethodCall = @"
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public struct Counter
+{
+    public int Value { get; private set; }
+
+    public void Increment()
+    {
+        Value++;
+    }
+}
+
+public class Module1 : Module<int>
+{
+    private Counter _counter;
+
+    protected override Task<int> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        _counter.Increment();
+        return Task.FromResult(_counter.Value);
+    }
+}
+";
+
+    private const string ModuleWithMutableStructMemberAssignment = @"
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public struct Counter
+{
+    public int Value { get; set; }
+}
+
+public class Module1 : Module<int>
+{
+    private Counter _counter;
+
+    protected override Task<int> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        _counter.Value = 1;
+        return Task.FromResult(_counter.Value);
+    }
+}
+";
+
     private const string PartialModuleWithWrite = @"
 #nullable enable
 using System.Collections.Generic;
@@ -366,6 +423,22 @@ public partial class Module1
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             PartialModuleWithWrite,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Mutable_Struct_Method_Call()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithMutableStructMethodCall,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Mutable_Struct_Member_Assignment()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithMutableStructMemberAssignment,
             StatefulModuleAnalyzer.DiagnosticId);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -426,6 +426,30 @@ public static class ModuleConfigurator
 }}
 ";
 
+    private const string BadModuleWithReadonlyStructContainingMutableState = $@"
+{TestSourceConstants.StandardModuleHeader}
+
+public readonly struct CacheHolder
+{{
+    public List<string> Items {{ get; }} = new();
+
+    public CacheHolder()
+    {{
+    }}
+}}
+
+public class Module1 : Module<int>
+{{
+    private CacheHolder {{|#0:_cache|}} = new();
+
+    protected override Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        _cache.Items.Add(""item"");
+        return Task.FromResult(_cache.Items.Count);
+    }}
+}}
+";
+
     private const string ModuleWithRefEscapedField = $@"
 {TestSourceConstants.StandardModuleHeader}
 
@@ -536,6 +560,16 @@ public class Module1 : Module<object>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             BadModuleWithMutableCollection
+                .Replace("{|#0:", string.Empty)
+                .Replace("|}", string.Empty),
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Readonly_Struct_With_Mutable_State()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            BadModuleWithReadonlyStructContainingMutableState
                 .Replace("{|#0:", string.Empty)
                 .Replace("|}", string.Empty),
             StatefulModuleAnalyzer.DiagnosticId);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -402,6 +402,33 @@ public class Module1 : Module<int>
 }
 ";
 
+    private const string ModuleWithInactiveFieldWrite = @"
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public class Module1 : Module<int>
+{
+    private int _state;
+
+#if MUTATE
+    private void Mutate()
+    {
+        _state = 1;
+    }
+#endif
+
+    protected override Task<int> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_state);
+    }
+}
+";
+
     private const string ModuleWithImplicitInArgument = @"
 #nullable enable
 using System.Threading;
@@ -883,6 +910,14 @@ public class Module1 : Module<int>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ModuleWithInExtensionReceiver,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Inactive_Field_Write()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithInactiveFieldWrite,
             StatefulModuleAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -372,6 +372,36 @@ public class Module1 : Module<int>
 }
 ";
 
+    private const string ModuleWithInExtensionReceiver = @"
+#nullable enable
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public static class IntExtensions
+{
+    public static void Increment(this in int value)
+    {
+        Unsafe.AsRef(in value)++;
+    }
+}
+
+public class Module1 : Module<int>
+{
+    private int _state;
+
+    protected override Task<int> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        _state.Increment();
+        return Task.FromResult(_state);
+    }
+}
+";
+
     private const string ModuleWithImplicitInArgument = @"
 #nullable enable
 using System.Threading;
@@ -845,6 +875,14 @@ public class Module1 : Module<int>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ModuleWithRefExtensionReceiver,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_In_Extension_Receiver()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithInExtensionReceiver,
             StatefulModuleAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -40,18 +40,40 @@ public class Module1 : Module<int>
 }}
 ";
 
-    private const string FixedModuleWithReadonlyCollection = $@"
+    private const string ModuleWithImmutableField = $@"
 {TestSourceConstants.StandardModuleHeader}
 
-public class Module1 : Module<int>
+public class Module1 : Module<string>
 {{
-    private readonly List<string> _items = new();
+    private string {{|#0:_name|}};
 
-    protected override async Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    public Module1()
     {{
-        await Task.Delay(1, cancellationToken);
-        _items.Add(""item"");
-        return _items.Count;
+        _name = ""module"";
+    }}
+
+    protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<string?>(_name);
+    }}
+}}
+";
+
+    private const string FixedModuleWithImmutableField = $@"
+{TestSourceConstants.StandardModuleHeader}
+
+public class Module1 : Module<string>
+{{
+    private readonly string _name;
+
+    public Module1()
+    {{
+        _name = ""module"";
+    }}
+
+    protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult<string?>(_name);
     }}
 }}
 ";
@@ -501,12 +523,22 @@ public class Module1 : Module<object>
     {
         var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId)
             .WithLocation(0)
-            .WithArguments("_items", "Module1");
+            .WithArguments("_name", "Module1");
 
         await VerifyCS.VerifyCodeFixAsync(
-            BadModuleWithMutableCollection,
+            ModuleWithImmutableField,
             expected,
-            FixedModuleWithReadonlyCollection);
+            FixedModuleWithImmutableField);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Mutable_Reference_Type()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            BadModuleWithMutableCollection
+                .Replace("{|#0:", string.Empty)
+                .Replace("|}", string.Empty),
+            StatefulModuleAnalyzer.DiagnosticId);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -257,6 +257,61 @@ public class Module1 : Module<string>
 }
 ";
 
+    private const string ModuleWithOtherInstanceConstructorWrite = @"
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public class Module1 : Module<string>
+{
+    private string _state = string.Empty;
+
+    public Module1(Module1 other)
+    {
+        other._state = ""updated"";
+    }
+
+    protected override Task<string?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult<string?>(_state);
+    }
+}
+";
+
+    private const string ModuleWithObjectInitializerConstructorWrite = @"
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public class Module1 : Module<string>
+{
+    private string _state = string.Empty;
+
+    public Module1()
+    {
+        _ = new Module1(true)
+        {
+            _state = ""updated"",
+        };
+    }
+
+    private Module1(bool _) { }
+
+    protected override Task<string?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult<string?>(_state);
+    }
+}
+";
+
     private const string ModuleWithMutableStructMethodCall = @"
 #nullable enable
 using System.Threading;
@@ -632,6 +687,22 @@ public class Module1 : Module<int>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ModuleWithConstructorNestedWrite,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Other_Instance_Constructor_Write()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithOtherInstanceConstructorWrite,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Object_Initializer_Constructor_Write()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithObjectInitializerConstructorWrite,
             StatefulModuleAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -481,6 +481,30 @@ public static class ModuleConfigurator
 }}
 ";
 
+    private const string NestedModuleWithEnclosingWrite = $@"
+{TestSourceConstants.StandardModuleHeader}
+
+public class ModuleContainer
+{{
+    public class Module1 : Module<int>
+    {{
+        private int _state;
+
+        protected override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {{
+            return Task.FromResult(_state);
+        }}
+    }}
+
+    public static void Configure(Module1 module)
+    {{
+        module._state = 1;
+    }}
+}}
+";
+
     private const string BadModuleWithReadonlyStructContainingMutableState = $@"
 {TestSourceConstants.StandardModuleHeader}
 
@@ -759,6 +783,14 @@ public class Module1 : Module<int>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ModuleWithExternallyWritableField,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Nested_Module()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            NestedModuleWithEnclosingWrite,
             StatefulModuleAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -341,6 +341,26 @@ public class Module1 : Module<object>
 }
 ";
 
+    private const string ModuleWithRequiredField = @"
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public class Module1 : Module<object>
+{
+    public required object State;
+
+    protected override Task<object?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult<object?>(State);
+    }
+}
+";
+
     private const string ModuleWithDeconstructionWrite = @"
 #nullable enable
 using System.Threading;
@@ -488,6 +508,14 @@ public class Module1 : Module<string>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ModuleWithVolatileField,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Required_Field()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithRequiredField,
             StatefulModuleAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -343,6 +343,35 @@ public class Module1 : Module<int>
 }
 ";
 
+    private const string ModuleWithRefExtensionReceiver = @"
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public static class IntExtensions
+{
+    public static void Increment(this ref int value)
+    {
+        value++;
+    }
+}
+
+public class Module1 : Module<int>
+{
+    private int _state;
+
+    protected override Task<int> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        _state.Increment();
+        return Task.FromResult(_state);
+    }
+}
+";
+
     private const string ModuleWithMutableStructMemberAssignment = @"
 #nullable enable
 using System.Threading;
@@ -783,6 +812,14 @@ public class Module1 : Module<int>
     {
         await VerifyCS.VerifyNoCodeFixAsync(
             ModuleWithExternallyWritableField,
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Ref_Extension_Receiver()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithRefExtensionReceiver,
             StatefulModuleAnalyzer.DiagnosticId);
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -466,6 +466,29 @@ public class Module1 : Module<object>
 }}
 ";
 
+    private const string ModuleWithAddressOfField = @"
+#nullable enable
+using System.Threading;
+using System.Threading.Tasks;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+public class Module1 : Module<int>
+{
+    private int _state;
+
+    protected override unsafe Task<int> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        fixed (int* pointer = &_state)
+        {
+            return Task.FromResult(*pointer);
+        }
+    }
+}
+";
+
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableField()
     {
@@ -645,5 +668,14 @@ public class Module1 : Module<object>
         await VerifyCS.VerifyNoCodeFixAsync(
             ModuleWithRefEscapedField,
             StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Address_Of_Field()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            ModuleWithAddressOfField,
+            StatefulModuleAnalyzer.DiagnosticId,
+            allowUnsafe: true);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -54,8 +54,8 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
     {
         var test = new Test
         {
-            TestCode = source,
-            FixedCode = fixedSource,
+            TestCode = source.ReplaceLineEndings(),
+            FixedCode = fixedSource.ReplaceLineEndings(),
             ReferenceAssemblies = Net.Net100,
             TestState =
             {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -73,7 +73,10 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
         await test.RunAsync(CancellationToken.None);
     }
 
-    public static async Task VerifyNoCodeFixAsync(string source, string diagnosticId)
+    public static async Task VerifyNoCodeFixAsync(
+        string source,
+        string diagnosticId,
+        bool allowUnsafe = false)
     {
         using var workspace = new AdhocWorkspace();
         var project = workspace.AddProject(
@@ -84,10 +87,12 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
                 "CodeFixTest",
                 LanguageNames.CSharp,
                 parseOptions: new CSharpParseOptions(LanguageVersion.Preview),
-                compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)));
+                compilationOptions: new CSharpCompilationOptions(
+                    OutputKind.DynamicallyLinkedLibrary,
+                    allowUnsafe: allowUnsafe)));
 
         var trustedPlatformAssemblies =
-            (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+            (string?) AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
         var referencePaths = trustedPlatformAssemblies
             .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
             .Append(typeof(IModuleContext).Assembly.Location)

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Verifiers/CSharpCodeFixVerifier`2.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/Verifiers/CSharpCodeFixVerifier`2.cs
@@ -1,8 +1,14 @@
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ModularPipelines.Context;
 
 namespace ModularPipelines.Analyzers.Test.Verifiers;
@@ -65,5 +71,54 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 
         test.ExpectedDiagnostics.AddRange(expected);
         await test.RunAsync(CancellationToken.None);
+    }
+
+    public static async Task VerifyNoCodeFixAsync(string source, string diagnosticId)
+    {
+        using var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject(
+            ProjectInfo.Create(
+                ProjectId.CreateNewId(),
+                VersionStamp.Create(),
+                "CodeFixTest",
+                "CodeFixTest",
+                LanguageNames.CSharp,
+                parseOptions: new CSharpParseOptions(LanguageVersion.Preview),
+                compilationOptions: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)));
+
+        var trustedPlatformAssemblies =
+            (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty;
+        var referencePaths = trustedPlatformAssemblies
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Append(typeof(IModuleContext).Assembly.Location)
+            .Append(typeof(ILogger).Assembly.Location)
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+        project = project.AddMetadataReferences(
+            referencePaths.Select(path => MetadataReference.CreateFromFile(path)));
+
+        var document = project.AddDocument(
+            "Test.cs",
+            SourceText.From(source.ReplaceLineEndings()));
+        var compilation = await document.Project.GetCompilationAsync();
+        Assert.IsNotNull(compilation);
+
+        var diagnostics = await compilation
+            .WithAnalyzers(ImmutableArray.Create<DiagnosticAnalyzer>(new TAnalyzer()))
+            .GetAnalyzerDiagnosticsAsync();
+        var matchingDiagnostics = diagnostics.Where(result => result.Id == diagnosticId).ToArray();
+        Assert.AreNotEqual(0, matchingDiagnostics.Length, $"Analyzer did not report {diagnosticId}.");
+
+        var actions = new List<CodeAction>();
+        foreach (var diagnostic in matchingDiagnostics)
+        {
+            var context = new CodeFixContext(
+                document,
+                diagnostic,
+                (action, _) => actions.Add(action),
+                CancellationToken.None);
+            await new TCodeFix().RegisterCodeFixesAsync(context);
+        }
+
+        Assert.AreEqual(0, actions.Count, "A code fix was registered for unsafe source.");
     }
 }

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -386,7 +386,7 @@ public class CommandLoggerTests : TestBase
         });
 
         var exception = await Assert.ThrowsAsync<AggregateException>(() =>
-            commandContext.ExecuteCommandLineTool(
+            commandContext.ExecuteCommandLineToolAsync(
                 new PowershellScriptOptions(
                     $"Write-Output '{marker}'; "
                     + "Start-Sleep -Milliseconds 750; "
@@ -411,7 +411,7 @@ public class CommandLoggerTests : TestBase
         });
 
         var exception = await Assert.ThrowsAsync<CommandException>(() =>
-            commandContext.ExecuteCommandLineTool(
+            commandContext.ExecuteCommandLineToolAsync(
                 new PowershellScriptOptions(
                     $"Write-Output '{marker}'; "
                     + "Start-Sleep -Milliseconds 750; "
@@ -446,7 +446,7 @@ public class CommandLoggerTests : TestBase
         });
 
         var commandTask =
-            commandContext.ExecuteCommandLineTool(
+            commandContext.ExecuteCommandLineToolAsync(
                 new PowershellScriptOptions(
                     $"Write-Output '{marker}'; Start-Sleep -Seconds 30"),
                 new CommandExecutionOptions


### PR DESCRIPTION
Closes #3315. Adds safe mechanical code fixes for MPDEP001, MPDEP003, LoggerInConstructor, ConsoleUse, StatefulModule, and AwaitThis. Reuses the DependsOn attribute remover, converts supported console writes and stored ILogger usage to context.Logger, and declines ambiguous transformations. Validation: ModularPipelines.Analyzers.sln Release build; all 61 analyzer tests pass.