### PR TITLE
Late-start queued AlwaysRun cleanup modules

### DIFF
--- a/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
@@ -49,7 +49,11 @@ internal class AlwaysRunHandler(
             await ProcessAlwaysRunModulesAsync(scheduler, modulesToProcess, exceptions).ConfigureAwait(false);
 
             var deferredModules = modulesToProcess
-                .Where(module => scheduler.GetModuleState(module.GetType())?.State == ModuleExecutionState.Pending)
+                .Where(module =>
+                {
+                    var moduleState = scheduler.GetModuleState(module.GetType());
+                    return moduleState != null && CanLateStartAlwaysRunModule(moduleState);
+                })
                 .ToList();
             var processedModules = modulesToProcess.Except(deferredModules).ToHashSet();
             remainingModules.RemoveAll(processedModules.Contains);
@@ -180,17 +184,21 @@ internal class AlwaysRunHandler(
             return null;
         }
 
-        // If the AlwaysRun module is still pending (never started), execute it now
+        // If the AlwaysRun module never started, execute it now. Queued modules can remain
+        // unconsumed after pipeline cancellation stops the scheduler workers.
         // Skip dependency waiting to prevent deadlocks - dependencies may never complete
-        if (moduleState.State == ModuleExecutionState.Pending)
+        if (CanLateStartAlwaysRunModule(moduleState))
         {
-            _logger.LogDebug("Starting pending AlwaysRun module: {ModuleName}", moduleType.Name);
+            _logger.LogDebug(
+                "Starting unexecuted AlwaysRun module: {ModuleName} (State={State})",
+                moduleType.Name,
+                moduleState.State);
 
             try
             {
                 await _moduleRunner.ExecuteWithoutDependencyWaitAsync(moduleState, scheduler, CancellationToken.None).ConfigureAwait(false);
 
-                if (moduleState.State == ModuleExecutionState.Pending)
+                if (CanLateStartAlwaysRunModule(moduleState))
                 {
                     _logger.LogDebug(
                         "AlwaysRun module {ModuleName} was deferred and will be retried",
@@ -234,6 +242,11 @@ internal class AlwaysRunHandler(
         }
 
         return null;
+    }
+
+    private static bool CanLateStartAlwaysRunModule(ModuleState moduleState)
+    {
+        return moduleState.State is ModuleExecutionState.Pending or ModuleExecutionState.Queued;
     }
 
     private static bool ShouldWaitForAlwaysRunModule(ModuleState moduleState)

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -85,11 +85,103 @@ public class AlwaysRunHandlerTests
     }
 
     [Test]
+    public async Task WaitForAlwaysRunModulesAsync_ExecutesQueuedModule()
+    {
+        var module = new FirstAlwaysRunModule();
+        var moduleState = new ModuleState(module, module.GetType())
+        {
+            State = ModuleExecutionState.Queued,
+        };
+        var scheduler = CreateScheduler(moduleState);
+        var moduleRunner = new Mock<IModuleRunner>();
+
+        moduleRunner
+            .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
+                moduleState,
+                scheduler.Object,
+                CancellationToken.None))
+            .Returns(() =>
+            {
+                moduleState.State = ModuleExecutionState.Completed;
+                moduleState.CompletionSource.TrySetResult(module);
+                return Task.CompletedTask;
+            });
+
+        var handler = CreateHandler(moduleRunner.Object);
+
+        await handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [module]);
+
+        moduleRunner.Verify(
+            x => x.ExecuteWithoutDependencyWaitAsync(
+                moduleState,
+                scheduler.Object,
+                CancellationToken.None),
+            Times.Once());
+        await Assert.That(moduleState.State).IsEqualTo(ModuleExecutionState.Completed);
+    }
+
+    [Test]
     public async Task WaitForAlwaysRunModulesAsync_RetriesDeferredPendingModule()
     {
         var module = new FirstAlwaysRunModule();
         var blocker = new BlockingModule();
         var moduleState = new ModuleState(module, module.GetType());
+        var blockerState = new ModuleState(blocker, blocker.GetType())
+        {
+            State = ModuleExecutionState.Executing,
+        };
+        var scheduler = CreateScheduler(moduleState, blockerState);
+        var moduleRunner = new Mock<IModuleRunner>();
+        var blockerWaitObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var attempts = 0;
+
+        scheduler
+            .Setup(x => x.GetModuleCompletionTask(blocker.GetType()))
+            .Callback(() => blockerWaitObserved.TrySetResult())
+            .Returns(blockerState.CompletionSource.Task);
+        moduleRunner
+            .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
+                moduleState,
+                scheduler.Object,
+                CancellationToken.None))
+            .Returns(() =>
+            {
+                if (Interlocked.Increment(ref attempts) == 2)
+                {
+                    moduleState.State = ModuleExecutionState.Completed;
+                    moduleState.CompletionSource.TrySetResult(module);
+                }
+
+                return Task.CompletedTask;
+            });
+
+        var handler = CreateHandler(moduleRunner.Object);
+
+        var handlerTask = handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [module, blocker]);
+        await blockerWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        var attemptsBeforeProgress = attempts;
+
+        blockerState.State = ModuleExecutionState.Completed;
+        blockerState.CompletionSource.TrySetResult(blocker);
+        await handlerTask;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(attemptsBeforeProgress).IsEqualTo(1);
+            await Assert.That(attempts).IsEqualTo(2);
+            await Assert.That(moduleState.State).IsEqualTo(ModuleExecutionState.Completed);
+        }
+    }
+
+    [Test]
+    public async Task WaitForAlwaysRunModulesAsync_RetriesDeferredQueuedModule()
+    {
+        var module = new FirstAlwaysRunModule();
+        var blocker = new BlockingModule();
+        var moduleState = new ModuleState(module, module.GetType())
+        {
+            State = ModuleExecutionState.Queued,
+        };
         var blockerState = new ModuleState(blocker, blocker.GetType())
         {
             State = ModuleExecutionState.Executing,

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -42,6 +42,21 @@ public class ModuleExecutorLoggingTests
         }
     }
 
