### PR TITLE
Certify core trim and Native AOT compatibility

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -537,3 +537,53 @@ jobs:
             }
             Write-Output "::endgroup::"
           }
+
+  trim-aot:
+    name: trim and Native AOT
+    needs: fast-fail
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    env:
+      MSBUILDDISABLENODEREUSE: "1"
+      DOTNET_gcServer: "0"
+
+    steps:
+      - name: Require fast-fail success
+        if: needs.fast-fail.result != 'success'
+        run: |
+          echo "::error::The fast-fail lane did not pass."
+          exit 1
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6.0.0
+        with:
+          dotnet-version: 10.0.x
+      - name: Publish and run trimmed smoke
+        shell: bash
+        run: |
+          dotnet publish \
+            test/ModularPipelines.TrimAotSmoke/ModularPipelines.TrimAotSmoke.csproj \
+            --configuration Release \
+            --runtime linux-x64 \
+            --self-contained true \
+            --output "$RUNNER_TEMP/trim-smoke" \
+            -p:PublishAot=false
+          "$RUNNER_TEMP/trim-smoke/ModularPipelines.TrimAotSmoke" |
+            grep -F TRIM_AOT_SMOKE_OK
+      - name: Publish and run Native AOT smoke
+        shell: bash
+        run: |
+          dotnet publish \
+            test/ModularPipelines.TrimAotSmoke/ModularPipelines.TrimAotSmoke.csproj \
+            --configuration Release \
+            --runtime linux-x64 \
+            --self-contained true \
+            --output "$RUNNER_TEMP/aot-smoke"
+          "$RUNNER_TEMP/aot-smoke/ModularPipelines.TrimAotSmoke" |
+            grep -F TRIM_AOT_SMOKE_OK

--- a/docs/docs/how-to/fsharp.md
+++ b/docs/docs/how-to/fsharp.md
@@ -9,6 +9,10 @@ ModularPipelines modules can be authored and executed from an F# project. Inheri
 from `Module<'T>`, override `ExecuteAsync`, and open
 `ModularPipelines.Extensions` for pipeline-builder extension methods.
 
+F# pipelines currently require a JIT-compiled application. Trimming and Native AOT
+are not supported because the metadata generators run only for C# compilations. The
+package emits `MPAOT001` if an F# project enables `PublishTrimmed` or `PublishAot`.
+
 ```fsharp
 open System.Threading
 open System.Threading.Tasks

--- a/docs/docs/how-to/native-aot.md
+++ b/docs/docs/how-to/native-aot.md
@@ -42,8 +42,9 @@ Native AOT does not support pipeline shapes introduced only at runtime:
 - module or result types supplied dynamically after compilation;
 - selector dependencies such as `DependsOnAllModulesInheritingFrom<T>`,
   `DependsOnModulesWithTag`, `DependsOnModulesInCategory`, custom
-  `DependsOnBaseAttribute` implementations, and similar runtime predicates; use
-  explicit `DependsOn<T>` dependencies instead;
+  `DependsOnBaseAttribute` implementations, custom `DependsOnAttribute`
+  subclasses, and similar runtime predicates; use built-in explicit
+  `DependsOn<T>` dependencies instead;
 - distributed type-erased `ModuleResult` JSON serialization and runtime history
   repositories;
 - reflection-based XML, YAML, or JSON serialization.

--- a/docs/docs/how-to/native-aot.md
+++ b/docs/docs/how-to/native-aot.md
@@ -40,8 +40,10 @@ Native AOT does not support pipeline shapes introduced only at runtime:
 
 - assembly scanning through `AddModulesFromAssembly` or plugin assembly loading;
 - module or result types supplied dynamically after compilation;
-- selector dependencies such as `DependsOnAllModulesInheritingFrom<T>`; use explicit
-  `DependsOn<T>` dependencies instead;
+- selector dependencies such as `DependsOnAllModulesInheritingFrom<T>`,
+  `DependsOnModulesWithTag`, `DependsOnModulesInCategory`, custom
+  `DependsOnBaseAttribute` implementations, and similar runtime predicates; use
+  explicit `DependsOn<T>` dependencies instead;
 - distributed type-erased `ModuleResult` JSON serialization and runtime history
   repositories;
 - reflection-based XML, YAML, or JSON serialization.

--- a/docs/docs/how-to/native-aot.md
+++ b/docs/docs/how-to/native-aot.md
@@ -35,6 +35,8 @@ Native AOT does not support pipeline shapes introduced only at runtime:
 
 - assembly scanning through `AddModulesFromAssembly` or plugin assembly loading;
 - module or result types supplied dynamically after compilation;
+- selector dependencies such as `DependsOnAllModulesInheritingFrom<T>`; use explicit
+  `DependsOn<T>` dependencies instead;
 - distributed type-erased `ModuleResult` JSON serialization and runtime history
   repositories;
 - reflection-based XML, YAML, or JSON serialization.

--- a/docs/docs/how-to/native-aot.md
+++ b/docs/docs/how-to/native-aot.md
@@ -1,0 +1,65 @@
+---
+title: Trimming and Native AOT
+---
+
+The core `ModularPipelines` package supports trimmed and Native AOT applications when
+the pipeline can be described at compile time. Its source generator emits the module,
+dependency, hook, command-option, and secret metadata needed by the runtime.
+
+## Supported pipeline shape
+
+Use generic registration for every module:
+
+```csharp
+using var builder = Pipeline.CreateBuilder(args);
+
+builder
+    .AddModule<BuildModule>()
+    .AddModule<TestModule>();
+
+await builder.ExecutePipelineAsync();
+```
+
+The source generator must run in the application project. Statically declared
+`DependsOn<TModule>` dependencies, module lifecycle attributes, command option
+attributes, and `SecretValue` properties then use generated metadata without runtime
+reflection.
+
+For JSON, use a source-generated `JsonSerializerContext` and the `JsonTypeInfo`
+overloads on `IJsonContext`. The convenience overloads that accept only a value or
+`JsonSerializerOptions` are marked as requiring dynamic code and unreferenced members.
+
+## Unsupported dynamic scenarios
+
+Native AOT does not support pipeline shapes introduced only at runtime:
+
+- assembly scanning through `AddModulesFromAssembly` or plugin assembly loading;
+- module or result types supplied dynamically after compilation;
+- distributed type-erased `ModuleResult` JSON serialization and runtime history
+  repositories;
+- reflection-based XML, YAML, or JSON serialization.
+
+These APIs remain available to JIT-compiled applications and carry trim/AOT
+annotations where appropriate. Tool integration packages are not AOT-certified unless
+their package explicitly declares `IsAotCompatible`.
+
+## Validate an application
+
+Enable the analyzers and publish for a concrete runtime identifier:
+
+```xml
+<PropertyGroup>
+  <PublishAot>true</PublishAot>
+  <PublishTrimmed>true</PublishTrimmed>
+  <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+  <EnableAotAnalyzer>true</EnableAotAnalyzer>
+</PropertyGroup>
+```
+
+```bash
+dotnet publish -c Release -r linux-x64 --self-contained true
+```
+
+The repository validates a representative pipeline with modules, dependencies,
+lifecycle hooks, command execution, generated command metadata, and secret masking in
+both trimmed and Native AOT CI lanes.

--- a/docs/docs/how-to/native-aot.md
+++ b/docs/docs/how-to/native-aot.md
@@ -2,9 +2,14 @@
 title: Trimming and Native AOT
 ---
 
-The core `ModularPipelines` package supports trimmed and Native AOT applications when
-the pipeline can be described at compile time. Its source generator emits the module,
-dependency, hook, command-option, and secret metadata needed by the runtime.
+The core `ModularPipelines` package supports trimmed and Native AOT C# applications
+when the pipeline can be described at compile time. Its C# source generator emits the
+module, dependency, hook, command-option, and secret metadata needed by the runtime.
+
+F# pipeline projects are not trim or Native AOT certified. The package emits
+`MPAOT001` when an F# project enables `PublishTrimmed` or `PublishAot`, because the C#
+source generators cannot emit metadata for an `.fsproj`. Keep F# pipelines
+JIT-compiled, or move their module declarations and registrations into a C# project.
 
 ## Supported pipeline shape
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -106,6 +106,16 @@ with Native AOT.
 
 **Severity:** Warning
 
+## MPG0013
+
+An `AddModule<TModule>()` call uses a type parameter. The source generator cannot
+determine every closed construction that may flow through the generic helper, so
+trim-safe runtime metadata cannot be generated. Register each concrete module type
+directly, or use a non-generic helper that lists concrete registrations explicitly,
+before publishing with Native AOT.
+
+**Severity:** Warning
+
 Diagnostics can be configured with standard MSBuild or `.editorconfig` settings.
 For example:
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -97,6 +97,15 @@ remains available for ordinary JIT deployments.
 
 **Severity:** Warning
 
+## MPG0012
+
+An `AddModule<T>()` call registers a closed generic module declared in another
+assembly. The consumer generator cannot add runtime metadata owned by that external
+assembly. Use a consumer-owned non-generic wrapper for the module before publishing
+with Native AOT.
+
+**Severity:** Warning
+
 Diagnostics can be configured with standard MSBuild or `.editorconfig` settings.
 For example:
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -125,6 +125,15 @@ module declarations before publishing with Native AOT.
 
 **Severity:** Warning
 
+## MPG0015
+
+An `AddModule` call uses a non-concrete static module type, such as `IModule` or an
+abstract module base class. The source generator cannot determine the concrete runtime
+type, so trim-safe runtime metadata cannot be generated. Register the concrete module
+type directly before publishing with Native AOT.
+
+**Severity:** Warning
+
 Diagnostics can be configured with standard MSBuild or `.editorconfig` settings.
 For example:
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -54,9 +54,11 @@ Modular Pipelines uses runtime reflection for the missing metadata.
 
 Command or secret metadata generation was skipped because its declaring type is
 generic or inaccessible to generated code. Make the type and its containing types
-accessible and non-generic. Until fixed, Modular Pipelines uses runtime reflection.
+accessible and non-generic before publishing with trimming or Native AOT. Until
+fixed, Modular Pipelines uses runtime reflection, and required command or secret
+members may be removed by trimming.
 
-**Severity:** Info
+**Severity:** Warning
 
 ## MPG0007
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -138,10 +138,12 @@ type directly before publishing with Native AOT.
 
 ## MPG0016
 
-A module, base class, or implemented interface uses
-`DependsOnAllModulesInheritingFrom<T>`. This selector is evaluated against the runtime
-module set and requires attribute reflection, so trimming can remove its metadata.
-Replace it with explicit `DependsOn<T>` dependencies before publishing with Native AOT.
+A module, base class, or implemented interface uses a runtime selector dependency,
+including `DependsOnAllModulesInheritingFrom<T>`, `DependsOnModulesWithTag`,
+`DependsOnModulesInCategory`, `DependsOnModulesWithAttribute<T>`, or a custom
+`DependsOnBaseAttribute`. These selectors are evaluated against the runtime module set
+and require attribute reflection, so trimming can remove their metadata. Replace them
+with explicit `DependsOn<T>` dependencies before publishing with Native AOT.
 
 **Severity:** Warning
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -99,10 +99,10 @@ remains available for ordinary JIT deployments.
 
 ## MPG0012
 
-An `AddModule<T>()` call registers a closed generic module declared in another
-assembly. The consumer generator cannot add runtime metadata owned by that external
-assembly. Use a consumer-owned non-generic wrapper for the module before publishing
-with Native AOT.
+A consumer references a closed generic module declared in another assembly, either
+through `AddModule<T>()` or a transitive `DependsOn<T>` chain. The consumer generator
+cannot add runtime metadata owned by that external assembly. Use a consumer-owned
+non-generic wrapper for the module before publishing with Native AOT.
 
 **Severity:** Warning
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -138,12 +138,12 @@ type directly before publishing with Native AOT.
 
 ## MPG0016
 
-A module, base class, or implemented interface uses a runtime selector dependency,
-including `DependsOnAllModulesInheritingFrom<T>`, `DependsOnModulesWithTag`,
-`DependsOnModulesInCategory`, `DependsOnModulesWithAttribute<T>`, or a custom
-`DependsOnBaseAttribute`. These selectors are evaluated against the runtime module set
-and require attribute reflection, so trimming can remove their metadata. Replace them
-with explicit `DependsOn<T>` dependencies before publishing with Native AOT.
+A module, base class, or implemented interface uses dependency metadata that requires
+runtime reflection. This includes `DependsOnAllModulesInheritingFrom<T>`,
+`DependsOnModulesWithTag`, `DependsOnModulesInCategory`,
+`DependsOnModulesWithAttribute<T>`, a custom `DependsOnBaseAttribute`, or a custom
+`DependsOnAttribute` subclass. Trimming can remove this metadata. Replace it with the
+built-in explicit `DependsOn<T>` attribute before publishing with Native AOT.
 
 **Severity:** Warning
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -88,6 +88,15 @@ A tool accessor would generate a property whose name is already available on
 
 **Severity:** Error
 
+## MPG0011
+
+Module runtime metadata generation was skipped because the module or one of its
+containing types is inaccessible to generated code. Make the module and its
+containing types accessible before publishing with Native AOT. Runtime reflection
+remains available for ordinary JIT deployments.
+
+**Severity:** Warning
+
 Diagnostics can be configured with standard MSBuild or `.editorconfig` settings.
 For example:
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -116,6 +116,15 @@ before publishing with Native AOT.
 
 **Severity:** Warning
 
+## MPG0014
+
+A module has one or more partial declarations. Another source generator can add a
+partial declaration that this generator cannot observe, so dependency metadata
+remains incomplete and runtime reflection is used as a fallback. Avoid partial
+module declarations before publishing with Native AOT.
+
+**Severity:** Warning
+
 Diagnostics can be configured with standard MSBuild or `.editorconfig` settings.
 For example:
 

--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -134,6 +134,15 @@ type directly before publishing with Native AOT.
 
 **Severity:** Warning
 
+## MPG0016
+
+A module, base class, or implemented interface uses
+`DependsOnAllModulesInheritingFrom<T>`. This selector is evaluated against the runtime
+module set and requires attribute reflection, so trimming can remove its metadata.
+Replace it with explicit `DependsOn<T>` dependencies before publishing with Native AOT.
+
+**Severity:** Warning
+
 Diagnostics can be configured with standard MSBuild or `.editorconfig` settings.
 For example:
 

--- a/docs/docs/how-to/storing-and-retrieving-results.md
+++ b/docs/docs/how-to/storing-and-retrieving-results.md
@@ -28,6 +28,10 @@ builder.AddResultsRepository<MyModuleRepository>();
 await builder.ExecutePipelineAsync();
 ```
 
