### PR TITLE
Inline fast command output

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -109,7 +109,10 @@ internal sealed class Command : ICommandContext
         var completeStandardOutputBuffer = CreateCompleteOutputBuffer(execOpts);
         var completeStandardErrorBuffer = CreateCompleteOutputBuffer(execOpts);
         var outputLogger = _commandLogger as ICommandOutputLogger;
-        var streamsOutput = outputLogger is not null && execOpts.OutputLoggingManipulator is null;
+        using var deferredOutputLogger = CreateDeferredOutputLogger(
+            outputLogger,
+            options,
+            execOpts);
         var stopwatch = Stopwatch.StartNew();
 
         var standardOutput = string.Empty;
@@ -139,18 +142,12 @@ internal sealed class Command : ICommandContext
                         standardOutputBuffer,
                         completeStandardOutputBuffer,
                         CreateStandardOutputLogger(
-                            streamsOutput,
-                            outputLogger,
-                            options,
-                            execOpts)))
+                            deferredOutputLogger)))
                     .WithStandardErrorPipe(CreateOutputTarget(
                         standardErrorBuffer,
                         completeStandardErrorBuffer,
                         CreateStandardErrorLogger(
-                            streamsOutput,
-                            outputLogger,
-                            options,
-                            execOpts)))
+                            deferredOutputLogger)))
                     .WithValidation(CommandResultValidation.None)
                     .ExecuteAsync(
                         configureStartInfo: ConfigureStartInfo,
@@ -179,7 +176,7 @@ internal sealed class Command : ICommandContext
                     standardError,
                     completeStandardOutputBuffer,
                     completeStandardErrorBuffer,
-                    streamsOutput,
+                    deferredOutputLogger,
                     command.WorkingDirPath);
 
                 if (result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode)
@@ -218,7 +215,7 @@ internal sealed class Command : ICommandContext
                     standardError,
                     completeStandardOutputBuffer,
                     completeStandardErrorBuffer,
-                    streamsOutput,
+                    deferredOutputLogger,
                     command.WorkingDirPath);
 
                 throw new CommandException(
@@ -252,7 +249,7 @@ internal sealed class Command : ICommandContext
                     standardError,
                     completeStandardOutputBuffer,
                     completeStandardErrorBuffer,
-                    streamsOutput,
+                    deferredOutputLogger,
                     command.WorkingDirPath);
 
                 throw new CommandException(
@@ -349,26 +346,30 @@ internal sealed class Command : ICommandContext
         }
     }
 
-    private static Action<string>? CreateStandardOutputLogger(
-        bool streamsOutput,
+    private static DeferredCommandOutputLogger? CreateDeferredOutputLogger(
         ICommandOutputLogger? outputLogger,
         CommandLineToolOptions options,
         CommandExecutionOptions executionOptions)
     {
-        return streamsOutput
-            ? line => outputLogger!.LogStandardOutputLine(options, executionOptions, line)
+        return outputLogger is not null && executionOptions.OutputLoggingManipulator is null
+            ? new DeferredCommandOutputLogger(outputLogger, options, executionOptions)
             : null;
     }
 
-    private static Action<string>? CreateStandardErrorLogger(
-        bool streamsOutput,
-        ICommandOutputLogger? outputLogger,
-        CommandLineToolOptions options,
-        CommandExecutionOptions executionOptions)
+    private static Action<string>? CreateStandardOutputLogger(
+        DeferredCommandOutputLogger? outputLogger)
     {
-        return streamsOutput
-            ? line => outputLogger!.LogStandardErrorLine(options, executionOptions, line)
-            : null;
+        return outputLogger is null
+            ? null
+            : outputLogger.LogStandardOutputLine;
+    }
+
+    private static Action<string>? CreateStandardErrorLogger(
+        DeferredCommandOutputLogger? outputLogger)
+    {
+        return outputLogger is null
+            ? null
+            : outputLogger.LogStandardErrorLine;
     }
 
     private static void ConfigureStartInfo(ProcessStartInfo startInfo)
@@ -840,19 +841,20 @@ internal sealed class Command : ICommandContext
         string standardError,
         BoundedCommandOutputBuffer? completeStandardOutputBuffer,
         BoundedCommandOutputBuffer? completeStandardErrorBuffer,
-        bool streamsOutput,
+        DeferredCommandOutputLogger? deferredOutputLogger,
         string workingDirectory)
     {
+        var hasStreamedOutput = deferredOutputLogger?.Complete() == true;
         _commandLogger.Log(
             options,
             executionOptions,
             input,
             exitCode,
             runTime,
-            streamsOutput
+            hasStreamedOutput
                 ? string.Empty
                 : completeStandardOutputBuffer?.ToString() ?? standardOutput,
-            streamsOutput
+            hasStreamedOutput
                 ? string.Empty
                 : completeStandardErrorBuffer?.ToString() ?? standardError,
             workingDirectory);

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -844,7 +844,8 @@ internal sealed class Command : ICommandContext
         DeferredCommandOutputLogger? deferredOutputLogger,
         string workingDirectory)
     {
-        var hasStreamedOutput = deferredOutputLogger?.Complete() == true;
+        var deferredOutput = deferredOutputLogger?.Complete();
+        var hasStreamedOutput = deferredOutput?.HasStreamedOutput == true;
         _commandLogger.Log(
             options,
             executionOptions,
@@ -853,7 +854,9 @@ internal sealed class Command : ICommandContext
             runTime,
             hasStreamedOutput
                 ? string.Empty
-                : completeStandardOutputBuffer?.ToString() ?? standardOutput,
+                : deferredOutput?.PendingStandardOutput
+                  ?? completeStandardOutputBuffer?.ToString()
+                  ?? standardOutput,
             hasStreamedOutput
                 ? string.Empty
                 : completeStandardErrorBuffer?.ToString() ?? standardError,

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -205,18 +205,20 @@ internal sealed class Command : ICommandContext
                 standardOutput = standardOutputBuffer.ToString();
                 standardError = standardErrorBuffer.ToString();
 
-                LogCommandCompletion(
-                    options,
-                    execOpts,
-                    inputToLog,
-                    e.ExitCode,
-                    stopwatch.Elapsed,
-                    standardOutput,
-                    standardError,
-                    completeStandardOutputBuffer,
-                    completeStandardErrorBuffer,
-                    deferredOutputLogger,
-                    command.WorkingDirPath);
+                var failure = CombineWithCompletionFailure(
+                    e,
+                    () => LogCommandCompletion(
+                        options,
+                        execOpts,
+                        inputToLog,
+                        e.ExitCode,
+                        stopwatch.Elapsed,
+                        standardOutput,
+                        standardError,
+                        completeStandardOutputBuffer,
+                        completeStandardErrorBuffer,
+                        deferredOutputLogger,
+                        command.WorkingDirPath));
 
                 throw new CommandException(
                     CreateFailureResult(
@@ -227,7 +229,7 @@ internal sealed class Command : ICommandContext
                         stopwatch.Elapsed,
                         standardOutput,
                         standardError),
-                    e);
+                    failure);
             }
             catch (Exception e) when (e is not CommandExecutionException and not CommandException)
             {
@@ -239,18 +241,20 @@ internal sealed class Command : ICommandContext
                 standardOutput = standardOutputBuffer.ToString();
                 standardError = standardErrorBuffer.ToString();
 
-                LogCommandCompletion(
-                    options,
-                    execOpts,
-                    inputToLog,
-                    -1,
-                    stopwatch.Elapsed,
-                    standardOutput,
-                    standardError,
-                    completeStandardOutputBuffer,
-                    completeStandardErrorBuffer,
-                    deferredOutputLogger,
-                    command.WorkingDirPath);
+                var failure = CombineWithCompletionFailure(
+                    e,
+                    () => LogCommandCompletion(
+                        options,
+                        execOpts,
+                        inputToLog,
+                        -1,
+                        stopwatch.Elapsed,
+                        standardOutput,
+                        standardError,
+                        completeStandardOutputBuffer,
+                        completeStandardErrorBuffer,
+                        deferredOutputLogger,
+                        command.WorkingDirPath));
 
                 throw new CommandException(
                     CreateFailureResult(
@@ -261,8 +265,23 @@ internal sealed class Command : ICommandContext
                         stopwatch.Elapsed,
                         standardOutput,
                         standardError),
-                    e);
+                    failure);
             }
