### PR TITLE
fix(http): stream response bodies

### DIFF
--- a/src/ModularPipelines/Context/Downloader.cs
+++ b/src/ModularPipelines/Context/Downloader.cs
@@ -25,14 +25,14 @@ internal class Downloader : IDownloaderContext
     public async Task<string?> DownloadStringAsync(DownloadOptions options,
         CancellationToken cancellationToken = default)
     {
-        var response = await DownloadResponseAsync(options, cancellationToken).ConfigureAwait(false);
+        using var response = await DownloadResponseAsync(options, cancellationToken).ConfigureAwait(false);
 
         return await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
     }
 
     public async Task<File> DownloadFileAsync(DownloadFileOptions options, CancellationToken cancellationToken = default)
     {
-        var response = await DownloadResponseAsync(options, cancellationToken).ConfigureAwait(false);
+        using var response = await DownloadResponseAsync(options, cancellationToken).ConfigureAwait(false);
 
         var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         await using (stream.ConfigureAwait(false))

--- a/src/ModularPipelines/Context/Downloader.cs
+++ b/src/ModularPipelines/Context/Downloader.cs
@@ -44,10 +44,23 @@ internal class Downloader : IDownloaderContext
                 throw new IOException($"{filePathToSave} already exists and overwrite is false");
             }
 
-            var newFile = _fileSystemProvider.Create(filePathToSave);
-            await using (newFile.ConfigureAwait(false))
+            var temporaryPath = filePathToSave + "." + _fileSystemProvider.GetRandomFileName() + ".download";
+            try
             {
-                await stream.CopyToAsync(newFile, cancellationToken).ConfigureAwait(false);
+                var newFile = _fileSystemProvider.Create(temporaryPath);
+                await using (newFile.ConfigureAwait(false))
+                {
+                    await stream.CopyToAsync(newFile, cancellationToken).ConfigureAwait(false);
+                }
+
+                _fileSystemProvider.MoveFile(temporaryPath, filePathToSave, options.Overwrite);
+            }
+            finally
+            {
+                if (_fileSystemProvider.FileExists(temporaryPath))
+                {
+                    _fileSystemProvider.DeleteFile(temporaryPath);
+                }
             }
 
             _moduleLoggerProvider.GetLogger().LogInformation("File {Uri} downloaded to {SaveLocation}", options.DownloadUri, filePathToSave);

--- a/src/ModularPipelines/Context/Downloader.cs
+++ b/src/ModularPipelines/Context/Downloader.cs
@@ -68,7 +68,15 @@ internal class Downloader : IDownloaderContext
             HttpClient = options.HttpClient,
         }, cancellationToken).ConfigureAwait(false);
 
-        return await response.EnsureSuccessStatusCodeWithContentAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            return await response.EnsureSuccessStatusCodeWithContentAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            response.Dispose();
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/ModularPipelines/Context/Downloader.cs
+++ b/src/ModularPipelines/Context/Downloader.cs
@@ -44,7 +44,10 @@ internal class Downloader : IDownloaderContext
                 throw new IOException($"{filePathToSave} already exists and overwrite is false");
             }
 
-            var temporaryPath = filePathToSave + "." + _fileSystemProvider.GetRandomFileName() + ".download";
+            var destinationDirectory = Path.GetDirectoryName(filePathToSave);
+            var temporaryPath = Path.Combine(
+                destinationDirectory ?? string.Empty,
+                _fileSystemProvider.GetRandomFileName());
             try
             {
                 var newFile = _fileSystemProvider.Create(temporaryPath);

--- a/src/ModularPipelines/FileSystem/IFileSystemProvider.cs
+++ b/src/ModularPipelines/FileSystem/IFileSystemProvider.cs
@@ -8,25 +8,36 @@ public interface IFileSystemProvider
 {
     // File read operations
     Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken = default);
+
     IAsyncEnumerable<string> ReadLinesAsync(string path, CancellationToken cancellationToken = default);
+
     Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default);
 
     // File write operations
     Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken = default);
+
     Task WriteAllBytesAsync(string path, byte[] contents, CancellationToken cancellationToken = default);
+
     Task WriteAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default);
+
     Task AppendAllTextAsync(string path, string contents, CancellationToken cancellationToken = default);
+
     Task AppendAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default);
 
     // File stream operations
     Stream OpenRead(string path);
+
     Stream Create(string path);
+
     Stream Open(string path, FileMode mode, FileAccess access);
 
     // File management operations
     void DeleteFile(string path);
+
     void CopyFile(string sourcePath, string destinationPath, bool overwrite);
+
     void MoveFile(string sourcePath, string destinationPath);
+
     void MoveFile(string sourcePath, string destinationPath, bool overwrite)
     {
         if (overwrite && FileExists(destinationPath))
@@ -42,15 +53,23 @@ public interface IFileSystemProvider
 
     // Directory operations
     void CreateDirectory(string path);
+
     void DeleteDirectory(string path, bool recursive);
+
     void MoveDirectory(string sourcePath, string destinationPath);
+
     bool DirectoryExists(string path);
+
     IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption);
+
     IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption);
 
     // Path operations
     string GetTempPath();
+
     string GetRandomFileName();
+
     string Combine(params string[] paths);
+
     string GetRelativePath(string relativeTo, string path);
 }

--- a/src/ModularPipelines/FileSystem/IFileSystemProvider.cs
+++ b/src/ModularPipelines/FileSystem/IFileSystemProvider.cs
@@ -27,6 +27,16 @@ public interface IFileSystemProvider
     void DeleteFile(string path);
     void CopyFile(string sourcePath, string destinationPath, bool overwrite);
     void MoveFile(string sourcePath, string destinationPath);
+    void MoveFile(string sourcePath, string destinationPath, bool overwrite)
+    {
+        if (overwrite && FileExists(destinationPath))
+        {
+            DeleteFile(destinationPath);
+        }
+
+        MoveFile(sourcePath, destinationPath);
+    }
+
     bool FileExists(string path);
 
     // Directory operations

--- a/src/ModularPipelines/FileSystem/IFileSystemProvider.cs
+++ b/src/ModularPipelines/FileSystem/IFileSystemProvider.cs
@@ -31,7 +31,8 @@ public interface IFileSystemProvider
     {
         if (overwrite && FileExists(destinationPath))
         {
-            DeleteFile(destinationPath);
+            throw new NotSupportedException(
+                "This file system provider does not support atomic overwrite moves.");
         }
 
         MoveFile(sourcePath, destinationPath);

--- a/src/ModularPipelines/FileSystem/SystemFileSystemProvider.cs
+++ b/src/ModularPipelines/FileSystem/SystemFileSystemProvider.cs
@@ -61,6 +61,9 @@ public sealed class SystemFileSystemProvider : IFileSystemProvider
     public void MoveFile(string sourcePath, string destinationPath)
         => System.IO.File.Move(sourcePath, destinationPath);
 
+    public void MoveFile(string sourcePath, string destinationPath, bool overwrite)
+        => System.IO.File.Move(sourcePath, destinationPath, overwrite);
+
     public bool FileExists(string path)
         => System.IO.File.Exists(path);
 

--- a/src/ModularPipelines/FileSystem/SystemFileSystemProvider.cs
+++ b/src/ModularPipelines/FileSystem/SystemFileSystemProvider.cs
@@ -9,11 +9,13 @@ namespace ModularPipelines.FileSystem;
 public sealed class SystemFileSystemProvider : IFileSystemProvider
 {
     /// <summary>
-    /// Singleton instance for use when no DI is available.
+    /// Gets singleton instance for use when no DI is available.
     /// </summary>
     public static SystemFileSystemProvider Instance { get; } = new();
 
-    private SystemFileSystemProvider() { }
+    private SystemFileSystemProvider()
+    {
+    }
 
     // File read operations
     public Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken = default)

--- a/src/ModularPipelines/Http/Http.cs
+++ b/src/ModularPipelines/Http/Http.cs
@@ -28,8 +28,12 @@ internal class Http : IHttpContext
 
     public async Task<HttpResponseMessage> SendAsync(HttpOptions httpOptions, CancellationToken cancellationToken = default)
     {
-        // Priority: options property > pipeline default > no timeout
-        var effectiveTimeout = httpOptions.Timeout ?? _pipelineOptions.Value.DefaultHttpTimeout;
+        var httpClient = httpOptions.HttpClient ?? GetHttpClient(httpOptions.LoggingType);
+
+        // Priority: options property > pipeline default > HttpClient timeout
+        var effectiveTimeout = httpOptions.Timeout
+                               ?? _pipelineOptions.Value.DefaultHttpTimeout
+                               ?? GetFiniteTimeout(httpClient);
 
         // Create timeout token if timeout is specified
         var timeoutCts = effectiveTimeout.HasValue
@@ -61,13 +65,12 @@ internal class Http : IHttpContext
             if (httpOptions.HttpClient != null)
             {
                 return await SendAndWrapLogging(
+                        httpClient,
                         httpOptions,
                         WrapResponse,
                         effectiveCancellationToken)
                     .ConfigureAwait(false);
             }
-
-            var httpClient = GetHttpClient(httpOptions.LoggingType);
 
             var response = await httpClient.SendAsync(
                     httpOptions.HttpRequestMessage,
@@ -107,6 +110,7 @@ internal class Http : IHttpContext
     }
 
     private async Task<HttpResponseMessage> SendAndWrapLogging(
+        HttpClient httpClient,
         HttpOptions httpOptions,
         Func<HttpResponseMessage, HttpResponseMessage> wrapResponse,
         CancellationToken cancellationToken)
@@ -127,7 +131,7 @@ internal class Http : IHttpContext
 
         var stopWatch = Stopwatch.StartNew();
 
-        var response = await httpOptions.HttpClient!.SendAsync(
+        var response = await httpClient.SendAsync(
                 httpOptions.HttpRequestMessage,
                 HttpCompletionOption.ResponseHeadersRead,
                 cancellationToken)
@@ -174,6 +178,13 @@ internal class Http : IHttpContext
         }
 
         return HttpLoggingOptions.Default;
+    }
+
+    private static TimeSpan? GetFiniteTimeout(HttpClient httpClient)
+    {
+        return httpClient.Timeout == System.Threading.Timeout.InfiniteTimeSpan
+            ? null
+            : httpClient.Timeout;
     }
 
     private void LogDuration(TimeSpan duration, HttpOptions httpOptions, HttpLoggingOptions loggingOptions)

--- a/src/ModularPipelines/Http/Http.cs
+++ b/src/ModularPipelines/Http/Http.cs
@@ -137,7 +137,6 @@ internal class Http : IHttpContext
                 cancellationToken)
             .ConfigureAwait(false);
 
-        response = wrapResponse(response);
         try
         {
             LogStatusCode(response.StatusCode, httpOptions, loggingOptions);
@@ -149,6 +148,8 @@ internal class Http : IHttpContext
                     .PrintResponse(response, logger, loggingOptions, cancellationToken)
                     .ConfigureAwait(false);
             }
+
+            response = wrapResponse(response);
 
             if (!httpOptions.ThrowOnNonSuccessStatusCode)
             {

--- a/src/ModularPipelines/Http/Http.cs
+++ b/src/ModularPipelines/Http/Http.cs
@@ -40,10 +40,13 @@ internal class Http : IHttpContext
             ? new CancellationTokenSource(effectiveTimeout.Value)
             : null;
 
-        // Link the timeout token with the passed cancellation token, or just use the original if no timeout
+        // Keep caller cancellation alive through streamed body consumption even when no
+        // finite timeout applies.
         var linkedCts = timeoutCts != null
             ? CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken)
-            : null;
+            : cancellationToken.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken)
+                : null;
 
         var effectiveCancellationToken = linkedCts?.Token ?? cancellationToken;
 
