### PR TITLE
Generate trim-safe module metadata

### DIFF
--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -1,0 +1,275 @@
+using System.Collections.Immutable;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ModularPipelines.SourceGenerator;
+
+/// <summary>
+/// Generates module discovery, DI registration, and static dependency metadata.
+/// </summary>
+[Generator]
+public sealed class ModuleMetadataGenerator : IIncrementalGenerator
+{
+    internal const string ModuleInterfaceFullName = "ModularPipelines.Modules.IModule";
+    internal const string DependsOnAttributeFullName = "ModularPipelines.Attributes.DependsOnAttribute";
+    internal const string GenericDependsOnAttributeMetadataName = "DependsOnAttribute`1";
+
+    public void Initialize(IncrementalGeneratorInitializationContext context)
+    {
+        var modules = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                static (node, _) => IsCandidate(node),
+                static (generatorContext, _) => GetModuleMetadata(generatorContext))
+            .Where(static metadata => metadata is not null)
+            .Select(static (metadata, _) => metadata!);
+
+        context.RegisterSourceOutput(
+            context.CompilationProvider.Combine(modules.Collect()),
+            static (sourceContext, input) =>
+            {
+                if (input.Left.GetTypeByMetadataName(ModuleInterfaceFullName) is not null)
+                {
+                    sourceContext.AddSource(
+                        "ModularPipelines.ModuleMetadata.g.cs",
+                        Generate(input.Left.AssemblyName, input.Right));
+                }
+            });
+    }
+
+    private static bool IsCandidate(SyntaxNode node)
+    {
+        return node is ClassDeclarationSyntax { BaseList.Types.Count: > 0 }
+               || (node is RecordDeclarationSyntax { BaseList.Types.Count: > 0 } record
+                   && record.ClassOrStructKeyword.ValueText != "struct");
+    }
+
+    private static ModuleMetadataInfo? GetModuleMetadata(GeneratorSyntaxContext context)
+    {
+        if (context.SemanticModel.GetDeclaredSymbol(context.Node) is not INamedTypeSymbol type
+            || type.IsAbstract
+            || type.IsGenericType
+            || !ImplementsModule(type, context.SemanticModel.Compilation))
+        {
+            return null;
+        }
+
+        var currentAssembly = context.SemanticModel.Compilation.Assembly;
+        var dependencies = ImmutableArray.CreateBuilder<DependencyMetadataInfo>();
+        var dependenciesComplete = true;
+
+        foreach (var attribute in GetDependencyAttributes(type))
+        {
+            if (!TryGetDependency(attribute, out var dependencyType, out var optional)
+                || dependencyType is not INamedTypeSymbol namedDependency
+                || namedDependency.IsUnboundGenericType
+                || !ImplementsModule(namedDependency, context.SemanticModel.Compilation)
+                || !IsTypeReferenceAccessible(namedDependency, currentAssembly))
+            {
+                dependenciesComplete = false;
+                continue;
+            }
+
+            dependencies.Add(new DependencyMetadataInfo(
+                namedDependency.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                optional));
+        }
+
+        return new ModuleMetadataInfo(
+            type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            IsTypeAccessible(type, currentAssembly),
+            dependencies
+                .OrderBy(static dependency => dependency.TypeName, StringComparer.Ordinal)
+                .ThenBy(static dependency => dependency.Optional)
+                .ToImmutableArray(),
+            dependenciesComplete);
+    }
+
+    private static IEnumerable<AttributeData> GetDependencyAttributes(INamedTypeSymbol type)
+    {
+        foreach (var interfaceType in type.AllInterfaces)
+        {
+            foreach (var attribute in interfaceType.GetAttributes().Where(IsDependsOnAttribute))
+            {
+                yield return attribute;
+            }
+        }
+
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            foreach (var attribute in current.GetAttributes().Where(IsDependsOnAttribute))
+            {
+                yield return attribute;
+            }
+        }
+    }
+
+    private static bool IsDependsOnAttribute(AttributeData attribute)
+    {
+        for (var current = attribute.AttributeClass; current is not null; current = current.BaseType)
+        {
+            if (current.ToDisplayString() == DependsOnAttributeFullName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetDependency(
+        AttributeData attribute,
+        out ITypeSymbol? dependencyType,
+        out bool optional)
+    {
+        optional = attribute.NamedArguments
+            .FirstOrDefault(static argument => argument.Key == "Optional")
+            .Value.Value as bool? ?? false;
+
+        for (var current = attribute.AttributeClass; current is not null; current = current.BaseType)
+        {
+            if (current.MetadataName == GenericDependsOnAttributeMetadataName
+                && current.ContainingNamespace.ToDisplayString() == "ModularPipelines.Attributes")
+            {
+                dependencyType = current.TypeArguments[0];
+                return true;
+            }
+        }
+
+        dependencyType = attribute.ConstructorArguments
+            .FirstOrDefault(static argument => argument.Kind == TypedConstantKind.Type)
+            .Value as ITypeSymbol;
+        return dependencyType is not null;
+    }
+
+    private static bool ImplementsModule(INamedTypeSymbol type, Compilation compilation)
+    {
+        var moduleInterface = compilation.GetTypeByMetadataName(ModuleInterfaceFullName);
+        if (moduleInterface is null)
+        {
+            return false;
+        }
+
+        return SymbolEqualityComparer.Default.Equals(type, moduleInterface)
+               || type.AllInterfaces.Any(candidate =>
+                   SymbolEqualityComparer.Default.Equals(candidate, moduleInterface));
+    }
+
+    private static bool IsTypeAccessible(INamedTypeSymbol type, IAssemblySymbol currentAssembly)
+    {
+        for (var current = type; current is not null; current = current.ContainingType)
+        {
+            if (current.IsFileLocal)
+            {
+                return false;
+            }
+
+            if (!IsAccessible(current, currentAssembly))
+            {
+                return false;
+            }
+        }
+
+        return type.TypeArguments.All(typeArgument =>
+            IsTypeReferenceAccessible(typeArgument, currentAssembly));
+    }
+
+    private static bool IsTypeReferenceAccessible(
+        ITypeSymbol type,
+        IAssemblySymbol currentAssembly)
+    {
+        return type switch
+        {
+            IArrayTypeSymbol arrayType =>
+                IsTypeReferenceAccessible(arrayType.ElementType, currentAssembly),
+            IPointerTypeSymbol pointerType =>
+                IsTypeReferenceAccessible(pointerType.PointedAtType, currentAssembly),
+            INamedTypeSymbol namedType => IsTypeAccessible(namedType, currentAssembly),
+            ITypeParameterSymbol => false,
+            _ => true,
+        };
+    }
+
+    private static bool IsAccessible(INamedTypeSymbol type, IAssemblySymbol currentAssembly)
+    {
+        return type.DeclaredAccessibility == Accessibility.Public
+               || (type.DeclaredAccessibility is (
+                       Accessibility.Internal or Accessibility.ProtectedOrInternal)
+                   && (SymbolEqualityComparer.Default.Equals(
+                           type.ContainingAssembly,
+                           currentAssembly)
+                       || type.ContainingAssembly.GivesAccessTo(currentAssembly)));
+    }
+
+    private static string Generate(string? assemblyName, ImmutableArray<ModuleMetadataInfo> items)
+    {
+        var modules = items
+            .GroupBy(static item => item.TypeName, StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .OrderBy(static item => item.TypeName, StringComparer.Ordinal)
+            .ToArray();
+        var emittedModules = modules.Where(static module => module.CanEmit).ToArray();
+        var isComplete = modules.All(static module => module.CanEmit);
+        var registrationTypeName = $"ModuleMetadataRegistration_{GetStableIdentifier(assemblyName)}";
+        var sb = new StringBuilder();
+
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("namespace ModularPipelines.Generated;");
+        sb.AppendLine();
+        sb.AppendLine($"internal static class {registrationTypeName}");
+        sb.AppendLine("{");
+        sb.AppendLine("    [global::System.Runtime.CompilerServices.ModuleInitializer]");
+        sb.AppendLine("    internal static void Register()");
+        sb.AppendLine("    {");
+        sb.AppendLine("        global::ModularPipelines.Engine.GeneratedModuleMetadata.Register(");
+        sb.AppendLine($"            typeof({registrationTypeName}).Assembly,");
+        sb.AppendLine("            new global::ModularPipelines.Engine.GeneratedModuleRegistration[]");
+        sb.AppendLine("            {");
+
+        foreach (var module in emittedModules)
+        {
+            sb.AppendLine($"                global::ModularPipelines.Engine.GeneratedModuleMetadata.CreateRegistration<{module.TypeName}>(");
+            sb.AppendLine("                    new global::ModularPipelines.Engine.ModuleDependencyMetadata[]");
+            sb.AppendLine("                    {");
+
+            foreach (var dependency in module.Dependencies)
+            {
+                sb.AppendLine($"                        new(typeof({dependency.TypeName}), {BooleanLiteral(dependency.Optional)}),");
+            }
+
+            sb.AppendLine($"                    }}, dependenciesComplete: {BooleanLiteral(module.DependenciesComplete)}),");
+        }
+
+        sb.AppendLine($"            }}, isComplete: {BooleanLiteral(isComplete)});");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+        return sb.ToString();
+    }
+
+    private static string BooleanLiteral(bool value) => value ? "true" : "false";
+
+    private static string GetStableIdentifier(string? value)
+    {
+        var text = value ?? "Assembly";
+        var identifier = new StringBuilder(text.Length + 9);
+        var hash = 2166136261;
+
+        foreach (var character in text)
+        {
+            identifier.Append(char.IsLetterOrDigit(character) ? character : '_');
+            hash = unchecked((hash ^ character) * 16777619);
+        }
+
+        return $"{identifier}_{hash:X8}";
+    }
+
+    private sealed record ModuleMetadataInfo(
+        string TypeName,
+        bool CanEmit,
+        ImmutableArray<DependencyMetadataInfo> Dependencies,
+        bool DependenciesComplete);
+
+    private sealed record DependencyMetadataInfo(string TypeName, bool Optional);
+}

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -228,6 +228,8 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 
         // Generators cannot observe modules emitted by other generators in the same
         // compilation, so assembly discovery must retain its reflection fallback.
+        // TODO(#3228): Revisit completeness when final trim/AOT certification can
+        // account for every generator participating in the compilation.
         const bool isComplete = false;
         var registrationTypeName = $"ModuleMetadataRegistration_{GetStableIdentifier(assemblyName)}";
         var sb = new StringBuilder();

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -70,9 +70,17 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                 continue;
             }
 
+            var isClosedGeneric = namedDependency.IsGenericType
+                                  && !namedDependency.IsUnboundGenericType;
+            var canEmitActivationRegistration = isClosedGeneric
+                                                && SymbolEqualityComparer.Default.Equals(
+                                                    namedDependency.ContainingAssembly,
+                                                    currentAssembly);
             dependencies.Add(new DependencyMetadataInfo(
                 namedDependency.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                optional));
+                optional,
+                canEmitActivationRegistration));
+            dependenciesComplete &= !isClosedGeneric || canEmitActivationRegistration;
         }
 
         return new ModuleMetadataInfo(
@@ -225,6 +233,17 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             .OrderBy(static item => item.TypeName, StringComparer.Ordinal)
             .ToArray();
         var emittedModules = modules.Where(static module => module.CanEmit).ToArray();
+        var emittedModuleNames = emittedModules
+            .Select(static module => module.TypeName)
+            .ToImmutableHashSet(StringComparer.Ordinal);
+        var closedGenericDependencies = modules
+            .SelectMany(static module => module.Dependencies)
+            .Where(static dependency => dependency.EmitActivationRegistration)
+            .Select(static dependency => dependency.TypeName)
+            .Where(typeName => !emittedModuleNames.Contains(typeName))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static typeName => typeName, StringComparer.Ordinal)
+            .ToArray();
 
         // Generators cannot observe modules emitted by other generators in the same
         // compilation, so assembly discovery must retain its reflection fallback.