+Result history resolves type-erased module results at runtime and is not supported for
+trimmed or Native AOT applications. `AddResultsRepository<TRepository>()` emits the
+corresponding trim and dynamic-code warnings.
+
 ```csharp
 public class MyModuleRepository : IModuleResultRepository
 {

--- a/src/ModularPipelines.Build/Modules/RunAllUnitTestsModule.cs
+++ b/src/ModularPipelines.Build/Modules/RunAllUnitTestsModule.cs
@@ -5,7 +5,9 @@ using ModularPipelines.Modules;
 
 namespace ModularPipelines.Build.Modules;
 
+#pragma warning disable MPG0016 // The build pipeline is JIT-only.
 [DependsOnAllModulesInheritingFrom<RunUnitTestModule>]
+#pragma warning restore MPG0016
 public class RunAllUnitTestsModule : Module<bool>
 {
     protected override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)

--- a/src/ModularPipelines.Examples/ModularPipelines.Examples.csproj
+++ b/src/ModularPipelines.Examples/ModularPipelines.Examples.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -121,9 +121,9 @@ internal static class GeneratorDiagnostics
 
     public static DiagnosticDescriptor SelectorDependencyRuntimeMetadata { get; } = Create(
         "MPG0016",
-        "Selector dependency metadata requires reflection",
-        "Selector dependency metadata for module '{0}' requires runtime attribute reflection "
-        + "and may be removed by trimming; use explicit DependsOn<T> dependencies before "
+        "Dependency metadata requires reflection",
+        "Dependency metadata for module '{0}' requires runtime attribute reflection and may "
+        + "be removed by trimming; use built-in explicit DependsOn<T> dependencies before "
         + "publishing with Native AOT",
         DiagnosticSeverity.Warning);
 

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -85,6 +85,14 @@ internal static class GeneratorDiagnostics
         + "before publishing with Native AOT",
         DiagnosticSeverity.Warning);
 
+    public static DiagnosticDescriptor ExternalClosedGenericModuleRuntimeMetadata { get; } = Create(
+        "MPG0012",
+        "External closed generic module lacks runtime metadata",
+        "Runtime metadata for externally declared closed generic module '{0}' cannot be generated "
+        + "from this AddModule call; use a consumer-owned non-generic wrapper before publishing "
+        + "with Native AOT",
+        DiagnosticSeverity.Warning);
+
     private static DiagnosticDescriptor Create(
         string id,
         string title,

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -101,6 +101,14 @@ internal static class GeneratorDiagnostics
         + "Native AOT",
         DiagnosticSeverity.Warning);
 
+    public static DiagnosticDescriptor PartialModuleRuntimeMetadata { get; } = Create(
+        "MPG0014",
+        "Partial module dependency metadata is incomplete",
+        "Runtime dependency metadata for partial module '{0}' is incomplete because another "
+        + "source generator can contribute partial declarations; avoid partial module "
+        + "declarations before publishing with Native AOT",
+        DiagnosticSeverity.Warning);
+
     private static DiagnosticDescriptor Create(
         string id,
         string title,

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -117,6 +117,14 @@ internal static class GeneratorDiagnostics
         + "with Native AOT",
         DiagnosticSeverity.Warning);
 
+    public static DiagnosticDescriptor SelectorDependencyRuntimeMetadata { get; } = Create(
+        "MPG0016",
+        "Selector dependency metadata requires reflection",
+        "Selector dependency metadata for module '{0}' requires runtime attribute reflection "
+        + "and may be removed by trimming; use explicit DependsOn<T> dependencies before "
+        + "publishing with Native AOT",
+        DiagnosticSeverity.Warning);
+
     private static DiagnosticDescriptor Create(
         string id,
         string title,

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -109,6 +109,14 @@ internal static class GeneratorDiagnostics
         + "declarations before publishing with Native AOT",
         DiagnosticSeverity.Warning);
 
+    public static DiagnosticDescriptor NonConcreteModuleRegistrationRuntimeMetadata { get; } = Create(
+        "MPG0015",
+        "Non-concrete module registration lacks runtime metadata",
+        "Runtime metadata cannot be generated for AddModule because the static module type "
+        + "'{0}' is not concrete; register the concrete module type directly before publishing "
+        + "with Native AOT",
+        DiagnosticSeverity.Warning);
+
     private static DiagnosticDescriptor Create(
         string id,
         string title,

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -93,6 +93,14 @@ internal static class GeneratorDiagnostics
         + "with Native AOT",
         DiagnosticSeverity.Warning);
 
+    public static DiagnosticDescriptor GenericModuleRegistrationRuntimeMetadata { get; } = Create(
+        "MPG0013",
+        "Generic module registration lacks runtime metadata",
+        "Runtime metadata cannot be generated for AddModule<{0}> because the module type is a "
+        + "type parameter; register each concrete module type directly before publishing with "
+        + "Native AOT",
+        DiagnosticSeverity.Warning);
+
     private static DiagnosticDescriptor Create(
         string id,
         string title,

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -89,7 +89,7 @@ internal static class GeneratorDiagnostics
         "MPG0012",
         "External closed generic module lacks runtime metadata",
         "Runtime metadata for externally declared closed generic module '{0}' cannot be generated "
-        + "from this AddModule call; use a consumer-owned non-generic wrapper before publishing "
+        + "from this consumer usage; use a consumer-owned non-generic wrapper before publishing "
         + "with Native AOT",
         DiagnosticSeverity.Warning);
 

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -47,8 +47,10 @@ internal static class GeneratorDiagnostics
         "MPG0006",
         "Runtime metadata generation skipped",
         "Runtime metadata generation for '{0}' was skipped because the type is generic or "
-        + "inaccessible; runtime reflection will be used",
-        DiagnosticSeverity.Info);
+        + "inaccessible; runtime reflection will be used and required members may be removed "
+        + "when trimming; make the type accessible and non-generic before publishing with "
+        + "Native AOT",
+        DiagnosticSeverity.Warning);
 
     public static DiagnosticDescriptor SkippedModuleEventMetadata { get; } = Create(
         "MPG0007",

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -77,6 +77,14 @@ internal static class GeneratorDiagnostics
         + "available on IToolsContext or object",
         DiagnosticSeverity.Error);
 
+    public static DiagnosticDescriptor SkippedModuleRuntimeMetadata { get; } = Create(
+        "MPG0011",
+        "Module runtime metadata generation skipped",
+        "Runtime metadata generation for module '{0}' was skipped because the type is "
+        + "inaccessible to generated code; make the module and its containing types accessible "
+        + "before publishing with Native AOT",
+        DiagnosticSeverity.Warning);
+
     private static DiagnosticDescriptor Create(
         string id,
         string title,

--- a/src/ModularPipelines.SourceGenerator/ModuleClassInfo.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleClassInfo.cs
@@ -5,5 +5,6 @@ namespace ModularPipelines.SourceGenerator;
 /// </summary>
 internal sealed record ModuleClassInfo(
     string ClassName,
-    string FullyQualifiedName
+    string FullyQualifiedName,
+    bool IsPublic
 );

--- a/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
@@ -41,10 +41,22 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
             .Select(static (candidate, _) => candidate!)
             .WithComparer(ModuleEventMetadataCandidateComparer.Instance);
 
+        var closedGenericDependencyCandidates = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                static (node, _) => IsTypeCandidate(node),
+                static (generatorContext, _) =>
+                    GetClosedGenericDependencyCandidates(generatorContext))
+            .SelectMany(static (candidates, _) => candidates)
+            .WithComparer(ModuleEventMetadataCandidateComparer.Instance);
+
         var allCandidates = moduleCandidates
             .Collect()
             .Combine(registeredClosedGenericCandidates.Collect())
-            .Select(static (input, _) => input.Left.AddRange(input.Right));
+            .Combine(closedGenericDependencyCandidates.Collect())
+            .Select(static (input, _) =>
+                input.Left.Left
+                    .AddRange(input.Left.Right)
+                    .AddRange(input.Right));
 
         context.RegisterSourceOutput(allCandidates, static (sourceContext, candidates) =>
         {
@@ -120,6 +132,29 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
                 context.SemanticModel.Compilation,
                 context.Node.GetLocation(),
                 allowConstructedGeneric: true);
+    }
+
+    private static ImmutableArray<ModuleEventMetadataCandidate>
+        GetClosedGenericDependencyCandidates(GeneratorSyntaxContext context)
+    {
+        var compilation = context.SemanticModel.Compilation;
+        if (context.SemanticModel.GetDeclaredSymbol(context.Node) is not INamedTypeSymbol type
+            || type.IsAbstract
+            || !InheritsFromModule(type, compilation))
+        {
+            return [];
+        }
+
+        return
+        [
+            .. ModuleMetadataGenerator
+                .GetClosedGenericModuleDependencies(type, compilation)
+                .Select(dependency => CreateModuleCandidate(
+                    dependency,
+                    compilation,
+                    context.Node.GetLocation(),
+                    allowConstructedGeneric: true)),
+        ];
     }
 
     private static ModuleEventMetadataCandidate CreateModuleCandidate(

--- a/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
@@ -145,16 +145,32 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
             return [];
         }
 
-        return
-        [
-            .. ModuleMetadataGenerator
-                .GetClosedGenericModuleDependencies(type, compilation)
-                .Select(dependency => CreateModuleCandidate(
-                    dependency,
-                    compilation,
-                    context.Node.GetLocation(),
-                    allowConstructedGeneric: true)),
-        ];
+        var candidates = ImmutableArray.CreateBuilder<ModuleEventMetadataCandidate>();
+        var pending = new Stack<INamedTypeSymbol>(
+            ModuleMetadataGenerator.GetClosedGenericModuleDependencies(type, compilation));
+        var visited = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
+        while (pending.Count > 0)
+        {
+            var dependency = pending.Pop();
+            if (!visited.Add(dependency))
+            {
+                continue;
+            }
+
+            candidates.Add(CreateModuleCandidate(
+                dependency,
+                compilation,
+                context.Node.GetLocation(),
+                allowConstructedGeneric: true));
+            foreach (var transitiveDependency in ModuleMetadataGenerator
+                         .GetClosedGenericModuleDependencies(dependency, compilation))
+            {
+                pending.Push(transitiveDependency);
+            }
+        }
+
+        return candidates.ToImmutable();
     }
 
     private static ModuleEventMetadataCandidate CreateModuleCandidate(

--- a/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
@@ -180,7 +180,7 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
         bool allowConstructedGeneric)
     {
         var typeName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        if (!IsTypeDeclarationAccessible(type, compilation.Assembly))
+        if (!IsTypeAccessible(type, compilation.Assembly))
         {
             return new ModuleEventMetadataCandidate(typeName, location, Metadata: null);
         }

--- a/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleEventMetadataGenerator.cs
@@ -33,7 +33,20 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
             .Select(static (candidate, _) => candidate!)
             .WithComparer(ModuleEventMetadataCandidateComparer.Instance);
 
-        context.RegisterSourceOutput(moduleCandidates.Collect(), static (sourceContext, candidates) =>
+        var registeredClosedGenericCandidates = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                static (node, _) => ModuleMetadataGenerator.IsModuleRegistrationCandidate(node),
+                static (generatorContext, _) => GetRegisteredModuleCandidate(generatorContext))
+            .Where(static candidate => candidate is not null)
+            .Select(static (candidate, _) => candidate!)
+            .WithComparer(ModuleEventMetadataCandidateComparer.Instance);
+
+        var allCandidates = moduleCandidates
+            .Collect()
+            .Combine(registeredClosedGenericCandidates.Collect())
+            .Select(static (input, _) => input.Left.AddRange(input.Right));
+
+        context.RegisterSourceOutput(allCandidates, static (sourceContext, candidates) =>
         {
             foreach (var skipped in candidates
                          .Where(static candidate => candidate.Metadata is null)
@@ -89,14 +102,39 @@ public sealed class ModuleEventMetadataGenerator : IIncrementalGenerator
             return null;
         }
 
+        return CreateModuleCandidate(
+            type,
+            compilation,
+            type.Locations.FirstOrDefault() ?? Location.None,
+            allowConstructedGeneric: false);
+    }
+
+    private static ModuleEventMetadataCandidate? GetRegisteredModuleCandidate(
+        GeneratorSyntaxContext context)
+    {
+        var type = ModuleMetadataGenerator.GetRegisteredClosedGenericModule(context);
+        return type is null
+            ? null
+            : CreateModuleCandidate(
+                type,
+                context.SemanticModel.Compilation,
+                context.Node.GetLocation(),
+                allowConstructedGeneric: true);
+    }
+
+    private static ModuleEventMetadataCandidate CreateModuleCandidate(
+        INamedTypeSymbol type,
+        Compilation compilation,
+        Location location,
+        bool allowConstructedGeneric)
+    {
         var typeName = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-        var location = type.Locations.FirstOrDefault() ?? Location.None;
         if (!IsTypeDeclarationAccessible(type, compilation.Assembly))
         {
             return new ModuleEventMetadataCandidate(typeName, location, Metadata: null);
         }
 
-        if (type.IsGenericType)
+        if (type.IsGenericType && !allowConstructedGeneric)
         {
             return new ModuleEventMetadataCandidate(typeName, location, Metadata: null);
         }

--- a/src/ModularPipelines.SourceGenerator/ModuleExtensionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleExtensionsGenerator.cs
@@ -103,7 +103,8 @@ public sealed class ModuleExtensionsGenerator : IIncrementalGenerator
         return new ModuleClassCandidate(
             new ModuleClassInfo(
                 ClassName: typeSymbol.Name,
-                FullyQualifiedName: typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)),
+                FullyQualifiedName: typeSymbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                IsPublic: typeSymbol.DeclaredAccessibility == Accessibility.Public),
             typeSymbol.Locations.FirstOrDefault() ?? classDeclaration.GetLocation()
         );
     }
@@ -111,7 +112,7 @@ public sealed class ModuleExtensionsGenerator : IIncrementalGenerator
     private static ImmutableArray<DuplicateModuleAccessorInfo> FindDuplicateAccessors(
         ImmutableArray<ModuleClassCandidate> candidates)
     {
-        return candidates
+        return [.. candidates
             .GroupBy(static candidate => candidate.Module)
             .Select(static group => group.First())
             .OrderBy(static candidate => candidate.Module.FullyQualifiedName, StringComparer.Ordinal)
@@ -124,8 +125,7 @@ public sealed class ModuleExtensionsGenerator : IIncrementalGenerator
                 string.Join(
                     ", ",
                     group.Select(static candidate => candidate.Module.FullyQualifiedName)),
-                group.First().Location))
-            .ToImmutableArray();
+                group.First().Location))];
     }
 
     /// <summary>
@@ -202,6 +202,7 @@ public sealed class ModuleExtensionsGenerator : IIncrementalGenerator
         foreach (var module in uniqueModules)
         {
             var methodName = StripModuleSuffix(module.ClassName);
+            var accessibility = module.IsPublic ? "public" : "internal";
 
             // GetXxxModule method - returns the module (which can be awaited for its result)
             sb.AppendLine($"    /// <summary>");
@@ -211,7 +212,7 @@ public sealed class ModuleExtensionsGenerator : IIncrementalGenerator
             sb.AppendLine($"    /// <param name=\"context\">The module context.</param>");
             sb.AppendLine($"    /// <returns>The module instance, which can be awaited for its result.</returns>");
             sb.AppendLine($"    /// <exception cref=\"ModularPipelines.Exceptions.ModuleNotRegisteredException\">Thrown when the module is not registered.</exception>");
-            sb.AppendLine($"    public static {module.FullyQualifiedName} Get{methodName}Module(this IModuleContext context)");
+            sb.AppendLine($"    {accessibility} static {module.FullyQualifiedName} Get{methodName}Module(this IModuleContext context)");
             sb.AppendLine($"        => context.GetModule<{module.FullyQualifiedName}>();");
             sb.AppendLine();
 
@@ -222,7 +223,7 @@ public sealed class ModuleExtensionsGenerator : IIncrementalGenerator
             sb.AppendLine($"    /// </summary>");
             sb.AppendLine($"    /// <param name=\"context\">The module context.</param>");
             sb.AppendLine($"    /// <returns>The module instance, or null if not registered.</returns>");
-            sb.AppendLine($"    public static {module.FullyQualifiedName}? Get{methodName}ModuleIfRegistered(this IModuleContext context)");
+            sb.AppendLine($"    {accessibility} static {module.FullyQualifiedName}? Get{methodName}ModuleIfRegistered(this IModuleContext context)");
             sb.AppendLine($"        => context.GetModuleIfRegistered<{module.FullyQualifiedName}>();");
             sb.AppendLine();
         }

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -114,6 +114,27 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         return type;
     }
 
+    internal static ImmutableArray<INamedTypeSymbol> GetClosedGenericModuleDependencies(
+        INamedTypeSymbol type,
+        Compilation compilation)
+    {
+        return
+        [
+            .. GetDependencyAttributes(type)
+                .Select(attribute =>
+                    TryGetDependency(attribute, out var dependencyType, out _)
+                        ? dependencyType as INamedTypeSymbol
+                        : null)
+                .OfType<INamedTypeSymbol>()
+                .Where(dependency =>
+                    dependency.IsGenericType
+                    && !dependency.IsUnboundGenericType
+                    && ImplementsModule(dependency, compilation)
+                    && IsTypeReferenceAccessible(dependency, compilation.Assembly))
+                .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default),
+        ];
+    }
+
     private static bool IsCandidate(SyntaxNode node)
     {
         return node is ClassDeclarationSyntax { BaseList.Types.Count: > 0 }

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -113,6 +113,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         {
             SimpleNameSyntax directName => directName,
             MemberAccessExpressionSyntax { Name: var memberName } => memberName,
+            MemberBindingExpressionSyntax { Name: var bindingName } => bindingName,
             _ => null,
         };
 

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -23,6 +23,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor SkippedModuleRuntimeMetadata =
         GeneratorDiagnostics.SkippedModuleRuntimeMetadata;
 
+    private static readonly DiagnosticDescriptor ExternalClosedGenericModuleRuntimeMetadata =
+        GeneratorDiagnostics.ExternalClosedGenericModuleRuntimeMetadata;
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var modules = context.SyntaxProvider
@@ -56,7 +59,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                                  .Select(static group => group.First()))
                     {
                         sourceContext.ReportDiagnostic(Diagnostic.Create(
-                            SkippedModuleRuntimeMetadata,
+                            skipped.IsExternalRegistration
+                                ? ExternalClosedGenericModuleRuntimeMetadata
+                                : SkippedModuleRuntimeMetadata,
                             skipped.Location,
                             skipped.TypeName));
                     }
@@ -121,12 +126,23 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             || !type.IsGenericType
             || type.IsUnboundGenericType
             || type.IsAbstract
-            || !ImplementsModule(type, context.SemanticModel.Compilation)
-            || !SymbolEqualityComparer.Default.Equals(
+            || !ImplementsModule(type, context.SemanticModel.Compilation))
+        {
+            return null;
+        }
+
+        if (!SymbolEqualityComparer.Default.Equals(
                 type.ContainingAssembly,
                 context.SemanticModel.Compilation.Assembly))
         {
-            return null;
+            return new ModuleMetadataInfo(
+                type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                GetModuleResultTypeName(type),
+                false,
+                invocation.GetLocation(),
+                [],
+                false,
+                true);
         }
 
         return CreateModuleMetadata(type, context.SemanticModel.Compilation);
@@ -165,7 +181,8 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             [.. dependencies
                 .OrderBy(static dependency => dependency.TypeName, StringComparer.Ordinal)
                 .ThenBy(static dependency => dependency.Optional)],
-            dependenciesComplete);
+            dependenciesComplete,
+            false);
     }
 
     private static bool HasPartialDeclaration(INamedTypeSymbol type)
@@ -456,7 +473,8 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         bool CanEmit,
         Location? Location,
         ImmutableArray<DependencyMetadataInfo> Dependencies,
-        bool DependenciesComplete);
+        bool DependenciesComplete,
+        bool IsExternalRegistration);
 
     private sealed record DependencyMetadataInfo(
         string TypeName,

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -13,6 +13,8 @@ namespace ModularPipelines.SourceGenerator;
 public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 {
     internal const string ModuleInterfaceFullName = "ModularPipelines.Modules.IModule";
+    internal const string ModuleNamespace = "ModularPipelines.Modules";
+    internal const string GenericModuleMetadataName = "Module`1";
     internal const string DependsOnAttributeFullName = "ModularPipelines.Attributes.DependsOnAttribute";
     internal const string GenericDependsOnAttributeMetadataName = "DependsOnAttribute`1";
 
@@ -78,6 +80,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 
         return new ModuleMetadataInfo(
             type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            GetModuleResultTypeName(type),
             IsTypeAccessible(type, currentAssembly),
             [.. dependencies
                 .OrderBy(static dependency => dependency.TypeName, StringComparer.Ordinal)
@@ -118,6 +121,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                                                 currentAssembly);
         dependency = new DependencyMetadataInfo(
             namedDependency.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            GetModuleResultTypeName(namedDependency),
             optional,
             canEmitActivationRegistration);
         dependencyComplete = !isClosedGeneric || canEmitActivationRegistration;
@@ -211,6 +215,21 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                    SymbolEqualityComparer.Default.Equals(candidate, moduleInterface));
     }
 
+    private static string? GetModuleResultTypeName(INamedTypeSymbol type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (current.OriginalDefinition.MetadataName == GenericModuleMetadataName
+                && current.OriginalDefinition.ContainingNamespace.ToDisplayString() == ModuleNamespace)
+            {
+                return current.TypeArguments[0]
+                    .ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+            }
+        }
+
+        return null;
+    }
+
     private static bool IsTypeAccessible(INamedTypeSymbol type, IAssemblySymbol currentAssembly)
     {
         for (var current = type; current is not null; current = current.ContainingType)
@@ -271,16 +290,16 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         var closedGenericDependencies = modules
             .SelectMany(static module => module.Dependencies)
             .Where(static dependency => dependency.EmitActivationRegistration)
-            .Select(static dependency => dependency.TypeName)
-            .Where(typeName => !emittedModuleNames.Contains(typeName))
-            .Distinct(StringComparer.Ordinal)
-            .OrderBy(static typeName => typeName, StringComparer.Ordinal)
+            .Where(dependency => !emittedModuleNames.Contains(dependency.TypeName))
+            .GroupBy(static dependency => dependency.TypeName, StringComparer.Ordinal)
+            .Select(static group => group.First())
+            .OrderBy(static dependency => dependency.TypeName, StringComparer.Ordinal)
             .ToArray();
 
         // Generators cannot observe modules emitted by other generators in the same
-        // compilation, so assembly discovery must retain its reflection fallback.
-        // TODO(#3228): Revisit completeness when final trim/AOT certification can
-        // account for every generator participating in the compilation.
+        // compilation. Assembly-wide discovery therefore remains incomplete and uses
+        // the documented reflection fallback; explicitly registered source modules use
+        // the trim-safe registrations below.
         const bool isComplete = false;
         var registrationTypeName = $"ModuleMetadataRegistration_{GetStableIdentifier(assemblyName)}";
         var sb = new StringBuilder();
@@ -302,7 +321,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 
         foreach (var module in emittedModules)
         {
-            sb.AppendLine($"                global::ModularPipelines.Engine.GeneratedModuleMetadata.CreateRegistration<{module.TypeName}>(");
+            sb.AppendLine($"                global::ModularPipelines.Engine.GeneratedModuleMetadata.CreateRegistration<{GetRegistrationTypeArguments(module.TypeName, module.ResultTypeName)}>(");
             sb.AppendLine("                    new global::ModularPipelines.Engine.ModuleDependencyMetadata[]");
             sb.AppendLine("                    {");
 
@@ -314,9 +333,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             sb.AppendLine($"                    }}, dependenciesComplete: {BooleanLiteral(module.DependenciesComplete)}),");
         }
 
-        foreach (var typeName in closedGenericDependencies)
+        foreach (var dependency in closedGenericDependencies)
         {
-            sb.AppendLine($"                global::ModularPipelines.Engine.GeneratedModuleMetadata.CreateRegistration<{typeName}>(");
+            sb.AppendLine($"                global::ModularPipelines.Engine.GeneratedModuleMetadata.CreateRegistration<{GetRegistrationTypeArguments(dependency.TypeName, dependency.ResultTypeName)}>(");
             sb.AppendLine("                    global::System.Array.Empty<global::ModularPipelines.Engine.ModuleDependencyMetadata>(),");
             sb.AppendLine("                    dependenciesComplete: false),");
         }
@@ -328,6 +347,13 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     }
 
     private static string BooleanLiteral(bool value) => value ? "true" : "false";
+
+    private static string GetRegistrationTypeArguments(string moduleTypeName, string? resultTypeName)
+    {
+        return resultTypeName is null
+            ? moduleTypeName
+            : $"{moduleTypeName}, {resultTypeName}";
+    }
 
     private static string GetStableIdentifier(string? value)
     {
@@ -346,12 +372,14 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 
     private sealed record ModuleMetadataInfo(
         string TypeName,
+        string? ResultTypeName,
         bool CanEmit,
         ImmutableArray<DependencyMetadataInfo> Dependencies,
         bool DependenciesComplete);
 
     private sealed record DependencyMetadataInfo(
         string TypeName,
+        string? ResultTypeName,
         bool Optional,
         bool EmitActivationRegistration);
 }

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -26,6 +26,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor ExternalClosedGenericModuleRuntimeMetadata =
         GeneratorDiagnostics.ExternalClosedGenericModuleRuntimeMetadata;
 
+    private static readonly DiagnosticDescriptor GenericModuleRegistrationRuntimeMetadata =
+        GeneratorDiagnostics.GenericModuleRegistrationRuntimeMetadata;
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var modules = context.SyntaxProvider
@@ -39,6 +42,12 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                 static (node, _) => IsModuleRegistrationCandidate(node),
                 static (generatorContext, _) => GetRegisteredModuleMetadata(generatorContext))
             .SelectMany(static (metadata, _) => metadata);
+
+        var genericModuleRegistrations = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                static (node, _) => IsModuleRegistrationCandidate(node),
+                static (generatorContext, _) => GetGenericModuleRegistration(generatorContext))
+            .Where(static registration => registration is not null);
 
         var allModules = modules
             .Collect()
@@ -69,6 +78,14 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                         Generate(input.Left.AssemblyName, input.Right));
                 }
             });
+
+        context.RegisterSourceOutput(
+            genericModuleRegistrations,
+            static (sourceContext, registration) =>
+                sourceContext.ReportDiagnostic(Diagnostic.Create(
+                    GenericModuleRegistrationRuntimeMetadata,
+                    registration!.Location,
+                    registration.TypeParameterName)));
     }
 
     internal static bool IsModuleRegistrationCandidate(SyntaxNode node)
@@ -131,6 +148,24 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                     && IsTypeReferenceAccessible(dependency, compilation.Assembly))
                 .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default),
         ];
+    }
+
+    private static GenericModuleRegistrationInfo? GetGenericModuleRegistration(
+        GeneratorSyntaxContext context)
+    {
+        if (context.Node is not InvocationExpressionSyntax invocation
+            || context.SemanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method
+            || (method.ReducedFrom ?? method).ContainingType.ToDisplayString()
+            != PipelineBuilderExtensionsFullName
+            || method.TypeArguments.Length != 1
+            || method.TypeArguments[0] is not ITypeParameterSymbol typeParameter)
+        {
+            return null;
+        }
+
+        return new GenericModuleRegistrationInfo(
+            typeParameter.Name,
+            invocation.GetLocation());
     }
 
     private static bool IsCandidate(SyntaxNode node)
@@ -576,4 +611,8 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         string? ResultTypeName,
         bool Optional,
         bool EmitActivationRegistration);
+
+    private sealed record GenericModuleRegistrationInfo(
+        string TypeParameterName,
+        Location Location);
 }

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -29,6 +29,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor GenericModuleRegistrationRuntimeMetadata =
         GeneratorDiagnostics.GenericModuleRegistrationRuntimeMetadata;
 
+    private static readonly DiagnosticDescriptor PartialModuleRuntimeMetadata =
+        GeneratorDiagnostics.PartialModuleRuntimeMetadata;
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var modules = context.SyntaxProvider
@@ -71,6 +74,17 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                                 : SkippedModuleRuntimeMetadata,
                             skipped.Location,
                             skipped.TypeName));
+                    }
+
+                    foreach (var partial in input.Right
+                                 .Where(static module => module.IsPartial)
+                                 .GroupBy(static module => module.TypeName, StringComparer.Ordinal)
+                                 .Select(static group => group.First()))
+                    {
+                        sourceContext.ReportDiagnostic(Diagnostic.Create(
+                            PartialModuleRuntimeMetadata,
+                            partial.Location,
+                            partial.TypeName));
                     }
 
                     sourceContext.AddSource(
@@ -211,6 +225,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                     invocation.GetLocation(),
                     [],
                     false,
+                    false,
                     true),
             ];
         }
@@ -253,6 +268,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                     GetDependencyLocation(type, dependency),
                     [],
                     false,
+                    false,
                     true));
             }
         }
@@ -283,7 +299,8 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     {
         var currentAssembly = compilation.Assembly;
         var dependencies = ImmutableArray.CreateBuilder<DependencyMetadataInfo>();
-        var dependenciesComplete = !HasPartialDeclaration(type);
+        var isPartial = HasPartialDeclaration(type);
+        var dependenciesComplete = !isPartial;
 
         foreach (var attribute in GetDependencyAttributes(type))
         {
@@ -311,6 +328,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                 .OrderBy(static dependency => dependency.TypeName, StringComparer.Ordinal)
                 .ThenBy(static dependency => dependency.Optional)],
             dependenciesComplete,
+            isPartial,
             false);
     }
 
@@ -603,6 +621,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         Location? Location,
         ImmutableArray<DependencyMetadataInfo> Dependencies,
         bool DependenciesComplete,
+        bool IsPartial,
         bool IsExternalRegistration);
 
     private sealed record DependencyMetadataInfo(

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -20,6 +20,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     internal const string SelectorDependencyAttributeFullName =
         "ModularPipelines.Attributes.DependsOnAllModulesInheritingFromAttribute";
 
+    internal const string PredicateDependencyAttributeFullName =
+        "ModularPipelines.Attributes.DependsOnBaseAttribute";
+
     internal const string PipelineBuilderExtensionsFullName =
         "ModularPipelines.Extensions.PipelineBuilderExtensions";
 
@@ -421,7 +424,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     {
         for (var current = attribute.AttributeClass; current is not null; current = current.BaseType)
         {
-            if (current.ToDisplayString() == SelectorDependencyAttributeFullName)
+            if (current.ToDisplayString() is
+                SelectorDependencyAttributeFullName
+                or PredicateDependencyAttributeFullName)
             {
                 return true;
             }

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -109,18 +109,14 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             return false;
         }
 
-        var genericName = invocation.Expression switch
+        var name = invocation.Expression switch
         {
-            GenericNameSyntax directName => directName,
-            MemberAccessExpressionSyntax { Name: GenericNameSyntax memberName } => memberName,
+            SimpleNameSyntax directName => directName,
+            MemberAccessExpressionSyntax { Name: var memberName } => memberName,
             _ => null,
         };
 
-        return genericName is
-        {
-            Identifier.ValueText: "AddModule",
-            TypeArgumentList.Arguments.Count: 1,
-        };
+        return name?.Identifier.ValueText == "AddModule";
     }
 
     internal static INamedTypeSymbol? GetRegisteredClosedGenericModule(

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -17,6 +17,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     internal const string GenericModuleMetadataName = "Module`1";
     internal const string DependsOnAttributeFullName = "ModularPipelines.Attributes.DependsOnAttribute";
     internal const string GenericDependsOnAttributeMetadataName = "DependsOnAttribute`1";
+    internal const string SelectorDependencyAttributeFullName =
+        "ModularPipelines.Attributes.DependsOnAllModulesInheritingFromAttribute";
+
     internal const string PipelineBuilderExtensionsFullName =
         "ModularPipelines.Extensions.PipelineBuilderExtensions";
 
@@ -34,6 +37,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 
     private static readonly DiagnosticDescriptor NonConcreteModuleRegistrationRuntimeMetadata =
         GeneratorDiagnostics.NonConcreteModuleRegistrationRuntimeMetadata;
+
+    private static readonly DiagnosticDescriptor SelectorDependencyRuntimeMetadata =
+        GeneratorDiagnostics.SelectorDependencyRuntimeMetadata;
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -94,6 +100,18 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                             PartialModuleRuntimeMetadata,
                             partial.Location,
                             partial.TypeName));
+                    }
+
+                    foreach (var selector in input.Right
+                                 .Where(static module =>
+                                     module.SelectorDependencyLocation is not null)
+                                 .GroupBy(static module => module.TypeName, StringComparer.Ordinal)
+                                 .Select(static group => group.First()))
+                    {
+                        sourceContext.ReportDiagnostic(Diagnostic.Create(
+                            SelectorDependencyRuntimeMetadata,
+                            selector.SelectorDependencyLocation,
+                            selector.TypeName));
                     }
 
                     sourceContext.AddSource(
@@ -260,7 +278,8 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                     [],
                     false,
                     false,
-                    true),
+                    true,
+                    null),
             ];
         }
 
@@ -303,7 +322,8 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                     [],
                     false,
                     false,
-                    true));
+                    true,
+                    null));
             }
         }
 
@@ -363,7 +383,51 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                 .ThenBy(static dependency => dependency.Optional)],
             dependenciesComplete,
             isPartial,