@@ -51,7 +54,7 @@ internal class Http : IHttpContext
         {
             HttpResponseMessage WrapResponse(HttpResponseMessage response)
             {
-                if (timeoutCts is null || linkedCts is null)
+                if (linkedCts is null)
                 {
                     return response;
                 }

--- a/src/ModularPipelines/Http/Http.cs
+++ b/src/ModularPipelines/Http/Http.cs
@@ -50,7 +50,11 @@ internal class Http : IHttpContext
 
         var httpClient = GetHttpClient(httpOptions.LoggingType);
 
-        var response = await httpClient.SendAsync(httpOptions.HttpRequestMessage, effectiveCancellationToken).ConfigureAwait(false);
+        var response = await httpClient.SendAsync(
+                httpOptions.HttpRequestMessage,
+                HttpCompletionOption.ResponseHeadersRead,
+                effectiveCancellationToken)
+            .ConfigureAwait(false);
 
         if (!httpOptions.ThrowOnNonSuccessStatusCode)
         {
@@ -78,7 +82,11 @@ internal class Http : IHttpContext
 
         var stopWatch = Stopwatch.StartNew();
 
-        var response = await httpOptions.HttpClient!.SendAsync(httpOptions.HttpRequestMessage, cancellationToken).ConfigureAwait(false);
+        var response = await httpOptions.HttpClient!.SendAsync(
+                httpOptions.HttpRequestMessage,
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken)
+            .ConfigureAwait(false);
 
         LogStatusCode(response.StatusCode, httpOptions, loggingOptions);
         LogDuration(stopWatch.Elapsed, httpOptions, loggingOptions);

--- a/src/ModularPipelines/Http/Http.cs
+++ b/src/ModularPipelines/Http/Http.cs
@@ -32,36 +32,72 @@ internal class Http : IHttpContext
         var effectiveTimeout = httpOptions.Timeout ?? _pipelineOptions.Value.DefaultHttpTimeout;
 
         // Create timeout token if timeout is specified
-        using var timeoutCts = effectiveTimeout.HasValue
+        var timeoutCts = effectiveTimeout.HasValue
             ? new CancellationTokenSource(effectiveTimeout.Value)
             : null;
 
         // Link the timeout token with the passed cancellation token, or just use the original if no timeout
-        using var linkedCts = timeoutCts != null
+        var linkedCts = timeoutCts != null
             ? CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken)
             : null;
 
         var effectiveCancellationToken = linkedCts?.Token ?? cancellationToken;
 
-        if (httpOptions.HttpClient != null)
+        try
         {
-            return await SendAndWrapLogging(httpOptions, effectiveCancellationToken).ConfigureAwait(false);
+            HttpResponseMessage WrapResponse(HttpResponseMessage response)
+            {
+                if (timeoutCts is null || linkedCts is null)
+                {
+                    return response;
+                }
+
+                response.Content = new TimeoutHttpContent(response.Content, timeoutCts, linkedCts);
+                timeoutCts = null;
+                linkedCts = null;
+                return response;
+            }
+
+            if (httpOptions.HttpClient != null)
+            {
+                return await SendAndWrapLogging(
+                        httpOptions,
+                        WrapResponse,
+                        effectiveCancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            var httpClient = GetHttpClient(httpOptions.LoggingType);
+
+            var response = await httpClient.SendAsync(
+                    httpOptions.HttpRequestMessage,
+                    HttpCompletionOption.ResponseHeadersRead,
+                    effectiveCancellationToken)
+                .ConfigureAwait(false);
+
+            response = WrapResponse(response);
+            try
+            {
+                if (!httpOptions.ThrowOnNonSuccessStatusCode)
+                {
+                    return response;
+                }
+
+                return await response
+                    .EnsureSuccessStatusCodeWithContentAsync(effectiveCancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                response.Dispose();
+                throw;
+            }
         }
-
-        var httpClient = GetHttpClient(httpOptions.LoggingType);
-
-        var response = await httpClient.SendAsync(
-                httpOptions.HttpRequestMessage,
-                HttpCompletionOption.ResponseHeadersRead,
-                effectiveCancellationToken)
-            .ConfigureAwait(false);
-
-        if (!httpOptions.ThrowOnNonSuccessStatusCode)
+        finally
         {
-            return response;
+            linkedCts?.Dispose();
+            timeoutCts?.Dispose();
         }
-
-        return await response.EnsureSuccessStatusCodeWithContentAsync(effectiveCancellationToken).ConfigureAwait(false);
     }
 
     private HttpClient GetHttpClient(HttpLoggingType loggingType)
@@ -70,7 +106,10 @@ internal class Http : IHttpContext
         return _httpClientFactory.CreateClient(clientName);
     }
 
-    private async Task<HttpResponseMessage> SendAndWrapLogging(HttpOptions httpOptions, CancellationToken cancellationToken)
+    private async Task<HttpResponseMessage> SendAndWrapLogging(
+        HttpOptions httpOptions,
+        Func<HttpResponseMessage, HttpResponseMessage> wrapResponse,
+        CancellationToken cancellationToken)
     {
         var logger = _moduleLoggerProvider.GetLogger();
         var loggingOptions = GetEffectiveLoggingOptions(httpOptions);
@@ -88,20 +127,29 @@ internal class Http : IHttpContext
                 cancellationToken)
             .ConfigureAwait(false);
 
-        LogStatusCode(response.StatusCode, httpOptions, loggingOptions);
-        LogDuration(stopWatch.Elapsed, httpOptions, loggingOptions);
-
-        if (httpOptions.LoggingType.HasFlag(HttpLoggingType.Response))
+        response = wrapResponse(response);
+        try
         {
-            await _httpLogger.PrintResponse(response, logger, loggingOptions).ConfigureAwait(false);
-        }
+            LogStatusCode(response.StatusCode, httpOptions, loggingOptions);
+            LogDuration(stopWatch.Elapsed, httpOptions, loggingOptions);
 
-        if (!httpOptions.ThrowOnNonSuccessStatusCode)
+            if (httpOptions.LoggingType.HasFlag(HttpLoggingType.Response))
+            {
+                await _httpLogger.PrintResponse(response, logger, loggingOptions).ConfigureAwait(false);
+            }
+
+            if (!httpOptions.ThrowOnNonSuccessStatusCode)
+            {
+                return response;
+            }
+
+            return await response.EnsureSuccessStatusCodeWithContentAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
         {
-            return response;
+            response.Dispose();
+            throw;
         }
-
-        return await response.EnsureSuccessStatusCodeWithContentAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private HttpLoggingOptions GetEffectiveLoggingOptions(HttpOptions httpOptions)

--- a/src/ModularPipelines/Http/Http.cs
+++ b/src/ModularPipelines/Http/Http.cs
@@ -116,7 +116,13 @@ internal class Http : IHttpContext
 
         if (httpOptions.LoggingType.HasFlag(HttpLoggingType.Request))
         {
-            await _httpLogger.PrintRequest(httpOptions.HttpRequestMessage, logger, loggingOptions).ConfigureAwait(false);
+            await _httpLogger
+                .PrintRequest(
+                    httpOptions.HttpRequestMessage,
+                    logger,
+                    loggingOptions,
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
 
         var stopWatch = Stopwatch.StartNew();
@@ -135,7 +141,9 @@ internal class Http : IHttpContext
 
             if (httpOptions.LoggingType.HasFlag(HttpLoggingType.Response))
             {
-                await _httpLogger.PrintResponse(response, logger, loggingOptions).ConfigureAwait(false);
+                await _httpLogger
+                    .PrintResponse(response, logger, loggingOptions, cancellationToken)
+                    .ConfigureAwait(false);
             }
 
             if (!httpOptions.ThrowOnNonSuccessStatusCode)

--- a/src/ModularPipelines/Http/HttpBodySecretRedactor.cs
+++ b/src/ModularPipelines/Http/HttpBodySecretRedactor.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Options;
+using ModularPipelines.Constants;
+using ModularPipelines.Engine;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Http;
+
+internal static class HttpBodySecretRedactor
+{
+    public static string Redact(
+        string body,
+        bool isTruncated,
+        ISecretObfuscator secretObfuscator,
+        ISecretProvider secretProvider,
+        IOptions<SecretMaskingOptions> maskingOptions)
+    {
+        var boundarySafeBody = isTruncated
+            ? RedactPartialSecretAtBoundary(body, secretProvider.GetSnapshot().Secrets, maskingOptions.Value)
+            : body;
+        return secretObfuscator.Obfuscate(boundarySafeBody, null);
+    }
+
+    private static string RedactPartialSecretAtBoundary(
+        string body,
+        IReadOnlyList<string> secrets,
+        SecretMaskingOptions options)
+    {
+        if (body.Length == 0)
+        {
+            return body;
+        }
+
+        var comparison = options.CaseInsensitive
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        var longestPartialMatch = 0;
+
+        foreach (var secret in secrets)
+        {
+            var maximumLength = Math.Min(body.Length, secret.Length - 1);
+            for (var length = maximumLength; length > longestPartialMatch; length--)
+            {
+                if (body.AsSpan(body.Length - length, length)
+                    .Equals(secret.AsSpan(0, length), comparison))
+                {
+                    longestPartialMatch = length;
+                    break;
+                }
+            }
+        }
+
+        if (longestPartialMatch == 0)
+        {
+            return body;
+        }
+
+        var mask = string.IsNullOrWhiteSpace(options.MaskValue)
+            ? LoggingConstants.SecretMask
+            : options.MaskValue;
+        return string.Concat(body.AsSpan(0, body.Length - longestPartialMatch), mask);
+    }
+}

--- a/src/ModularPipelines/Http/HttpContentPreviewReader.cs
+++ b/src/ModularPipelines/Http/HttpContentPreviewReader.cs
@@ -82,6 +82,7 @@ internal static class HttpContentPreviewReader
     /// <param name="maxBytes">The maximum number of bytes to include in the preview.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The preview, truncation state, replayable content, and total length.</returns>
+    /// <remarks>This method takes ownership of and disposes <paramref name="content"/>.</remarks>
     public static async Task<(string Preview, bool IsTruncated, HttpContent ReplayContent, long? TotalLength)>
         ReadReplayableAsync(
             HttpContent content,

--- a/src/ModularPipelines/Http/HttpContentPreviewReader.cs
+++ b/src/ModularPipelines/Http/HttpContentPreviewReader.cs
@@ -28,21 +28,36 @@ internal static class HttpContentPreviewReader
         }
 
         var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var cancellationRegistration = cancellationToken.Register(
+            static state => ((Stream) state!).Dispose(),
+            stream);
         var buffer = new byte[maxBytes + 1];
         var bytesRead = 0;
 
-        while (bytesRead < buffer.Length)
+        try
         {
-            var read = await stream.ReadAsync(
-                    buffer.AsMemory(bytesRead, buffer.Length - bytesRead),
-                    cancellationToken)
-                .ConfigureAwait(false);
-            if (read == 0)
+            while (bytesRead < buffer.Length)
             {
-                break;
-            }
+                var read = await stream.ReadAsync(
+                        buffer.AsMemory(bytesRead, buffer.Length - bytesRead),
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                if (read == 0)
+                {
+                    break;
+                }
 
-            bytesRead += read;
+                bytesRead += read;
+            }
+        }
+        catch (Exception exception)
+            when (cancellationToken.IsCancellationRequested
+                  && exception is ObjectDisposedException or IOException)
+        {
+            throw new OperationCanceledException(
+                "The HTTP content preview read was cancelled.",
+                exception,
+                cancellationToken);
         }
 
         var isTruncated = bytesRead > maxBytes;

--- a/src/ModularPipelines/Http/HttpContentPreviewReader.cs
+++ b/src/ModularPipelines/Http/HttpContentPreviewReader.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Text;
 
 namespace ModularPipelines.Http;
@@ -7,6 +8,8 @@ namespace ModularPipelines.Http;
 /// </summary>
 internal static class HttpContentPreviewReader
 {
+    private const int MaximumPreviewBufferSize = 81920;
+
     /// <summary>
     /// Reads at most one byte beyond the configured preview limit.
     /// </summary>
@@ -37,23 +40,29 @@ internal static class HttpContentPreviewReader
         using var cancellationRegistration = cancellationToken.Register(
             static state => ((Stream) state!).Dispose(),
             stream);
-        var buffer = new byte[maxBytes + 1];
-        var bytesRead = 0;
+        var probeLength = maxBytes + 1;
+        var readBuffer = ArrayPool<byte>.Shared.Rent(
+            Math.Min(probeLength, MaximumPreviewBufferSize));
+        using var buffer = new MemoryStream(GetInitialCapacity(content, probeLength));
 
         try
         {
-            while (bytesRead < buffer.Length)
+            while (buffer.Length < probeLength)
             {
+                var bytesRemaining = probeLength - (int) buffer.Length;
                 var read = await stream.ReadAsync(
-                        buffer.AsMemory(bytesRead, buffer.Length - bytesRead),
+                        readBuffer.AsMemory(
+                            0,
+                            Math.Min(MaximumPreviewBufferSize, bytesRemaining)),
                         cancellationToken)
                     .ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
                 if (read == 0)
                 {
                     break;
                 }
 
-                bytesRead += read;
+                buffer.Write(readBuffer, 0, read);
             }
         }
         catch (Exception exception)
@@ -65,12 +74,18 @@ internal static class HttpContentPreviewReader
                 exception,
                 cancellationToken);
         }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(readBuffer);
+        }
 
+        var bufferedBytes = buffer.ToArray();
+        var bytesRead = bufferedBytes.Length;
         var isTruncated = bytesRead > maxBytes;
         var previewLength = Math.Min(bytesRead, maxBytes);
         var encoding = GetEncoding(content);
-        var preview = DecodeCompletePrefix(encoding, buffer, previewLength);
-        var replayContent = CreateReplayContent(content, stream, buffer.AsSpan(0, bytesRead).ToArray());
+        var preview = DecodeCompletePrefix(encoding, bufferedBytes, previewLength);
+        var replayContent = CreateReplayContent(content, stream, bufferedBytes);
 
         return (preview, isTruncated, replayContent, content.Headers.ContentLength);
     }
@@ -131,6 +146,14 @@ internal static class HttpContentPreviewReader
                 exception,
                 cancellationToken);
         }
+    }
+
+    private static int GetInitialCapacity(HttpContent content, int probeLength)
+    {
+        var declaredLength = content.Headers.ContentLength;
+        return declaredLength is >= 0
+            ? (int) Math.Min(Math.Min(declaredLength.Value, probeLength), MaximumPreviewBufferSize)
+            : Math.Min(probeLength, MaximumPreviewBufferSize);
     }
 
     private static Encoding GetEncoding(HttpContent content)

--- a/src/ModularPipelines/Http/HttpContentPreviewReader.cs
+++ b/src/ModularPipelines/Http/HttpContentPreviewReader.cs
@@ -135,6 +135,7 @@ internal static class HttpContentPreviewReader
         try
         {
             await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
             return buffer.ToArray();
         }
         catch (Exception exception)

