### PR TITLE
Replace live HTTP dependencies in core tests

### DIFF
--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -5,6 +5,7 @@ using ModularPipelines.Context.Domains.Network;
 using ModularPipelines.Http;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
+using ModularPipelines.UnitTests.Helpers;
 using NReco.Logging.File;
 using File = System.IO.File;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
@@ -32,19 +33,19 @@ public class HttpTests : TestBase
     [Test]
     public async Task Can_Send_Request_With_String_To_Request_Implicit_Conversion()
     {
-        var result = await GetService<IHttpContext>((context, collection) => { });
+        await using var server = LocalHttpServer.Start();
+        var (http, _) = await GetService<IHttpContext>((_, _) => { });
 
-        var http = result.T;
-
-        await http.SendAsync(new Uri("https://thomhurst.github.io/TUnit"));
+        await http.SendAsync(server.Uri);
     }
 
     [Test]
     public async Task When_Log_Request_False_Then_Do_Not_Log_Request()
     {
+        await using var server = LocalHttpServer.Start();
         var file = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".txt");
 
-        var result = await GetService<IHttpContext>((_, collection) =>
+        var (http, host) = await GetService<IHttpContext>((_, collection) =>
         {
             collection.AddLogging(builder =>
             {
@@ -53,27 +54,28 @@ public class HttpTests : TestBase
             });
         });
 
-        await result.T.SendAsync(new HttpOptions(new HttpRequestMessage(HttpMethod.Get, new Uri("https://thomhurst.github.io/TUnit")))
+        await http.SendAsync(new HttpOptions(new HttpRequestMessage(HttpMethod.Get, server.Uri))
         {
             ThrowOnNonSuccessStatusCode = false,
             LoggingType = HttpLoggingType.Response,
         });
 
-        await result.Host.DisposeAsync();
+        await host.DisposeAsync();
 
         var logFile = await File.ReadAllTextAsync(file);
         await Assert.That(logFile).DoesNotContain("HTTP Request:");
-        await Assert.That(logFile).DoesNotContain("GET https://thomhurst.github.io/TUnit HTTP/1.1");
+        await Assert.That(logFile).DoesNotContain($"GET {server.Uri} HTTP/1.1");
         await Assert.That(logFile).Contains("HTTP Response:");
-        await Assert.That(logFile).Contains("Server: GitHub.com");
+        await Assert.That(logFile).Contains("Server: LocalHttpServer");
     }
 
     [Test]
     public async Task When_Log_Response_False_Then_Do_Not_Log_Response()
     {
+        await using var server = LocalHttpServer.Start();
         var file = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".txt");
 
-        var result = await GetService<IHttpContext>((_, collection) =>
+        var (http, host) = await GetService<IHttpContext>((_, collection) =>
         {
             collection.AddLogging(builder =>
             {
@@ -82,19 +84,19 @@ public class HttpTests : TestBase
             });
         });
 
-        await result.T.SendAsync(new HttpOptions(new HttpRequestMessage(HttpMethod.Get, new Uri("https://thomhurst.github.io/TUnit")))
+        await http.SendAsync(new HttpOptions(new HttpRequestMessage(HttpMethod.Get, server.Uri))
         {
             ThrowOnNonSuccessStatusCode = false,
             LoggingType = HttpLoggingType.Request,
         });
 
-        await result.Host.DisposeAsync();
+        await host.DisposeAsync();
 
         var logFile = await File.ReadAllTextAsync(file);
         await Assert.That(logFile).Contains("HTTP Request:");
-        await Assert.That(logFile).Contains("GET https://thomhurst.github.io/TUnit HTTP/1.1");
+        await Assert.That(logFile).Contains($"GET {server.Uri} HTTP/1.1");
         await Assert.That(logFile).DoesNotContain("HTTP Response:");
-        await Assert.That(logFile).DoesNotContain("Server: GitHub.com");
+        await Assert.That(logFile).DoesNotContain("Server: LocalHttpServer");
     }
 
     [Test]
@@ -102,9 +104,10 @@ public class HttpTests : TestBase
     [Arguments(false)]
     public async Task Assert_SendAsync_Logs_As_Expected(bool customHttpClient)
     {
+        await using var server = LocalHttpServer.Start();
         var file = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".txt");
 
-        var result = await GetService<IHttpContext>((_, collection) =>
+        var (http, host) = await GetService<IHttpContext>((_, collection) =>
         {
             collection.AddLogging(builder =>
             {
@@ -115,25 +118,25 @@ public class HttpTests : TestBase
 
         if (!customHttpClient)
         {
-            await result.T.SendAsync(new Uri("https://thomhurst.github.io/TUnit"));
+            await http.SendAsync(server.Uri);
         }
         else
         {
-            await result.T.SendAsync(new HttpOptions(new HttpRequestMessage(HttpMethod.Get, new Uri("https://thomhurst.github.io/TUnit")))
+            await http.SendAsync(new HttpOptions(new HttpRequestMessage(HttpMethod.Get, server.Uri))
             {
                 ThrowOnNonSuccessStatusCode = false,
                 HttpClient = new HttpClient()
             });
         }
 
-        await result.Host.DisposeAsync();
+        await host.DisposeAsync();
 
         var logFile = await File.ReadAllTextAsync(file);
         await Assert.That(logFile).Contains("HTTP Request:");
-        await Assert.That(logFile).Contains("GET https://thomhurst.github.io/TUnit HTTP/1.1");
+        await Assert.That(logFile).Contains($"GET {server.Uri} HTTP/1.1");
         await Assert.That(logFile).Contains("HTTP Response:");
         await Assert.That(logFile).Contains("Headers");
-        await Assert.That(logFile).Contains("Server: GitHub.com");
+        await Assert.That(logFile).Contains("Server: LocalHttpServer");
         await Assert.That(logFile).Contains("Body");
         await Assert.That(logFile).Contains("Duration:");
         await Assert.That(logFile).Contains("HTTP Status:");

--- a/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
@@ -8,20 +8,15 @@ namespace ModularPipelines.UnitTests.Helpers;
 
 public class DownloaderTests : TestBase
 {
-    // NOTE: This test depends on an external URL (GitHub release artifact).
-    // The URL points to a specific versioned release which should remain stable,
-    // but if the test fails, verify the URL is still accessible and the checksum
-    // matches. The Retry(3) attribute helps handle transient network issues.
-    // Using a well-known, versioned release URL provides reasonable stability
-    // while testing real download functionality.
-    [Test, Retry(3)]
+    [Test]
     public async Task Can_Download()
     {
         var downloader = await GetService<IDownloaderContext>();
         var checksum = await GetService<IChecksumContext>();
+        await using var server = LocalHttpServer.Start("local download fixture"u8.ToArray());
 
-        var file = await downloader.DownloadFileAsync(new DownloadFileOptions(new Uri(
-            "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.5.7/npp.8.5.7.portable.minimalist.7z")));
-        await Assert.That(checksum.Md5(file)).IsEqualTo("A7EE66BAC064F451BC3A758D16E33080");
+        var file = await downloader.DownloadFileAsync(new DownloadFileOptions(server.Uri));
+
+        await Assert.That(checksum.Md5(file)).IsEqualTo("AEDF5D7C23744269F358814E602AFE89");
     }
 }

--- a/test/ModularPipelines.UnitTests/Helpers/LocalHttpServer.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/LocalHttpServer.cs
@@ -8,7 +8,7 @@ internal sealed class LocalHttpServer : IAsyncDisposable
 {
     private static readonly byte[] DefaultResponseBody = "local HTTP response"u8.ToArray();
 
-    private readonly CancellationTokenSource _cancellationTokenSource = new(TimeSpan.FromSeconds(10));
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly TcpListener _listener;
     private readonly byte[] _responseBody;
     private readonly Task _serverTask;

--- a/test/ModularPipelines.UnitTests/Helpers/LocalHttpServer.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/LocalHttpServer.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace ModularPipelines.UnitTests.Helpers;
+
+internal sealed class LocalHttpServer : IAsyncDisposable
+{
+    private static readonly byte[] DefaultResponseBody = "local HTTP response"u8.ToArray();
+
+    private readonly CancellationTokenSource _cancellationTokenSource = new(TimeSpan.FromSeconds(10));
+    private readonly TcpListener _listener;
+    private readonly byte[] _responseBody;
+    private readonly Task _serverTask;
+
+    private LocalHttpServer(byte[] responseBody)
+    {
+        _responseBody = responseBody;
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        Uri = new Uri($"http://127.0.0.1:{((IPEndPoint) _listener.LocalEndpoint).Port}/fixture.bin");
+        _serverTask = RunAsync(_cancellationTokenSource.Token);
+    }
+
+    public Uri Uri { get; }
+
+    public static LocalHttpServer Start(byte[]? responseBody = null) =>
+        new(responseBody ?? DefaultResponseBody);
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cancellationTokenSource.CancelAsync();
+        _listener.Stop();
+        await _serverTask;
+        _cancellationTokenSource.Dispose();
+    }
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var client = await _listener.AcceptTcpClientAsync(cancellationToken);
+            await using var stream = client.GetStream();
+            using var reader = new StreamReader(
+                stream,
+                Encoding.ASCII,
+                detectEncodingFromByteOrderMarks: false,
+                leaveOpen: true);
+
+            while (!string.IsNullOrEmpty(await reader.ReadLineAsync(cancellationToken)))
+            {
+            }
+
+            var headers = Encoding.ASCII.GetBytes(
+                "HTTP/1.1 200 OK\r\n" +
+                "Server: LocalHttpServer\r\n" +
+                "Content-Type: application/octet-stream\r\n" +
+                $"Content-Length: {_responseBody.Length}\r\n" +
+                "Connection: close\r\n\r\n");
+
+            await stream.WriteAsync(headers, cancellationToken);
+            await stream.WriteAsync(_responseBody, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (SocketException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace four live `thomhurst.github.io` requests with a loopback HTTP fixture
- replace the GitHub release download and retry with deterministic local bytes
- preserve request/response logging and checksum coverage using an in-process TCP server on port 0

## Validation
- Release build: `ModularPipelines.UnitTests.csproj` (0 errors; 60 existing warnings)
- Release focused tests: 7/7 passed (`HttpTests` and `DownloaderTests`)
- touched-file `dotnet format --verify-no-changes --severity info`: passed

Closes #3519