### PR TITLE
Fix CommandLogger tests after async API rename

### DIFF
--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -386,7 +386,7 @@ public class CommandLoggerTests : TestBase
         });
 
         var exception = await Assert.ThrowsAsync<AggregateException>(() =>
-            commandContext.ExecuteCommandLineTool(
+            commandContext.ExecuteCommandLineToolAsync(
                 new PowershellScriptOptions(
                     $"Write-Output '{marker}'; "
                     + "Start-Sleep -Milliseconds 750; "
@@ -411,7 +411,7 @@ public class CommandLoggerTests : TestBase
         });
 
         var exception = await Assert.ThrowsAsync<CommandException>(() =>
-            commandContext.ExecuteCommandLineTool(
+            commandContext.ExecuteCommandLineToolAsync(
                 new PowershellScriptOptions(
                     $"Write-Output '{marker}'; "
                     + "Start-Sleep -Milliseconds 750; "
@@ -446,7 +446,7 @@ public class CommandLoggerTests : TestBase
         });
 
         var commandTask =
-            commandContext.ExecuteCommandLineTool(
+            commandContext.ExecuteCommandLineToolAsync(
                 new PowershellScriptOptions(
                     $"Write-Output '{marker}'; Start-Sleep -Seconds 30"),
                 new CommandExecutionOptions


### PR DESCRIPTION
## Summary
- update three newly added deferred-logging tests to call ExecuteCommandLineToolAsync
- restore compilation after the command context API rename

## Validation
- CommandLoggerTests: 46/46 passed on net10.0
- whitespace verification passed
- info-level analyzer verification reports only pre-existing diagnostics elsewhere in CommandLoggerTests.cs