--- a/src/ModularPipelines/Http/HttpContentPreviewReader.cs
+++ b/src/ModularPipelines/Http/HttpContentPreviewReader.cs
@@ -1,0 +1,170 @@
+using System.Text;
+
+namespace ModularPipelines.Http;
+
+/// <summary>
+/// Reads bounded text previews while preserving the complete content stream for its consumer.
+/// </summary>
+internal static class HttpContentPreviewReader
+{
+    /// <summary>
+    /// Reads at most one byte beyond the configured preview limit.
+    /// </summary>
+    /// <param name="content">The HTTP content to preview.</param>
+    /// <param name="maxBytes">The maximum number of bytes to include in the preview.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The preview, truncation state, replayable content, and declared total length.</returns>
+    public static async Task<(string Preview, bool IsTruncated, HttpContent ReplayContent, long? TotalLength)>
+        ReadAsync(
+            HttpContent content,
+            int maxBytes,
+            CancellationToken cancellationToken)
+    {
+        if (maxBytes <= 0 || maxBytes == int.MaxValue)
+        {
+            var unboundedBody = await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            return (unboundedBody, false, content, content.Headers.ContentLength);
+        }
+
+        var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var buffer = new byte[maxBytes + 1];
+        var bytesRead = 0;
+
+        while (bytesRead < buffer.Length)
+        {
+            var read = await stream.ReadAsync(
+                    buffer.AsMemory(bytesRead, buffer.Length - bytesRead),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+
+            bytesRead += read;
+        }
+
+        var isTruncated = bytesRead > maxBytes;
+        var previewLength = Math.Min(bytesRead, maxBytes);
+        var encoding = GetEncoding(content);
+        var preview = encoding.GetString(buffer, 0, previewLength);
+        var replayContent = CreateReplayContent(content, stream, buffer.AsSpan(0, bytesRead).ToArray());
+
+        return (preview, isTruncated, replayContent, content.Headers.ContentLength);
+    }
+
+    private static Encoding GetEncoding(HttpContent content)
+    {
+        var charset = content.Headers.ContentType?.CharSet?.Trim('"');
+        if (string.IsNullOrWhiteSpace(charset))
+        {
+            return Encoding.UTF8;
+        }
+
+        try
+        {
+            return Encoding.GetEncoding(charset);
+        }
+        catch (ArgumentException)
+        {
+            return Encoding.UTF8;
+        }
+    }
+
+    private static StreamContent CreateReplayContent(
+        HttpContent originalContent,
+        Stream remainingStream,
+        byte[] prefix)
+    {
+        var replayContent = new StreamContent(
+            new PrefixReplayStream(prefix, remainingStream, originalContent));
+        foreach (var header in originalContent.Headers)
+        {
+            replayContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        return replayContent;
+    }
+
+    private sealed class PrefixReplayStream(
+        byte[] prefix,
+        Stream remainingStream,
+        HttpContent ownedContent) : Stream
+    {
+        private int _prefixPosition;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var prefixBytesRead = ReadPrefix(buffer.AsSpan(offset, count));
+            return prefixBytesRead > 0
+                ? prefixBytesRead
+                : remainingStream.Read(buffer, offset, count);
+        }
+
+        public override Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken)
+        {
+            return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            var prefixBytesRead = ReadPrefix(buffer.Span);
+            return prefixBytesRead > 0
+                ? prefixBytesRead
+                : await remainingStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                ownedContent.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private int ReadPrefix(Span<byte> destination)
+        {
+            var bytesToCopy = Math.Min(destination.Length, prefix.Length - _prefixPosition);
+            if (bytesToCopy <= 0)
+            {
+                return 0;
+            }
+
+            prefix.AsSpan(_prefixPosition, bytesToCopy).CopyTo(destination);
+            _prefixPosition += bytesToCopy;
+            return bytesToCopy;
+        }
+    }
+}

--- a/src/ModularPipelines/Http/HttpContentPreviewReader.cs
+++ b/src/ModularPipelines/Http/HttpContentPreviewReader.cs
@@ -22,6 +22,7 @@ internal static class HttpContentPreviewReader
     {
         if (maxBytes <= 0 || maxBytes == int.MaxValue)
         {
+            // ReadAsStringAsync buffers HttpContent, so returning the same instance preserves replay.
             var unboundedBody = await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             return (unboundedBody, false, content, content.Headers.ContentLength);
         }

--- a/src/ModularPipelines/Http/HttpContentPreviewReader.cs
+++ b/src/ModularPipelines/Http/HttpContentPreviewReader.cs
@@ -54,6 +54,35 @@ internal static class HttpContentPreviewReader
         return (preview, isTruncated, replayContent, content.Headers.ContentLength);
     }
 
+    /// <summary>
+    /// Reads request content into replayable storage so redirects and authentication retries can resend it.
+    /// </summary>
+    /// <param name="content">The HTTP request content to preview.</param>
+    /// <param name="maxBytes">The maximum number of bytes to include in the preview.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The preview, truncation state, replayable content, and total length.</returns>
+    public static async Task<(string Preview, bool IsTruncated, HttpContent ReplayContent, long? TotalLength)>
+        ReadReplayableAsync(
+            HttpContent content,
+            int maxBytes,
+            CancellationToken cancellationToken)
+    {
+        var bytes = await content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        var previewLength = maxBytes <= 0 || maxBytes == int.MaxValue
+            ? bytes.Length
+            : Math.Min(bytes.Length, maxBytes);
+        var isTruncated = previewLength < bytes.Length;
+        var preview = DecodeCompletePrefix(GetEncoding(content), bytes, previewLength);
+        var replayContent = new ByteArrayContent(bytes);
+        CopyHeaders(content, replayContent);
+
+        return (
+            preview,
+            isTruncated,
+            replayContent,
+            content.Headers.ContentLength ?? bytes.LongLength);
+    }
+
     private static Encoding GetEncoding(HttpContent content)
     {
         var charset = content.Headers.ContentType?.CharSet?.Trim('"');
@@ -93,12 +122,17 @@ internal static class HttpContentPreviewReader
     {
         var replayContent = new StreamContent(
             new PrefixReplayStream(prefix, remainingStream, originalContent));
-        foreach (var header in originalContent.Headers)
-        {
-            replayContent.Headers.TryAddWithoutValidation(header.Key, header.Value);
-        }
+        CopyHeaders(originalContent, replayContent);
 
         return replayContent;
+    }
+
+    private static void CopyHeaders(HttpContent source, HttpContent destination)
+    {
+        foreach (var header in source.Headers)
+        {
+            destination.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
     }
 
     private sealed class PrefixReplayStream(

--- a/src/ModularPipelines/Http/HttpContentPreviewReader.cs
+++ b/src/ModularPipelines/Http/HttpContentPreviewReader.cs
@@ -22,9 +22,15 @@ internal static class HttpContentPreviewReader
     {
         if (maxBytes <= 0 || maxBytes == int.MaxValue)
         {
-            // ReadAsStringAsync buffers HttpContent, so returning the same instance preserves replay.
-            var unboundedBody = await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-            return (unboundedBody, false, content, content.Headers.ContentLength);
+            var totalLength = content.Headers.ContentLength;
+            var bytes = await ReadAllBytesAsync(content, cancellationToken).ConfigureAwait(false);
+            var unboundedReplayContent = new ByteArrayContent(bytes);
+            CopyHeaders(content, unboundedReplayContent);
+            content.Dispose();
+            return (DecodeCompletePrefix(GetEncoding(unboundedReplayContent), bytes, bytes.Length),
+                false,
+                unboundedReplayContent,
+                totalLength ?? bytes.LongLength);
         }
 
         var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
@@ -82,7 +88,8 @@ internal static class HttpContentPreviewReader
             int maxBytes,
             CancellationToken cancellationToken)
     {
-        var bytes = await content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        var totalLength = content.Headers.ContentLength;
+        var bytes = await ReadAllBytesAsync(content, cancellationToken).ConfigureAwait(false);
         var previewLength = maxBytes <= 0 || maxBytes == int.MaxValue
             ? bytes.Length
             : Math.Min(bytes.Length, maxBytes);
@@ -90,12 +97,39 @@ internal static class HttpContentPreviewReader
         var preview = DecodeCompletePrefix(GetEncoding(content), bytes, previewLength);
         var replayContent = new ByteArrayContent(bytes);
         CopyHeaders(content, replayContent);
+        content.Dispose();
 
         return (
             preview,
             isTruncated,
             replayContent,
-            content.Headers.ContentLength ?? bytes.LongLength);
+            totalLength ?? bytes.LongLength);
+    }
+
+    private static async Task<byte[]> ReadAllBytesAsync(
+        HttpContent content,
+        CancellationToken cancellationToken)
+    {
+        var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        using var cancellationRegistration = cancellationToken.Register(
+            static state => ((Stream) state!).Dispose(),
+            stream);
+        using var buffer = new MemoryStream();
+
+        try
+        {
+            await stream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+            return buffer.ToArray();
+        }
+        catch (Exception exception)
+            when (cancellationToken.IsCancellationRequested
+                  && exception is ObjectDisposedException or IOException)
+        {
+            throw new OperationCanceledException(
+                "The HTTP content read was cancelled.",
+                exception,
+                cancellationToken);
+        }
     }
 
     private static Encoding GetEncoding(HttpContent content)

--- a/src/ModularPipelines/Http/HttpContentPreviewReader.cs
+++ b/src/ModularPipelines/Http/HttpContentPreviewReader.cs
@@ -48,7 +48,7 @@ internal static class HttpContentPreviewReader
         var isTruncated = bytesRead > maxBytes;
         var previewLength = Math.Min(bytesRead, maxBytes);
         var encoding = GetEncoding(content);
-        var preview = encoding.GetString(buffer, 0, previewLength);
+        var preview = DecodeCompletePrefix(encoding, buffer, previewLength);
         var replayContent = CreateReplayContent(content, stream, buffer.AsSpan(0, bytesRead).ToArray());
 
         return (preview, isTruncated, replayContent, content.Headers.ContentLength);
@@ -70,6 +70,20 @@ internal static class HttpContentPreviewReader
         {
             return Encoding.UTF8;
         }
+    }
+
+    private static string DecodeCompletePrefix(Encoding encoding, byte[] buffer, int length)
+    {
+        var decoder = encoding.GetDecoder();
+        var characters = new char[encoding.GetMaxCharCount(length)];
+        decoder.Convert(
+            buffer.AsSpan(0, length),
+            characters,
+            flush: false,
+            out _,
+            out var charactersUsed,
+            out _);
+        return new string(characters, 0, charactersUsed);
     }
 
     private static StreamContent CreateReplayContent(

--- a/src/ModularPipelines/Http/HttpLogger.cs
+++ b/src/ModularPipelines/Http/HttpLogger.cs
@@ -28,7 +28,20 @@ internal class HttpLogger : IHttpLogger
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public Task PrintRequest(HttpRequestMessage request, IModuleLogger logger)
     {
-        return PrintRequest(request, logger, HttpLoggingOptions.Default);
+        return PrintRequest(
+            request,
+            logger,
+            HttpLoggingOptions.Default,
+            CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public Task PrintRequest(
+        HttpRequestMessage request,
+        IModuleLogger logger,
+        CancellationToken cancellationToken)
+    {
+        return PrintRequest(request, logger, HttpLoggingOptions.Default, cancellationToken);
     }
 
     /// <summary>
@@ -38,14 +51,26 @@ internal class HttpLogger : IHttpLogger
     /// <param name="logger">The current module logger.</param>
     /// <param name="options">Options controlling what parts of the request to log.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public async Task PrintRequest(HttpRequestMessage request, IModuleLogger logger, HttpLoggingOptions options)
+    public Task PrintRequest(HttpRequestMessage request, IModuleLogger logger, HttpLoggingOptions options)
+    {
+        return PrintRequest(request, logger, options, CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public async Task PrintRequest(
+        HttpRequestMessage request,
+        IModuleLogger logger,
+        HttpLoggingOptions options,
+        CancellationToken cancellationToken)
     {
         if (!options.LogRequest)
         {
             return;
         }
 
-        var formattedRequest = await _requestFormatter.FormatAsync(request, options).ConfigureAwait(false);
+        var formattedRequest = await _requestFormatter
+            .FormatAsync(request, options, cancellationToken)
+            .ConfigureAwait(false);
         logger.LogInformation("HTTP Request:\n{Request}", formattedRequest);
     }
 
@@ -57,7 +82,20 @@ internal class HttpLogger : IHttpLogger
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public Task PrintResponse(HttpResponseMessage response, IModuleLogger logger)
     {
-        return PrintResponse(response, logger, HttpLoggingOptions.Default);
+        return PrintResponse(
+            response,
+            logger,
+            HttpLoggingOptions.Default,
+            CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public Task PrintResponse(
+        HttpResponseMessage response,
+        IModuleLogger logger,
+        CancellationToken cancellationToken)
+    {
+        return PrintResponse(response, logger, HttpLoggingOptions.Default, cancellationToken);
     }
 
     /// <summary>
@@ -67,20 +105,32 @@ internal class HttpLogger : IHttpLogger
     /// <param name="logger">The current module logger.</param>
     /// <param name="options">Options controlling what parts of the response to log.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    public async Task PrintResponse(HttpResponseMessage response, IModuleLogger logger, HttpLoggingOptions options)
+    public Task PrintResponse(HttpResponseMessage response, IModuleLogger logger, HttpLoggingOptions options)
+    {
+        return PrintResponse(response, logger, options, CancellationToken.None);
+    }
+
+    /// <inheritdoc/>
+    public async Task PrintResponse(
+        HttpResponseMessage response,
+        IModuleLogger logger,
+        HttpLoggingOptions options,
+        CancellationToken cancellationToken)
     {
         if (!options.LogResponse)
         {
             return;
         }
 
-        var formattedResponse = await _responseFormatter.FormatAsync(response, options).ConfigureAwait(false);
+        var formattedResponse = await _responseFormatter
+            .FormatAsync(response, options, cancellationToken)
+            .ConfigureAwait(false);
         logger.LogInformation("HTTP Response:\n{Response}", formattedResponse);
     }
 
     public void PrintStatusCode(HttpStatusCode? httpStatusCode, IModuleLogger logger)
     {
-        var statusCode = httpStatusCode == null ? null as int? : (int)httpStatusCode;
+        var statusCode = httpStatusCode == null ? null as int? : (int) httpStatusCode;
         var icon = statusCode is >= 200 and < 300 ? "+" : "x";
 
         logger.LogInformation("{Icon} HTTP Status: {StatusCode} {HttpStatusCode}", icon, statusCode, httpStatusCode);

--- a/src/ModularPipelines/Http/HttpRequestFormatter.cs
+++ b/src/ModularPipelines/Http/HttpRequestFormatter.cs
@@ -70,7 +70,7 @@ internal class HttpRequestFormatter : IHttpRequestFormatter
 
         if (options.LogRequestBody)
         {
-            await AppendBodyAsync(sb, request.Content, options.MaxBodySizeToLog, cancellationToken).ConfigureAwait(false);
+            await AppendBodyAsync(sb, request, options.MaxBodySizeToLog, cancellationToken).ConfigureAwait(false);
         }
 
         return sb.ToString();
@@ -127,10 +127,15 @@ internal class HttpRequestFormatter : IHttpRequestFormatter
         return false;
     }
 
-    private async Task AppendBodyAsync(StringBuilder sb, HttpContent? content, int maxBodySize, CancellationToken cancellationToken)
+    private async Task AppendBodyAsync(
+        StringBuilder sb,
+        HttpRequestMessage request,
+        int maxBodySize,
+        CancellationToken cancellationToken)
     {
         sb.AppendLine("Body");
 
+        var content = request.Content;
         if (content == null)
         {
             sb.AppendLine("\t(null)");
@@ -146,9 +151,12 @@ internal class HttpRequestFormatter : IHttpRequestFormatter
             return;
         }
 
-        var body = await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        var (body, isTruncated, replayContent, totalLength) = await HttpContentPreviewReader
+            .ReadAsync(content, maxBodySize, cancellationToken)
+            .ConfigureAwait(false);
+        request.Content = replayContent;
 
-        if (string.IsNullOrWhiteSpace(body))
+        if (string.IsNullOrWhiteSpace(body) && !isTruncated)
         {
             sb.AppendLine("\t(empty)");
             return;
@@ -157,16 +165,22 @@ internal class HttpRequestFormatter : IHttpRequestFormatter
         // Obfuscate sensitive values in the body
         var obfuscatedBody = _secretObfuscator.Obfuscate(body, null);
 
-        // Truncate if body is too large
-        if (maxBodySize > 0 && obfuscatedBody.Length > maxBodySize)
+        sb.AppendLine($"\t{obfuscatedBody}");
+        if (isTruncated)
         {
-            sb.AppendLine($"\t{obfuscatedBody[..maxBodySize]}");
-            sb.AppendLine($"\t... [truncated, total size: {obfuscatedBody.Length:N0} characters]");
+            AppendTruncationMessage(sb, maxBodySize, totalLength);
         }
-        else
-        {
-            sb.AppendLine($"\t{obfuscatedBody}");
-        }
+    }
+
+    private static void AppendTruncationMessage(
+        StringBuilder sb,
+        int maxBodySize,
+        long? totalLength)
+    {
+        var size = totalLength.HasValue
+            ? $"total size: {totalLength.Value:N0} bytes"
+            : $"after {maxBodySize:N0} bytes";
+        sb.AppendLine($"\t... [truncated, {size}]");
     }
 
     private static bool IsBinaryContent(HttpContent content)

--- a/src/ModularPipelines/Http/HttpRequestFormatter.cs
+++ b/src/ModularPipelines/Http/HttpRequestFormatter.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text;
+using Microsoft.Extensions.Options;
 using ModularPipelines.Constants;
 using ModularPipelines.Engine;
 using ModularPipelines.Options;
@@ -31,10 +32,17 @@ namespace ModularPipelines.Http;
 internal class HttpRequestFormatter : IHttpRequestFormatter
 {
     private readonly ISecretObfuscator _secretObfuscator;
+    private readonly ISecretProvider _secretProvider;
+    private readonly IOptions<SecretMaskingOptions> _secretMaskingOptions;
 
-    public HttpRequestFormatter(ISecretObfuscator secretObfuscator)
+    public HttpRequestFormatter(
+        ISecretObfuscator secretObfuscator,
+        ISecretProvider secretProvider,
+        IOptions<SecretMaskingOptions> secretMaskingOptions)
     {
         _secretObfuscator = secretObfuscator;
+        _secretProvider = secretProvider;
+        _secretMaskingOptions = secretMaskingOptions;
     }
 
     private static readonly HashSet<string> TextMediaTypes = new(StringComparer.OrdinalIgnoreCase)
@@ -163,7 +171,12 @@ internal class HttpRequestFormatter : IHttpRequestFormatter
         }
 
         // Obfuscate sensitive values in the body
-        var obfuscatedBody = _secretObfuscator.Obfuscate(body, null);
+        var obfuscatedBody = HttpBodySecretRedactor.Redact(
+            body,
+            isTruncated,
+            _secretObfuscator,
+            _secretProvider,
+            _secretMaskingOptions);
 
         sb.AppendLine($"\t{obfuscatedBody}");
         if (isTruncated)

--- a/src/ModularPipelines/Http/HttpRequestFormatter.cs
+++ b/src/ModularPipelines/Http/HttpRequestFormatter.cs
@@ -163,7 +163,6 @@ internal class HttpRequestFormatter : IHttpRequestFormatter
             .ReadReplayableAsync(content, maxBodySize, cancellationToken)
             .ConfigureAwait(false);
         request.Content = replayContent;
-        content.Dispose();
 
         if (string.IsNullOrWhiteSpace(body) && !isTruncated)
         {

--- a/src/ModularPipelines/Http/HttpRequestFormatter.cs
+++ b/src/ModularPipelines/Http/HttpRequestFormatter.cs
@@ -160,9 +160,10 @@ internal class HttpRequestFormatter : IHttpRequestFormatter
         }
 
         var (body, isTruncated, replayContent, totalLength) = await HttpContentPreviewReader
-            .ReadAsync(content, maxBodySize, cancellationToken)
+            .ReadReplayableAsync(content, maxBodySize, cancellationToken)
             .ConfigureAwait(false);
         request.Content = replayContent;
+        content.Dispose();
 
         if (string.IsNullOrWhiteSpace(body) && !isTruncated)
         {

--- a/src/ModularPipelines/Http/HttpResponseExtensions.cs
+++ b/src/ModularPipelines/Http/HttpResponseExtensions.cs
@@ -30,27 +30,19 @@ internal static class HttpResponseExtensions
         {
             responseContent = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (ObjectDisposedException)
-        {
-            // Response content stream was already disposed - continue with null content
-        }
-        catch (InvalidOperationException)
-        {
-            // Content stream is in an invalid state - continue with null content
-        }
-        catch (HttpRequestException)
-        {
-            // Network error while reading content - continue with null content
-        }
         catch (OperationCanceledException)
         {
-            // Reading was cancelled - continue with null content
+            throw;
         }
         catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
         {
-            // Other unexpected errors reading content - continue with null content
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Errors reading content do not hide the primary HTTP status failure.
             // The primary error information is in the status code and reason phrase
         }
+
+        cancellationToken.ThrowIfCancellationRequested();
 
         throw new HttpResponseException(
             response.StatusCode,

--- a/src/ModularPipelines/Http/HttpResponseFormatter.cs
+++ b/src/ModularPipelines/Http/HttpResponseFormatter.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text;
+using Microsoft.Extensions.Options;
 using ModularPipelines.Constants;
 using ModularPipelines.Engine;
 using ModularPipelines.Options;
@@ -31,10 +32,17 @@ namespace ModularPipelines.Http;
 internal class HttpResponseFormatter : IHttpResponseFormatter
 {
     private readonly ISecretObfuscator _secretObfuscator;
+    private readonly ISecretProvider _secretProvider;
+    private readonly IOptions<SecretMaskingOptions> _secretMaskingOptions;
 
-    public HttpResponseFormatter(ISecretObfuscator secretObfuscator)
+    public HttpResponseFormatter(
+        ISecretObfuscator secretObfuscator,
+        ISecretProvider secretProvider,
+        IOptions<SecretMaskingOptions> secretMaskingOptions)
     {
         _secretObfuscator = secretObfuscator;
+        _secretProvider = secretProvider;
+        _secretMaskingOptions = secretMaskingOptions;
     }
 
     private static readonly HashSet<string> TextMediaTypes = new(StringComparer.OrdinalIgnoreCase)
@@ -163,7 +171,12 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
         }
 
         // Obfuscate sensitive values in the body
-        var obfuscatedBody = _secretObfuscator.Obfuscate(body, null);
+        var obfuscatedBody = HttpBodySecretRedactor.Redact(
+            body,
+            isTruncated,
+            _secretObfuscator,
+            _secretProvider,
+            _secretMaskingOptions);
 
         sb.AppendLine($"\t{obfuscatedBody}");
         if (isTruncated)

--- a/src/ModularPipelines/Http/HttpResponseFormatter.cs
+++ b/src/ModularPipelines/Http/HttpResponseFormatter.cs
@@ -70,7 +70,7 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
 
         if (options.LogResponseBody)
         {
-            await AppendBodyAsync(sb, response.Content, options.MaxBodySizeToLog, cancellationToken).ConfigureAwait(false);
+            await AppendBodyAsync(sb, response, options.MaxBodySizeToLog, cancellationToken).ConfigureAwait(false);
         }
 
         return sb.ToString();
@@ -127,10 +127,15 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
         return false;
     }
 
-    private async Task AppendBodyAsync(StringBuilder sb, HttpContent? content, int maxBodySize, CancellationToken cancellationToken)
+    private async Task AppendBodyAsync(
+        StringBuilder sb,
+        HttpResponseMessage response,
+        int maxBodySize,
+        CancellationToken cancellationToken)
     {
         sb.AppendLine("Body");
 
+        var content = response.Content;
         if (content == null)
         {
             sb.AppendLine("\t(null)");
@@ -146,9 +151,12 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
             return;
         }
 
-        var body = await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        var (body, isTruncated, replayContent, totalLength) = await HttpContentPreviewReader
+            .ReadAsync(content, maxBodySize, cancellationToken)
+            .ConfigureAwait(false);
+        response.Content = replayContent;
 
-        if (string.IsNullOrWhiteSpace(body))
+        if (string.IsNullOrWhiteSpace(body) && !isTruncated)
         {
             sb.AppendLine("\t(empty)");
             return;
@@ -157,16 +165,22 @@ internal class HttpResponseFormatter : IHttpResponseFormatter
         // Obfuscate sensitive values in the body
         var obfuscatedBody = _secretObfuscator.Obfuscate(body, null);
 
-        // Truncate if body is too large
-        if (maxBodySize > 0 && obfuscatedBody.Length > maxBodySize)
+        sb.AppendLine($"\t{obfuscatedBody}");
+        if (isTruncated)
         {
-            sb.AppendLine($"\t{obfuscatedBody[..maxBodySize]}");
-            sb.AppendLine($"\t... [truncated, total size: {obfuscatedBody.Length:N0} characters]");
+            AppendTruncationMessage(sb, maxBodySize, totalLength);
         }
-        else
-        {
-            sb.AppendLine($"\t{obfuscatedBody}");
-        }
+    }
+
+    private static void AppendTruncationMessage(
+        StringBuilder sb,
+        int maxBodySize,
+        long? totalLength)
+    {
+        var size = totalLength.HasValue
+            ? $"total size: {totalLength.Value:N0} bytes"
+            : $"after {maxBodySize:N0} bytes";
+        sb.AppendLine($"\t... [truncated, {size}]");
     }
 
     private static bool IsBinaryContent(HttpContent content)

--- a/src/ModularPipelines/Http/IHttpLogger.cs
+++ b/src/ModularPipelines/Http/IHttpLogger.cs
@@ -29,7 +29,7 @@ public interface IHttpLogger
         IModuleLogger logger,
         CancellationToken cancellationToken)
     {
-        return PrintRequest(request, logger);
+        return PrintRequest(request, logger).WaitAsync(cancellationToken);
     }
 
     /// <summary>
@@ -55,7 +55,7 @@ public interface IHttpLogger
         HttpLoggingOptions options,
         CancellationToken cancellationToken)
     {
-        return PrintRequest(request, logger, options);
+        return PrintRequest(request, logger, options).WaitAsync(cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines/Http/IHttpLogger.cs
+++ b/src/ModularPipelines/Http/IHttpLogger.cs
@@ -78,7 +78,7 @@ public interface IHttpLogger
         IModuleLogger logger,
         CancellationToken cancellationToken)
     {
-        return PrintResponse(response, logger);
+        return PrintResponse(response, logger).WaitAsync(cancellationToken);
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ public interface IHttpLogger
         HttpLoggingOptions options,
         CancellationToken cancellationToken)
     {
-        return PrintResponse(response, logger, options);
+        return PrintResponse(response, logger, options).WaitAsync(cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines/Http/IHttpLogger.cs
+++ b/src/ModularPipelines/Http/IHttpLogger.cs
@@ -18,6 +18,21 @@ public interface IHttpLogger
     Task PrintRequest(HttpRequestMessage request, IModuleLogger logger);
 
     /// <summary>
+    /// Prints the HTTP request.
+    /// </summary>
+    /// <param name="request">The HTTP request to print.</param>
+    /// <param name="logger">The current module logger.</param>
+    /// <param name="cancellationToken">A token to cancel request formatting.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task PrintRequest(
+        HttpRequestMessage request,
+        IModuleLogger logger,
+        CancellationToken cancellationToken)
+    {
+        return PrintRequest(request, logger);
+    }
+
+    /// <summary>
     /// Prints the HTTP request with logging options.
     /// </summary>
     /// <param name="request">The HTTP request to print.</param>
@@ -25,6 +40,23 @@ public interface IHttpLogger
     /// <param name="options">Options controlling what parts of the request to log.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     Task PrintRequest(HttpRequestMessage request, IModuleLogger logger, HttpLoggingOptions options);
+
+    /// <summary>
+    /// Prints the HTTP request with logging options.
+    /// </summary>
+    /// <param name="request">The HTTP request to print.</param>
+    /// <param name="logger">The current module logger.</param>
+    /// <param name="options">Options controlling what parts of the request to log.</param>
+    /// <param name="cancellationToken">A token to cancel request formatting.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task PrintRequest(
+        HttpRequestMessage request,
+        IModuleLogger logger,
+        HttpLoggingOptions options,
+        CancellationToken cancellationToken)
+    {
+        return PrintRequest(request, logger, options);
+    }
 
     /// <summary>
     /// Prints the HTTP response.
@@ -35,6 +67,21 @@ public interface IHttpLogger
     Task PrintResponse(HttpResponseMessage response, IModuleLogger logger);
 
     /// <summary>
+    /// Prints the HTTP response.
+    /// </summary>
+    /// <param name="response">The HTTP response to print.</param>
+    /// <param name="logger">The current module logger.</param>
+    /// <param name="cancellationToken">A token to cancel response formatting.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task PrintResponse(
+        HttpResponseMessage response,
+        IModuleLogger logger,
+        CancellationToken cancellationToken)
+    {
+        return PrintResponse(response, logger);
+    }
+
+    /// <summary>
     /// Prints the HTTP response with logging options.
     /// </summary>
     /// <param name="response">The HTTP response to print.</param>
@@ -42,6 +89,23 @@ public interface IHttpLogger
     /// <param name="options">Options controlling what parts of the response to log.</param>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     Task PrintResponse(HttpResponseMessage response, IModuleLogger logger, HttpLoggingOptions options);
+
+    /// <summary>
+    /// Prints the HTTP response with logging options.
+    /// </summary>
+    /// <param name="response">The HTTP response to print.</param>
+    /// <param name="logger">The current module logger.</param>
+    /// <param name="options">Options controlling what parts of the response to log.</param>
+    /// <param name="cancellationToken">A token to cancel response formatting.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    Task PrintResponse(
+        HttpResponseMessage response,
+        IModuleLogger logger,
+        HttpLoggingOptions options,
+        CancellationToken cancellationToken)
+    {
+        return PrintResponse(response, logger, options);
+    }
 
     /// <summary>
     /// Prints the HTTP status code.

--- a/src/ModularPipelines/Http/RequestLoggingHttpHandler.cs
+++ b/src/ModularPipelines/Http/RequestLoggingHttpHandler.cs
@@ -17,7 +17,9 @@ internal class RequestLoggingHttpHandler : DelegatingHandler
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         var logger = _loggerProvider.GetLogger();
-        await _httpLogger.PrintRequest(request, logger).ConfigureAwait(false);
+        await _httpLogger
+            .PrintRequest(request, logger, cancellationToken)
+            .ConfigureAwait(false);
 
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 

--- a/src/ModularPipelines/Http/ResilienceHttpHandler.cs
+++ b/src/ModularPipelines/Http/ResilienceHttpHandler.cs
@@ -105,14 +105,21 @@ internal class ResilienceHttpHandler : DelegatingHandler
                 outcome.Exception.GetType().Name,
                 outcome.Exception.Message,
                 retryAttempt,
-                (int)delay.TotalMilliseconds);
+                (int) delay.TotalMilliseconds);
         }
         else if (outcome.Result != null)
         {
-            logger.LogWarning("HTTP request returned {StatusCode}. Retry attempt {RetryAttempt} after {Delay}ms",
-                (int)outcome.Result.StatusCode,
-                retryAttempt,
-                (int)delay.TotalMilliseconds);
+            try
+            {
+                logger.LogWarning("HTTP request returned {StatusCode}. Retry attempt {RetryAttempt} after {Delay}ms",
+                    (int) outcome.Result.StatusCode,
+                    retryAttempt,
+                    (int) delay.TotalMilliseconds);
+            }
+            finally
+            {
+                outcome.Result.Dispose();
+            }
         }
 
         return Task.CompletedTask;

--- a/src/ModularPipelines/Http/ResponseLoggingHttpHandler.cs
+++ b/src/ModularPipelines/Http/ResponseLoggingHttpHandler.cs
@@ -18,9 +18,18 @@ internal class ResponseLoggingHttpHandler : DelegatingHandler
     {
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-        var logger = _loggerProvider.GetLogger();
-        await _httpLogger.PrintResponse(response, logger).ConfigureAwait(false);
-
-        return response;
+        try
+        {
+            var logger = _loggerProvider.GetLogger();
+            await _httpLogger
+                .PrintResponse(response, logger, cancellationToken)
+                .ConfigureAwait(false);
+            return response;
+        }
+        catch
+        {
+            response.Dispose();
+            throw;
+        }
     }
 }

--- a/src/ModularPipelines/Http/ResponseLoggingHttpHandler.cs
+++ b/src/ModularPipelines/Http/ResponseLoggingHttpHandler.cs
@@ -18,11 +18,6 @@ internal class ResponseLoggingHttpHandler : DelegatingHandler
     {
         var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
-        // Buffer the response content so it can be read multiple times.
-        // Without this, reading the body for logging consumes the stream,
-        // making it unreadable by subsequent code. See issue #1610.
-        await response.Content.LoadIntoBufferAsync().ConfigureAwait(false);
-
         var logger = _loggerProvider.GetLogger();
         await _httpLogger.PrintResponse(response, logger).ConfigureAwait(false);
 

--- a/src/ModularPipelines/Http/TimeoutHttpContent.cs
+++ b/src/ModularPipelines/Http/TimeoutHttpContent.cs
@@ -1,0 +1,195 @@
+using System.Net;
+
+namespace ModularPipelines.Http;
+
+internal sealed class TimeoutHttpContent : HttpContent
+{
+    private readonly HttpContent _innerContent;
+    private readonly CancellationTokenSource _timeoutCancellationTokenSource;
+    private readonly CancellationTokenSource _linkedCancellationTokenSource;
+
+    public TimeoutHttpContent(
+        HttpContent innerContent,
+        CancellationTokenSource timeoutCancellationTokenSource,
+        CancellationTokenSource linkedCancellationTokenSource)
+    {
+        _innerContent = innerContent;
+        _timeoutCancellationTokenSource = timeoutCancellationTokenSource;
+        _linkedCancellationTokenSource = linkedCancellationTokenSource;
+
+        foreach (var header in innerContent.Headers)
+        {
+            Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+    }
+
+    protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+    {
+        return _innerContent.CopyToAsync(stream, _linkedCancellationTokenSource.Token);
+    }
+
+    protected override async Task SerializeToStreamAsync(
+        Stream stream,
+        TransportContext? context,
+        CancellationToken cancellationToken)
+    {
+        using var readCancellationTokenSource = CreateReadCancellationTokenSource(cancellationToken);
+        await _innerContent.CopyToAsync(
+                stream,
+                readCancellationTokenSource?.Token ?? _linkedCancellationTokenSource.Token)
+            .ConfigureAwait(false);
+    }
+
+    protected override async Task<Stream> CreateContentReadStreamAsync()
+    {
+        var stream = await _innerContent
+            .ReadAsStreamAsync(_linkedCancellationTokenSource.Token)
+            .ConfigureAwait(false);
+        return new TimeoutReadStream(stream, _linkedCancellationTokenSource.Token);
+    }
+
+    protected override async Task<Stream> CreateContentReadStreamAsync(
+        CancellationToken cancellationToken)
+    {
+        using var readCancellationTokenSource = CreateReadCancellationTokenSource(cancellationToken);
+        var effectiveCancellationToken =
+            readCancellationTokenSource?.Token ?? _linkedCancellationTokenSource.Token;
+        var stream = await _innerContent
+            .ReadAsStreamAsync(effectiveCancellationToken)
+            .ConfigureAwait(false);
+        return new TimeoutReadStream(stream, _linkedCancellationTokenSource.Token);
+    }
+
+    protected override bool TryComputeLength(out long length)
+    {
+        if (_innerContent.Headers.ContentLength is { } contentLength)
+        {
+            length = contentLength;
+            return true;
+        }
+
+        length = 0;
+        return false;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _innerContent.Dispose();
+            _linkedCancellationTokenSource.Dispose();
+            _timeoutCancellationTokenSource.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private CancellationTokenSource? CreateReadCancellationTokenSource(
+        CancellationToken cancellationToken)
+    {
+        return cancellationToken.CanBeCanceled &&
+               cancellationToken != _linkedCancellationTokenSource.Token
+            ? CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                _linkedCancellationTokenSource.Token)
+            : null;
+    }
+
+    private sealed class TimeoutReadStream(
+        Stream innerStream,
+        CancellationToken timeoutCancellationToken) : Stream
+    {
+        public override bool CanRead => innerStream.CanRead;
+
+        public override bool CanSeek => innerStream.CanSeek;
+
+        public override bool CanWrite => innerStream.CanWrite;
+
+        public override long Length => innerStream.Length;
+
+        public override long Position
+        {
+            get => innerStream.Position;
+            set => innerStream.Position = value;
+        }
+
+        public override void Flush() => innerStream.Flush();
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return innerStream.FlushAsync(cancellationToken);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            timeoutCancellationToken.ThrowIfCancellationRequested();
+            return innerStream.Read(buffer, offset, count);
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            timeoutCancellationToken.ThrowIfCancellationRequested();
+            return innerStream.Read(buffer);
+        }
+
+        public override Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken)
+        {
+            return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            using var readCancellationTokenSource =
+                CreateReadCancellationTokenSource(cancellationToken);
+            return await innerStream.ReadAsync(
+                    buffer,
+                    readCancellationTokenSource?.Token ?? timeoutCancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return innerStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value) => innerStream.SetLength(value);
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            innerStream.Write(buffer, offset, count);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await innerStream.DisposeAsync().ConfigureAwait(false);
+            GC.SuppressFinalize(this);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                innerStream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private CancellationTokenSource? CreateReadCancellationTokenSource(
+            CancellationToken cancellationToken)
+        {
+            return cancellationToken.CanBeCanceled &&
+                   cancellationToken != timeoutCancellationToken
+                ? CancellationTokenSource.CreateLinkedTokenSource(
+                    cancellationToken,
+                    timeoutCancellationToken)
+                : null;
+        }
+    }
+}

--- a/src/ModularPipelines/Http/TimeoutHttpContent.cs
+++ b/src/ModularPipelines/Http/TimeoutHttpContent.cs
@@ -110,6 +110,7 @@ internal sealed class TimeoutHttpContent : HttpContent
         try
         {
             await source.CopyToAsync(destination, effectiveCancellationToken).ConfigureAwait(false);
+            effectiveCancellationToken.ThrowIfCancellationRequested();
         }
         catch (Exception exception)
             when (effectiveCancellationToken.IsCancellationRequested
@@ -216,10 +217,12 @@ internal sealed class TimeoutHttpContent : HttpContent
                 innerStream);
             try
             {
-                return await innerStream.ReadAsync(
+                var bytesRead = await innerStream.ReadAsync(
                         buffer,
                         effectiveCancellationToken)
                     .ConfigureAwait(false);
+                effectiveCancellationToken.ThrowIfCancellationRequested();
+                return bytesRead;
             }
             catch (Exception exception)
                 when (effectiveCancellationToken.IsCancellationRequested &&

--- a/src/ModularPipelines/Http/TimeoutHttpContent.cs
+++ b/src/ModularPipelines/Http/TimeoutHttpContent.cs
@@ -222,10 +222,12 @@ internal sealed class TimeoutHttpContent : HttpContent
                     .ConfigureAwait(false);
             }
             catch (Exception exception)
-                when (timeoutCancellationToken.IsCancellationRequested &&
+                when (effectiveCancellationToken.IsCancellationRequested &&
                       exception is ObjectDisposedException or IOException)
             {
-                throw CreateTimeoutException(exception);
+                throw CreateReadCancellationException(
+                    exception,
+                    effectiveCancellationToken);
             }
         }
 
@@ -276,6 +278,16 @@ internal sealed class TimeoutHttpContent : HttpContent
                 "The HTTP response body read timed out.",
                 exception,
                 timeoutCancellationToken);
+        }
+
+        private static OperationCanceledException CreateReadCancellationException(
+            Exception exception,
+            CancellationToken cancellationToken)
+        {
+            return new OperationCanceledException(
+                "The HTTP response body read was cancelled.",
+                exception,
+                cancellationToken);
         }
     }
 }

--- a/src/ModularPipelines/Http/TimeoutHttpContent.cs
+++ b/src/ModularPipelines/Http/TimeoutHttpContent.cs
@@ -48,6 +48,15 @@ internal sealed class TimeoutHttpContent : HttpContent
         return new TimeoutReadStream(stream, _linkedCancellationTokenSource.Token);
     }
 
+    protected override Stream CreateContentReadStream(CancellationToken cancellationToken)
+    {
+        using var readCancellationTokenSource = CreateReadCancellationTokenSource(cancellationToken);
+        var effectiveCancellationToken =
+            readCancellationTokenSource?.Token ?? _linkedCancellationTokenSource.Token;
+        var stream = _innerContent.ReadAsStream(effectiveCancellationToken);
+        return new TimeoutReadStream(stream, _linkedCancellationTokenSource.Token);
+    }
+
     protected override async Task<Stream> CreateContentReadStreamAsync(
         CancellationToken cancellationToken)
     {
@@ -99,6 +108,11 @@ internal sealed class TimeoutHttpContent : HttpContent
         Stream innerStream,
         CancellationToken timeoutCancellationToken) : Stream
     {
+        private readonly CancellationTokenRegistration _timeoutRegistration =
+            timeoutCancellationToken.Register(
+                static state => ((Stream) state!).Dispose(),
+                innerStream);
+
         public override bool CanRead => innerStream.CanRead;
 
         public override bool CanSeek => innerStream.CanSeek;
@@ -123,13 +137,29 @@ internal sealed class TimeoutHttpContent : HttpContent
         public override int Read(byte[] buffer, int offset, int count)
         {
             timeoutCancellationToken.ThrowIfCancellationRequested();
-            return innerStream.Read(buffer, offset, count);
+            try
+            {
+                return innerStream.Read(buffer, offset, count);
+            }
+            catch (ObjectDisposedException exception)
+                when (timeoutCancellationToken.IsCancellationRequested)
+            {
+                throw CreateTimeoutException(exception);
+            }
         }
 
         public override int Read(Span<byte> buffer)
         {
             timeoutCancellationToken.ThrowIfCancellationRequested();
-            return innerStream.Read(buffer);
+            try
+            {
+                return innerStream.Read(buffer);
+            }
+            catch (ObjectDisposedException exception)
+                when (timeoutCancellationToken.IsCancellationRequested)
+            {
+                throw CreateTimeoutException(exception);
+            }
         }
 
         public override Task<int> ReadAsync(
@@ -167,6 +197,7 @@ internal sealed class TimeoutHttpContent : HttpContent
 
         public override async ValueTask DisposeAsync()
         {
+            _timeoutRegistration.Dispose();
             await innerStream.DisposeAsync().ConfigureAwait(false);
             GC.SuppressFinalize(this);
         }
@@ -175,6 +206,7 @@ internal sealed class TimeoutHttpContent : HttpContent
         {
             if (disposing)
             {
+                _timeoutRegistration.Dispose();
                 innerStream.Dispose();
             }
 
@@ -190,6 +222,14 @@ internal sealed class TimeoutHttpContent : HttpContent
                     cancellationToken,
                     timeoutCancellationToken)
                 : null;
+        }
+
+        private OperationCanceledException CreateTimeoutException(Exception exception)
+        {
+            return new OperationCanceledException(
+                "The HTTP response body read timed out.",
+                exception,
+                timeoutCancellationToken);
         }
     }
 }

--- a/src/ModularPipelines/Http/TimeoutHttpContent.cs
+++ b/src/ModularPipelines/Http/TimeoutHttpContent.cs
@@ -169,7 +169,9 @@ internal sealed class TimeoutHttpContent : HttpContent
             timeoutCancellationToken.ThrowIfCancellationRequested();
             try
             {
-                return innerStream.Read(buffer, offset, count);
+                var bytesRead = innerStream.Read(buffer, offset, count);
+                timeoutCancellationToken.ThrowIfCancellationRequested();
+                return bytesRead;
             }
             catch (Exception exception)
                 when (timeoutCancellationToken.IsCancellationRequested &&
@@ -184,7 +186,9 @@ internal sealed class TimeoutHttpContent : HttpContent
             timeoutCancellationToken.ThrowIfCancellationRequested();
             try
             {
-                return innerStream.Read(buffer);
+                var bytesRead = innerStream.Read(buffer);
+                timeoutCancellationToken.ThrowIfCancellationRequested();
+                return bytesRead;
             }
             catch (Exception exception)
                 when (timeoutCancellationToken.IsCancellationRequested &&

--- a/src/ModularPipelines/Http/TimeoutHttpContent.cs
+++ b/src/ModularPipelines/Http/TimeoutHttpContent.cs
@@ -25,6 +25,7 @@ internal sealed class TimeoutHttpContent : HttpContent
 
     protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
     {
+        _linkedCancellationTokenSource.Token.ThrowIfCancellationRequested();
         return _innerContent.CopyToAsync(stream, _linkedCancellationTokenSource.Token);
     }
 
@@ -34,14 +35,18 @@ internal sealed class TimeoutHttpContent : HttpContent
         CancellationToken cancellationToken)
     {
         using var readCancellationTokenSource = CreateReadCancellationTokenSource(cancellationToken);
+        var effectiveCancellationToken =
+            readCancellationTokenSource?.Token ?? _linkedCancellationTokenSource.Token;
+        effectiveCancellationToken.ThrowIfCancellationRequested();
         await _innerContent.CopyToAsync(
                 stream,
-                readCancellationTokenSource?.Token ?? _linkedCancellationTokenSource.Token)
+                effectiveCancellationToken)
             .ConfigureAwait(false);
     }
 
     protected override async Task<Stream> CreateContentReadStreamAsync()
     {
+        _linkedCancellationTokenSource.Token.ThrowIfCancellationRequested();
         var stream = await _innerContent
             .ReadAsStreamAsync(_linkedCancellationTokenSource.Token)
             .ConfigureAwait(false);
@@ -53,6 +58,7 @@ internal sealed class TimeoutHttpContent : HttpContent
         using var readCancellationTokenSource = CreateReadCancellationTokenSource(cancellationToken);
         var effectiveCancellationToken =
             readCancellationTokenSource?.Token ?? _linkedCancellationTokenSource.Token;
+        effectiveCancellationToken.ThrowIfCancellationRequested();
         var stream = _innerContent.ReadAsStream(effectiveCancellationToken);
         return new TimeoutReadStream(stream, _linkedCancellationTokenSource.Token);
     }
@@ -63,6 +69,7 @@ internal sealed class TimeoutHttpContent : HttpContent
         using var readCancellationTokenSource = CreateReadCancellationTokenSource(cancellationToken);
         var effectiveCancellationToken =
             readCancellationTokenSource?.Token ?? _linkedCancellationTokenSource.Token;
+        effectiveCancellationToken.ThrowIfCancellationRequested();
         var stream = await _innerContent
             .ReadAsStreamAsync(effectiveCancellationToken)
             .ConfigureAwait(false);
@@ -141,8 +148,9 @@ internal sealed class TimeoutHttpContent : HttpContent
             {
                 return innerStream.Read(buffer, offset, count);
             }
-            catch (ObjectDisposedException exception)
-                when (timeoutCancellationToken.IsCancellationRequested)
+            catch (Exception exception)
+                when (timeoutCancellationToken.IsCancellationRequested &&
+                      exception is ObjectDisposedException or IOException)
             {
                 throw CreateTimeoutException(exception);
             }
@@ -155,8 +163,9 @@ internal sealed class TimeoutHttpContent : HttpContent
             {
                 return innerStream.Read(buffer);
             }
-            catch (ObjectDisposedException exception)
-                when (timeoutCancellationToken.IsCancellationRequested)
+            catch (Exception exception)
+                when (timeoutCancellationToken.IsCancellationRequested &&
+                      exception is ObjectDisposedException or IOException)
             {
                 throw CreateTimeoutException(exception);
             }
@@ -177,9 +186,12 @@ internal sealed class TimeoutHttpContent : HttpContent
         {
             using var readCancellationTokenSource =
                 CreateReadCancellationTokenSource(cancellationToken);
+            var effectiveCancellationToken =
+                readCancellationTokenSource?.Token ?? timeoutCancellationToken;
+            effectiveCancellationToken.ThrowIfCancellationRequested();
             return await innerStream.ReadAsync(
                     buffer,
-                    readCancellationTokenSource?.Token ?? timeoutCancellationToken)
+                    effectiveCancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/ModularPipelines/Http/TimeoutHttpContent.cs
+++ b/src/ModularPipelines/Http/TimeoutHttpContent.cs
@@ -25,8 +25,7 @@ internal sealed class TimeoutHttpContent : HttpContent
 
     protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
     {
-        _linkedCancellationTokenSource.Token.ThrowIfCancellationRequested();
-        return _innerContent.CopyToAsync(stream, _linkedCancellationTokenSource.Token);
+        return CopyInnerContentToAsync(stream, CancellationToken.None);
     }
 
     protected override async Task SerializeToStreamAsync(
@@ -34,14 +33,7 @@ internal sealed class TimeoutHttpContent : HttpContent
         TransportContext? context,
         CancellationToken cancellationToken)
     {
-        using var readCancellationTokenSource = CreateReadCancellationTokenSource(cancellationToken);
-        var effectiveCancellationToken =
-            readCancellationTokenSource?.Token ?? _linkedCancellationTokenSource.Token;
-        effectiveCancellationToken.ThrowIfCancellationRequested();
-        await _innerContent.CopyToAsync(
-                stream,
-                effectiveCancellationToken)
-            .ConfigureAwait(false);
+        await CopyInnerContentToAsync(stream, cancellationToken).ConfigureAwait(false);
     }
 
     protected override async Task<Stream> CreateContentReadStreamAsync()
@@ -98,6 +90,36 @@ internal sealed class TimeoutHttpContent : HttpContent
         }
 
         base.Dispose(disposing);
+    }
+
+    private async Task CopyInnerContentToAsync(
+        Stream destination,
+        CancellationToken cancellationToken)
+    {
+        using var readCancellationTokenSource = CreateReadCancellationTokenSource(cancellationToken);
+        var effectiveCancellationToken =
+            readCancellationTokenSource?.Token ?? _linkedCancellationTokenSource.Token;
+        effectiveCancellationToken.ThrowIfCancellationRequested();
+        var source = await _innerContent
+            .ReadAsStreamAsync(effectiveCancellationToken)
+            .ConfigureAwait(false);
+        using var cancellationRegistration = effectiveCancellationToken.Register(
+            static state => ((Stream) state!).Dispose(),
+            source);
+
+        try
+        {
+            await source.CopyToAsync(destination, effectiveCancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+            when (effectiveCancellationToken.IsCancellationRequested
+                  && exception is ObjectDisposedException or IOException)
+        {
+            throw new OperationCanceledException(
+                "The HTTP response body copy was cancelled.",
+                exception,
+                effectiveCancellationToken);
+        }
     }
 
     private CancellationTokenSource? CreateReadCancellationTokenSource(
@@ -189,6 +211,9 @@ internal sealed class TimeoutHttpContent : HttpContent
             var effectiveCancellationToken =
                 readCancellationTokenSource?.Token ?? timeoutCancellationToken;
             effectiveCancellationToken.ThrowIfCancellationRequested();
+            using var cancellationRegistration = readCancellationTokenSource?.Token.Register(
+                static state => ((Stream) state!).Dispose(),
+                innerStream);
             try
             {
                 return await innerStream.ReadAsync(

--- a/src/ModularPipelines/Http/TimeoutHttpContent.cs
+++ b/src/ModularPipelines/Http/TimeoutHttpContent.cs
@@ -5,12 +5,12 @@ namespace ModularPipelines.Http;
 internal sealed class TimeoutHttpContent : HttpContent
 {
     private readonly HttpContent _innerContent;
-    private readonly CancellationTokenSource _timeoutCancellationTokenSource;
+    private readonly CancellationTokenSource? _timeoutCancellationTokenSource;
     private readonly CancellationTokenSource _linkedCancellationTokenSource;
 
     public TimeoutHttpContent(
         HttpContent innerContent,
-        CancellationTokenSource timeoutCancellationTokenSource,
+        CancellationTokenSource? timeoutCancellationTokenSource,
         CancellationTokenSource linkedCancellationTokenSource)
     {
         _innerContent = innerContent;
@@ -94,7 +94,7 @@ internal sealed class TimeoutHttpContent : HttpContent
         {
             _innerContent.Dispose();
             _linkedCancellationTokenSource.Dispose();
-            _timeoutCancellationTokenSource.Dispose();
+            _timeoutCancellationTokenSource?.Dispose();
         }
 
         base.Dispose(disposing);
@@ -189,10 +189,19 @@ internal sealed class TimeoutHttpContent : HttpContent
             var effectiveCancellationToken =
                 readCancellationTokenSource?.Token ?? timeoutCancellationToken;
             effectiveCancellationToken.ThrowIfCancellationRequested();
-            return await innerStream.ReadAsync(
-                    buffer,
-                    effectiveCancellationToken)
-                .ConfigureAwait(false);
+            try
+            {
+                return await innerStream.ReadAsync(
+                        buffer,
+                        effectiveCancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+                when (timeoutCancellationToken.IsCancellationRequested &&
+                      exception is ObjectDisposedException or IOException)
+            {
+                throw CreateTimeoutException(exception);
+            }
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/src/ModularPipelines/Options/DownloadOptions.cs
+++ b/src/ModularPipelines/Options/DownloadOptions.cs
@@ -21,5 +21,6 @@ public record DownloadOptions(Uri DownloadUri)
     /// <summary>
     /// Gets the type of HTTP logging to perform during the download.
     /// </summary>
-    public HttpLoggingType LoggingType { get; init; } = HttpLoggingType.Request | HttpLoggingType.Response | HttpLoggingType.StatusCode | HttpLoggingType.Duration;
+    public HttpLoggingType LoggingType { get; init; } =
+        HttpLoggingType.Request | HttpLoggingType.StatusCode | HttpLoggingType.Duration;
 }

--- a/src/ModularPipelines/Options/HttpLoggingOptions.cs
+++ b/src/ModularPipelines/Options/HttpLoggingOptions.cs
@@ -67,7 +67,7 @@ public record HttpLoggingOptions
     public bool LogDuration { get; init; } = true;
 
     /// <summary>
-    /// Gets the maximum body size in characters to log. Default is 4096.
+    /// Gets the maximum body size in bytes to read and log. Default is 4096.
     /// Bodies larger than this will be truncated with a message indicating the full size.
     /// Set to 0 or negative to disable truncation.
     /// </summary>

--- a/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
@@ -38,6 +38,24 @@ public class HttpFormatterTests
     }
 
     [Test]
+    public async Task ResponseFormatter_DoesNotAllocateEntireLargePreviewLimit()
+    {
+        var stream = new CountingReadStream([]);
+        using var response = new HttpResponseMessage
+        {
+            Content = CreateTextContent(stream),
+        };
+        var formatter = CreateResponseFormatter();
+
+        await formatter.FormatAsync(response, new HttpLoggingOptions
+        {
+            MaxBodySizeToLog = 64 * 1024 * 1024,
+        });
+
+        await Assert.That(stream.MaximumRequestedReadSize).IsLessThanOrEqualTo(81920);
+    }
+
+    [Test]
     public async Task RequestFormatter_PreservesBodyForRepeatedSends()
     {
         const string body = "abcdefghijklmnopqrstuvwxyz";
@@ -245,12 +263,15 @@ public class HttpFormatterTests
     {
         public int BytesRead { get; private set; }
 
+        public int MaximumRequestedReadSize { get; private set; }
+
         public bool IsDisposed { get; private set; }
 
         public override async ValueTask<int> ReadAsync(
             Memory<byte> buffer,
             CancellationToken cancellationToken = default)
         {
+            MaximumRequestedReadSize = Math.Max(MaximumRequestedReadSize, buffer.Length);
             var read = await base.ReadAsync(buffer, cancellationToken);
             BytesRead += read;
             return read;

--- a/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
@@ -154,6 +154,28 @@ public class HttpFormatterTests
         }
     }
 
+    [Test]
+    public async Task ResponseFormatter_RedactsSecretWhenPreviewSplitsMultibyteCharacter()
+    {
+        const string secret = "abcédef";
+        using var response = new HttpResponseMessage
+        {
+            Content = CreateTextContent(new MemoryStream(Encoding.UTF8.GetBytes($"prefix-{secret}-suffix"))),
+        };
+        var formatter = CreateResponseFormatter(secret);
+
+        var formatted = await formatter.FormatAsync(response, new HttpLoggingOptions
+        {
+            MaxBodySizeToLog = 11,
+        });
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(formatted).Contains($"prefix-{LoggingConstants.SecretMask}");
+            await Assert.That(formatted).DoesNotContain("prefix-abc");
+        }
+    }
+
     private static StreamContent CreateTextContent(Stream stream)
     {
         var content = new StreamContent(stream);

--- a/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text;
+using ModularPipelines.Constants;
 using ModularPipelines.Engine;
 using ModularPipelines.Http;
 using ModularPipelines.Options;
@@ -18,7 +19,7 @@ public class HttpFormatterTests
         {
             Content = CreateTextContent(stream),
         };
-        var formatter = new HttpResponseFormatter(CreateObfuscator());
+        var formatter = CreateResponseFormatter();
 
         var formatted = await formatter.FormatAsync(response, new HttpLoggingOptions
         {
@@ -45,7 +46,7 @@ public class HttpFormatterTests
         {
             Content = CreateTextContent(stream),
         };
-        var formatter = new HttpRequestFormatter(CreateObfuscator());
+        var formatter = CreateRequestFormatter();
 
         var formatted = await formatter.FormatAsync(request, new HttpLoggingOptions
         {
@@ -63,6 +64,50 @@ public class HttpFormatterTests
         }
     }
 
+    [Test]
+    public async Task ResponseFormatter_RedactsSecretCrossingPreviewBoundary()
+    {
+        const string secret = "secret-value";
+        using var response = new HttpResponseMessage
+        {
+            Content = CreateTextContent(new MemoryStream(Encoding.UTF8.GetBytes($"prefix-{secret}-suffix"))),
+        };
+        var formatter = CreateResponseFormatter(secret);
+
+        var formatted = await formatter.FormatAsync(response, new HttpLoggingOptions
+        {
+            MaxBodySizeToLog = 13,
+        });
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(formatted).Contains($"prefix-{LoggingConstants.SecretMask}");
+            await Assert.That(formatted).DoesNotContain("prefix-secret");
+        }
+    }
+
+    [Test]
+    public async Task RequestFormatter_RedactsSecretCrossingPreviewBoundary()
+    {
+        const string secret = "secret-value";
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test")
+        {
+            Content = CreateTextContent(new MemoryStream(Encoding.UTF8.GetBytes($"prefix-{secret}-suffix"))),
+        };
+        var formatter = CreateRequestFormatter(secret);
+
+        var formatted = await formatter.FormatAsync(request, new HttpLoggingOptions
+        {
+            MaxBodySizeToLog = 13,
+        });
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(formatted).Contains($"prefix-{LoggingConstants.SecretMask}");
+            await Assert.That(formatted).DoesNotContain("prefix-secret");
+        }
+    }
+
     private static StreamContent CreateTextContent(Stream stream)
     {
         var content = new StreamContent(stream);
@@ -73,13 +118,43 @@ public class HttpFormatterTests
         return content;
     }
 
-    private static ISecretObfuscator CreateObfuscator()
+    private static ISecretObfuscator CreateObfuscator(params string[] secrets)
     {
         var obfuscator = new Mock<ISecretObfuscator>();
         obfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
-            .Returns((string? input, object? _) => input ?? string.Empty);
+            .Returns((string? input, object? _) => secrets.Aggregate(
+                input ?? string.Empty,
+                (value, secret) => value.Replace(
+                    secret,
+                    LoggingConstants.SecretMask,
+                    StringComparison.Ordinal)));
         return obfuscator.Object;
+    }
+
+    private static HttpRequestFormatter CreateRequestFormatter(params string[] secrets)
+    {
+        return new HttpRequestFormatter(
+            CreateObfuscator(secrets),
+            CreateSecretProvider(secrets),
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+    }
+
+    private static HttpResponseFormatter CreateResponseFormatter(params string[] secrets)
+    {
+        return new HttpResponseFormatter(
+            CreateObfuscator(secrets),
+            CreateSecretProvider(secrets),
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+    }
+
+    private static ISecretProvider CreateSecretProvider(string[] secrets)
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider
+            .Setup(x => x.GetSnapshot())
+            .Returns(new SecretSnapshot(0, secrets));
+        return secretProvider.Object;
     }
 
     private sealed class CountingReadStream(byte[] contents) : MemoryStream(contents)

--- a/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
@@ -1,0 +1,98 @@
+using System.Net.Http.Headers;
+using System.Text;
+using ModularPipelines.Engine;
+using ModularPipelines.Http;
+using ModularPipelines.Options;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Context;
+
+public class HttpFormatterTests
+{
+    [Test]
+    public async Task ResponseFormatter_BoundsPreviewReadAndPreservesBody()
+    {
+        const string body = "abcdefghijklmnopqrstuvwxyz";
+        var stream = new CountingReadStream(Encoding.UTF8.GetBytes(body));
+        using var response = new HttpResponseMessage
+        {
+            Content = CreateTextContent(stream),
+        };
+        var formatter = new HttpResponseFormatter(CreateObfuscator());
+
+        var formatted = await formatter.FormatAsync(response, new HttpLoggingOptions
+        {
+            MaxBodySizeToLog = 5,
+        });
+        var bytesReadForPreview = stream.BytesRead;
+        var replayedBody = await response.Content.ReadAsStringAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(bytesReadForPreview).IsLessThanOrEqualTo(6);
+            await Assert.That(formatted).Contains("\tabcde");
+            await Assert.That(formatted).DoesNotContain("abcdef");
+            await Assert.That(replayedBody).IsEqualTo(body);
+        }
+    }
+
+    [Test]
+    public async Task RequestFormatter_BoundsPreviewReadAndPreservesBody()
+    {
+        const string body = "abcdefghijklmnopqrstuvwxyz";
+        var stream = new CountingReadStream(Encoding.UTF8.GetBytes(body));
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test")
+        {
+            Content = CreateTextContent(stream),
+        };
+        var formatter = new HttpRequestFormatter(CreateObfuscator());
+
+        var formatted = await formatter.FormatAsync(request, new HttpLoggingOptions
+        {
+            MaxBodySizeToLog = 5,
+        });
+        var bytesReadForPreview = stream.BytesRead;
+        var replayedBody = await request.Content.ReadAsStringAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(bytesReadForPreview).IsLessThanOrEqualTo(6);
+            await Assert.That(formatted).Contains("\tabcde");
+            await Assert.That(formatted).DoesNotContain("abcdef");
+            await Assert.That(replayedBody).IsEqualTo(body);
+        }
+    }
+
+    private static StreamContent CreateTextContent(Stream stream)
+    {
+        var content = new StreamContent(stream);
+        content.Headers.ContentType = new MediaTypeHeaderValue("text/plain")
+        {
+            CharSet = "utf-8",
+        };
+        return content;
+    }
+
+    private static ISecretObfuscator CreateObfuscator()
+    {
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? input, object? _) => input ?? string.Empty);
+        return obfuscator.Object;
+    }
+
+    private sealed class CountingReadStream(byte[] contents) : MemoryStream(contents)
+    {
+        public int BytesRead { get; private set; }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            var read = await base.ReadAsync(buffer, cancellationToken);
+            BytesRead += read;
+            return read;
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
@@ -42,9 +42,10 @@ public class HttpFormatterTests
     {
         const string body = "abcdefghijklmnopqrstuvwxyz";
         var stream = new CountingReadStream(Encoding.UTF8.GetBytes(body));
+        var content = CreateTextContent(stream);
         using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test")
         {
-            Content = CreateTextContent(stream),
+            Content = content,
         };
         var formatter = CreateRequestFormatter();
 
@@ -64,6 +65,7 @@ public class HttpFormatterTests
             await Assert.That(Encoding.UTF8.GetString(firstSend.ToArray())).IsEqualTo(body);
             await Assert.That(Encoding.UTF8.GetString(secondSend.ToArray())).IsEqualTo(body);
             await Assert.That(stream.IsDisposed).IsTrue();
+            await Assert.That(content.DisposeCount).IsEqualTo(1);
         }
     }
 
@@ -179,14 +181,25 @@ public class HttpFormatterTests
         }
     }
 
-    private static StreamContent CreateTextContent(Stream stream)
+    private static CountingStreamContent CreateTextContent(Stream stream)
     {
-        var content = new StreamContent(stream);
+        var content = new CountingStreamContent(stream);
         content.Headers.ContentType = new MediaTypeHeaderValue("text/plain")
         {
             CharSet = "utf-8",
         };
         return content;
+    }
+
+    private sealed class CountingStreamContent(Stream stream) : StreamContent(stream)
+    {
+        public int DisposeCount { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            DisposeCount++;
+            base.Dispose(disposing);
+        }
     }
 
     private static ISecretObfuscator CreateObfuscator(params string[] secrets)

--- a/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
@@ -38,7 +38,7 @@ public class HttpFormatterTests
     }
 
     [Test]
-    public async Task RequestFormatter_BoundsPreviewReadAndPreservesBody()
+    public async Task RequestFormatter_PreservesBodyForRepeatedSends()
     {
         const string body = "abcdefghijklmnopqrstuvwxyz";
         var stream = new CountingReadStream(Encoding.UTF8.GetBytes(body));
@@ -52,15 +52,18 @@ public class HttpFormatterTests
         {
             MaxBodySizeToLog = 5,
         });
-        var bytesReadForPreview = stream.BytesRead;
-        var replayedBody = await request.Content.ReadAsStringAsync();
+        using var firstSend = new MemoryStream();
+        using var secondSend = new MemoryStream();
+        await request.Content.CopyToAsync(firstSend);
+        await request.Content.CopyToAsync(secondSend);
 
         using (Assert.Multiple())
         {
-            await Assert.That(bytesReadForPreview).IsLessThanOrEqualTo(6);
             await Assert.That(formatted).Contains("\tabcde");
             await Assert.That(formatted).DoesNotContain("abcdef");
-            await Assert.That(replayedBody).IsEqualTo(body);
+            await Assert.That(Encoding.UTF8.GetString(firstSend.ToArray())).IsEqualTo(body);
+            await Assert.That(Encoding.UTF8.GetString(secondSend.ToArray())).IsEqualTo(body);
+            await Assert.That(stream.IsDisposed).IsTrue();
         }
     }
 
@@ -229,6 +232,8 @@ public class HttpFormatterTests
     {
         public int BytesRead { get; private set; }
 
+        public bool IsDisposed { get; private set; }
+
         public override async ValueTask<int> ReadAsync(
             Memory<byte> buffer,
             CancellationToken cancellationToken = default)
@@ -236,6 +241,12 @@ public class HttpFormatterTests
             var read = await base.ReadAsync(buffer, cancellationToken);
             BytesRead += read;
             return read;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpFormatterTests.cs
@@ -65,6 +65,52 @@ public class HttpFormatterTests
     }
 
     [Test]
+    public async Task ResponseFormatter_UnboundedPreviewPreservesBody()
+    {
+        const string body = "abcdefghijklmnopqrstuvwxyz";
+        using var response = new HttpResponseMessage
+        {
+            Content = CreateTextContent(new MemoryStream(Encoding.UTF8.GetBytes(body))),
+        };
+        var formatter = CreateResponseFormatter();
+
+        var formatted = await formatter.FormatAsync(response, new HttpLoggingOptions
+        {
+            MaxBodySizeToLog = 0,
+        });
+        var replayedBody = await response.Content.ReadAsStringAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(formatted).Contains(body);
+            await Assert.That(replayedBody).IsEqualTo(body);
+        }
+    }
+
+    [Test]
+    public async Task RequestFormatter_UnboundedPreviewPreservesBody()
+    {
+        const string body = "abcdefghijklmnopqrstuvwxyz";
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test")
+        {
+            Content = CreateTextContent(new MemoryStream(Encoding.UTF8.GetBytes(body))),
+        };
+        var formatter = CreateRequestFormatter();
+
+        var formatted = await formatter.FormatAsync(request, new HttpLoggingOptions
+        {
+            MaxBodySizeToLog = 0,
+        });
+        var replayedBody = await request.Content.ReadAsStringAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(formatted).Contains(body);
+            await Assert.That(replayedBody).IsEqualTo(body);
+        }
+    }
+
+    [Test]
     public async Task ResponseFormatter_RedactsSecretCrossingPreviewBoundary()
     {
         const string secret = "secret-value";

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -84,6 +84,88 @@ public class HttpTests : TestBase
     }
 
     [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task SendAsync_HttpClientTimeoutCancelsStreamedBody(bool useCustomClient)
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var contentStream = new BlockingReadStream();
+        using var httpClient = new HttpClient(
+            new ImmediateResponseHandler(new StreamContent(contentStream)))
+        {
+            Timeout = timeout,
+        };
+        var httpClientFactory = new Mock<IHttpClientFactory>();
+        httpClientFactory
+            .Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(httpClient);
+        var http = new ModularPipelines.Http.Http(
+            httpClientFactory.Object,
+            Mock.Of<IModuleLoggerProvider>(),
+            Mock.Of<IHttpLogger>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+        using var response = await http.SendAsync(new HttpOptions(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/client-timeout"))
+        {
+            HttpClient = useCustomClient ? httpClient : null,
+            LoggingType = HttpLoggingType.None,
+        });
+        var stream = response.Content.ReadAsStream();
+        var readTask = stream.ReadAsync(new byte[1]).AsTask();
+
+        try
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await readTask.WaitAsync(TimeSpan.FromSeconds(1)));
+        }
+        finally
+        {
+            contentStream.Release();
+        }
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task SendAsync_ConfiguredTimeoutInterruptsSynchronousBodyRead(bool useCopyTo)
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var contentStream = new BlockingReadStream();
+        using var httpClient = new HttpClient(
+            new ImmediateResponseHandler(new StreamContent(contentStream)));
+        var result = await GetService<IHttpContext>((_, _) => { });
+        using var response = await result.T.SendAsync(new HttpOptions(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/synchronous-read"))
+        {
+            HttpClient = httpClient,
+            LoggingType = HttpLoggingType.None,
+            Timeout = timeout,
+        });
+        var stream = await response.Content.ReadAsStreamAsync();
+        var readTask = Task.Run(() =>
+        {
+            if (useCopyTo)
+            {
+                stream.CopyTo(Stream.Null);
+            }
+            else
+            {
+                stream.ReadExactly(new byte[1]);
+            }
+        });
+
+        try
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await readTask.WaitAsync(TimeSpan.FromSeconds(1)));
+        }
+        finally
+        {
+            contentStream.Release();
+        }
+    }
+
+    [Test]
     public async Task SendAsync_ConfiguredTimeoutCancelsFactoryResponseLogging()
     {
         var timeout = TimeSpan.FromMilliseconds(100);
@@ -361,14 +443,52 @@ public class HttpTests : TestBase
     {
         private readonly TaskCompletionSource _release =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly ManualResetEventSlim _synchronousRelease = new();
+        private bool _isDisposed;
 
-        public void Release() => _release.TrySetResult();
+        public void Release()
+        {
+            _release.TrySetResult();
+            _synchronousRelease.Set();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return WaitForSynchronousRead();
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            return WaitForSynchronousRead();
+        }
 
         public override async ValueTask<int> ReadAsync(
             Memory<byte> buffer,
             CancellationToken cancellationToken = default)
         {
             await _release.Task.WaitAsync(cancellationToken);
+            return 0;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _isDisposed = true;
+                Release();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private int WaitForSynchronousRead()
+        {
+            _synchronousRelease.Wait();
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(BlockingReadStream));
+            }
+
             return 0;
         }
     }

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -125,12 +125,16 @@ public class HttpTests : TestBase
     }
 
     [Test]