@@ -263,6 +282,13 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             sb.AppendLine($"                    }}, dependenciesComplete: {BooleanLiteral(module.DependenciesComplete)}),");
         }
 
+        foreach (var typeName in closedGenericDependencies)
+        {
+            sb.AppendLine($"                global::ModularPipelines.Engine.GeneratedModuleMetadata.CreateRegistration<{typeName}>(");
+            sb.AppendLine("                    global::System.Array.Empty<global::ModularPipelines.Engine.ModuleDependencyMetadata>(),");
+            sb.AppendLine("                    dependenciesComplete: false),");
+        }
+
         sb.AppendLine($"            }}, isComplete: {BooleanLiteral(isComplete)});");
         sb.AppendLine("    }");
         sb.AppendLine("}");
@@ -292,5 +318,8 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         ImmutableArray<DependencyMetadataInfo> Dependencies,
         bool DependenciesComplete);
 
-    private sealed record DependencyMetadataInfo(string TypeName, bool Optional);
+    private sealed record DependencyMetadataInfo(
+        string TypeName,
+        bool Optional,
+        bool EmitActivationRegistration);
 }

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -60,27 +60,19 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 
         foreach (var attribute in GetDependencyAttributes(type))
         {
-            if (!TryGetDependency(attribute, out var dependencyType, out var optional)
-                || dependencyType is not INamedTypeSymbol namedDependency
-                || namedDependency.IsUnboundGenericType
-                || !ImplementsModule(namedDependency, context.SemanticModel.Compilation)
-                || !IsTypeReferenceAccessible(namedDependency, currentAssembly))
+            if (!TryGetDependencyMetadata(
+                    attribute,
+                    context.SemanticModel.Compilation,
+                    currentAssembly,
+                    out var dependency,
+                    out var dependencyComplete))
             {
                 dependenciesComplete = false;
                 continue;
             }
 
-            var isClosedGeneric = namedDependency.IsGenericType
-                                  && !namedDependency.IsUnboundGenericType;
-            var canEmitActivationRegistration = isClosedGeneric
-                                                && SymbolEqualityComparer.Default.Equals(
-                                                    namedDependency.ContainingAssembly,
-                                                    currentAssembly);
-            dependencies.Add(new DependencyMetadataInfo(
-                namedDependency.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                optional,
-                canEmitActivationRegistration));
-            dependenciesComplete &= !isClosedGeneric || canEmitActivationRegistration;
+            dependencies.Add(dependency);
+            dependenciesComplete &= dependencyComplete;
         }
 
         return new ModuleMetadataInfo(
@@ -90,6 +82,38 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                 .OrderBy(static dependency => dependency.TypeName, StringComparer.Ordinal)
                 .ThenBy(static dependency => dependency.Optional)],
             dependenciesComplete);