+        }
+    }
+
+    private static Exception CombineWithCompletionFailure(
+        Exception executionFailure,
+        Action complete)
+    {
+        try
+        {
+            complete();
+            return executionFailure;
+        }
+        catch (Exception completionFailure)
+        {
+            return new AggregateException(executionFailure, completionFailure);
         }
     }
 

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -240,22 +240,8 @@ internal sealed class Command : ICommandContext
                     failure);
             }
 
-            LogCommandCompletion(
-                options,
-                execOpts,
-                inputToLog,
-                result.ExitCode,
-                result.RunTime,
-                standardOutput,
-                standardError,
-                completeStandardOutputBuffer,
-                completeStandardErrorBuffer,
-                deferredOutputLogger,
-                command.WorkingDirPath);
-
-            if (result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode)
-            {
-                throw new CommandException(CreateFailureResult(
+            var commandFailure = result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode
+                ? new CommandException(CreateFailureResult(
                     command,
                     execOpts,
                     inputToLog,
@@ -264,7 +250,34 @@ internal sealed class Command : ICommandContext
                     standardOutput,
                     standardError,
                     result.StartTime,
-                    result.ExitTime));
+                    result.ExitTime))
+                : null;
+
+            try
+            {
+                LogCommandCompletion(
+                    options,
+                    execOpts,
+                    inputToLog,
+                    result.ExitCode,
+                    result.RunTime,
+                    standardOutput,
+                    standardError,
+                    completeStandardOutputBuffer,
+                    completeStandardErrorBuffer,
+                    deferredOutputLogger,
+                    command.WorkingDirPath);
+            }
+            catch (Exception completionFailure) when (commandFailure is not null)
+            {
+                throw new CommandException(
+                    commandFailure.Result,
+                    new AggregateException(commandFailure, completionFailure));
+            }
+
+            if (commandFailure is not null)
+            {
+                throw commandFailure;
             }
 
             return new CommandResult(command, result, standardOutput, standardError);

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -135,6 +135,7 @@ internal sealed class Command : ICommandContext
             () => ScheduleForcefulCancellation(forcefulCancellationToken, execOpts.GracefulShutdownTimeout));
         await using (registration.ConfigureAwait(false))
         {
+            CliWrap.CommandResult result;
             try
             {
                 var executionTask = command
@@ -156,7 +157,7 @@ internal sealed class Command : ICommandContext
                         gracefulCancellationToken: linkedCancellationToken.Token);
                 using var descendantCaptureRegistration =
                     linkedCancellationToken.Token.Register(processTreeTerminator.BeginGracefulShutdown);
-                var result = await executionTask.ConfigureAwait(false);
+                result = await executionTask.ConfigureAwait(false);
 
                 await WaitForForcefulCancellationAsync(
                     processTreeTerminator,
@@ -165,35 +166,6 @@ internal sealed class Command : ICommandContext
 
                 standardOutput = standardOutputBuffer.ToString();
                 standardError = standardErrorBuffer.ToString();
-
-                LogCommandCompletion(
-                    options,
-                    execOpts,
-                    inputToLog,
-                    result.ExitCode,
-                    result.RunTime,
-                    standardOutput,
-                    standardError,
-                    completeStandardOutputBuffer,
-                    completeStandardErrorBuffer,
-                    deferredOutputLogger,
-                    command.WorkingDirPath);
-
-                if (result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode)
-                {
-                    throw new CommandException(CreateFailureResult(
-                        command,
-                        execOpts,
-                        inputToLog,
-                        result.ExitCode,
-                        result.RunTime,
-                        standardOutput,
-                        standardError,
-                        result.StartTime,
-                        result.ExitTime));
-                }
-
-                return new CommandResult(command, result, standardOutput, standardError);
             }
             catch (CommandExecutionException e)
             {
@@ -267,6 +239,35 @@ internal sealed class Command : ICommandContext
                         standardError),
                     failure);
             }