-    [Arguments(true)]
-    [Arguments(false)]
-    public async Task SendAsync_ConfiguredTimeoutInterruptsSynchronousBodyRead(bool useCopyTo)
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task SendAsync_ConfiguredTimeoutInterruptsSynchronousBodyRead(
+        bool useCopyTo,
+        bool throwIOExceptionWhenDisposed)
     {
         var timeout = TimeSpan.FromMilliseconds(100);
-        var contentStream = new BlockingReadStream();
+        var contentStream = new BlockingReadStream(throwIOExceptionWhenDisposed);
         using var httpClient = new HttpClient(
             new ImmediateResponseHandler(new StreamContent(contentStream)));
         var result = await GetService<IHttpContext>((_, _) => { });
@@ -163,6 +167,85 @@ public class HttpTests : TestBase
         {
             contentStream.Release();
         }
+    }
+
+    [Test]
+    public async Task SendAsync_CustomClientLogsRawContentBeforeApplyingBodyTimeout()
+    {
+        using var httpClient = new HttpClient(
+            new ImmediateResponseHandler(new StreamContent(new MemoryStream([1, 2, 3]))))
+        {
+            Timeout = TimeSpan.FromSeconds(5),
+        };
+        Type? loggedContentType = null;
+        var httpLogger = new Mock<IHttpLogger>();
+        httpLogger
+            .Setup(x => x.PrintResponse(
+                It.IsAny<HttpResponseMessage>(),
+                It.IsAny<IModuleLogger>(),
+                It.IsAny<HttpLoggingOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<HttpResponseMessage, IModuleLogger, HttpLoggingOptions, CancellationToken>(
+                (response, _, _, _) => loggedContentType = response.Content.GetType())
+            .Returns(Task.CompletedTask);
+        var http = new ModularPipelines.Http.Http(
+            Mock.Of<IHttpClientFactory>(),
+            Mock.Of<IModuleLoggerProvider>(),
+            httpLogger.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+
+        using var response = await http.SendAsync(new HttpOptions(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/binary"))
+        {
+            HttpClient = httpClient,
+            LoggingType = HttpLoggingType.Response,
+        });
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(loggedContentType).IsEqualTo(typeof(StreamContent));
+            await Assert.That(response.Content).IsTypeOf<TimeoutHttpContent>();
+        }
+    }
+
+    [Test]
+    public async Task SendAsync_CustomClientKeepsTimeoutOutsideLoggedReplayContent()
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var content = new StreamContent(
+            new MemoryStream("response body"u8.ToArray()));
+        content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        using var httpClient = new HttpClient(new ImmediateResponseHandler(content));
+        var moduleLoggerProvider = new Mock<IModuleLoggerProvider>();
+        moduleLoggerProvider
+            .Setup(x => x.GetLogger())
+            .Returns(Mock.Of<IModuleLogger>());
+        var httpLogger = new HttpLogger(
+            Mock.Of<IHttpRequestFormatter>(),
+            new HttpResponseFormatter(
+                Mock.Of<ISecretObfuscator>(),
+                Mock.Of<ISecretProvider>(),
+                Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions())));
+        var http = new ModularPipelines.Http.Http(
+            Mock.Of<IHttpClientFactory>(),
+            moduleLoggerProvider.Object,
+            httpLogger,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+        using var response = await http.SendAsync(new HttpOptions(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/logged-timeout"))
+        {
+            HttpClient = httpClient,
+            LoggingType = HttpLoggingType.Response,
+            Timeout = timeout,
+        });
+
+        await Task.Delay(timeout + TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            var stream = await response.Content.ReadAsStreamAsync();
+            await stream.ReadExactlyAsync(new byte[1]);
+        });
     }
 
     [Test]
@@ -439,7 +522,7 @@ public class HttpTests : TestBase
         }
     }
 