+    private class QueuedAlwaysRunModule : Module<bool>
+    {
+        protected override ModuleConfiguration Configure() =>
+            ModuleConfiguration.Create()
+                .WithAlwaysRun()
+                .Build();
+
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
     [Test]
     public async Task SuccessfulCompletion_DoesNotLogCancellation()
     {
@@ -135,6 +150,114 @@ public class ModuleExecutorLoggingTests
             .Throws<InvalidOperationException>();
 
         await Assert.That(exception).IsSameReferenceAs(sharedException);
+    }
+
+    [Test]
+    public async Task StopOnFirstException_LateStartsQueuedAlwaysRunModule()
+    {
+        var faultingModule = new FaultingModule();
+        var alwaysRunModule = new QueuedAlwaysRunModule();
+        var faultingState = new ModuleState(faultingModule, typeof(FaultingModule))
+        {
+            State = ModuleExecutionState.Queued,
+        };
+        var alwaysRunState = new ModuleState(alwaysRunModule, typeof(QueuedAlwaysRunModule))
+        {
+            State = ModuleExecutionState.Queued,
+        };
+        var moduleStates = new Dictionary<Type, ModuleState>
+        {
+            [typeof(FaultingModule)] = faultingState,
+            [typeof(QueuedAlwaysRunModule)] = alwaysRunState,
+        };
+        var readyModules = Channel.CreateUnbounded<ModuleState>();
+        readyModules.Writer.TryWrite(faultingState);
+        readyModules.Writer.TryWrite(alwaysRunState);
+        readyModules.Writer.Complete();
+
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler.SetupGet(x => x.ReadyModules).Returns(readyModules.Reader);
+        scheduler.Setup(x => x.RunSchedulerAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        scheduler
+            .Setup(x => x.GetModuleState(It.IsAny<Type>()))
+            .Returns((Type moduleType) => moduleStates[moduleType]);
+        scheduler
+            .Setup(x => x.GetModuleCompletionTask(It.IsAny<Type>()))
+            .Returns((Type moduleType) => moduleStates[moduleType].CompletionSource.Task);
+
+        var schedulerFactory = new Mock<IModuleSchedulerFactory>();
+        schedulerFactory.Setup(x => x.Create()).Returns(scheduler.Object);
+
+        var registrationEvents = new Mock<IRegistrationEventExecutor>();
+        registrationEvents.Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(Task.CompletedTask);
+
+        var parallelLimitProvider = new Mock<IParallelLimitProvider>();
+        parallelLimitProvider.Setup(x => x.GetMaxDegreeOfParallelism()).Returns(1);
+
+        var moduleRunner = new Mock<IModuleRunner>();
+        var primaryException = new InvalidOperationException("Primary failure");
+        moduleRunner
+            .Setup(x => x.ExecuteAsync(
+                faultingState,
+                scheduler.Object,
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(primaryException);
+        moduleRunner
+            .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
+                alwaysRunState,
+                scheduler.Object,
+                CancellationToken.None))
+            .Returns(() =>
+            {
+                alwaysRunState.State = ModuleExecutionState.Completed;
+                alwaysRunState.CompletionSource.TrySetResult(alwaysRunModule);
+                return Task.CompletedTask;
+            });
+
+        var pipelineOptions = Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+        {
+            ExecutionMode = ExecutionMode.StopOnFirstException,
+        });
+        var alwaysRunHandler = new AlwaysRunHandler(
+            moduleRunner.Object,
+            parallelLimitProvider.Object,
+            pipelineOptions,
+            NullLogger<AlwaysRunHandler>.Instance);
+        var executor = new ModuleExecutor(
+            schedulerFactory.Object,
+            moduleRunner.Object,
+            alwaysRunHandler,
+            Mock.Of<IModuleResultRegistrar>(),
+            Mock.Of<IModuleResultRegistry>(),
+            parallelLimitProvider.Object,
+            registrationEvents.Object,
+            Mock.Of<IMetricsCollector>(),
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()),
+            new SecondaryExceptionContainer(),
+            pipelineOptions,
+            NullLogger<ModuleExecutor>.Instance);
+
+        var exception = await Assert.That(async () =>
+                await executor.ExecuteAsync([faultingModule, alwaysRunModule]))
+            .Throws<InvalidOperationException>();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception).IsSameReferenceAs(primaryException);
+            await Assert.That(alwaysRunState.State).IsEqualTo(ModuleExecutionState.Completed);
+        }
+
+        moduleRunner.Verify(
+            x => x.ExecuteWithoutDependencyWaitAsync(
+                alwaysRunState,
+                scheduler.Object,
+                CancellationToken.None),
+            Times.Once());
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- late-start AlwaysRun modules left queued when fail-fast cancellation stops scheduler workers
- include both pending and queued states in deferred retry bookkeeping
- cover direct late-start, constraint retry, and the stopped-channel failure path

## Test plan
- [x] `AlwaysRunHandlerTests` (8/8)
- [x] `ModuleExecutorLoggingTests` (11/11)
- [x] core Release build (0 errors)
- [x] scoped whitespace and changed-file analyzer verification
- [x] full core unit project: 1292 passed, 4 skipped; one existing timing-sensitive cumulative-timeout test failed under full parallel load and passed on focused rerun (8/8)

Closes #3457