### PR TITLE
Avoid recursive module cycle detection

### DIFF
--- a/src/ModularPipelines/Engine/DependencyCycleDetector.cs
+++ b/src/ModularPipelines/Engine/DependencyCycleDetector.cs
@@ -1,0 +1,97 @@
+namespace ModularPipelines.Engine;
+
+internal static class DependencyCycleDetector
+{
+    public static IReadOnlyList<Type>? FindCycle<TDependencies>(
+        IReadOnlyDictionary<Type, TDependencies> graph)
+        where TDependencies : IEnumerable<Type>
+    {
+        var colors = graph.Keys.ToDictionary(type => type, _ => VisitColor.White);
+        var currentPath = new List<Type>();
+
+        foreach (var start in graph.Keys)
+        {
+            if (colors[start] != VisitColor.White)
+            {
+                continue;
+            }
+
+            var cycle = FindCycleFrom(start, graph, colors, currentPath);
+            if (cycle is not null)
+            {
+                return cycle;
+            }
+        }
+
+        return null;
+    }
+
+    private static List<Type>? FindCycleFrom<TDependencies>(
+        Type start,
+        IReadOnlyDictionary<Type, TDependencies> graph,
+        Dictionary<Type, VisitColor> colors,
+        List<Type> currentPath)
+        where TDependencies : IEnumerable<Type>
+    {
+        var stack = new Stack<(Type Module, IEnumerator<Type> Dependencies)>();
+        colors[start] = VisitColor.Gray;
+        currentPath.Add(start);
+        stack.Push((start, graph[start].GetEnumerator()));
+
+        while (stack.Count > 0)
+        {
+            var (module, dependencies) = stack.Pop();
+            if (!dependencies.MoveNext())
+            {
+                dependencies.Dispose();
+                colors[module] = VisitColor.Black;
+                currentPath.RemoveAt(currentPath.Count - 1);
+                continue;
+            }
+
+            var dependency = dependencies.Current;
+            stack.Push((module, dependencies));
+
+            if (!colors.TryGetValue(dependency, out var color))
+            {
+                continue;
+            }
+
+            if (color == VisitColor.Gray)
+            {
+                DisposeEnumerators(stack);
+                var cycleStartIndex = currentPath.IndexOf(dependency);
+                var cycle = currentPath.GetRange(
+                    cycleStartIndex,
+                    currentPath.Count - cycleStartIndex);
+                cycle.Add(dependency);
+                return cycle;
+            }
+
+            if (color == VisitColor.White)
+            {
+                colors[dependency] = VisitColor.Gray;
+                currentPath.Add(dependency);
+                stack.Push((dependency, graph[dependency].GetEnumerator()));
+            }
+        }
+
+        return null;
+    }
+
+    private static void DisposeEnumerators(
+        Stack<(Type Module, IEnumerator<Type> Dependencies)> stack)
+    {
+        foreach (var (_, dependencies) in stack)
+        {
+            dependencies.Dispose();
+        }
+    }
+
+    private enum VisitColor
+    {
+        White,
+        Gray,
+        Black,
+    }
+}

--- a/src/ModularPipelines/Engine/DependencyGraphValidator.cs
+++ b/src/ModularPipelines/Engine/DependencyGraphValidator.cs
@@ -34,28 +34,10 @@ internal static class DependencyGraphValidator
         // Build adjacency list: module type -> its dependencies (types it depends on)
         var adjacencyList = BuildAdjacencyList(moduleTypeSet);
 
-        // Track visit states for cycle detection
-        // 0 = not visited, 1 = in current DFS path (gray), 2 = fully processed (black)
-        var visitState = new Dictionary<Type, int>();
-        foreach (var moduleType in moduleTypeSet)
+        var cycle = DependencyCycleDetector.FindCycle(adjacencyList);
+        if (cycle is not null)
         {
-            visitState[moduleType] = 0;
-        }
-
-        // Track the current path for error reporting
-        var currentPath = new List<Type>();
-
-        // Run DFS from each unvisited node
-        foreach (var moduleType in moduleTypeSet)
-        {
-            if (visitState[moduleType] == 0)
-            {
-                if (DetectCycleDfs(moduleType, adjacencyList, visitState, currentPath, moduleTypeSet))
-                {
-                    // Cycle detected - currentPath contains the cycle
-                    throw CircularDependencyException.CreateWithCyclePath(currentPath.ToList());
-                }
-            }
+            throw CircularDependencyException.CreateWithCyclePath(cycle);
         }
     }
 
