### PR TITLE
Cache build system detection

### DIFF
--- a/src/ModularPipelines/BuildSystemDetector.cs
+++ b/src/ModularPipelines/BuildSystemDetector.cs
@@ -33,35 +33,49 @@ namespace ModularPipelines;
 /// </example>
 internal class BuildSystemDetector : IBuildSystemDetector
 {
-    private readonly IEnvironmentVariablesContext _environmentVariables;
+    private static readonly (string Variable, BuildSystem BuildSystem)[] DetectionOrder =
+    [
+        ("TF_BUILD", BuildSystem.AzurePipelines),
+        ("TEAMCITY_VERSION", BuildSystem.TeamCity),
+        ("GITHUB_ACTIONS", BuildSystem.GitHubActions),
+        ("JENKINS_URL", BuildSystem.Jenkins),
+        ("GITLAB_CI", BuildSystem.GitLab),
+        ("BITBUCKET_BUILD_NUMBER", BuildSystem.Bitbucket),
+        ("TRAVIS", BuildSystem.TravisCI),
+        ("APPVEYOR", BuildSystem.AppVeyor),
+    ];
 
-    private readonly Dictionary<string, BuildSystem> _variablesToBuildSystem = new()
-    {
-        ["TF_BUILD"] = BuildSystem.AzurePipelines,
-        ["TEAMCITY_VERSION"] = BuildSystem.TeamCity,
-        ["GITHUB_ACTIONS"] = BuildSystem.GitHubActions,
-        ["JENKINS_URL"] = BuildSystem.Jenkins,
-        ["GITLAB_CI"] = BuildSystem.GitLab,
-        ["BITBUCKET_BUILD_NUMBER"] = BuildSystem.Bitbucket,
-        ["TRAVIS"] = BuildSystem.TravisCI,
-        ["APPVEYOR"] = BuildSystem.AppVeyor,
-    };
+    private readonly IEnvironmentVariablesContext _environmentVariables;
+    private readonly Lazy<DetectionResult> _detection;
 
     public BuildSystemDetector(IEnvironmentVariablesContext environmentVariables)
     {
         _environmentVariables = environmentVariables;
+        _detection = new Lazy<DetectionResult>(DetectCurrentBuildSystem);
     }
 
-    public BuildSystem GetCurrentBuildSystem()
+    public BuildSystem Current => _detection.Value.BuildSystem;
+
+    public string? MatchedEnvironmentVariable => _detection.Value.EnvironmentVariable;
+
+    public BuildSystem GetCurrentBuildSystem() => Current;
+
+    private DetectionResult DetectCurrentBuildSystem()
     {
-        return _variablesToBuildSystem.Keys
-                   .Where(environmentVariable => !IsEmptyEnvironmentVariable(environmentVariable))
-                   .Select(x => _variablesToBuildSystem[x])
-                   .OfType<BuildSystem?>()
-                   .FirstOrDefault()
-               ?? BuildSystem.Unknown;
+        foreach (var (variable, buildSystem) in DetectionOrder)
+        {
+            if (string.IsNullOrEmpty(_environmentVariables.GetEnvironmentVariable(variable)))
+            {
+                continue;
+            }
+
+            return new DetectionResult(buildSystem, variable);
+        }
+
+        return new DetectionResult(BuildSystem.Unknown, null);
     }
 
-    private bool IsEmptyEnvironmentVariable(string environmentVariable) =>
-        string.IsNullOrEmpty(_environmentVariables.GetEnvironmentVariable(environmentVariable));
+    private readonly record struct DetectionResult(
+        BuildSystem BuildSystem,
+        string? EnvironmentVariable);
 }

--- a/src/ModularPipelines/Context/ContextExtensions.cs
+++ b/src/ModularPipelines/Context/ContextExtensions.cs
@@ -24,7 +24,8 @@ public static class ContextExtensions
     /// var myService = context.GetService&lt;IMyService&gt;();
     /// </code>
     /// </example>
-    public static T GetService<T>(this IPipelineContext context) where T : class
+    public static T GetService<T>(this IPipelineContext context)
+        where T : class
     {
         return context.Services.Get<T>();
     }
@@ -44,7 +45,8 @@ public static class ContextExtensions
     /// }
     /// </code>
     /// </example>