+
+            LogCommandCompletion(
+                options,
+                execOpts,
+                inputToLog,
+                result.ExitCode,
+                result.RunTime,
+                standardOutput,
+                standardError,
+                completeStandardOutputBuffer,
+                completeStandardErrorBuffer,
+                deferredOutputLogger,
+                command.WorkingDirPath);
+
+            if (result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode)
+            {
+                throw new CommandException(CreateFailureResult(
+                    command,
+                    execOpts,
+                    inputToLog,
+                    result.ExitCode,
+                    result.RunTime,
+                    standardOutput,
+                    standardError,
+                    result.StartTime,
+                    result.ExitTime));
+            }
+
+            return new CommandResult(command, result, standardOutput, standardError);
         }
     }
 

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -10,6 +10,8 @@ namespace ModularPipelines.Logging;
 
 internal class CommandLogger : ICommandLogger, ICommandOutputLogger
 {
+    internal const int MaximumInlineOutputLength = 100;
+
     private readonly IModuleLoggerProvider _moduleLoggerProvider;
     private readonly IOptions<PipelineOptions> _pipelineOptions;
     private readonly ISecretObfuscator _secretObfuscator;
@@ -157,19 +159,13 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
 
         LogCapturedOutput(options, trimmedOutput, hasShortOutput);
         LogCapturedError(options, standardErrorToLog, exitCode);
-
-        // Log working directory only at Diagnostic level (separate line, indented)
-        if (options.Verbosity >= CommandLogVerbosity.Diagnostic || options.ShowWorkingDirectory)
-        {
-            Logger.LogInformation("  Working Directory: {WorkingDirectory}", workingDirectory);
-        }
     }
 
     private static bool ShouldInlineOutput(CommandLoggingOptions options, string output)
     {
         return !string.IsNullOrEmpty(output)
                && !output.Contains('\n')
-               && output.Length <= 100
+               && output.Length <= MaximumInlineOutputLength
                && options.Verbosity >= CommandLogVerbosity.Normal
                && options.ShowStandardOutput;
     }

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -146,7 +146,8 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
 
         var trimmedOutput = standardOutputToLog.Trim();
         var hasShortOutput = ShouldInlineOutput(options, trimmedOutput);
-        var inlineOutput = hasShortOutput && isSuccess
+        var hasInlineOutput = hasShortOutput && isSuccess;
+        var inlineOutput = hasInlineOutput
             ? $" → {_secretObfuscator.Obfuscate(trimmedOutput, null)}"
             : string.Empty;
         var commandStatus = BuildCommandStatus(options, isSuccess, exitCode, runTime);
@@ -157,7 +158,7 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
             inlineOutput,
             commandStatus);
 
-        LogCapturedOutput(options, trimmedOutput, hasShortOutput);
+        LogCapturedOutput(options, trimmedOutput, hasInlineOutput);
         LogCapturedError(options, standardErrorToLog, exitCode);
     }
 

--- a/src/ModularPipelines/Logging/DeferredCommandOutputLogger.cs
+++ b/src/ModularPipelines/Logging/DeferredCommandOutputLogger.cs
@@ -53,7 +53,7 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
         {
             if (_completion is not null)
             {
-                _loggingFailure?.Throw();
+                ThrowLoggingFailure();
                 return _completion;
             }
 
@@ -67,7 +67,7 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
             _completion = new DeferredCommandOutputCompletion(
                 HasStreamedOutput,
                 pendingStandardOutput);
-            _loggingFailure?.Throw();
+            ThrowLoggingFailure();
             return _completion;
         }
     }
@@ -163,6 +163,13 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
         {
             _outputLogger.LogStandardOutputLine(_toolOptions, _executionOptions, line.Text);
         }
+    }
+
+    private void ThrowLoggingFailure()
+    {
+        var loggingFailure = _loggingFailure;
+        _loggingFailure = null;
+        loggingFailure?.Throw();
     }
 
     private readonly record struct BufferedLine(string Text, bool IsError);

--- a/src/ModularPipelines/Logging/DeferredCommandOutputLogger.cs
+++ b/src/ModularPipelines/Logging/DeferredCommandOutputLogger.cs
@@ -1,0 +1,140 @@
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Logging;
+
+internal sealed class DeferredCommandOutputLogger : IDisposable
+{
+    private static readonly TimeSpan DefaultStreamingDelay = TimeSpan.FromMilliseconds(500);
+    private readonly CommandExecutionOptions _executionOptions;
+    private readonly Lock _lock = new();
+    private readonly ICommandOutputLogger _outputLogger;
+    private readonly List<BufferedLine> _pendingLines = [];
+    private readonly TimeSpan _streamingDelay;
+    private readonly CommandLineToolOptions _toolOptions;
+    private Timer? _timer;
+    private bool _isCompleted;
+
+    internal DeferredCommandOutputLogger(
+        ICommandOutputLogger outputLogger,
+        CommandLineToolOptions toolOptions,
+        CommandExecutionOptions executionOptions)
+        : this(outputLogger, toolOptions, executionOptions, DefaultStreamingDelay)
+    {
+    }
+
+    internal DeferredCommandOutputLogger(
+        ICommandOutputLogger outputLogger,
+        CommandLineToolOptions toolOptions,
+        CommandExecutionOptions executionOptions,
+        TimeSpan streamingDelay)
+    {
+        _outputLogger = outputLogger;
+        _toolOptions = toolOptions;
+        _executionOptions = executionOptions;
+        _streamingDelay = streamingDelay;
+    }
+
+    public void LogStandardOutputLine(string line)
+    {
+        LogLine(new BufferedLine(line, IsError: false));
+    }
+
+    public void LogStandardErrorLine(string line)
+    {
+        LogLine(new BufferedLine(line, IsError: true));
+    }
+
+    public bool Complete()
+    {
+        lock (_lock)
+        {
+            _isCompleted = true;
+            _timer?.Dispose();
+            _timer = null;
+            _pendingLines.Clear();
+            return HasStreamedOutput;
+        }
+    }
+
+    public void Dispose()
+    {
+        Complete();
+    }
+
+    private bool HasStreamedOutput { get; set; }
+
+    private void LogLine(BufferedLine line)
+    {
+        lock (_lock)
+        {
+            if (_isCompleted)
+            {
+                return;
+            }
+
+            if (HasStreamedOutput)
+            {
+                WriteLine(line);
+                return;
+            }
+
+            _pendingLines.Add(line);
+
+            // Only a single short stdout line can join the compact command summary.
+            // Stream anything else immediately and keep the deferred buffer bounded.
+            if (line.IsError
+                || line.Text.Length > CommandLogger.MaximumInlineOutputLength
+                || _pendingLines.Count > 1)
+            {
+                FlushPendingLinesUnderLock();
+                return;
+            }
+
+            _timer ??= new Timer(
+                static state => ((DeferredCommandOutputLogger) state!).FlushPendingLines(),
+                this,
+                _streamingDelay,
+                Timeout.InfiniteTimeSpan);
+        }
+    }
+
+    private void FlushPendingLines()
+    {
+        lock (_lock)
+        {
+            if (_isCompleted)
+            {
+                return;
+            }
+
+            FlushPendingLinesUnderLock();
+        }
+    }
+
+    private void FlushPendingLinesUnderLock()
+    {
+        HasStreamedOutput = true;
+        foreach (var line in _pendingLines)
+        {
+            WriteLine(line);
+        }
+
+        _pendingLines.Clear();
+        _timer?.Dispose();
+        _timer = null;
+    }
+
+    private void WriteLine(BufferedLine line)
+    {
+        if (line.IsError)
+        {
+            _outputLogger.LogStandardErrorLine(_toolOptions, _executionOptions, line.Text);
+        }
+        else
+        {
+            _outputLogger.LogStandardOutputLine(_toolOptions, _executionOptions, line.Text);
+        }
+    }
+
+    private readonly record struct BufferedLine(string Text, bool IsError);
+}

