### PR TITLE
Write CI workflow commands directly to stdout

### DIFF
--- a/src/ModularPipelines.Azure.Pipelines/AzurePipeline.cs
+++ b/src/ModularPipelines.Azure.Pipelines/AzurePipeline.cs
@@ -50,19 +50,13 @@ internal class AzurePipeline : IAzurePipeline
             _formatter = formatter;
 
             var startCommand = formatter.GetStartBlockCommand(name);
-            if (startCommand != null)
-            {
-                _buffer.WriteLine(startCommand);
-            }
+            buffer.WriteGroupCommand(formatter, startCommand);
         }
 
         public void Dispose()
         {
             var endCommand = _formatter.GetEndBlockCommand(_name);
-            if (endCommand != null)
-            {
-                _buffer.WriteLine(endCommand);
-            }
+            _buffer.WriteGroupCommand(_formatter, endCommand);
         }
     }
 }

--- a/src/ModularPipelines.GitHub/GitHub.cs
+++ b/src/ModularPipelines.GitHub/GitHub.cs
@@ -85,19 +85,13 @@ internal class GitHub : IGitHub
             _formatter = formatter;
 
             var startCommand = formatter.GetStartBlockCommand(name);
-            if (startCommand != null)
-            {
-                _github._buffer.WriteLine(startCommand);
-            }
+            github._buffer.WriteGroupCommand(formatter, startCommand);
         }
 
         public void Dispose()
         {
             var endCommand = _formatter.GetEndBlockCommand(_name);
-            if (endCommand != null)
-            {
-                _github._buffer.WriteLine(endCommand);
-            }
+            _github._buffer.WriteGroupCommand(_formatter, endCommand);
         }
     }
 }

--- a/src/ModularPipelines.TeamCity/TeamCity.cs
+++ b/src/ModularPipelines.TeamCity/TeamCity.cs
@@ -43,19 +43,13 @@ internal class TeamCity : ITeamCity
             _formatter = formatter;
 
             var startCommand = formatter.GetStartBlockCommand(name);
-            if (startCommand != null)
-            {
-                _buffer.WriteLine(startCommand);
-            }
+            buffer.WriteGroupCommand(formatter, startCommand);
         }
 
         public void Dispose()
         {
             var endCommand = _formatter.GetEndBlockCommand(_name);
-            if (endCommand != null)
-            {
-                _buffer.WriteLine(endCommand);
-            }
+            _buffer.WriteGroupCommand(_formatter, endCommand);
         }
     }
 }

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -35,6 +35,14 @@ internal interface IModuleOutputBuffer
     void WriteLine(string message);
 
     /// <summary>
+    /// Buffers a build-system group command while preserving its position relative to section output.
+    /// Raw CI commands bypass Spectre when flushed; local headers retain normal rendering.
+    /// </summary>
+    /// <param name="formatter">The active build-system formatter.</param>
+    /// <param name="command">The group command, or <see langword="null"/> when unsupported.</param>
+    void WriteGroupCommand(IBuildSystemFormatter formatter, string? command);
+
+    /// <summary>
     /// Adds a structured log event to the buffer.
     /// Used for ILogger calls.
     /// </summary>

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -106,6 +106,17 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     /// <inheritdoc />
+    public void WriteGroupCommand(IBuildSystemFormatter formatter, string? command)
+    {
+        formatter.WriteGroupCommand(
+            command,
+            value => AddOutput(
+                BufferedOutput.FromRawBuildSystemCommand(value),
+                allowAfterCompletion: true),
+            WriteLine);
+    }
+
+    /// <inheritdoc />
     public void AddLogEvent(IBufferedLogEvent logEvent)
     {
         AddOutput(BufferedOutput.FromLogEvent(logEvent), allowAfterCompletion: false);
@@ -444,7 +455,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (output.IsString)
+            if (output.IsRawBuildSystemCommand)
+            {
+                console.WriteLine(output.StringValue);
+            }
+            else if (output.IsString)
             {
                 WriteDirect(directConsole, console, output.StringValue);
             }
@@ -671,14 +686,10 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         IBuildSystemFormatter formatter,
         string command)
     {
-        if (formatter.UsesRawCommands)
-        {
-            console.WriteLine(command);
-        }
-        else
-        {
-            WriteDirect(directConsole, console, command);
-        }
+        formatter.WriteGroupCommand(
+            command,
+            console.WriteLine,
+            value => WriteDirect(directConsole, console, value));
     }
 }
 
@@ -703,9 +714,24 @@ internal readonly struct BufferedOutput
     public bool IsString => StringValue != null;
 
     /// <summary>
+    /// Gets a value indicating whether this string is a raw build-system command.
+    /// </summary>
+    public bool IsRawBuildSystemCommand { get; private init; }
+
+    /// <summary>
     /// Creates a buffered output from a string.
     /// </summary>
     public static BufferedOutput FromString(string value) => new() { StringValue = value };