+    }
+
+    private static bool TryGetDependencyMetadata(
+        AttributeData attribute,
+        Compilation compilation,
+        IAssemblySymbol currentAssembly,
+        out DependencyMetadataInfo dependency,
+        out bool dependencyComplete)
+    {
+        dependency = default!;
+        dependencyComplete = false;
+        if (!TryGetDependency(attribute, out var dependencyType, out var optional)
+            || dependencyType is not INamedTypeSymbol namedDependency
+            || namedDependency.IsUnboundGenericType
+            || !ImplementsModule(namedDependency, compilation)
+            || !IsTypeReferenceAccessible(namedDependency, currentAssembly))
+        {
+            return false;
+        }
+
+        var isClosedGeneric = namedDependency.IsGenericType
+                              && !namedDependency.IsUnboundGenericType;
+        var canEmitActivationRegistration = isClosedGeneric
+                                            && SymbolEqualityComparer.Default.Equals(
+                                                namedDependency.ContainingAssembly,
+                                                currentAssembly);
+        dependency = new DependencyMetadataInfo(
+            namedDependency.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            optional,
+            canEmitActivationRegistration);
+        dependencyComplete = !isClosedGeneric || canEmitActivationRegistration;
+        return true;
     }
 
     private static IEnumerable<AttributeData> GetDependencyAttributes(INamedTypeSymbol type)

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ModularPipelines.SourceGenerator;
@@ -56,7 +57,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 
         var currentAssembly = context.SemanticModel.Compilation.Assembly;
         var dependencies = ImmutableArray.CreateBuilder<DependencyMetadataInfo>();
-        var dependenciesComplete = true;
+        var dependenciesComplete = !HasPartialDeclaration(type);
 
         foreach (var attribute in GetDependencyAttributes(type))
         {
@@ -82,6 +83,13 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                 .OrderBy(static dependency => dependency.TypeName, StringComparer.Ordinal)
                 .ThenBy(static dependency => dependency.Optional)],
             dependenciesComplete);
+    }
+
+    private static bool HasPartialDeclaration(INamedTypeSymbol type)
+    {
+        return type.DeclaringSyntaxReferences.Any(static reference =>
+            reference.GetSyntax() is TypeDeclarationSyntax declaration
+            && declaration.Modifiers.Any(SyntaxKind.PartialKeyword));
     }
 
     private static bool TryGetDependencyMetadata(

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -78,10 +78,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         return new ModuleMetadataInfo(
             type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
             IsTypeAccessible(type, currentAssembly),
-            dependencies
+            [.. dependencies
                 .OrderBy(static dependency => dependency.TypeName, StringComparer.Ordinal)
-                .ThenBy(static dependency => dependency.Optional)
-                .ToImmutableArray(),
+                .ThenBy(static dependency => dependency.Optional)],
             dependenciesComplete);
     }
 
@@ -122,6 +121,13 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         out ITypeSymbol? dependencyType,
         out bool optional)
     {
+        if (!IsBuiltInDependsOnAttribute(attribute.AttributeClass))
+        {
+            dependencyType = null;
+            optional = false;
+            return false;
+        }
+
         optional = attribute.NamedArguments
             .FirstOrDefault(static argument => argument.Key == "Optional")
             .Value.Value as bool? ?? false;
@@ -140,6 +146,16 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             .FirstOrDefault(static argument => argument.Kind == TypedConstantKind.Type)
             .Value as ITypeSymbol;
         return dependencyType is not null;
+    }
+
+    private static bool IsBuiltInDependsOnAttribute(INamedTypeSymbol? attributeType)
+    {
+        return attributeType is not null
+               && (attributeType.ToDisplayString() == DependsOnAttributeFullName
+                   || (attributeType.OriginalDefinition.MetadataName
+                           == GenericDependsOnAttributeMetadataName
+                       && attributeType.ContainingNamespace.ToDisplayString()
+                           == "ModularPipelines.Attributes"));
     }
 
     private static bool ImplementsModule(INamedTypeSymbol type, Compilation compilation)
@@ -209,7 +225,10 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             .OrderBy(static item => item.TypeName, StringComparer.Ordinal)
             .ToArray();
         var emittedModules = modules.Where(static module => module.CanEmit).ToArray();
-        var isComplete = modules.All(static module => module.CanEmit);
+
+        // Generators cannot observe modules emitted by other generators in the same
+        // compilation, so assembly discovery must retain its reflection fallback.
+        const bool isComplete = false;
         var registrationTypeName = $"ModuleMetadataRegistration_{GetStableIdentifier(assemblyName)}";
         var sb = new StringBuilder();
 

--- a/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
@@ -1,7 +1,7 @@
 using System.Collections.Frozen;
 using System.Reflection;
 using ModularPipelines.Attributes;
-using ModularPipelines.Extensions;
+using ModularPipelines.Engine;
 using ModularPipelines.Models;
 
 namespace ModularPipelines.Configuration;
