### PR TITLE
Repair scheduled CLI option generation

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -976,6 +976,7 @@ jobs:
     steps:
       - name: Create or update failure issue
         env:
+          GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           ISSUE_TITLE: Generate CLI Options scheduled run failed
           RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -958,9 +958,13 @@ jobs:
         && github.event_name == 'schedule'
         && (
           needs.validate-generation-safety.result == 'failure'
+          || needs.validate-generation-safety.result == 'cancelled'
           || needs.tool-catalog.result == 'failure'
+          || needs.tool-catalog.result == 'cancelled'
           || needs.generate.result == 'failure'
+          || needs.generate.result == 'cancelled'
           || needs.generate-windows.result == 'failure'
+          || needs.generate-windows.result == 'cancelled'
         )
       }}
     needs:

--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   validate-generation-safety:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -37,6 +38,7 @@ jobs:
   tool-catalog:
     needs: validate-generation-safety
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     outputs:
       linux: ${{ steps.catalog.outputs.linux }}
       windows: ${{ steps.catalog.outputs.windows }}
@@ -86,6 +88,7 @@ jobs:
       - validate-generation-safety
       - tool-catalog
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write
@@ -668,6 +671,7 @@ jobs:
       - validate-generation-safety
       - tool-catalog
     runs-on: windows-latest
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write
@@ -945,3 +949,69 @@ jobs:
         if: steps.api-compat.outcome == 'failure'
         shell: pwsh
         run: throw "Generated API is not backward compatible. Auto-merge was not enabled."