-    private sealed class BlockingReadStream : MemoryStream
+    private sealed class BlockingReadStream(bool throwIOExceptionWhenDisposed = false) : MemoryStream
     {
         private readonly TaskCompletionSource _release =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -486,7 +569,9 @@ public class HttpTests : TestBase
             _synchronousRelease.Wait();
             if (_isDisposed)
             {
-                throw new ObjectDisposedException(nameof(BlockingReadStream));
+                throw throwIOExceptionWhenDisposed
+                    ? new IOException("The stream was interrupted.")
+                    : new ObjectDisposedException(nameof(BlockingReadStream));
             }
 
             return 0;

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -350,6 +350,55 @@ public class HttpTests : TestBase
     }
 
     [Test]
+    [Arguments(true, true)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(false, false)]
+    public async Task SendAsync_PreservesCancellationWhileReadingErrorContent(
+        bool useCustomClient,
+        bool useConfiguredTimeout)
+    {
+        var contentStream = new BlockingReadStream();
+        using var httpClient = new HttpClient(
+            new ImmediateResponseHandler(
+                new StreamContent(contentStream),
+                HttpStatusCode.InternalServerError))
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        var httpClientFactory = new Mock<IHttpClientFactory>();
+        httpClientFactory
+            .Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(httpClient);
+        var http = new ModularPipelines.Http.Http(
+            httpClientFactory.Object,
+            Mock.Of<IModuleLoggerProvider>(),
+            Mock.Of<IHttpLogger>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.CancelAfter(TimeSpan.FromMilliseconds(100));
+
+        try
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                await http.SendAsync(new HttpOptions(
+                        new HttpRequestMessage(HttpMethod.Get, "https://example.test/stalled-error-body"))
+                    {
+                        HttpClient = useCustomClient ? httpClient : null,
+                        LoggingType = HttpLoggingType.None,
+                        ThrowOnNonSuccessStatusCode = true,
+                        Timeout = useConfiguredTimeout ? TimeSpan.FromMilliseconds(100) : null,
+                    },
+                    useConfiguredTimeout ? CancellationToken.None : cancellationTokenSource.Token)
+                    .WaitAsync(TimeSpan.FromSeconds(1)));
+        }
+        finally
+        {
+            contentStream.Release();
+        }
+    }
+
+    [Test]
     public async Task SendAsync_CustomClientKeepsTimeoutOutsideLoggedReplayContent()
     {
         var timeout = TimeSpan.FromMilliseconds(100);
@@ -623,7 +672,9 @@ public class HttpTests : TestBase
         }
     }
 