@@ -69,7 +51,7 @@ internal static class DependencyGraphValidator
         foreach (var moduleType in moduleTypes)
         {
             var dependencies = GetDependencyTypes(moduleType, moduleTypes);
-            adjacencyList[moduleType] = dependencies.ToList();
+            adjacencyList[moduleType] = [.. dependencies];
         }
 
         return adjacencyList;
@@ -116,70 +98,5 @@ internal static class DependencyGraphValidator
                 }
             }
         }
-    }
-
-    /// <summary>
-    /// Performs depth-first search to detect cycles.
-    /// </summary>
-    /// <returns>True if a cycle is detected, false otherwise.</returns>
-    private static bool DetectCycleDfs(
-        Type current,
-        Dictionary<Type, List<Type>> adjacencyList,
-        Dictionary<Type, int> visitState,
-        List<Type> currentPath,
-        HashSet<Type> moduleTypeSet)
-    {
-        // Mark as in-progress (gray)
-        visitState[current] = 1;
-        currentPath.Add(current);
-
-        // Check all dependencies
-        if (adjacencyList.TryGetValue(current, out var dependencies))
-        {
-            foreach (var dependency in dependencies)
-            {
-                // Skip dependencies that aren't in our module set (they're not being registered)
-                if (!moduleTypeSet.Contains(dependency))
-                {
-                    continue;
-                }
-
-                if (visitState.TryGetValue(dependency, out var state))
-                {
-                    if (state == 1)
-                    {
-                        // Found a back edge - cycle detected!
-                        // Add the dependency again to show the complete cycle
-                        currentPath.Add(dependency);
-
-                        // Trim the path to show only the cycle
-                        var cycleStartIndex = currentPath.IndexOf(dependency);
-                        if (cycleStartIndex >= 0 && cycleStartIndex < currentPath.Count - 1)
-                        {
-                            currentPath.RemoveRange(0, cycleStartIndex);
-                        }
-
-                        return true;
-                    }
-
-                    if (state == 0)
-                    {
-                        // Not visited - recurse
-                        if (DetectCycleDfs(dependency, adjacencyList, visitState, currentPath, moduleTypeSet))
-                        {
-                            return true;
-                        }
-                    }
-
-                    // If state == 2, already fully processed, no cycle through this node
-                }
-            }
-        }
-
-        // Mark as fully processed (black)
-        visitState[current] = 2;
-        currentPath.RemoveAt(currentPath.Count - 1);
-
-        return false;
     }
 }

--- a/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
+++ b/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
@@ -19,6 +19,33 @@ public static class ModuleDependencyValidator
     public static void Validate(IEnumerable<IModule> registeredModules)
         => Validate(registeredModules, dynamicRegistry: null, metadataRegistry: null);
 
+    /// <summary>
+    /// Validates all registered module dependencies.
+    /// </summary>
+    /// <param name="registeredModuleTypes">The types of all registered modules.</param>
+    /// <exception cref="ModuleReferencingSelfException">
+    /// Thrown when a module depends on itself.
+    /// </exception>
+    /// <exception cref="DependencyCollisionException">
+    /// Thrown when circular dependencies are detected.
+    /// </exception>
+    /// <exception cref="ModuleNotRegisteredException">
+    /// Thrown when a required dependency is not registered.
+    /// </exception>
+    public static void Validate(IEnumerable<Type> registeredModuleTypes)
+    {
+        var moduleTypes = registeredModuleTypes.ToHashSet();
+
+        if (moduleTypes.Count == 0)
+        {
+            return;
+        }
+
+        ValidateSelfReferences(moduleTypes);
+        ValidateMissingDependencies(moduleTypes);
+        ValidateCircularDependencies(moduleTypes);
+    }
+
     internal static void Validate(
         IEnumerable<IModule> registeredModules,
         IModuleDependencyRegistry? dynamicRegistry,
@@ -76,30 +103,44 @@ public static class ModuleDependencyValidator
     }
 
     /// <summary>
-    /// Validates all registered module dependencies.
+    /// Validates a dependency graph that may have been extended at runtime.
     /// </summary>