--- a/src/ModularPipelines/Logging/DeferredCommandOutputLogger.cs
+++ b/src/ModularPipelines/Logging/DeferredCommandOutputLogger.cs
@@ -96,7 +96,7 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
 
             if (HasStreamedOutput)
             {
-                WriteLine(line);
+                WriteLineSafely(line);
                 return;
             }
 
@@ -108,7 +108,7 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
                 || line.Text.Length > CommandLogger.MaximumInlineOutputLength
                 || _pendingLines.Count > 1)
             {
-                FlushPendingLinesUnderLock();
+                FlushPendingLinesSafely();
                 return;
             }
 
@@ -124,19 +124,24 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
     {
         lock (_lock)
         {
-            if (_isCompleted)
+            if (_isCompleted || _loggingFailure is not null)
             {
                 return;
             }
 
-            try
-            {
-                FlushPendingLinesUnderLock();
-            }
-            catch (Exception exception)
-            {
-                _loggingFailure = ExceptionDispatchInfo.Capture(exception);
-            }
+            FlushPendingLinesSafely();
+        }
+    }
+
+    private void FlushPendingLinesSafely()
+    {
+        try
+        {
+            FlushPendingLinesUnderLock();
+        }
+        catch (Exception exception)
+        {
+            CaptureLoggingFailure(exception);
         }
     }
 
@@ -149,6 +154,25 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
         }
 
         _pendingLines.Clear();
+        _timer?.Dispose();
+        _timer = null;
+    }
+
+    private void WriteLineSafely(BufferedLine line)
+    {
+        try
+        {
+            WriteLine(line);
+        }
+        catch (Exception exception)
+        {
+            CaptureLoggingFailure(exception);
+        }
+    }
+
+    private void CaptureLoggingFailure(Exception exception)
+    {
+        _loggingFailure ??= ExceptionDispatchInfo.Capture(exception);
         _timer?.Dispose();
         _timer = null;
     }

--- a/src/ModularPipelines/Logging/DeferredCommandOutputLogger.cs
+++ b/src/ModularPipelines/Logging/DeferredCommandOutputLogger.cs
@@ -1,3 +1,4 @@
+using System.Runtime.ExceptionServices;
 using ModularPipelines.Options;
 
 namespace ModularPipelines.Logging;
@@ -11,6 +12,8 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
     private readonly List<BufferedLine> _pendingLines = [];
     private readonly TimeSpan _streamingDelay;
     private readonly CommandLineToolOptions _toolOptions;
+    private DeferredCommandOutputCompletion? _completion;
+    private ExceptionDispatchInfo? _loggingFailure;
     private Timer? _timer;
     private bool _isCompleted;
 
@@ -44,7 +47,32 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
         LogLine(new BufferedLine(line, IsError: true));
     }
 
-    public bool Complete()
+    public DeferredCommandOutputCompletion Complete()
+    {
+        lock (_lock)
+        {
+            if (_completion is not null)
+            {
+                _loggingFailure?.Throw();
+                return _completion;
+            }
+
+            _isCompleted = true;
+            _timer?.Dispose();
+            _timer = null;
+            var pendingStandardOutput = HasStreamedOutput || _pendingLines.Count == 0
+                ? string.Empty
+                : _pendingLines[0].Text;
+            _pendingLines.Clear();
+            _completion = new DeferredCommandOutputCompletion(
+                HasStreamedOutput,
+                pendingStandardOutput);
+            _loggingFailure?.Throw();
+            return _completion;
+        }
+    }
+
+    public void Dispose()
     {
         lock (_lock)
         {
@@ -52,13 +80,7 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
             _timer?.Dispose();
             _timer = null;
             _pendingLines.Clear();
-            return HasStreamedOutput;
         }
-    }
-
-    public void Dispose()
-    {
-        Complete();
     }
 
     private bool HasStreamedOutput { get; set; }
@@ -107,7 +129,14 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
                 return;
             }
 
-            FlushPendingLinesUnderLock();
+            try
+            {
+                FlushPendingLinesUnderLock();
+            }
+            catch (Exception exception)
+            {
+                _loggingFailure = ExceptionDispatchInfo.Capture(exception);
+            }
         }
     }
 
@@ -137,4 +166,13 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
     }
 
     private readonly record struct BufferedLine(string Text, bool IsError);
+}
+
+internal sealed class DeferredCommandOutputCompletion(
+    bool hasStreamedOutput,
+    string pendingStandardOutput)
+{
+    public bool HasStreamedOutput { get; } = hasStreamedOutput;
+
+    public string PendingStandardOutput { get; } = pendingStandardOutput;
 }