-    public static T? TryGetService<T>(this IPipelineContext context) where T : class
+    public static T? TryGetService<T>(this IPipelineContext context)
+        where T : class
     {
         return context.Services.TryGet<T>();
     }
@@ -106,14 +108,7 @@ public static class ContextExtensions
     /// </example>
     public static bool IsRunningIn(this IPipelineContext context, BuildSystem buildSystem)
     {
-        return buildSystem switch
-        {
-            BuildSystem.GitHubActions => context.Environment.BuildSystem.IsGitHubActions,
-            BuildSystem.AzurePipelines => context.Environment.BuildSystem.IsAzurePipelines,
-            BuildSystem.TeamCity => context.Environment.BuildSystem.IsTeamCity,
-            BuildSystem.Jenkins => context.Environment.BuildSystem.IsJenkins,
-            _ => false,
-        };
+        return context.Environment.BuildSystem.Current == buildSystem;
     }
 
     /// <summary>

--- a/src/ModularPipelines/Context/Domains/Environment/IBuildSystemContext.cs
+++ b/src/ModularPipelines/Context/Domains/Environment/IBuildSystemContext.cs
@@ -1,3 +1,5 @@
+using ModularPipelines.Enums;
+
 namespace ModularPipelines.Context.Domains.Environment;
 
 /// <summary>
@@ -6,47 +8,64 @@ namespace ModularPipelines.Context.Domains.Environment;
 public interface IBuildSystemContext
 {
     /// <summary>
-    /// True if running on GitHub Actions.
+    /// Gets the current build system.
+    /// </summary>
+    BuildSystem Current =>
+        this switch
+        {
+            { IsAzurePipelines: true } => BuildSystem.AzurePipelines,
+            { IsTeamCity: true } => BuildSystem.TeamCity,
+            { IsGitHubActions: true } => BuildSystem.GitHubActions,
+            { IsJenkins: true } => BuildSystem.Jenkins,
+            { IsGitLab: true } => BuildSystem.GitLab,
+            { IsBitbucket: true } => BuildSystem.Bitbucket,
+            { IsTravisCI: true } => BuildSystem.TravisCI,
+            { IsAppVeyor: true } => BuildSystem.AppVeyor,
+            _ => BuildSystem.Unknown,
+        };
+
+    /// <summary>
+    /// Gets a value indicating whether this is running on GitHub Actions.
     /// </summary>
     bool IsGitHubActions { get; }
 
     /// <summary>
-    /// True if running on Azure Pipelines.
+    /// Gets a value indicating whether this is running on Azure Pipelines.
     /// </summary>
     bool IsAzurePipelines { get; }
 
     /// <summary>
-    /// True if running on TeamCity.
+    /// Gets a value indicating whether this is running on TeamCity.
     /// </summary>
     bool IsTeamCity { get; }
 
     /// <summary>
-    /// True if running on Jenkins.
+    /// Gets a value indicating whether this is running on Jenkins.
     /// </summary>
     bool IsJenkins { get; }
 
     /// <summary>
-    /// True if running on GitLab CI/CD.
+    /// Gets a value indicating whether this is running on GitLab CI/CD.
     /// </summary>
     bool IsGitLab { get; }
 
     /// <summary>
-    /// True if running on Bitbucket Pipelines.
+    /// Gets a value indicating whether this is running on Bitbucket Pipelines.
     /// </summary>
     bool IsBitbucket { get; }
 
     /// <summary>
-    /// True if running on Travis CI.
+    /// Gets a value indicating whether this is running on Travis CI.
     /// </summary>
     bool IsTravisCI { get; }
 
     /// <summary>
-    /// True if running on AppVeyor.
+    /// Gets a value indicating whether this is running on AppVeyor.
     /// </summary>
     bool IsAppVeyor { get; }
 
     /// <summary>
-    /// True if running on any CI/CD build server.
+    /// Gets a value indicating whether this is running on any CI/CD build server.
     /// </summary>
     bool IsBuildServer { get; }
 }

--- a/src/ModularPipelines/Context/Domains/Implementations/BuildSystemContext.cs
+++ b/src/ModularPipelines/Context/Domains/Implementations/BuildSystemContext.cs
@@ -1,47 +1,41 @@
 using ModularPipelines.Context.Domains.Environment;
 
