### PR TITLE
fix(cmd): preserve cancellation semantics

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -228,6 +228,33 @@ internal sealed class Command : ICommandContext
                         deferredOutputLogger,
                         command.WorkingDirPath));
 
+                if (e is OperationCanceledException && cancellationToken.IsCancellationRequested)
+                {
+                    if (ReferenceEquals(failure, e))
+                    {
+                        throw;
+                    }
+
+                    throw new CommandException(
+                        CreateFailureResult(
+                            command,
+                            execOpts,
+                            inputToLog,
+                            -1,
+                            stopwatch.Elapsed,
+                            standardOutput,
+                            standardError),
+                        failure);
+                }
+
+                if (e is OperationCanceledException
+                    && timeoutCancellationToken?.IsCancellationRequested is true)
+                {
+                    throw new TimeoutException(
+                        $"Command execution timed out after {execOpts.ExecutionTimeout!.Value}.",
+                        failure);
+                }
+
                 throw new CommandException(
                     CreateFailureResult(
                         command,

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -246,18 +246,13 @@ internal sealed class Command : ICommandContext
                     timeoutCancellationToken);
             }
 
-            var commandFailure = result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode
-                ? new CommandException(CreateFailureResult(
-                    command,
-                    execOpts,
-                    inputToLog,
-                    result.ExitCode,
-                    result.RunTime,
-                    standardOutput,
-                    standardError,
-                    result.StartTime,
-                    result.ExitTime))
-                : null;
+            var commandFailure = CreateCommandFailure(
+                command,
+                result,
+                execOpts,
+                inputToLog,
+                standardOutput,
+                standardError);
 
             try
             {
@@ -378,6 +373,28 @@ internal sealed class Command : ICommandContext
             endTime: completedAt,
             duration: duration,
             exitCode: exitCode);
+    }
+
+    private CommandException? CreateCommandFailure(
+        CliWrap.Command command,
+        CliWrap.CommandResult result,
+        CommandExecutionOptions execOpts,
+        string input,
+        string standardOutput,
+        string standardError)
+    {
+        return result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode
+            ? new CommandException(CreateFailureResult(
+                command,
+                execOpts,
+                input,
+                result.ExitCode,
+                result.RunTime,
+                standardOutput,
+                standardError,
+                result.StartTime,
+                result.ExitTime))
+            : null;
     }
 
     private static BoundedCommandOutputBuffer? CreateCompleteOutputBuffer(CommandExecutionOptions options)

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -228,43 +228,22 @@ internal sealed class Command : ICommandContext
                         deferredOutputLogger,
                         command.WorkingDirPath));
 
-                if (e is OperationCanceledException && cancellationToken.IsCancellationRequested)
+                if (ShouldPreserveCallerCancellation(e, failure, cancellationToken))
                 {
-                    if (ReferenceEquals(failure, e))
-                    {
-                        throw;
-                    }
-
-                    throw new CommandException(
-                        CreateFailureResult(
-                            command,
-                            execOpts,
-                            inputToLog,
-                            -1,
-                            stopwatch.Elapsed,
-                            standardOutput,
-                            standardError),
-                        failure);
+                    throw;
                 }
 
-                if (e is OperationCanceledException
-                    && timeoutCancellationToken?.IsCancellationRequested is true)
-                {
-                    throw new TimeoutException(
-                        $"Command execution timed out after {execOpts.ExecutionTimeout!.Value}.",
-                        failure);
-                }
-
-                throw new CommandException(
-                    CreateFailureResult(
-                        command,
-                        execOpts,
-                        inputToLog,
-                        -1,
-                        stopwatch.Elapsed,
-                        standardOutput,
-                        standardError),
-                    failure);
+                throw CreateExecutionFailure(
+                    e,
+                    failure,
+                    command,
+                    execOpts,
+                    inputToLog,
+                    stopwatch.Elapsed,
+                    standardOutput,
+                    standardError,
+                    cancellationToken,
+                    timeoutCancellationToken);
             }
 
             var commandFailure = result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode
@@ -324,6 +303,49 @@ internal sealed class Command : ICommandContext
         {
             return new AggregateException(executionFailure, completionFailure);
         }