--- a/src/ModularPipelines/Logging/DeferredCommandOutputLogger.cs
+++ b/src/ModularPipelines/Logging/DeferredCommandOutputLogger.cs
@@ -89,7 +89,7 @@ internal sealed class DeferredCommandOutputLogger : IDisposable
     {
         lock (_lock)
         {
-            if (_isCompleted)
+            if (_isCompleted || _loggingFailure is not null)
             {
                 return;
             }

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -239,9 +239,8 @@ public class CommandLoggerTests : TestBase
         var logFile = await File.ReadAllTextAsync(file);
         // New compact format: command line includes working directory and command
         await Assert.That(logFile).Contains($"{Environment.CurrentDirectory}>");
-        // Output is streamed on a separate line
-        await Assert.That(logFile).Contains("↳");
-        await Assert.That(Regex.Matches(logFile, "↳ Hello").Count).IsEqualTo(1);
+        // Fast commands inline output; slower commands may begin streaming under load.
+        await Assert.That(Regex.Matches(logFile, "(?:→|↳) Hello").Count).IsEqualTo(1);
         // Normal doesn't show exit code or duration
         await Assert.That(logFile).DoesNotContain("exit ");
         await Assert.That(Regex.IsMatch(logFile, @"\[\d+m?s")).IsFalse();
@@ -257,8 +256,8 @@ public class CommandLoggerTests : TestBase
         var logFile = await File.ReadAllTextAsync(file);
         // New compact format: all info on one line
         await Assert.That(logFile).Contains($"{Environment.CurrentDirectory}>");
-        // Output is streamed on a separate line
-        await Assert.That(logFile).Contains("↳");
+        // Output is logged exactly once, inline or streamed if startup exceeds the deferral.
+        await Assert.That(Regex.Matches(logFile, "(?:→|↳) Hello").Count).IsEqualTo(1);
         // Exit code and duration shown inline
         await Assert.That(logFile).Contains("exit ");
         await Assert.That(Regex.IsMatch(logFile, @"\[\d+m?s")).IsTrue();
@@ -274,13 +273,13 @@ public class CommandLoggerTests : TestBase
         var logFile = await File.ReadAllTextAsync(file);
         // New compact format: all info on one line
         await Assert.That(logFile).Contains($"{Environment.CurrentDirectory}>");
-        // Output is streamed on a separate line
-        await Assert.That(logFile).Contains("↳");
+        // Output is logged exactly once, inline or streamed if startup exceeds the deferral.
+        await Assert.That(Regex.Matches(logFile, "(?:→|↳) Hello").Count).IsEqualTo(1);
         // Exit code and duration shown inline
         await Assert.That(logFile).Contains("exit ");
         await Assert.That(Regex.IsMatch(logFile, @"\[\d+m?s")).IsTrue();
-        // Working directory logged separately at Diagnostic level
-        await Assert.That(logFile).Contains("Working Directory:");
+        // The working directory stays in the command summary instead of adding another log entry.
+        await Assert.That(logFile).DoesNotContain("Working Directory:");
     }
 
     private async Task<string> RunPowershellCommandWithLoggingOptions(string command, CommandLoggingOptions loggingOptions)

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -374,7 +374,7 @@ public class CommandLoggerTests : TestBase
     }
 
     [Test]
-    public async Task Deferred_Logging_Failure_Is_Wrapped_Once_By_Command()
+    public async Task Deferred_Logging_Failure_After_Success_Is_Not_A_Command_Failure()
     {
         var marker = $"throwing-output-{Guid.NewGuid():N}";
         using var loggingProvider = new SelectiveThrowingLoggerProvider($"  ↳ {marker}");
@@ -385,18 +385,16 @@ public class CommandLoggerTests : TestBase
             collection.AddLogging(builder => builder.AddProvider(loggingProvider));
         });
 
-        var exception = await Assert.ThrowsAsync<CommandException>(() =>
+        var exception = await Assert.ThrowsAsync<AggregateException>(() =>
             commandContext.ExecuteCommandLineTool(
                 new PowershellScriptOptions(
                     $"Write-Output '{marker}'; "
                     + "Start-Sleep -Milliseconds 750; "
                     + $"Write-Output '{marker}'")));
 
-        var loggingFailure = exception!.InnerException as AggregateException;
-        await Assert.That(loggingFailure).IsNotNull();
-        await Assert.That(loggingFailure!.InnerExceptions).Count().IsEqualTo(1);
-        await Assert.That(loggingFailure.InnerExceptions[0]).IsTypeOf<InvalidOperationException>();
-        await Assert.That(loggingFailure.InnerExceptions[0].Message).IsEqualTo("Logging failed.");
+        await Assert.That(exception!.InnerExceptions).Count().IsEqualTo(1);
+        await Assert.That(exception.InnerExceptions[0]).IsTypeOf<InvalidOperationException>();
+        await Assert.That(exception.InnerExceptions[0].Message).IsEqualTo("Logging failed.");
         await Assert.That(loggingProvider.ThrowCount).IsEqualTo(1);
     }
 

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -282,7 +282,37 @@ public class CommandLoggerTests : TestBase
         await Assert.That(logFile).DoesNotContain("Working Directory:");
     }
 
-    private async Task<string> RunPowershellCommandWithLoggingOptions(string command, CommandLoggingOptions loggingOptions)
+    [Test]
+    public async Task Fast_Command_Logs_Complete_Output_When_Result_Is_Truncated()
+    {
+        const string output = "complete-output";
+        var file = await RunPowershellCommandWithLoggingOptions(
+            $"Write-Output '{output}'",
+            new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Normal },
+            maxCapturedOutputLength: 4);
+
+        var logFile = await File.ReadAllTextAsync(file);
+        await Assert.That(logFile).Contains($"→ {output}");
+        await Assert.That(logFile).DoesNotContain("truncated");
+    }
+
+    [Test]
+    public async Task Failed_Fast_Command_Logs_Short_Standard_Output()
+    {
+        const string output = "failure-output";
+        var file = await RunPowershellCommandWithLoggingOptions(
+            $"Write-Output '{output}'; exit 1",
+            new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Detailed });
+
+        var logFile = await File.ReadAllTextAsync(file);
+        await Assert.That(Regex.Matches(logFile, $"↳ {output}").Count).IsEqualTo(1);
+        await Assert.That(logFile).Contains("exit 1");
+    }
+
+    private async Task<string> RunPowershellCommandWithLoggingOptions(
+        string command,
+        CommandLoggingOptions loggingOptions,
+        int? maxCapturedOutputLength = null)
     {
         var file = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".txt");
 
