### PR TITLE
Bound distributed result waits by default

### DIFF
--- a/src/ModularPipelines/Distributed/DistributedOptions.cs
+++ b/src/ModularPipelines/Distributed/DistributedOptions.cs
@@ -16,7 +16,8 @@ public class DistributedOptions
 
     /// <summary>
     /// Gets or sets the default timeout in seconds for waiting for a distributed module result.
-    /// Applied when a module has no explicit Timeout configured. 0 = no timeout (wait forever).
+    /// Defaults to 2700 seconds (45 minutes) and applies when a module has no explicit Timeout configured.
+    /// Set to 0 to wait indefinitely.
     /// </summary>
-    public int ModuleResultTimeoutSeconds { get; set; }
+    public int ModuleResultTimeoutSeconds { get; set; } = 2700;
 }

--- a/test/ModularPipelines.Distributed.UnitTests/Configuration/DistributedOptionsTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Configuration/DistributedOptionsTests.cs
@@ -5,6 +5,14 @@ namespace ModularPipelines.Distributed.UnitTests.Configuration;
 public class DistributedOptionsTests
 {
     [Test]
+    public async Task ModuleResultTimeout_Defaults_To_Forty_Five_Minutes()
+    {
+        var options = new DistributedOptions();
+
+        await Assert.That(options.ModuleResultTimeoutSeconds).IsEqualTo(2700);
+    }
+
+    [Test]
     public async Task Capabilities_CanBeBoundFromConfiguration()
     {
         var configuration = new ConfigurationBuilder()

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using ModularPipelines.Attributes;
+using ModularPipelines.Configuration;
 using ModularPipelines.Conditions;
 using ModularPipelines.Distributed.Artifacts;
 using ModularPipelines.Distributed.Coordination;
@@ -41,6 +42,18 @@ public class DistributedModuleExecutorTests
 
     private class DistributedModule : Module<SimpleResult>
     {
+        protected internal override Task<SimpleResult?> ExecuteAsync(
+            Context.IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult<SimpleResult?>(new SimpleResult { Message = "done" });
+    }
+
+    private class ShortTimeoutDistributedModule : Module<SimpleResult>
+    {
+        protected override ModuleConfiguration Configure() =>
+            ModuleConfiguration.Create()
+                .WithTimeout(TimeSpan.FromMilliseconds(50))
+                .Build();
+
         protected internal override Task<SimpleResult?> ExecuteAsync(
             Context.IModuleContext context, CancellationToken cancellationToken)
             => Task.FromResult<SimpleResult?>(new SimpleResult { Message = "done" });
@@ -169,7 +182,8 @@ public class DistributedModuleExecutorTests
         IModuleResultRegistry? resultRegistry = null,
         IDistributedCoordinator? coordinator = null,
         DistributedResultCollector? resultCollector = null,
-        ArtifactLifecycleManager? artifactManager = null)
+        ArtifactLifecycleManager? artifactManager = null,
+        DistributedOptions? distributedOptions = null)
     {
         var lifetime = new Mock<IHostApplicationLifetime>();
         lifetime.Setup(l => l.ApplicationStopping).Returns(CancellationToken.None);
@@ -202,7 +216,7 @@ public class DistributedModuleExecutorTests
             resultRegistry,
             NewDependencyRegistry(),
             NewMetadataRegistry(),
-            Microsoft.Extensions.Options.Options.Create(new DistributedOptions()),
+            Microsoft.Extensions.Options.Options.Create(distributedOptions ?? new DistributedOptions()),
             artifactManager,
             NullLogger<DistributedModuleExecutor>.Instance);
     }
@@ -393,6 +407,93 @@ public class DistributedModuleExecutorTests
         var registeredResult = resultRegistry.GetResult(typeof(DistributedModule));
         await Assert.That(registeredResult).IsNotNull();
         await Assert.That(registeredResult!.ExceptionOrDefault).IsNotNull();
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task Missing_Result_Times_Out_And_Completes_Pipeline(CancellationToken testCancellation)
+    {
+        var module = new DistributedModule();
+        var moduleState = new ModuleState(module, typeof(DistributedModule));
+        var scheduler = CreateMockScheduler(moduleState);
+        var resultRegistry = new ModuleResultRegistry();
+        var coordinator = new NoDequeueCoordinator(new InMemoryDistributedCoordinator());
+        var options = new DistributedOptions { ModuleResultTimeoutSeconds = 1 };
+        var executor = CreateExecutor(
+            scheduler,
+            resultRegistry: resultRegistry,
+            coordinator: coordinator,
+            distributedOptions: options);
+
+        await executor.ExecuteAsync([module]).WaitAsync(TimeSpan.FromSeconds(3), testCancellation);
+
+        var registeredResult = resultRegistry.GetResult(typeof(DistributedModule));
+        await Assert.That(registeredResult).IsNotNull();
+        await Assert.That(registeredResult!.ExceptionOrDefault).IsTypeOf<TimeoutException>();
+        scheduler.Verify(
+            instance => instance.MarkModuleCompleted(typeof(DistributedModule), false, null, null),
+            Times.Once());
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task Module_Timeout_Takes_Precedence_Over_Default_Result_Timeout(CancellationToken testCancellation)
+    {
+        var module = new ShortTimeoutDistributedModule();
+        var moduleState = new ModuleState(module, typeof(ShortTimeoutDistributedModule));
+        var scheduler = CreateMockScheduler(moduleState);
+        var resultRegistry = new ModuleResultRegistry();
+        var coordinator = new NoDequeueCoordinator(new InMemoryDistributedCoordinator());
+        var options = new DistributedOptions { ModuleResultTimeoutSeconds = 30 };
+        var executor = CreateExecutor(
+            scheduler,
+            resultRegistry: resultRegistry,
+            coordinator: coordinator,
+            distributedOptions: options);
+
+        await executor.ExecuteAsync([module]).WaitAsync(TimeSpan.FromSeconds(2), testCancellation);
+
+        var registeredResult = resultRegistry.GetResult(typeof(ShortTimeoutDistributedModule));
+        await Assert.That(registeredResult).IsNotNull();
+        await Assert.That(registeredResult!.ExceptionOrDefault).IsTypeOf<TimeoutException>();
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task Zero_Result_Timeout_Waits_Until_Result_Is_Published(CancellationToken testCancellation)
+    {
+        var module = new DistributedModule();
+        var moduleState = new ModuleState(module, typeof(DistributedModule));
+        var scheduler = CreateMockScheduler(moduleState);
+        var resultRegistry = new ModuleResultRegistry();
+        var innerCoordinator = new InMemoryDistributedCoordinator();
+        var coordinator = new NoDequeueCoordinator(innerCoordinator);
+        var options = new DistributedOptions { ModuleResultTimeoutSeconds = 0 };
+        var executor = CreateExecutor(
+            scheduler,
+            resultRegistry: resultRegistry,
+            coordinator: coordinator,
+            distributedOptions: options);
+
+        var execution = executor.ExecuteAsync([module]);
+
+        await Assert.That(async () => await execution.WaitAsync(TimeSpan.FromMilliseconds(100), testCancellation))
+            .Throws<TimeoutException>();
+
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(DistributedModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var successResult = CreateSuccessResult(new SimpleResult { Message = "done" }, "DistributedModule");
+        var serialized = serializer.Serialize(
+            successResult,
+            typeof(DistributedModule).FullName!,
+            typeof(SimpleResult).FullName!,
+            1);
+
+        await innerCoordinator.PublishResultAsync(serialized, testCancellation);
+        await execution.WaitAsync(TimeSpan.FromSeconds(2), testCancellation);
+
+        await Assert.That(resultRegistry.GetResult(typeof(DistributedModule))).IsNotNull();
     }
 
     // =================================================================


### PR DESCRIPTION
## Summary
- default distributed module-result waits to 45 minutes
- preserve explicit zero as wait-forever and module-specific timeout precedence
- cover timeout, override, and indefinite-wait paths

## Test plan
- [x] Distributed unit tests (86/86)
- [x] Release build of distributed unit-test project (0 errors)
- [x] Scoped whitespace formatting

Closes #3518