+    }
+
+    private static bool ShouldPreserveCallerCancellation(
+        Exception executionFailure,
+        Exception combinedFailure,
+        CancellationToken cancellationToken)
+    {
+        return executionFailure is OperationCanceledException
+               && cancellationToken.IsCancellationRequested
+               && ReferenceEquals(combinedFailure, executionFailure);
+    }
+
+    private Exception CreateExecutionFailure(
+        Exception executionFailure,
+        Exception combinedFailure,
+        CliWrap.Command command,
+        CommandExecutionOptions execOpts,
+        string input,
+        TimeSpan duration,
+        string standardOutput,
+        string standardError,
+        CancellationToken cancellationToken,
+        CancellationTokenSource? timeoutCancellationToken)
+    {
+        if (executionFailure is OperationCanceledException
+            && !cancellationToken.IsCancellationRequested
+            && timeoutCancellationToken?.IsCancellationRequested is true)
+        {
+            return new TimeoutException(
+                $"Command execution timed out after {execOpts.ExecutionTimeout!.Value}.",
+                combinedFailure);
+        }
+
+        return new CommandException(
+            CreateFailureResult(
+                command,
+                execOpts,
+                input,
+                -1,
+                duration,
+                standardOutput,
+                standardError),
+            combinedFailure);
     }
 
     private CommandResult CreateFailureResult(

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -3,9 +3,11 @@ using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Attributes;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
+using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.Engine;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
+using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
@@ -19,6 +21,7 @@ public class EngineCancellationTokenTests : TestBase
 {
     private static readonly TimeSpan WaitForCancellationDelay = TimeSpan.FromMilliseconds(100);
     private static TaskCompletionSource PeerModuleStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private static string CommandReadyFile = string.Empty;
 
     private class BadModule : ThrowingTestModule<bool>
     {
@@ -72,6 +75,56 @@ public class EngineCancellationTokenTests : TestBase
             PeerModuleStarted.TrySetResult();
             await Task.Delay(WaitForCancellationDelay, cancellationToken);
             return true;
+        }
+    }
+
+    private class RunningCommandModule : Module<CommandResult>
+    {
+        protected internal override async Task<CommandResult?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return await context.Shell.Command.ExecuteCommandLineToolAsync(
+                new GenericCommandLineToolOptions("pwsh")
+                {
+                    Arguments =
+                    [
+                        "-NoProfile",
+                        "-Command",
+                        "Set-Content -LiteralPath $env:MP_COMMAND_READY_FILE -Value ready; Start-Sleep -Seconds 60",
+                    ],
+                },
+                new CommandExecutionOptions
+                {
+                    EnvironmentVariables = new Dictionary<string, string?>
+                    {
+                        ["MP_COMMAND_READY_FILE"] = CommandReadyFile,
+                    },
+                    ExecutionTimeout = null,
+                    GracefulShutdownTimeout = TimeSpan.FromMilliseconds(50),
+                },
+                cancellationToken);
+        }
+    }
+
+    private class FailAfterCommandStartsModule : Module<bool>
+    {
+        protected internal override async Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            while (!File.Exists(CommandReadyFile))
+            {
+                if (stopwatch.Elapsed > TimeSpan.FromSeconds(10))
+                {
+                    throw new TimeoutException("The command process did not signal readiness.");
+                }
+
+                await Task.Delay(10, cancellationToken);
+            }
+
+            throw new InvalidOperationException("Expected test failure");
         }
     }
 
