### PR TITLE
Fix stale README module example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,14 @@ public class BuildModule : Module<BuildInfo>
 
 // PublishModule retrieves and uses it
 [DependsOn<BuildModule>]
-public class PublishModule : Module
+public class PublishModule : Module<None>
 {
-    protected override async Task ExecuteModuleAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task<None> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
         var buildResult = await context.GetModule<BuildModule>();
         var outputPath = buildResult.ValueOrDefault!.OutputPath; // Strongly-typed, compile-time checked
         // Publish using the build output...
+        return None.Value;
     }
 }
 ```

--- a/README_Template.md
+++ b/README_Template.md
@@ -86,13 +86,14 @@ public class BuildModule : Module<BuildInfo>
 
 // PublishModule retrieves and uses it
 [DependsOn<BuildModule>]
-public class PublishModule : Module
+public class PublishModule : Module<None>
 {
-    protected override async Task ExecuteModuleAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task<None> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
         var buildResult = await context.GetModule<BuildModule>();
         var outputPath = buildResult.ValueOrDefault!.OutputPath; // Strongly-typed, compile-time checked
         // Publish using the build output...
+        return None.Value;
     }
 }
 ```

--- a/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
+++ b/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
@@ -64,6 +64,40 @@ public class DocumentationSnippetTests
         await Assert.That(readme).Contains("await builder.ExecutePipelineAsync();");
     }
 
+    [Test]
+    public async Task Readme_Module_Sharing_Fence_Matches_Compiled_Current_Api_Shape()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        string[] currentApiShape =
+        [
+            "PublishModule : Module<None>",
+            "protected override async Task<None> ExecuteAsync(",
+            "return None.Value;",
+        ];
+        var compiledFixture = await File.ReadAllTextAsync(Path.Combine(
+                repositoryRoot,
+                "test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs"))
+            .ConfigureAwait(false);
+
+        foreach (var expected in currentApiShape)
+        {
+            await Assert.That(compiledFixture).Contains(expected);
+        }
+
+        foreach (var fileName in new[] { "README_Template.md", "README.md" })
+        {
+            var readme = await File.ReadAllTextAsync(Path.Combine(repositoryRoot, fileName))
+                .ConfigureAwait(false);
+
+            foreach (var expected in currentApiShape)
+            {
+                await Assert.That(readme).Contains(expected);
+            }
+
+            await Assert.That(readme).DoesNotContain("ExecuteModuleAsync(");
+        }
+    }
+
     private static string FindRepositoryRoot()
     {
         var directory = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
## Summary
- replace the removed non-generic Module/ExecuteModuleAsync README example with Module<None>/ExecuteAsync
- keep README.md generated content aligned with README_Template.md
- guard both README fences against the compiled documentation fixture shape

## Validation
- DocumentationSnippetTests: 3/3 passed
- ModularPipelines.DocumentationSnippets Release build: 0 errors
- targeted severity-info formatting passed
- generated README/template comparison passed

Closes #3484