-            false);
+            false,
+            GetSelectorDependencyLocation(type));
+    }
+
+    private static Location? GetSelectorDependencyLocation(INamedTypeSymbol type)
+    {
+        foreach (var interfaceType in type.AllInterfaces)
+        {
+            var attribute = interfaceType.GetAttributes()
+                .FirstOrDefault(IsSelectorDependencyAttribute);
+            if (attribute is not null)
+            {
+                return GetAttributeLocation(attribute, type);
+            }
+        }
+
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            var attribute = current.GetAttributes().FirstOrDefault(IsSelectorDependencyAttribute);
+            if (attribute is not null)
+            {
+                return GetAttributeLocation(attribute, type);
+            }
+        }
+
+        return null;
+    }
+
+    private static Location? GetAttributeLocation(AttributeData attribute, INamedTypeSymbol type)
+    {
+        return attribute.ApplicationSyntaxReference?.GetSyntax().GetLocation()
+               ?? type.Locations.FirstOrDefault(static location => location.IsInSource);
+    }
+
+    private static bool IsSelectorDependencyAttribute(AttributeData attribute)
+    {
+        for (var current = attribute.AttributeClass; current is not null; current = current.BaseType)
+        {
+            if (current.ToDisplayString() == SelectorDependencyAttributeFullName)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool HasPartialDeclaration(INamedTypeSymbol type)
@@ -656,7 +720,8 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         ImmutableArray<DependencyMetadataInfo> Dependencies,
         bool DependenciesComplete,
         bool IsPartial,
-        bool IsExternalRegistration);
+        bool IsExternalRegistration,
+        Location? SelectorDependencyLocation);
 
     private sealed record DependencyMetadataInfo(
         string TypeName,

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -121,7 +121,10 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             || !type.IsGenericType
             || type.IsUnboundGenericType
             || type.IsAbstract
-            || !ImplementsModule(type, context.SemanticModel.Compilation))
+            || !ImplementsModule(type, context.SemanticModel.Compilation)
+            || !SymbolEqualityComparer.Default.Equals(
+                type.ContainingAssembly,
+                context.SemanticModel.Compilation.Assembly))
         {
             return null;
         }

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -144,8 +144,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                 .Where(dependency =>
                     dependency.IsGenericType
                     && !dependency.IsUnboundGenericType
-                    && ImplementsModule(dependency, compilation)
-                    && IsTypeReferenceAccessible(dependency, compilation.Assembly))
+                    && ImplementsModule(dependency, compilation))
                 .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default),
         ];
     }

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -422,6 +422,12 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 
     private static bool IsSelectorDependencyAttribute(AttributeData attribute)
     {
+        if (IsDependsOnAttribute(attribute)
+            && !IsBuiltInDependsOnAttribute(attribute.AttributeClass))
+        {
+            return true;
+        }
+
         for (var current = attribute.AttributeClass; current is not null; current = current.BaseType)
         {
             if (current.ToDisplayString() is

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -32,15 +32,13 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             .CreateSyntaxProvider(
                 static (node, _) => IsCandidate(node),
                 static (generatorContext, _) => GetModuleMetadata(generatorContext))
-            .Where(static metadata => metadata is not null)
-            .Select(static (metadata, _) => metadata!);
+            .SelectMany(static (metadata, _) => metadata);
 
         var registeredClosedGenericModules = context.SyntaxProvider
             .CreateSyntaxProvider(
                 static (node, _) => IsModuleRegistrationCandidate(node),
                 static (generatorContext, _) => GetRegisteredModuleMetadata(generatorContext))
-            .Where(static metadata => metadata is not null)
-            .Select(static (metadata, _) => metadata!);
+            .SelectMany(static (metadata, _) => metadata);
 
         var allModules = modules
             .Collect()
@@ -142,26 +140,27 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                    && record.ClassOrStructKeyword.ValueText != "struct");
     }
 
-    private static ModuleMetadataInfo? GetModuleMetadata(GeneratorSyntaxContext context)
+    private static ImmutableArray<ModuleMetadataInfo> GetModuleMetadata(
+        GeneratorSyntaxContext context)
     {
         if (context.SemanticModel.GetDeclaredSymbol(context.Node) is not INamedTypeSymbol type
             || type.IsAbstract
             || type.IsGenericType
             || !ImplementsModule(type, context.SemanticModel.Compilation))
         {
-            return null;
+            return [];
         }
 
-        return CreateModuleMetadata(type, context.SemanticModel.Compilation);
+        return CreateModuleMetadataGraph(type, context.SemanticModel.Compilation);
     }
 
-    private static ModuleMetadataInfo? GetRegisteredModuleMetadata(
+    private static ImmutableArray<ModuleMetadataInfo> GetRegisteredModuleMetadata(
         GeneratorSyntaxContext context)
     {
         var type = GetRegisteredClosedGenericModule(context);
         if (type is null)
         {
-            return null;
+            return [];
         }
 
         var invocation = (InvocationExpressionSyntax) context.Node;
@@ -169,17 +168,50 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                 type.ContainingAssembly,
                 context.SemanticModel.Compilation.Assembly))
         {
-            return new ModuleMetadataInfo(
-                type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                GetModuleResultTypeName(type),
-                false,
-                invocation.GetLocation(),
-                [],
-                false,
-                true);
+            return
+            [
+                new ModuleMetadataInfo(
+                    type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    GetModuleResultTypeName(type),
+                    false,
+                    invocation.GetLocation(),
+                    [],
+                    false,
+                    true),
+            ];
         }
 
-        return CreateModuleMetadata(type, context.SemanticModel.Compilation);
+        return CreateModuleMetadataGraph(type, context.SemanticModel.Compilation);
+    }
+
+    private static ImmutableArray<ModuleMetadataInfo> CreateModuleMetadataGraph(
+        INamedTypeSymbol root,
+        Compilation compilation)
+    {
+        var metadata = ImmutableArray.CreateBuilder<ModuleMetadataInfo>();
+        var pending = new Stack<INamedTypeSymbol>();
+        var visited = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        pending.Push(root);
+
+        while (pending.Count > 0)
+        {
+            var type = pending.Pop();
+            if (!visited.Add(type))
+            {
+                continue;
+            }
+
+            metadata.Add(CreateModuleMetadata(type, compilation));
+            foreach (var dependency in GetClosedGenericModuleDependencies(type, compilation)
+                         .Where(dependency => SymbolEqualityComparer.Default.Equals(
+                             dependency.ContainingAssembly,
+                             compilation.Assembly)))
+            {
+                pending.Push(dependency);
+            }
+        }
+
+        return metadata.ToImmutable();
     }
 
     private static ModuleMetadataInfo CreateModuleMetadata(

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -17,6 +17,8 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     internal const string GenericModuleMetadataName = "Module`1";
     internal const string DependsOnAttributeFullName = "ModularPipelines.Attributes.DependsOnAttribute";
     internal const string GenericDependsOnAttributeMetadataName = "DependsOnAttribute`1";
+    internal const string PipelineBuilderExtensionsFullName =
+        "ModularPipelines.Extensions.PipelineBuilderExtensions";
 
     private static readonly DiagnosticDescriptor SkippedModuleRuntimeMetadata =
         GeneratorDiagnostics.SkippedModuleRuntimeMetadata;
@@ -30,8 +32,20 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             .Where(static metadata => metadata is not null)
             .Select(static (metadata, _) => metadata!);
 
+        var registeredClosedGenericModules = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                static (node, _) => IsModuleRegistrationCandidate(node),
+                static (generatorContext, _) => GetRegisteredModuleMetadata(generatorContext))
+            .Where(static metadata => metadata is not null)
+            .Select(static (metadata, _) => metadata!);
+
+        var allModules = modules
+            .Collect()
+            .Combine(registeredClosedGenericModules.Collect())
+            .Select(static (input, _) => input.Left.AddRange(input.Right));
+
         context.RegisterSourceOutput(
-            context.CompilationProvider.Combine(modules.Collect()),
+            context.CompilationProvider.Combine(allModules),
             static (sourceContext, input) =>
             {
                 if (input.Left.GetTypeByMetadataName(ModuleInterfaceFullName) is not null)
@@ -61,6 +75,27 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                    && record.ClassOrStructKeyword.ValueText != "struct");
     }
 
+    private static bool IsModuleRegistrationCandidate(SyntaxNode node)
+    {
+        if (node is not InvocationExpressionSyntax invocation)
+        {
+            return false;
+        }
+
+        var genericName = invocation.Expression switch
+        {
+            GenericNameSyntax directName => directName,
+            MemberAccessExpressionSyntax { Name: GenericNameSyntax memberName } => memberName,
+            _ => null,
+        };
+
+        return genericName is
+        {
+            Identifier.ValueText: "AddModule",
+            TypeArgumentList.Arguments.Count: 1,
+        };
+    }
+
     private static ModuleMetadataInfo? GetModuleMetadata(GeneratorSyntaxContext context)
     {
         if (context.SemanticModel.GetDeclaredSymbol(context.Node) is not INamedTypeSymbol type
@@ -71,7 +106,34 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             return null;
         }
 
-        var currentAssembly = context.SemanticModel.Compilation.Assembly;
+        return CreateModuleMetadata(type, context.SemanticModel.Compilation);
+    }
+
+    private static ModuleMetadataInfo? GetRegisteredModuleMetadata(
+        GeneratorSyntaxContext context)
+    {
+        if (context.Node is not InvocationExpressionSyntax invocation
+            || context.SemanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method
+            || (method.ReducedFrom ?? method).ContainingType.ToDisplayString()
+            != PipelineBuilderExtensionsFullName
+            || method.TypeArguments.Length != 1
+            || method.TypeArguments[0] is not INamedTypeSymbol type
+            || !type.IsGenericType
+            || type.IsUnboundGenericType
+            || type.IsAbstract
+            || !ImplementsModule(type, context.SemanticModel.Compilation))
+        {
+            return null;
+        }
+
+        return CreateModuleMetadata(type, context.SemanticModel.Compilation);
+    }
+
+    private static ModuleMetadataInfo CreateModuleMetadata(
+        INamedTypeSymbol type,
+        Compilation compilation)
+    {
+        var currentAssembly = compilation.Assembly;
         var dependencies = ImmutableArray.CreateBuilder<DependencyMetadataInfo>();
         var dependenciesComplete = !HasPartialDeclaration(type);
 
@@ -79,7 +141,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         {
             if (!TryGetDependencyMetadata(
                     attribute,
-                    context.SemanticModel.Compilation,
+                    compilation,
                     currentAssembly,
                     out var dependency,
                     out var dependencyComplete))

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -73,14 +73,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             });
     }
 
-    private static bool IsCandidate(SyntaxNode node)
-    {
-        return node is ClassDeclarationSyntax { BaseList.Types.Count: > 0 }
-               || (node is RecordDeclarationSyntax { BaseList.Types.Count: > 0 } record
-                   && record.ClassOrStructKeyword.ValueText != "struct");
-    }
-
-    private static bool IsModuleRegistrationCandidate(SyntaxNode node)
+    internal static bool IsModuleRegistrationCandidate(SyntaxNode node)
     {
         if (node is not InvocationExpressionSyntax invocation)
         {
@@ -101,20 +94,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         };
     }
 
-    private static ModuleMetadataInfo? GetModuleMetadata(GeneratorSyntaxContext context)
-    {
-        if (context.SemanticModel.GetDeclaredSymbol(context.Node) is not INamedTypeSymbol type
-            || type.IsAbstract
-            || type.IsGenericType
-            || !ImplementsModule(type, context.SemanticModel.Compilation))
-        {
-            return null;
-        }
-
-        return CreateModuleMetadata(type, context.SemanticModel.Compilation);
-    }
-
-    private static ModuleMetadataInfo? GetRegisteredModuleMetadata(
+    internal static INamedTypeSymbol? GetRegisteredClosedGenericModule(
         GeneratorSyntaxContext context)
     {
         if (context.Node is not InvocationExpressionSyntax invocation
@@ -131,6 +111,39 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             return null;
         }
 
+        return type;
+    }
+
+    private static bool IsCandidate(SyntaxNode node)
+    {
+        return node is ClassDeclarationSyntax { BaseList.Types.Count: > 0 }
+               || (node is RecordDeclarationSyntax { BaseList.Types.Count: > 0 } record
+                   && record.ClassOrStructKeyword.ValueText != "struct");
+    }
+
+    private static ModuleMetadataInfo? GetModuleMetadata(GeneratorSyntaxContext context)
+    {
+        if (context.SemanticModel.GetDeclaredSymbol(context.Node) is not INamedTypeSymbol type
+            || type.IsAbstract
+            || type.IsGenericType
+            || !ImplementsModule(type, context.SemanticModel.Compilation))
+        {
+            return null;
+        }
+
+        return CreateModuleMetadata(type, context.SemanticModel.Compilation);
+    }
+
+    private static ModuleMetadataInfo? GetRegisteredModuleMetadata(
+        GeneratorSyntaxContext context)
+    {
+        var type = GetRegisteredClosedGenericModule(context);
+        if (type is null)
+        {
+            return null;
+        }
+
+        var invocation = (InvocationExpressionSyntax) context.Node;
         if (!SymbolEqualityComparer.Default.Equals(
                 type.ContainingAssembly,
                 context.SemanticModel.Compilation.Assembly))

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -32,6 +32,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor PartialModuleRuntimeMetadata =
         GeneratorDiagnostics.PartialModuleRuntimeMetadata;
 
+    private static readonly DiagnosticDescriptor NonConcreteModuleRegistrationRuntimeMetadata =
+        GeneratorDiagnostics.NonConcreteModuleRegistrationRuntimeMetadata;
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var modules = context.SyntaxProvider
@@ -50,6 +53,12 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             .CreateSyntaxProvider(
                 static (node, _) => IsModuleRegistrationCandidate(node),
                 static (generatorContext, _) => GetGenericModuleRegistration(generatorContext))
+            .Where(static registration => registration is not null);
+
+        var nonConcreteModuleRegistrations = context.SyntaxProvider
+            .CreateSyntaxProvider(
+                static (node, _) => IsModuleRegistrationCandidate(node),
+                static (generatorContext, _) => GetNonConcreteModuleRegistration(generatorContext))
             .Where(static registration => registration is not null);
 
         var allModules = modules
@@ -100,6 +109,14 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                     GenericModuleRegistrationRuntimeMetadata,
                     registration!.Location,
                     registration.TypeParameterName)));
+
+        context.RegisterSourceOutput(
+            nonConcreteModuleRegistrations,
+            static (sourceContext, registration) =>
+                sourceContext.ReportDiagnostic(Diagnostic.Create(
+                    NonConcreteModuleRegistrationRuntimeMetadata,
+                    registration!.Location,
+                    registration.TypeName)));
     }
 
     internal static bool IsModuleRegistrationCandidate(SyntaxNode node)
@@ -175,6 +192,26 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 
         return new GenericModuleRegistrationInfo(
             typeParameter.Name,
+            invocation.GetLocation());
+    }
+
+    private static NonConcreteModuleRegistrationInfo? GetNonConcreteModuleRegistration(
+        GeneratorSyntaxContext context)
+    {
+        if (context.Node is not InvocationExpressionSyntax invocation
+            || context.SemanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method
+            || (method.ReducedFrom ?? method).ContainingType.ToDisplayString()
+            != PipelineBuilderExtensionsFullName
+            || method.TypeArguments.Length != 1
+            || method.TypeArguments[0] is not INamedTypeSymbol type
+            || !ImplementsModule(type, context.SemanticModel.Compilation)
+            || (!type.IsAbstract && type.TypeKind != TypeKind.Interface))
+        {
+            return null;
+        }
+
+        return new NonConcreteModuleRegistrationInfo(
+            type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
             invocation.GetLocation());
     }
 
@@ -629,5 +666,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
 
     private sealed record GenericModuleRegistrationInfo(
         string TypeParameterName,
+        Location Location);
+
+    private sealed record NonConcreteModuleRegistrationInfo(
+        string TypeName,
         Location Location);
 }

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -18,6 +18,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     internal const string DependsOnAttributeFullName = "ModularPipelines.Attributes.DependsOnAttribute";
     internal const string GenericDependsOnAttributeMetadataName = "DependsOnAttribute`1";
 
+    private static readonly DiagnosticDescriptor SkippedModuleRuntimeMetadata =
+        GeneratorDiagnostics.SkippedModuleRuntimeMetadata;
+
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var modules = context.SyntaxProvider
@@ -33,6 +36,17 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             {
                 if (input.Left.GetTypeByMetadataName(ModuleInterfaceFullName) is not null)
                 {
+                    foreach (var skipped in input.Right
+                                 .Where(static module => !module.CanEmit)
+                                 .GroupBy(static module => module.TypeName, StringComparer.Ordinal)
+                                 .Select(static group => group.First()))
+                    {
+                        sourceContext.ReportDiagnostic(Diagnostic.Create(
+                            SkippedModuleRuntimeMetadata,
+                            skipped.Location,
+                            skipped.TypeName));
+                    }
+
                     sourceContext.AddSource(
                         "ModularPipelines.ModuleMetadata.g.cs",
                         Generate(input.Left.AssemblyName, input.Right));
@@ -82,6 +96,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
             GetModuleResultTypeName(type),
             IsTypeAccessible(type, currentAssembly),
+            type.Locations.FirstOrDefault(static location => location.IsInSource),
             [.. dependencies
                 .OrderBy(static dependency => dependency.TypeName, StringComparer.Ordinal)
                 .ThenBy(static dependency => dependency.Optional)],
@@ -374,6 +389,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         string TypeName,
         string? ResultTypeName,
         bool CanEmit,
+        Location? Location,
         ImmutableArray<DependencyMetadataInfo> Dependencies,
         bool DependenciesComplete);
 

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -202,16 +202,45 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             }
 
             metadata.Add(CreateModuleMetadata(type, compilation));
-            foreach (var dependency in GetClosedGenericModuleDependencies(type, compilation)
-                         .Where(dependency => SymbolEqualityComparer.Default.Equals(
-                             dependency.ContainingAssembly,
-                             compilation.Assembly)))
+            foreach (var dependency in GetClosedGenericModuleDependencies(type, compilation))
             {
-                pending.Push(dependency);
+                if (SymbolEqualityComparer.Default.Equals(
+                        dependency.ContainingAssembly,
+                        compilation.Assembly))
+                {
+                    pending.Push(dependency);
+                    continue;
+                }
+
+                metadata.Add(new ModuleMetadataInfo(
+                    dependency.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    GetModuleResultTypeName(dependency),
+                    false,
+                    GetDependencyLocation(type, dependency),
+                    [],
+                    false,
+                    true));
             }
         }
 
         return metadata.ToImmutable();
+    }
+
+    private static Location? GetDependencyLocation(
+        INamedTypeSymbol type,
+        INamedTypeSymbol dependency)
+    {
+        foreach (var attribute in GetDependencyAttributes(type))
+        {
+            if (TryGetDependency(attribute, out var candidate, out _)
+                && SymbolEqualityComparer.Default.Equals(candidate, dependency))
+            {
+                return attribute.ApplicationSyntaxReference?.GetSyntax().GetLocation()
+                       ?? type.Locations.FirstOrDefault(static location => location.IsInSource);
+            }
+        }
+
+        return type.Locations.FirstOrDefault(static location => location.IsInSource);
     }
 
     private static ModuleMetadataInfo CreateModuleMetadata(

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -422,7 +422,7 @@ internal sealed class OutputCoordinator : IOutputCoordinator
 
         if (GeneratedModuleMetadata.TryGetRuntime(moduleType, out var runtime))
         {
-            return runtime.GetLogger(_serviceProvider);
+            return runtime.GetOutputLogger(_serviceProvider);
         }
 
         var loggerType = typeof(ILogger<>).MakeGenericType(moduleType);

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -409,11 +409,20 @@ internal sealed class OutputCoordinator : IOutputCoordinator
             .ConfigureAwait(false);
     }
 
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Generated runtime metadata handles statically known modules; MakeGenericType is the documented fallback for dynamic modules.")]
     private ILogger GetModuleLogger(Type moduleType)
     {
         if (moduleType == typeof(void))
         {
             return _loggerFactory.CreateLogger(OutputLoggerCategories.Pipeline);
+        }
+
+        if (GeneratedModuleMetadata.TryGetRuntime(moduleType, out var runtime))
+        {
+            return runtime.GetLogger(_serviceProvider);
         }
 
         var loggerType = typeof(ILogger<>).MakeGenericType(moduleType);

--- a/src/ModularPipelines/Context/Domains/Data/IJsonContext.cs
+++ b/src/ModularPipelines/Context/Domains/Data/IJsonContext.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 namespace ModularPipelines.Context.Domains.Data;
 
@@ -13,6 +15,8 @@ public interface IJsonContext
     /// <typeparam name="T">The type of object to serialize.</typeparam>
     /// <param name="input">The object to serialize.</param>
     /// <returns>The JSON string representation of the object.</returns>
+    [RequiresDynamicCode("Reflection-based JSON serialization may require runtime code generation. Use the JsonTypeInfo overload for Native AOT.")]
+    [RequiresUnreferencedCode("Reflection-based JSON serialization may require members that trimming cannot statically discover. Use the JsonTypeInfo overload when trimming.")]
     string ToJson<T>(T input);
 
     /// <summary>
@@ -22,7 +26,18 @@ public interface IJsonContext
     /// <param name="input">The object to serialize.</param>
     /// <param name="options">The JSON serializer options to use.</param>
     /// <returns>The JSON string representation of the object.</returns>
+    [RequiresDynamicCode("Reflection-based JSON serialization may require runtime code generation. Use the JsonTypeInfo overload for Native AOT.")]
+    [RequiresUnreferencedCode("Reflection-based JSON serialization may require members that trimming cannot statically discover. Use the JsonTypeInfo overload when trimming.")]
     string ToJson<T>(T input, JsonSerializerOptions options);
+
+    /// <summary>
+    /// Serializes an object using source-generated JSON metadata.
+    /// </summary>
+    /// <typeparam name="T">The type of object to serialize.</typeparam>
+    /// <param name="input">The object to serialize.</param>
+    /// <param name="jsonTypeInfo">The source-generated JSON metadata to use.</param>
+    /// <returns>The JSON string representation of the object.</returns>
+    string ToJson<T>(T input, JsonTypeInfo<T> jsonTypeInfo);
 
     /// <summary>
     /// Deserializes a JSON string to an object using default options.
@@ -30,6 +45,8 @@ public interface IJsonContext
     /// <typeparam name="T">The type to deserialize to.</typeparam>
     /// <param name="input">The JSON string to deserialize.</param>
     /// <returns>The deserialized object, or null if deserialization fails.</returns>
+    [RequiresDynamicCode("Reflection-based JSON deserialization may require runtime code generation. Use the JsonTypeInfo overload for Native AOT.")]
+    [RequiresUnreferencedCode("Reflection-based JSON deserialization may require members that trimming cannot statically discover. Use the JsonTypeInfo overload when trimming.")]
     T? FromJson<T>(string input);
 
     /// <summary>
@@ -39,5 +56,16 @@ public interface IJsonContext
     /// <param name="input">The JSON string to deserialize.</param>
     /// <param name="options">The JSON serializer options to use.</param>
     /// <returns>The deserialized object, or null if deserialization fails.</returns>
+    [RequiresDynamicCode("Reflection-based JSON deserialization may require runtime code generation. Use the JsonTypeInfo overload for Native AOT.")]
+    [RequiresUnreferencedCode("Reflection-based JSON deserialization may require members that trimming cannot statically discover. Use the JsonTypeInfo overload when trimming.")]
     T? FromJson<T>(string input, JsonSerializerOptions options);
+
+    /// <summary>
+    /// Deserializes JSON using source-generated JSON metadata.
+    /// </summary>
+    /// <typeparam name="T">The type to deserialize to.</typeparam>
+    /// <param name="input">The JSON string to deserialize.</param>
+    /// <param name="jsonTypeInfo">The source-generated JSON metadata to use.</param>
+    /// <returns>The deserialized object, or null if deserialization fails.</returns>
+    T? FromJson<T>(string input, JsonTypeInfo<T> jsonTypeInfo);
 }

--- a/src/ModularPipelines/Context/Domains/Data/IXmlContext.cs
+++ b/src/ModularPipelines/Context/Domains/Data/IXmlContext.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Xml.Linq;
 
 namespace ModularPipelines.Context.Domains.Data;
@@ -14,6 +15,8 @@ public interface IXmlContext
     /// <param name="input">The object to serialize.</param>
     /// <param name="options">The save options to use when generating the XML string.</param>
     /// <returns>The XML string representation of the object.</returns>
+    [RequiresDynamicCode("XmlSerializer may require runtime code generation.")]
+    [RequiresUnreferencedCode("XmlSerializer requires members that trimming cannot statically discover.")]
     string ToXml<T>(T input, SaveOptions options = SaveOptions.None);
 
     /// <summary>
@@ -23,6 +26,8 @@ public interface IXmlContext
     /// <param name="input">The XML string to deserialize.</param>
     /// <param name="options">The load options to use when parsing the XML string.</param>
     /// <returns>The deserialized object, or null if deserialization fails.</returns>
+    [RequiresDynamicCode("XmlSerializer may require runtime code generation.")]
+    [RequiresUnreferencedCode("XmlSerializer requires members that trimming cannot statically discover.")]
     T? FromXml<T>(string input, LoadOptions options = LoadOptions.PreserveWhitespace)
         where T : class;
 
@@ -33,6 +38,8 @@ public interface IXmlContext
     /// <param name="element">The XElement to deserialize.</param>
     /// <param name="options">The load options to use when processing the element.</param>
     /// <returns>The deserialized object, or null if deserialization fails.</returns>
+    [RequiresDynamicCode("XmlSerializer may require runtime code generation.")]
+    [RequiresUnreferencedCode("XmlSerializer requires members that trimming cannot statically discover.")]
     T? FromXml<T>(XElement element, LoadOptions options = LoadOptions.PreserveWhitespace)
         where T : class;
 }