@@ -150,6 +203,38 @@ public class EngineCancellationTokenTests : TestBase
         await Assert.That(longRunningModuleResult).IsNotNull();
         await Assert.That(longRunningModuleResult!.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
         await Assert.That(longRunningModuleResult.ModuleDuration).IsLessThan(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Running_Command_Is_PipelineTerminated_When_Engine_Cancels()
+    {
+        CommandReadyFile = Path.Combine(
+            Path.GetTempPath(),
+            $"modular-pipelines-command-ready-{Guid.NewGuid():N}");
+
+        try
+        {
+            var builder = TestPipelineHostBuilder.Create()
+                .AddModule<RunningCommandModule>()
+                .AddModule<FailAfterCommandStartsModule>();
+            builder.ConfigurePipelineOptions(options => options with
+            {
+                ThrowOnPipelineFailure = true,
+            });
+
+            var host = await builder.BuildAsync();
+            var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+
+            await Assert.ThrowsAsync<ModuleFailedException>(async () => await host.RunAsync());
+
+            var commandResult = resultRegistry.GetResult(typeof(RunningCommandModule));
+            await Assert.That(commandResult).IsNotNull();
+            await Assert.That(commandResult!.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+        }
+        finally
+        {
+            File.Delete(CommandReadyFile);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -344,7 +344,7 @@ public class CommandTests : TestBase
             childProcess = Process.GetProcessById(childProcessId);
             cancellationTokenSource.Cancel();
 
-            await Assert.ThrowsAsync<CommandException>(async () => await executionTask);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await executionTask);
 
             var childExited = await WaitForExitAsync(childProcess, TimeSpan.FromSeconds(2));
             await Assert.That(childExited).IsTrue();
@@ -397,7 +397,7 @@ public class CommandTests : TestBase
             cancellationTokenSource.Cancel();
             await File.WriteAllTextAsync(parentExitFile, string.Empty);
 
-            await Assert.ThrowsAsync<CommandException>(async () => await executionTask);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await executionTask);
 
             var childExited = await WaitForExitAsync(childProcess, TimeSpan.FromSeconds(2));
             await Assert.That(childExited).IsTrue();
@@ -447,13 +447,33 @@ public class CommandTests : TestBase
             cancellationTokenSource.Cancel();
             await File.WriteAllTextAsync(parentExitFile, string.Empty);
 
-            await Assert.ThrowsAsync<CommandException>(async () => await executionTask);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await executionTask);
             await Assert.That(stopwatch.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
         }
         finally
         {
             File.Delete(parentExitFile);
         }
+    }
+
+    [Test]
+    public async Task ExecuteCommandLineToolAsync_ExecutionTimeout_ThrowsTimeoutException()
+    {
+        var command = await GetService<ICommandContext>();
+
+        var exception = await Assert.ThrowsAsync<TimeoutException>(() =>
+            command.ExecuteCommandLineToolAsync(
+                new GenericCommandLineToolOptions("pwsh")
+                {
+                    Arguments = ["-NoProfile", "-Command", "Start-Sleep -Seconds 60"],
+                },
+                new CommandExecutionOptions
+                {
+                    ExecutionTimeout = TimeSpan.FromMilliseconds(100),
+                    GracefulShutdownTimeout = TimeSpan.FromMilliseconds(50),
+                }));
+
+        await Assert.That(exception!.Message).Contains("timed out after");
     }
 
     [Test]
@@ -511,7 +531,7 @@ public class CommandTests : TestBase
                 grandchildPidFile,
                 grandchildPidFileTimeout.Token);
             grandchildProcess = Process.GetProcessById(grandchildProcessId);
-            await Assert.ThrowsAsync<CommandException>(async () => await executionTask);
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await executionTask);
 
             var grandchildExited = await WaitForExitAsync(grandchildProcess, TimeSpan.FromSeconds(2));
             await Assert.That(grandchildExited).IsTrue();


### PR DESCRIPTION
## Summary

- rethrow caller-requested command cancellation as `OperationCanceledException`
- convert internal execution-timeout cancellation to `TimeoutException`
- preserve command completion logging and its existing failure aggregation
- prove engine cancellation registers an in-flight command module as `PipelineTerminated`

## Tests

- `CommandTests`: 16/16 passed
- `EngineCancellationTokenTests`: 7/7 passed
- deferred logging failure during cancellation: passed
- `ModularPipelines.sln` Release build: passed (0 errors; 217 existing warnings in final incremental build)
- full core unit project with coverage: attempted once; repository guard stopped it at 2,566 MB over the mandated 2 GB limit

## TDD

Before implementation, both caller cancellation and execution timeout regression tests received `CommandException`. They now receive `OperationCanceledException` and `TimeoutException`, respectively.

Closes #3468