@@ -65,11 +65,11 @@ internal static class ModuleConfigurationAttributeAdapter
         Type moduleType,
         IReadOnlyList<DeclaredDependency> configuredDependencies)
     {
-        var attributeDependencies = moduleType
-            .GetCustomAttributesIncludingBaseInterfaces<DependsOnAttribute>()
-            .Select(attribute => attribute.Optional
-                ? DeclaredDependency.Optional(attribute.Type)
-                : DeclaredDependency.Required(attribute.Type));
+        var attributeDependencies = ModuleDependencyResolver
+            .GetDependencies(moduleType)
+            .Select(dependency => dependency.Optional
+                ? DeclaredDependency.Optional(dependency.DependencyType)
+                : DeclaredDependency.Required(dependency.DependencyType));
 
         return attributeDependencies
             .Concat(configuredDependencies)

--- a/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
+++ b/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
@@ -14,7 +14,7 @@ internal class AssemblyLoadedTypesProvider : IAssemblyLoadedTypesProvider
         return AppDomain.CurrentDomain
             .GetAssemblies()
             .Where(ReferencesModularPipelines)
-            .SelectMany(GetLoadableTypes)
+            .SelectMany(assembly => GetKnownTypes(assembly, type))
             .Where(t => t.IsAssignableTo(type))
             .Where(t => !t.IsAbstract)
             .ToArray();
@@ -34,7 +34,23 @@ internal class AssemblyLoadedTypesProvider : IAssemblyLoadedTypesProvider
     [UnconditionalSuppressMessage(
         "Trimming",
         "IL2026",
-        Justification = "Unused-module diagnostics tolerate types removed by trimming.")]
+        Justification = "Generated metadata is used when complete; reflection is the explicit compatibility fallback for dynamic assemblies.")]
+    internal static IEnumerable<Type> GetKnownTypes(Assembly assembly, Type assignableTo)
+    {
+        if (typeof(IModule).IsAssignableFrom(assignableTo)
+            && GeneratedModuleMetadata.TryGetModuleTypes(
+                assembly,
+                out var generatedModuleTypes,
+                out var generatedMetadataIsComplete)
+            && generatedMetadataIsComplete)
+        {
+            return generatedModuleTypes;
+        }
+
+        return GetLoadableTypes(assembly);
+    }
+
+    [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetTypes()")]
     private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
     {
         try

--- a/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
+++ b/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
@@ -11,13 +11,15 @@ internal class AssemblyLoadedTypesProvider : IAssemblyLoadedTypesProvider
 
     public Type[] GetLoadedTypesAssignableTo(Type type)
     {
-        return AppDomain.CurrentDomain
+        return
+        [
+            .. AppDomain.CurrentDomain
             .GetAssemblies()
             .Where(ReferencesModularPipelines)
             .SelectMany(assembly => GetKnownTypes(assembly, type))
             .Where(t => t.IsAssignableTo(type))
-            .Where(t => !t.IsAbstract)
-            .ToArray();
+            .Where(t => !t.IsAbstract),
+        ];
     }
 
     [UnconditionalSuppressMessage(
@@ -47,19 +49,6 @@ internal class AssemblyLoadedTypesProvider : IAssemblyLoadedTypesProvider
             return generatedModuleTypes;
         }
 
-        return GetLoadableTypes(assembly);
-    }
-
-    [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetTypes()")]
-    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
-    {
-        try
-        {
-            return assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException e)
-        {
-            return e.Types.OfType<Type>();
-        }
+        return AssemblyTypeLoader.GetLoadableTypes(assembly);
     }
 }

--- a/src/ModularPipelines/Engine/AssemblyTypeLoader.cs
+++ b/src/ModularPipelines/Engine/AssemblyTypeLoader.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace ModularPipelines.Engine;
+
+internal static class AssemblyTypeLoader
+{
+    [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetTypes()")]
+    internal static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException exception)
+        {
+            return exception.Types.OfType<Type>();
+        }
+    }
+}

--- a/src/ModularPipelines/Engine/DependencyGraphValidator.cs
+++ b/src/ModularPipelines/Engine/DependencyGraphValidator.cs
@@ -81,16 +81,16 @@ internal static class DependencyGraphValidator
     private static IEnumerable<Type> GetDependencyTypes(Type moduleType, HashSet<Type> availableModuleTypes)
     {
         // Get direct DependsOn attributes
-        foreach (var attribute in moduleType.GetCustomAttributesIncludingBaseInterfaces<DependsOnAttribute>())
+        foreach (var dependency in ModuleDependencyResolver.GetDependencies(moduleType))
         {
             // Only include if this dependency type is actually being registered
             // Also handle Optional - if the dependency is not registered and
             // Optional is true, we skip it for cycle detection
-            if (availableModuleTypes.Contains(attribute.Type))
+            if (availableModuleTypes.Contains(dependency.DependencyType))
             {
-                yield return attribute.Type;
+                yield return dependency.DependencyType;
             }
-            else if (!attribute.Optional)
+            else if (!dependency.Optional)
             {
                 // If the dependency is not registered and Optional is false,
                 // we still yield it so the runtime can fail appropriately later.

--- a/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
+++ b/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
@@ -1,0 +1,152 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Extensions;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Stores module discovery, registration, and dependency metadata emitted by
+/// <c>ModularPipelines.SourceGenerator</c>.
+/// </summary>
+public static class GeneratedModuleMetadata
+{
+    private static readonly object RegistrationLock = new();
+    private static readonly ConcurrentDictionary<Assembly, AssemblyModuleMetadata> Assemblies = new();
+    private static readonly ConcurrentDictionary<Type, GeneratedModuleRegistration> Modules = new();
+
+    /// <summary>
+    /// Creates trim-safe registration metadata for one module.
+    /// </summary>
+    /// <returns>The generated registration metadata.</returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static GeneratedModuleRegistration CreateRegistration<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TModule>(
+        IReadOnlyList<ModuleDependencyMetadata> dependencies,
+        bool dependenciesComplete = true)
+        where TModule : class, IModule
+    {
+        return new GeneratedModuleRegistration(
+            typeof(TModule),
+            static services => services.AddModule<TModule>(),
+            dependencies.ToArray(),
+            dependenciesComplete);
+    }
+
+    /// <summary>
+    /// Registers generated module metadata for one assembly.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void Register(
+        Assembly assembly,
+        IReadOnlyList<GeneratedModuleRegistration> registrations,
+        bool isComplete = true)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        ArgumentNullException.ThrowIfNull(registrations);
+
+        var registrationsByType = registrations.ToDictionary(static registration => registration.ModuleType);
+        if (registrationsByType.Keys.Any(moduleType => moduleType.Assembly != assembly))
+        {
+            throw new ArgumentException(
+                "Every generated module must belong to the registered assembly.",
+                nameof(registrations));
+        }
+
+        lock (RegistrationLock)
+        {
+            if (Assemblies.ContainsKey(assembly))
+            {
+                throw new InvalidOperationException(
+                    $"Module metadata is already registered for {assembly.FullName}.");
+            }
+
+            var duplicateModuleType = registrationsByType.Keys.FirstOrDefault(Modules.ContainsKey);
+            if (duplicateModuleType is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Module metadata is already registered for {duplicateModuleType}.");
+            }
+
+            var normalizedRegistrations = registrationsByType.Values
+                .Select(static registration => registration with
+                {
+                    Dependencies = registration.Dependencies.ToArray(),
+                })
+                .ToArray();
+            Assemblies[assembly] = new AssemblyModuleMetadata(normalizedRegistrations, isComplete);
+            foreach (var registration in normalizedRegistrations)
+            {
+                Modules[registration.ModuleType] = registration;
+            }
+        }
+    }
+
+    internal static bool TryGetModuleTypes(
+        Assembly assembly,
+        out IReadOnlyList<Type> moduleTypes,
+        out bool isComplete)
+    {
+        if (Assemblies.TryGetValue(assembly, out var metadata))
+        {
+            moduleTypes = metadata.Registrations
+                .Select(static registration => registration.ModuleType)
+                .ToArray();
+            isComplete = metadata.IsComplete;
+            return true;
+        }
+
+        moduleTypes = Array.Empty<Type>();
+        isComplete = false;
+        return false;
+    }
+
+    internal static bool TryGetDependencies(
+        Type moduleType,
+        out IReadOnlyList<ModuleDependencyMetadata> dependencies)
+    {
+        if (Modules.TryGetValue(moduleType, out var registration)
+            && registration.DependenciesComplete)
+        {
+            dependencies = registration.Dependencies;
+            return true;
+        }
+
+        dependencies = Array.Empty<ModuleDependencyMetadata>();
+        return false;
+    }
+
+    internal static bool TryRegisterModule(IServiceCollection services, Type moduleType)
+    {
+        if (!Modules.TryGetValue(moduleType, out var registration))
+        {
+            return false;
+        }
+
+        registration.Register(services);
+        return true;
+    }
+
+    private sealed record AssemblyModuleMetadata(
+        IReadOnlyList<GeneratedModuleRegistration> Registrations,
+        bool IsComplete);
+}
+
+/// <summary>
+/// Describes one generated module and provides its reflection-free DI registration.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public sealed record GeneratedModuleRegistration(
+    Type ModuleType,
+    Action<IServiceCollection> Register,
+    IReadOnlyList<ModuleDependencyMetadata> Dependencies,
+    bool DependenciesComplete = true);
+
+/// <summary>
+/// Describes a statically declared module dependency.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public sealed record ModuleDependencyMetadata(Type DependencyType, bool Optional);