+
+    /// <summary>
+    /// Creates a buffered output from a raw build-system command.
+    /// </summary>
+    public static BufferedOutput FromRawBuildSystemCommand(string value) =>
+        new()
+        {
+            StringValue = value,
+            IsRawBuildSystemCommand = true,
+        };
 
     /// <summary>
     /// Creates a buffered output from a log event.

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -396,7 +396,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             // synchronous rendering, so unrelated logger calls cannot enter this group.
             if (startCommand != null)
             {
-                WriteDirect(directConsole, console, startCommand);
+                WriteGroupCommand(console, directConsole, formatter, startCommand);
                 groupStarted = true;
             }
 
@@ -418,7 +418,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             if (groupStarted && endCommand != null)
             {
-                console.WriteLine(endCommand);
+                WriteGroupCommand(console, directConsole, formatter, endCommand);
             }
 
             if (groupStarted || flushCompleted)
@@ -662,6 +662,22 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             // CI workflow commands and arbitrary output can contain brackets that are not Spectre markup.
             console.WriteLine(value);
+        }
+    }
+
+    private static void WriteGroupCommand(
+        TextWriter console,
+        IAnsiConsole directConsole,
+        IBuildSystemFormatter formatter,
+        string command)
+    {
+        if (formatter.UsesRawCommands)
+        {
+            console.WriteLine(command);
+        }
+        else
+        {
+            WriteDirect(directConsole, console, command);
         }
     }
 }

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -294,6 +294,7 @@ internal static class DependencyInjectionSetup
             .AddSingleton<ISecretProvider>(sp => sp.GetRequiredService<SecretProvider>())
             .AddSingleton<ISecretRegistry>(sp => sp.GetRequiredService<SecretProvider>())
             .AddSingleton<ISecretObfuscator, SecretObfuscator>()
+            .AddSingleton<IBuildSystemCommandWriter, BuildSystemCommandWriter>()
             .AddSingleton<IBuildSystemSecretMasker, BuildSystemSecretMasker>()
             .AddSingleton<IBuildSystemDetector, BuildSystemDetector>()
             .AddSingleton<IBuildSystemFormatterProvider, BuildSystemFormatterProvider>();

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -288,13 +288,16 @@ internal static class DependencyInjectionSetup
     /// </summary>
     private static void RegisterBuildSystemServices(IServiceCollection services)
     {
+        // Capture before service-provider construction and ConsoleCoordinator.Install() can redirect stdout.
+        var commandWriter = new BuildSystemCommandWriter(System.Console.Out);
+
         services
             .Configure<SecretMaskingOptions>(_ => { })
             .AddSingleton<SecretProvider>()
             .AddSingleton<ISecretProvider>(sp => sp.GetRequiredService<SecretProvider>())
             .AddSingleton<ISecretRegistry>(sp => sp.GetRequiredService<SecretProvider>())
             .AddSingleton<ISecretObfuscator, SecretObfuscator>()
-            .AddSingleton<IBuildSystemCommandWriter, BuildSystemCommandWriter>()
+            .AddSingleton<IBuildSystemCommandWriter>(commandWriter)
             .AddSingleton<IBuildSystemSecretMasker, BuildSystemSecretMasker>()
             .AddSingleton<IBuildSystemDetector, BuildSystemDetector>()
             .AddSingleton<IBuildSystemFormatterProvider, BuildSystemFormatterProvider>();

--- a/src/ModularPipelines/Engine/BuildSystemCommandWriter.cs
+++ b/src/ModularPipelines/Engine/BuildSystemCommandWriter.cs
@@ -1,0 +1,38 @@
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Writes CI workflow commands without passing through Spectre rendering or console interception.
+/// </summary>
+internal sealed class BuildSystemCommandWriter : IBuildSystemCommandWriter
+{
+    private readonly TextWriter _originalStandardOutput;
+    private readonly Lock _writeLock = new();
+
+    public BuildSystemCommandWriter()
+        : this(System.Console.Out)
+    {
+    }
+
+    internal BuildSystemCommandWriter(TextWriter originalStandardOutput)
+    {
+        ArgumentNullException.ThrowIfNull(originalStandardOutput);
+        _originalStandardOutput = originalStandardOutput;
+    }
+
+    /// <inheritdoc />
+    public void WriteLine(string command)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(command);
+        if (command.Contains('\n'))
+        {
+            throw new ArgumentException(
+                "Build-system commands must contain exactly one physical line.",
+                nameof(command));
+        }
+
+        lock (_writeLock)
+        {
+            _originalStandardOutput.WriteLine(command);
+        }
+    }
+}

--- a/src/ModularPipelines/Engine/BuildSystemCommandWriter.cs
+++ b/src/ModularPipelines/Engine/BuildSystemCommandWriter.cs
@@ -8,6 +8,13 @@ internal sealed class BuildSystemCommandWriter : IBuildSystemCommandWriter
     private readonly TextWriter _originalStandardOutput;
     private readonly Lock _writeLock = new();
 