@@ -298,6 +328,8 @@ public class CommandLoggerTests : TestBase
             {
                 LogSettings = loggingOptions,
                 ThrowOnNonZeroExitCode = false,
+                MaxCapturedOutputLength =
+                    maxCapturedOutputLength ?? CommandExecutionOptions.DefaultMaxCapturedOutputLength,
             });
 
         await result.Host.DisposeAsync();

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -400,6 +400,44 @@ public class CommandLoggerTests : TestBase
         await Assert.That(loggingProvider.ThrowCount).IsEqualTo(1);
     }
 
+    [Test]
+    public async Task Deferred_Logging_Failure_During_Cancellation_Is_Wrapped_By_Command()
+    {
+        var marker = $"throwing-cancellation-output-{Guid.NewGuid():N}";
+        using var loggingProvider = new SelectiveThrowingLoggerProvider($"  ↳ {marker}");
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var (commandContext, _) = await GetService<ICommandContext>((_, collection) =>
+        {
+            collection.Configure<LoggerFilterOptions>(
+                options => options.MinLevel = LogLevel.Information);
+            collection.AddLogging(builder => builder.AddProvider(loggingProvider));
+        });
+
+        var commandTask =
+            commandContext.ExecuteCommandLineTool(
+                new PowershellScriptOptions(
+                    $"Write-Output '{marker}'; Start-Sleep -Seconds 30"),
+                new CommandExecutionOptions
+                {
+                    GracefulShutdownTimeout = TimeSpan.FromMilliseconds(100),
+                },
+                cancellationToken: cancellationTokenSource.Token);
+
+        await loggingProvider.LoggingFailed.WaitAsync(TimeSpan.FromSeconds(30));
+        await cancellationTokenSource.CancelAsync();
+
+        var exception = await Assert.ThrowsAsync<CommandException>(() => commandTask);
+
+        var failures = (exception!.InnerException as AggregateException)
+            ?.Flatten().InnerExceptions;
+        await Assert.That(failures).IsNotNull();
+        await Assert.That(failures!)
+            .Contains(failure =>
+                failure is InvalidOperationException
+                && failure.Message == "Logging failed.");
+        await Assert.That(loggingProvider.ThrowCount).IsEqualTo(1);
+    }
+
     private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
     {
         var timeoutTask = Task.Delay(timeout);
@@ -476,7 +514,11 @@ public class CommandLoggerTests : TestBase
     private sealed class SelectiveThrowingLoggerProvider(string messageToThrowOn)
         : ILoggerProvider
     {
+        private readonly TaskCompletionSource _loggingFailed =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
         private int _throwCount;
+
+        public Task LoggingFailed => _loggingFailed.Task;
 
         public int ThrowCount => _throwCount;
 
@@ -487,6 +529,7 @@ public class CommandLoggerTests : TestBase
                 if (message == messageToThrowOn)
                 {
                     Interlocked.Increment(ref _throwCount);
+                    _loggingFailed.TrySetResult();
                     throw new InvalidOperationException("Logging failed.");
                 }
             });

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -388,7 +388,9 @@ public class CommandLoggerTests : TestBase
         var exception = await Assert.ThrowsAsync<CommandException>(() =>
             commandContext.ExecuteCommandLineTool(
                 new PowershellScriptOptions(
-                    $"Write-Output '{marker}'; Start-Sleep -Milliseconds 750")));
+                    $"Write-Output '{marker}'; "
+                    + "Start-Sleep -Milliseconds 750; "
+                    + $"Write-Output '{marker}'")));
 
         var loggingFailure = exception!.InnerException as AggregateException;
         await Assert.That(loggingFailure).IsNotNull();

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -399,6 +399,40 @@ public class CommandLoggerTests : TestBase
     }
 
     [Test]
+    public async Task Deferred_Logging_Failure_After_NonZero_Exit_Preserves_Command_Failure()
+    {
+        var marker = $"throwing-failure-output-{Guid.NewGuid():N}";
+        using var loggingProvider = new SelectiveThrowingLoggerProvider($"  ↳ {marker}");
+        var (commandContext, _) = await GetService<ICommandContext>((_, collection) =>
+        {
+            collection.Configure<LoggerFilterOptions>(
+                options => options.MinLevel = LogLevel.Information);
+            collection.AddLogging(builder => builder.AddProvider(loggingProvider));
+        });
+
+        var exception = await Assert.ThrowsAsync<CommandException>(() =>
+            commandContext.ExecuteCommandLineTool(
+                new PowershellScriptOptions(
+                    $"Write-Output '{marker}'; "
+                    + "Start-Sleep -Milliseconds 750; "
+                    + "exit 7")));
+
+        await Assert.That(exception!.Result.ExitCode).IsEqualTo(7);
+        var failures = (exception.InnerException as AggregateException)
+            ?.Flatten().InnerExceptions;
+        await Assert.That(failures).IsNotNull();
+        await Assert.That(failures!)
+            .Contains(failure =>
+                failure is CommandException commandFailure
+                && commandFailure.Result.ExitCode == 7);
+        await Assert.That(failures)
+            .Contains(failure =>
+                failure is InvalidOperationException
+                && failure.Message == "Logging failed.");
+        await Assert.That(loggingProvider.ThrowCount).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Deferred_Logging_Failure_During_Cancellation_Is_Wrapped_By_Command()
     {
         var marker = $"throwing-cancellation-output-{Guid.NewGuid():N}";

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 using NReco.Logging.File;
@@ -372,6 +373,31 @@ public class CommandLoggerTests : TestBase
         }
     }
 