--- a/src/ModularPipelines/Context/Domains/Data/IYamlContext.cs
+++ b/src/ModularPipelines/Context/Domains/Data/IYamlContext.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -14,6 +15,7 @@ public interface IYamlContext
     /// <typeparam name="T">The type of object to serialize.</typeparam>
     /// <param name="input">The object to serialize.</param>
     /// <returns>The YAML string representation of the object.</returns>
+    [RequiresDynamicCode("YamlDotNet serialization may require runtime code generation.")]
     string ToYaml<T>(T input) => ToYaml(input, CamelCaseNamingConvention.Instance);
 
     /// <summary>
@@ -23,6 +25,7 @@ public interface IYamlContext
     /// <param name="input">The object to serialize.</param>
     /// <param name="namingConvention">The naming convention to use for property names.</param>
     /// <returns>The YAML string representation of the object.</returns>
+    [RequiresDynamicCode("YamlDotNet serialization may require runtime code generation.")]
     string ToYaml<T>(T input, INamingConvention namingConvention);
 
     /// <summary>
@@ -31,6 +34,7 @@ public interface IYamlContext
     /// <typeparam name="T">The type to deserialize to.</typeparam>
     /// <param name="input">The YAML string to deserialize.</param>
     /// <returns>The deserialized object.</returns>
+    [RequiresDynamicCode("YamlDotNet deserialization may require runtime code generation.")]
     T FromYaml<T>(string input) => FromYaml<T>(input, CamelCaseNamingConvention.Instance);
 
     /// <summary>
@@ -40,5 +44,6 @@ public interface IYamlContext
     /// <param name="input">The YAML string to deserialize.</param>
     /// <param name="namingConvention">The naming convention to use for property names.</param>
     /// <returns>The deserialized object.</returns>
+    [RequiresDynamicCode("YamlDotNet deserialization may require runtime code generation.")]
     T FromYaml<T>(string input, INamingConvention namingConvention);
 }

--- a/src/ModularPipelines/Context/Domains/Data/IYamlContext.cs
+++ b/src/ModularPipelines/Context/Domains/Data/IYamlContext.cs
@@ -16,6 +16,7 @@ public interface IYamlContext
     /// <param name="input">The object to serialize.</param>
     /// <returns>The YAML string representation of the object.</returns>
     [RequiresDynamicCode("YamlDotNet serialization may require runtime code generation.")]
+    [RequiresUnreferencedCode("YamlDotNet serialization uses reflection over members that may be removed by trimming.")]
     string ToYaml<T>(T input) => ToYaml(input, CamelCaseNamingConvention.Instance);
 
     /// <summary>
@@ -26,6 +27,7 @@ public interface IYamlContext
     /// <param name="namingConvention">The naming convention to use for property names.</param>
     /// <returns>The YAML string representation of the object.</returns>
     [RequiresDynamicCode("YamlDotNet serialization may require runtime code generation.")]
+    [RequiresUnreferencedCode("YamlDotNet serialization uses reflection over members that may be removed by trimming.")]
     string ToYaml<T>(T input, INamingConvention namingConvention);
 
     /// <summary>
@@ -35,6 +37,7 @@ public interface IYamlContext
     /// <param name="input">The YAML string to deserialize.</param>
     /// <returns>The deserialized object.</returns>
     [RequiresDynamicCode("YamlDotNet deserialization may require runtime code generation.")]
+    [RequiresUnreferencedCode("YamlDotNet deserialization uses reflection over members that may be removed by trimming.")]
     T FromYaml<T>(string input) => FromYaml<T>(input, CamelCaseNamingConvention.Instance);
 
     /// <summary>
@@ -45,5 +48,6 @@ public interface IYamlContext
     /// <param name="namingConvention">The naming convention to use for property names.</param>
     /// <returns>The deserialized object.</returns>
     [RequiresDynamicCode("YamlDotNet deserialization may require runtime code generation.")]
+    [RequiresUnreferencedCode("YamlDotNet deserialization uses reflection over members that may be removed by trimming.")]
     T FromYaml<T>(string input, INamingConvention namingConvention);
 }

--- a/src/ModularPipelines/Context/Json.cs
+++ b/src/ModularPipelines/Context/Json.cs
@@ -1,27 +1,47 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using ModularPipelines.Context.Domains.Data;
 
 namespace ModularPipelines.Context;
 
 internal class Json : IJsonContext
 {
+    [RequiresDynamicCode("Reflection-based JSON serialization may require runtime code generation. Use the JsonTypeInfo overload for Native AOT.")]
+    [RequiresUnreferencedCode("Reflection-based JSON serialization may require members that trimming cannot statically discover. Use the JsonTypeInfo overload when trimming.")]
     public string ToJson<T>(T input)
     {
         return JsonSerializer.Serialize(input);
     }
 
+    [RequiresDynamicCode("Reflection-based JSON serialization may require runtime code generation. Use the JsonTypeInfo overload for Native AOT.")]
+    [RequiresUnreferencedCode("Reflection-based JSON serialization may require members that trimming cannot statically discover. Use the JsonTypeInfo overload when trimming.")]
     public string ToJson<T>(T input, JsonSerializerOptions options)
     {
         return JsonSerializer.Serialize(input, options);
     }
 
+    public string ToJson<T>(T input, JsonTypeInfo<T> jsonTypeInfo)
+    {
+        return JsonSerializer.Serialize(input, jsonTypeInfo);
+    }
+
+    [RequiresDynamicCode("Reflection-based JSON deserialization may require runtime code generation. Use the JsonTypeInfo overload for Native AOT.")]
+    [RequiresUnreferencedCode("Reflection-based JSON deserialization may require members that trimming cannot statically discover. Use the JsonTypeInfo overload when trimming.")]
     public T? FromJson<T>(string input)
     {
         return JsonSerializer.Deserialize<T>(input);
     }
 
+    [RequiresDynamicCode("Reflection-based JSON deserialization may require runtime code generation. Use the JsonTypeInfo overload for Native AOT.")]
+    [RequiresUnreferencedCode("Reflection-based JSON deserialization may require members that trimming cannot statically discover. Use the JsonTypeInfo overload when trimming.")]
     public T? FromJson<T>(string input, JsonSerializerOptions options)
     {
         return JsonSerializer.Deserialize<T>(input, options);
+    }
+
+    public T? FromJson<T>(string input, JsonTypeInfo<T> jsonTypeInfo)
+    {
+        return JsonSerializer.Deserialize(input, jsonTypeInfo);
     }
 }

--- a/src/ModularPipelines/Context/Xml.cs
+++ b/src/ModularPipelines/Context/Xml.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Xml.Linq;
 using System.Xml.Serialization;
 using ModularPipelines.Context.Domains.Data;