+using ModularPipelines.Enums;
+
 namespace ModularPipelines.Context.Domains.Implementations;
 
 /// <summary>
 /// Adapter that wraps <see cref="IBuildSystemDetector"/> to provide the <see cref="IBuildSystemContext"/> interface.
 /// </summary>
-internal class BuildSystemContext : IBuildSystemContext
+internal class BuildSystemContext(IBuildSystemDetector detector) : IBuildSystemContext
 {
-    private readonly IBuildSystemDetector _detector;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BuildSystemContext"/> class.
-    /// </summary>
-    /// <param name="detector">The build system detector to wrap.</param>
-    public BuildSystemContext(IBuildSystemDetector detector)
-    {
-        _detector = detector;
-    }
+    /// <inheritdoc />
+    public BuildSystem Current => detector.Current;
 
     /// <inheritdoc />
-    public bool IsGitHubActions => _detector.IsRunningOnGitHubActions;
+    public bool IsGitHubActions => detector.IsRunningOnGitHubActions;
 
     /// <inheritdoc />
-    public bool IsAzurePipelines => _detector.IsRunningOnAzurePipelines;
+    public bool IsAzurePipelines => detector.IsRunningOnAzurePipelines;
 
     /// <inheritdoc />
-    public bool IsTeamCity => _detector.IsRunningOnTeamCity;
+    public bool IsTeamCity => detector.IsRunningOnTeamCity;
 
     /// <inheritdoc />
-    public bool IsJenkins => _detector.IsRunningOnJenkins;
+    public bool IsJenkins => detector.IsRunningOnJenkins;
 
     /// <inheritdoc />
-    public bool IsGitLab => _detector.IsRunningOnGitLab;
+    public bool IsGitLab => detector.IsRunningOnGitLab;
 
     /// <inheritdoc />
-    public bool IsBitbucket => _detector.IsRunningOnBitbucket;
+    public bool IsBitbucket => detector.IsRunningOnBitbucket;
 
     /// <inheritdoc />
-    public bool IsTravisCI => _detector.IsRunningOnTravisCI;
+    public bool IsTravisCI => detector.IsRunningOnTravisCI;
 
     /// <inheritdoc />
-    public bool IsAppVeyor => _detector.IsRunningOnAppVeyor;
+    public bool IsAppVeyor => detector.IsRunningOnAppVeyor;
 
     /// <inheritdoc />
-    public bool IsBuildServer => _detector.IsKnownBuildAgent;
+    public bool IsBuildServer => detector.IsKnownBuildAgent;
 }

--- a/src/ModularPipelines/Engine/Executors/PipelineInitializer.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineInitializer.cs
@@ -1,88 +1,53 @@
 using System.Collections;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Enums;
 using ModularPipelines.Helpers;
 using ModularPipelines.Models;
 using Spectre.Console;
 
 namespace ModularPipelines.Engine.Executors;
 