+    [Test]
+    public async Task Deferred_Logging_Failure_Is_Wrapped_Once_By_Command()
+    {
+        var marker = $"throwing-output-{Guid.NewGuid():N}";
+        using var loggingProvider = new SelectiveThrowingLoggerProvider($"  ↳ {marker}");
+        var (commandContext, _) = await GetService<ICommandContext>((_, collection) =>
+        {
+            collection.Configure<LoggerFilterOptions>(
+                options => options.MinLevel = LogLevel.Information);
+            collection.AddLogging(builder => builder.AddProvider(loggingProvider));
+        });
+
+        var exception = await Assert.ThrowsAsync<CommandException>(() =>
+            commandContext.ExecuteCommandLineTool(
+                new PowershellScriptOptions(
+                    $"Write-Output '{marker}'; Start-Sleep -Milliseconds 750")));
+
+        var loggingFailure = exception!.InnerException as AggregateException;
+        await Assert.That(loggingFailure).IsNotNull();
+        await Assert.That(loggingFailure!.InnerExceptions).Count().IsEqualTo(1);
+        await Assert.That(loggingFailure.InnerExceptions[0]).IsTypeOf<InvalidOperationException>();
+        await Assert.That(loggingFailure.InnerExceptions[0].Message).IsEqualTo("Logging failed.");
+        await Assert.That(loggingProvider.ThrowCount).IsEqualTo(1);
+    }
+
     private static async Task<bool> WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
     {
         var timeoutTask = Task.Delay(timeout);
@@ -442,6 +468,30 @@ public class CommandLoggerTests : TestBase
             Func<TState, Exception?, string> formatter)
         {
             record(formatter(state, exception));
+        }
+    }
+
+    private sealed class SelectiveThrowingLoggerProvider(string messageToThrowOn)
+        : ILoggerProvider
+    {
+        private int _throwCount;
+
+        public int ThrowCount => _throwCount;
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return new ObserverLogger(message =>
+            {
+                if (message == messageToThrowOn)
+                {
+                    Interlocked.Increment(ref _throwCount);
+                    throw new InvalidOperationException("Logging failed.");
+                }
+            });
+        }
+
+        public void Dispose()
+        {
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Commands/DeferredCommandOutputLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/DeferredCommandOutputLoggerTests.cs
@@ -88,6 +88,40 @@ public class DeferredCommandOutputLoggerTests
         await Assert.That(completion.HasStreamedOutput).IsTrue();
     }
 
+    [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Immediate_Logging_Failure_Stops_Writes_And_Is_Propagated_Once(
+        bool useStandardError)
+    {
+        var outputLogger = new ThrowingOutputLogger();
+        using var deferredLogger = new DeferredCommandOutputLogger(
+            outputLogger,
+            new TestCommandOptions(),
+            new CommandExecutionOptions(),
+            TimeSpan.FromMilliseconds(10));
+
+        if (useStandardError)
+        {
+            deferredLogger.LogStandardErrorLine("error");
+        }
+        else
+        {
+            deferredLogger.LogStandardOutputLine("first");
+            deferredLogger.LogStandardOutputLine("second");
+        }
+
+        deferredLogger.LogStandardOutputLine("later output");
+        await Task.Delay(TimeSpan.FromMilliseconds(50));
+        await Assert.That(outputLogger.AttemptCount).IsEqualTo(1);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => deferredLogger.Complete());
+        await Assert.That(exception.Message).IsEqualTo("Logging failed.");
+
+        var completion = deferredLogger.Complete();
+        await Assert.That(completion.HasStreamedOutput).IsTrue();
+    }
+
     private sealed class RecordingOutputLogger(int expectedLineCount) : ICommandOutputLogger
     {
         private readonly TaskCompletionSource _expectedLinesReceived =

--- a/test/ModularPipelines.UnitTests/Commands/DeferredCommandOutputLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/DeferredCommandOutputLoggerTests.cs
@@ -1,0 +1,98 @@
+using ModularPipelines.Logging;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.UnitTests.Commands;
+
+public class DeferredCommandOutputLoggerTests
+{
+    [Test]
+    public async Task Completion_Before_Delay_Keeps_Output_For_Inline_Summary()
+    {
+        var outputLogger = new RecordingOutputLogger(expectedLineCount: 1);
+        using var deferredLogger = new DeferredCommandOutputLogger(
+            outputLogger,
+            new TestCommandOptions(),
+            new CommandExecutionOptions(),
+            TimeSpan.FromDays(1));
+
+        deferredLogger.LogStandardOutputLine("output");
+
+        await Assert.That(deferredLogger.Complete()).IsFalse();
+        await Assert.That(outputLogger.Lines).IsEmpty();
+    }
+
+    [Test]
+    public async Task Output_Is_Streamed_When_Command_Remains_Active()
+    {
+        var outputLogger = new RecordingOutputLogger(expectedLineCount: 1);
+        using var deferredLogger = new DeferredCommandOutputLogger(
+            outputLogger,
+            new TestCommandOptions(),
+            new CommandExecutionOptions(),
+            TimeSpan.FromMilliseconds(10));
+
+        deferredLogger.LogStandardOutputLine("output");
+        await outputLogger.ExpectedLinesReceived.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(deferredLogger.Complete()).IsTrue();
+        await Assert.That(outputLogger.Lines).IsEquivalentTo([(Text: "output", IsError: false)]);
+    }
+
+    [Test]
+    public async Task Multiple_Lines_Are_Streamed_Immediately()
+    {
+        var outputLogger = new RecordingOutputLogger(expectedLineCount: 2);
+        using var deferredLogger = new DeferredCommandOutputLogger(
+            outputLogger,
+            new TestCommandOptions(),
+            new CommandExecutionOptions(),
+            TimeSpan.FromDays(1));
+
+        deferredLogger.LogStandardOutputLine("first");
+        deferredLogger.LogStandardOutputLine("second");
+        await outputLogger.ExpectedLinesReceived.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(deferredLogger.Complete()).IsTrue();
+        await Assert.That(outputLogger.Lines).IsEquivalentTo([
+            (Text: "first", IsError: false),
+            (Text: "second", IsError: false),
+        ]);
+    }
+
+    private sealed class RecordingOutputLogger(int expectedLineCount) : ICommandOutputLogger
+    {
+        private readonly TaskCompletionSource _expectedLinesReceived =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public List<(string Text, bool IsError)> Lines { get; } = [];
+
+        public Task ExpectedLinesReceived => _expectedLinesReceived.Task;
+
+        public void LogStandardOutputLine(
+            CommandLineToolOptions options,
+            CommandExecutionOptions executionOptions,
+            string line)
+        {
+            Record(line, isError: false);
+        }
+
+        public void LogStandardErrorLine(
+            CommandLineToolOptions options,
+            CommandExecutionOptions executionOptions,
+            string line)
+        {
+            Record(line, isError: true);
+        }
+
+        private void Record(string line, bool isError)
+        {
+            Lines.Add((line, isError));
+            if (Lines.Count == expectedLineCount)
+            {
+                _expectedLinesReceived.TrySetResult();
+            }
+        }
+    }
+
+    private sealed record TestCommandOptions : CommandLineToolOptions;
+}

--- a/test/ModularPipelines.UnitTests/Commands/DeferredCommandOutputLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/DeferredCommandOutputLoggerTests.cs
@@ -17,7 +17,9 @@ public class DeferredCommandOutputLoggerTests
 
         deferredLogger.LogStandardOutputLine("output");
 
-        await Assert.That(deferredLogger.Complete()).IsFalse();
+        var completion = deferredLogger.Complete();
+        await Assert.That(completion.HasStreamedOutput).IsFalse();
+        await Assert.That(completion.PendingStandardOutput).IsEqualTo("output");
         await Assert.That(outputLogger.Lines).IsEmpty();
     }
 