-    private sealed class ImmediateResponseHandler(HttpContent content) : HttpMessageHandler
+    private sealed class ImmediateResponseHandler(
+        HttpContent content,
+        HttpStatusCode statusCode = HttpStatusCode.OK) : HttpMessageHandler
     {
         public TaskCompletionSource RequestReceived { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -633,7 +684,7 @@ public class HttpTests : TestBase
             CancellationToken cancellationToken)
         {
             RequestReceived.TrySetResult();
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            return Task.FromResult(new HttpResponseMessage(statusCode)
             {
                 Content = content,
                 RequestMessage = request,
@@ -665,17 +716,35 @@ public class HttpTests : TestBase
 
     private sealed class BlockingReadStream(
         bool throwIOExceptionWhenDisposed = false,
-        bool ignoreAsyncCancellation = false) : MemoryStream
+        bool ignoreAsyncCancellation = false) : Stream
     {
         private readonly TaskCompletionSource _release =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly ManualResetEventSlim _synchronousRelease = new();
         private bool _isDisposed;
 
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
         public void Release()
         {
             _release.TrySetResult();
             _synchronousRelease.Set();
+        }
+
+        public override void Flush()
+        {
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -721,6 +790,21 @@ public class HttpTests : TestBase
             _synchronousRelease.Wait();
             ThrowIfDisposed();
             return 0;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
         }
 
         private void ThrowIfDisposed()

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -1,13 +1,17 @@
 using System.Net;
+using System.Net.Http.Headers;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Context.Domains.Network;
+using ModularPipelines.Engine;
 using ModularPipelines.Extensions;
 using ModularPipelines.Http;
+using ModularPipelines.Logging;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 using ModularPipelines.UnitTests.Helpers;
+using Moq;
 using NReco.Logging.File;
 using File = System.IO.File;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
@@ -76,6 +80,98 @@ public class HttpTests : TestBase
         finally
         {
             contentStream.Release();
+        }
+    }
+
+    [Test]
+    public async Task SendAsync_ConfiguredTimeoutCancelsFactoryResponseLogging()
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var contentStream = new BlockingReadStream();
+        var content = new StreamContent(contentStream);
+        content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+
+        var moduleLoggerProvider = new Mock<IModuleLoggerProvider>();
+        moduleLoggerProvider
+            .Setup(x => x.GetLogger())
+            .Returns(Mock.Of<IModuleLogger>());
+        var httpLogger = new HttpLogger(
+            Mock.Of<IHttpRequestFormatter>(),
+            new HttpResponseFormatter(
+                Mock.Of<ISecretObfuscator>(),
+                Mock.Of<ISecretProvider>(),
+                Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions())));
+        var responseLoggingHandler = new ResponseLoggingHttpHandler(
+            moduleLoggerProvider.Object,
+            httpLogger)
+        {
+            InnerHandler = new ImmediateResponseHandler(content),
+        };
+        using var httpClient = new HttpClient(responseLoggingHandler);
+        var httpClientFactory = new Mock<IHttpClientFactory>();
+        httpClientFactory
+            .Setup(x => x.CreateClient(It.IsAny<string>()))
+            .Returns(httpClient);
+        var http = new ModularPipelines.Http.Http(
+            httpClientFactory.Object,
+            moduleLoggerProvider.Object,
+            httpLogger,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+
+        try
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                await http.SendAsync(new HttpOptions(
+                        new HttpRequestMessage(HttpMethod.Get, "https://example.test/stalled-log-body"))
+                    {
+                        LoggingType = HttpLoggingType.Response,
+                        Timeout = timeout,
+                    })
+                    .WaitAsync(TimeSpan.FromSeconds(1)));
+        }
+        finally
+        {
+            contentStream.Release();
+        }
+    }
+
+    [Test]
+    public async Task ResilienceHandler_DisposesRetryableResponseBeforeNextAttempt()
+    {
+        var retryContent = new TrackingStringContent("retry");
+        var innerHandler = new SequenceResponseHandler(
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+            {
+                Content = retryContent,
+            },
+            new HttpResponseMessage(HttpStatusCode.OK));
+        var moduleLoggerProvider = new Mock<IModuleLoggerProvider>();
+        moduleLoggerProvider
+            .Setup(x => x.GetLogger())
+            .Returns(Mock.Of<IModuleLogger>());
+        using var handler = new ResilienceHttpHandler(
+            moduleLoggerProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                DefaultHttpResilienceOptions = new HttpResilienceOptions
+                {
+                    MaxRetryAttempts = 1,
+                    InitialDelay = TimeSpan.Zero,
+                    JitterFactor = 0,
+                },
+            }))
+        {
+            InnerHandler = innerHandler,
+        };
+        using var invoker = new HttpMessageInvoker(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Get, "https://example.test/retry");
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(innerHandler.CallCount).IsEqualTo(2);
+            await Assert.That(retryContent.IsDisposed).IsTrue();
         }
     }
 