--- a/src/ModularPipelines/Engine/ModuleActivator.cs
+++ b/src/ModularPipelines/Engine/ModuleActivator.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Logging;
 using ModularPipelines.Modules;
@@ -34,6 +35,26 @@ internal sealed class ModuleActivator : IModuleActivator
         finally
         {
             // Restore previous context
+            ModuleLogger.CurrentModuleType.Value = previousType;
+        }
+    }
+
+    internal static TModule CreateModule<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TModule>(
+        IServiceProvider serviceProvider)
+        where TModule : class, IModule
+    {
+        var previousType = ModuleLogger.CurrentModuleType.Value;
+        ModuleLogger.CurrentModuleType.Value = typeof(TModule);
+
+        try
+        {
+            var module = ActivatorUtilities.CreateInstance<TModule>(serviceProvider);
+            _ = module.Configuration;
+            return module;
+        }
+        finally
+        {
             ModuleLogger.CurrentModuleType.Value = previousType;
         }
     }

--- a/src/ModularPipelines/Engine/ModuleActivator.cs
+++ b/src/ModularPipelines/Engine/ModuleActivator.cs
@@ -24,23 +24,10 @@ internal sealed class ModuleActivator : IModuleActivator
         Justification = "This runtime-Type overload is the reflection fallback; generated registrations use the annotated generic overload.")]
     public IModule CreateModule(Type moduleType, IServiceProvider serviceProvider)
     {
-        // Save previous context (typically null during construction phase)
-        var previousType = ModuleLogger.CurrentModuleType.Value;
-
-        // Set AsyncLocal context BEFORE construction so constructors can log with context
-        ModuleLogger.CurrentModuleType.Value = moduleType;
-
-        try
-        {
-            var module = (IModule) ActivatorUtilities.CreateInstance(serviceProvider, moduleType);
-            _ = module.Configuration;
-            return module;
-        }
-        finally
-        {
-            // Restore previous context
-            ModuleLogger.CurrentModuleType.Value = previousType;
-        }
+        return CreateModuleWithContext(
+            moduleType,
+            serviceProvider,
+            provider => (IModule) ActivatorUtilities.CreateInstance(provider, moduleType));
     }
 
     internal static TModule CreateModule<
@@ -48,12 +35,24 @@ internal sealed class ModuleActivator : IModuleActivator
         IServiceProvider serviceProvider)
         where TModule : class, IModule
     {
+        return CreateModuleWithContext(
+            typeof(TModule),
+            serviceProvider,
+            static provider => ActivatorUtilities.CreateInstance<TModule>(provider));
+    }
+
+    private static TModule CreateModuleWithContext<TModule>(
+        Type moduleType,
+        IServiceProvider serviceProvider,
+        Func<IServiceProvider, TModule> activate)
+        where TModule : IModule
+    {
         var previousType = ModuleLogger.CurrentModuleType.Value;
-        ModuleLogger.CurrentModuleType.Value = typeof(TModule);
+        ModuleLogger.CurrentModuleType.Value = moduleType;
 
         try
         {
-            var module = ActivatorUtilities.CreateInstance<TModule>(serviceProvider);
+            var module = activate(serviceProvider);
             _ = module.Configuration;
             return module;
         }

--- a/src/ModularPipelines/Engine/ModuleActivator.cs
+++ b/src/ModularPipelines/Engine/ModuleActivator.cs
@@ -18,6 +18,10 @@ namespace ModularPipelines.Engine;
 internal sealed class ModuleActivator : IModuleActivator
 {
     /// <inheritdoc />
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2067",
+        Justification = "This runtime-Type overload is the reflection fallback; generated registrations use the annotated generic overload.")]
     public IModule CreateModule(Type moduleType, IServiceProvider serviceProvider)
     {
         // Save previous context (typically null during construction phase)

--- a/src/ModularPipelines/Engine/ModuleAutoRegistrar.cs
+++ b/src/ModularPipelines/Engine/ModuleAutoRegistrar.cs
@@ -63,8 +63,10 @@ internal static class ModuleAutoRegistrar
         // Register all discovered missing dependencies
         foreach (var moduleType in modulesToAdd)
         {
-            // Use the standard AddModule pattern which handles tracking
-            services.AddModule(moduleType);
+            if (!GeneratedModuleMetadata.TryRegisterModule(services, moduleType))
+            {
+                services.AddModule(moduleType);
+            }
         }
     }
 

--- a/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
+++ b/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
@@ -20,9 +20,9 @@ internal static class ModuleDependencyResolver
     /// </summary>
     public static IEnumerable<(Type DependencyType, bool Optional)> GetDependencies(Type moduleType)
     {
-        foreach (var attribute in moduleType.GetCustomAttributesIncludingBaseInterfaces<DependsOnAttribute>())
+        foreach (var dependency in GetDeclaredDependencies(moduleType))
         {
-            yield return (attribute.Type, attribute.Optional);
+            yield return dependency;
         }
     }
 
@@ -53,9 +53,9 @@ internal static class ModuleDependencyResolver
         var availableModuleTypesList = availableModuleTypes as IReadOnlyList<Type> ?? availableModuleTypes.ToList();
 
         // Handle regular DependsOn attributes
-        foreach (var attribute in moduleType.GetCustomAttributesIncludingBaseInterfaces<DependsOnAttribute>())
+        foreach (var dependency in GetDeclaredDependencies(moduleType))
         {
-            yield return (attribute.Type, attribute.Optional);
+            yield return dependency;
         }
 
         foreach (var dependency in GetSelectorDependencies(moduleType, availableModuleTypesList, dependencyContext))