@@ -34,7 +36,9 @@ public class DeferredCommandOutputLoggerTests
         deferredLogger.LogStandardOutputLine("output");
         await outputLogger.ExpectedLinesReceived.WaitAsync(TimeSpan.FromSeconds(5));
 
-        await Assert.That(deferredLogger.Complete()).IsTrue();
+        var completion = deferredLogger.Complete();
+        await Assert.That(completion.HasStreamedOutput).IsTrue();
+        await Assert.That(completion.PendingStandardOutput).IsEmpty();
         await Assert.That(outputLogger.Lines).IsEquivalentTo([(Text: "output", IsError: false)]);
     }
 
@@ -52,11 +56,30 @@ public class DeferredCommandOutputLoggerTests
         deferredLogger.LogStandardOutputLine("second");
         await outputLogger.ExpectedLinesReceived.WaitAsync(TimeSpan.FromSeconds(5));
 
-        await Assert.That(deferredLogger.Complete()).IsTrue();
+        var completion = deferredLogger.Complete();
+        await Assert.That(completion.HasStreamedOutput).IsTrue();
+        await Assert.That(completion.PendingStandardOutput).IsEmpty();
         await Assert.That(outputLogger.Lines).IsEquivalentTo([
             (Text: "first", IsError: false),
             (Text: "second", IsError: false),
         ]);
+    }
+
+    [Test]
+    public async Task Delayed_Logging_Failure_Is_Propagated_On_Completion()
+    {
+        var outputLogger = new ThrowingOutputLogger();
+        using var deferredLogger = new DeferredCommandOutputLogger(
+            outputLogger,
+            new TestCommandOptions(),
+            new CommandExecutionOptions(),
+            TimeSpan.FromMilliseconds(10));
+
+        deferredLogger.LogStandardOutputLine("output");
+        await outputLogger.LoggingAttempted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => deferredLogger.Complete());
+        await Assert.That(exception.Message).IsEqualTo("Logging failed.");
     }
 
     private sealed class RecordingOutputLogger(int expectedLineCount) : ICommandOutputLogger
@@ -91,6 +114,31 @@ public class DeferredCommandOutputLoggerTests
             {
                 _expectedLinesReceived.TrySetResult();
             }
+        }
+    }
+
+    private sealed class ThrowingOutputLogger : ICommandOutputLogger
+    {
+        private readonly TaskCompletionSource _loggingAttempted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task LoggingAttempted => _loggingAttempted.Task;
+
+        public void LogStandardOutputLine(
+            CommandLineToolOptions options,
+            CommandExecutionOptions executionOptions,
+            string line)
+        {
+            _loggingAttempted.TrySetResult();
+            throw new InvalidOperationException("Logging failed.");
+        }
+
+        public void LogStandardErrorLine(
+            CommandLineToolOptions options,
+            CommandExecutionOptions executionOptions,
+            string line)
+        {
+            throw new InvalidOperationException("Logging failed.");
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Commands/DeferredCommandOutputLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/DeferredCommandOutputLoggerTests.cs
@@ -80,6 +80,9 @@ public class DeferredCommandOutputLoggerTests
 
         var exception = Assert.Throws<InvalidOperationException>(() => deferredLogger.Complete());
         await Assert.That(exception.Message).IsEqualTo("Logging failed.");
+
+        var completion = deferredLogger.Complete();
+        await Assert.That(completion.HasStreamedOutput).IsTrue();
     }
 
     private sealed class RecordingOutputLogger(int expectedLineCount) : ICommandOutputLogger

--- a/test/ModularPipelines.UnitTests/Commands/DeferredCommandOutputLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/DeferredCommandOutputLoggerTests.cs
@@ -66,7 +66,7 @@ public class DeferredCommandOutputLoggerTests
     }
 
     [Test]
-    public async Task Delayed_Logging_Failure_Is_Propagated_On_Completion()
+    public async Task Delayed_Logging_Failure_Stops_Writes_And_Is_Propagated_Once()
     {
         var outputLogger = new ThrowingOutputLogger();
         using var deferredLogger = new DeferredCommandOutputLogger(
@@ -77,6 +77,9 @@ public class DeferredCommandOutputLoggerTests
 
         deferredLogger.LogStandardOutputLine("output");
         await outputLogger.LoggingAttempted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        deferredLogger.LogStandardOutputLine("later output");
+        await Assert.That(outputLogger.AttemptCount).IsEqualTo(1);
 
         var exception = Assert.Throws<InvalidOperationException>(() => deferredLogger.Complete());
         await Assert.That(exception.Message).IsEqualTo("Logging failed.");
@@ -124,14 +127,18 @@ public class DeferredCommandOutputLoggerTests
     {
         private readonly TaskCompletionSource _loggingAttempted =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _attemptCount;
 
         public Task LoggingAttempted => _loggingAttempted.Task;
+
+        public int AttemptCount => _attemptCount;
 
         public void LogStandardOutputLine(
             CommandLineToolOptions options,
             CommandExecutionOptions executionOptions,
             string line)
         {
+            Interlocked.Increment(ref _attemptCount);
             _loggingAttempted.TrySetResult();
             throw new InvalidOperationException("Logging failed.");
         }
@@ -141,6 +148,7 @@ public class DeferredCommandOutputLoggerTests
             CommandExecutionOptions executionOptions,
             string line)
         {
+            Interlocked.Increment(ref _attemptCount);
             throw new InvalidOperationException("Logging failed.");
         }
     }


### PR DESCRIPTION
Closes #2623

## What changed
- defer one short stdout line briefly so fast commands can render as one compact log entry
- preserve immediate live streaming for multiline, long, stderr, and long-running output
- remove the redundant diagnostic working-directory log row
- add deterministic tests for deferred completion and streaming transitions

## Validation
- 41 focused command logging tests pass
- targeted whitespace verification passes
- `ModularPipelines.sln` Release build succeeds (0 errors; existing warnings remain)