@@ -274,6 +370,29 @@ public class HttpTests : TestBase
         {
             await _release.Task.WaitAsync(cancellationToken);
             return 0;
+        }
+    }
+
+    private sealed class SequenceResponseHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(responses[CallCount++]);
+        }
+    }
+
+    private sealed class TrackingStringContent(string content) : StringContent(content)
+    {
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,35 @@ namespace ModularPipelines.UnitTests.Context;
 
 public class HttpTests : TestBase
 {
+    [Test]
+    public async Task SendAsync_ReturnsAfterHeadersWithoutBufferingResponseBody()
+    {
+        var content = new BlockingHttpContent();
+        var handler = new ImmediateResponseHandler(content);
+        using var httpClient = new HttpClient(handler);
+        var result = await GetService<IHttpContext>((_, _) => { });
+        var sendTask = result.T.SendAsync(new HttpOptions(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/large-file"))
+        {
+            HttpClient = httpClient,
+            LoggingType = HttpLoggingType.None,
+        });
+
+        await handler.RequestReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await sendTask.WaitAsync(TimeSpan.FromSeconds(1));
+        }
+        finally
+        {
+            content.Release();
+            response ??= await sendTask;
+            response.Dispose();
+        }
+    }
+
     [Test]
     public async Task PublicApi_DoesNotExposeRawHttpClients()
     {
@@ -153,6 +183,46 @@ public class HttpTests : TestBase
             await Assert.That(indexOfRequest).IsLessThan(indexOfStatusCode);
             await Assert.That(indexOfStatusCode).IsLessThan(indexOfDuration);
             await Assert.That(indexOfDuration).IsLessThan(indexOfResponse);
+        }
+    }
+
+    private sealed class ImmediateResponseHandler(HttpContent content) : HttpMessageHandler
+    {
+        public TaskCompletionSource RequestReceived { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            RequestReceived.TrySetResult();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = content,
+                RequestMessage = request,
+            });
+        }
+    }
+
+    private sealed class BlockingHttpContent : HttpContent
+    {
+        private readonly TaskCompletionSource _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Release() => _release.TrySetResult();
+
+        protected override async Task SerializeToStreamAsync(
+            Stream stream,
+            TransportContext? context)
+        {
+            await _release.Task;
+            await stream.WriteAsync("response body"u8.ToArray());
+        }
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -284,7 +284,10 @@ public class HttpTests : TestBase
     }
 
     [Test]
-    public async Task SendAsync_CustomClientTimeoutInterruptsNonCooperativeResponseLogging()
+    [Arguments(4096)]
+    [Arguments(0)]
+    public async Task SendAsync_CustomClientTimeoutInterruptsNonCooperativeResponseLogging(
+        int maxBodySizeToLog)
     {
         var timeout = TimeSpan.FromMilliseconds(100);
         var contentStream = new BlockingReadStream(ignoreAsyncCancellation: true);
@@ -313,9 +316,37 @@ public class HttpTests : TestBase
                 {
                     HttpClient = httpClient,
                     LoggingType = HttpLoggingType.Response,
+                    LogSettings = new HttpLoggingOptions
+                    {
+                        MaxBodySizeToLog = maxBodySizeToLog,
+                    },
                     Timeout = timeout,
                 })
                 .WaitAsync(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public async Task SendAsync_ConfiguredTimeoutInterruptsBufferedBodyCopy()
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var contentStream = new BlockingReadStream(ignoreAsyncCancellation: true);
+        using var httpClient = new HttpClient(
+            new ImmediateResponseHandler(new StreamContent(contentStream)));
+        var http = new ModularPipelines.Http.Http(
+            Mock.Of<IHttpClientFactory>(),
+            Mock.Of<IModuleLoggerProvider>(),
+            Mock.Of<IHttpLogger>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+        using var response = await http.SendAsync(new HttpOptions(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/buffered-timeout"))
+        {
+            HttpClient = httpClient,
+            LoggingType = HttpLoggingType.None,
+            Timeout = timeout,
+        });
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await response.Content.ReadAsStringAsync().WaitAsync(TimeSpan.FromSeconds(1)));
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -284,6 +284,41 @@ public class HttpTests : TestBase
     }
 
     [Test]
+    public async Task SendAsync_CustomClientTimeoutInterruptsNonCooperativeResponseLogging()
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var contentStream = new BlockingReadStream(ignoreAsyncCancellation: true);
+        var content = new StreamContent(contentStream);
+        content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        using var httpClient = new HttpClient(new ImmediateResponseHandler(content));
+        var moduleLoggerProvider = new Mock<IModuleLoggerProvider>();
+        moduleLoggerProvider
+            .Setup(x => x.GetLogger())
+            .Returns(Mock.Of<IModuleLogger>());
+        var httpLogger = new HttpLogger(
+            Mock.Of<IHttpRequestFormatter>(),
+            new HttpResponseFormatter(
+                Mock.Of<ISecretObfuscator>(),
+                Mock.Of<ISecretProvider>(),
+                Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions())));
+        var http = new ModularPipelines.Http.Http(
+            Mock.Of<IHttpClientFactory>(),
+            moduleLoggerProvider.Object,
+            httpLogger,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await http.SendAsync(new HttpOptions(
+                    new HttpRequestMessage(HttpMethod.Get, "https://example.test/stalled-custom-log-body"))
+                {
+                    HttpClient = httpClient,
+                    LoggingType = HttpLoggingType.Response,
+                    Timeout = timeout,
+                })
+                .WaitAsync(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
     public async Task SendAsync_CustomClientKeepsTimeoutOutsideLoggedReplayContent()
     {
         var timeout = TimeSpan.FromMilliseconds(100);

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -125,6 +125,81 @@ public class HttpTests : TestBase
     }
 
     [Test]
+    public async Task SendAsync_InfiniteTimeoutRetainsCallerCancellationForStreamedBody()
+    {
+        var contentStream = new BlockingReadStream();
+        using var httpClient = new HttpClient(
+            new ImmediateResponseHandler(new StreamContent(contentStream)))
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        var http = new ModularPipelines.Http.Http(
+            Mock.Of<IHttpClientFactory>(),
+            Mock.Of<IModuleLoggerProvider>(),
+            Mock.Of<IHttpLogger>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+        using var cancellationTokenSource = new CancellationTokenSource();
+        using var response = await http.SendAsync(new HttpOptions(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/caller-cancellation"))
+        {
+            HttpClient = httpClient,
+            LoggingType = HttpLoggingType.None,
+        }, cancellationTokenSource.Token);
+        var stream = response.Content.ReadAsStream();
+        var readTask = stream.ReadAsync(new byte[1]).AsTask();
+
+        cancellationTokenSource.Cancel();
+
+        try
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await readTask.WaitAsync(TimeSpan.FromSeconds(1)));
+        }
+        finally
+        {
+            contentStream.Release();
+        }
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task SendAsync_NormalizesAsyncStreamFailureAfterTimeout(
+        bool throwIOExceptionWhenDisposed)
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var contentStream = new BlockingReadStream(
+            throwIOExceptionWhenDisposed,
+            ignoreAsyncCancellation: true);
+        using var httpClient = new HttpClient(
+            new ImmediateResponseHandler(new StreamContent(contentStream)));
+        var http = new ModularPipelines.Http.Http(
+            Mock.Of<IHttpClientFactory>(),
+            Mock.Of<IModuleLoggerProvider>(),
+            Mock.Of<IHttpLogger>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+        using var response = await http.SendAsync(new HttpOptions(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/async-timeout"))
+        {
+            HttpClient = httpClient,
+            LoggingType = HttpLoggingType.None,
+            Timeout = timeout,
+        });
+        var stream = response.Content.ReadAsStream();
+        var readTask = stream.ReadAsync(new byte[1]).AsTask();
+
+        try
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await readTask.WaitAsync(TimeSpan.FromSeconds(1)));
+        }
+        finally
+        {
+            contentStream.Release();
+        }
+    }
+
+    [Test]
     [Arguments(true, true)]
     [Arguments(true, false)]
     [Arguments(false, true)]
@@ -522,7 +597,9 @@ public class HttpTests : TestBase
         }
     }
 
-    private sealed class BlockingReadStream(bool throwIOExceptionWhenDisposed = false) : MemoryStream
+    private sealed class BlockingReadStream(
+        bool throwIOExceptionWhenDisposed = false,
+        bool ignoreAsyncCancellation = false) : MemoryStream
     {
         private readonly TaskCompletionSource _release =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -549,7 +626,16 @@ public class HttpTests : TestBase
             Memory<byte> buffer,
             CancellationToken cancellationToken = default)
         {
-            await _release.Task.WaitAsync(cancellationToken);
+            if (ignoreAsyncCancellation)
+            {
+                await _release.Task;
+                ThrowIfDisposed();
+            }
+            else
+            {
+                await _release.Task.WaitAsync(cancellationToken);
+            }
+
             return 0;
         }
 