-internal class PipelineInitializer : IPipelineInitializer
+internal class PipelineInitializer(
+    IConsolePrinter consolePrinter,
+    ModuleRetriever moduleRetriever,
+    IDependencyChainProvider dependencyChainProvider,
+    IRequirementChecker requirementsChecker,
+    IDependencyDetector dependencyDetector,
+    IPipelineSetupExecutor pipelineSetupExecutor,
+    IBuildSystemDetector buildSystemDetector,
+    IPipelineFileWriter pipelineFileWriter,
+    ILogger<PipelineInitializer> logger,
+    IConsoleWriter consoleWriter,
+    ISecretObfuscator secretObfuscator) : IPipelineInitializer
 {
-    private readonly IDependencyDetector _dependencyDetector;
-    private readonly IRequirementChecker _requirementsChecker;
-    private readonly ModuleRetriever _moduleRetriever;
-    private readonly IDependencyChainProvider _dependencyChainProvider;
-    private readonly IConsolePrinter _consolePrinter;
-    private readonly IPipelineSetupExecutor _pipelineSetupExecutor;
-    private readonly IBuildSystemDetector _buildSystemDetector;
-    private readonly IPipelineFileWriter _pipelineFileWriter;
-    private readonly ILogger<PipelineInitializer> _logger;
-    private readonly IConsoleWriter _consoleWriter;
-    private readonly ISecretObfuscator _secretObfuscator;
-    private OrganizedModules? _organizedModules;
+    private static readonly Action<ILogger, BuildSystem, string, Exception?> LogDetectedBuildSystem =
+        LoggerMessage.Define<BuildSystem, string>(
+            LogLevel.Information,
+            new EventId(1, nameof(LogDetectedBuildSystem)),
+            "Build System: {BuildSystem} (detected from {EnvironmentVariable})");
 
-    public PipelineInitializer(IConsolePrinter consolePrinter,
-        ModuleRetriever moduleRetriever,
-        IDependencyChainProvider dependencyChainProvider,
-        IRequirementChecker requirementsChecker,
-        IDependencyDetector dependencyDetector,
-        IPipelineSetupExecutor pipelineSetupExecutor,
-        IBuildSystemDetector buildSystemDetector,
-        IPipelineFileWriter pipelineFileWriter,
-        ILogger<PipelineInitializer> logger,
-        IConsoleWriter consoleWriter,
-        ISecretObfuscator secretObfuscator)
-    {
-        _consolePrinter = consolePrinter;
-        _moduleRetriever = moduleRetriever;
-        _dependencyChainProvider = dependencyChainProvider;
-        _requirementsChecker = requirementsChecker;
-        _dependencyDetector = dependencyDetector;
-        _pipelineSetupExecutor = pipelineSetupExecutor;
-        _buildSystemDetector = buildSystemDetector;
-        _pipelineFileWriter = pipelineFileWriter;
-        _logger = logger;
-        _consoleWriter = consoleWriter;
-        _secretObfuscator = secretObfuscator;
-    }
+    private static readonly Action<ILogger, BuildSystem, Exception?> LogBuildSystem =
+        LoggerMessage.Define<BuildSystem>(
+            LogLevel.Information,
+            new EventId(2, nameof(LogBuildSystem)),
+            "Build System: {BuildSystem}");
+
+    private readonly IDependencyDetector _dependencyDetector = dependencyDetector;
+    private readonly IRequirementChecker _requirementsChecker = requirementsChecker;
+    private readonly ModuleRetriever _moduleRetriever = moduleRetriever;
+    private readonly IDependencyChainProvider _dependencyChainProvider = dependencyChainProvider;
+    private readonly IConsolePrinter _consolePrinter = consolePrinter;
+    private readonly IPipelineSetupExecutor _pipelineSetupExecutor = pipelineSetupExecutor;
+    private readonly IBuildSystemDetector _buildSystemDetector = buildSystemDetector;
+    private readonly IPipelineFileWriter _pipelineFileWriter = pipelineFileWriter;
+    private readonly ILogger<PipelineInitializer> _logger = logger;
+    private readonly IConsoleWriter _consoleWriter = consoleWriter;
+    private readonly ISecretObfuscator _secretObfuscator = secretObfuscator;
+    private OrganizedModules? _organizedModules;
 
     public async Task<OrganizedModules> Initialize(CancellationToken cancellationToken = default)
     {
         return _organizedModules ??= await InitializeInternal(cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<OrganizedModules> InitializeInternal(CancellationToken cancellationToken)
-    {
-        _consolePrinter.PrintLogo();
-
-        PrintEnvironmentVariables();
-
-        _logger.LogInformation("Build System: {BuildSystem}",
-            _buildSystemDetector.GetCurrentBuildSystem().ToString());
-
-        await _pipelineFileWriter.WritePipelineFiles().ConfigureAwait(false);
-
-        await _pipelineSetupExecutor.OnPipelineStartAsync().ConfigureAwait(false);
-
-        await _requirementsChecker.CheckRequirementsAsync().ConfigureAwait(false);
-
-        var organizedModules = await _moduleRetriever.GetOrganizedModules(cancellationToken).ConfigureAwait(false);
-        _dependencyChainProvider.Initialize(organizedModules.AllModules);
-        _dependencyDetector.Check();
-
-        return organizedModules;
-    }
-
-    private void PrintEnvironmentVariables()
-    {
-        if (!_logger.IsEnabled(LogLevel.Trace))
-        {
-            return;
-        }
-
-        _consoleWriter.Write(CreateEnvironmentVariablesTable(
-            Environment.GetEnvironmentVariables(),
-            value => _secretObfuscator.Obfuscate(value, null)));
     }
 
     internal static Table CreateEnvironmentVariablesTable(
@@ -109,5 +74,46 @@ internal class PipelineInitializer : IPipelineInitializer
         }
 
         return table;
+    }
+
+    private async Task<OrganizedModules> InitializeInternal(CancellationToken cancellationToken)
+    {
+        _consolePrinter.PrintLogo();
+
+        PrintEnvironmentVariables();
+
+        var buildSystem = _buildSystemDetector.Current;
+        if (_buildSystemDetector.MatchedEnvironmentVariable is { } variable)
+        {
+            LogDetectedBuildSystem(_logger, buildSystem, variable, null);
+        }
+        else
+        {
+            LogBuildSystem(_logger, buildSystem, null);
+        }
+
+        await _pipelineFileWriter.WritePipelineFiles().ConfigureAwait(false);
+
+        await _pipelineSetupExecutor.OnPipelineStartAsync().ConfigureAwait(false);
+
+        await _requirementsChecker.CheckRequirementsAsync().ConfigureAwait(false);
+
+        var organizedModules = await _moduleRetriever.GetOrganizedModules(cancellationToken).ConfigureAwait(false);
+        _dependencyChainProvider.Initialize(organizedModules.AllModules);
+        _dependencyDetector.Check();
+
+        return organizedModules;
+    }
+
+    private void PrintEnvironmentVariables()
+    {
+        if (!_logger.IsEnabled(LogLevel.Trace))
+        {
+            return;
+        }
+
+        _consoleWriter.Write(CreateEnvironmentVariablesTable(
+            Environment.GetEnvironmentVariables(),
+            value => _secretObfuscator.Obfuscate(value, null)));
     }
 }

--- a/src/ModularPipelines/IBuildSystemDetector.cs
+++ b/src/ModularPipelines/IBuildSystemDetector.cs
@@ -8,6 +8,16 @@ namespace ModularPipelines;
 public interface IBuildSystemDetector
 {
     /// <summary>
+    /// Gets the current build agent type, if known.
+    /// </summary>
+    BuildSystem Current => GetCurrentBuildSystem();
+
+    /// <summary>
+    /// Gets the environment variable that identified the current build system, if known.
+    /// </summary>
+    string? MatchedEnvironmentVariable => null;
+
+    /// <summary>
     /// Gets a value indicating whether the current build agent is Azure Pipelines.
     /// </summary>
     bool IsRunningOnAzurePipelines => Is(BuildSystem.AzurePipelines);
@@ -63,5 +73,5 @@ public interface IBuildSystemDetector
     /// </summary>
     /// <param name="buildSystem">The build system type to check for.</param>
     /// <returns>True if the pipeline is running on the specified build system; otherwise, false.</returns>
-    bool Is(BuildSystem buildSystem) => GetCurrentBuildSystem() == buildSystem;
+    bool Is(BuildSystem buildSystem) => Current == buildSystem;
 }

--- a/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
@@ -2,7 +2,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains;
+using ModularPipelines.Context.Domains.Environment;
 using ModularPipelines.Context.Domains.Implementations;
+using ModularPipelines.Enums;
 using ModularPipelines.Options;
 using Moq;
 
@@ -139,6 +141,30 @@ public class ContextExtensionsTests
         // Act & Assert
         await Assert.That(() => mockContext.Object.GetRequiredConfigValue("MissingKey"))
             .ThrowsExactly<InvalidOperationException>();
+    }
+
+    [Test]
+    [Arguments(BuildSystem.AzurePipelines)]
+    [Arguments(BuildSystem.TeamCity)]
+    [Arguments(BuildSystem.GitHubActions)]
+    [Arguments(BuildSystem.Jenkins)]
+    [Arguments(BuildSystem.GitLab)]
+    [Arguments(BuildSystem.Bitbucket)]
+    [Arguments(BuildSystem.TravisCI)]
+    [Arguments(BuildSystem.AppVeyor)]
+    [Arguments(BuildSystem.Unknown)]
+    public async Task IsRunningIn_Uses_Current_Build_System(BuildSystem buildSystem)
+    {
+        var buildSystemContext = new Mock<IBuildSystemContext>();
+        buildSystemContext.SetupGet(context => context.Current).Returns(buildSystem);
+        var environmentContext = new Mock<IEnvironmentDomainContext>();
+        environmentContext
+            .SetupGet(context => context.BuildSystem)
+            .Returns(buildSystemContext.Object);
+        var context = new Mock<IPipelineContext>();
+        context.SetupGet(pipelineContext => pipelineContext.Environment).Returns(environmentContext.Object);
+
+        await Assert.That(context.Object.IsRunningIn(buildSystem)).IsTrue();
     }
 
     private static ServicesContext CreateServicesContext(IServiceProvider serviceProvider)

