### PR TITLE
Complete pending module awaiters on cancellation

### DIFF
--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -188,6 +188,23 @@ internal class DistributedModuleExecutor(
             new OperationCanceledException(cancellationToken));
     }
 
+    internal static IModuleResult CreateCollectorFailureResult(
+        IModule module,
+        Type moduleType,
+        Exception exception,
+        Enums.Status status)
+    {
+        var executionContext = new ModuleExecutionContext(module, moduleType)
+        {
+            Status = status,
+            Exception = exception,
+        };
+        return ModuleResultFactory.CreateException(
+            module.ResultType,
+            exception,
+            executionContext);
+    }
+
     private async Task WaitForWorkersAsync(CancellationToken cancellationToken)
     {
         var expectedWorkers = _options.Value.TotalInstances - 1;
@@ -428,20 +445,24 @@ internal class DistributedModuleExecutor(
         {
             // Timeout expired (not pipeline cancellation)
             _logger.LogError("Distributed module {Module} timed out waiting for result — worker may have died", moduleType.Name);
-            RegisterFailureResult(module, moduleType, new TimeoutException(
-                $"Module {moduleType.Name} did not produce a result within the configured timeout"));
+            RegisterFailureResult(
+                module,
+                moduleType,
+                new TimeoutException(
+                    $"Module {moduleType.Name} did not produce a result within the configured timeout"),
+                Enums.Status.TimedOut);
             scheduler.MarkModuleCompleted(moduleType, false);
             await cts.CancelAsync();
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException exception)
         {
-            RegisterFailureResult(module, moduleType, new OperationCanceledException("Module was cancelled"));
+            _resultRegistrar.RegisterTerminatedResult(module, moduleType, exception);
             scheduler.MarkModuleCompleted(moduleType, false);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to publish or collect distributed module {Module}", moduleType.Name);
-            RegisterFailureResult(module, moduleType, ex);
+            RegisterFailureResult(module, moduleType, ex, Enums.Status.Failed);
             scheduler.MarkModuleCompleted(moduleType, false, ex);
             await cts.CancelAsync();
         }
@@ -489,14 +510,19 @@ internal class DistributedModuleExecutor(
         }
     }
 
-    private void RegisterFailureResult(IModule module, Type moduleType, Exception exception)
+    private void RegisterFailureResult(
+        IModule module,
+        Type moduleType,
+        Exception exception,
+        Enums.Status status)
     {
         try
         {
-            var failureResult = ModuleResultFactory.CreateException(
-                module.ResultType,
+            var failureResult = CreateCollectorFailureResult(
+                module,
+                moduleType,
                 exception,
-                new ModuleExecutionContext(module, moduleType));
+                status);
             ModuleCompletionSourceApplicator.TryApply(module, failureResult);
             _resultRegistry.RegisterResult(moduleType, failureResult);
         }

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -25,6 +25,7 @@ internal class DistributedModuleExecutor(
     ModuleTypeRegistry typeRegistry,
     ModuleResultSerializer serializer,
     IModuleResultRegistry resultRegistry,
+    IModuleResultRegistrar resultRegistrar,
     IModuleDependencyRegistry dependencyRegistry,
     IModuleMetadataRegistry metadataRegistry,
     IOptions<DistributedOptions> options,
@@ -41,6 +42,7 @@ internal class DistributedModuleExecutor(
     private readonly ModuleTypeRegistry _typeRegistry = typeRegistry;
     private readonly ModuleResultSerializer _serializer = serializer;
     private readonly IModuleResultRegistry _resultRegistry = resultRegistry;
+    private readonly IModuleResultRegistrar _resultRegistrar = resultRegistrar;
     private readonly IModuleDependencyRegistry _dependencyRegistry = dependencyRegistry;
     private readonly IModuleMetadataRegistry _metadataRegistry = metadataRegistry;
     private readonly IOptions<DistributedOptions> _options = options;
@@ -89,7 +91,7 @@ internal class DistributedModuleExecutor(
                 _resultRegistry);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_lifetime.ApplicationStopping);
-            cts.Token.Register(() => scheduler.CancelPendingModules());
+            cts.Token.Register(() => CompleteCancelledModules(scheduler, _resultRegistrar, cts.Token));
 
             var schedulerTask = scheduler.RunSchedulerAsync(cts.Token);
             var resultTasks = new List<Task>();
@@ -169,6 +171,17 @@ internal class DistributedModuleExecutor(
         }
 
         return modules;
+    }
+
+    internal static void CompleteCancelledModules(
+        IModuleScheduler scheduler,
+        IModuleResultRegistrar resultRegistrar,
+        CancellationToken cancellationToken)
+    {
+        var cancelledModules = scheduler.CancelPendingModules(cancelModuleResultAwaiters: false);
+        resultRegistrar.RegisterTerminatedResultsForCancelledModules(
+            cancelledModules,
+            new OperationCanceledException(cancellationToken));
     }
 
     private async Task WaitForWorkersAsync(CancellationToken cancellationToken)

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -111,13 +111,13 @@ internal class DistributedModuleExecutor(
                         continue;
                     }
 
-                    var collectTask = CollectDistributedResultAsync(moduleState.Module, moduleType, scheduler, cts);
+                    var collectTask = PublishAndCollectDistributedResultAsync(
+                        assignment,
+                        moduleState.Module,
+                        moduleType,
+                        scheduler,
+                        cts);
                     resultTasks.Add(collectTask);
-
-                    // TODO(matrix): MatrixModuleExpander.ScanForExpansions not yet connected.
-                    // Modules with [MatrixTarget] will run once, not N times.
-                    _logger.LogInformation("Distributing module {Module} to workers", moduleType.Name);
-                    await _publisher.PublishAsync(assignment, cts.Token);
                 }
             }
             catch (OperationCanceledException)
@@ -406,12 +406,21 @@ internal class DistributedModuleExecutor(
         }
     }
 