+    /// <summary>
+    /// Initialises a writer over the original standard output stream.
+    /// </summary>
+    /// <remarks>
+    /// DI must construct this dependency before <c>ConsoleCoordinator.Install()</c> redirects
+    /// <see cref="System.Console.Out"/>.
+    /// </remarks>
     public BuildSystemCommandWriter()
         : this(System.Console.Out)
     {

--- a/src/ModularPipelines/Engine/BuildSystemCommandWriter.cs
+++ b/src/ModularPipelines/Engine/BuildSystemCommandWriter.cs
@@ -9,11 +9,11 @@ internal sealed class BuildSystemCommandWriter : IBuildSystemCommandWriter
     private readonly Lock _writeLock = new();
 
     /// <summary>
-    /// Initialises a writer over the original standard output stream.
+    /// Initialises a new instance of the <see cref="BuildSystemCommandWriter"/> class.
     /// </summary>
     /// <remarks>
-    /// DI must construct this dependency before <c>ConsoleCoordinator.Install()</c> redirects
-    /// <see cref="System.Console.Out"/>.
+    /// The writer captures the original standard output stream. DI must construct this dependency
+    /// before <c>ConsoleCoordinator.Install()</c> redirects <see cref="System.Console.Out"/>.
     /// </remarks>
     public BuildSystemCommandWriter()
         : this(System.Console.Out)

--- a/src/ModularPipelines/Engine/BuildSystemCommandWriter.cs
+++ b/src/ModularPipelines/Engine/BuildSystemCommandWriter.cs
@@ -8,18 +8,6 @@ internal sealed class BuildSystemCommandWriter : IBuildSystemCommandWriter
     private readonly TextWriter _originalStandardOutput;
     private readonly Lock _writeLock = new();
 
-    /// <summary>
-    /// Initialises a new instance of the <see cref="BuildSystemCommandWriter"/> class.
-    /// </summary>
-    /// <remarks>
-    /// The writer captures the original standard output stream. DI must construct this dependency
-    /// before <c>ConsoleCoordinator.Install()</c> redirects <see cref="System.Console.Out"/>.
-    /// </remarks>
-    public BuildSystemCommandWriter()
-        : this(System.Console.Out)
-    {
-    }
-
     internal BuildSystemCommandWriter(TextWriter originalStandardOutput)
     {
         ArgumentNullException.ThrowIfNull(originalStandardOutput);

--- a/src/ModularPipelines/Engine/BuildSystemFormatterExtensions.cs
+++ b/src/ModularPipelines/Engine/BuildSystemFormatterExtensions.cs
@@ -1,0 +1,35 @@
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Centralizes routing for build-system group commands.
+/// </summary>
+internal static class BuildSystemFormatterExtensions
+{
+    /// <summary>
+    /// Writes a group command without rendering raw CI commands through Spectre.
+    /// </summary>
+    /// <param name="formatter">The active build-system formatter.</param>
+    /// <param name="command">The group command, or <see langword="null"/> when unsupported.</param>
+    /// <param name="rawWriter">Writes commands that must bypass rendering and interception.</param>
+    /// <param name="fallbackWriter">Writes locally rendered group headers.</param>
+    public static void WriteGroupCommand(
+        this IBuildSystemFormatter formatter,
+        string? command,
+        Action<string> rawWriter,
+        Action<string> fallbackWriter)
+    {
+        if (command is null)
+        {
+            return;
+        }
+
+        if (formatter.UsesRawCommands)
+        {
+            rawWriter(command);
+        }
+        else
+        {
+            fallbackWriter(command);
+        }
+    }
+}

--- a/src/ModularPipelines/Engine/BuildSystemFormatters/AzurePipelinesFormatter.cs
+++ b/src/ModularPipelines/Engine/BuildSystemFormatters/AzurePipelinesFormatter.cs
@@ -22,11 +22,14 @@ namespace ModularPipelines.Engine.BuildSystemFormatters;
 /// </example>
 internal class AzurePipelinesFormatter : IBuildSystemFormatter
 {
+    public bool UsesRawCommands => true;
+
     public string GetStartBlockCommand(string name) => $"##[group]{name}";
 
     public string GetEndBlockCommand(string name) => "##[endgroup]";
 
-    public string GetMaskSecretCommand(string secret) => $"##vso[task.setvariable variable=secret_{Guid.NewGuid():N};issecret=true]{secret}";
+    public string GetMaskSecretCommand(string secret) =>
+        $"##vso[task.setvariable variable=secret_{Guid.NewGuid():N};issecret=true]{EscapeLoggingCommandValue(secret)}";
 
     public string? GetLogIssueCommand(LogLevel logLevel, string message)
     {

--- a/src/ModularPipelines/Engine/BuildSystemFormatters/GitHubActionsFormatter.cs
+++ b/src/ModularPipelines/Engine/BuildSystemFormatters/GitHubActionsFormatter.cs
@@ -20,6 +20,8 @@ namespace ModularPipelines.Engine.BuildSystemFormatters;
 /// </example>
 internal class GitHubActionsFormatter : IBuildSystemFormatter
 {
+    public bool UsesRawCommands => true;
+
     public string GetStartBlockCommand(string name) => $"::group::{name}";
 
     public string GetEndBlockCommand(string name) => "::endgroup::";

--- a/src/ModularPipelines/Engine/BuildSystemFormatters/GitLabFormatter.cs
+++ b/src/ModularPipelines/Engine/BuildSystemFormatters/GitLabFormatter.cs
@@ -19,6 +19,8 @@ namespace ModularPipelines.Engine.BuildSystemFormatters;
 /// </example>
 internal class GitLabFormatter : IBuildSystemFormatter
 {
+    public bool UsesRawCommands => true;
+
     public string GetStartBlockCommand(string name)
     {
         var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();

--- a/src/ModularPipelines/Engine/BuildSystemFormatters/TeamCityFormatter.cs
+++ b/src/ModularPipelines/Engine/BuildSystemFormatters/TeamCityFormatter.cs
@@ -20,6 +20,8 @@ namespace ModularPipelines.Engine.BuildSystemFormatters;
 /// </example>
 internal class TeamCityFormatter : IBuildSystemFormatter
 {
+    public bool UsesRawCommands => true;
+
     public string GetStartBlockCommand(string name) => $"##teamcity[blockOpened name='{EscapeValue(name)}']";
 
     public string GetEndBlockCommand(string name) => $"##teamcity[blockClosed name='{EscapeValue(name)}']";

--- a/src/ModularPipelines/Engine/BuildSystemFormatters/TravisCIFormatter.cs
+++ b/src/ModularPipelines/Engine/BuildSystemFormatters/TravisCIFormatter.cs
@@ -18,6 +18,8 @@ namespace ModularPipelines.Engine.BuildSystemFormatters;
 /// </example>
 internal class TravisCIFormatter : IBuildSystemFormatter
 {
+    public bool UsesRawCommands => true;
+
     public string GetStartBlockCommand(string name)
     {
         var foldId = IdSanitizer.ToSectionId(name);

--- a/src/ModularPipelines/Engine/BuildSystemSecretMasker.cs
+++ b/src/ModularPipelines/Engine/BuildSystemSecretMasker.cs
@@ -24,7 +24,7 @@ namespace ModularPipelines.Engine;
 /// </remarks>
 /// <example>
 /// <code>
-/// var masker = new BuildSystemSecretMasker(formatterProvider, consoleWriter);
+/// var masker = new BuildSystemSecretMasker(formatterProvider, commandWriter);
 ///
 /// // Mask multiple secrets
 /// masker.MaskSecrets(new[] { "password123", "api-key-xyz" });
@@ -38,16 +38,16 @@ namespace ModularPipelines.Engine;
 internal class BuildSystemSecretMasker : IBuildSystemSecretMasker
 {
     private readonly IBuildSystemFormatterProvider _formatterProvider;
-    private readonly IConsoleWriter _consoleWriter;
+    private readonly IBuildSystemCommandWriter _commandWriter;
 
     private readonly HashSet<string> _alreadyMaskedSecrets = new();
     private readonly object _lock = new();
 
     public BuildSystemSecretMasker(IBuildSystemFormatterProvider formatterProvider,
-        IConsoleWriter consoleWriter)
+        IBuildSystemCommandWriter commandWriter)
     {
         _formatterProvider = formatterProvider;
-        _consoleWriter = consoleWriter;
+        _commandWriter = commandWriter;
     }
 
     public void MaskSecrets(IEnumerable<string> secrets)
@@ -67,7 +67,7 @@ internal class BuildSystemSecretMasker : IBuildSystemSecretMasker
                 var maskCommand = formatter.GetMaskSecretCommand(secret);
                 if (maskCommand != null)
                 {
-                    _consoleWriter.LogToConsole(maskCommand);
+                    _commandWriter.WriteLine(maskCommand);
                 }
             }
         }

--- a/src/ModularPipelines/Engine/DependencyPrinter.cs
+++ b/src/ModularPipelines/Engine/DependencyPrinter.cs
@@ -9,18 +9,21 @@ internal class DependencyPrinter : IDependencyPrinter
 {
     private readonly IDependencyChainProvider _dependencyChainProvider;
     private readonly IConsoleWriter _consoleWriter;
+    private readonly IBuildSystemCommandWriter _commandWriter;
     private readonly IBuildSystemFormatter _formatter;
     private readonly IOptions<PipelineOptions> _options;
     private readonly IDependencyTreeFormatter _treeFormatter;
 
     public DependencyPrinter(IDependencyChainProvider dependencyChainProvider,
         IConsoleWriter consoleWriter,
+        IBuildSystemCommandWriter commandWriter,
         IBuildSystemFormatterProvider formatterProvider,
         IOptions<PipelineOptions> options,
         IDependencyTreeFormatter treeFormatter)
     {
         _dependencyChainProvider = dependencyChainProvider;
         _consoleWriter = consoleWriter;
+        _commandWriter = commandWriter;
         _formatter = formatterProvider.GetFormatter();
         _options = options;
         _treeFormatter = treeFormatter;
@@ -49,7 +52,7 @@ internal class DependencyPrinter : IDependencyPrinter
         var startCommand = _formatter.GetStartBlockCommand("Module Dependencies");
         if (startCommand != null)
         {
-            _consoleWriter.LogToConsole(startCommand);
+            WriteGroupCommand(startCommand);
         }
 
         _consoleWriter.Write(tree);
@@ -57,7 +60,19 @@ internal class DependencyPrinter : IDependencyPrinter
         var endCommand = _formatter.GetEndBlockCommand("Module Dependencies");
         if (endCommand != null)
         {
-            _consoleWriter.LogToConsole(endCommand);
+            WriteGroupCommand(endCommand);
+        }
+    }
+
+    private void WriteGroupCommand(string command)
+    {
+        if (_formatter.UsesRawCommands)
+        {
+            _commandWriter.WriteLine(command);
+        }
+        else
+        {
+            _consoleWriter.LogToConsole(command);
         }
     }
 }

--- a/src/ModularPipelines/Engine/DependencyPrinter.cs
+++ b/src/ModularPipelines/Engine/DependencyPrinter.cs
@@ -50,29 +50,17 @@ internal class DependencyPrinter : IDependencyPrinter
     private void Print(Tree tree)
     {
         var startCommand = _formatter.GetStartBlockCommand("Module Dependencies");
-        if (startCommand != null)
-        {
-            WriteGroupCommand(startCommand);
-        }
+        _formatter.WriteGroupCommand(
+            startCommand,
+            _commandWriter.WriteLine,
+            _consoleWriter.LogToConsole);
 
         _consoleWriter.Write(tree);
 
         var endCommand = _formatter.GetEndBlockCommand("Module Dependencies");
-        if (endCommand != null)
-        {
-            WriteGroupCommand(endCommand);
-        }
-    }
-
-    private void WriteGroupCommand(string command)
-    {
-        if (_formatter.UsesRawCommands)
-        {
-            _commandWriter.WriteLine(command);
-        }
-        else
-        {
-            _consoleWriter.LogToConsole(command);
-        }
+        _formatter.WriteGroupCommand(
+            endCommand,
+            _commandWriter.WriteLine,
+            _consoleWriter.LogToConsole);
     }
 }

--- a/src/ModularPipelines/Engine/IBuildSystemCommandWriter.cs
+++ b/src/ModularPipelines/Engine/IBuildSystemCommandWriter.cs
@@ -1,0 +1,13 @@
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Writes CI workflow commands directly to the original standard output stream.
+/// </summary>
+internal interface IBuildSystemCommandWriter
+{
+    /// <summary>
+    /// Writes one complete build-system command as a single physical line.
+    /// </summary>
+    /// <param name="command">The formatted build-system command.</param>
+    void WriteLine(string command);
+}

--- a/src/ModularPipelines/Engine/IBuildSystemFormatter.cs
+++ b/src/ModularPipelines/Engine/IBuildSystemFormatter.cs
@@ -15,19 +15,24 @@ namespace ModularPipelines.Engine;
 /// var startCommand = formatter.GetStartBlockCommand("Build Step");
 /// if (startCommand != null)
 /// {
-///     console.WriteLine(startCommand);
+///     commandWriter.WriteLine(startCommand);
 /// }
 ///
 /// // Mask a secret
 /// var maskCommand = formatter.GetMaskSecretCommand("my-secret-value");
 /// if (maskCommand != null)
 /// {
-///     console.WriteLine(maskCommand);
+///     commandWriter.WriteLine(maskCommand);
 /// }
 /// </code>
 /// </example>
 internal interface IBuildSystemFormatter
 {
+    /// <summary>
+    /// Gets a value indicating whether group commands must bypass rich-console rendering.
+    /// </summary>
+    bool UsesRawCommands => false;
+
     /// <summary>
     /// Gets the command to start a collapsible log block/group.
     /// </summary>

--- a/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
-using Spectre.Console;
 
 namespace ModularPipelines.Logging;
 
@@ -13,25 +12,27 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
     ];
 
     private readonly IBuildSystemFormatter _formatter;
-    private readonly IAnsiConsole _console;
+    private readonly IBuildSystemCommandWriter _commandWriter;
 
-    public BuildSystemLogIssueLoggerProvider(IBuildSystemFormatterProvider formatterProvider)
-        : this(formatterProvider.GetFormatter(), ModularPipelines.Console.DelegatingAnsiConsole.Instance)
+    public BuildSystemLogIssueLoggerProvider(
+        IBuildSystemFormatterProvider formatterProvider,
+        IBuildSystemCommandWriter commandWriter)
+        : this(formatterProvider.GetFormatter(), commandWriter)
     {
     }
 
     internal BuildSystemLogIssueLoggerProvider(
         IBuildSystemFormatter formatter,
-        IAnsiConsole console)
+        IBuildSystemCommandWriter commandWriter)
     {
         _formatter = formatter;
-        _console = console;
+        _commandWriter = commandWriter;
     }
 
     public ILogger CreateLogger(string categoryName) =>
         new BuildSystemLogIssueLogger(
             _formatter,
-            _console,
+            _commandWriter,
             IsIssueCategory(categoryName));
 
     public void Dispose()
@@ -45,7 +46,7 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
 
     private sealed class BuildSystemLogIssueLogger(
         IBuildSystemFormatter formatter,
-        IAnsiConsole console,
+        IBuildSystemCommandWriter commandWriter,
         bool isIssueCategory) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state)
@@ -76,7 +77,7 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
             var command = formatter.GetLogIssueCommand(logLevel, message);
             if (command is not null)
             {
-                console.Profile.Out.Writer.WriteLine(command);
+                commandWriter.WriteLine(command);
             }
         }
     }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -9,6 +9,44 @@ namespace ModularPipelines.UnitTests.Console;
 public class ModuleOutputBufferTests
 {
     [Test]
+    public async Task Flush_Writes_Group_Commands_Without_Markup_Rendering()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        buffer.WriteLine("output");
+
+        await buffer.FlushToAsync(
+            writer,
+            new MarkupLikeBuildSystemFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        await Assert.That(writer.ToString()).Contains("[red]::group::[/]");
+    }
+
+    [Test]
+    public async Task Flush_Renders_Local_Group_Header_Markup()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        buffer.WriteLine("output");
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("▶");
+        await Assert.That(output).DoesNotContain("[bold cyan]");
+    }
+
+    [Test]
     public async Task Flush_Writes_Structured_Logs_Before_Group_End()
     {
         var writer = new StringWriter();
@@ -781,5 +819,16 @@ public class ModuleOutputBufferTests
         }
 
         public Task FlushAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+    }
+
+    private sealed class MarkupLikeBuildSystemFormatter : IBuildSystemFormatter
+    {
+        public bool UsesRawCommands => true;
+
+        public string GetStartBlockCommand(string name) => "[red]::group::[/]";
+
+        public string GetEndBlockCommand(string name) => "::endgroup::";
+
+        public string? GetMaskSecretCommand(string secret) => null;
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -27,6 +27,38 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task Flush_Preserves_Buffered_Raw_Group_Command_Order()
+    {
+        const string startCommand = "[red]::group::dynamic[name][/]";
+        const string body = "section body";
+        const string endCommand = "::endgroup::dynamic";
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var formatter = new MarkupLikeBuildSystemFormatter();
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+
+        buffer.WriteGroupCommand(formatter, startCommand);
+        buffer.WriteLine(body);
+        buffer.WriteGroupCommand(formatter, endCommand);
+
+        await buffer.FlushToAsync(
+            writer,
+            formatter,
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        var output = writer.ToString();
+        var startIndex = output.IndexOf(startCommand, StringComparison.Ordinal);
+        var bodyIndex = output.IndexOf(body, StringComparison.Ordinal);
+        var endIndex = output.IndexOf(endCommand, StringComparison.Ordinal);
+
+        await Assert.That(startIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(bodyIndex).IsGreaterThan(startIndex);
+        await Assert.That(endIndex).IsGreaterThan(bodyIndex);
+    }
+
+    [Test]
     public async Task Flush_Renders_Local_Group_Header_Markup()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -570,6 +570,14 @@ public class OutputCoordinatorTests
         {
         }
 
+        public void WriteGroupCommand(IBuildSystemFormatter formatter, string? command)
+        {
+            if (command is not null)
+            {
+                WriteLine(command);
+            }
+        }
+
         public void AddLogEvent(IBufferedLogEvent logEvent)
         {
         }
@@ -614,6 +622,14 @@ public class OutputCoordinatorTests
 
         public void WriteLine(string message)
         {
+        }
+
+        public void WriteGroupCommand(IBuildSystemFormatter formatter, string? command)
+        {
+            if (command is not null)
+            {
+                WriteLine(command);
+            }
         }
 
         public void AddLogEvent(IBufferedLogEvent logEvent)
@@ -663,6 +679,14 @@ public class OutputCoordinatorTests
         {
         }
 
+        public void WriteGroupCommand(IBuildSystemFormatter formatter, string? command)
+        {
+            if (command is not null)
+            {
+                WriteLine(command);
+            }
+        }
+
         public void AddLogEvent(IBufferedLogEvent logEvent)
         {
         }
@@ -710,6 +734,14 @@ public class OutputCoordinatorTests
 
         public void WriteLine(string message)
         {
+        }
+
+        public void WriteGroupCommand(IBuildSystemFormatter formatter, string? command)
+        {
+            if (command is not null)
+            {
+                WriteLine(command);
+            }
         }
 
         public void AddLogEvent(IBufferedLogEvent logEvent)
@@ -767,6 +799,14 @@ public class OutputCoordinatorTests
         {
         }
 
+        public void WriteGroupCommand(IBuildSystemFormatter formatter, string? command)
+        {
+            if (command is not null)
+            {
+                WriteLine(command);
+            }
+        }
+
         public void AddLogEvent(IBufferedLogEvent logEvent)
         {
         }
@@ -806,6 +846,14 @@ public class OutputCoordinatorTests
 
         public void WriteLine(string message)
         {
+        }
+
+        public void WriteGroupCommand(IBuildSystemFormatter formatter, string? command)
+        {
+            if (command is not null)
+            {
+                WriteLine(command);
+            }
         }
 
         public void AddLogEvent(IBufferedLogEvent logEvent)

--- a/test/ModularPipelines.UnitTests/Engine/AzurePipelinesFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/AzurePipelinesFormatterTests.cs
@@ -37,4 +37,16 @@ public class AzurePipelinesFormatterTests
         await Assert.That(command)
             .IsEqualTo("##vso[task.logissue type=warning;]50%AZP25%3B%5D%0D%0Anext");
     }
+
+    [Test]
+    public async Task GetMaskSecretCommand_EscapesReservedCharacters()
+    {
+        var command = new AzurePipelinesFormatter()
+            .GetMaskSecretCommand("50%;]\r\nnext");
+
+        await Assert.That(command)
+            .EndsWith(";issecret=true]50%AZP25%3B%5D%0D%0Anext");
+        await Assert.That(command).DoesNotContain("\r");
+        await Assert.That(command).DoesNotContain("\n");
+    }
 }

--- a/test/ModularPipelines.UnitTests/Engine/BuildSystemCommandWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/BuildSystemCommandWriterTests.cs
@@ -1,9 +1,42 @@
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.DependencyInjection;
 using ModularPipelines.Engine;
 
 namespace ModularPipelines.UnitTests.Engine;
 
+[TUnit.Core.NotInParallel]
 public class BuildSystemCommandWriterTests
 {
+#pragma warning disable TUnit0055
+    [Test]
+    public async Task DependencyRegistration_Captures_Output_Before_Service_Resolution()
+    {
+        const string command = "::add-mask::registration-order";
+        var originalOutput = System.Console.Out;
+        using var registeredOutput = new StringWriter();
+        using var redirectedOutput = new StringWriter();
+
+        try
+        {
+            System.Console.SetOut(registeredOutput);
+            var services = new ServiceCollection();
+            DependencyInjectionSetup.Initialize(services);
+
+            System.Console.SetOut(redirectedOutput);
+            using var serviceProvider = services.BuildServiceProvider();
+            serviceProvider.GetRequiredService<IBuildSystemCommandWriter>().WriteLine(command);
+        }
+        finally
+        {
+            System.Console.SetOut(originalOutput);
+        }
+
+        await Assert.That(registeredOutput.ToString())
+            .IsEqualTo($"{command}{Environment.NewLine}");
+        await Assert.That(redirectedOutput.ToString()).IsEmpty();
+    }
+#pragma warning restore TUnit0055
+
     [Test]
     public async Task Writes_Long_Command_As_One_Unmodified_Line()
     {

--- a/test/ModularPipelines.UnitTests/Engine/BuildSystemCommandWriterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/BuildSystemCommandWriterTests.cs
@@ -1,0 +1,27 @@
+using ModularPipelines.Engine;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class BuildSystemCommandWriterTests
+{
+    [Test]
+    public async Task Writes_Long_Command_As_One_Unmodified_Line()
+    {
+        var output = new StringWriter();
+        var writer = new BuildSystemCommandWriter(output);
+        var command = $"::add-mask::{new string('x', 512)}";
+
+        writer.WriteLine(command);
+
+        await Assert.That(output.ToString()).IsEqualTo($"{command}{Environment.NewLine}");
+    }
+
+    [Test]
+    public async Task Rejects_Multiple_Physical_Lines()
+    {
+        var writer = new BuildSystemCommandWriter(new StringWriter());
+
+        await Assert.That(() => writer.WriteLine("::notice::first\nsecond"))
+            .Throws<ArgumentException>();
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/BuildSystemFormatterExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/BuildSystemFormatterExtensionsTests.cs
@@ -1,0 +1,36 @@
+using ModularPipelines.Engine;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class BuildSystemFormatterExtensionsTests
+{
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task WriteGroupCommand_Routes_To_Expected_Writer(bool usesRawCommands)
+    {
+        const string command = "[red]::group::dynamic[name][/]";
+        var rawWrites = new List<string>();
+        var fallbackWrites = new List<string>();
+        var formatter = new TestFormatter(usesRawCommands);
+
+        formatter.WriteGroupCommand(command, rawWrites.Add, fallbackWrites.Add);
+
+        var expectedRawWrites = usesRawCommands ? new[] { command } : [];
+        var expectedFallbackWrites = usesRawCommands ? [] : new[] { command };
+
+        await Assert.That(rawWrites).IsEquivalentTo(expectedRawWrites);
+        await Assert.That(fallbackWrites).IsEquivalentTo(expectedFallbackWrites);
+    }
+
+    private sealed class TestFormatter(bool usesRawCommands) : IBuildSystemFormatter
+    {
+        public bool UsesRawCommands { get; } = usesRawCommands;
+
+        public string? GetStartBlockCommand(string name) => null;
+
+        public string? GetEndBlockCommand(string name) => null;
+
+        public string? GetMaskSecretCommand(string secret) => null;
+    }
+}

--- a/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.BuildSystemFormatters;
 using ModularPipelines.Logging;
-using Spectre.Console;
 
 namespace ModularPipelines.UnitTests.Logging;
 
@@ -86,11 +85,8 @@ public class BuildSystemLogIssueLoggerProviderTests
         IBuildSystemFormatter formatter,
         TextWriter writer)
     {
-        var console = AnsiConsole.Create(new AnsiConsoleSettings
-        {
-            Out = new AnsiConsoleOutput(writer),
-        });
-
-        return new BuildSystemLogIssueLoggerProvider(formatter, console);
+        return new BuildSystemLogIssueLoggerProvider(
+            formatter,
+            new BuildSystemCommandWriter(writer));
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Engine;
 using ModularPipelines.Enums;
 using ModularPipelines.Extensions;
 using ModularPipelines.TestHelpers;
@@ -12,8 +13,10 @@ public class SecretObfuscatorTests
 {
     private readonly Mock<IBuildSystemDetector> _buildSystemMock;
     private readonly Mock<IConsoleWriter> _consoleWriterMock;
+    private readonly Mock<IBuildSystemCommandWriter> _commandWriterMock;
 
-    private readonly StringBuilder _stringBuilder = new();
+    private readonly StringBuilder _consoleOutput = new();
+    private readonly StringBuilder _buildSystemCommands = new();
 
     public SecretObfuscatorTests()
     {
@@ -21,7 +24,11 @@ public class SecretObfuscatorTests
 
         _consoleWriterMock = new Mock<IConsoleWriter>();
         _consoleWriterMock.Setup(x => x.LogToConsole(It.IsAny<string>()))
-            .Callback<string>(value => _stringBuilder.AppendLine(value));
+            .Callback<string>(value => _consoleOutput.AppendLine(value));
+
+        _commandWriterMock = new Mock<IBuildSystemCommandWriter>();
+        _commandWriterMock.Setup(x => x.WriteLine(It.IsAny<string>()))
+            .Callback<string>(value => _buildSystemCommands.AppendLine(value));
     }
 
     [Test]
@@ -31,9 +38,24 @@ public class SecretObfuscatorTests
 
         await ExecutePipelineAsync();
 
-        var logOutput = _stringBuilder.ToString();
+        var logOutput = _buildSystemCommands.ToString();
         await Assert.That(logOutput).Contains("::add-mask::This is a secret value!");
         await Assert.That(logOutput).DoesNotContain("::add-mask::This is NOT a secret value!");
+    }
+
+    [Test]
+    public async Task GitHubActions_MaskCommands_BypassRichConsoleWriter()
+    {
+        _buildSystemMock.Setup(x => x.GetCurrentBuildSystem()).Returns(BuildSystem.GitHubActions);
+
+        await ExecutePipelineAsync();
+
+        _consoleWriterMock.Verify(
+            writer => writer.LogToConsole(It.Is<string>(
+                value => value.StartsWith("::add-mask::", StringComparison.Ordinal))),
+            Times.Never);
+        await Assert.That(_consoleOutput.ToString())
+            .DoesNotContain("VGhpcyBpcyBhIHNlY3JldCB2YWx1ZSE=");
     }
 
     [Test]
@@ -43,7 +65,7 @@ public class SecretObfuscatorTests
 
         await ExecutePipelineAsync();
 
-        var logOutput = _stringBuilder.ToString();
+        var logOutput = _buildSystemCommands.ToString();
         await Assert.That(logOutput).DoesNotContain("::add-mask::This is a secret value!");
         await Assert.That(logOutput).DoesNotContain("::add-mask::This is NOT a secret value!");
     }
@@ -54,6 +76,7 @@ public class SecretObfuscatorTests
         builder.Services.AddSingleton(_buildSystemMock.Object);
         builder.Services.Configure<MyModel>(builder.Configuration);
         builder.Services.AddSingleton(_consoleWriterMock.Object);
+        builder.Services.AddSingleton(_commandWriterMock.Object);
         builder.AddModule<GlobalDummyModule>();
         return await builder.BuildAsync();
     }


### PR DESCRIPTION
## Summary

- add a dedicated raw command writer that captures original stdout and emits each CI command as one physical line
- route secret masks, CI issue annotations, and CI group boundaries around Spectre/intercepting writers while preserving rich local headers
- escape Azure secret-mask command values and add regressions proving generated mask patterns never enter rich-console output

## Validation

- `ModularPipelines.UnitTests`: 46 focused security/output tests passed
- `ModularPipelines.sln` Release build: 0 errors; 217 existing warnings
- touched-file whitespace verification passed
- full core test run exceeded the mandated 2 GB agent guard (2,828 MB); CI owns full-suite validation
- solution-wide whitespace verification still reports nine unrelated baseline violations in untouched HTTP/timeout files

Credential rotation for any values exposed by historical CI logs remains an external owner/security action.

Closes #3549