--- a/test/ModularPipelines.UnitTests/Engine/BuildSystemDetectorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/BuildSystemDetectorTests.cs
@@ -19,6 +19,14 @@ public class BuildSystemDetectorTests : TestBase
     }
 
     [Test]
+    public async Task Registration_Resolves_Without_Logger_Cycle()
+    {
+        var detector = await GetService<IBuildSystemDetector>();
+
+        await Assert.That(detector).IsNotNull();
+    }
+
+    [Test]
     public async Task When_No_Known_BuildAgent_Variable_Then_IsKnownBuildAgent_Returns_False()
     {
         await Assert.That(_buildSystemDetector.IsKnownBuildAgent).IsFalse();
@@ -73,5 +81,62 @@ public class BuildSystemDetectorTests : TestBase
             .Setup(x => x.GetEnvironmentVariable(environmentVariableName, It.IsAny<EnvironmentVariableTarget>()))
             .Returns("dummy value");
         await Assert.That(_buildSystemDetector.GetCurrentBuildSystem()).IsEqualTo(expectedBuildSystem);
+    }
+
+    [Test]
+    public async Task Detection_Is_Cached()
+    {
+        _ = _buildSystemDetector.Current;
+        _ = _buildSystemDetector.Current;
+        _ = _buildSystemDetector.GetCurrentBuildSystem();
+
+        foreach (var environmentVariable in new[]
+                 {
+                     "TF_BUILD",
+                     "TEAMCITY_VERSION",
+                     "GITHUB_ACTIONS",
+                     "JENKINS_URL",
+                     "GITLAB_CI",
+                     "BITBUCKET_BUILD_NUMBER",
+                     "TRAVIS",
+                     "APPVEYOR",
+                 })
+        {
+            _environmentVariables.Verify(
+                variables => variables.GetEnvironmentVariable(
+                    environmentVariable,
+                    It.IsAny<EnvironmentVariableTarget>()),
+                Times.Once);
+        }
+    }
+
+    [Test]
+    public async Task Detection_Uses_Explicit_Precedence()
+    {
+        _environmentVariables
+            .Setup(variables => variables.GetEnvironmentVariable(
+                "TF_BUILD",
+                It.IsAny<EnvironmentVariableTarget>()))
+            .Returns("true");
+        _environmentVariables
+            .Setup(variables => variables.GetEnvironmentVariable(
+                "GITHUB_ACTIONS",
+                It.IsAny<EnvironmentVariableTarget>()))
+            .Returns("true");
+
+        await Assert.That(_buildSystemDetector.Current).IsEqualTo(BuildSystem.AzurePipelines);
+    }
+
+    [Test]
+    public async Task Detection_Reports_Matched_Environment_Variable()
+    {
+        _environmentVariables
+            .Setup(variables => variables.GetEnvironmentVariable(
+                "TF_BUILD",
+                It.IsAny<EnvironmentVariableTarget>()))
+            .Returns("true");
+
+        await Assert.That(_buildSystemDetector.Current).IsEqualTo(BuildSystem.AzurePipelines);
+        await Assert.That(_buildSystemDetector.MatchedEnvironmentVariable).IsEqualTo("TF_BUILD");
     }
 }


### PR DESCRIPTION
## Summary
- cache build-system detection and make precedence explicit
- expose the current build system and use equality for every supported system
- log the matched environment variable after dependency injection is complete, avoiding the logger/provider cycle

## Validation
- BuildSystemDetectorTests: 23 passed
- ContextExtensionsTests: 16 passed
- PipelineInitializerTests: 2 passed
- changed-file format/info and whitespace gates
- git diff --check

Closes #3271