@@ -6,6 +7,8 @@ namespace ModularPipelines.Context;
 
 internal class Xml : IXmlContext
 {
+    [RequiresDynamicCode("XmlSerializer may require runtime code generation.")]
+    [RequiresUnreferencedCode("XmlSerializer requires members that trimming cannot statically discover.")]
     public string ToXml<T>(T input, SaveOptions options = SaveOptions.None)
     {
         var serializer = new XmlSerializer(typeof(T));
@@ -19,6 +22,8 @@ internal class Xml : IXmlContext
         return document.ToString();
     }
 
+    [RequiresDynamicCode("XmlSerializer may require runtime code generation.")]
+    [RequiresUnreferencedCode("XmlSerializer requires members that trimming cannot statically discover.")]
     public T? FromXml<T>(string input, LoadOptions options = LoadOptions.PreserveWhitespace)
         where T : class
     {
@@ -32,6 +37,8 @@ internal class Xml : IXmlContext
         return FromXml<T>(document.Root, options);
     }
 
+    [RequiresDynamicCode("XmlSerializer may require runtime code generation.")]
+    [RequiresUnreferencedCode("XmlSerializer requires members that trimming cannot statically discover.")]
     public T? FromXml<T>(XElement element, LoadOptions options = LoadOptions.PreserveWhitespace)
         where T : class
     {

--- a/src/ModularPipelines/Context/Yaml.cs
+++ b/src/ModularPipelines/Context/Yaml.cs
@@ -7,6 +7,7 @@ namespace ModularPipelines.Context;
 internal class Yaml : IYamlContext
 {
     [RequiresDynamicCode("YamlDotNet serialization may require runtime code generation.")]
+    [RequiresUnreferencedCode("YamlDotNet serialization uses reflection over members that may be removed by trimming.")]
     public string ToYaml<T>(T input, INamingConvention namingConvention)
     {
         return new SerializerBuilder()
@@ -17,6 +18,7 @@ internal class Yaml : IYamlContext
     }
 
     [RequiresDynamicCode("YamlDotNet deserialization may require runtime code generation.")]
+    [RequiresUnreferencedCode("YamlDotNet deserialization uses reflection over members that may be removed by trimming.")]
     public T FromYaml<T>(string input, INamingConvention namingConvention)
     {
         return new DeserializerBuilder()

--- a/src/ModularPipelines/Context/Yaml.cs
+++ b/src/ModularPipelines/Context/Yaml.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Context.Domains.Data;
 using YamlDotNet.Serialization;
 
@@ -5,6 +6,7 @@ namespace ModularPipelines.Context;
 
 internal class Yaml : IYamlContext
 {
+    [RequiresDynamicCode("YamlDotNet serialization may require runtime code generation.")]
     public string ToYaml<T>(T input, INamingConvention namingConvention)
     {
         return new SerializerBuilder()
@@ -14,6 +16,7 @@ internal class Yaml : IYamlContext
             .Serialize(input);
     }
 
+    [RequiresDynamicCode("YamlDotNet deserialization may require runtime code generation.")]
     public T FromYaml<T>(string input, INamingConvention namingConvention)
     {
         return new DeserializerBuilder()

--- a/src/ModularPipelines/Distributed/Extensions/DistributedPipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Distributed/Extensions/DistributedPipelineBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -26,6 +27,8 @@ public static class DistributedPipelineBuilderExtensions
     /// <summary>
     /// Enables distributed execution mode from configuration.
     /// </summary>
+    [RequiresUnreferencedCode("Configuration binding requires members of DistributedOptions that cannot be statically discovered.")]
+    [RequiresDynamicCode("Configuration binding may require runtime code generation.")]
     public static PipelineBuilder AddDistributedMode(this PipelineBuilder builder, IConfigurationSection section)
     {
         builder.Services.Configure<DistributedOptions>(section);
@@ -38,7 +41,9 @@ public static class DistributedPipelineBuilderExtensions
     /// <summary>
     /// Registers a custom distributed coordinator implementation.
     /// </summary>
-    public static PipelineBuilder AddDistributedCoordinator<TCoordinator>(this PipelineBuilder builder)
+    public static PipelineBuilder AddDistributedCoordinator<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TCoordinator>(
+        this PipelineBuilder builder)
         where TCoordinator : class, IDistributedCoordinator
     {
         builder.Services.AddSingleton<IDistributedCoordinator, TCoordinator>();
@@ -48,7 +53,9 @@ public static class DistributedPipelineBuilderExtensions
     /// <summary>
     /// Registers a distributed coordinator factory for async initialization.
     /// </summary>
-    public static PipelineBuilder AddDistributedCoordinatorFactory<TFactory>(this PipelineBuilder builder)
+    public static PipelineBuilder AddDistributedCoordinatorFactory<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TFactory>(
+        this PipelineBuilder builder)
         where TFactory : class, IDistributedCoordinatorFactory
     {
         builder.Services.AddSingleton<IDistributedCoordinatorFactory, TFactory>();

--- a/src/ModularPipelines/Distributed/Extensions/DistributedPipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Distributed/Extensions/DistributedPipelineBuilderExtensions.cs
@@ -13,6 +13,7 @@ public static class DistributedPipelineBuilderExtensions
     /// Enables distributed execution mode. When <see cref="DistributedOptions.TotalInstances"/> is greater than 1,
     /// the pipeline switches to master/worker mode. Otherwise, execution remains in-process.
     /// </summary>
+    /// <returns>The pipeline builder.</returns>
     public static PipelineBuilder AddDistributedMode(this PipelineBuilder builder, Action<DistributedOptions> configure)
     {
         builder.Services.Configure<DistributedOptions>(o =>
@@ -27,6 +28,7 @@ public static class DistributedPipelineBuilderExtensions
     /// <summary>
     /// Enables distributed execution mode from configuration.
     /// </summary>
+    /// <returns>The pipeline builder.</returns>
     [RequiresUnreferencedCode("Configuration binding requires members of DistributedOptions that cannot be statically discovered.")]
     [RequiresDynamicCode("Configuration binding may require runtime code generation.")]
     public static PipelineBuilder AddDistributedMode(this PipelineBuilder builder, IConfigurationSection section)
@@ -41,6 +43,7 @@ public static class DistributedPipelineBuilderExtensions
     /// <summary>
     /// Registers a custom distributed coordinator implementation.
     /// </summary>
+    /// <returns>The pipeline builder.</returns>
     public static PipelineBuilder AddDistributedCoordinator<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TCoordinator>(
         this PipelineBuilder builder)
@@ -53,6 +56,7 @@ public static class DistributedPipelineBuilderExtensions
     /// <summary>
     /// Registers a distributed coordinator factory for async initialization.
     /// </summary>
+    /// <returns>The pipeline builder.</returns>
     public static PipelineBuilder AddDistributedCoordinatorFactory<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TFactory>(
         this PipelineBuilder builder)

--- a/src/ModularPipelines/Distributed/Extensions/DistributedPipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Distributed/Extensions/DistributedPipelineBuilderExtensions.cs
@@ -14,6 +14,10 @@ public static class DistributedPipelineBuilderExtensions
     /// the pipeline switches to master/worker mode. Otherwise, execution remains in-process.
     /// </summary>
     /// <returns>The pipeline builder.</returns>
+    [RequiresUnreferencedCode(
+        "Distributed type-erased result serialization is unsupported in trimmed applications.")]
+    [RequiresDynamicCode(
+        "Distributed type-erased result serialization is unsupported in Native AOT.")]
     public static PipelineBuilder AddDistributedMode(this PipelineBuilder builder, Action<DistributedOptions> configure)
     {
         builder.Services.Configure<DistributedOptions>(o =>

--- a/src/ModularPipelines/Distributed/Serialization/ModuleResultSerializer.cs
+++ b/src/ModularPipelines/Distributed/Serialization/ModuleResultSerializer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using ModularPipelines.Distributed.Serialization;
 using ModularPipelines.Models;
@@ -30,6 +31,14 @@ internal class ModuleResultSerializer
         }
     }
 
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Distributed type-erased result serialization is explicitly unsupported in Native AOT.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Distributed type-erased result serialization is explicitly unsupported in trimmed applications.")]
     public ModularPipelines.Distributed.SerializedModuleResult Serialize(IModuleResult result, string moduleTypeName, string resultTypeName, int workerIndex)
     {
         // Serialize as the ModuleResult<T> base type so the custom converter writes the $type discriminator.
@@ -48,6 +57,14 @@ internal class ModuleResultSerializer
         );
     }
 
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Distributed type-erased result serialization is explicitly unsupported in Native AOT.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Distributed type-erased result serialization is explicitly unsupported in trimmed applications.")]
     public IModuleResult? Deserialize(ModularPipelines.Distributed.SerializedModuleResult serialized)
     {
         var resolved = _typeRegistry.Resolve(serialized.ModuleTypeName) ?? throw new InvalidOperationException(

--- a/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
+++ b/src/ModularPipelines/Engine/AssemblyLoadedTypesProvider.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using ModularPipelines.Modules;
 
 namespace ModularPipelines.Engine;
@@ -11,14 +12,19 @@ internal class AssemblyLoadedTypesProvider : IAssemblyLoadedTypesProvider
 
     public Type[] GetLoadedTypesAssignableTo(Type type)
     {
+        var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+        var knownTypes = RuntimeFeature.IsDynamicCodeSupported
+            ? loadedAssemblies
+                .Where(ReferencesModularPipelines)
+                .SelectMany(assembly => GetKnownTypes(assembly, type))
+            : loadedAssemblies
+                .SelectMany(assembly => GetGeneratedKnownTypes(assembly, type));
+
         return
         [
-            .. AppDomain.CurrentDomain
-            .GetAssemblies()
-            .Where(ReferencesModularPipelines)
-            .SelectMany(assembly => GetKnownTypes(assembly, type))
-            .Where(t => t.IsAssignableTo(type))
-            .Where(t => !t.IsAbstract),
+            .. knownTypes
+                .Where(t => t.IsAssignableTo(type))
+                .Where(t => !t.IsAbstract),
         ];
     }
 
@@ -39,16 +45,37 @@ internal class AssemblyLoadedTypesProvider : IAssemblyLoadedTypesProvider
         Justification = "Generated metadata is used when complete; reflection is the explicit compatibility fallback for dynamic assemblies.")]
     internal static IEnumerable<Type> GetKnownTypes(Assembly assembly, Type assignableTo)
     {
-        if (typeof(IModule).IsAssignableFrom(assignableTo)
-            && GeneratedModuleMetadata.TryGetModuleTypes(
-                assembly,
-                out var generatedModuleTypes,
-                out var generatedMetadataIsComplete)
-            && generatedMetadataIsComplete)
+        if (TryGetGeneratedKnownTypes(assembly, assignableTo, out var generatedModuleTypes))
         {
             return generatedModuleTypes;
         }
 
         return AssemblyTypeLoader.GetLoadableTypes(assembly);
+    }
+
+    internal static IEnumerable<Type> GetGeneratedKnownTypes(Assembly assembly, Type assignableTo)
+    {
+        return TryGetGeneratedKnownTypes(assembly, assignableTo, out var generatedModuleTypes)
+            ? generatedModuleTypes
+            : [];
+    }
+
+    private static bool TryGetGeneratedKnownTypes(
+        Assembly assembly,
+        Type assignableTo,
+        out IReadOnlyList<Type> generatedModuleTypes)
+    {
+        if (typeof(IModule).IsAssignableFrom(assignableTo)
+            && GeneratedModuleMetadata.TryGetModuleTypes(
+                assembly,
+                out generatedModuleTypes,
+                out var generatedMetadataIsComplete)
+            && generatedMetadataIsComplete)
+        {
+            return true;
+        }
+
+        generatedModuleTypes = [];
+        return false;
     }
 }

--- a/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Exceptions;
@@ -20,6 +21,10 @@ internal class DependencyWaiter : IDependencyWaiter
     }
 
     /// <inheritdoc />
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Generated runtime metadata handles statically known modules; MakeGenericType is the documented fallback for dynamic modules.")]
     public async Task WaitForDependenciesAsync(ModuleState moduleState, IModuleScheduler scheduler, IServiceProvider scopedServiceProvider)
     {
         foreach (var (dependencyType, optional) in moduleState.Dependencies)
@@ -34,8 +39,12 @@ internal class DependencyWaiter : IDependencyWaiter
                 }
                 catch (Exception e) when (moduleState.Module.ModuleRunType == ModuleRunType.AlwaysRun)
                 {
-                    var loggerType = typeof(ModuleLogger<>).MakeGenericType(moduleState.ModuleType);
-                    var depLogger = (IModuleLogger) scopedServiceProvider.GetRequiredService(loggerType);
+                    var depLogger = GeneratedModuleMetadata.TryGetRuntime(
+                        moduleState.ModuleType,
+                        out var runtime)
+                            ? runtime.GetLogger(scopedServiceProvider)
+                            : (IModuleLogger) scopedServiceProvider.GetRequiredService(
+                                typeof(ModuleLogger<>).MakeGenericType(moduleState.ModuleType));
                     _secondaryExceptionContainer.RegisterException(new AlwaysRunPostponedException(
                         $"{dependencyType.Name} threw an exception when {moduleState.ModuleType.Name} was waiting for it as a dependency",
                         e));

--- a/src/ModularPipelines/Engine/Execution/ExecutionContextFactory.cs
+++ b/src/ModularPipelines/Engine/Execution/ExecutionContextFactory.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -28,11 +29,20 @@ internal static class ExecutionContextFactory
     /// <returns>A typed ModuleExecutionContext.</returns>
     public static ModuleExecutionContext Create(IModule module, Type moduleType)
     {
+        if (GeneratedModuleMetadata.TryGetRuntime(moduleType, out var runtime))
+        {
+            return runtime.CreateExecutionContext(module, moduleType);
+        }
+
         var resultType = module.ResultType;
         var factory = ContextFactoryCache.GetOrAdd(resultType, CreateFactory);
         return factory(module, moduleType);
     }
 
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Generated runtime metadata creates contexts for statically known modules; this factory is the documented fallback for dynamic modules.")]
     private static CreateContextDelegate CreateFactory(Type resultType)
     {
         // Parameters

--- a/src/ModularPipelines/Engine/Execution/ModuleExecutionDelegateFactory.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleExecutionDelegateFactory.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using ModularPipelines.Context;
@@ -28,19 +29,11 @@ internal static class ModuleExecutionDelegateFactory
 
     private static readonly ConcurrentDictionary<Type, ExecuteModuleDelegate> ExecutorCache = new();
 
-    /// <summary>
-    /// Cache for generic MethodInfo instances created via MakeGenericMethod.
-    /// Key is the result type, value is the specialized MethodInfo.
-    /// </summary>
-    private static readonly ConcurrentDictionary<Type, MethodInfo> ExecuteAsyncMethodCache = new();
     private static readonly ConcurrentDictionary<Type, MethodInfo> ExecuteAndCastAsyncMethodCache = new();
 
     /// <summary>
     /// Base method definitions, cached once on first use.
     /// </summary>
-    private static readonly MethodInfo ExecuteAsyncMethodDefinition =
-        typeof(IModuleExecutionPipeline).GetMethod(nameof(IModuleExecutionPipeline.ExecuteAsync))!;
-
     private static readonly MethodInfo ExecuteAndCastAsyncMethodDefinition =
         typeof(ModuleExecutionDelegateFactory).GetMethod(nameof(ExecuteAndCastAsync), BindingFlags.NonPublic | BindingFlags.Static)!;
 
@@ -54,6 +47,10 @@ internal static class ModuleExecutionDelegateFactory
         return ExecutorCache.GetOrAdd(resultType, CreateExecutor);
     }
 
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Generated runtime metadata handles statically known modules; this factory is the documented fallback for dynamic modules.")]
     private static ExecuteModuleDelegate CreateExecutor(Type resultType)
     {
         // Parameters for the delegate
@@ -66,8 +63,6 @@ internal static class ModuleExecutionDelegateFactory
         // Get the generic types
         var moduleType = typeof(Module<>).MakeGenericType(resultType);
         var executionContextType = typeof(ModuleExecutionContext<>).MakeGenericType(resultType);
-        var moduleResultType = typeof(ModuleResult<>).MakeGenericType(resultType);
-        var taskType = typeof(Task<>).MakeGenericType(moduleResultType);
 
         // Cast module to Module<T>
         var castModule = Expression.Convert(moduleParam, moduleType);
@@ -75,25 +70,11 @@ internal static class ModuleExecutionDelegateFactory
         // Cast executionContext to ModuleExecutionContext<T>
         var castContext = Expression.Convert(contextParam, executionContextType);
 
-        // Get the ExecuteAsync method (cached)
-        var executeMethod = ExecuteAsyncMethodCache.GetOrAdd(
-            resultType,
-            static type => ExecuteAsyncMethodDefinition.MakeGenericMethod(type));
-
-        // Call pipeline.ExecuteAsync<T>(module, executionContext, moduleContext, cancellationToken)
-        var callExecute = Expression.Call(
-            pipelineParam,
-            executeMethod,
-            castModule,
-            castContext,
-            moduleContextParam,
-            cancellationTokenParam);
-
         // We need to create an async wrapper that awaits the task and casts the result to IModuleResult
         // Since Expression trees can't directly represent async/await, we'll use a helper method (cached)
         var helperMethod = ExecuteAndCastAsyncMethodCache.GetOrAdd(
             resultType,
-            static type => ExecuteAndCastAsyncMethodDefinition.MakeGenericMethod(type));
+            MakeExecuteAndCastAsyncMethod);
 
         var callHelper = Expression.Call(
             helperMethod,
@@ -113,6 +94,19 @@ internal static class ModuleExecutionDelegateFactory
             cancellationTokenParam);
 
         return lambda.Compile();
+    }
+
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Generated runtime metadata handles statically known modules; this factory is the documented fallback for dynamic modules.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2060",
+        Justification = "Generated runtime metadata handles statically known modules; this factory is the documented fallback for dynamic modules.")]
+    private static MethodInfo MakeExecuteAndCastAsyncMethod(Type resultType)
+    {
+        return ExecuteAndCastAsyncMethodDefinition.MakeGenericMethod(resultType);
     }
 
     private static async Task<IModuleResult> ExecuteAndCastAsync<T>(

--- a/src/ModularPipelines/Engine/Execution/ModuleResultFactory.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleResultFactory.cs
@@ -70,7 +70,7 @@ internal static class ModuleResultFactory
             .GetMethod(nameof(CreateSkippedGeneric), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
             .MakeGenericMethod(resultType);
 
-        return (IModuleResult)method.Invoke(null, [executionContext.SkipResult ?? SkipDecision.DoNotSkip, executionContext])!;
+        return (IModuleResult) method.Invoke(null, [executionContext.SkipResult ?? SkipDecision.DoNotSkip, executionContext])!;
     }
 
     /// <summary>
@@ -86,17 +86,7 @@ internal static class ModuleResultFactory
             .GetMethod(nameof(CreateFailureGeneric), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
             .MakeGenericMethod(resultType);
 
-        return (IModuleResult)method.Invoke(null, [exception, executionContext])!;
-    }
-
-    private static IModuleResult CreateSkippedGeneric<T>(SkipDecision decision, ModuleExecutionContext ctx)
-    {
-        return ModuleResult<T>.CreateSkipped(decision, ctx);
-    }
-
-    private static IModuleResult CreateFailureGeneric<T>(Exception exception, ModuleExecutionContext ctx)
-    {
-        return ModuleResult<T>.CreateFailure(exception, ctx);
+        return (IModuleResult) method.Invoke(null, [exception, executionContext])!;
     }
 
     /// <summary>
@@ -144,7 +134,17 @@ internal static class ModuleResultFactory
             .GetMethod(nameof(WithStatusGeneric), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
             .MakeGenericMethod(valueType);
 
-        return (IModuleResult)method.Invoke(null, [result, status])!;
+        return (IModuleResult) method.Invoke(null, [result, status])!;
+    }
+
+    private static IModuleResult CreateSkippedGeneric<T>(SkipDecision decision, ModuleExecutionContext ctx)
+    {
+        return ModuleResult<T>.CreateSkipped(decision, ctx);
+    }
+
+    private static IModuleResult CreateFailureGeneric<T>(Exception exception, ModuleExecutionContext ctx)
+    {
+        return ModuleResult<T>.CreateFailure(exception, ctx);
     }
 
     private static IModuleResult WithStatusGeneric<T>(ModuleResult<T> result, Status status)

--- a/src/ModularPipelines/Engine/Execution/ModuleResultFactory.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleResultFactory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Enums;
 using ModularPipelines.Models;
 
@@ -59,6 +60,10 @@ internal static class ModuleResultFactory
     /// <summary>
     /// Creates a skipped ModuleResult (type-erased version for engine use).
     /// </summary>
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Type-erased result creation is used by dynamic and history paths that are unsupported in Native AOT.")]
     public static IModuleResult CreateSkipped(Type resultType, ModuleExecutionContext executionContext)
     {
         var method = typeof(ModuleResultFactory)
@@ -71,6 +76,10 @@ internal static class ModuleResultFactory
     /// <summary>
     /// Creates a failure ModuleResult (type-erased version for engine use).
     /// </summary>
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Type-erased result creation is used by dynamic and history paths that are unsupported in Native AOT.")]
     public static IModuleResult CreateException(Type resultType, Exception exception, ModuleExecutionContext executionContext)
     {
         var method = typeof(ModuleResultFactory)
@@ -93,6 +102,10 @@ internal static class ModuleResultFactory
     /// <summary>
     /// Creates a copy of the result with a different status (type-erased version for engine use).
     /// </summary>
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Type-erased result mutation is used by dynamic and history paths that are unsupported in Native AOT.")]
     public static IModuleResult WithStatus(IModuleResult result, Status status)
     {
         // Handle non-generic Failure/Skipped types directly (most efficient path)

--- a/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
@@ -32,8 +32,9 @@ internal class ModuleResultRegistrar : IModuleResultRegistrar
         executionContext.Status = Enums.Status.PipelineTerminated;
         executionContext.Exception = exception;
 
-        // Create ModuleResult<T> with the exception using compiled delegate factory
-        var result = ModuleResultFactory.CreateException(resultType, exception, executionContext);
+        var result = GeneratedModuleMetadata.TryGetRuntime(moduleType, out var runtime)
+            ? runtime.CreateFailure(exception, executionContext)
+            : ModuleResultFactory.CreateException(resultType, exception, executionContext);
 
         _resultRegistry.RegisterResult(moduleType, result);
     }

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -147,8 +148,7 @@ internal class ModuleRunner : IModuleRunner
         // Create module-specific context
         var executionContext = CreateExecutionContext(module, moduleType);
         ApplyDependencySkip(moduleState, executionContext);
-        var loggerType = typeof(ModuleLogger<>).MakeGenericType(moduleType);
-        var logger = (IModuleLogger) scopedServiceProvider.GetRequiredService(loggerType);
+        var logger = GetModuleLogger(scopedServiceProvider, moduleType);
         var moduleContext = new ModuleContext(pipelineContext, module, executionContext, logger);
 
         // Start Activity for distributed tracing (Phase 1: alongside AsyncLocal for compatibility)
@@ -228,7 +228,7 @@ internal class ModuleRunner : IModuleRunner
             // Invoke OnModuleStart lifecycle event
             await _lifecycleEventInvoker.InvokeStartEventAsync(lifecycleContext).ConfigureAwait(false);
 
-            // Execute via the ModuleExecutionPipeline using reflection to handle the generic type
+            // Execute through generated typed metadata when available.
             var result = await ExecuteTypedModule(module, executionContext, moduleContext, cancellationToken).ConfigureAwait(false);
 
             moduleState.Result = result;
@@ -319,9 +319,37 @@ internal class ModuleRunner : IModuleRunner
         IModuleContext moduleContext,
         CancellationToken cancellationToken)
     {
-        // Use compiled delegate instead of MakeGenericMethod + Invoke + GetProperty("Result")
+        if (GeneratedModuleMetadata.TryGetRuntime(module.GetType(), out var runtime))
+        {
+            return await runtime.ExecuteAsync(
+                    _executionPipeline,
+                    module,
+                    executionContext,
+                    moduleContext,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        // Dynamic/plugin modules retain the annotated reflection fallback.
         var executor = ModuleExecutionDelegateFactory.GetExecutor(module.ResultType);
         return await executor(_executionPipeline, module, executionContext, moduleContext, cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Generated runtime metadata handles statically known modules; MakeGenericType is the documented fallback for dynamic modules.")]
+    private static IModuleLogger GetModuleLogger(
+        IServiceProvider serviceProvider,
+        Type moduleType)
+    {
+        if (GeneratedModuleMetadata.TryGetRuntime(moduleType, out var runtime))
+        {
+            return runtime.GetLogger(serviceProvider);
+        }
+
+        var loggerType = typeof(ModuleLogger<>).MakeGenericType(moduleType);
+        return (IModuleLogger) serviceProvider.GetRequiredService(loggerType);
     }
 }

--- a/src/ModularPipelines/Engine/Execution/ResultRepositoryDelegateFactory.cs
+++ b/src/ModularPipelines/Engine/Execution/ResultRepositoryDelegateFactory.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
 using ModularPipelines.Context;
@@ -22,19 +23,11 @@ internal static class ResultRepositoryDelegateFactory
 
     private static readonly ConcurrentDictionary<Type, GetResultDelegate> GetResultCache = new();
 
-    /// <summary>
-    /// Cache for generic MethodInfo instances created via MakeGenericMethod.
-    /// Key is the result type, value is the specialized MethodInfo.
-    /// </summary>
-    private static readonly ConcurrentDictionary<Type, MethodInfo> GetResultAsyncMethodCache = new();
     private static readonly ConcurrentDictionary<Type, MethodInfo> GetResultAndCastAsyncMethodCache = new();
 
     /// <summary>
     /// Base method definitions, cached once on first use.
     /// </summary>
-    private static readonly MethodInfo GetResultAsyncMethodDefinition =
-        typeof(IModuleResultRepository).GetMethod(nameof(IModuleResultRepository.GetResultAsync))!;
-
     private static readonly MethodInfo GetResultAndCastAsyncMethodDefinition =
         typeof(ResultRepositoryDelegateFactory).GetMethod(nameof(GetResultAndCastAsync), BindingFlags.NonPublic | BindingFlags.Static)!;
 
@@ -46,6 +39,10 @@ internal static class ResultRepositoryDelegateFactory
         return GetResultCache.GetOrAdd(resultType, CreateGetResultDelegate);
     }
 
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Runtime result repositories support dynamic result types only outside Native AOT.")]
     private static GetResultDelegate CreateGetResultDelegate(Type resultType)
     {
         var repositoryParam = Expression.Parameter(typeof(IModuleResultRepository), "repository");
@@ -58,23 +55,28 @@ internal static class ResultRepositoryDelegateFactory
         // Cast module to Module<T>
         var castModule = Expression.Convert(moduleParam, moduleType);
 
-        // Get the GetResultAsync<T> method (cached)
-        var method = GetResultAsyncMethodCache.GetOrAdd(
-            resultType,
-            static type => GetResultAsyncMethodDefinition.MakeGenericMethod(type));
-
-        // Call: repository.GetResultAsync<T>((Module<T>)module, context)
-        var callMethod = Expression.Call(repositoryParam, method, castModule, contextParam);
-
         // We need an async helper since expression trees can't represent async (cached)
         var helperMethod = GetResultAndCastAsyncMethodCache.GetOrAdd(
             resultType,
-            static type => GetResultAndCastAsyncMethodDefinition.MakeGenericMethod(type));
+            MakeGetResultAndCastAsyncMethod);
 
         var callHelper = Expression.Call(helperMethod, repositoryParam, castModule, contextParam);
 
         var lambda = Expression.Lambda<GetResultDelegate>(callHelper, repositoryParam, moduleParam, contextParam);
         return lambda.Compile();
+    }
+
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Runtime result repositories support dynamic result types only outside Native AOT.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2060",
+        Justification = "Runtime result repositories support dynamic result types only outside Native AOT.")]
+    private static MethodInfo MakeGetResultAndCastAsyncMethod(Type resultType)
+    {
+        return GetResultAndCastAsyncMethodDefinition.MakeGenericMethod(resultType);
     }
 
     private static async Task<IModuleResult?> GetResultAndCastAsync<T>(

--- a/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
@@ -127,13 +127,26 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
         executionContext.Status = Status.Skipped;
         executionContext.SkipResult = ignoredModule.SkipDecision;
 
-        // Create ModuleResult<T> with the skipped status using compiled delegate factory
-        var result = ModuleResultFactory.CreateSkipped(resultType, executionContext);
+        // Prefer generated typed metadata so Native AOT has compiled result and
+        // completion-source adapters.
+        var hasGeneratedRuntime = GeneratedModuleMetadata.TryGetRuntime(
+            moduleType,
+            out var runtime);
+        var result = hasGeneratedRuntime
+            ? runtime.CreateSkipped(executionContext)
+            : ModuleResultFactory.CreateSkipped(resultType, executionContext);
 
         _resultRegistry.RegisterResult(moduleType, result);
 
         // Set the completion source so awaiting the module returns immediately
-        SetModuleCompletionSource(module, resultType, result);
+        if (hasGeneratedRuntime)
+        {
+            runtime.SetCompletionSource(module, result);
+        }
+        else
+        {
+            SetModuleCompletionSource(module, resultType, result);
+        }
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -182,6 +183,14 @@ internal static class CompletionSourceSetterCache
         return Cache.GetOrAdd(resultType, CreateSetter);
     }
 
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "The dynamic completion-source setter is used by history paths that are unsupported in Native AOT.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2075",
+        Justification = "The dynamic completion-source setter is used by history paths that are unsupported when trimming.")]
     private static Action<IModule, IModuleResult> CreateSetter(Type resultType)
     {
         // Create compiled delegate for: ((Module<T>)module).CompletionSource.TrySetResult((ModuleResult<T>)result)

--- a/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
+++ b/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
@@ -197,7 +197,11 @@ internal interface IGeneratedModuleRuntime
 {
     ModuleExecutionContext CreateExecutionContext(IModule module, Type moduleType);
 
+    IModuleResult CreateSkipped(ModuleExecutionContext executionContext);
+
     IModuleLogger GetLogger(IServiceProvider serviceProvider);
+
+    void SetCompletionSource(IModule module, IModuleResult result);
 
     Task<IModuleResult> ExecuteAsync(
         IModuleExecutionPipeline pipeline,
@@ -215,9 +219,21 @@ internal sealed class GeneratedModuleRuntime<TModule, TResult> : IGeneratedModul
         return new ModuleExecutionContext<TResult>((Module<TResult>) module, moduleType);
     }
 
+    public IModuleResult CreateSkipped(ModuleExecutionContext executionContext)
+    {
+        return ModuleResult<TResult>.CreateSkipped(
+            executionContext.SkipResult ?? SkipDecision.DoNotSkip,
+            (ModuleExecutionContext<TResult>) executionContext);
+    }
+
     public IModuleLogger GetLogger(IServiceProvider serviceProvider)
     {
         return serviceProvider.GetRequiredService<ModuleLogger<TModule>>();
+    }
+
+    public void SetCompletionSource(IModule module, IModuleResult result)
+    {
+        ((Module<TResult>) module).CompletionSource.TrySetResult((ModuleResult<TResult>) result);
     }
 
     public async Task<IModuleResult> ExecuteAsync(

--- a/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
+++ b/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using ModularPipelines.Context;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Extensions;
@@ -205,6 +206,8 @@ internal interface IGeneratedModuleRuntime
 
     IModuleLogger GetLogger(IServiceProvider serviceProvider);
 
+    ILogger GetOutputLogger(IServiceProvider serviceProvider);
+
     void SetCompletionSource(IModule module, IModuleResult result);
 
     Task<IModuleResult> ExecuteAsync(
@@ -242,6 +245,11 @@ internal sealed class GeneratedModuleRuntime<TModule, TResult> : IGeneratedModul
     public IModuleLogger GetLogger(IServiceProvider serviceProvider)
     {
         return serviceProvider.GetRequiredService<ModuleLogger<TModule>>();
+    }
+
+    public ILogger GetOutputLogger(IServiceProvider serviceProvider)
+    {
+        return serviceProvider.GetRequiredService<ILogger<TModule>>();
     }
 
     public void SetCompletionSource(IModule module, IModuleResult result)

--- a/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
+++ b/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
@@ -197,6 +197,10 @@ internal interface IGeneratedModuleRuntime
 {
     ModuleExecutionContext CreateExecutionContext(IModule module, Type moduleType);
 
+    IModuleResult CreateFailure(
+        Exception exception,
+        ModuleExecutionContext executionContext);
+
     IModuleResult CreateSkipped(ModuleExecutionContext executionContext);
 
     IModuleLogger GetLogger(IServiceProvider serviceProvider);
@@ -217,6 +221,15 @@ internal sealed class GeneratedModuleRuntime<TModule, TResult> : IGeneratedModul
     public ModuleExecutionContext CreateExecutionContext(IModule module, Type moduleType)
     {
         return new ModuleExecutionContext<TResult>((Module<TResult>) module, moduleType);
+    }
+
+    public IModuleResult CreateFailure(
+        Exception exception,
+        ModuleExecutionContext executionContext)
+    {
+        return ModuleResult<TResult>.CreateFailure(
+            exception,
+            (ModuleExecutionContext<TResult>) executionContext);
     }
 
     public IModuleResult CreateSkipped(ModuleExecutionContext executionContext)

--- a/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
+++ b/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
@@ -3,7 +3,11 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Context;
+using ModularPipelines.Engine.Execution;
 using ModularPipelines.Extensions;
+using ModularPipelines.Logging;
+using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
 namespace ModularPipelines.Engine;
@@ -34,6 +38,28 @@ public static class GeneratedModuleMetadata
             static services => services.AddModule<TModule>(),
             dependencies.ToArray(),
             dependenciesComplete);
+    }
+
+    /// <summary>
+    /// Creates trim-safe registration and runtime metadata for one typed module.
+    /// </summary>
+    /// <returns>The generated registration metadata.</returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static GeneratedModuleRegistration CreateRegistration<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TModule,
+        TResult>(
+        IReadOnlyList<ModuleDependencyMetadata> dependencies,
+        bool dependenciesComplete = true)
+        where TModule : Module<TResult>
+    {
+        return new GeneratedModuleRegistration(
+            typeof(TModule),
+            static services => services.AddModule<TModule>(),
+            dependencies.ToArray(),
+            dependenciesComplete)
+        {
+            Runtime = new GeneratedModuleRuntime<TModule, TResult>(),
+        };
     }
 
     /// <summary>
@@ -130,6 +156,19 @@ public static class GeneratedModuleMetadata
         return true;
     }
 
+    internal static bool TryGetRuntime(Type moduleType, out IGeneratedModuleRuntime runtime)
+    {
+        if (Modules.TryGetValue(moduleType, out var registration)
+            && registration.Runtime is not null)
+        {
+            runtime = registration.Runtime;
+            return true;
+        }
+
+        runtime = null!;
+        return false;
+    }
+
     private sealed record AssemblyModuleMetadata(
         IReadOnlyList<GeneratedModuleRegistration> Registrations,
         bool IsComplete);
@@ -143,10 +182,56 @@ public sealed record GeneratedModuleRegistration(
     Type ModuleType,
     Action<IServiceCollection> Register,
     IReadOnlyList<ModuleDependencyMetadata> Dependencies,
-    bool DependenciesComplete = true);
+    bool DependenciesComplete = true)
+{
+    internal IGeneratedModuleRuntime? Runtime { get; init; }
+}
 
 /// <summary>
 /// Describes a statically declared module dependency.
 /// </summary>
 [EditorBrowsable(EditorBrowsableState.Never)]
 public sealed record ModuleDependencyMetadata(Type DependencyType, bool Optional);
+
+internal interface IGeneratedModuleRuntime
+{
+    ModuleExecutionContext CreateExecutionContext(IModule module, Type moduleType);
+
+    IModuleLogger GetLogger(IServiceProvider serviceProvider);
+
+    Task<IModuleResult> ExecuteAsync(
+        IModuleExecutionPipeline pipeline,
+        IModule module,
+        ModuleExecutionContext executionContext,
+        IModuleContext moduleContext,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class GeneratedModuleRuntime<TModule, TResult> : IGeneratedModuleRuntime
+    where TModule : Module<TResult>
+{
+    public ModuleExecutionContext CreateExecutionContext(IModule module, Type moduleType)
+    {
+        return new ModuleExecutionContext<TResult>((Module<TResult>) module, moduleType);
+    }
+
+    public IModuleLogger GetLogger(IServiceProvider serviceProvider)
+    {
+        return serviceProvider.GetRequiredService<ModuleLogger<TModule>>();
+    }
+
+    public async Task<IModuleResult> ExecuteAsync(
+        IModuleExecutionPipeline pipeline,
+        IModule module,
+        ModuleExecutionContext executionContext,
+        IModuleContext moduleContext,
+        CancellationToken cancellationToken)
+    {
+        return await pipeline.ExecuteAsync(
+                (Module<TResult>) module,
+                (ModuleExecutionContext<TResult>) executionContext,
+                moduleContext,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/ModularPipelines/Engine/OptionsProvider.cs
+++ b/src/ModularPipelines/Engine/OptionsProvider.cs
@@ -130,6 +130,7 @@ internal class OptionsProvider : IOptionsProvider
     /// <summary>
     /// Creates a delegate to access the Value property of an IOptions&lt;T&gt; instance.
     /// </summary>
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicProperties, typeof(IOptions<>))]
     [UnconditionalSuppressMessage(
         "Trimming",
         "IL2070",

--- a/src/ModularPipelines/Engine/OptionsProvider.cs
+++ b/src/ModularPipelines/Engine/OptionsProvider.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq.Expressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.DependencyInjection;
@@ -26,7 +25,7 @@ namespace ModularPipelines.Engine;
 internal class OptionsProvider : IOptionsProvider
 {
     /// <summary>
-    /// Cache of compiled property accessors for IOptions&lt;T&gt;.Value.
+    /// Cache of property accessors for IOptions&lt;T&gt;.Value.
     /// Avoids repeated reflection for property access.
     /// </summary>
     private static readonly ConcurrentDictionary<Type, Func<object, object?>> ValueGetterCache = new();
@@ -105,8 +104,8 @@ internal class OptionsProvider : IOptionsProvider
                 continue;
             }
 
-            // Use cached compiled delegate instead of reflection
-            var getter = ValueGetterCache.GetOrAdd(option.GetType(), CreateValueGetter);
+            // Cache the interface property lookup used for each options type
+            var getter = ValueGetterCache.GetOrAdd(optionsType, CreateValueGetter);
             yield return getter(option);
         }
     }
@@ -128,12 +127,8 @@ internal class OptionsProvider : IOptionsProvider
     }
 
     /// <summary>
-    /// Creates a compiled delegate to access the Value property of an IOptions&lt;T&gt; instance.
+    /// Creates a delegate to access the Value property of an IOptions&lt;T&gt; instance.
     /// </summary>
-    [UnconditionalSuppressMessage(
-        "AOT",
-        "IL3050",
-        Justification = "Options registered through the static DI path are rooted; runtime-discovered option types are unsupported in Native AOT.")]
     [UnconditionalSuppressMessage(
         "Trimming",
         "IL2070",
@@ -143,13 +138,7 @@ internal class OptionsProvider : IOptionsProvider
         var valueProperty = optionsType.GetProperty("Value")
             ?? throw new InvalidOperationException($"Property 'Value' not found on type '{optionsType.Name}'.");
 
-        // Build: (object obj) => (object?)((OptionsType)obj).Value
-        var param = Expression.Parameter(typeof(object), "obj");
-        var cast = Expression.Convert(param, optionsType);
-        var propertyAccess = Expression.Property(cast, valueProperty);
-        var convertToObject = Expression.Convert(propertyAccess, typeof(object));
-
-        return Expression.Lambda<Func<object, object?>>(convertToObject, param).Compile();
+        return instance => valueProperty.GetValue(instance);
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/OptionsProvider.cs
+++ b/src/ModularPipelines/Engine/OptionsProvider.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.DependencyInjection;
@@ -40,8 +42,8 @@ internal class OptionsProvider : IOptionsProvider
     /// Using a HashSet for O(1) lookup instead of multiple IsAssignableTo calls.
     /// This is read-only after static initialization so no synchronization needed.
     /// </summary>
-    private static readonly HashSet<Type> OptionsTypeDefinitions = new()
-    {
+    private static readonly HashSet<Type> OptionsTypeDefinitions =
+    [
         typeof(IConfigureOptions<>),
         typeof(IPostConfigureOptions<>),
         typeof(IOptions<>),
@@ -49,7 +51,7 @@ internal class OptionsProvider : IOptionsProvider
         typeof(IOptionsSnapshot<>),
         typeof(IValidateOptions<>),
         typeof(IConfigureNamedOptions<>),
-    };
+    ];
 
     private readonly IPipelineServiceContainerWrapper _pipelineServiceContainerWrapper;
     private readonly IServiceProvider _serviceProvider;
@@ -67,12 +69,11 @@ internal class OptionsProvider : IOptionsProvider
 
         // Use Lazy<T> for thread-safe initialization
         _cachedOptionTypes = new Lazy<IReadOnlyList<Type>>(
-            () => _pipelineServiceContainerWrapper.ServiceCollection
+            () => [.. _pipelineServiceContainerWrapper.ServiceCollection
                 .Select(sd => sd.ServiceType)
                 .Where(t => t.IsGenericType && t.IsConstructedGenericType && IsOptionsType(t.GetGenericTypeDefinition()))
                 .Select(s => s.GetGenericArguments()[0])
-                .Distinct()
-                .ToList(),
+                .Distinct()],
             LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
@@ -138,7 +139,18 @@ internal class OptionsProvider : IOptionsProvider
         var valueProperty = optionsType.GetProperty("Value")
             ?? throw new InvalidOperationException($"Property 'Value' not found on type '{optionsType.Name}'.");
 
-        return instance => valueProperty.GetValue(instance);
+        return instance =>
+        {
+            try
+            {
+                return valueProperty.GetValue(instance);
+            }
+            catch (TargetInvocationException exception) when (exception.InnerException is not null)
+            {
+                ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+                throw;
+            }
+        };
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/OptionsProvider.cs
+++ b/src/ModularPipelines/Engine/OptionsProvider.cs
@@ -1,7 +1,11 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.DependencyInjection;
+using ModularPipelines.Distributed;
+using ModularPipelines.Options;
 
 namespace ModularPipelines.Engine;
 
@@ -80,11 +84,20 @@ internal class OptionsProvider : IOptionsProvider
     /// <remarks>
     /// This method is thread-safe. The options type list is cached on first access.
     /// </remarks>
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(PipelineOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(SchedulerOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(ConcurrencyOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(HttpResilienceOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(ModuleRegistrationOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(SecretMaskingOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(DistributedOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(ArtifactOptions))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(LoggerFilterOptions))]
     public IEnumerable<object?> GetOptions()
     {
         foreach (var t in _cachedOptionTypes.Value)
         {
-            var optionsType = IOptionsTypeCache.GetOrAdd(t, static innerType => typeof(IOptions<>).MakeGenericType(innerType));
+            var optionsType = IOptionsTypeCache.GetOrAdd(t, CreateOptionsType);
             var option = _serviceProvider.GetService(optionsType);
 
             if (option is null)
@@ -99,8 +112,32 @@ internal class OptionsProvider : IOptionsProvider
     }
 
     /// <summary>
+    /// Creates the closed IOptions type for a runtime-discovered options type.
+    /// </summary>
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Options registered through the static DI path are rooted; runtime-discovered option types are unsupported in Native AOT.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2071",
+        Justification = "Options registered through the static DI path are rooted; runtime-discovered option types are unsupported when trimming.")]
+    private static Type CreateOptionsType(Type optionsType)
+    {
+        return typeof(IOptions<>).MakeGenericType(optionsType);
+    }
+
+    /// <summary>
     /// Creates a compiled delegate to access the Value property of an IOptions&lt;T&gt; instance.
     /// </summary>
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Options registered through the static DI path are rooted; runtime-discovered option types are unsupported in Native AOT.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2070",
+        Justification = "Options registered through the static DI path are rooted; runtime-discovered option types are unsupported when trimming.")]
     private static Func<object, object?> CreateValueGetter(Type optionsType)
     {
         var valueProperty = optionsType.GetProperty("Value")

--- a/src/ModularPipelines/Engine/SecretMaskingPatternGenerator.cs
+++ b/src/ModularPipelines/Engine/SecretMaskingPatternGenerator.cs
@@ -11,14 +11,14 @@ internal static class SecretMaskingPatternGenerator
 {
     public static IReadOnlyList<string> Generate(string secret)
     {
-        var json = JsonSerializer.Serialize(secret);
+        var jsonEscaped = JsonEncodedText.Encode(secret).ToString();
         var patterns = new HashSet<string>(StringComparer.Ordinal)
         {
             secret,
             Convert.ToBase64String(Encoding.UTF8.GetBytes(secret)),
             Uri.EscapeDataString(secret),
             WebUtility.UrlEncode(secret),
-            json[1..^1],
+            jsonEscaped,
         };
 
         return patterns.ToArray();

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -139,7 +139,10 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
         }
     }
 
-    [RequiresUnreferencedCode("Calls ModularPipelines.Engine.SecretProvider.GetSecretProperties(Type)")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Generated secret accessors handle statically known option types; GetSecretProperties is the documented reflection fallback for dynamic options.")]
     public IEnumerable<string> GetSecretsInObject(object? value)
     {
         if (value is null)
@@ -264,7 +267,6 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             .ToArray();
     }
 
-    [RequiresUnreferencedCode("Calls ModularPipelines.Engine.SecretProvider.GetSecretsInObject(Object)")]
     private IEnumerable<string> GetSecrets(IEnumerable<object?> options)
     {
         foreach (var option in options)

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -165,6 +165,33 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
         }
     }
 
+    /// <inheritdoc />
+    public Task InitializeAsync()
+    {
+        // Use double-checked locking pattern for thread-safety
+        // The volatile read of _initialized before the lock provides a fast-path
+        // for subsequent calls after initialization is complete
+        if (_initialized)
+        {
+            return Task.CompletedTask;
+        }
+
+        lock (_initLock)
+        {
+            // Re-check inside lock to prevent race condition
+            if (_initialized)
+            {
+                return Task.CompletedTask;
+            }
+
+            AddSecrets(GetSecrets(_optionsProvider.GetOptions()));
+
+            _initialized = true;
+        }
+
+        return Task.CompletedTask;
+    }
+
     private static IEnumerable<string> GetSecretsFromProperty(
         SecretPropertyAccessor property,
         object value)
@@ -226,32 +253,6 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             IEnumerable<char> characters => new string(characters.ToArray()),
             _ => value.ToString(),
         };
-    }
-
-    public Task InitializeAsync()
-    {
-        // Use double-checked locking pattern for thread-safety
-        // The volatile read of _initialized before the lock provides a fast-path
-        // for subsequent calls after initialization is complete
-        if (_initialized)
-        {
-            return Task.CompletedTask;
-        }
-
-        lock (_initLock)
-        {
-            // Re-check inside lock to prevent race condition
-            if (_initialized)
-            {
-                return Task.CompletedTask;
-            }
-
-            AddSecrets(GetSecrets(_optionsProvider.GetOptions()));
-
-            _initialized = true;
-        }
-
-        return Task.CompletedTask;
     }
 
     [RequiresUnreferencedCode("Reflection fallback requires SecretValue-attributed properties. Ensure ModularPipelines.SourceGenerator runs for trim-safe secret access.")]

--- a/src/ModularPipelines/Extensions/AttributeHelpers.cs
+++ b/src/ModularPipelines/Extensions/AttributeHelpers.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace ModularPipelines.Extensions;
@@ -22,6 +23,10 @@ internal static class AttributeHelpers
         return attributes.Cast<T>();
     }
 
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2070",
+        Justification = "This method is the documented reflection fallback for dynamically supplied types; generated module event metadata handles statically known modules.")]
     private static object[] GetAttributesInternal<T>(Type type)
         where T : Attribute
     {

--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -361,7 +361,8 @@ public static class PipelineBuilderExtensions
     /// <param name="builder">The pipeline builder.</param>
     /// <param name="configureOptions">The configuration action.</param>
     /// <returns>The same builder instance for chaining.</returns>
-    public static PipelineBuilder Configure<TOptions>(
+    public static PipelineBuilder Configure<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(
         this PipelineBuilder builder,
         Action<TOptions> configureOptions)
         where TOptions : class

--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -66,6 +66,10 @@ public static class PipelineBuilderExtensions
     /// <param name="builder">The pipeline builder.</param>
     /// <param name="moduleTypes">The module types to add.</param>
     /// <returns>The same builder instance for chaining.</returns>
+    [RequiresUnreferencedCode(
+        "Runtime type module registration relies on reflection. Use AddModule<TModule>() for trim-safe registration.")]
+    [RequiresDynamicCode(
+        "Runtime type module registration may require runtime code generation. Use AddModule<TModule>() for Native AOT.")]
     public static PipelineBuilder AddModules(this PipelineBuilder builder, params Type[] moduleTypes)
     {
         ArgumentNullException.ThrowIfNull(moduleTypes);

--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -241,6 +241,10 @@ public static class PipelineBuilderExtensions
     /// <param name="builder">The pipeline builder.</param>
     /// <typeparam name="TRepository">The type of result repository to add.</typeparam>
     /// <returns>The same builder instance for chaining.</returns>
+    [RequiresUnreferencedCode(
+        "Result history resolves module result types through reflection.")]
+    [RequiresDynamicCode(
+        "Result history creates generic delegates for runtime module result types.")]
     public static PipelineBuilder AddResultsRepository<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TRepository>(this PipelineBuilder builder)
         where TRepository : class, IModuleResultRepository
     {

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -11,7 +11,10 @@ internal sealed class CommandModelProvider : ICommandModelProvider
     private readonly ConcurrentDictionary<Type, IReadOnlyList<PropertyCommandLinePart>> _cache = new();
 
     /// <inheritdoc/>
-    [RequiresUnreferencedCode("Calls ModularPipelines.Helpers.Internal.CommandModelProvider.BuildModel(Type)")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Generated command metadata handles statically known options; BuildModel is the documented reflection fallback for dynamic options.")]
     public IReadOnlyList<PropertyCommandLinePart> GetCommandModel(Type optionsType)
     {
         return _cache.GetOrAdd(optionsType, static type =>

--- a/src/ModularPipelines/Logging/ModuleLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/ModuleLoggerProvider.cs
@@ -1,5 +1,7 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Engine;
 
 namespace ModularPipelines.Logging;
 
@@ -37,8 +39,17 @@ internal class ModuleLoggerProvider : IInternalModuleLoggerProvider
     /// Gets a logger for a specific module type.
     /// Does not cache to _moduleLogger to avoid conflicts with parameterless GetLogger().
     /// </summary>
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Generated runtime metadata handles statically known modules; MakeGenericType is the documented fallback for dynamic modules.")]
     public IModuleLogger GetLogger(Type type)
     {
+        if (GeneratedModuleMetadata.TryGetRuntime(type, out var runtime))
+        {
+            return runtime.GetLogger(_serviceProvider);
+        }
+
         var loggerType = typeof(ModuleLogger<>).MakeGenericType(type);
         return (IModuleLogger) _serviceProvider.GetRequiredService(loggerType);
     }

--- a/src/ModularPipelines/Models/ModuleResult.cs
+++ b/src/ModularPipelines/Models/ModuleResult.cs
@@ -583,6 +583,10 @@ internal sealed class ModuleResultJsonConverterFactory : JsonConverterFactory
         return false;
     }
 
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Reflection-based ModuleResult JSON conversion is unsupported in Native AOT; use source-generated serialization metadata.")]
     public override JsonConverter? CreateConverter(Type typeToConvert, JsonSerializerOptions options)
     {
         // For non-generic types
@@ -621,6 +625,10 @@ internal sealed class ModuleResultNonGenericJsonConverter : JsonConverter<Module
     private static readonly ExceptionJsonConverter ExceptionConverter = new();
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Module result serialization requires runtime type metadata.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Reflection-based ModuleResult JSON conversion is unsupported in Native AOT; use source-generated serialization metadata.")]
     public override ModuleResult? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType == JsonTokenType.Null)
@@ -722,6 +730,10 @@ internal sealed class ModuleResultNonGenericJsonConverter : JsonConverter<Module
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Module result serialization requires runtime type metadata.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Reflection-based ModuleResult JSON conversion is unsupported in Native AOT; use source-generated serialization metadata.")]
     public override void Write(Utf8JsonWriter writer, ModuleResult value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();
@@ -774,6 +786,10 @@ internal sealed class ModuleResultJsonConverter<T> : JsonConverter<ModuleResult<
     private static readonly ExceptionJsonConverter ExceptionConverter = new();
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Module result serialization requires runtime type metadata.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Reflection-based ModuleResult JSON conversion is unsupported in Native AOT; use source-generated serialization metadata.")]
     public override ModuleResult<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType == JsonTokenType.Null)
@@ -888,6 +904,10 @@ internal sealed class ModuleResultJsonConverter<T> : JsonConverter<ModuleResult<
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Module result serialization requires runtime type metadata.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "Reflection-based ModuleResult JSON conversion is unsupported in Native AOT; use source-generated serialization metadata.")]
     public override void Write(Utf8JsonWriter writer, ModuleResult<T> value, JsonSerializerOptions options)
     {
         writer.WriteStartObject();

--- a/src/ModularPipelines/ModularPipelines.csproj
+++ b/src/ModularPipelines/ModularPipelines.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <ModularPipelineReadMeDescription>The base package for Modular Pipelines. This contains the framework for building, executing, controlling and reporting your modules.</ModularPipelineReadMeDescription>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <PropertyGroup>
     <Description>Write your pipelines in C#!</Description>

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -341,6 +341,11 @@ public sealed class PipelineBuilder : IDisposable
 
     private void LoadModularPipelineAssembliesIfNotLoadedYet()
     {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            return;
+        }
+
         var coreVersion = typeof(PipelineBuilder).Assembly.GetName().Version;
         LoadReferencedModularPipelineAssemblies(coreVersion);
 

--- a/src/ModularPipelines/PipelineImpl.cs
+++ b/src/ModularPipelines/PipelineImpl.cs
@@ -1,7 +1,5 @@
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Initialization.Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -20,8 +18,6 @@ namespace ModularPipelines;
 /// </summary>
 internal sealed class PipelineImpl : IPipeline
 {
-    private static readonly ConcurrentDictionary<Type, PropertyInfo?> DisposablesPropertyCache = new();
-
     private readonly IHost _host;
     private readonly AsyncServiceScope _serviceScope;
 
@@ -82,18 +78,7 @@ internal sealed class PipelineImpl : IPipeline
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
-        var servicesType = Services.GetType();
-        var disposablesProperty = DisposablesPropertyCache.GetOrAdd(
-            servicesType,
-            static type => type.GetProperty("Disposables", BindingFlags.Instance | BindingFlags.NonPublic));
-
-        var disposables = disposablesProperty?.GetValue(Services) as List<object>;
-
-        foreach (var disposable in disposables?.OfType<IDisposable>() ?? Array.Empty<IDisposable>())
-        {
-            await Disposer.DisposeObjectAsync(disposable).ConfigureAwait(false);
-        }
-
+        await _serviceScope.DisposeAsync().ConfigureAwait(false);
         await Disposer.DisposeObjectAsync(_host).ConfigureAwait(false);
         GC.SuppressFinalize(this);
     }

--- a/src/ModularPipelines/buildTransitive/ModularPipelines.targets
+++ b/src/ModularPipelines/buildTransitive/ModularPipelines.targets
@@ -36,6 +36,15 @@ if (!File.Exists(FilePath)
   </PropertyGroup>
 
   <Target
+    Name="_WarnUnsupportedModularPipelinesFSharpTrimAot"
+    BeforeTargets="PrepareForPublish"
+    Condition="'$(MSBuildProjectExtension)' == '.fsproj' and ('$(PublishAot)' == 'true' or '$(PublishTrimmed)' == 'true')">
+    <Warning
+      Code="MPAOT001"
+      Text="F# pipeline projects are not supported with trimming or Native AOT because the ModularPipelines metadata generators are C#-only. Disable PublishAot and PublishTrimmed, or move pipeline declarations and registrations to a C# project." />
+  </Target>
+
+  <Target
     Name="_GenerateModularPipelinesBuildServerFilesForCrossTargetingBuild"
     BeforeTargets="DispatchToInnerBuilds"
     DependsOnTargets="_ComputeTargetFrameworkItems"

--- a/test/ModularPipelines.FSharp.TestFixtures/ModularPipelines.FSharp.TestFixtures.fsproj
+++ b/test/ModularPipelines.FSharp.TestFixtures/ModularPipelines.FSharp.TestFixtures.fsproj
@@ -12,4 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\ModularPipelines\ModularPipelines.csproj" />
   </ItemGroup>
+  <!-- Project references do not import the package's buildTransitive assets. Import
+       the target directly so repository validation exercises the consumer warning. -->
+  <Import Project="..\..\src\ModularPipelines\buildTransitive\ModularPipelines.targets" />
 </Project>

--- a/test/ModularPipelines.SourceGenerator.UnitTests/GeneratorTestHarness.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/GeneratorTestHarness.cs
@@ -19,6 +19,37 @@ internal static class GeneratorTestHarness
         string source)
     {
         var compilation = CreateCompilation(infrastructure, source);
+        return Run(generator, compilation);
+    }
+
+    public static GeneratorDriverRunResult RunWithExternalAssembly(
+        IIncrementalGenerator generator,
+        string infrastructure,
+        string externalSource,
+        string source)
+    {
+        var infrastructureReference = CreateMetadataReference(
+            "ModularPipelines",
+            [infrastructure],
+            References);
+        var externalReference = CreateMetadataReference(
+            "ExternalModules",
+            [externalSource],
+            [.. References, infrastructureReference]);
+        var compilation = CSharpCompilation.Create(
+            "GeneratorTests",
+            [CSharpSyntaxTree.ParseText(source)],
+            [.. References, infrastructureReference, externalReference],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        ThrowForCompilationErrors(compilation);
+
+        return Run(generator, compilation);
+    }
+
+    private static GeneratorDriverRunResult Run(
+        IIncrementalGenerator generator,
+        CSharpCompilation compilation)
+    {
         GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
 
         driver = driver.RunGeneratorsAndUpdateCompilation(
@@ -69,12 +100,43 @@ internal static class GeneratorTestHarness
             ],
             References,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        ThrowForCompilationErrors(compilation);
+
+        return compilation;
+    }
+
+    private static void ThrowForCompilationErrors(CSharpCompilation compilation)
+    {
         var compilationErrors = compilation.GetDiagnostics()
             .Where(static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
             .ToArray();
+        if (compilationErrors.Length > 0)
+        {
+            throw new InvalidOperationException(string.Join(Environment.NewLine, compilationErrors));
+        }
+    }
 
-        return compilationErrors.Length == 0
-            ? compilation
-            : throw new InvalidOperationException(string.Join(Environment.NewLine, compilationErrors));
+    private static PortableExecutableReference CreateMetadataReference(
+        string assemblyName,
+        IEnumerable<string> sources,
+        IEnumerable<MetadataReference> references)
+    {
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            sources.Select(static source => CSharpSyntaxTree.ParseText(source)),
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        ThrowForCompilationErrors(compilation);
+
+        using var stream = new MemoryStream();
+        var emitResult = compilation.Emit(stream);
+        if (!emitResult.Success)
+        {
+            throw new InvalidOperationException(string.Join(
+                Environment.NewLine,
+                emitResult.Diagnostics));
+        }
+
+        return MetadataReference.CreateFromImage(stream.ToArray());
     }
 }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
@@ -91,7 +91,7 @@ public class IncompleteMetadataDiagnosticTests
     }
 
     [Test]
-    public async Task Inaccessible_Command_Options_Type_Reports_Informational_Skip()
+    public async Task Inaccessible_Command_Options_Type_Reports_Warning()
     {
         var result = GeneratorTestRunner.Run(
             new CommandOptionsGenerator(),
@@ -107,11 +107,12 @@ public class IncompleteMetadataDiagnosticTests
         await AssertSkippedDiagnostic(
             result,
             "MPG0006",
-            "global::Container.HiddenOptions");
+            "global::Container.HiddenOptions",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]
-    public async Task Inaccessible_Secret_Type_Reports_Informational_Skip()
+    public async Task Inaccessible_Secret_Type_Reports_Warning()
     {
         var result = GeneratorTestRunner.Run(
             new CommandOptionsGenerator(),
@@ -130,7 +131,8 @@ public class IncompleteMetadataDiagnosticTests
         await AssertSkippedDiagnostic(
             result,
             "MPG0006",
-            "global::Container.HiddenSecrets");
+            "global::Container.HiddenSecrets",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]
@@ -147,7 +149,8 @@ public class IncompleteMetadataDiagnosticTests
         await AssertSkippedDiagnostic(
             result,
             "MPG0006",
-            "global::GenericOptions<T>");
+            "global::GenericOptions<T>",
+            DiagnosticSeverity.Warning);
     }
 
     [Test]
@@ -260,14 +263,15 @@ public class IncompleteMetadataDiagnosticTests
     private static async Task AssertSkippedDiagnostic(
         GeneratorDriverRunResult result,
         string diagnosticId,
-        string typeName)
+        string typeName,
+        DiagnosticSeverity severity = DiagnosticSeverity.Info)
     {
         var diagnostic = result.Diagnostics.Single();
 
         using (Assert.Multiple())
         {
             await Assert.That(diagnostic.Id).IsEqualTo(diagnosticId);
-            await Assert.That(diagnostic.Severity).IsEqualTo(DiagnosticSeverity.Info);
+            await Assert.That(diagnostic.Severity).IsEqualTo(severity);
             await Assert.That(diagnostic.GetMessage()).Contains(typeName);
             await Assert.That(diagnostic.GetMessage()).Contains("runtime reflection");
             await Assert.That(diagnostic.Descriptor.HelpLinkUri).EndsWith($"#{diagnosticId.ToLowerInvariant()}");

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
@@ -87,6 +87,44 @@ public class ModuleEventMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Registered_Closed_Generic_Module_With_Inaccessible_Argument_Is_Skipped()
+    {
+        var result = GeneratorTestRunner.Run(
+            new ModuleEventMetadataGenerator(),
+            Infrastructure,
+            """
+            namespace Consumer
+            {
+                using ModularPipelines.Extensions;
+
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                public static class Registration
+                {
+                    private sealed class PrivatePayload;
+
+                    public static void Configure(ModularPipelines.PipelineBuilder builder)
+                    {
+                        builder.AddModule<GenericModule<PrivatePayload>>();
+                    }
+                }
+            }
+            """);
+
+        var generated = string.Join(
+            Environment.NewLine,
+            result.GeneratedTrees.Select(static tree => tree.GetText().ToString()));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated).DoesNotContain("GenericModule<global::Consumer.Registration.PrivatePayload>");
+            await Assert.That(result.Diagnostics)
+                .Contains(diagnostic => diagnostic.Id == "MPG0007"
+                                        && diagnostic.GetMessage().Contains("PrivatePayload"));
+        }
+    }
+
+    [Test]
     public async Task Closed_Generic_Dependency_Emits_Event_Metadata()
     {
         var result = GeneratorTestRunner.Run(
@@ -114,6 +152,39 @@ public class ModuleEventMetadataGeneratorTests
                 .Contains("typeof(global::Consumer.GenericModule<int>)");
             await Assert.That(generated)
                 .Contains("new global::Consumer.MarkerAttribute()");
+        }
+    }
+
+    [Test]
+    public async Task Closed_Generic_Dependency_With_Inaccessible_Argument_Is_Skipped()
+    {
+        var result = GeneratorTestRunner.Run(
+            new ModuleEventMetadataGenerator(),
+            Infrastructure,
+            """
+            namespace Consumer
+            {
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                public static class Container
+                {
+                    private sealed class PrivatePayload;
+
+                    [ModularPipelines.Attributes.DependsOn<GenericModule<PrivatePayload>>]
+                    public sealed class ParentModule : ModularPipelines.Modules.Module<bool>;
+                }
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated).DoesNotContain("GenericModule<global::Consumer.Container.PrivatePayload>");
+            await Assert.That(generated).Contains("typeof(global::Consumer.Container.ParentModule)");
+            await Assert.That(result.Diagnostics)
+                .Contains(diagnostic => diagnostic.Id == "MPG0007"
+                                        && diagnostic.GetMessage().Contains("PrivatePayload"));
         }
     }
 

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
@@ -1,0 +1,66 @@
+namespace ModularPipelines.SourceGenerator.UnitTests;
+
+public class ModuleEventMetadataGeneratorTests
+{
+    private const string Infrastructure = """
+        namespace ModularPipelines
+        {
+            public sealed class PipelineBuilder;
+        }
+
+        namespace ModularPipelines.Modules
+        {
+            public interface IModule;
+
+            public abstract class Module<T> : IModule;
+        }
+
+        namespace ModularPipelines.Extensions
+        {
+            public static class PipelineBuilderExtensions
+            {
+                public static ModularPipelines.PipelineBuilder AddModule<TModule>(
+                    this ModularPipelines.PipelineBuilder builder)
+                    where TModule : class, ModularPipelines.Modules.IModule => builder;
+            }
+        }
+        """;
+
+    [Test]
+    public async Task Registered_Closed_Generic_Module_Emits_Event_Metadata()
+    {
+        var result = GeneratorTestRunner.Run(
+            new ModuleEventMetadataGenerator(),
+            Infrastructure,
+            """
+            namespace Consumer
+            {
+                using ModularPipelines.Extensions;
+
+                [System.AttributeUsage(System.AttributeTargets.Class)]
+                public sealed class MarkerAttribute : System.Attribute;
+
+                [Marker]
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                public static class Registration
+                {
+                    public static void Configure(ModularPipelines.PipelineBuilder builder)
+                    {
+                        builder.AddModule<GenericModule<string>>();
+                    }
+                }
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .Contains("typeof(global::Consumer.GenericModule<string>)");
+            await Assert.That(generated)
+                .Contains("new global::Consumer.MarkerAttribute()");
+        }
+    }
+}

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
@@ -140,6 +140,9 @@ public class ModuleEventMetadataGeneratorTests
                     {
                         builder.AddModule(new GenericModule<int>());
                         builder.AddModule(_ => new GenericModule<string>());
+                        builder?.AddModule<GenericModule<long>>();
+                        builder?.AddModule(new GenericModule<decimal>());
+                        builder?.AddModule(_ => new GenericModule<bool>());
                     }
                 }
             }
@@ -153,6 +156,12 @@ public class ModuleEventMetadataGeneratorTests
                 .Contains("typeof(global::Consumer.GenericModule<int>)");
             await Assert.That(generated)
                 .Contains("typeof(global::Consumer.GenericModule<string>)");
+            await Assert.That(generated)
+                .Contains("typeof(global::Consumer.GenericModule<long>)");
+            await Assert.That(generated)
+                .Contains("typeof(global::Consumer.GenericModule<decimal>)");
+            await Assert.That(generated)
+                .Contains("typeof(global::Consumer.GenericModule<bool>)");
             await Assert.That(generated)
                 .Contains("new global::Consumer.MarkerAttribute()");
         }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
@@ -22,6 +22,16 @@ public class ModuleEventMetadataGeneratorTests
                 public static ModularPipelines.PipelineBuilder AddModule<TModule>(
                     this ModularPipelines.PipelineBuilder builder)
                     where TModule : class, ModularPipelines.Modules.IModule => builder;
+
+                public static ModularPipelines.PipelineBuilder AddModule<TModule>(
+                    this ModularPipelines.PipelineBuilder builder,
+                    TModule module)
+                    where TModule : class, ModularPipelines.Modules.IModule => builder;
+
+                public static ModularPipelines.PipelineBuilder AddModule<TModule>(
+                    this ModularPipelines.PipelineBuilder builder,
+                    System.Func<System.IServiceProvider, TModule> factory)
+                    where TModule : class, ModularPipelines.Modules.IModule => builder;
             }
         }
 
@@ -102,6 +112,47 @@ public class ModuleEventMetadataGeneratorTests
         {
             await Assert.That(generated)
                 .Contains("typeof(global::Consumer.GenericModule<int>)");
+            await Assert.That(generated)
+                .Contains("new global::Consumer.MarkerAttribute()");
+        }
+    }
+
+    [Test]
+    public async Task Inferred_Closed_Generic_Registrations_Emit_Event_Metadata()
+    {
+        var result = GeneratorTestRunner.Run(
+            new ModuleEventMetadataGenerator(),
+            Infrastructure,
+            """
+            namespace Consumer
+            {
+                using ModularPipelines.Extensions;
+
+                [System.AttributeUsage(System.AttributeTargets.Class)]
+                public sealed class MarkerAttribute : System.Attribute;
+
+                [Marker]
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                public static class Registration
+                {
+                    public static void Configure(ModularPipelines.PipelineBuilder builder)
+                    {
+                        builder.AddModule(new GenericModule<int>());
+                        builder.AddModule(_ => new GenericModule<string>());
+                    }
+                }
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .Contains("typeof(global::Consumer.GenericModule<int>)");
+            await Assert.That(generated)
+                .Contains("typeof(global::Consumer.GenericModule<string>)");
             await Assert.That(generated)
                 .Contains("new global::Consumer.MarkerAttribute()");
         }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
@@ -24,6 +24,18 @@ public class ModuleEventMetadataGeneratorTests
                     where TModule : class, ModularPipelines.Modules.IModule => builder;
             }
         }
+
+        namespace ModularPipelines.Attributes
+        {
+            [System.AttributeUsage(
+                System.AttributeTargets.Class,
+                AllowMultiple = true,
+                Inherited = true)]
+            public abstract class DependsOnAttribute : System.Attribute;
+
+            public sealed class DependsOnAttribute<TModule> : DependsOnAttribute
+                where TModule : ModularPipelines.Modules.IModule;
+        }
         """;
 
     [Test]
@@ -59,6 +71,37 @@ public class ModuleEventMetadataGeneratorTests
         {
             await Assert.That(generated)
                 .Contains("typeof(global::Consumer.GenericModule<string>)");
+            await Assert.That(generated)
+                .Contains("new global::Consumer.MarkerAttribute()");
+        }
+    }
+
+    [Test]
+    public async Task Closed_Generic_Dependency_Emits_Event_Metadata()
+    {
+        var result = GeneratorTestRunner.Run(
+            new ModuleEventMetadataGenerator(),
+            Infrastructure,
+            """
+            namespace Consumer
+            {
+                [System.AttributeUsage(System.AttributeTargets.Class)]
+                public sealed class MarkerAttribute : System.Attribute;
+
+                [Marker]
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                [ModularPipelines.Attributes.DependsOn<GenericModule<int>>]
+                public sealed class ParentModule : ModularPipelines.Modules.Module<bool>;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .Contains("typeof(global::Consumer.GenericModule<int>)");
             await Assert.That(generated)
                 .Contains("new global::Consumer.MarkerAttribute()");
         }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleEventMetadataGeneratorTests.cs
@@ -106,4 +106,77 @@ public class ModuleEventMetadataGeneratorTests
                 .Contains("new global::Consumer.MarkerAttribute()");
         }
     }
+
+    [Test]
+    public async Task Transitive_Closed_Generic_Dependency_Emits_Event_Metadata()
+    {
+        var result = GeneratorTestRunner.Run(
+            new ModuleEventMetadataGenerator(),
+            Infrastructure,
+            """
+            namespace Consumer
+            {
+                [System.AttributeUsage(System.AttributeTargets.Class)]
+                public sealed class MarkerAttribute : System.Attribute;
+
+                [Marker]
+                public sealed class LeafModule<T> : ModularPipelines.Modules.Module<T>;
+
+                [ModularPipelines.Attributes.DependsOn<LeafModule<string>>]
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                [ModularPipelines.Attributes.DependsOn<GenericModule<int>>]
+                public sealed class ParentModule : ModularPipelines.Modules.Module<bool>;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .Contains("typeof(global::Consumer.GenericModule<int>)");
+            await Assert.That(generated)
+                .Contains("typeof(global::Consumer.LeafModule<string>)");
+            await Assert.That(generated)
+                .Contains("new global::Consumer.MarkerAttribute()");
+        }
+    }
+
+    [Test]
+    public async Task Transitive_Closed_Generic_Dependency_Cycle_Emits_Each_Module_Once()
+    {
+        var result = GeneratorTestRunner.Run(
+            new ModuleEventMetadataGenerator(),
+            Infrastructure,
+            """
+            namespace Consumer
+            {
+                [ModularPipelines.Attributes.DependsOn<GenericModule<int>>]
+                public sealed class LeafModule<T> : ModularPipelines.Modules.Module<T>;
+
+                [ModularPipelines.Attributes.DependsOn<LeafModule<string>>]
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                [ModularPipelines.Attributes.DependsOn<GenericModule<int>>]
+                public sealed class ParentModule : ModularPipelines.Modules.Module<bool>;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated
+                .Split(
+                    "typeof(global::Consumer.GenericModule<int>)",
+                    StringSplitOptions.None)
+                .Length - 1).IsEqualTo(1);
+            await Assert.That(generated
+                .Split(
+                    "typeof(global::Consumer.LeafModule<string>)",
+                    StringSplitOptions.None)
+                .Length - 1).IsEqualTo(1);
+        }
+    }
 }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleExtensionsGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleExtensionsGeneratorTests.cs
@@ -57,6 +57,28 @@ public class ModuleExtensionsGeneratorTests
     }
 
     [Test]
+    public async Task Internal_Modules_Generate_Internal_Accessors()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleExtensionsGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                internal sealed class BuildModule : ModularPipelines.Modules.Module<string>;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics).IsEmpty();
+            await Assert.That(generated)
+                .Contains("internal static global::Consumer.BuildModule GetBuildModule(");
+            await Assert.That(generated)
+                .Contains("internal static global::Consumer.BuildModule? GetBuildModuleIfRegistered(");
+        }
+    }
+
+    [Test]
     public async Task Partial_Module_Declarations_Do_Not_Report_A_Collision()
     {
         var result = GeneratorTestHarness.Run(new ModuleExtensionsGenerator(), TestInfrastructure, """

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -198,6 +198,38 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Transitive_Closed_Generic_Dependency_Metadata_Is_Emitted()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                public sealed class LeafModule<T> : ModularPipelines.Modules.Module<T>;
+
+                [ModularPipelines.Attributes.DependsOn<LeafModule<string>>]
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                [ModularPipelines.Attributes.DependsOn<GenericModule<int>>]
+                public sealed class BuildModule : ModularPipelines.Modules.Module<string>;
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .Contains("CreateRegistration<global::Consumer.GenericModule<int>, int>");
+            await Assert.That(generated)
+                .Contains("new(typeof(global::Consumer.LeafModule<string>), false)");
+            await Assert.That(generated)
+                .Contains("CreateRegistration<global::Consumer.LeafModule<string>, string>");
+            await Assert.That(CountOccurrences(
+                generated,
+                "dependenciesComplete: true")).IsEqualTo(3);
+        }
+    }
+
+    [Test]
     public async Task Registered_Closed_Generic_Module_Is_Emitted()
     {
         var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -198,6 +198,35 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Inaccessible_Closed_Generic_Dependency_Reports_Aot_Diagnostic()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace Consumer
+            {
+                public static class Container
+                {
+                    private sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                    [ModularPipelines.Attributes.DependsOn<GenericModule<int>>]
+                    public sealed class BuildModule : ModularPipelines.Modules.Module<string>;
+                }
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated).DoesNotContain("GenericModule<int>");
+            await Assert.That(generated).Contains("dependenciesComplete: false");
+            await Assert.That(result.Diagnostics)
+                .Contains(diagnostic => diagnostic.Id == "MPG0011"
+                                        && diagnostic.GetMessage()
+                                            .Contains("Container.GenericModule<int>"));
+        }
+    }
+
+    [Test]
     public async Task Transitive_Closed_Generic_Dependency_Metadata_Is_Emitted()
     {
         var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -100,6 +100,10 @@ public class ModuleMetadataGeneratorTests
             await Assert.That(generated)
                 .Contains("new(typeof(global::Consumer.DependencyModule), false)");
             await Assert.That(generated).Contains("dependenciesComplete: false");
+            await Assert.That(result.Diagnostics)
+                .Contains(diagnostic => diagnostic.Id == "MPG0014"
+                                        && diagnostic.GetMessage()
+                                            .Contains("Consumer.BuildModule"));
         }
     }
 

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -479,6 +479,36 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Inherited_Selector_Dependency_Reports_Aot_Diagnostic()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace ModularPipelines.Attributes
+            {
+                public class DependsOnAllModulesInheritingFromAttribute : System.Attribute;
+
+                public class DependsOnAllModulesInheritingFromAttribute<TModule>
+                    : DependsOnAllModulesInheritingFromAttribute;
+            }
+
+            namespace Consumer
+            {
+                public abstract class BaseModule : ModularPipelines.Modules.Module<string>;
+
+                [ModularPipelines.Attributes.DependsOnAllModulesInheritingFrom<BaseModule>]
+                public interface IHasSelectorDependency;
+
+                public sealed class BuildModule
+                    : ModularPipelines.Modules.Module<string>, IHasSelectorDependency;
+            }
+            """);
+
+        await Assert.That(result.Diagnostics)
+            .Contains(diagnostic => diagnostic.Id == "MPG0016"
+                                    && diagnostic.GetMessage().Contains("Consumer.BuildModule")
+                                    && diagnostic.Descriptor.HelpLinkUri.EndsWith("#mpg0016"));
+    }
+
+    [Test]
     public async Task Registered_External_Closed_Generic_Module_Reports_Aot_Diagnostic()
     {
         var result = GeneratorTestHarness.RunWithExternalAssembly(

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -509,6 +509,60 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Predicate_Selector_Dependencies_Report_Aot_Diagnostics()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace ModularPipelines.Attributes
+            {
+                public abstract class DependsOnBaseAttribute : System.Attribute;
+
+                public sealed class DependsOnModulesWithTagAttribute(string tag)
+                    : DependsOnBaseAttribute;
+
+                public sealed class DependsOnModulesInCategoryAttribute(string category)
+                    : DependsOnBaseAttribute;
+
+                public sealed class DependsOnModulesWithAttributeAttribute<TAttribute>
+                    : DependsOnBaseAttribute
+                    where TAttribute : System.Attribute;
+
+                public sealed class CustomSelectorAttribute : DependsOnBaseAttribute;
+            }
+
+            namespace Consumer
+            {
+                public sealed class MarkerAttribute : System.Attribute;
+
+                [ModularPipelines.Attributes.DependsOnModulesWithTag("build")]
+                public sealed class TagModule : ModularPipelines.Modules.Module<string>;
+
+                [ModularPipelines.Attributes.DependsOnModulesInCategory("deploy")]
+                public sealed class CategoryModule : ModularPipelines.Modules.Module<string>;
+
+                [ModularPipelines.Attributes.DependsOnModulesWithAttribute<MarkerAttribute>]
+                public sealed class AttributeModule : ModularPipelines.Modules.Module<string>;
+
+                [ModularPipelines.Attributes.CustomSelector]
+                public sealed class CustomModule : ModularPipelines.Modules.Module<string>;
+            }
+            """);
+
+        var diagnostics = result.Diagnostics
+            .Where(diagnostic => diagnostic.Id == "MPG0016")
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(diagnostics).Count().IsEqualTo(4);
+            await Assert.That(diagnostics.Select(static diagnostic => diagnostic.GetMessage()))
+                .Contains(message => message.Contains("Consumer.TagModule"))
+                .And.Contains(message => message.Contains("Consumer.CategoryModule"))
+                .And.Contains(message => message.Contains("Consumer.AttributeModule"))
+                .And.Contains(message => message.Contains("Consumer.CustomModule"));
+        }
+    }
+
+    [Test]
     public async Task Registered_External_Closed_Generic_Module_Reports_Aot_Diagnostic()
     {
         var result = GeneratorTestHarness.RunWithExternalAssembly(

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -240,6 +240,53 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Registered_External_Closed_Generic_Module_Is_Not_Emitted()
+    {
+        var result = GeneratorTestHarness.RunWithExternalAssembly(
+            new ModuleMetadataGenerator(),
+            TestInfrastructure,
+            """
+            namespace ExternalModules
+            {
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+            }
+            """,
+            """
+            namespace ModularPipelines
+            {
+                public sealed class PipelineBuilder;
+            }
+
+            namespace ModularPipelines.Extensions
+            {
+                public static class PipelineBuilderExtensions
+                {
+                    public static ModularPipelines.PipelineBuilder AddModule<TModule>(
+                        this ModularPipelines.PipelineBuilder builder)
+                        where TModule : class, ModularPipelines.Modules.IModule => builder;
+                }
+            }
+
+            namespace Consumer
+            {
+                using ModularPipelines.Extensions;
+
+                public static class Registration
+                {
+                    public static void Configure(ModularPipelines.PipelineBuilder builder)
+                    {
+                        builder.AddModule<ExternalModules.GenericModule<string>>();
+                    }
+                }
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        await Assert.That(generated).DoesNotContain("ExternalModules.GenericModule");
+    }
+
+    [Test]
     public async Task Direct_IModule_Implementation_Is_Registered()
     {
         var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -422,6 +422,63 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task NonConcrete_Module_Registrations_Report_Aot_Diagnostic()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace ModularPipelines
+            {
+                public sealed class PipelineBuilder;
+            }
+
+            namespace ModularPipelines.Extensions
+            {
+                public static class PipelineBuilderExtensions
+                {
+                    public static ModularPipelines.PipelineBuilder AddModule<TModule>(
+                        this ModularPipelines.PipelineBuilder builder,
+                        TModule module)
+                        where TModule : class, ModularPipelines.Modules.IModule => builder;
+
+                    public static ModularPipelines.PipelineBuilder AddModule<TModule>(
+                        this ModularPipelines.PipelineBuilder builder,
+                        System.Func<System.IServiceProvider, TModule> factory)
+                        where TModule : class, ModularPipelines.Modules.IModule => builder;
+                }
+            }
+
+            namespace Consumer
+            {
+                using ModularPipelines.Extensions;
+
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                public static class Registration
+                {
+                    public static void Configure(ModularPipelines.PipelineBuilder builder)
+                    {
+                        ModularPipelines.Modules.IModule module = new GenericModule<int>();
+                        builder.AddModule(module);
+                        builder.AddModule<ModularPipelines.Modules.IModule>(
+                            _ => new GenericModule<string>());
+                    }
+                }
+            }
+            """);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics.Count(diagnostic => diagnostic.Id == "MPG0015"))
+                .IsEqualTo(2);
+            await Assert.That(result.Diagnostics)
+                .All(diagnostic => diagnostic.Id != "MPG0015"
+                                   || diagnostic.GetMessage().Contains("IModule"));
+            await Assert.That(result.GeneratedTrees.Single().GetText().ToString())
+                .DoesNotContain("GenericModule<int>")
+                .And.DoesNotContain("GenericModule<string>");
+        }
+    }
+
+    [Test]
     public async Task Registered_External_Closed_Generic_Module_Reports_Aot_Diagnostic()
     {
         var result = GeneratorTestHarness.RunWithExternalAssembly(

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -145,6 +145,9 @@ public class ModuleMetadataGeneratorTests
                 .Contains("CreateRegistration<global::Consumer.BuildModule, string>");
             await Assert.That(generated).DoesNotContain("HiddenModule");
             await Assert.That(generated).Contains("isComplete: false");
+            await Assert.That(result.Diagnostics)
+                .Contains(diagnostic => diagnostic.Id == "MPG0011"
+                                        && diagnostic.GetMessage().Contains("HiddenModule"));
         }
     }
 

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -240,7 +240,7 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
-    public async Task Registered_External_Closed_Generic_Module_Is_Not_Emitted()
+    public async Task Registered_External_Closed_Generic_Module_Reports_Aot_Diagnostic()
     {
         var result = GeneratorTestHarness.RunWithExternalAssembly(
             new ModuleMetadataGenerator(),
@@ -283,7 +283,14 @@ public class ModuleMetadataGeneratorTests
 
         var generated = result.GeneratedTrees.Single().GetText().ToString();
 
-        await Assert.That(generated).DoesNotContain("ExternalModules.GenericModule");
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated).DoesNotContain("ExternalModules.GenericModule");
+            await Assert.That(result.Diagnostics)
+                .Contains(diagnostic => diagnostic.Id == "MPG0012"
+                                        && diagnostic.GetMessage()
+                                            .Contains("ExternalModules.GenericModule<string>"));
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -305,6 +305,59 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Inferred_Closed_Generic_Registrations_Are_Emitted()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace ModularPipelines
+            {
+                public sealed class PipelineBuilder;
+            }
+
+            namespace ModularPipelines.Extensions
+            {
+                public static class PipelineBuilderExtensions
+                {
+                    public static ModularPipelines.PipelineBuilder AddModule<TModule>(
+                        this ModularPipelines.PipelineBuilder builder,
+                        TModule module)
+                        where TModule : class, ModularPipelines.Modules.IModule => builder;
+
+                    public static ModularPipelines.PipelineBuilder AddModule<TModule>(
+                        this ModularPipelines.PipelineBuilder builder,
+                        System.Func<System.IServiceProvider, TModule> factory)
+                        where TModule : class, ModularPipelines.Modules.IModule => builder;
+                }
+            }
+
+            namespace Consumer
+            {
+                using ModularPipelines.Extensions;
+
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                public static class Registration
+                {
+                    public static void Configure(ModularPipelines.PipelineBuilder builder)
+                    {
+                        builder.AddModule(new GenericModule<int>());
+                        builder.AddModule(_ => new GenericModule<string>());
+                    }
+                }
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .Contains("CreateRegistration<global::Consumer.GenericModule<int>, int>");
+            await Assert.That(generated)
+                .Contains("CreateRegistration<global::Consumer.GenericModule<string>, string>");
+        }
+    }
+
+    [Test]
     public async Task Generic_Helper_Module_Registration_Reports_Aot_Diagnostic()
     {
         var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -53,11 +53,11 @@ public class ModuleMetadataGeneratorTests
         using (Assert.Multiple())
         {
             await Assert.That(generated)
-                .Contains("CreateRegistration<global::Consumer.BuildModule>");
+                .Contains("CreateRegistration<global::Consumer.BuildModule, string>");
             await Assert.That(generated)
                 .Contains("new(typeof(global::Consumer.DependencyModule), true)");
             await Assert.That(generated)
-                .Contains("CreateRegistration<global::Consumer.DependencyModule>");
+                .Contains("CreateRegistration<global::Consumer.DependencyModule, string>");
             await Assert.That(generated).Contains("isComplete: false");
         }
     }
@@ -77,7 +77,7 @@ public class ModuleMetadataGeneratorTests
 
         await Assert.That(CountOccurrences(
             generated,
-            "CreateRegistration<global::Consumer.BuildModule>")).IsEqualTo(1);
+            "CreateRegistration<global::Consumer.BuildModule, string>")).IsEqualTo(1);
     }
 
     [Test]