-    /// <param name="registeredModuleTypes">The types of all registered modules.</param>
-    /// <exception cref="ModuleReferencingSelfException">
-    /// Thrown when a module depends on itself.
-    /// </exception>
-    /// <exception cref="DependencyCollisionException">
-    /// Thrown when circular dependencies are detected.
-    /// </exception>
-    /// <exception cref="ModuleNotRegisteredException">
-    /// Thrown when a required dependency is not registered.
-    /// </exception>
-    public static void Validate(IEnumerable<Type> registeredModuleTypes)
+    /// <param name="dependencyGraph">The declared dependencies keyed by registered module type.</param>
+    /// <exception cref="DependencyCollisionException">Thrown when circular dependencies are detected.</exception>
+    internal static void ValidateCircularDependencies(IReadOnlyDictionary<Type, HashSet<Type>> dependencyGraph)
     {
-        var moduleTypes = registeredModuleTypes.ToHashSet();
+        // Detect cycles using DFS with coloring
+        // White (0) = not visited, Gray (1) = in current path, Black (2) = fully processed
+        var colors = new Dictionary<Type, int>();
+        var parent = new Dictionary<Type, Type?>();
 
-        if (moduleTypes.Count == 0)
+        foreach (var moduleType in dependencyGraph.Keys)
         {
-            return;
+            colors[moduleType] = 0;
+            parent[moduleType] = null;
         }
 
-        ValidateSelfReferences(moduleTypes);
-        ValidateMissingDependencies(moduleTypes);
-        ValidateCircularDependencies(moduleTypes);
+        foreach (var moduleType in dependencyGraph.Keys)
+        {
+            if (colors[moduleType] == 0)
+            {
+                var cycleStart = DetectCycle(moduleType, dependencyGraph, colors, parent);
+                if (cycleStart != null)
+                {
+                    var cycle = BuildCyclePath(cycleStart, parent);
+                    var formattedArray = cycle.Select(t => t.Name).ToArray();
+
+                    // Format with bold markers on first and last to match existing behavior
+                    formattedArray[0] = $"**{formattedArray[0]}**";
+                    formattedArray[^1] = $"**{formattedArray[^1]}**";
+
+                    var cycleDescription = string.Join(" -> ", formattedArray);
+
+                    throw new DependencyCollisionException(
+                        $"Dependency collision detected: {cycleDescription}");
+                }
+            }
+        }
     }
 
     private static HashSet<(Type DependencyType, bool Optional)> GetAllDependencies(
@@ -187,87 +228,52 @@ public static class ModuleDependencyValidator
     }
 
     /// <summary>
-    /// Validates a dependency graph that may have been extended at runtime.
+    /// Performs iterative DFS to detect cycles, returning the start of a cycle if found.
     /// </summary>