@@ -219,5 +219,19 @@ internal static class ModuleDependencyResolver
                 yield return (dynamicDep, false);
             }
         }
+    }
+
+    private static IEnumerable<(Type DependencyType, bool Optional)> GetDeclaredDependencies(Type moduleType)
+    {
+        if (GeneratedModuleMetadata.TryGetDependencies(moduleType, out var generatedDependencies))
+        {
+            return generatedDependencies.Select(static dependency => (
+                dependency.DependencyType,
+                dependency.Optional));
+        }
+
+        return moduleType
+            .GetCustomAttributesIncludingBaseInterfaces<DependsOnAttribute>()
+            .Select(static attribute => (attribute.Type, attribute.Optional));
     }
 }

--- a/src/ModularPipelines/Engine/UnusedModuleDetector.cs
+++ b/src/ModularPipelines/Engine/UnusedModuleDetector.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using ModularPipelines.Attributes;
 using ModularPipelines.DependencyInjection;
 using ModularPipelines.Extensions;
 using ModularPipelines.Helpers;
@@ -39,10 +38,9 @@ internal class UnusedModuleDetector : IUnusedModuleDetector
             .ToList();
 
         var unregisteredDependencies = registeredServices
-            .SelectMany(moduleType => moduleType.GetCustomAttributes(typeof(DependsOnAttribute), inherit: true)
-                .Cast<DependsOnAttribute>())
-            .Where(attr => !attr.Optional)
-            .Select(attr => attr.Type)
+            .SelectMany(ModuleDependencyResolver.GetDependencies)
+            .Where(static dependency => !dependency.Optional)
+            .Select(static dependency => dependency.DependencyType)
             .Distinct()
             .Where(depType => !registeredServices.Contains(depType))
             .ToList();

--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -20,7 +20,9 @@ public static class PipelineBuilderExtensions
     /// <param name="builder">The pipeline builder.</param>
     /// <typeparam name="TModule">The type of Module to add.</typeparam>
     /// <returns>The same builder instance for chaining.</returns>
-    public static PipelineBuilder AddModule<TModule>(this PipelineBuilder builder)
+    public static PipelineBuilder AddModule<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TModule>(
+        this PipelineBuilder builder)
         where TModule : class, IModule
     {
         builder.Services.AddModule<TModule>();

--- a/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
@@ -274,14 +274,16 @@ internal static class ServiceCollectionExtensions
             assembly,
             out var generatedModuleTypes,
             out var generatedMetadataIsComplete);
-        var modules = hasGeneratedMetadata && generatedMetadataIsComplete
-            ? generatedModuleTypes.ToList()
-            : GetLoadableTypes(assembly)
-                .Where(type => type.IsAssignableTo(typeof(IModule)))
-                .Where(type => type.IsClass)
-                .Where(type => !type.IsAbstract)
-                .Where(type => !type.IsGenericTypeDefinition)
-                .ToList();
+        List<Type> modules = hasGeneratedMetadata && generatedMetadataIsComplete
+            ? [.. generatedModuleTypes]
+            :
+            [
+                .. AssemblyTypeLoader.GetLoadableTypes(assembly)
+                    .Where(type => type.IsAssignableTo(typeof(IModule)))
+                    .Where(type => type.IsClass)
+                    .Where(type => !type.IsAbstract)
+                    .Where(type => !type.IsGenericTypeDefinition),
+            ];
 
         // Get already registered module types
         var existingModuleTypes = GetRegisteredModuleTypes(services);
@@ -347,19 +349,6 @@ internal static class ServiceCollectionExtensions
     internal static IServiceCollection AddServiceCollection(this IServiceCollection serviceCollection)
     {
         return serviceCollection.AddSingleton<IPipelineServiceContainerWrapper>(new PipelineServiceContainerWrapper(serviceCollection));
-    }
-
-    [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetTypes()")]
-    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
-    {
-        try
-        {
-            return assembly.GetTypes();
-        }
-        catch (ReflectionTypeLoadException exception)
-        {
-            return exception.Types.OfType<Type>();
-        }
     }
 
     /// <summary>

--- a/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
@@ -35,14 +35,15 @@ internal static class ServiceCollectionExtensions
     ///     .AddModule&lt;DeployModule&gt;();
     /// </code>
     /// </example>
-    internal static IServiceCollection AddModule<TModule>(this IServiceCollection services)
+    internal static IServiceCollection AddModule<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TModule>(
+        this IServiceCollection services)
         where TModule : class, IModule
     {
         // Track module type for auto-registration and unused module detection
         GetOrCreateModuleTypesHolder(services).Add(typeof(TModule));
 
-        services.AddSingleton<IModule>(sp =>
-            sp.GetRequiredService<IModuleActivator>().CreateModule(typeof(TModule), sp));
+        services.AddSingleton<IModule>(ModuleActivator.CreateModule<TModule>);
         return services;
     }
 
@@ -269,12 +270,18 @@ internal static class ServiceCollectionExtensions
     [RequiresUnreferencedCode("Module discovery scans all types in an assembly.")]
     internal static IServiceCollection AddModulesFromAssembly(this IServiceCollection services, Assembly assembly)
     {
-        var modules = assembly.GetTypes()
-            .Where(type => type.IsAssignableTo(typeof(IModule)))
-            .Where(type => type.IsClass)
-            .Where(type => !type.IsAbstract)
-            .Where(type => !type.IsGenericTypeDefinition) // Skip open generic types - DI cannot instantiate them
-            .ToList();
+        var hasGeneratedMetadata = GeneratedModuleMetadata.TryGetModuleTypes(
+            assembly,
+            out var generatedModuleTypes,
+            out var generatedMetadataIsComplete);
+        var modules = hasGeneratedMetadata && generatedMetadataIsComplete
+            ? generatedModuleTypes.ToList()
+            : GetLoadableTypes(assembly)
+                .Where(type => type.IsAssignableTo(typeof(IModule)))
+                .Where(type => type.IsClass)
+                .Where(type => !type.IsAbstract)
+                .Where(type => !type.IsGenericTypeDefinition)
+                .ToList();
 
         // Get already registered module types
         var existingModuleTypes = GetRegisteredModuleTypes(services);
@@ -288,13 +295,16 @@ internal static class ServiceCollectionExtensions
         var holder = GetOrCreateModuleTypesHolder(services);
         foreach (var moduleType in modules)
         {
-            // Track module type for auto-registration and unused module detection
-            holder.Add(moduleType);
+            if (!GeneratedModuleMetadata.TryRegisterModule(services, moduleType))
+            {
+                // Track module type for auto-registration and unused module detection
+                holder.Add(moduleType);
 
-            // Capture moduleType in closure to avoid closure over loop variable
-            var capturedType = moduleType;
-            services.AddSingleton(typeof(IModule), sp =>
-                sp.GetRequiredService<IModuleActivator>().CreateModule(capturedType, sp));
+                // Capture moduleType in closure to avoid closure over loop variable
+                var capturedType = moduleType;
+                services.AddSingleton(typeof(IModule), sp =>
+                    sp.GetRequiredService<IModuleActivator>().CreateModule(capturedType, sp));
+            }
         }
 
         return services;
@@ -337,6 +347,19 @@ internal static class ServiceCollectionExtensions
     internal static IServiceCollection AddServiceCollection(this IServiceCollection serviceCollection)
     {
         return serviceCollection.AddSingleton<IPipelineServiceContainerWrapper>(new PipelineServiceContainerWrapper(serviceCollection));
+    }
+
+    [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetTypes()")]
+    private static IEnumerable<Type> GetLoadableTypes(Assembly assembly)
+    {
+        try
+        {
+            return assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException exception)
+        {
+            return exception.Types.OfType<Type>();
+        }
     }
 
     /// <summary>

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -164,6 +164,9 @@ public class ModuleMetadataGeneratorTests
         {
             await Assert.That(generated)
                 .Contains("new(typeof(global::Consumer.GenericModule<string>), false)");
+            await Assert.That(CountOccurrences(
+                generated,
+                "CreateRegistration<global::Consumer.GenericModule<string>>")).IsEqualTo(1);
             await Assert.That(generated).Contains("dependenciesComplete: true");
         }
     }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -58,7 +58,7 @@ public class ModuleMetadataGeneratorTests
                 .Contains("new(typeof(global::Consumer.DependencyModule), true)");
             await Assert.That(generated)
                 .Contains("CreateRegistration<global::Consumer.DependencyModule>");
-            await Assert.That(generated).Contains("isComplete: true");
+            await Assert.That(generated).Contains("isComplete: false");
         }
     }
 