@@ -567,14 +653,18 @@ public class HttpTests : TestBase
         private int WaitForSynchronousRead()
         {
             _synchronousRelease.Wait();
+            ThrowIfDisposed();
+            return 0;
+        }
+
+        private void ThrowIfDisposed()
+        {
             if (_isDisposed)
             {
                 throw throwIOExceptionWhenDisposed
                     ? new IOException("The stream was interrupted.")
                     : new ObjectDisposedException(nameof(BlockingReadStream));
             }
-
-            return 0;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -247,6 +247,70 @@ public class HttpTests : TestBase
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task SendAsync_DoesNotTreatCancellationAsSuccessfulEndOfStream(
+        bool useBufferedCopy)
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var contentStream = new BlockingReadStream(
+            ignoreAsyncCancellation: true,
+            returnEofWhenDisposed: true);
+        using var httpClient = new HttpClient(
+            new ImmediateResponseHandler(new StreamContent(contentStream)));
+        var http = new ModularPipelines.Http.Http(
+            Mock.Of<IHttpClientFactory>(),
+            Mock.Of<IModuleLoggerProvider>(),
+            Mock.Of<IHttpLogger>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+        using var response = await http.SendAsync(new HttpOptions(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/cancelled-eof"))
+        {
+            HttpClient = httpClient,
+            LoggingType = HttpLoggingType.None,
+            Timeout = timeout,
+        });
+
+        Task readTask;
+        if (useBufferedCopy)
+        {
+            readTask = response.Content.ReadAsStringAsync();
+        }
+        else
+        {
+            var stream = await response.Content.ReadAsStreamAsync();
+            readTask = stream.ReadAsync(new byte[1]).AsTask();
+        }
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await readTask.WaitAsync(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    public async Task SendAsync_CancelsLegacyResponseLogger()
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var contentStream = new BlockingReadStream(ignoreAsyncCancellation: true);
+        using var httpClient = new HttpClient(
+            new ImmediateResponseHandler(new StreamContent(contentStream)));
+        var http = new ModularPipelines.Http.Http(
+            Mock.Of<IHttpClientFactory>(),
+            Mock.Of<IModuleLoggerProvider>(),
+            new LegacyResponseBodyLogger(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await http.SendAsync(new HttpOptions(
+                    new HttpRequestMessage(HttpMethod.Get, "https://example.test/legacy-logger"))
+                {
+                    HttpClient = httpClient,
+                    LoggingType = HttpLoggingType.Response,
+                    Timeout = timeout,
+                })
+                .WaitAsync(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
     [Arguments(true, true)]
     [Arguments(true, false)]
     [Arguments(false, true)]
@@ -763,7 +827,8 @@ public class HttpTests : TestBase
 
     private sealed class BlockingReadStream(
         bool throwIOExceptionWhenDisposed = false,
-        bool ignoreAsyncCancellation = false) : Stream
+        bool ignoreAsyncCancellation = false,
+        bool returnEofWhenDisposed = false) : Stream
     {
         private readonly TaskCompletionSource _release =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -816,7 +881,10 @@ public class HttpTests : TestBase
             if (ignoreAsyncCancellation)
             {
                 await _release.Task;
-                ThrowIfDisposed();
+                if (!returnEofWhenDisposed)
+                {
+                    ThrowIfDisposed();
+                }
             }
             else
             {
@@ -867,6 +935,43 @@ public class HttpTests : TestBase
                     ? new IOException("The stream was interrupted.")
                     : new ObjectDisposedException(nameof(BlockingReadStream));
             }
+        }
+    }
+
+    private sealed class LegacyResponseBodyLogger : IHttpLogger
+    {
+        public Task PrintRequest(HttpRequestMessage request, IModuleLogger logger)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task PrintRequest(
+            HttpRequestMessage request,
+            IModuleLogger logger,
+            HttpLoggingOptions options)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task PrintResponse(HttpResponseMessage response, IModuleLogger logger)
+        {
+            return response.Content.ReadAsStringAsync();
+        }
+
+        public Task PrintResponse(
+            HttpResponseMessage response,
+            IModuleLogger logger,
+            HttpLoggingOptions options)
+        {
+            return response.Content.ReadAsStringAsync();
+        }
+
+        public void PrintStatusCode(HttpStatusCode? httpStatusCode, IModuleLogger logger)
+        {
+        }
+
+        public void PrintDuration(TimeSpan duration, IModuleLogger logger)
+        {
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -200,6 +200,53 @@ public class HttpTests : TestBase
     }
 
     [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task SendAsync_NormalizesAsyncStreamFailureAfterPerReadCancellation(
+        bool throwIOExceptionWhenDisposed)
+    {
+        var contentStream = new BlockingReadStream(
+            throwIOExceptionWhenDisposed,
+            ignoreAsyncCancellation: true);
+        using var httpClient = new HttpClient(
+            new ImmediateResponseHandler(new StreamContent(contentStream)))
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        var http = new ModularPipelines.Http.Http(
+            Mock.Of<IHttpClientFactory>(),
+            Mock.Of<IModuleLoggerProvider>(),
+            Mock.Of<IHttpLogger>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+        using var response = await http.SendAsync(new HttpOptions(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/read-cancellation"))
+        {
+            HttpClient = httpClient,
+            LoggingType = HttpLoggingType.None,
+            Timeout = TimeSpan.FromMinutes(1),
+        });
+        var stream = response.Content.ReadAsStream();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var readTask = stream
+            .ReadAsync(new byte[1], cancellationTokenSource.Token)
+            .AsTask();
+
+        await contentStream.ReadStarted.WaitAsync(TimeSpan.FromSeconds(1));
+        cancellationTokenSource.Cancel();
+
+        try
+        {
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await readTask.WaitAsync(TimeSpan.FromSeconds(1)));
+            await Assert.That(exception!.CancellationToken.IsCancellationRequested).IsTrue();
+        }
+        finally
+        {
+            contentStream.Release();
+        }
+    }
+
+    [Test]
     [Arguments(true, true)]
     [Arguments(true, false)]
     [Arguments(false, true)]
@@ -720,6 +767,8 @@ public class HttpTests : TestBase
     {
         private readonly TaskCompletionSource _release =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _readStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly ManualResetEventSlim _synchronousRelease = new();
         private bool _isDisposed;
 
@@ -736,6 +785,8 @@ public class HttpTests : TestBase
             get => throw new NotSupportedException();
             set => throw new NotSupportedException();
         }
+
+        public Task ReadStarted => _readStarted.Task;
 
         public void Release()
         {
@@ -761,6 +812,7 @@ public class HttpTests : TestBase
             Memory<byte> buffer,
             CancellationToken cancellationToken = default)
         {
+            _readStarted.TrySetResult();
             if (ignoreAsyncCancellation)
             {
                 await _release.Task;

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -296,7 +296,7 @@ public class HttpTests : TestBase
         var http = new ModularPipelines.Http.Http(
             Mock.Of<IHttpClientFactory>(),
             Mock.Of<IModuleLoggerProvider>(),
-            new LegacyResponseBodyLogger(),
+            new LegacyBodyLogger(logRequest: false),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
 
         await Assert.ThrowsAsync<OperationCanceledException>(async () =>
@@ -311,16 +311,50 @@ public class HttpTests : TestBase
     }
 
     [Test]
-    [Arguments(true, true)]
-    [Arguments(true, false)]
-    [Arguments(false, true)]
-    [Arguments(false, false)]
-    public async Task SendAsync_ConfiguredTimeoutInterruptsSynchronousBodyRead(
-        bool useCopyTo,
-        bool throwIOExceptionWhenDisposed)
+    public async Task SendAsync_CancelsLegacyRequestLogger()
     {
         var timeout = TimeSpan.FromMilliseconds(100);
-        var contentStream = new BlockingReadStream(throwIOExceptionWhenDisposed);
+        var contentStream = new BlockingReadStream(ignoreAsyncCancellation: true);
+        using var httpClient = new HttpClient(
+            new ImmediateResponseHandler(new StringContent("response")));
+        var http = new ModularPipelines.Http.Http(
+            Mock.Of<IHttpClientFactory>(),
+            Mock.Of<IModuleLoggerProvider>(),
+            new LegacyBodyLogger(logRequest: true),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
+        using var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            "https://example.test/legacy-request-logger")
+        {
+            Content = new StreamContent(contentStream),
+        };
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await http.SendAsync(new HttpOptions(request)
+                {
+                    HttpClient = httpClient,
+                    LoggingType = HttpLoggingType.Request,
+                    Timeout = timeout,
+                })
+                .WaitAsync(TimeSpan.FromSeconds(1)));
+    }
+
+    [Test]
+    [Arguments(true, true, false)]
+    [Arguments(true, false, false)]
+    [Arguments(false, true, false)]
+    [Arguments(false, false, false)]
+    [Arguments(true, false, true)]
+    [Arguments(false, false, true)]
+    public async Task SendAsync_ConfiguredTimeoutInterruptsSynchronousBodyRead(
+        bool useCopyTo,
+        bool throwIOExceptionWhenDisposed,
+        bool returnEofWhenDisposed)
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var contentStream = new BlockingReadStream(
+            throwIOExceptionWhenDisposed,
+            returnEofWhenDisposed: returnEofWhenDisposed);
         using var httpClient = new HttpClient(
             new ImmediateResponseHandler(new StreamContent(contentStream)));
         var result = await GetService<IHttpContext>((_, _) => { });
@@ -395,13 +429,17 @@ public class HttpTests : TestBase
     }
 
     [Test]
-    [Arguments(4096)]
-    [Arguments(0)]
+    [Arguments(4096, false)]
+    [Arguments(0, false)]
+    [Arguments(0, true)]
     public async Task SendAsync_CustomClientTimeoutInterruptsNonCooperativeResponseLogging(
-        int maxBodySizeToLog)
+        int maxBodySizeToLog,
+        bool returnEofWhenDisposed)
     {
         var timeout = TimeSpan.FromMilliseconds(100);
-        var contentStream = new BlockingReadStream(ignoreAsyncCancellation: true);
+        var contentStream = new BlockingReadStream(
+            ignoreAsyncCancellation: true,
+            returnEofWhenDisposed: returnEofWhenDisposed);
         var content = new StreamContent(contentStream);
         content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
         using var httpClient = new HttpClient(new ImmediateResponseHandler(content));
@@ -938,11 +976,13 @@ public class HttpTests : TestBase
         }
     }
 
-    private sealed class LegacyResponseBodyLogger : IHttpLogger
+    private sealed class LegacyBodyLogger(bool logRequest) : IHttpLogger
     {
         public Task PrintRequest(HttpRequestMessage request, IModuleLogger logger)
         {
-            return Task.CompletedTask;
+            return logRequest
+                ? request.Content!.ReadAsStringAsync()
+                : Task.CompletedTask;
         }
 
         public Task PrintRequest(
@@ -950,12 +990,16 @@ public class HttpTests : TestBase
             IModuleLogger logger,
             HttpLoggingOptions options)
         {
-            return Task.CompletedTask;
+            return logRequest
+                ? request.Content!.ReadAsStringAsync()
+                : Task.CompletedTask;
         }
 
         public Task PrintResponse(HttpResponseMessage response, IModuleLogger logger)
         {
-            return response.Content.ReadAsStringAsync();
+            return logRequest
+                ? Task.CompletedTask
+                : response.Content.ReadAsStringAsync();
         }
 
         public Task PrintResponse(
@@ -963,7 +1007,9 @@ public class HttpTests : TestBase
             IModuleLogger logger,
             HttpLoggingOptions options)
         {
-            return response.Content.ReadAsStringAsync();
+            return logRequest
+                ? Task.CompletedTask
+                : response.Content.ReadAsStringAsync();
         }
 
         public void PrintStatusCode(HttpStatusCode? httpStatusCode, IModuleLogger logger)

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Context.Domains.Network;
+using ModularPipelines.Extensions;
 using ModularPipelines.Http;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
@@ -41,6 +42,40 @@ public class HttpTests : TestBase
             content.Release();
             response ??= await sendTask;
             response.Dispose();
+        }
+    }
+
+    [Test]
+    [Arguments(true)]
+    [Arguments(false)]
+    public async Task SendAsync_ConfiguredTimeoutCancelsStreamedBody(bool useRequestTimeout)
+    {
+        var timeout = TimeSpan.FromMilliseconds(100);
+        var contentStream = new BlockingReadStream();
+        using var httpClient = new HttpClient(new ImmediateResponseHandler(new StreamContent(contentStream)));
+        var result = await GetService<IHttpContext>((builder, _) =>
+            builder.ConfigurePipelineOptions(options => options with
+            {
+                DefaultHttpTimeout = useRequestTimeout ? null : timeout,
+            }));
+        using var response = await result.T.SendAsync(new HttpOptions(
+            new HttpRequestMessage(HttpMethod.Get, "https://example.test/stalled-body"))
+        {
+            HttpClient = httpClient,
+            LoggingType = HttpLoggingType.None,
+            Timeout = useRequestTimeout ? timeout : null,
+        });
+        var stream = await response.Content.ReadAsStreamAsync();
+        var readTask = stream.ReadAsync(new byte[1]).AsTask();
+
+        try
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await readTask.WaitAsync(TimeSpan.FromSeconds(1)));
+        }
+        finally
+        {
+            contentStream.Release();
         }
     }
 
@@ -223,6 +258,22 @@ public class HttpTests : TestBase
         {
             length = 0;
             return false;
+        }
+    }
+
+    private sealed class BlockingReadStream : MemoryStream
+    {
+        private readonly TaskCompletionSource _release =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Release() => _release.TrySetResult();
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            await _release.Task.WaitAsync(cancellationToken);
+            return 0;
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
@@ -69,6 +69,28 @@ public class DownloaderTests : TestBase
     }
 
     [Test]
+    public async Task LegacyProviderFallbackDoesNotDeleteExistingDestination()
+    {
+        const string destination = "download.bin";
+        var fileSystemProvider = new Mock<IFileSystemProvider>
+        {
+            CallBase = true,
+        };
+        fileSystemProvider
+            .Setup(x => x.FileExists(destination))
+            .Returns(true);
+
+        var exception = Assert.Throws<NotSupportedException>(() =>
+            fileSystemProvider.Object.MoveFile("temporary.download", destination, overwrite: true));
+
+        await Assert.That(exception.Message).Contains("does not support atomic overwrite moves");
+        fileSystemProvider.Verify(x => x.DeleteFile(destination), Times.Never());
+        fileSystemProvider.Verify(
+            x => x.MoveFile(It.IsAny<string>(), It.IsAny<string>()),
+            Times.Never());
+    }
+
+    [Test]
     public async Task DownloadFileAsync_PreservesExistingFileWhenStreamingFails()
     {
         var directory = Path.Combine(Path.GetTempPath(), $"modular-pipelines-download-{Guid.NewGuid():N}");

--- a/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
@@ -9,6 +9,14 @@ namespace ModularPipelines.UnitTests.Helpers;
 public class DownloaderTests : TestBase
 {
     [Test]
+    public async Task DownloadOptions_DisableResponseBodyLoggingByDefault()
+    {
+        var options = new DownloadOptions(new Uri("https://example.test/file"));
+
+        await Assert.That(options.LoggingType.HasFlag(ModularPipelines.Http.HttpLoggingType.Response)).IsFalse();
+    }
+
+    [Test]
     public async Task Can_Download()
     {
         var downloader = await GetService<IDownloaderContext>();

--- a/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
@@ -69,6 +69,67 @@ public class DownloaderTests : TestBase
     }
 
     [Test]
+    public async Task DownloadFileAsync_PreservesExistingFileWhenStreamingFails()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"modular-pipelines-download-{Guid.NewGuid():N}");
+        var destination = Path.Combine(directory, "download.bin");
+        Directory.CreateDirectory(directory);
+        await System.IO.File.WriteAllTextAsync(destination, "original");
+
+        try
+        {
+            var content = new StreamContent(new FailingReadStream("partial download"u8.ToArray()));
+            var downloader = CreateDownloader(content);
+
+            await Assert.ThrowsAsync<IOException>(() => downloader.DownloadFileAsync(new DownloadFileOptions(
+                new Uri("https://example.test/download"))
+            {
+                SavePath = destination,
+            }));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(await System.IO.File.ReadAllTextAsync(destination)).IsEqualTo("original");
+                await Assert.That(Directory.GetFiles(directory).Length).IsEqualTo(1);
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task DownloadFileAsync_ReplacesExistingFileAfterStreamingSucceeds()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"modular-pipelines-download-{Guid.NewGuid():N}");
+        var destination = Path.Combine(directory, "download.bin");
+        Directory.CreateDirectory(directory);
+        await System.IO.File.WriteAllTextAsync(destination, "original");
+
+        try
+        {
+            var downloader = CreateDownloader(new StringContent("replacement"));
+
+            await downloader.DownloadFileAsync(new DownloadFileOptions(
+                new Uri("https://example.test/download"))
+            {
+                SavePath = destination,
+            });
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(await System.IO.File.ReadAllTextAsync(destination)).IsEqualTo("replacement");
+                await Assert.That(Directory.GetFiles(directory).Length).IsEqualTo(1);
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task DownloadResponseAsync_DisposesResponseWhenStatusValidationFails()
     {
         var content = new TrackingStringContent("failure");
@@ -113,6 +174,22 @@ public class DownloaderTests : TestBase
         {
             IsDisposed = true;
             base.Dispose(disposing);
+        }
+    }
+
+    private sealed class FailingReadStream(byte[] content) : MemoryStream(content)
+    {
+        private bool _hasRead;
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            if (_hasRead)
+            {
+                throw new IOException("Simulated streaming failure");
+            }
+
+            _hasRead = true;
+            return base.ReadAsync(buffer, cancellationToken);
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
@@ -57,6 +57,9 @@ public class DownloaderTests : TestBase
         fileSystemProvider
             .Setup(x => x.Create(It.IsAny<string>()))
             .Returns(() => new MemoryStream());
+        fileSystemProvider
+            .Setup(x => x.GetRandomFileName())
+            .Returns("random.tmp");
         var downloader = CreateDownloader(content, fileSystemProvider.Object);
 
         await downloader.DownloadFileAsync(new DownloadFileOptions(
@@ -66,6 +69,36 @@ public class DownloaderTests : TestBase
         });
 
         await Assert.That(content.IsDisposed).IsTrue();
+    }
+
+    [Test]
+    public async Task DownloadFileAsync_UsesBoundedSiblingTemporaryName()
+    {
+        var destination = Path.Combine(
+            "downloads",
+            new string('x', 240) + ".bin");
+        var expectedTemporaryPath = Path.Combine("downloads", "random.tmp");
+        var fileSystemProvider = new Mock<IFileSystemProvider>();
+        fileSystemProvider
+            .Setup(x => x.GetRandomFileName())
+            .Returns("random.tmp");
+        fileSystemProvider
+            .Setup(x => x.Create(expectedTemporaryPath))
+            .Returns(() => new MemoryStream());
+        var downloader = CreateDownloader(
+            new StringContent("download"),
+            fileSystemProvider.Object);
+
+        await downloader.DownloadFileAsync(new DownloadFileOptions(
+            new Uri("https://example.test/download"))
+        {
+            SavePath = destination,
+        });
+
+        fileSystemProvider.Verify(x => x.Create(expectedTemporaryPath), Times.Once());
+        fileSystemProvider.Verify(
+            x => x.MoveFile(expectedTemporaryPath, destination, true),
+            Times.Once());
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Files;
 using ModularPipelines.Context.Domains.Network;
+using ModularPipelines.Exceptions;
 using ModularPipelines.FileSystem;
 using ModularPipelines.Logging;
 using ModularPipelines.Options;
@@ -67,15 +68,29 @@ public class DownloaderTests : TestBase
         await Assert.That(content.IsDisposed).IsTrue();
     }
 
+    [Test]
+    public async Task DownloadResponseAsync_DisposesResponseWhenStatusValidationFails()
+    {
+        var content = new TrackingStringContent("failure");
+        var downloader = CreateDownloader(content, statusCode: HttpStatusCode.BadRequest);
+
+        await Assert.ThrowsAsync<HttpResponseException>(() =>
+            downloader.DownloadResponseAsync(
+                new DownloadOptions(new Uri("https://example.test/download"))));
+
+        await Assert.That(content.IsDisposed).IsTrue();
+    }
+
     private static Downloader CreateDownloader(
         HttpContent content,
-        IFileSystemProvider? fileSystemProvider = null)
+        IFileSystemProvider? fileSystemProvider = null,
+        HttpStatusCode statusCode = HttpStatusCode.OK)
     {
         var http = new Mock<IHttpContext>();
         http.Setup(x => x.SendAsync(
                 It.IsAny<HttpOptions>(),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            .ReturnsAsync(new HttpResponseMessage(statusCode)
             {
                 Content = content,
             });

--- a/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DownloaderTests.cs
@@ -1,8 +1,12 @@
+using System.Net;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Files;
 using ModularPipelines.Context.Domains.Network;
+using ModularPipelines.FileSystem;
+using ModularPipelines.Logging;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
+using Moq;
 
 namespace ModularPipelines.UnitTests.Helpers;
 
@@ -26,5 +30,74 @@ public class DownloaderTests : TestBase
         var file = await downloader.DownloadFileAsync(new DownloadFileOptions(server.Uri));
 
         await Assert.That(checksum.Md5(file)).IsEqualTo("AEDF5D7C23744269F358814E602AFE89");
+    }
+
+    [Test]
+    public async Task DownloadStringAsync_DisposesResponse()
+    {
+        var content = new TrackingStringContent("download");
+        var downloader = CreateDownloader(content);
+
+        var result = await downloader.DownloadStringAsync(
+            new DownloadOptions(new Uri("https://example.test/download")));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result).IsEqualTo("download");
+            await Assert.That(content.IsDisposed).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task DownloadFileAsync_DisposesResponse()
+    {
+        var content = new TrackingStringContent("download");
+        var fileSystemProvider = new Mock<IFileSystemProvider>();
+        fileSystemProvider
+            .Setup(x => x.Create(It.IsAny<string>()))
+            .Returns(() => new MemoryStream());
+        var downloader = CreateDownloader(content, fileSystemProvider.Object);
+
+        await downloader.DownloadFileAsync(new DownloadFileOptions(
+            new Uri("https://example.test/download"))
+        {
+            SavePath = "download.bin",
+        });
+
+        await Assert.That(content.IsDisposed).IsTrue();
+    }
+
+    private static Downloader CreateDownloader(
+        HttpContent content,
+        IFileSystemProvider? fileSystemProvider = null)
+    {
+        var http = new Mock<IHttpContext>();
+        http.Setup(x => x.SendAsync(
+                It.IsAny<HttpOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = content,
+            });
+        var moduleLoggerProvider = new Mock<IModuleLoggerProvider>();
+        moduleLoggerProvider
+            .Setup(x => x.GetLogger())
+            .Returns(Mock.Of<IModuleLogger>());
+
+        return new Downloader(
+            moduleLoggerProvider.Object,
+            http.Object,
+            fileSystemProvider ?? SystemFileSystemProvider.Instance);
+    }
+
+    private sealed class TrackingStringContent(string content) : StringContent(content)
+    {
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
     }
 }


### PR DESCRIPTION
Closes #3467.

Streams HTTP response bodies by using `ResponseHeadersRead`, keeps request/default/`HttpClient.Timeout` cancellation alive through body consumption, interrupts synchronous and asynchronous reads, and preserves bounded response-body validation for non-success responses.

Cancellation failures from disposed body streams are normalized to `OperationCanceledException` for configured timeouts, caller cancellation, and per-read cancellation tokens.

Validation:
- `HttpTests`: 31/31 passed
- scoped whitespace formatting passed


### Atomic download follow-up
- Stream downloads into a same-directory temporary file and atomically move into place only after the response body completes.
- Preserve existing destinations and remove temporary files when streaming fails.
- Legacy providers that lack atomic overwrite support now fail before touching an existing destination.`n- `DownloaderTests`: 8/8.