@@ -142,7 +142,7 @@ public class ModuleMetadataGeneratorTests
         using (Assert.Multiple())
         {
             await Assert.That(generated)
-                .Contains("CreateRegistration<global::Consumer.BuildModule>");
+                .Contains("CreateRegistration<global::Consumer.BuildModule, string>");
             await Assert.That(generated).DoesNotContain("HiddenModule");
             await Assert.That(generated).Contains("isComplete: false");
         }
@@ -189,7 +189,7 @@ public class ModuleMetadataGeneratorTests
                 .Contains("new(typeof(global::Consumer.GenericModule<string>), false)");
             await Assert.That(CountOccurrences(
                 generated,
-                "CreateRegistration<global::Consumer.GenericModule<string>>")).IsEqualTo(1);
+                "CreateRegistration<global::Consumer.GenericModule<string>, string>")).IsEqualTo(1);
             await Assert.That(generated).Contains("dependenciesComplete: true");
         }
     }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -563,6 +563,36 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Custom_DependsOn_Subclass_Reports_Aot_Diagnostic()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace ModularPipelines.Attributes
+            {
+                public sealed class CustomDependsOnAttribute : DependsOnAttribute
+                {
+                    public CustomDependsOnAttribute()
+                        : base(typeof(Consumer.BaseModule))
+                    {
+                    }
+                }
+            }
+
+            namespace Consumer
+            {
+                public sealed class BaseModule : ModularPipelines.Modules.Module<string>;
+
+                [ModularPipelines.Attributes.CustomDependsOn]
+                public sealed class BuildModule : ModularPipelines.Modules.Module<string>;
+            }
+            """);
+
+        await Assert.That(result.Diagnostics)
+            .Contains(diagnostic => diagnostic.Id == "MPG0016"
+                                    && diagnostic.GetMessage().Contains("Consumer.BuildModule")
+                                    && diagnostic.Descriptor.HelpLinkUri.EndsWith("#mpg0016"));
+    }
+
+    [Test]
     public async Task Registered_External_Closed_Generic_Module_Reports_Aot_Diagnostic()
     {
         var result = GeneratorTestHarness.RunWithExternalAssembly(

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -318,6 +318,10 @@ public class ModuleMetadataGeneratorTests
                 public static class PipelineBuilderExtensions
                 {
                     public static ModularPipelines.PipelineBuilder AddModule<TModule>(
+                        this ModularPipelines.PipelineBuilder builder)
+                        where TModule : class, ModularPipelines.Modules.IModule => builder;
+
+                    public static ModularPipelines.PipelineBuilder AddModule<TModule>(
                         this ModularPipelines.PipelineBuilder builder,
                         TModule module)
                         where TModule : class, ModularPipelines.Modules.IModule => builder;
@@ -341,6 +345,9 @@ public class ModuleMetadataGeneratorTests
                     {
                         builder.AddModule(new GenericModule<int>());
                         builder.AddModule(_ => new GenericModule<string>());
+                        builder?.AddModule<GenericModule<long>>();
+                        builder?.AddModule(new GenericModule<decimal>());
+                        builder?.AddModule(_ => new GenericModule<bool>());
                     }
                 }
             }
@@ -354,6 +361,12 @@ public class ModuleMetadataGeneratorTests
                 .Contains("CreateRegistration<global::Consumer.GenericModule<int>, int>");
             await Assert.That(generated)
                 .Contains("CreateRegistration<global::Consumer.GenericModule<string>, string>");
+            await Assert.That(generated)
+                .Contains("CreateRegistration<global::Consumer.GenericModule<long>, long>");
+            await Assert.That(generated)
+                .Contains("CreateRegistration<global::Consumer.GenericModule<decimal>, decimal>");
+            await Assert.That(generated)
+                .Contains("CreateRegistration<global::Consumer.GenericModule<bool>, bool>");
         }
     }
 

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -326,6 +326,32 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task External_Closed_Generic_Dependency_Reports_Aot_Diagnostic()
+    {
+        var result = GeneratorTestHarness.RunWithExternalAssembly(
+            new ModuleMetadataGenerator(),
+            TestInfrastructure,
+            """
+            namespace ExternalModules
+            {
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+            }
+            """,
+            """
+            namespace Consumer
+            {
+                [ModularPipelines.Attributes.DependsOn<ExternalModules.GenericModule<string>>]
+                public sealed class BuildModule : ModularPipelines.Modules.Module<bool>;
+            }
+            """);
+
+        await Assert.That(result.Diagnostics)
+            .Contains(diagnostic => diagnostic.Id == "MPG0012"
+                                    && diagnostic.GetMessage()
+                                        .Contains("ExternalModules.GenericModule<string>"));
+    }
+
+    [Test]
     public async Task Direct_IModule_Implementation_Is_Registered()
     {
         var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -198,6 +198,48 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Registered_Closed_Generic_Module_Is_Emitted()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace ModularPipelines
+            {
+                public sealed class PipelineBuilder;
+            }
+
+            namespace ModularPipelines.Extensions
+            {
+                public static class PipelineBuilderExtensions
+                {
+                    public static ModularPipelines.PipelineBuilder AddModule<TModule>(
+                        this ModularPipelines.PipelineBuilder builder)
+                        where TModule : class, ModularPipelines.Modules.IModule => builder;
+                }
+            }
+
+            namespace Consumer
+            {
+                using ModularPipelines.Extensions;
+
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                public static class Registration
+                {
+                    public static void Configure(ModularPipelines.PipelineBuilder builder)
+                    {
+                        builder.AddModule<GenericModule<string>>();
+                    }
+                }
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        await Assert.That(CountOccurrences(
+            generated,
+            "CreateRegistration<global::Consumer.GenericModule<string>, string>")).IsEqualTo(1);
+    }
+
+    [Test]
     public async Task Direct_IModule_Implementation_Is_Registered()
     {
         var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -272,6 +272,57 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Generic_Helper_Module_Registration_Reports_Aot_Diagnostic()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace ModularPipelines
+            {
+                public sealed class PipelineBuilder;
+            }
+
+            namespace ModularPipelines.Extensions
+            {
+                public static class PipelineBuilderExtensions
+                {
+                    public static ModularPipelines.PipelineBuilder AddModule<TModule>(
+                        this ModularPipelines.PipelineBuilder builder)
+                        where TModule : class, ModularPipelines.Modules.IModule => builder;
+                }
+            }
+
+            namespace Consumer
+            {
+                using ModularPipelines.Extensions;
+
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                public static class Registration
+                {
+                    public static void Register<TModule>(ModularPipelines.PipelineBuilder builder)
+                        where TModule : class, ModularPipelines.Modules.IModule
+                    {
+                        builder.AddModule<TModule>();
+                    }
+
+                    public static void Configure(ModularPipelines.PipelineBuilder builder)
+                    {
+                        Register<GenericModule<int>>(builder);
+                    }
+                }
+            }
+            """);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics)
+                .Contains(diagnostic => diagnostic.Id == "MPG0013"
+                                        && diagnostic.GetMessage().Contains("AddModule<TModule>"));
+            await Assert.That(result.GeneratedTrees.Single().GetText().ToString())
+                .DoesNotContain("GenericModule<int>");
+        }
+    }
+
+    [Test]
     public async Task Registered_External_Closed_Generic_Module_Reports_Aot_Diagnostic()
     {
         var result = GeneratorTestHarness.RunWithExternalAssembly(

--- a/test/ModularPipelines.TrimAotSmoke/ModularPipelines.TrimAotSmoke.csproj
+++ b/test/ModularPipelines.TrimAotSmoke/ModularPipelines.TrimAotSmoke.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks />
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <WarningsAsErrors>$(WarningsAsErrors);IL2026;IL2046;IL2060;IL2070;IL2071;IL2075;IL2091;IL3050</WarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ModularPipelines\ModularPipelines.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/ModularPipelines.TrimAotSmoke/ModularPipelines.TrimAotSmoke.csproj
+++ b/test/ModularPipelines.TrimAotSmoke/ModularPipelines.TrimAotSmoke.csproj
@@ -13,5 +13,10 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ModularPipelines\ModularPipelines.csproj" />
+    <ProjectReference
+      Include="..\..\src\ModularPipelines.SourceGenerator\ModularPipelines.SourceGenerator.csproj"
+      ReferenceOutputAssembly="false"
+      OutputItemType="Analyzer"
+      SetTargetFramework="TargetFramework=netstandard2.0" />
   </ItemGroup>
 </Project>

--- a/test/ModularPipelines.TrimAotSmoke/Program.cs
+++ b/test/ModularPipelines.TrimAotSmoke/Program.cs
@@ -31,10 +31,10 @@ builder.IgnoreCategories("ignored");
 await using var pipeline = await builder.BuildAsync();
 await pipeline.RunAsync();
 
-if (SmokeState.HookInvocations != 2)
+if (SmokeState.HookInvocations != 3)
 {
     throw new InvalidOperationException(
-        $"Expected two generated hook invocations, got {SmokeState.HookInvocations}.");
+        $"Expected three generated hook invocations, got {SmokeState.HookInvocations}.");
 }
 
 using var failureBuilder = Pipeline.CreateBuilder(args);
@@ -166,7 +166,19 @@ internal sealed class IgnoredValueModule : Module<int>
 }
 
 [SmokeHook]