@@ -78,6 +78,25 @@ public class ModuleMetadataGeneratorTests
         await Assert.That(CountOccurrences(
             generated,
             "CreateRegistration<global::Consumer.BuildModule>")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Assembly_Metadata_Remains_Incomplete_When_No_Source_Module_Is_Visible()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                public static class Marker;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated).DoesNotContain("CreateRegistration<global::Consumer");
+            await Assert.That(generated).Contains("isComplete: false");
+        }
     }
 
     [Test]
@@ -107,7 +126,7 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
-    public async Task Open_Generic_Module_Is_Omitted_Without_Forcing_Fallback()
+    public async Task Open_Generic_Module_Is_Omitted_With_Assembly_Fallback()
     {
         var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
             namespace Consumer
@@ -122,7 +141,7 @@ public class ModuleMetadataGeneratorTests
         using (Assert.Multiple())
         {
             await Assert.That(generated).DoesNotContain("GenericModule");
-            await Assert.That(generated).Contains("isComplete: true");
+            await Assert.That(generated).Contains("isComplete: false");
         }
     }
 
@@ -181,6 +200,38 @@ public class ModuleMetadataGeneratorTests
         using (Assert.Multiple())
         {
             await Assert.That(generated).DoesNotContain("new(typeof(string)");
+            await Assert.That(generated).Contains("dependenciesComplete: false");
+        }
+    }
+
+    [Test]
+    public async Task Custom_Generic_Dependency_Attribute_Uses_Reflection_Fallback()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                public sealed class DependencyModule : ModularPipelines.Modules.Module<string>;
+
+                public sealed class OptionalDependencyAttribute
+                    : ModularPipelines.Attributes.DependsOnAttribute<DependencyModule>
+                {
+                    public OptionalDependencyAttribute()
+                    {
+                        Optional = true;
+                    }
+                }
+
+                [OptionalDependency]
+                public sealed class BuildModule : ModularPipelines.Modules.Module<string>;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .DoesNotContain("new(typeof(global::Consumer.DependencyModule)");
             await Assert.That(generated).Contains("dependenciesComplete: false");
         }
     }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -81,6 +81,29 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Partial_Module_Dependency_Metadata_Remains_Incomplete()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                public sealed class DependencyModule : ModularPipelines.Modules.Module<string>;