-    /// <param name="dependencyGraph">The declared dependencies keyed by registered module type.</param>
-    /// <exception cref="DependencyCollisionException">Thrown when circular dependencies are detected.</exception>
-    internal static void ValidateCircularDependencies(IReadOnlyDictionary<Type, HashSet<Type>> dependencyGraph)
-    {
-        // Detect cycles using DFS with coloring
-        // White (0) = not visited, Gray (1) = in current path, Black (2) = fully processed
-        var colors = new Dictionary<Type, int>();
-        var parent = new Dictionary<Type, Type?>();
-
-        foreach (var moduleType in dependencyGraph.Keys)
-        {
-            colors[moduleType] = 0;
-            parent[moduleType] = null;
-        }
-
-        foreach (var moduleType in dependencyGraph.Keys)
-        {
-            if (colors[moduleType] == 0)
-            {
-                var cycleStart = DetectCycleDfs(moduleType, dependencyGraph, colors, parent);
-                if (cycleStart != null)
-                {
-                    var cycle = BuildCyclePath(cycleStart, parent);
-                    var formattedArray = cycle.Select(t => t.Name).ToArray();
-
-                    // Format with bold markers on first and last to match existing behavior
-                    formattedArray[0] = $"**{formattedArray[0]}**";
-                    formattedArray[^1] = $"**{formattedArray[^1]}**";
-
-                    var cycleDescription = string.Join(" -> ", formattedArray);
-
-                    throw new DependencyCollisionException(
-                        $"Dependency collision detected: {cycleDescription}");
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Performs DFS to detect cycles, returning the start of a cycle if found.
-    /// </summary>
-    private static Type? DetectCycleDfs(
-        Type current,
+    private static Type? DetectCycle(
+        Type start,
         IReadOnlyDictionary<Type, HashSet<Type>> graph,
         Dictionary<Type, int> colors,
         Dictionary<Type, Type?> parent)
     {
-        colors[current] = 1; // Gray - currently being processed
+        var stack = new Stack<(Type Module, HashSet<Type>.Enumerator Dependencies)>();
+        colors[start] = 1; // Gray - currently being processed
+        stack.Push((start, graph[start].GetEnumerator()));
 
-        if (graph.TryGetValue(current, out var dependencies))
+        while (stack.Count > 0)
         {
-            foreach (var dependency in dependencies)
+            var (module, dependencies) = stack.Pop();
+
+            if (!dependencies.MoveNext())
             {
-                // Dependencies not yet registered cannot participate in a cycle.
-                if (!colors.ContainsKey(dependency))
-                {
-                    continue;
-                }
+                colors[module] = 2; // Black - fully processed
+                continue;
+            }
 
-                if (colors[dependency] == 1)
-                {
-                    // Found a cycle - dependency is currently being processed
-                    parent[dependency] = current;
-                    return dependency;
-                }
+            var dependency = dependencies.Current;
+            stack.Push((module, dependencies));
 
-                if (colors[dependency] == 0)
-                {
-                    parent[dependency] = current;
-                    var cycleStart = DetectCycleDfs(dependency, graph, colors, parent);
-                    if (cycleStart != null)
-                    {
-                        return cycleStart;
-                    }
-                }
+            // Dependencies not yet registered cannot participate in a cycle.
+            if (!colors.TryGetValue(dependency, out var color))
+            {
+                continue;
+            }
+
+            if (color == 1)
+            {
+                // Found a cycle - dependency is currently being processed
+                parent[dependency] = module;
+                return dependency;
+            }
+
+            if (color == 0)
+            {
+                parent[dependency] = module;
+                colors[dependency] = 1;
+                stack.Push((dependency, graph[dependency].GetEnumerator()));
             }
         }
 
-        colors[current] = 2; // Black - fully processed
         return null;
     }
 

--- a/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
+++ b/src/ModularPipelines/Modules/ModuleDependencyValidator.cs
@@ -109,37 +109,19 @@ public static class ModuleDependencyValidator
     /// <exception cref="DependencyCollisionException">Thrown when circular dependencies are detected.</exception>
     internal static void ValidateCircularDependencies(IReadOnlyDictionary<Type, HashSet<Type>> dependencyGraph)
     {
-        // Detect cycles using DFS with coloring
-        // White (0) = not visited, Gray (1) = in current path, Black (2) = fully processed
-        var colors = new Dictionary<Type, int>();
-        var parent = new Dictionary<Type, Type?>();
-
-        foreach (var moduleType in dependencyGraph.Keys)
+        var cycle = DependencyCycleDetector.FindCycle(dependencyGraph);
+        if (cycle is not null)
         {
-            colors[moduleType] = 0;
-            parent[moduleType] = null;
-        }
+            var formattedArray = cycle.Select(t => t.Name).ToArray();
 
-        foreach (var moduleType in dependencyGraph.Keys)
-        {
-            if (colors[moduleType] == 0)
-            {
-                var cycleStart = DetectCycle(moduleType, dependencyGraph, colors, parent);
-                if (cycleStart != null)
-                {
-                    var cycle = BuildCyclePath(cycleStart, parent);
-                    var formattedArray = cycle.Select(t => t.Name).ToArray();
+            // Format with bold markers on first and last to match existing behavior
+            formattedArray[0] = $"**{formattedArray[0]}**";
+            formattedArray[^1] = $"**{formattedArray[^1]}**";
 
-                    // Format with bold markers on first and last to match existing behavior
-                    formattedArray[0] = $"**{formattedArray[0]}**";
-                    formattedArray[^1] = $"**{formattedArray[^1]}**";
+            var cycleDescription = string.Join(" -> ", formattedArray);
 
-                    var cycleDescription = string.Join(" -> ", formattedArray);
-
-                    throw new DependencyCollisionException(
-                        $"Dependency collision detected: {cycleDescription}");
-                }
-            }
+            throw new DependencyCollisionException(
+                $"Dependency collision detected: {cycleDescription}");
         }
     }
 
@@ -225,75 +207,5 @@ public static class ModuleDependencyValidator
         }
 
         ValidateCircularDependencies(dependencyGraph);
-    }
-
-    /// <summary>
-    /// Performs iterative DFS to detect cycles, returning the start of a cycle if found.
-    /// </summary>
-    private static Type? DetectCycle(
-        Type start,
-        IReadOnlyDictionary<Type, HashSet<Type>> graph,
-        Dictionary<Type, int> colors,
-        Dictionary<Type, Type?> parent)
-    {
-        var stack = new Stack<(Type Module, HashSet<Type>.Enumerator Dependencies)>();
-        colors[start] = 1; // Gray - currently being processed
-        stack.Push((start, graph[start].GetEnumerator()));
-
-        while (stack.Count > 0)
-        {
-            var (module, dependencies) = stack.Pop();
-
-            if (!dependencies.MoveNext())
-            {
-                colors[module] = 2; // Black - fully processed
-                continue;
-            }
-
-            var dependency = dependencies.Current;
-            stack.Push((module, dependencies));
-
-            // Dependencies not yet registered cannot participate in a cycle.
-            if (!colors.TryGetValue(dependency, out var color))
-            {
-                continue;
-            }
-
-            if (color == 1)
-            {
-                // Found a cycle - dependency is currently being processed
-                parent[dependency] = module;
-                return dependency;
-            }
-
-            if (color == 0)
-            {
-                parent[dependency] = module;
-                colors[dependency] = 1;
-                stack.Push((dependency, graph[dependency].GetEnumerator()));
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Builds the path of a detected cycle for error reporting.
-    /// </summary>
-    private static List<Type> BuildCyclePath(Type cycleStart, Dictionary<Type, Type?> parent)
-    {
-        var path = new List<Type> { cycleStart };
-        var current = parent[cycleStart];
-
-        while (current != null && current != cycleStart)
-        {
-            path.Add(current);
-            current = parent[current];
-        }
-
-        path.Add(cycleStart); // Complete the cycle
-        path.Reverse();
-
-        return path;
     }
 }

--- a/test/ModularPipelines.UnitTests/Modules/ModuleDependencyValidatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/ModuleDependencyValidatorTests.cs
@@ -44,6 +44,65 @@ public class ModuleDependencyValidatorTests
             .ThrowsNothing();
     }
 
+    [Test]
+    public async Task Validate_Long_Linear_Dependency_Graph_Does_Not_Overflow()
+    {
+        const int chainLength = 20_000;
+        var moduleTypes = CreateGraphNodeTypes(chainLength);
+        var dependencyGraph = moduleTypes.ToDictionary(
+            moduleType => moduleType,
+            _ => new HashSet<Type>());
+
+        for (var index = 0; index < moduleTypes.Length - 1; index++)
+        {
+            dependencyGraph[moduleTypes[index]].Add(moduleTypes[index + 1]);
+        }
+
+        await Assert.That(() => ModuleDependencyValidator.ValidateCircularDependencies(dependencyGraph))
+            .ThrowsNothing();
+    }
+
+    private static Type[] CreateGraphNodeTypes(int count)
+    {
+        Type[] argumentTypes =
+        [
+            typeof(bool),
+            typeof(byte),
+            typeof(char),
+            typeof(decimal),
+            typeof(double),
+            typeof(float),
+            typeof(int),
+            typeof(long),
+            typeof(object),
+            typeof(sbyte),
+            typeof(short),
+            typeof(string),
+            typeof(uint),
+            typeof(ulong),
+            typeof(ushort),
+            typeof(Guid),
+        ];
+        var genericType = typeof(GraphNode<,,,,,,,>);
+        var moduleTypes = new Type[count];
+
+        for (var index = 0; index < count; index++)
+        {
+            var value = index;
+            var genericArguments = new Type[8];
+
+            for (var argumentIndex = 0; argumentIndex < genericArguments.Length; argumentIndex++)
+            {
+                genericArguments[argumentIndex] = argumentTypes[value % argumentTypes.Length];
+                value /= argumentTypes.Length;
+            }
+
+            moduleTypes[index] = genericType.MakeGenericType(genericArguments);
+        }
+
+        return moduleTypes;
+    }
+
     private sealed class ProducerModule : Module<string>
     {
         protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -55,4 +114,6 @@ public class ModuleDependencyValidatorTests
         protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<string?>("consumed");
     }
+
+    private sealed class GraphNode<T1, T2, T3, T4, T5, T6, T7, T8>;
 }


### PR DESCRIPTION
Closes #3250.

Replaces recursive dependency-cycle DFS with an explicit stack while preserving coloring, parent tracking, missing-node handling, and existing cycle messages. Adds a 20,000-node linear graph regression proving validation no longer risks stack overflow.

Validation:
- ModuleDependencyValidatorTests: 3/3 passed
- focused info/whitespace format gates passed
- git diff --check passed