+
+  report-scheduled-failure:
+    name: Report scheduled failure
+    if: >-
+      ${{
+        always()
+        && github.event_name == 'schedule'
+        && (
+          needs.validate-generation-safety.result == 'failure'
+          || needs.tool-catalog.result == 'failure'
+          || needs.generate.result == 'failure'
+          || needs.generate-windows.result == 'failure'
+        )
+      }}
+    needs:
+      - validate-generation-safety
+      - tool-catalog
+      - generate
+      - generate-windows
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create or update failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: Generate CLI Options scheduled run failed
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          VALIDATE_RESULT: ${{ needs.validate-generation-safety.result }}
+          CATALOG_RESULT: ${{ needs.tool-catalog.result }}
+          LINUX_RESULT: ${{ needs.generate.result }}
+          WINDOWS_RESULT: ${{ needs.generate-windows.result }}
+        run: |
+          issue_body="$(cat <<EOF
+          Scheduled CLI option generation failed.
+
+          - Run: $RUN_URL
+          - Generation safety: $VALIDATE_RESULT
+          - Tool catalog: $CATALOG_RESULT
+          - Linux generation: $LINUX_RESULT
+          - Windows generation: $WINDOWS_RESULT
+
+          Inspect failed matrix jobs and keep this issue open until a scheduled run succeeds.
+          EOF
+          )"
+
+          existing_issue="$(
+            gh issue list \
+              --state open \
+              --search "$ISSUE_TITLE in:title" \
+              --limit 10 \
+              --json number,title \
+              --jq ".[] | select(.title == \"$ISSUE_TITLE\") | .number" |
+              head -n 1
+          )"
+
+          if [ -n "$existing_issue" ]; then
+            gh issue comment "$existing_issue" --body "$issue_body"
+          else
+            gh issue create \
+              --title "$ISSUE_TITLE" \
+              --body "$issue_body" \
+              --label bug
+          fi

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class AwsCliScraperTests
+{
+    [Test]
+    public async Task Scrape_Normalizes_Ansi_Formatted_Section_Headers()
+    {
+        var scraper = new AwsCliScraper(
+            new AwsHelpExecutor(),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<AwsCliScraper>.Instance);
+        var commands = new List<CliCommandDefinition>();
+
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        await Assert.That(commands.Select(command => command.FullCommand))
+            .IsEquivalentTo(["aws ec2 describe-instances"]);
+    }
+
+    private sealed class AwsHelpExecutor : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            var output = arguments switch
+            {
+                "help" => "\u001b[1mAVAILABLE SERVICES\u001b[0m\n       o ec2",
+                "ec2 help" => "\u001b[1mAVAILABLE COMMANDS\u001b[0m\n       o describe-instances",
+                "ec2 describe-instances help" => """
+                    DESCRIPTION
+                           Describes EC2 instances.
+
+                    OPTIONS
+                           --instance-ids (list)
+                           Instance identifiers.
+                    """,
+                _ => string.Empty,
+            };
+
+            return Task.FromResult(new CliCommandResult
+            {
+                StandardOutput = output,
+                StandardError = string.Empty,
+                ExitCode = string.IsNullOrEmpty(output) ? 1 : 0,
+            });
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/HelmCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/HelmCliScraperTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class HelmCliScraperTests
+{
+    [Test]
+    public async Task Uses_Version_Subcommand_For_Availability_And_Version()
+    {
+        var executor = new RecordingExecutor();
+        var scraper = new HelmCliScraper(
+            executor,
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<HelmCliScraper>.Instance);
+
+        var isAvailable = await scraper.IsAvailableAsync();
+        var version = await scraper.GetVersionAsync();
+
+        await Assert.That(isAvailable).IsTrue();
+        await Assert.That(version).IsEqualTo("version.BuildInfo{Version:\"v4.0.0\"}");
+        await Assert.That(executor.Arguments).IsEquivalentTo(["version", "version"]);
+    }
+
+    private sealed class RecordingExecutor : ICliCommandExecutor
+    {
+        public List<string> Arguments { get; } = [];
+
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            Arguments.Add(arguments);
+            var success = arguments == "version";
+            return Task.FromResult(new CliCommandResult
+            {
+                StandardOutput = success ? "version.BuildInfo{Version:\"v4.0.0\"}" : string.Empty,
+                StandardError = success ? string.Empty : "Error: unknown flag: --version",
+                ExitCode = success ? 0 : 1,
+            });
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
@@ -30,6 +30,9 @@ public class YarnCliScraperTests
               yarn workspaces focus [--json] [-A,--all] ...
                 install a single workspace and its dependencies
 
+              yarn cache clean
+                remove cached archives
+
               yarn rebuild ...
                 rebuild native packages
 
@@ -40,7 +43,7 @@ public class YarnCliScraperTests
         var commands = new TestYarnCliScraper().Extract(helpText);
 
         await Assert.That(commands).IsEquivalentTo(
-            ["add", "bin", "workspace", "workspaces", "workspaces focus", "rebuild", "node"]);
+            ["add", "bin", "workspace", "workspaces focus", "cache clean", "rebuild", "node"]);
     }
 
     private sealed class TestYarnCliScraper : YarnCliScraper

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
@@ -29,12 +29,18 @@ public class YarnCliScraperTests
 
               yarn workspaces focus [--json] [-A,--all] ...
                 install a single workspace and its dependencies
+
+              yarn rebuild ...
+                rebuild native packages
+
+              yarn node …
+                run Node with Yarn's module resolution
             """;
 
         var commands = new TestYarnCliScraper().Extract(helpText);
 
         await Assert.That(commands).IsEquivalentTo(
-            ["add", "bin", "workspace", "workspaces", "workspaces focus"]);
+            ["add", "bin", "workspace", "workspaces", "workspaces focus", "rebuild", "node"]);
     }
 
     private sealed class TestYarnCliScraper : YarnCliScraper

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class YarnCliScraperTests
+{
+    [Test]
+    public async Task Extracts_Current_Plain_Category_Commands()
+    {
+        const string helpText = """
+            Yarn Package Manager - 4.17.1
+
+              $ yarn <command>
+
+            General commands
+
+              yarn add [--json] [-F,--fixed] ...
+                add dependencies to the project
+
+              yarn bin [-v,--verbose] [--json] [name]
+                get the path to a binary script
+
+            Workspace-related commands
+
+              yarn workspace <workspaceName> <commandName> ...
+                run a command within the specified workspace
+
+              yarn workspaces focus [--json] [-A,--all] ...
+                install a single workspace and its dependencies
+            """;
+
+        var commands = new TestYarnCliScraper().Extract(helpText);
+
+        await Assert.That(commands).IsEquivalentTo(
+            ["add", "bin", "workspace", "workspaces", "workspaces focus"]);
+    }
+
+    private sealed class TestYarnCliScraper : YarnCliScraper
+    {
+        public TestYarnCliScraper()
+            : base(
+                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<YarnCliScraper>.Instance)
+        {
+        }
+
+        public List<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/ZeroOutputScraperTests.cs
@@ -226,7 +226,7 @@ public class ZeroOutputScraperTests
         }));
 
         await Assert.That((await ScrapeAsync(scraper)).Select(command => command.FullCommand))
-            .IsEquivalentTo(["yarn add", "yarn cache", "yarn cache clean", "yarn npm", "yarn npm info"]);
+            .IsEquivalentTo(["yarn add", "yarn cache clean", "yarn npm info"]);
     }
 
     private static async Task<IReadOnlyList<CliCommandDefinition>> ScrapeAsync(ICliScraper scraper)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/HelmCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/HelmCliScraper.cs
@@ -14,8 +14,21 @@ public class HelmCliScraper : CobraCliScraper
     public override string TargetNamespace => "ModularPipelines.Helm";
     public override string OutputDirectory => "src/ModularPipelines.Helm";
 
+    protected override string VersionArguments => "version";
+
     public HelmCliScraper(ICliCommandExecutor executor, IHelpTextCache helpCache, ILogger<HelmCliScraper> logger)
         : base(executor, helpCache, logger)
     {
+    }
+
+    public override async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        var result = await Executor.ExecuteAsync(
+                ExecutablePath,
+                VersionArguments,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return result.Success;
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -148,64 +148,19 @@ public partial class YarnCliScraper : CliScraperBase
         //   yarn add [--json] [-E,--exact] [-T,--tilde] ...
         //     Add dependencies to the project.
         var categoryMatches = ClipanionCategoryPattern().Matches(helpText);
-        foreach (Match categoryMatch in categoryMatches)
+        if (categoryMatches.Count == 0)
         {
-            var categoryStart = categoryMatch.Index + categoryMatch.Length;
-
-            // Find the end of this category section (next category header or end of text)
-            var nextCategoryMatch = ClipanionCategoryPattern().Match(helpText, categoryStart);
-            var categoryEnd = nextCategoryMatch.Success ? nextCategoryMatch.Index : helpText.Length;
-
-            var categorySection = helpText.Substring(categoryStart, categoryEnd - categoryStart);
-
-            // Parse command lines in this category
-            // Format: "  yarn <command> [options...]" or "  yarn <parent> <sub> [options...]"
-            var commandMatches = ClipanionCommandLinePattern().Matches(categorySection);
-            foreach (Match commandMatch in commandMatches)
+            AddClipanionCommands(helpText, subcommands, seenCommands);
+        }
+        else
+        {
+            foreach (Match categoryMatch in categoryMatches)
             {
-                var commandPart = commandMatch.Groups["command"].Value.Trim();
-
-                if (!string.IsNullOrEmpty(commandPart))
-                {
-                    // Extract just the first command word (e.g., "add" from "add [--json]")
-                    // Handle multi-word commands like "npm info" or "workspaces focus"
-                    var commandWords = commandPart.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                    if (commandWords.Length > 0)
-                    {
-                        // Get the full command path (may be multi-word like "npm info")
-                        var fullCommand = new List<string>();
-                        foreach (var word in commandWords)
-                        {
-                            // Stop at options (words starting with [ or -)
-                            if (word.StartsWith('[') || word.StartsWith('-') || word.StartsWith('<'))
-                            {
-                                break;
-                            }
-
-                            fullCommand.Add(word);
-                        }
-
-                        if (fullCommand.Count > 0)
-                        {
-                            // For now, take the first command part (we can expand later for subcommands)
-                            var commandName = fullCommand[0];
-                            if (IsValidCommand(commandName) && seenCommands.Add(commandName))
-                            {
-                                subcommands.Add(commandName);
-                            }
-
-                            // Also add the full multi-word command if different
-                            if (fullCommand.Count > 1)
-                            {
-                                var fullCommandName = string.Join(" ", fullCommand);
-                                if (seenCommands.Add(fullCommandName))
-                                {
-                                    subcommands.Add(fullCommandName);
-                                }
-                            }
-                        }
-                    }
-                }
+                var categoryStart = categoryMatch.Index + categoryMatch.Length;
+                var nextCategoryMatch = ClipanionCategoryPattern().Match(helpText, categoryStart);
+                var categoryEnd = nextCategoryMatch.Success ? nextCategoryMatch.Index : helpText.Length;
+                var categorySection = helpText[categoryStart..categoryEnd];
+                AddClipanionCommands(categorySection, subcommands, seenCommands);
             }
         }
 
@@ -290,6 +245,43 @@ public partial class YarnCliScraper : CliScraperBase
         }
 
         return subcommands;
+    }
+
+    private static void AddClipanionCommands(
+        string helpText,
+        List<string> subcommands,
+        HashSet<string> seenCommands)
+    {
+        foreach (Match commandMatch in ClipanionCommandLinePattern().Matches(helpText))
+        {
+            var commandWords = commandMatch.Groups["command"].Value
+                .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .TakeWhile(word =>
+                    !word.StartsWith('[')
+                    && !word.StartsWith('-')
+                    && !word.StartsWith('<'))
+                .ToArray();
+
+            if (commandWords.Length == 0)
+            {
+                continue;
+            }
+
+            var commandName = commandWords[0];
+            if (IsValidCommand(commandName) && seenCommands.Add(commandName))
+            {
+                subcommands.Add(commandName);
+            }
+
+            if (commandWords.Length > 1)
+            {
+                var fullCommandName = string.Join(" ", commandWords);
+                if (seenCommands.Add(fullCommandName))
+                {
+                    subcommands.Add(fullCommandName);
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -268,19 +268,15 @@ public partial class YarnCliScraper : CliScraperBase
                 continue;
             }
 
-            var commandName = commandWords[0];
-            if (IsValidCommand(commandName) && seenCommands.Add(commandName))
+            if (!commandWords.All(IsValidCommand))
             {
-                subcommands.Add(commandName);
+                continue;
             }
 
-            if (commandWords.Length > 1)
+            var commandName = string.Join(" ", commandWords);
+            if (seenCommands.Add(commandName))
             {
-                var fullCommandName = string.Join(" ", commandWords);
-                if (seenCommands.Add(fullCommandName))
-                {
-                    subcommands.Add(fullCommandName);
-                }
+                subcommands.Add(commandName);
             }
         }
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -259,7 +259,8 @@ public partial class YarnCliScraper : CliScraperBase
                 .TakeWhile(word =>
                     !word.StartsWith('[')
                     && !word.StartsWith('-')
-                    && !word.StartsWith('<'))
+                    && !word.StartsWith('<')
+                    && word is not "..." and not "…")
                 .ToArray();
 
             if (commandWords.Length == 0)


### PR DESCRIPTION
## Summary
- use Helm's supported `version` subcommand and parse Yarn 4's plain command categories
- lock in the ANSI-normalization regression that fixes AWS command discovery
- bound every generation job and create or update a diagnostic issue when a scheduled run fails

The remaining failures from the referenced run are covered by generator fixes already present on `main` for Trivy, Liquibase, AWS, DotNet, Cosign, and Eksctl.

## Test plan
- [x] OptionsGenerator tests (688 passed)
- [x] OptionsGenerator Release build (0 warnings, 0 errors)
- [x] scoped whitespace verification
- [x] workflow YAML validation and reporter shell syntax validation

Closes #3451