+[DependsOn<TransitiveGenericModule<string>>]
 internal sealed class ClosedGenericModule<T> : Module<bool>
+{
+    protected override Task<bool> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(true);
+    }
+}
+
+[SmokeHook]
+internal sealed class TransitiveGenericModule<T> : Module<bool>
 {
     protected override Task<bool> ExecuteAsync(
         IModuleContext context,

--- a/test/ModularPipelines.TrimAotSmoke/Program.cs
+++ b/test/ModularPipelines.TrimAotSmoke/Program.cs
@@ -61,6 +61,8 @@ Console.WriteLine("TRIM_AOT_SMOKE_OK");
 
 internal static class SmokeState
 {
+    private static int _hookInvocations;
+
     public const string ChildArgument = "--aot-smoke-child";
 
     public const string ExpectedFailure = "trim-aot-expected-failure";
@@ -69,7 +71,12 @@ internal static class SmokeState
 
     public const string OptionsMarker = "trim-aot-options-marker";
 
-    public static int HookInvocations { get; set; }
+    public static int HookInvocations => Volatile.Read(ref _hookInvocations);
+
+    public static void RecordHookInvocation()
+    {
+        Interlocked.Increment(ref _hookInvocations);
+    }
 }
 
 internal sealed class SmokePipelineOptions
@@ -82,7 +89,7 @@ internal sealed class SmokeHookAttribute : Attribute, IModuleStartHandler
 {
     public Task OnModuleStartAsync(IModuleHookContext context)
     {
-        SmokeState.HookInvocations++;
+        SmokeState.RecordHookInvocation();
         return Task.CompletedTask;
     }
 }

--- a/test/ModularPipelines.TrimAotSmoke/Program.cs
+++ b/test/ModularPipelines.TrimAotSmoke/Program.cs
@@ -18,7 +18,10 @@ if (args is [SmokeState.ChildArgument, var childValue])
 using var builder = Pipeline.CreateBuilder(args);
 builder
     .AddModule<CommandModule>()
-    .AddModule<VerificationModule>();
+    .AddModule<VerificationModule>()
+    .AddModule<IgnoredValueModule>()
+    .WithCategory("ignored");
+builder.IgnoreCategories("ignored");
 
 await using var pipeline = await builder.BuildAsync();
 await pipeline.RunAsync();
@@ -107,5 +110,15 @@ internal sealed class VerificationModule(
         }
 
         return true;
+    }
+}
+
+internal sealed class IgnoredValueModule : Module<int>
+{
+    protected override Task<int> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("Ignored module should not execute.");
     }
 }