+
+                [ModularPipelines.Attributes.DependsOn<DependencyModule>]
+                public sealed partial class BuildModule : ModularPipelines.Modules.Module<string>;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .Contains("new(typeof(global::Consumer.DependencyModule), false)");
+            await Assert.That(generated).Contains("dependenciesComplete: false");
+        }
+    }
+
+    [Test]
     public async Task Assembly_Metadata_Remains_Incomplete_When_No_Source_Module_Is_Visible()
     {
         var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -1,0 +1,216 @@
+namespace ModularPipelines.SourceGenerator.UnitTests;
+
+public class ModuleMetadataGeneratorTests
+{
+    private const string TestInfrastructure = """
+        namespace ModularPipelines.Modules
+        {
+            public interface IModule;
+            public abstract class Module<T> : IModule;
+        }
+
+        namespace ModularPipelines.Attributes
+        {
+            [System.AttributeUsage(
+                System.AttributeTargets.Class | System.AttributeTargets.Interface,
+                AllowMultiple = true,
+                Inherited = true)]
+            public class DependsOnAttribute : System.Attribute
+            {
+                public DependsOnAttribute(System.Type type) => Type = type;
+                public System.Type Type { get; }
+                public bool Optional { get; set; }
+            }
+
+            public class DependsOnAttribute<T> : DependsOnAttribute
+            {
+                public DependsOnAttribute() : base(typeof(T))
+                {
+                }
+            }
+        }
+        """;
+
+    [Test]
+    public async Task Generates_Registration_And_Inherited_Dependency_Metadata()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                public sealed class DependencyModule : ModularPipelines.Modules.Module<string>;
+
+                [ModularPipelines.Attributes.DependsOn<DependencyModule>(Optional = true)]
+                public interface IHasDependency;
+
+                public abstract class BaseModule : ModularPipelines.Modules.Module<string>, IHasDependency;
+
+                public sealed class BuildModule : BaseModule;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .Contains("CreateRegistration<global::Consumer.BuildModule>");
+            await Assert.That(generated)
+                .Contains("new(typeof(global::Consumer.DependencyModule), true)");
+            await Assert.That(generated)
+                .Contains("CreateRegistration<global::Consumer.DependencyModule>");
+            await Assert.That(generated).Contains("isComplete: true");
+        }
+    }
+
+    [Test]
+    public async Task Partial_Declarations_Produce_One_Registration()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                public sealed partial class BuildModule : ModularPipelines.Modules.Module<string>;
+                public sealed partial class BuildModule : ModularPipelines.Modules.Module<string>;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        await Assert.That(CountOccurrences(
+            generated,
+            "CreateRegistration<global::Consumer.BuildModule>")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Inaccessible_Module_Uses_Incomplete_Assembly_Metadata()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                public sealed class BuildModule : ModularPipelines.Modules.Module<string>;
+
+                public static class Container
+                {
+                    private sealed class HiddenModule : ModularPipelines.Modules.Module<string>;
+                }
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .Contains("CreateRegistration<global::Consumer.BuildModule>");
+            await Assert.That(generated).DoesNotContain("HiddenModule");
+            await Assert.That(generated).Contains("isComplete: false");
+        }
+    }
+
+    [Test]
+    public async Task Open_Generic_Module_Is_Omitted_Without_Forcing_Fallback()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                public sealed class BuildModule : ModularPipelines.Modules.Module<string>;
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated).DoesNotContain("GenericModule");
+            await Assert.That(generated).Contains("isComplete: true");
+        }
+    }
+
+    [Test]
+    public async Task Closed_Generic_Dependency_Is_Emitted()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                [ModularPipelines.Attributes.DependsOn(typeof(GenericModule<string>))]
+                public sealed class BuildModule : ModularPipelines.Modules.Module<string>;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .Contains("new(typeof(global::Consumer.GenericModule<string>), false)");
+            await Assert.That(generated).Contains("dependenciesComplete: true");
+        }
+    }
+
+    [Test]
+    public async Task Direct_IModule_Implementation_Is_Registered()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                public sealed class DirectModule : ModularPipelines.Modules.IModule;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        await Assert.That(generated)
+            .Contains("CreateRegistration<global::Consumer.DirectModule>");
+    }
+
+    [Test]
+    public async Task Invalid_Legacy_Dependency_Uses_Reflection_Fallback()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                [ModularPipelines.Attributes.DependsOn(typeof(string))]
+                public sealed class BuildModule : ModularPipelines.Modules.Module<string>;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated).DoesNotContain("new(typeof(string)");
+            await Assert.That(generated).Contains("dependenciesComplete: false");
+        }
+    }
+
+    [Test]
+    public async Task Unchanged_Compilation_Uses_Incremental_Cache()
+    {
+        var result = GeneratorTestHarness.RunTwiceWithStepTracking(
+            new ModuleMetadataGenerator(),
+            TestInfrastructure,
+            """
+            namespace Consumer
+            {
+                public sealed class BuildModule : ModularPipelines.Modules.Module<string>;
+            }
+            """);
+
+        await Assert.That(GeneratorTestHarness.HasCachedOutput(result)).IsTrue();
+    }
+
+    private static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        var startIndex = 0;
+        while ((startIndex = source.IndexOf(value, startIndex, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            startIndex += value.Length;
+        }
+
+        return count;
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
@@ -1,0 +1,130 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Engine;
+using ModularPipelines.Extensions;
+using ModularPipelines.Modules;
+using ModularPipelines.TestHelpers;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class GeneratedModuleMetadataTests
+{
+    [Test]
+    public async Task Generated_Dependencies_Are_Used_For_Dependency_Only_Registration()
+    {
+        var services = new ServiceCollection();
+        services.AddModule<GeneratedMetadataDependentModule>();
+
+        var found = GeneratedModuleMetadata.TryGetDependencies(
+            typeof(GeneratedMetadataDependentModule),
+            out var dependencies);
+        ModuleAutoRegistrar.AutoRegisterMissingDependencies(services);
+        var registeredTypes = ServiceCollectionExtensions.GetRegisteredModuleTypes(services);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(found).IsTrue();
+            await Assert.That(dependencies)
+                .Contains(dependency => dependency.DependencyType == typeof(GeneratedMetadataDependencyModule)
+                                        && !dependency.Optional);
+            await Assert.That(registeredTypes).Contains(typeof(GeneratedMetadataDependencyModule));
+        }
+    }
+
+    [Test]
+    public async Task Generated_Registration_Preserves_Duplicate_Module_Behavior()
+    {
+        var services = new ServiceCollection();
+
+        var first = GeneratedModuleMetadata.TryRegisterModule(
+            services,
+            typeof(GeneratedMetadataDependencyModule));
+        var second = GeneratedModuleMetadata.TryRegisterModule(
+            services,
+            typeof(GeneratedMetadataDependencyModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(first).IsTrue();
+            await Assert.That(second).IsTrue();
+            await Assert.That(services.Count(descriptor => descriptor.ServiceType == typeof(IModule)))
+                .IsEqualTo(2);
+        }
+    }
+
+    [Test]
+    public async Task Dynamic_Assembly_Uses_Reflection_Fallback()
+    {
+        var (assembly, _, module) = CreateDynamicModule("DynamicModule");
+
+        var knownTypes = AssemblyLoadedTypesProvider
+            .GetKnownTypes(assembly, typeof(IModule))
+            .ToArray();
+        var services = new ServiceCollection();
+        services.AddModulesFromAssembly(assembly);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(knownTypes).Contains(module);
+            await Assert.That(ServiceCollectionExtensions.GetRegisteredModuleTypes(services))
+                .Contains(module);
+        }
+    }
+
+    [Test]
+    public async Task Complete_Generated_Metadata_Is_Preferred_Over_Assembly_Scan()
+    {
+        var (_, moduleBuilder, includedModule) = CreateDynamicModule("IncludedModule");
+        _ = CreateDynamicModule(moduleBuilder, "ExcludedModule");
+        var assembly = includedModule.Assembly;
+        GeneratedModuleMetadata.Register(
+            assembly,
+            [
+                new GeneratedModuleRegistration(
+                    includedModule,
+                    static _ => { },
+                    [],
+                    DependenciesComplete: true),
+            ],
+            isComplete: true);
+
+        var knownTypes = AssemblyLoadedTypesProvider
+            .GetKnownTypes(assembly, typeof(IModule))
+            .ToArray();
+
+        await Assert.That(knownTypes).IsEquivalentTo([includedModule]);
+    }
+
+    private static (AssemblyBuilder Assembly, ModuleBuilder ModuleBuilder, Type Module)
+        CreateDynamicModule(string name)
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName($"DynamicModules_{Guid.NewGuid():N}"),
+            AssemblyBuilderAccess.Run);
+        var module = assembly.DefineDynamicModule("Main");
+        return (assembly, module, CreateDynamicModule(module, name));
+    }
+
+    private static Type CreateDynamicModule(ModuleBuilder module, string name)
+    {
+        var typeBuilder = module.DefineType(
+            name,
+            TypeAttributes.Public | TypeAttributes.Class,
+            typeof(TrueModule));
+        var constructor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            Type.EmptyTypes);
+        var il = constructor.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, typeof(TrueModule).GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Ret);
+        return typeBuilder.CreateType()!;
+    }
+}
+
+public sealed class GeneratedMetadataDependencyModule : TrueModule;
+
+[ModularPipelines.Attributes.DependsOn<GeneratedMetadataDependencyModule>]
+public sealed class GeneratedMetadataDependentModule : TrueModule;


### PR DESCRIPTION
## Summary
- emit assembly module discovery, DI registration, and direct dependency metadata
- prefer generated metadata in registration, auto-registration, dependency resolution, and unused-module discovery
- retain annotated reflection fallback for dynamic or incomplete assemblies

## Validation
- core Release build (0 errors; existing warnings only)
- source-generator tests: 17 passed
- generated metadata runtime tests: 4 passed
- dependency/cycle/unused/loaded-type regressions: 27 passed
- targeted whitespace verification

Closes #3226