-    private async Task CollectDistributedResultAsync(IModule module, Type moduleType, IModuleScheduler scheduler, CancellationTokenSource cts)
+    private async Task PublishAndCollectDistributedResultAsync(
+        ModuleAssignment assignment,
+        IModule module,
+        Type moduleType,
+        IModuleScheduler scheduler,
+        CancellationTokenSource cts)
     {
         using var timeoutCts = CreateResultTimeoutSource(module.Configuration.Timeout, cts.Token);
 
         try
         {
+            // TODO(matrix): MatrixModuleExpander.ScanForExpansions not yet connected.
+            // Modules with [MatrixTarget] will run once, not N times.
+            _logger.LogInformation("Distributing module {Module} to workers", moduleType.Name);
+            await _publisher.PublishAsync(assignment, cts.Token);
             await CollectResultAsync(module, moduleType, scheduler, cts, timeoutCts?.Token ?? cts.Token);
         }
         catch (OperationCanceledException) when (!cts.IsCancellationRequested)
@@ -430,7 +439,7 @@ internal class DistributedModuleExecutor(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to collect result for distributed module {Module}", moduleType.Name);
+            _logger.LogError(ex, "Failed to publish or collect distributed module {Module}", moduleType.Name);
             RegisterFailureResult(module, moduleType, ex);
             scheduler.MarkModuleCompleted(moduleType, false, ex);
             await cts.CancelAsync();

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -414,14 +414,15 @@ internal class DistributedModuleExecutor(
         CancellationTokenSource cts)
     {
         using var timeoutCts = CreateResultTimeoutSource(module.Configuration.Timeout, cts.Token);
+        var lifecycleToken = timeoutCts?.Token ?? cts.Token;
 
         try
         {
             // TODO(matrix): MatrixModuleExpander.ScanForExpansions not yet connected.
             // Modules with [MatrixTarget] will run once, not N times.
             _logger.LogInformation("Distributing module {Module} to workers", moduleType.Name);
-            await _publisher.PublishAsync(assignment, cts.Token);
-            await CollectResultAsync(module, moduleType, scheduler, cts, timeoutCts?.Token ?? cts.Token);
+            await _publisher.PublishAsync(assignment, lifecycleToken);
+            await CollectResultAsync(module, moduleType, scheduler, cts, lifecycleToken);
         }
         catch (OperationCanceledException) when (!cts.IsCancellationRequested)
         {

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -408,7 +408,11 @@ internal class DistributedModuleExecutor(
 
         try
         {
-            scheduler.MarkModuleStarted(moduleType);
+            if (!scheduler.MarkModuleStarted(moduleType))
+            {
+                return;
+            }
+
             await CollectResultAsync(module, moduleType, scheduler, cts, timeoutCts?.Token ?? cts.Token);
         }
         catch (OperationCanceledException) when (!cts.IsCancellationRequested)

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -105,6 +105,10 @@ internal class DistributedModuleExecutor(
                 await foreach (var moduleState in scheduler.ReadyModules.ReadAllAsync(cts.Token))
                 {
                     var moduleType = moduleState.Module.GetType();
+                    if (!scheduler.MarkModuleStarted(moduleType))
+                    {
+                        continue;
+                    }
 
                     // TODO(matrix): MatrixModuleExpander.ScanForExpansions not yet connected.
                     // Modules with [MatrixTarget] will run once, not N times.
@@ -408,11 +412,6 @@ internal class DistributedModuleExecutor(
 
         try
         {
-            if (!scheduler.MarkModuleStarted(moduleType))
-            {
-                return;
-            }
-
             await CollectResultAsync(module, moduleType, scheduler, cts, timeoutCts?.Token ?? cts.Token);
         }
         catch (OperationCanceledException) when (!cts.IsCancellationRequested)

--- a/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
+++ b/src/ModularPipelines/Distributed/Master/DistributedModuleExecutor.cs
@@ -105,19 +105,19 @@ internal class DistributedModuleExecutor(
                 await foreach (var moduleState in scheduler.ReadyModules.ReadAllAsync(cts.Token))
                 {
                     var moduleType = moduleState.Module.GetType();
+                    var assignment = _publisher.CreateAssignment(moduleState.Module);
                     if (!scheduler.MarkModuleStarted(moduleType))
                     {
                         continue;
                     }
 
+                    var collectTask = CollectDistributedResultAsync(moduleState.Module, moduleType, scheduler, cts);
+                    resultTasks.Add(collectTask);
+
                     // TODO(matrix): MatrixModuleExpander.ScanForExpansions not yet connected.
                     // Modules with [MatrixTarget] will run once, not N times.
                     _logger.LogInformation("Distributing module {Module} to workers", moduleType.Name);
-                    var assignment = _publisher.CreateAssignment(moduleState.Module);
                     await _publisher.PublishAsync(assignment, cts.Token);
-
-                    var collectTask = CollectDistributedResultAsync(moduleState.Module, moduleType, scheduler, cts);
-                    resultTasks.Add(collectTask);
                 }
             }
             catch (OperationCanceledException)
@@ -487,6 +487,7 @@ internal class DistributedModuleExecutor(
                 module.ResultType,
                 exception,
                 new ModuleExecutionContext(module, moduleType));
+            ModuleCompletionSourceApplicator.TryApply(module, failureResult);
             _resultRegistry.RegisterResult(moduleType, failureResult);
         }
         catch (Exception ex)

--- a/src/ModularPipelines/Distributed/Worker/WorkerModuleScheduler.cs
+++ b/src/ModularPipelines/Distributed/Worker/WorkerModuleScheduler.cs
@@ -32,8 +32,9 @@ internal sealed class WorkerModuleScheduler : IModuleScheduler
 
     public ModuleState? GetModuleState(Type moduleType) => null;
 
-    public void CancelPendingModules(bool cancelModuleResultAwaiters = true)
+    public IReadOnlyList<IModule> CancelPendingModules(bool cancelModuleResultAwaiters = true)
     {
+        return [];
     }
 
     public void Dispose()

--- a/src/ModularPipelines/Distributed/Worker/WorkerModuleScheduler.cs
+++ b/src/ModularPipelines/Distributed/Worker/WorkerModuleScheduler.cs
@@ -32,7 +32,7 @@ internal sealed class WorkerModuleScheduler : IModuleScheduler
 
     public ModuleState? GetModuleState(Type moduleType) => null;
 
-    public void CancelPendingModules()
+    public void CancelPendingModules(bool cancelModuleResultAwaiters = true)
     {
     }
 

--- a/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
@@ -55,6 +55,13 @@ internal class ModuleResultRegistrar : IModuleResultRegistrar
     {
         foreach (var module in modules)
         {
+            // AlwaysRun modules may still execute after scheduler cancellation.
+            // Their final execution path must own both registry and typed-task completion.
+            if (module.ModuleRunType == ModuleRunType.AlwaysRun)
+            {
+                continue;
+            }
+
             var moduleType = module.GetType();
 
             // Check if a result was already registered for this module

--- a/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleResultRegistrar.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Engine.Executors;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
@@ -32,11 +33,21 @@ internal class ModuleResultRegistrar : IModuleResultRegistrar
         executionContext.Status = Enums.Status.PipelineTerminated;
         executionContext.Exception = exception;
 
-        var result = GeneratedModuleMetadata.TryGetRuntime(moduleType, out var runtime)
+        var hasGeneratedRuntime = GeneratedModuleMetadata.TryGetRuntime(moduleType, out var runtime);
+        var result = hasGeneratedRuntime
             ? runtime.CreateFailure(exception, executionContext)
             : ModuleResultFactory.CreateException(resultType, exception, executionContext);
 
         _resultRegistry.RegisterResult(moduleType, result);
+
+        if (hasGeneratedRuntime)
+        {
+            runtime.SetCompletionSource(module, result);
+        }
+        else
+        {
+            CompletionSourceSetterCache.GetOrCreate(resultType)(module, result);
+        }
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
+++ b/src/ModularPipelines/Engine/GeneratedModuleMetadata.cs
@@ -208,6 +208,8 @@ internal interface IGeneratedModuleRuntime
 
     ILogger GetOutputLogger(IServiceProvider serviceProvider);
 
+    void CancelCompletionSource(IModule module);
+
     void SetCompletionSource(IModule module, IModuleResult result);
 
     Task<IModuleResult> ExecuteAsync(
@@ -250,6 +252,11 @@ internal sealed class GeneratedModuleRuntime<TModule, TResult> : IGeneratedModul
     public ILogger GetOutputLogger(IServiceProvider serviceProvider)
     {
         return serviceProvider.GetRequiredService<ILogger<TModule>>();
+    }
+
+    public void CancelCompletionSource(IModule module)
+    {
+        ((Module<TResult>) module).CompletionSource.TrySetCanceled();
     }
 
     public void SetCompletionSource(IModule module, IModuleResult result)

--- a/src/ModularPipelines/Engine/IModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/IModuleScheduler.cs
@@ -56,5 +56,6 @@ internal interface IModuleScheduler : IDisposable
     /// Whether to cancel typed module result awaiters immediately. Set to <see langword="false"/>
     /// when terminated results will be registered after scheduler cancellation.
     /// </param>
-    void CancelPendingModules(bool cancelModuleResultAwaiters = true);
+    /// <returns>The modules transitioned to the completed state by cancellation.</returns>
+    IReadOnlyList<IModule> CancelPendingModules(bool cancelModuleResultAwaiters = true);
 }

--- a/src/ModularPipelines/Engine/IModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/IModuleScheduler.cs
@@ -52,5 +52,9 @@ internal interface IModuleScheduler : IDisposable
     /// Cancels all modules that are queued or pending (not yet executing)
     /// This is used when the pipeline is cancelled to ensure TaskCompletionSources are properly completed.
     /// </summary>
-    void CancelPendingModules();
+    /// <param name="cancelModuleResultAwaiters">
+    /// Whether to cancel typed module result awaiters immediately. Set to <see langword="false"/>
+    /// when terminated results will be registered after scheduler cancellation.
+    /// </param>
+    void CancelPendingModules(bool cancelModuleResultAwaiters = true);
 }

--- a/src/ModularPipelines/Engine/IModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/IModuleStateTracker.cs
@@ -41,7 +41,8 @@ internal interface IModuleStateTracker
     /// Whether to cancel typed module result awaiters immediately. Set to <see langword="false"/>
     /// when terminated results will be registered after scheduler cancellation.
     /// </param>
-    void CancelPendingModules(bool cancelModuleResultAwaiters = true);
+    /// <returns>The modules transitioned to the completed state by cancellation.</returns>
+    IReadOnlyList<IModule> CancelPendingModules(bool cancelModuleResultAwaiters = true);
 
     /// <summary>
     /// Gets the state for a specific module.

--- a/src/ModularPipelines/Engine/IModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/IModuleStateTracker.cs
@@ -10,9 +10,9 @@ namespace ModularPipelines.Engine;
 /// This interface encapsulates the state management responsibility previously
 /// embedded in ModuleScheduler, following the Single Responsibility Principle.
 /// State transitions include:
-/// - Marking modules as started (Pending/Queued -> Executing)
-/// - Marking modules as completed (Executing -> Completed)
-/// - Cancelling pending modules during pipeline cancellation
+/// - Marking modules as started (Pending/Queued -> Executing).
+/// - Marking modules as completed (Executing -> Completed).
+/// - Cancelling pending modules during pipeline cancellation.
 /// </remarks>
 internal interface IModuleStateTracker
 {

--- a/src/ModularPipelines/Engine/IModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/IModuleStateTracker.cs
@@ -37,7 +37,11 @@ internal interface IModuleStateTracker
     /// This is used when the pipeline is cancelled to ensure TaskCompletionSources are properly completed.
     /// Note: AlwaysRun modules are not cancelled as they should be allowed to complete.
     /// </summary>
-    void CancelPendingModules();
+    /// <param name="cancelModuleResultAwaiters">
+    /// Whether to cancel typed module result awaiters immediately. Set to <see langword="false"/>
+    /// when terminated results will be registered after scheduler cancellation.
+    /// </param>
+    void CancelPendingModules(bool cancelModuleResultAwaiters = true);
 
     /// <summary>
     /// Gets the state for a specific module.

--- a/src/ModularPipelines/Engine/ModuleCompletionSourceCanceller.cs
+++ b/src/ModularPipelines/Engine/ModuleCompletionSourceCanceller.cs
@@ -25,25 +25,7 @@ internal static class ModuleCompletionSourceCanceller
             return;
         }
 
-        var resultType = GetResultType(moduleType);
-        if (resultType is not null)
-        {
-            Cache.GetOrAdd(resultType, CreateCanceller)(module);
-        }
-    }
-
-    private static Type? GetResultType(Type moduleType)
-    {
-        for (var currentType = moduleType; currentType is not null; currentType = currentType.BaseType)
-        {
-            if (currentType.IsGenericType
-                && currentType.GetGenericTypeDefinition() == typeof(Module<>))
-            {
-                return currentType.GetGenericArguments()[0];
-            }
-        }
-
-        return null;
+        Cache.GetOrAdd(module.ResultType, CreateCanceller)(module);
     }
 
     [UnconditionalSuppressMessage(

--- a/src/ModularPipelines/Engine/ModuleCompletionSourceCanceller.cs
+++ b/src/ModularPipelines/Engine/ModuleCompletionSourceCanceller.cs
@@ -1,0 +1,76 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Cancels typed module completion sources when modules terminate before execution.
+/// </summary>
+internal static class ModuleCompletionSourceCanceller
+{
+    private static readonly ConcurrentDictionary<Type, Action<IModule>> Cache = new();
+
+    /// <summary>
+    /// Cancels the module's typed completion source.
+    /// </summary>
+    /// <param name="module">The module instance to cancel.</param>
+    /// <param name="moduleType">The concrete module type.</param>
+    public static void Cancel(IModule module, Type moduleType)
+    {
+        if (GeneratedModuleMetadata.TryGetRuntime(moduleType, out var runtime))
+        {
+            runtime.CancelCompletionSource(module);
+            return;
+        }
+
+        var resultType = GetResultType(moduleType);
+        if (resultType is not null)
+        {
+            Cache.GetOrAdd(resultType, CreateCanceller)(module);
+        }
+    }
+
+    private static Type? GetResultType(Type moduleType)
+    {
+        for (var currentType = moduleType; currentType is not null; currentType = currentType.BaseType)
+        {
+            if (currentType.IsGenericType
+                && currentType.GetGenericTypeDefinition() == typeof(Module<>))
+            {
+                return currentType.GetGenericArguments()[0];
+            }
+        }
+
+        return null;
+    }
+
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "The dynamic completion-source canceller is a fallback for modules without generated runtime metadata.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2075",
+        Justification = "The dynamic completion-source canceller is a fallback for modules without generated runtime metadata.")]
+    private static Action<IModule> CreateCanceller(Type resultType)
+    {
+        var moduleType = typeof(Module<>).MakeGenericType(resultType);
+        var moduleParameter = Expression.Parameter(typeof(IModule), "module");
+        var typedModule = Expression.Convert(moduleParameter, moduleType);
+        var completionSourceProperty = moduleType.GetProperty(
+            "CompletionSource",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"CompletionSource property not found on {moduleType.Name}");
+        var completionSource = Expression.Property(typedModule, completionSourceProperty);
+        var trySetCanceledMethod = completionSourceProperty.PropertyType.GetMethod(
+            "TrySetCanceled",
+            Type.EmptyTypes)
+            ?? throw new InvalidOperationException(
+                $"TrySetCanceled method not found on {completionSourceProperty.PropertyType.Name}");
+        var cancel = Expression.Call(completionSource, trySetCanceledMethod);
+
+        return Expression.Lambda<Action<IModule>>(cancel, moduleParameter).Compile();
+    }
+}

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -188,7 +188,8 @@ internal class ModuleExecutor : IModuleExecutor
 
     private void RegisterCancellationCallback(CancellationTokenSource cancellationTokenSource, IModuleScheduler scheduler)
     {
-        cancellationTokenSource.Token.Register(scheduler.CancelPendingModules);
+        cancellationTokenSource.Token.Register(
+            () => scheduler.CancelPendingModules(cancelModuleResultAwaiters: false));
     }
 
     private async Task<Exception?> ExecuteWorkerPoolAsync(

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -224,11 +224,22 @@ internal class ModuleExecutor : IModuleExecutor
                     }
                     catch (Exception ex) when (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                     {
+                        var isFirstFailure = false;
+
                         if (!IsExpectedWorkerCancellation(ex, ct)
                             && recordedWorkerExceptions.TryAdd(ex, 0))
                         {
                             _secondaryExceptionContainer.RegisterException(ex);
-                            Interlocked.CompareExchange(ref firstException, ex, null);
+                            isFirstFailure = Interlocked.CompareExchange(ref firstException, ex, null) == null;
+                        }
+
+                        if (isFirstFailure)
+                        {
+                            var cancelledModules =
+                                scheduler.CancelPendingModules(cancelModuleResultAwaiters: false);
+                            _resultRegistrar.RegisterTerminatedResultsForCancelledModules(
+                                cancelledModules,
+                                ex);
                         }
 
                         EnsureCancellation(cancellationTokenSource);

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -155,6 +155,15 @@ internal class ModuleExecutor : IModuleExecutor
         {
             firstException = await ExecuteWorkerPoolAsync(scheduler, cancellationTokenSource).ConfigureAwait(false);
         }
+        catch (Exception exception)
+        {
+            var cancelledModules =
+                scheduler.CancelPendingModules(cancelModuleResultAwaiters: false);
+            _resultRegistrar.RegisterTerminatedResultsForCancelledModules(
+                cancelledModules,
+                exception);
+            throw;
+        }
         finally
         {
             EnsureCancellation(cancellationTokenSource);

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -18,9 +18,9 @@ namespace ModularPipelines.Engine;
 /// <remarks>
 /// This class follows the Single Responsibility Principle by focusing solely on orchestration.
 /// Individual responsibilities are delegated to:
-/// - <see cref="IModuleRunner"/>: Executes individual modules
-/// - <see cref="IAlwaysRunHandler"/>: Handles AlwaysRun module completion
-/// - <see cref="IModuleResultRegistrar"/>: Registers module results
+/// - <see cref="IModuleRunner"/>: Executes individual modules.
+/// - <see cref="IAlwaysRunHandler"/>: Handles AlwaysRun module completion.
+/// - <see cref="IModuleResultRegistrar"/>: Registers module results.
 /// </remarks>
 internal class ModuleExecutor : IModuleExecutor
 {

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -337,14 +337,14 @@ internal class ModuleScheduler : IModuleScheduler
     /// <param name="cancelModuleResultAwaiters">
     /// Whether to cancel typed module result awaiters immediately.
     /// </param>
-    public void CancelPendingModules(bool cancelModuleResultAwaiters = true)
+    public IReadOnlyList<IModule> CancelPendingModules(bool cancelModuleResultAwaiters = true)
     {
         if (IsDisposed)
         {
-            return;
+            return [];
         }
 
-        _stateTracker.CancelPendingModules(cancelModuleResultAwaiters);
+        return _stateTracker.CancelPendingModules(cancelModuleResultAwaiters);
     }
 
     public void Dispose()

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -334,14 +334,17 @@ internal class ModuleScheduler : IModuleScheduler
     /// This is used when the pipeline is cancelled to ensure TaskCompletionSources are properly completed
     /// Note: AlwaysRun modules are not cancelled as they should be allowed to complete.
     /// </summary>
-    public void CancelPendingModules()
+    /// <param name="cancelModuleResultAwaiters">
+    /// Whether to cancel typed module result awaiters immediately.
+    /// </param>
+    public void CancelPendingModules(bool cancelModuleResultAwaiters = true)
     {
         if (IsDisposed)
         {
             return;
         }
 
-        _stateTracker.CancelPendingModules();
+        _stateTracker.CancelPendingModules(cancelModuleResultAwaiters);
     }
 
     public void Dispose()
@@ -585,7 +588,7 @@ internal class ModuleScheduler : IModuleScheduler
         IReadOnlyDictionary<Type, Type?> parentByType)
     {
         var pathFromModule = new Stack<Type>();
-        Type? currentType = dependentType;
+        var currentType = (Type?) dependentType;
 
         while (currentType is not null && currentType != moduleType)
         {

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -86,10 +86,10 @@ internal class ModuleStateTracker : IModuleStateTracker
         // of lock recursion (the snapshot is a plain List, not protected by lock).
         // Releasing the lock between constraint check and state mutation would
         // create a race condition where another thread could start a conflicting module.
-        bool needsReschedule = false;
+        var needsReschedule = false;
         DateTimeOffset? executionStartTime = null;
-        int executingCount = 0;
-        bool result = false;
+        var executingCount = 0;
+        var result = false;
 
         _stateLock.EnterWriteLock();
         try
@@ -252,7 +252,7 @@ internal class ModuleStateTracker : IModuleStateTracker
     }
 
     /// <inheritdoc />
-    public void CancelPendingModules()
+    public void CancelPendingModules(bool cancelModuleResultAwaiters = true)
     {
         List<(ModuleState Module, ModuleExecutionState OriginalState)> cancelledModules;
 
@@ -283,7 +283,10 @@ internal class ModuleStateTracker : IModuleStateTracker
         foreach (var (moduleState, _) in cancelledModules)
         {
             moduleState.CompletionSource.TrySetCanceled();
-            ModuleCompletionSourceCanceller.Cancel(moduleState.Module, moduleState.ModuleType);
+            if (cancelModuleResultAwaiters)
+            {
+                ModuleCompletionSourceCanceller.Cancel(moduleState.Module, moduleState.ModuleType);
+            }
         }
 
         // Logging outside lock

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -252,15 +252,15 @@ internal class ModuleStateTracker : IModuleStateTracker
     }
 
     /// <inheritdoc />
-    public void CancelPendingModules(bool cancelModuleResultAwaiters = true)
+    public IReadOnlyList<IModule> CancelPendingModules(bool cancelModuleResultAwaiters = true)
     {
-        List<(ModuleState Module, ModuleExecutionState OriginalState)> cancelledModules;
+        List<(ModuleState State, ModuleExecutionState OriginalState)> cancelledModules;
 
         _stateLock.EnterWriteLock();
         try
         {
             var pendingModules = _stateQueries.GetCancellablePendingModules().ToList();
-            cancelledModules = new List<(ModuleState, ModuleExecutionState)>();
+            cancelledModules = [];
 
             foreach (var moduleState in pendingModules)
             {
@@ -302,6 +302,8 @@ internal class ModuleStateTracker : IModuleStateTracker
                 moduleState.ModuleType.Name,
                 originalState);
         }
+
+        return [.. cancelledModules.Select(x => x.State.Module)];
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -283,6 +283,7 @@ internal class ModuleStateTracker : IModuleStateTracker
         foreach (var (moduleState, _) in cancelledModules)
         {
             moduleState.CompletionSource.TrySetCanceled();
+            ModuleCompletionSourceCanceller.Cancel(moduleState.Module, moduleState.ModuleType);
         }
 
         // Logging outside lock

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -32,7 +32,7 @@ internal class ModuleStateTracker : IModuleStateTracker
     private readonly Func<bool> _isSchedulerCompleted;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ModuleStateTracker"/> class.
+    /// Initialises a new instance of the <see cref="ModuleStateTracker"/> class.
     /// </summary>
     /// <param name="logger">Logger for diagnostic output.</param>
     /// <param name="timeProvider">Provider for current time.</param>
@@ -301,19 +301,6 @@ internal class ModuleStateTracker : IModuleStateTracker
         }
     }
 
-    private static ModuleStateCounters CreateCounters(
-        ConcurrentDictionary<Type, ModuleState> moduleStates)
-    {
-        var counters = new ModuleStateCounters();
-        foreach (var state in moduleStates.Values)
-        {
-            counters.AddPendingModule();
-            counters.Transition(ModuleExecutionState.Pending, state.State);
-        }
-
-        return counters;
-    }
-
     /// <inheritdoc />
     public ModuleState? GetModuleState(Type moduleType)
     {
@@ -326,6 +313,19 @@ internal class ModuleStateTracker : IModuleStateTracker
         return _moduleStates.TryGetValue(moduleType, out var state)
             ? state.CompletionSource.Task
             : null;
+    }
+
+    private static ModuleStateCounters CreateCounters(
+        ConcurrentDictionary<Type, ModuleState> moduleStates)
+    {
+        var counters = new ModuleStateCounters();
+        foreach (var state in moduleStates.Values)
+        {
+            counters.AddPendingModule();
+            counters.Transition(ModuleExecutionState.Pending, state.State);
+        }
+
+        return counters;
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -99,6 +99,11 @@ internal class ModuleStateTracker : IModuleStateTracker
                 return false;
             }
 
+            if (state.State is not (ModuleExecutionState.Pending or ModuleExecutionState.Queued))
+            {
+                return false;
+            }
+
             // Take snapshot of executing modules for constraint checking
             // The constraint evaluator operates on this snapshot, not the live collection
             var executingSnapshot = _executingModules.ToList();

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -813,6 +813,36 @@ public class DistributedModuleExecutorTests
     }
 
     [Test]
+    public async Task Cancelled_Queued_Module_Does_Not_Collect_Or_Overwrite_Result()
+    {
+        var module = new DistributedModule();
+        var moduleState = new ModuleState(module, typeof(DistributedModule));
+        var scheduler = CreateMockScheduler(moduleState);
+        scheduler.Setup(s => s.MarkModuleStarted(typeof(DistributedModule))).Returns(false);
+
+        var coordinator = new Mock<IDistributedCoordinator>();
+        coordinator.Setup(c => c.EnqueueModuleAsync(It.IsAny<ModuleAssignment>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        coordinator.Setup(c => c.SignalCompletionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var executor = CreateExecutor(scheduler, coordinator: coordinator.Object);
+
+        await executor.ExecuteAsync([module]);
+
+        coordinator.Verify(
+            c => c.WaitForResultAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never());
+        scheduler.Verify(
+            s => s.MarkModuleCompleted(
+                typeof(DistributedModule),
+                It.IsAny<bool>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Status?>()),
+            Times.Never());
+    }
+
+    [Test]
     public async Task Distributed_Module_Failure_Marks_Scheduler_With_Success_False()
     {
         // Arrange

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -813,7 +813,7 @@ public class DistributedModuleExecutorTests
     }
 
     [Test]
-    public async Task Cancelled_Queued_Module_Does_Not_Collect_Or_Overwrite_Result()
+    public async Task Rejected_Start_Does_Not_Publish_Or_Collect_Result()
     {
         var module = new DistributedModule();
         var moduleState = new ModuleState(module, typeof(DistributedModule));
@@ -831,6 +831,9 @@ public class DistributedModuleExecutorTests
         await executor.ExecuteAsync([module]);
 
         coordinator.Verify(
+            c => c.EnqueueModuleAsync(It.IsAny<ModuleAssignment>(), It.IsAny<CancellationToken>()),
+            Times.Never());
+        coordinator.Verify(
             c => c.WaitForResultAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never());
         scheduler.Verify(
@@ -840,6 +843,46 @@ public class DistributedModuleExecutorTests
                 It.IsAny<Exception?>(),
                 It.IsAny<Status?>()),
             Times.Never());
+    }
+
+    [Test]
+    public async Task Deferred_Start_Publishes_Only_After_Scheduler_Requeues_Module()
+    {
+        var module = new DistributedModule();
+        var moduleState = new ModuleState(module, typeof(DistributedModule));
+        var scheduler = CreateMockScheduler(moduleState, moduleState);
+        scheduler.SetupSequence(s => s.MarkModuleStarted(typeof(DistributedModule)))
+            .Returns(false)
+            .Returns(true);
+        var coordinator = new InMemoryDistributedCoordinator();
+        var noDequeue = new NoDequeueCoordinator(coordinator);
+        var typeRegistry = new ModuleTypeRegistry();
+        typeRegistry.Register(typeof(DistributedModule));
+        var serializer = new ModuleResultSerializer(typeRegistry);
+        var resultCollector = new DistributedResultCollector(noDequeue, serializer);
+        var executor = CreateExecutor(
+            scheduler,
+            coordinator: noDequeue,
+            resultCollector: resultCollector);
+
+        var successResult = CreateSuccessResult(new SimpleResult { Message = "ok" }, "DistributedModule");
+        var serialized = serializer.Serialize(
+            successResult,
+            typeof(DistributedModule).FullName!,
+            typeof(SimpleResult).FullName!,
+            1);
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(50);
+            await coordinator.PublishResultAsync(serialized, CancellationToken.None);
+        });
+
+        await executor.ExecuteAsync([module]);
+
+        scheduler.Verify(s => s.MarkModuleStarted(typeof(DistributedModule)), Times.Exactly(2));
+        scheduler.Verify(
+            s => s.MarkModuleCompleted(typeof(DistributedModule), true, null, null),
+            Times.Once());
     }
 
     [Test]

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -992,6 +992,51 @@ public class DistributedModuleExecutorTests
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task Publish_Timeout_Completes_Module_Result(
+        CancellationToken testCancellation)
+    {
+        var module = new ShortTimeoutDistributedModule();
+        var moduleState = new ModuleState(module, typeof(ShortTimeoutDistributedModule));
+        var scheduler = CreateMockScheduler(moduleState);
+
+        var coordinator = new Mock<IDistributedCoordinator>();
+        coordinator.Setup(c => c.EnqueueModuleAsync(
+                It.IsAny<ModuleAssignment>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<ModuleAssignment, CancellationToken>(
+                (_, token) => Task.Delay(Timeout.InfiniteTimeSpan, token));
+        coordinator.Setup(c => c.DequeueModuleAsync(
+                It.IsAny<IReadOnlySet<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ModuleAssignment?)null);
+        coordinator.Setup(c => c.SignalCompletionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var resultRegistry = new ModuleResultRegistry();
+        var executor = CreateExecutor(
+            scheduler,
+            resultRegistry: resultRegistry,
+            coordinator: coordinator.Object);
+
+        await executor.ExecuteAsync([module])
+            .WaitAsync(TimeSpan.FromSeconds(3), testCancellation);
+        var moduleResult = await ((IModule)module).ResultTask
+            .WaitAsync(TimeSpan.FromSeconds(1), testCancellation);
+
+        await Assert.That(moduleResult.ExceptionOrDefault)
+            .IsTypeOf<TimeoutException>();
+        await Assert.That(resultRegistry.GetResult(typeof(ShortTimeoutDistributedModule)))
+            .IsSameReferenceAs(moduleResult);
+        coordinator.Verify(
+            c => c.WaitForResultAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never());
+        scheduler.Verify(
+            s => s.MarkModuleCompleted(typeof(ShortTimeoutDistributedModule), false, null, null),
+            Times.Once());
+    }
+
+    [Test]
     public async Task Distributed_Module_Failure_Marks_Scheduler_With_Success_False()
     {
         // Arrange

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -186,10 +186,11 @@ public class DistributedModuleExecutorTests
         IDistributedCoordinator? coordinator = null,
         DistributedResultCollector? resultCollector = null,
         ArtifactLifecycleManager? artifactManager = null,
-        DistributedOptions? distributedOptions = null)
+        DistributedOptions? distributedOptions = null,
+        CancellationToken applicationStopping = default)
     {
         var lifetime = new Mock<IHostApplicationLifetime>();
-        lifetime.Setup(l => l.ApplicationStopping).Returns(CancellationToken.None);
+        lifetime.Setup(l => l.ApplicationStopping).Returns(applicationStopping);
 
         var factory = new Mock<IModuleSchedulerFactory>();
         factory.Setup(f => f.Create()).Returns(scheduler.Object);
@@ -882,6 +883,63 @@ public class DistributedModuleExecutorTests
         scheduler.Verify(s => s.MarkModuleStarted(typeof(DistributedModule)), Times.Exactly(2));
         scheduler.Verify(
             s => s.MarkModuleCompleted(typeof(DistributedModule), true, null, null),
+            Times.Once());
+    }
+
+    [Test]
+    [Timeout(5_000)]
+    public async Task Cancellation_After_Start_Claim_Completes_Module_Result(
+        CancellationToken testCancellation)
+    {
+        using var stoppingCts = new CancellationTokenSource();
+        var module = new DistributedModule();
+        var moduleState = new ModuleState(module, typeof(DistributedModule));
+        var scheduler = CreateMockScheduler(moduleState);
+        scheduler.Setup(s => s.CancelPendingModules(false))
+            .Returns([]);
+        scheduler.Setup(s => s.MarkModuleStarted(typeof(DistributedModule)))
+            .Returns(() =>
+            {
+                stoppingCts.Cancel();
+                return true;
+            });
+
+        var coordinator = new Mock<IDistributedCoordinator>();
+        coordinator.Setup(c => c.EnqueueModuleAsync(
+                It.IsAny<ModuleAssignment>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<ModuleAssignment, CancellationToken>((_, token) => Task.FromCanceled(token));
+        coordinator.Setup(c => c.WaitForResultAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<string, CancellationToken>((_, token) =>
+                Task.FromCanceled<SerializedModuleResult>(token));
+        coordinator.Setup(c => c.DequeueModuleAsync(
+                It.IsAny<IReadOnlySet<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ModuleAssignment?)null);
+        coordinator.Setup(c => c.SignalCompletionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var resultRegistry = new ModuleResultRegistry();
+        var executor = CreateExecutor(
+            scheduler,
+            resultRegistry: resultRegistry,
+            coordinator: coordinator.Object,
+            applicationStopping: stoppingCts.Token);
+
+        await executor.ExecuteAsync([module])
+            .WaitAsync(TimeSpan.FromSeconds(3), testCancellation);
+        var moduleResult = await ((IModule)module).ResultTask
+            .WaitAsync(TimeSpan.FromSeconds(1), testCancellation);
+
+        await Assert.That(moduleResult).IsNotNull();
+        await Assert.That(moduleResult!.ExceptionOrDefault)
+            .IsTypeOf<OperationCanceledException>();
+        await Assert.That(resultRegistry.GetResult(typeof(DistributedModule)))
+            .IsSameReferenceAs(moduleResult);
+        scheduler.Verify(
+            s => s.MarkModuleCompleted(typeof(DistributedModule), false, null, null),
             Times.Once());
     }
 

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -944,6 +944,54 @@ public class DistributedModuleExecutorTests
     }
 
     [Test]
+    [Timeout(5_000)]
+    public async Task Publish_Failure_Completes_Module_Result(
+        CancellationToken testCancellation)
+    {
+        var module = new DistributedModule();
+        var moduleState = new ModuleState(module, typeof(DistributedModule));
+        var scheduler = CreateMockScheduler(moduleState);
+        scheduler.Setup(s => s.CancelPendingModules(false))
+            .Returns([]);
+
+        var publishException = new InvalidOperationException("Broker unavailable");
+        var coordinator = new Mock<IDistributedCoordinator>();
+        coordinator.Setup(c => c.EnqueueModuleAsync(
+                It.IsAny<ModuleAssignment>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(publishException);
+        coordinator.Setup(c => c.DequeueModuleAsync(
+                It.IsAny<IReadOnlySet<string>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ModuleAssignment?)null);
+        coordinator.Setup(c => c.SignalCompletionAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var resultRegistry = new ModuleResultRegistry();
+        var executor = CreateExecutor(
+            scheduler,
+            resultRegistry: resultRegistry,
+            coordinator: coordinator.Object);
+
+        await executor.ExecuteAsync([module])
+            .WaitAsync(TimeSpan.FromSeconds(3), testCancellation);
+        var moduleResult = await ((IModule)module).ResultTask
+            .WaitAsync(TimeSpan.FromSeconds(1), testCancellation);
+
+        await Assert.That(moduleResult).IsNotNull();
+        await Assert.That(moduleResult!.ExceptionOrDefault)
+            .IsSameReferenceAs(publishException);
+        await Assert.That(resultRegistry.GetResult(typeof(DistributedModule)))
+            .IsSameReferenceAs(moduleResult);
+        coordinator.Verify(
+            c => c.WaitForResultAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never());
+        scheduler.Verify(
+            s => s.MarkModuleCompleted(typeof(DistributedModule), false, publishException, null),
+            Times.Once());
+    }
+
+    [Test]
     public async Task Distributed_Module_Failure_Marks_Scheduler_With_Success_False()
     {
         // Arrange

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -33,6 +33,9 @@ public class DistributedModuleExecutorTests
             Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
             new ModuleAttributeEventService());
 
+    private static IModuleResultRegistrar NewResultRegistrar() =>
+        Mock.Of<IModuleResultRegistrar>();
+
     // --- Test module types ---
 
     private class SimpleResult
@@ -214,6 +217,7 @@ public class DistributedModuleExecutorTests
             typeRegistry,
             serializer,
             resultRegistry,
+            NewResultRegistrar(),
             NewDependencyRegistry(),
             NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions ?? new DistributedOptions()),
@@ -882,7 +886,7 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, NewDependencyRegistry(), NewMetadataRegistry(),
+            resultRegistry, NewResultRegistrar(), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(new DistributedOptions()),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
@@ -930,7 +934,7 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             noDequeue, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, NewDependencyRegistry(), NewMetadataRegistry(),
+            resultRegistry, NewResultRegistrar(), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
@@ -1026,7 +1030,7 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, NewDependencyRegistry(), NewMetadataRegistry(),
+            resultRegistry, NewResultRegistrar(), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -33,8 +33,8 @@ public class DistributedModuleExecutorTests
             Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
             new ModuleAttributeEventService());
 
-    private static IModuleResultRegistrar NewResultRegistrar() =>
-        Mock.Of<IModuleResultRegistrar>();
+    private static ModuleResultRegistrar NewResultRegistrar(IModuleResultRegistry resultRegistry) =>
+        new ModuleResultRegistrar(resultRegistry, NullLogger<ModuleResultRegistrar>.Instance);
 
     // --- Test module types ---
 
@@ -175,6 +175,7 @@ public class DistributedModuleExecutorTests
                 return tcs.Task;
             });
         scheduler.Setup(s => s.MarkModuleStarted(It.IsAny<Type>())).Returns(true);
+        scheduler.Setup(s => s.CancelPendingModules(It.IsAny<bool>())).Returns([]);
 
         return scheduler;
     }
@@ -218,7 +219,7 @@ public class DistributedModuleExecutorTests
             typeRegistry,
             serializer,
             resultRegistry,
-            NewResultRegistrar(),
+            NewResultRegistrar(resultRegistry),
             NewDependencyRegistry(),
             NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions ?? new DistributedOptions()),
@@ -917,7 +918,7 @@ public class DistributedModuleExecutorTests
         coordinator.Setup(c => c.DequeueModuleAsync(
                 It.IsAny<IReadOnlySet<string>>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync((ModuleAssignment?)null);
+            .ReturnsAsync((ModuleAssignment?) null);
         coordinator.Setup(c => c.SignalCompletionAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
@@ -930,7 +931,7 @@ public class DistributedModuleExecutorTests
 
         await executor.ExecuteAsync([module])
             .WaitAsync(TimeSpan.FromSeconds(3), testCancellation);
-        var moduleResult = await ((IModule)module).ResultTask
+        var moduleResult = await ((IModule) module).ResultTask
             .WaitAsync(TimeSpan.FromSeconds(1), testCancellation);
 
         await Assert.That(moduleResult).IsNotNull();
@@ -963,7 +964,7 @@ public class DistributedModuleExecutorTests
         coordinator.Setup(c => c.DequeueModuleAsync(
                 It.IsAny<IReadOnlySet<string>>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync((ModuleAssignment?)null);
+            .ReturnsAsync((ModuleAssignment?) null);
         coordinator.Setup(c => c.SignalCompletionAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
@@ -975,7 +976,7 @@ public class DistributedModuleExecutorTests
 
         await executor.ExecuteAsync([module])
             .WaitAsync(TimeSpan.FromSeconds(3), testCancellation);
-        var moduleResult = await ((IModule)module).ResultTask
+        var moduleResult = await ((IModule) module).ResultTask
             .WaitAsync(TimeSpan.FromSeconds(1), testCancellation);
 
         await Assert.That(moduleResult).IsNotNull();
@@ -1009,7 +1010,7 @@ public class DistributedModuleExecutorTests
         coordinator.Setup(c => c.DequeueModuleAsync(
                 It.IsAny<IReadOnlySet<string>>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync((ModuleAssignment?)null);
+            .ReturnsAsync((ModuleAssignment?) null);
         coordinator.Setup(c => c.SignalCompletionAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
@@ -1021,7 +1022,7 @@ public class DistributedModuleExecutorTests
 
         await executor.ExecuteAsync([module])
             .WaitAsync(TimeSpan.FromSeconds(3), testCancellation);
-        var moduleResult = await ((IModule)module).ResultTask
+        var moduleResult = await ((IModule) module).ResultTask
             .WaitAsync(TimeSpan.FromSeconds(1), testCancellation);
 
         await Assert.That(moduleResult.ExceptionOrDefault)
@@ -1110,7 +1111,7 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, NewResultRegistrar(), NewDependencyRegistry(), NewMetadataRegistry(),
+            resultRegistry, NewResultRegistrar(resultRegistry), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(new DistributedOptions()),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
@@ -1158,7 +1159,7 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             noDequeue, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, NewResultRegistrar(), NewDependencyRegistry(), NewMetadataRegistry(),
+            resultRegistry, NewResultRegistrar(resultRegistry), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 
@@ -1254,7 +1255,7 @@ public class DistributedModuleExecutorTests
         var executor = new DistributedModuleExecutor(
             lifetime.Object, factory.Object, moduleRunner.Object, regEventExecutor.Object,
             coordinator.Object, publisher, resultCollector, typeRegistry, serializer,
-            resultRegistry, NewResultRegistrar(), NewDependencyRegistry(), NewMetadataRegistry(),
+            resultRegistry, NewResultRegistrar(resultRegistry), NewDependencyRegistry(), NewMetadataRegistry(),
             Microsoft.Extensions.Options.Options.Create(distributedOptions),
             null, NullLogger<DistributedModuleExecutor>.Instance);
 

--- a/test/ModularPipelines.UnitTests/Distributed/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.UnitTests/Distributed/DistributedModuleExecutorTests.cs
@@ -1,4 +1,6 @@
+using ModularPipelines.Context;
 using ModularPipelines.Distributed.Master;
+using ModularPipelines.Enums;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Modules;
@@ -8,6 +10,16 @@ namespace ModularPipelines.UnitTests.Distributed;
 
 public class DistributedModuleExecutorTests
 {
+    private sealed class TestModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
     [Test]
     public void CompleteCancelledModules_RegistersTerminatedResults()
     {
@@ -32,5 +44,26 @@ public class DistributedModuleExecutorTests
                 It.Is<OperationCanceledException>(
                     exception => exception.CancellationToken == cancellationToken)),
             Times.Once);
+    }
+
+    [Test]
+    [Arguments(Status.TimedOut)]
+    [Arguments(Status.Failed)]
+    public async Task CreateCollectorFailureResult_PreservesTerminalStatus(Status status)
+    {
+        var module = new TestModule();
+        var exception = new InvalidOperationException("Collector failed");
+
+        var result = DistributedModuleExecutor.CreateCollectorFailureResult(
+            module,
+            typeof(TestModule),
+            exception,
+            status);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.ModuleStatus).IsEqualTo(status);
+            await Assert.That(result.ExceptionOrDefault).IsSameReferenceAs(exception);
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Distributed/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.UnitTests/Distributed/DistributedModuleExecutorTests.cs
@@ -1,0 +1,36 @@
+using ModularPipelines.Distributed.Master;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Execution;
+using ModularPipelines.Modules;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Distributed;
+
+public class DistributedModuleExecutorTests
+{
+    [Test]
+    public void CompleteCancelledModules_RegistersTerminatedResults()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+        var cancellationToken = cancellationTokenSource.Token;
+        IReadOnlyList<IModule> cancelledModules = [Mock.Of<IModule>()];
+        var scheduler = new Mock<IModuleScheduler>();
+        var resultRegistrar = new Mock<IModuleResultRegistrar>();
+        scheduler
+            .Setup(x => x.CancelPendingModules(false))
+            .Returns(cancelledModules);
+
+        DistributedModuleExecutor.CompleteCancelledModules(
+            scheduler.Object,
+            resultRegistrar.Object,
+            cancellationToken);
+
+        resultRegistrar.Verify(
+            x => x.RegisterTerminatedResultsForCancelledModules(
+                cancelledModules,
+                It.Is<OperationCanceledException>(
+                    exception => exception.CancellationToken == cancellationToken)),
+            Times.Once);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
@@ -76,6 +76,21 @@ public class GeneratedModuleMetadataTests
     }
 
     [Test]
+    public async Task Generated_Runtime_Cancels_Typed_Completion_Source()
+    {
+        var module = new GeneratedMetadataDependencyModule();
+
+        var found = GeneratedModuleMetadata.TryGetRuntime(module.GetType(), out var runtime);
+        runtime.CancelCompletionSource(module);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(found).IsTrue();
+            await Assert.That(module.CompletionSource.Task.IsCanceled).IsTrue();
+        }
+    }
+
+    [Test]
     public async Task Generated_Runtime_Resolves_Unbuffered_Output_Logger()
     {
         var services = new ServiceCollection();

--- a/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
@@ -3,6 +3,8 @@ using System.Reflection.Emit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Configuration;
+using ModularPipelines.Context;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Extensions;
@@ -75,6 +77,26 @@ public class GeneratedModuleMetadataTests
         await Assert.That(result).IsAssignableTo<ModuleResult<bool>>();
         await Assert.That(result!.ExceptionOrDefault).IsSameReferenceAs(exception);
         await Assert.That(awaitedResult).IsSameReferenceAs(result);
+    }
+
+    [Test]
+    public async Task Cancelled_Result_Registration_Defers_AlwaysRun_Completion()
+    {
+        var module = new GeneratedAlwaysRunModule();
+        var registry = new ModuleResultRegistry();
+        var registrar = new ModuleResultRegistrar(
+            registry,
+            NullLogger<ModuleResultRegistrar>.Instance);
+
+        registrar.RegisterTerminatedResultsForCancelledModules(
+            [module],
+            new InvalidOperationException("Pipeline terminated"));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(registry.GetResult(module.GetType())).IsNull();
+            await Assert.That(module.CompletionSource.Task.IsCompleted).IsFalse();
+        }
     }
 
     [Test]
@@ -218,6 +240,20 @@ public class GeneratedModuleMetadataTests
         il.Emit(OpCodes.Call, typeof(TrueModule).GetConstructor(Type.EmptyTypes)!);
         il.Emit(OpCodes.Ret);
         return typeBuilder.CreateType()!;
+    }
+
+    private sealed class GeneratedAlwaysRunModule : Module<bool>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithAlwaysRun()
+            .Build();
+
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
     }
 }
 

--- a/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/GeneratedModuleMetadataTests.cs
@@ -71,8 +71,10 @@ public class GeneratedModuleMetadataTests
         registrar.RegisterTerminatedResult(module, module.GetType(), exception);
 
         var result = registry.GetResult(module.GetType());
+        var awaitedResult = await ((IModule) module).ResultTask.WaitAsync(TimeSpan.FromSeconds(1));
         await Assert.That(result).IsAssignableTo<ModuleResult<bool>>();
         await Assert.That(result!.ExceptionOrDefault).IsSameReferenceAs(exception);
+        await Assert.That(awaitedResult).IsSameReferenceAs(result);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -548,6 +548,24 @@ public class ModuleExecutorLoggingTests
         await Assert.That(logs.ToString()).Contains("Cancelling 1 pending/queued modules");
     }
 
+    [Test]
+    public async Task CancelPendingModules_CompletesPendingModuleAwaitable()
+    {
+        var module = new LaterModule();
+        var state = new ModuleState(module, module.GetType());
+        var moduleStates = new ConcurrentDictionary<Type, ModuleState>();
+        moduleStates[state.ModuleType] = state;
+        var tracker = CreateModuleStateTracker(new StringBuilder(), moduleStates);
+
+        tracker.CancelPendingModules();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(module.CompletionSource.Task.IsCanceled).IsTrue();
+            await Assert.That(((IModule) module).ResultTask.IsCompleted).IsTrue();
+        }
+    }
+
     private static ModuleExecutor CreateStopOnFirstExceptionExecutor(
         FaultingModule faultingModule,
         LaterModule laterModule,

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -103,7 +103,7 @@ public class ModuleExecutorLoggingTests
 
         var logOutput = logs.ToString();
         await Assert.That(logOutput).DoesNotContain("Cancellation triggered");
-        scheduler.Verify(x => x.CancelPendingModules(), Times.Once);
+        scheduler.Verify(x => x.CancelPendingModules(false), Times.Once);
     }
 
     [Test]
@@ -536,9 +536,8 @@ public class ModuleExecutorLoggingTests
     public async Task CancelPendingModules_WithPendingModule_LogsCancellation()
     {
         var logs = new StringBuilder();
-        var module = new Mock<IModule>();
-        module.SetupGet(x => x.ModuleRunType).Returns(ModuleRunType.OnSuccessfulDependencies);
-        var state = new ModuleState(module.Object, typeof(IModule));
+        var module = new LaterModule();
+        var state = new ModuleState(module, module.GetType());
         var moduleStates = new ConcurrentDictionary<Type, ModuleState>();
         moduleStates[state.ModuleType] = state;
         var tracker = CreateModuleStateTracker(logs, moduleStates);

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -10,6 +10,7 @@ using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Engine.Scheduling;
 using ModularPipelines.Enums;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers;
 using ModularPipelines.Interfaces;
 using ModularPipelines.Models;
@@ -104,6 +105,77 @@ public class ModuleExecutorLoggingTests
         var logOutput = logs.ToString();
         await Assert.That(logOutput).DoesNotContain("Cancellation triggered");
         scheduler.Verify(x => x.CancelPendingModules(false), Times.Once);
+    }
+
+    [Test]
+    public async Task SchedulerFault_RegistersTerminatedResultsBeforeAlwaysRun()
+    {
+        var schedulerException = new DependencyCollisionException("Scheduler fault");
+        var readyModules = Channel.CreateUnbounded<ModuleState>();
+        readyModules.Writer.Complete(schedulerException);
+        var cancelledModule = new LaterModule();
+        IReadOnlyList<IModule> cancelledModules = [cancelledModule];
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler.SetupGet(x => x.ReadyModules).Returns(readyModules.Reader);
+        scheduler.Setup(x => x.RunSchedulerAsync(It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        scheduler.Setup(x => x.CancelPendingModules(false))
+            .Returns(cancelledModules);
+        var schedulerFactory = new Mock<IModuleSchedulerFactory>();
+        schedulerFactory.Setup(x => x.Create()).Returns(scheduler.Object);
+        var resultRegistrar = new Mock<IModuleResultRegistrar>();
+        var terminatedResultsRegistered = false;
+        resultRegistrar
+            .Setup(x => x.RegisterTerminatedResultsForCancelledModules(
+                cancelledModules,
+                schedulerException))
+            .Callback(() => terminatedResultsRegistered = true);
+        var alwaysRunHandler = new Mock<IAlwaysRunHandler>();
+        alwaysRunHandler
+            .Setup(x => x.WaitForAlwaysRunModulesAsync(
+                scheduler.Object,
+                It.IsAny<IReadOnlyList<IModule>>()))
+            .Callback(() =>
+            {
+                if (!terminatedResultsRegistered)
+                {
+                    throw new InvalidOperationException(
+                        "Terminated results were not registered before AlwaysRun processing.");
+                }
+            })
+            .Returns(Task.CompletedTask);
+        var registrationEvents = new Mock<IRegistrationEventExecutor>();
+        registrationEvents
+            .Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(Task.CompletedTask);
+        var parallelLimitProvider = new Mock<IParallelLimitProvider>();
+        parallelLimitProvider.Setup(x => x.GetMaxDegreeOfParallelism()).Returns(1);
+        var executor = new ModuleExecutor(
+            schedulerFactory.Object,
+            Mock.Of<IModuleRunner>(),
+            alwaysRunHandler.Object,
+            resultRegistrar.Object,
+            Mock.Of<IModuleResultRegistry>(),
+            parallelLimitProvider.Object,
+            registrationEvents.Object,
+            Mock.Of<IMetricsCollector>(),
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()),
+            Mock.Of<ISecondaryExceptionContainer>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
+            NullLogger<ModuleExecutor>.Instance);
+
+        await Assert.ThrowsAsync<DependencyCollisionException>(
+            async () => await executor.ExecuteAsync([cancelledModule]));
+
+        resultRegistrar.Verify(x => x.RegisterTerminatedResultsForCancelledModules(
+            cancelledModules,
+            schedulerException), Times.Once);
+        alwaysRunHandler.Verify(x => x.WaitForAlwaysRunModulesAsync(
+            scheduler.Object,
+            It.IsAny<IReadOnlyList<IModule>>()), Times.Once);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -293,6 +293,25 @@ public class ModuleSchedulerDynamicCycleTests
     }
 
     [Test]
+    public async Task MarkModuleStarted_AfterQueuedModuleIsCancelled_ReturnsFalse()
+    {
+        using var scheduler = CreateScheduler();
+        scheduler.InitializeModules([new CompletedDependencyModule()]);
+        var moduleState = scheduler.GetModuleState(typeof(CompletedDependencyModule))!;
+        moduleState.State = ModuleExecutionState.Queued;
+
+        var cancelledModules = scheduler.CancelPendingModules();
+        var started = scheduler.MarkModuleStarted(typeof(CompletedDependencyModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(cancelledModules).HasSingleItem();
+            await Assert.That(moduleState.State).IsEqualTo(ModuleExecutionState.Completed);
+            await Assert.That(started).IsFalse();
+        }
+    }
+
+    [Test]
     public async Task AddModule_WhenExistingPredicateCreatesCycle_ThrowsAndRollsBack()
     {
         using var scheduler = CreateScheduler();

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -175,6 +175,10 @@ public class EngineCancellationTokenTests : TestBase
 
     private class AwaitingTerminatedModule : Module<bool>
     {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithAlwaysRun()
+            .Build();
+
         protected internal override async Task<bool> ExecuteAsync(
             IModuleContext context,
             CancellationToken cancellationToken)
@@ -394,7 +398,7 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
-    public async Task TerminatedBeforeExecutionModule_UnblocksRuntimeAwaiter()
+    public async Task AlwaysRunModuleAwaitingTerminatedModule_UnblocksRuntimeAwaiter()
     {
         AwaitingTerminatedModuleStarted =
             new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -413,11 +417,20 @@ public class EngineCancellationTokenTests : TestBase
             .AddModule<CoordinatedDependencyFailureModule>()
             .AddModule<TerminatedBeforeExecutionModule>();
 
+        var host = await builder.BuildAsync();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
         var exception = await Assert.ThrowsAsync<ModuleFailedException>(
-            async () => await builder.ExecutePipelineAsync().WaitAsync(TimeSpan.FromSeconds(5)));
+            async () => await host.RunAsync().WaitAsync(TimeSpan.FromSeconds(5)));
+        var alwaysRunResult = resultRegistry.GetResult<bool>(typeof(AwaitingTerminatedModule));
 
-        await Assert.That(exception!.InnerException).IsTypeOf<InvalidOperationException>();
-        await Assert.That(exception.InnerException!).HasMessageEqualTo("Dependency failure");
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.InnerException).IsTypeOf<InvalidOperationException>();
+            await Assert.That(exception.InnerException!).HasMessageEqualTo("Dependency failure");
+            await Assert.That(alwaysRunResult).IsNotNull();
+            await Assert.That(alwaysRunResult!.ModuleStatus).IsEqualTo(Status.Successful);
+            await Assert.That(alwaysRunResult.ValueOrDefault).IsTrue();
+        }
     }
 
     [Test]
@@ -445,7 +458,7 @@ public class EngineCancellationTokenTests : TestBase
 
         var exception = await Assert.ThrowsAsync<ModuleFailedException>(
             async () => await host.RunAsync().WaitAsync(TimeSpan.FromSeconds(5)));
-        var awaitedResult = await ((IModule)pendingModule).ResultTask
+        var awaitedResult = await ((IModule) pendingModule).ResultTask
             .WaitAsync(TimeSpan.FromSeconds(1));
         var registeredResult = resultRegistry.GetResult(typeof(StopOnFirstPendingModule));
 

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -20,6 +20,7 @@ namespace ModularPipelines.UnitTests.Execution;
 public class EngineCancellationTokenTests : TestBase
 {
     private static readonly TimeSpan WaitForCancellationDelay = TimeSpan.FromMilliseconds(100);
+    private static TaskCompletionSource AwaitingPendingModuleStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private static TaskCompletionSource PeerModuleStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private static string CommandReadyFile = string.Empty;
 
@@ -132,6 +133,40 @@ public class EngineCancellationTokenTests : TestBase
     private class WaitForAllPendingModule : Module<bool>
     {
         protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
+    private class AwaitingPendingModule : Module<bool>
+    {
+        protected internal override async Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            AwaitingPendingModuleStarted.TrySetResult();
+            var result = await context.GetModule<CancelledBeforeStartModule>();
+            return result.ValueOrDefault == true;
+        }
+    }
+
+    private class CoordinatedFailingModule : Module<bool>
+    {
+        protected internal override async Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            await AwaitingPendingModuleStarted.Task.WaitAsync(cancellationToken);
+            throw new InvalidOperationException("Coordinated failure");
+        }
+    }
+
+    [ModularPipelines.Attributes.DependsOn<CoordinatedFailingModule>]
+    private class CancelledBeforeStartModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
         {
             return Task.FromResult(true);
         }
@@ -263,6 +298,33 @@ public class EngineCancellationTokenTests : TestBase
         var longRunningModuleResult = resultRegistry.GetResult(typeof(LongRunningModuleWithoutCancellation));
         await Assert.That(longRunningModuleResult).IsNotNull();
         await Assert.That(longRunningModuleResult!.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+    }
+
+    [Test]
+    public async Task CancelledBeforeStartModule_UnblocksRuntimeAwaiter()
+    {
+        AwaitingPendingModuleStarted =
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var builder = TestPipelineHostBuilder.Create()
+            .ConfigurePipelineOptions(options => options with
+            {
+                DefaultModuleTimeout = TimeSpan.Zero,
+                ThrowOnPipelineFailure = true,
+                Concurrency = options.Concurrency with
+                {
+                    MaxParallelism = 2,
+                },
+            })
+            .AddModule<AwaitingPendingModule>()
+            .AddModule<CoordinatedFailingModule>()
+            .AddModule<CancelledBeforeStartModule>();
+
+        var exception = await Assert.ThrowsAsync<ModuleFailedException>(
+            async () => await builder.ExecutePipelineAsync().WaitAsync(TimeSpan.FromSeconds(5)));
+
+        await Assert.That(exception!.InnerException).IsTypeOf<InvalidOperationException>();
+        await Assert.That(exception.InnerException!).HasMessageEqualTo("Coordinated failure");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -207,6 +207,37 @@ public class EngineCancellationTokenTests : TestBase
         }
     }
 
+    private class StopOnFirstFailingModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            throw new InvalidOperationException("Stop-on-first failure");
+        }
+    }
+
+    private class StopOnFirstQueuedDependencyModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
+    [ModularPipelines.Attributes.DependsOn<StopOnFirstQueuedDependencyModule>]
+    private class StopOnFirstPendingModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
     [Test]
     public async Task Dispose_Releases_Global_Event_Subscriptions()
     {
@@ -387,6 +418,44 @@ public class EngineCancellationTokenTests : TestBase
 
         await Assert.That(exception!.InnerException).IsTypeOf<InvalidOperationException>();
         await Assert.That(exception.InnerException!).HasMessageEqualTo("Dependency failure");
+    }
+
+    [Test]
+    public async Task StopOnFirstException_PendingModuleAwaiterReturnsTerminatedResult()
+    {
+        var builder = TestPipelineHostBuilder.Create()
+            .ConfigurePipelineOptions(options => options with
+            {
+                DefaultModuleTimeout = TimeSpan.Zero,
+                ThrowOnPipelineFailure = true,
+                Concurrency = options.Concurrency with
+                {
+                    MaxParallelism = 1,
+                },
+            })
+            .AddModule<StopOnFirstFailingModule>()
+            .AddModule<StopOnFirstQueuedDependencyModule>()
+            .AddModule<StopOnFirstPendingModule>();
+
+        var host = await builder.BuildAsync();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+        var pendingModule = host.Services.GetServices<IModule>()
+            .OfType<StopOnFirstPendingModule>()
+            .Single();
+
+        var exception = await Assert.ThrowsAsync<ModuleFailedException>(
+            async () => await host.RunAsync().WaitAsync(TimeSpan.FromSeconds(5)));
+        var awaitedResult = await ((IModule)pendingModule).ResultTask
+            .WaitAsync(TimeSpan.FromSeconds(1));
+        var registeredResult = resultRegistry.GetResult(typeof(StopOnFirstPendingModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(awaitedResult).IsSameReferenceAs(registeredResult);
+            await Assert.That(awaitedResult.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+            await Assert.That(awaitedResult.ExceptionOrDefault)
+                .IsSameReferenceAs(exception);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -21,6 +21,7 @@ public class EngineCancellationTokenTests : TestBase
 {
     private static readonly TimeSpan WaitForCancellationDelay = TimeSpan.FromMilliseconds(100);
     private static TaskCompletionSource AwaitingPendingModuleStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private static TaskCompletionSource AwaitingTerminatedModuleStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private static TaskCompletionSource PeerModuleStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private static string CommandReadyFile = string.Empty;
 
@@ -163,6 +164,40 @@ public class EngineCancellationTokenTests : TestBase
 
     [ModularPipelines.Attributes.DependsOn<CoordinatedFailingModule>]
     private class CancelledBeforeStartModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
+    private class AwaitingTerminatedModule : Module<bool>
+    {
+        protected internal override async Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            AwaitingTerminatedModuleStarted.TrySetResult();
+            var result = await context.GetModule<TerminatedBeforeExecutionModule>();
+            return result.ModuleStatus == Status.PipelineTerminated;
+        }
+    }
+
+    private class CoordinatedDependencyFailureModule : Module<bool>
+    {
+        protected internal override async Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            await AwaitingTerminatedModuleStarted.Task.WaitAsync(cancellationToken);
+            throw new InvalidOperationException("Dependency failure");
+        }
+    }
+
+    [ModularPipelines.Attributes.DependsOn<CoordinatedDependencyFailureModule>]
+    private class TerminatedBeforeExecutionModule : Module<bool>
     {
         protected internal override Task<bool> ExecuteAsync(
             IModuleContext context,
@@ -325,6 +360,33 @@ public class EngineCancellationTokenTests : TestBase
 
         await Assert.That(exception!.InnerException).IsTypeOf<InvalidOperationException>();
         await Assert.That(exception.InnerException!).HasMessageEqualTo("Coordinated failure");
+    }
+
+    [Test]
+    public async Task TerminatedBeforeExecutionModule_UnblocksRuntimeAwaiter()
+    {
+        AwaitingTerminatedModuleStarted =
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var builder = TestPipelineHostBuilder.Create()
+            .ConfigurePipelineOptions(options => options with
+            {
+                DefaultModuleTimeout = TimeSpan.Zero,
+                ThrowOnPipelineFailure = true,
+                Concurrency = options.Concurrency with
+                {
+                    MaxParallelism = 2,
+                },
+            })
+            .AddModule<AwaitingTerminatedModule>()
+            .AddModule<CoordinatedDependencyFailureModule>()
+            .AddModule<TerminatedBeforeExecutionModule>();
+
+        var exception = await Assert.ThrowsAsync<ModuleFailedException>(
+            async () => await builder.ExecutePipelineAsync().WaitAsync(TimeSpan.FromSeconds(5)));
+
+        await Assert.That(exception!.InnerException).IsTypeOf<InvalidOperationException>();
+        await Assert.That(exception.InnerException!).HasMessageEqualTo("Dependency failure");
     }
 
     [Test]


### PR DESCRIPTION
Closes #3458

## Summary
- complete every pending or queued `Module<T>` typed completion source during scheduler cancellation
- register rich `PipelineTerminated` results without racing bare task cancellation
- handle standalone, dynamic runtime-await, `AlwaysRun`, dependency-failure, and distributed cancellation paths
- use generated runtime metadata when available, with a cached reflection fallback for dynamic modules

## Validation
- `EngineCancellationTokenTests`: 9/9 passed
- `ModuleExecutorLoggingTests`: 11/11 passed
- `GeneratedModuleMetadataTests`: 9/9 passed
- distributed executor tests: 22/22 passed
- distributed test project Release build: 0 errors
- `ModularPipelines.sln` Release build: 0 errors (existing warnings only)
- scoped whitespace verification: passed

The latest follow-up updates all distributed executor fixtures for the new required `IModuleResultRegistrar` dependency, fixing the cross-platform CI compilation failure.


### Collector race follow-up
- Reserve the scheduler start transition before publishing an assignment, so terminal modules are not published and constraint-deferred modules are safely requeued without duplicate side effects.
- `DistributedModuleExecutorTests`: 24/24.