--- a/test/ModularPipelines.TrimAotSmoke/Program.cs
+++ b/test/ModularPipelines.TrimAotSmoke/Program.cs
@@ -19,6 +19,7 @@ using var builder = Pipeline.CreateBuilder(args);
 builder
     .AddModule<CommandModule>()
     .AddModule<VerificationModule>()
+    .AddModule<ClosedGenericModule<int>>()
     .AddModule<IgnoredValueModule>()
     .WithCategory("ignored");
 builder.IgnoreCategories("ignored");
@@ -32,11 +33,33 @@ if (SmokeState.HookInvocations != 1)
         $"Expected one generated hook invocation, got {SmokeState.HookInvocations}.");
 }
 
+using var failureBuilder = Pipeline.CreateBuilder(args);
+failureBuilder
+    .AddModule<FailingModule>()
+    .AddModule<PendingAfterFailureModule>();
+failureBuilder.ConfigurePipelineOptions(options => options with
+{
+    ThrowOnPipelineFailure = true,
+});
+
+await using var failurePipeline = await failureBuilder.BuildAsync();
+try
+{
+    await failurePipeline.RunAsync();
+    throw new InvalidOperationException("Expected the failure smoke pipeline to throw.");
+}
+catch (Exception exception) when (
+    exception.ToString().Contains(SmokeState.ExpectedFailure, StringComparison.Ordinal))
+{
+}
+
 Console.WriteLine("TRIM_AOT_SMOKE_OK");
 
 internal static class SmokeState
 {
     public const string ChildArgument = "--aot-smoke-child";
+
+    public const string ExpectedFailure = "trim-aot-expected-failure";
 
     public const string Secret = "trim-aot-smoke-secret";
 
@@ -120,5 +143,36 @@ internal sealed class IgnoredValueModule : Module<int>
         CancellationToken cancellationToken)
     {
         throw new InvalidOperationException("Ignored module should not execute.");
+    }
+}
+
+internal sealed class ClosedGenericModule<T> : Module<bool>
+{
+    protected override Task<bool> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(true);
+    }
+}
+
+internal sealed class FailingModule : Module<bool>
+{
+    protected override Task<bool> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException(SmokeState.ExpectedFailure);
+    }
+}
+
+[DependsOn<FailingModule>]
+internal sealed class PendingAfterFailureModule : Module<int>
+{
+    protected override Task<int> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        throw new InvalidOperationException("Pending module should not execute.");
     }
 }

--- a/test/ModularPipelines.TrimAotSmoke/Program.cs
+++ b/test/ModularPipelines.TrimAotSmoke/Program.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines;
+using ModularPipelines.Attributes;
+using ModularPipelines.Attributes.Events;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Extensions;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+
+if (args is [SmokeState.ChildArgument, var childValue])
+{
+    Console.WriteLine(childValue);
+    return;
+}
+
+using var builder = Pipeline.CreateBuilder(args);
+builder
+    .AddModule<CommandModule>()
+    .AddModule<VerificationModule>();
+
+await using var pipeline = await builder.BuildAsync();
+await pipeline.RunAsync();
+
+if (SmokeState.HookInvocations != 1)
+{
+    throw new InvalidOperationException(
+        $"Expected one generated hook invocation, got {SmokeState.HookInvocations}.");
+}
+
+Console.WriteLine("TRIM_AOT_SMOKE_OK");
+
+internal static class SmokeState
+{
+    public const string ChildArgument = "--aot-smoke-child";
+
+    public const string Secret = "trim-aot-smoke-secret";
+
+    public static int HookInvocations { get; set; }
+}
+
+[AttributeUsage(AttributeTargets.Class)]
+internal sealed class SmokeHookAttribute : Attribute, IModuleStartHandler
+{
+    public Task OnModuleStartAsync(IModuleHookContext context)
+    {
+        SmokeState.HookInvocations++;
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed record SmokeCommandOptions : CommandLineToolOptions
+{
+    [CliArgument(0)]
+    public string? Mode { get; init; }
+
+    [CliArgument(1)]
+    [SecretValue]
+    public string? Secret { get; init; }
+}
+
+[SmokeHook]
+internal sealed class CommandModule : Module<CommandResult>
+{
+    protected override Task<CommandResult?> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        var options = new SmokeCommandOptions
+        {
+            Tool = Environment.ProcessPath
+                ?? throw new InvalidOperationException("The current executable path is unavailable."),
+            Mode = SmokeState.ChildArgument,
+            Secret = SmokeState.Secret,
+        };
+
+        return context.Shell.Command.ExecuteCommandLineToolAsync(
+            options,
+            cancellationToken: cancellationToken)!;
+    }
+}
+
+[DependsOn<CommandModule>]
+internal sealed class VerificationModule(
+    ISecretObfuscator secretObfuscator) : Module<bool>
+{
+    protected override async Task<bool> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        var result = await context.GetModule<CommandModule>();
+        var command = result.ValueOrDefault
+            ?? throw new InvalidOperationException("Command module returned no value.");
+
+        if (command.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Child command exited with {command.ExitCode}: {command.StandardError}");
+        }
+
+        var masked = secretObfuscator.Obfuscate(command.StandardOutput, null);
+        if (masked.Contains(SmokeState.Secret, StringComparison.Ordinal)
+            || !masked.Contains("********", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Secret masking did not redact command output.");
+        }
+
+        return true;
+    }
+}

--- a/test/ModularPipelines.TrimAotSmoke/Program.cs
+++ b/test/ModularPipelines.TrimAotSmoke/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using ModularPipelines;
 using ModularPipelines.Attributes;
 using ModularPipelines.Attributes.Events;
@@ -16,6 +17,10 @@ if (args is [SmokeState.ChildArgument, var childValue])
 }
 
 using var builder = Pipeline.CreateBuilder(args);
+
+// Exercise OptionsProvider's runtime-discovered IOptions<T> path after trimming.
+builder.Services.AddSingleton<IOptions<SmokePipelineOptions>>(
+    Options.Create(new SmokePipelineOptions { Marker = SmokeState.OptionsMarker }));
 builder
     .AddModule<CommandModule>()
     .AddModule<VerificationModule>()
@@ -63,7 +68,14 @@ internal static class SmokeState
 
     public const string Secret = "trim-aot-smoke-secret";
 
+    public const string OptionsMarker = "trim-aot-options-marker";
+
     public static int HookInvocations { get; set; }
+}
+
+internal sealed class SmokePipelineOptions
+{
+    public string? Marker { get; set; }
 }
 
 [AttributeUsage(AttributeTargets.Class)]

--- a/test/ModularPipelines.TrimAotSmoke/Program.cs
+++ b/test/ModularPipelines.TrimAotSmoke/Program.cs
@@ -24,7 +24,6 @@ builder.Services.AddSingleton<IOptions<SmokePipelineOptions>>(
 builder
     .AddModule<CommandModule>()
     .AddModule<VerificationModule>()
-    .AddModule<ClosedGenericModule<int>>()
     .AddModule<IgnoredValueModule>()
     .WithCategory("ignored");
 builder.IgnoreCategories("ignored");
@@ -32,10 +31,10 @@ builder.IgnoreCategories("ignored");
 await using var pipeline = await builder.BuildAsync();
 await pipeline.RunAsync();
 
-if (SmokeState.HookInvocations != 1)
+if (SmokeState.HookInvocations != 2)
 {
     throw new InvalidOperationException(
-        $"Expected one generated hook invocation, got {SmokeState.HookInvocations}.");
+        $"Expected two generated hook invocations, got {SmokeState.HookInvocations}.");
 }
 
 using var failureBuilder = Pipeline.CreateBuilder(args);
@@ -120,6 +119,7 @@ internal sealed class CommandModule : Module<CommandResult>
 }
 
 [DependsOn<CommandModule>]
+[DependsOn<ClosedGenericModule<int>>]
 internal sealed class VerificationModule(
     ISecretObfuscator secretObfuscator) : Module<bool>
 {
@@ -158,6 +158,7 @@ internal sealed class IgnoredValueModule : Module<int>
     }
 }
 
+[SmokeHook]
 internal sealed class ClosedGenericModule<T> : Module<bool>
 {
     protected override Task<bool> ExecuteAsync(

--- a/test/ModularPipelines.UnitTests/Api/DistributedApiAnnotationTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/DistributedApiAnnotationTests.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using ModularPipelines.Distributed;
+using ModularPipelines.Distributed.Extensions;
+
+namespace ModularPipelines.UnitTests.Api;
+
+public class DistributedApiAnnotationTests
+{
+    [Test]
+    public async Task Action_Overload_Warns_Trim_And_Aot_Callers()
+    {
+        var method = typeof(DistributedPipelineBuilderExtensions).GetMethod(
+            nameof(DistributedPipelineBuilderExtensions.AddDistributedMode),
+            [typeof(PipelineBuilder), typeof(Action<DistributedOptions>)]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(method).IsNotNull();
+            await Assert.That(method!.GetCustomAttribute<RequiresUnreferencedCodeAttribute>())
+                .IsNotNull();
+            await Assert.That(method.GetCustomAttribute<RequiresDynamicCodeAttribute>())
+                .IsNotNull();
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Api/PipelineBuilderApiAnnotationTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/PipelineBuilderApiAnnotationTests.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using ModularPipelines.Extensions;
+
+namespace ModularPipelines.UnitTests.Api;
+
+public class PipelineBuilderApiAnnotationTests
+{
+    [Test]
+    public async Task Runtime_Type_Registration_Warns_Trim_And_Aot_Callers()
+    {
+        var method = typeof(PipelineBuilderExtensions).GetMethod(
+            nameof(PipelineBuilderExtensions.AddModules),
+            [typeof(PipelineBuilder), typeof(Type[])]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(method).IsNotNull();
+            await Assert.That(method!.GetCustomAttribute<RequiresUnreferencedCodeAttribute>())
+                .IsNotNull();
+            await Assert.That(method.GetCustomAttribute<RequiresDynamicCodeAttribute>())
+                .IsNotNull();
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Api/PipelineBuilderApiAnnotationTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/PipelineBuilderApiAnnotationTests.cs
@@ -22,4 +22,22 @@ public class PipelineBuilderApiAnnotationTests
                 .IsNotNull();
         }
     }
+
+    [Test]
+    public async Task Result_History_Warns_Trim_And_Aot_Callers()
+    {
+        var method = typeof(PipelineBuilderExtensions)
+            .GetMethods()
+            .Single(candidate =>
+                candidate.Name == nameof(PipelineBuilderExtensions.AddResultsRepository)
+                && candidate.IsGenericMethodDefinition);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(method.GetCustomAttribute<RequiresUnreferencedCodeAttribute>())
+                .IsNotNull();
+            await Assert.That(method.GetCustomAttribute<RequiresDynamicCodeAttribute>())
+                .IsNotNull();
+        }
+    }
 }

--- a/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
@@ -1,10 +1,12 @@
 using System.Reflection;
 using System.Reflection.Emit;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Extensions;
+using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
@@ -71,6 +73,27 @@ public class GeneratedModuleMetadataTests
         var result = registry.GetResult(module.GetType());
         await Assert.That(result).IsAssignableTo<ModuleResult<bool>>();
         await Assert.That(result!.ExceptionOrDefault).IsSameReferenceAs(exception);
+    }
+
+    [Test]
+    public async Task Generated_Runtime_Resolves_Unbuffered_Output_Logger()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var found = GeneratedModuleMetadata.TryGetRuntime(
+            typeof(GeneratedMetadataDependencyModule),
+            out var runtime);
+        var logger = runtime.GetOutputLogger(serviceProvider);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(found).IsTrue();
+            await Assert.That(logger)
+                .IsAssignableTo<ILogger<GeneratedMetadataDependencyModule>>();
+            await Assert.That(logger).IsNotAssignableTo<ModuleLogger>();
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
@@ -112,8 +112,44 @@ public class GeneratedModuleMetadataTests
         var knownTypes = AssemblyLoadedTypesProvider
             .GetKnownTypes(assembly, typeof(IModule))
             .ToArray();
+        var generatedKnownTypes = AssemblyLoadedTypesProvider
+            .GetGeneratedKnownTypes(assembly, typeof(IModule))
+            .ToArray();
 
-        await Assert.That(knownTypes).IsEquivalentTo([includedModule]);
+        using (Assert.Multiple())
+        {
+            await Assert.That(knownTypes).IsEquivalentTo([includedModule]);
+            await Assert.That(generatedKnownTypes).IsEquivalentTo([includedModule]);
+        }
+    }
+
+    [Test]
+    public async Task Incomplete_Generated_Metadata_Is_Skipped_Without_Reflection_Fallback()
+    {
+        var (assembly, _, module) = CreateDynamicModule("IncompleteModule");
+        GeneratedModuleMetadata.Register(
+            assembly,
+            [
+                new GeneratedModuleRegistration(
+                    module,
+                    static _ => { },
+                    [],
+                    DependenciesComplete: true),
+            ],
+            isComplete: false);
+
+        var knownTypes = AssemblyLoadedTypesProvider
+            .GetKnownTypes(assembly, typeof(IModule))
+            .ToArray();
+        var generatedKnownTypes = AssemblyLoadedTypesProvider
+            .GetGeneratedKnownTypes(assembly, typeof(IModule))
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(knownTypes).Contains(module);
+            await Assert.That(generatedKnownTypes).IsEmpty();
+        }
     }
 
     private static (AssemblyBuilder Assembly, ModuleBuilder ModuleBuilder, Type Module)

--- a/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
@@ -1,8 +1,11 @@
 using System.Reflection;
 using System.Reflection.Emit;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Engine;
+using ModularPipelines.Engine.Execution;
 using ModularPipelines.Extensions;
+using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
 
@@ -51,6 +54,23 @@ public class GeneratedModuleMetadataTests
             await Assert.That(services.Count(descriptor => descriptor.ServiceType == typeof(IModule)))
                 .IsEqualTo(2);
         }
+    }
+
+    [Test]
+    public async Task Generated_Runtime_Creates_Typed_Terminated_Result()
+    {
+        var module = new GeneratedMetadataDependencyModule();
+        var registry = new ModuleResultRegistry();
+        var registrar = new ModuleResultRegistrar(
+            registry,
+            NullLogger<ModuleResultRegistrar>.Instance);
+        var exception = new InvalidOperationException("Pipeline terminated");
+
+        registrar.RegisterTerminatedResult(module, module.GetType(), exception);
+
+        var result = registry.GetResult(module.GetType());
+        await Assert.That(result).IsAssignableTo<ModuleResult<bool>>();
+        await Assert.That(result!.ExceptionOrDefault).IsSameReferenceAs(exception);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
@@ -149,7 +149,8 @@ public class GeneratedModuleMetadataTests
     [Test]
     public async Task Incomplete_Generated_Metadata_Is_Skipped_Without_Reflection_Fallback()
     {
-        var (assembly, _, module) = CreateDynamicModule("IncompleteModule");
+        var (_, _, module) = CreateDynamicModule("IncompleteModule");
+        var assembly = module.Assembly;
         GeneratedModuleMetadata.Register(
             assembly,
             [

--- a/test/ModularPipelines.UnitTests/Engine/OptionsProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/OptionsProviderTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using ModularPipelines.DependencyInjection;
 using ModularPipelines.Engine;
 
@@ -21,8 +22,30 @@ public class OptionsProviderTests
         await Assert.That(options.Value).IsEqualTo("configured");
     }
 
+    [Test]
+    public async Task GetOptions_Preserves_Value_Getter_Exception()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IOptions<TestOptions>, ThrowingOptions>();
+        using var serviceProvider = services.BuildServiceProvider();
+        var provider = new OptionsProvider(
+            new PipelineServiceContainerWrapper(services),
+            serviceProvider);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => provider.GetOptions().ToList());
+
+        await Assert.That(exception!.Message).IsEqualTo("Invalid options.");
+        await Assert.That(exception.StackTrace).Contains(nameof(ThrowingOptions));
+    }
+
     private sealed class TestOptions
     {
         public string? Value { get; set; }
+    }
+
+    private sealed class ThrowingOptions : IOptions<TestOptions>
+    {
+        public TestOptions Value => throw new InvalidOperationException("Invalid options.");
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/OptionsProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/OptionsProviderTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.DependencyInjection;
+using ModularPipelines.Engine;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class OptionsProviderTests
+{
+    [Test]
+    public async Task GetOptions_Reads_Value_Through_IOptions_Contract()
+    {
+        var services = new ServiceCollection();
+        services.Configure<TestOptions>(options => options.Value = "configured");
+        using var serviceProvider = services.BuildServiceProvider();
+        var provider = new OptionsProvider(
+            new PipelineServiceContainerWrapper(services),
+            serviceProvider);
+
+        var options = provider.GetOptions().OfType<TestOptions>().Single();
+
+        await Assert.That(options.Value).IsEqualTo("configured");
+    }
+
+    private sealed class TestOptions
+    {
+        public string? Value { get; set; }
+    }
+}

--- a/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
+++ b/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
+    <!-- Test fixtures intentionally use private nested modules and are not AOT publish inputs. -->
+    <NoWarn>$(NoWarn);MPG0011</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />


### PR DESCRIPTION
## Summary
- generate typed module runtime metadata so static pipelines avoid reflection under trimming and Native AOT
- annotate or isolate unsupported dynamic, distributed, and reflection-based serialization paths
- add trim/AOT analyzer coverage, representative trimmed/Native AOT smoke CI, and compatibility documentation

## Validation
- `ModularPipelines.sln` Release build passed
- core trim/AOT analyzer rebuild: 0 IL diagnostics
- source-generator metadata tests: 11 passed
- focused unit tests: 38 passed
- self-contained trimmed `win-x64` smoke published and ran with `TRIM_AOT_SMOKE_OK`
- examples build passed with 0 IL diagnostics

Local Native AOT compilation reached the native linker prerequisite, but this Windows workstation lacks the Desktop Development for C++ workload. The new Ubuntu CI lane performs the actual Native AOT publish and run.

Closes #3228