### PR TITLE
Harden category filter matching and validation

### DIFF
--- a/docs/docs/how-to/categories.md
+++ b/docs/docs/how-to/categories.md
@@ -17,6 +17,9 @@ If "Run Categories" have been set with some values, only Modules that have any o
 ## Ignore Categories
 If "Ignore Categories" have been set with some values, if a Module has one of those categories, it will not run.
 
+Category names are matched case-insensitively. Pipeline validation fails when a configured run or ignore category
+does not match any registered module, including when a `RunOnlyCategories` filter would select zero modules.
+
 
 ## Example of Running Specific Categories
 

--- a/src/ModularPipelines/Engine/ModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/ModuleConditionHandler.cs
@@ -90,24 +90,24 @@ internal class ModuleConditionHandler : IModuleConditionHandler
     {
         var runOnlyCategories = _pipelineOptions.Value.RunOnlyCategories?.ToArray();
 
-        if (runOnlyCategories?.Any() != true)
+        if (runOnlyCategories is not { Length: > 0 })
         {
             return true;
         }
 
-        return category != null && runOnlyCategories.Contains(category);
+        return category != null && runOnlyCategories.Contains(category, StringComparer.OrdinalIgnoreCase);
     }
 
     private bool IsIgnoreCategory(string? category)
     {
         var ignoreCategories = _pipelineOptions.Value.IgnoreCategories?.ToArray();
 
-        if (ignoreCategories?.Any() != true)
+        if (ignoreCategories is not { Length: > 0 })
         {
             return false;
         }
 
-        return category != null && ignoreCategories.Contains(category);
+        return category != null && ignoreCategories.Contains(category, StringComparer.OrdinalIgnoreCase);
     }
 
     private async Task<(bool IsRunnable, SkipDecision? SkipDecision)> IsRunnableCondition(

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -65,7 +65,8 @@ public record PipelineOptions
     public TimeSpan DefaultModuleTimeout { get; init; } = TimeSpan.FromMinutes(30);
 
     /// <summary>
-    /// Gets the collection of module categories to run exclusively. If specified, only modules in these categories will run.
+    /// Gets the collection of module categories to run exclusively, matched case-insensitively.
+    /// If specified, only modules in these categories will run.
     /// </summary>
     public IReadOnlyList<string>? RunOnlyCategories
     {
@@ -76,7 +77,7 @@ public record PipelineOptions
     }
 
     /// <summary>
-    /// Gets the collection of module categories to ignore during execution.
+    /// Gets the collection of module categories to ignore during execution, matched case-insensitively.
     /// </summary>
     public IReadOnlyList<string>? IgnoreCategories
     {

--- a/src/ModularPipelines/Validation/IOptionsValidator.cs
+++ b/src/ModularPipelines/Validation/IOptionsValidator.cs
@@ -22,5 +22,5 @@ public interface IOptionsValidator : IPipelineValidator
     /// <returns>A validation result containing any errors found.</returns>
     ValidationResult ValidateOptions(
         PipelineOptions options,
-        IReadOnlySet<string> registeredCategories);
+        IReadOnlySet<string> registeredCategories) => ValidateOptions(options);
 }

--- a/src/ModularPipelines/Validation/IOptionsValidator.cs
+++ b/src/ModularPipelines/Validation/IOptionsValidator.cs
@@ -8,9 +8,19 @@ namespace ModularPipelines.Validation;
 public interface IOptionsValidator : IPipelineValidator
 {
     /// <summary>
-    /// Validates the pipeline options.
+    /// Validates pipeline option values that do not depend on registered modules.
     /// </summary>
     /// <param name="options">The pipeline options to validate.</param>
     /// <returns>A validation result containing any errors found.</returns>
     ValidationResult ValidateOptions(PipelineOptions options);
+
+    /// <summary>
+    /// Validates the pipeline options, including category filters against registered categories.
+    /// </summary>
+    /// <param name="options">The pipeline options to validate.</param>
+    /// <param name="registeredCategories">The categories assigned to registered modules.</param>
+    /// <returns>A validation result containing any errors found.</returns>
+    ValidationResult ValidateOptions(
+        PipelineOptions options,
+        IReadOnlySet<string> registeredCategories);
 }

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Modules;
 using ModularPipelines.Options;
 
 namespace ModularPipelines.Validation;
@@ -21,7 +23,10 @@ internal class OptionsValidator : IOptionsValidator
             return ValidationResult.Success();
         }
 
-        return ValidateOptions(optionsSnapshot.Value);
+        var options = optionsSnapshot.Value;
+        var result = ValidateOptions(options);
+        ValidateRegisteredCategories(services, options, result);
+        return result;
     }
 
     /// <inheritdoc />
@@ -84,7 +89,9 @@ internal class OptionsValidator : IOptionsValidator
         // Validate conflicting category filters
         if (options.RunOnlyCategories != null && options.IgnoreCategories != null)
         {
-            var conflicts = options.RunOnlyCategories.Intersect(options.IgnoreCategories).ToList();
+            var conflicts = options.RunOnlyCategories
+                .Intersect(options.IgnoreCategories, StringComparer.OrdinalIgnoreCase)
+                .ToList();
             if (conflicts.Count > 0)
             {
                 result.AddError(new ValidationError(
@@ -94,5 +101,86 @@ internal class OptionsValidator : IOptionsValidator
         }
 
         return result;
+    }
+
+    private static void ValidateRegisteredCategories(
+        IServiceProvider services,
+        PipelineOptions options,
+        ValidationResult result)
+    {
+        var modules = services.GetServices<IModule>().ToArray();
+        if (modules.Length == 0)
+        {
+            return;
+        }
+
+        var metadataRegistry = services.GetRequiredService<IModuleMetadataRegistry>();
+        var registeredCategories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var module in modules)
+        {
+            var moduleType = module.GetType();
+            metadataRegistry.FinalizeMetadata(moduleType, module);
+            if (metadataRegistry.GetCategory(moduleType) is { } category)
+            {
+                registeredCategories.Add(category);
+            }
+        }
+
+        ValidateRunOnlyCategories(options.RunOnlyCategories, registeredCategories, result);
+        ValidateIgnoreCategories(options.IgnoreCategories, registeredCategories, result);
+    }
+
+    private static void ValidateRunOnlyCategories(
+        IReadOnlyList<string>? categories,
+        HashSet<string> registeredCategories,
+        ValidationResult result)
+    {
+        var configuredCategories = categories?
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray() ?? [];
+        if (configuredCategories.Length == 0)
+        {
+            return;
+        }
+
+        var unmatchedCategories = configuredCategories
+            .Where(category => !registeredCategories.Contains(category))
+            .ToArray();
+
+        if (unmatchedCategories.Length == configuredCategories.Length)
+        {
+            result.AddError(new ValidationError(
+                ValidationErrorCategory.Options,
+                "RunOnlyCategories would select zero registered modules. " +
+                $"No registered module matches: {string.Join(", ", unmatchedCategories)}"));
+        }
+        else if (unmatchedCategories.Length > 0)
+        {
+            result.AddError(new ValidationError(
+                ValidationErrorCategory.Options,
+                "RunOnlyCategories contains categories with no registered modules: " +
+                string.Join(", ", unmatchedCategories)));
+        }
+    }
+
+    private static void ValidateIgnoreCategories(
+        IReadOnlyList<string>? categories,
+        HashSet<string> registeredCategories,
+        ValidationResult result)
+    {
+        var unmatchedCategories = categories?
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(category => !registeredCategories.Contains(category))
+            .ToArray() ?? [];
+        if (unmatchedCategories.Length == 0)
+        {
+            return;
+        }
+
+        result.AddError(new ValidationError(
+            ValidationErrorCategory.Options,
+            "IgnoreCategories contains categories with no registered modules: " +
+            string.Join(", ", unmatchedCategories)));
     }
 }

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -111,8 +111,10 @@ internal class OptionsValidator : IOptionsValidator
         ArgumentNullException.ThrowIfNull(registeredCategories);
 
         var result = ValidateOptions(options);
-        ValidateRunOnlyCategories(options.RunOnlyCategories, registeredCategories, result);
-        ValidateIgnoreCategories(options.IgnoreCategories, registeredCategories, result);
+        var normalizedRegisteredCategories =
+            new HashSet<string>(registeredCategories, StringComparer.OrdinalIgnoreCase);
+        ValidateRunOnlyCategories(options.RunOnlyCategories, normalizedRegisteredCategories, result);
+        ValidateIgnoreCategories(options.IgnoreCategories, normalizedRegisteredCategories, result);
         return result;
     }
 

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -23,10 +23,9 @@ internal class OptionsValidator : IOptionsValidator
             return ValidationResult.Success();
         }
 
-        var options = optionsSnapshot.Value;
-        var result = ValidateOptions(options);
-        ValidateRegisteredCategories(services, options, result);
-        return result;
+        return ValidateOptions(
+            optionsSnapshot.Value,
+            GetRegisteredCategories(services));
     }
 
     /// <inheritdoc />
@@ -103,21 +102,26 @@ internal class OptionsValidator : IOptionsValidator
         return result;
     }
 
-    private static void ValidateRegisteredCategories(
-        IServiceProvider services,
+    /// <inheritdoc />
+    public ValidationResult ValidateOptions(
         PipelineOptions options,
-        ValidationResult result)
+        IReadOnlySet<string> registeredCategories)
     {
-        var modules = services.GetServices<IModule>().ToArray();
-        if (modules.Length == 0)
-        {
-            return;
-        }
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(registeredCategories);
 
+        var result = ValidateOptions(options);
+        ValidateRunOnlyCategories(options.RunOnlyCategories, registeredCategories, result);
+        ValidateIgnoreCategories(options.IgnoreCategories, registeredCategories, result);
+        return result;
+    }
+
+    private static IReadOnlySet<string> GetRegisteredCategories(IServiceProvider services)
+    {
         var metadataRegistry = services.GetRequiredService<IModuleMetadataRegistry>();
         var registeredCategories = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var module in modules)
+        foreach (var module in services.GetServices<IModule>())
         {
             var moduleType = module.GetType();
             metadataRegistry.FinalizeMetadata(moduleType, module);
@@ -127,13 +131,12 @@ internal class OptionsValidator : IOptionsValidator
             }
         }
 
-        ValidateRunOnlyCategories(options.RunOnlyCategories, registeredCategories, result);
-        ValidateIgnoreCategories(options.IgnoreCategories, registeredCategories, result);
+        return registeredCategories;
     }
 
     private static void ValidateRunOnlyCategories(
         IReadOnlyList<string>? categories,
-        HashSet<string> registeredCategories,
+        IReadOnlySet<string> registeredCategories,
         ValidationResult result)
     {
         var configuredCategories = categories?
@@ -166,7 +169,7 @@ internal class OptionsValidator : IOptionsValidator
 
     private static void ValidateIgnoreCategories(
         IReadOnlyList<string>? categories,
-        HashSet<string> registeredCategories,
+        IReadOnlySet<string> registeredCategories,
         ValidationResult result)
     {
         var unmatchedCategories = categories?

--- a/test/ModularPipelines.UnitTests/Execution/ModuleHistoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleHistoryTests.cs
@@ -22,6 +22,15 @@ public class ModuleHistoryTests
         }
     }
 
+    [ModuleCategory("2")]
+    private class RunnableCategoryModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+
     [ModularPipelines.Attributes.DependsOn<SkipFromCategory>]
     private class UsesCategoryDependency : Module<Status>
     {
@@ -135,6 +144,7 @@ public class ModuleHistoryTests
     {
         var host = await TestPipelineHostBuilder.Create()
             .AddModule<SkipFromCategory>()
+            .AddModule<RunnableCategoryModule>()
             .RunCategories("2")
             .BuildAsync();
 
@@ -194,6 +204,7 @@ public class ModuleHistoryTests
     {
         var host = await TestPipelineHostBuilder.Create()
             .AddModule<SkipFromCategory>()
+            .AddModule<RunnableCategoryModule>()
             .RunCategories("2")
             .AddResultsRepository<NotFoundModuleRepository>()
             .BuildAsync();
@@ -295,6 +306,7 @@ public class ModuleHistoryTests
     {
         var host = await TestPipelineHostBuilder.Create()
             .AddModule<SkipFromCategory>()
+            .AddModule<RunnableCategoryModule>()
             .RunCategories("2")
             .AddResultsRepository<GoodModuleRepository>()
             .BuildAsync();

--- a/test/ModularPipelines.UnitTests/Execution/RunnableCategoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RunnableCategoryTests.cs
@@ -78,6 +78,21 @@ public class RunnableCategoryTests : TestBase
     }
 
     [Test]
+    public async Task RunCategories_Matches_Module_Category_Ignoring_Case()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<RunnableModule1>()
+            .RunCategories("run1")
+            .BuildAsync();
+
+        await host.RunAsync();
+
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+        await Assert.That(resultRegistry.GetResult(typeof(RunnableModule1))!.ModuleStatus)
+            .IsEqualTo(Status.Successful);
+    }
+
+    [Test]
     public async Task When_IgnoreCategories_Specified_Then_Expected_Modules_Run()
     {
         var host = await TestPipelineHostBuilder.Create()
@@ -103,6 +118,21 @@ public class RunnableCategoryTests : TestBase
             await Assert.That(resultRegistry.GetResult(typeof(NonRunnableModule2))!.ModuleStatus).IsEqualTo(Status.Skipped);
             await Assert.That(resultRegistry.GetResult(typeof(OtherModule3))!.ModuleStatus).IsEqualTo(Status.Successful);
         }
+    }
+
+    [Test]
+    public async Task IgnoreCategories_Matches_Module_Category_Ignoring_Case()
+    {
+        var host = await TestPipelineHostBuilder.Create()
+            .AddModule<NonRunnableModule1>()
+            .IgnoreCategories("norun1")
+            .BuildAsync();
+
+        await host.RunAsync();
+
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+        await Assert.That(resultRegistry.GetResult(typeof(NonRunnableModule1))!.ModuleStatus)
+            .IsEqualTo(Status.Skipped);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Results/ResultsRepositoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Results/ResultsRepositoryTests.cs
@@ -46,6 +46,12 @@ public class ResultsRepositoryTests : TestBase
         protected override bool Result => true;
     }
 
+    [ModuleCategory("Other")]
+    private class OtherCategoryModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
     [Test]
     [TUnit.Core.NotInParallel(nameof(ResultsRepositoryTests), Order = 1)]
     public async Task RunOne()
@@ -77,6 +83,7 @@ public class ResultsRepositoryTests : TestBase
             .AddResultsRepository<JsonResultRepository>()
             .AddModule<Module1>()
             .AddModule<Module2>()
+            .AddModule<OtherCategoryModule>()
             .RunCategories("Other")
             .BuildAsync();
 

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -27,6 +27,13 @@ public class ValidationTests
             => Task.FromResult(42);
     }
 
+    [ModuleCategory("Build")]
+    private class CategorizedModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+            => Task.FromResult<string?>("categorized");
+    }
+
     // Module that depends on itself (invalid)
     [ModularPipelines.Attributes.DependsOn<SelfReferencingModule>]
     private class SelfReferencingModule : Module<string>
@@ -578,6 +585,96 @@ public class ValidationTests
         await Assert.That(result.Errors.Any(e =>
             e.Category == ValidationErrorCategory.Options &&
             e.Message.Contains("Category1"))).IsTrue();
+    }
+
+    [Test]
+    public async Task ValidateAsync_WithCaseInsensitiveCategoryConflict_ReturnsError()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.AddModule<CategorizedModule>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            RunOnlyCategories = ["Build"],
+            IgnoreCategories = ["build"],
+        });
+
+        var result = await builder.ValidateAsync();
+
+        await Assert.That(result.Errors.Any(e =>
+            e.Category == ValidationErrorCategory.Options &&
+            e.Message.Contains("Build", StringComparison.OrdinalIgnoreCase))).IsTrue();
+    }
+
+    [Test]
+    public async Task ValidateAsync_WithUnknownRunOnlyCategory_ReturnsError()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.AddModule<CategorizedModule>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            RunOnlyCategories = ["Typo"],
+        });
+
+        var result = await builder.ValidateAsync();
+
+        await Assert.That(result.Errors.Any(e =>
+            e.Category == ValidationErrorCategory.Options &&
+            e.Message.Contains("RunOnlyCategories") &&
+            e.Message.Contains("zero registered modules") &&
+            e.Message.Contains("Typo"))).IsTrue();
+    }
+
+    [Test]
+    public async Task ValidateAsync_WithPartlyUnknownRunOnlyCategories_ReturnsError()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.AddModule<CategorizedModule>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            RunOnlyCategories = ["build", "Typo"],
+        });
+
+        var result = await builder.ValidateAsync();
+
+        await Assert.That(result.Errors.Any(e =>
+            e.Category == ValidationErrorCategory.Options &&
+            e.Message.Contains("RunOnlyCategories") &&
+            e.Message.Contains("Typo"))).IsTrue();
+    }
+
+    [Test]
+    public async Task ValidateAsync_WithUnknownIgnoreCategory_ReturnsError()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.AddModule<CategorizedModule>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            IgnoreCategories = ["Typo"],
+        });
+
+        var result = await builder.ValidateAsync();
+
+        await Assert.That(result.Errors.Any(e =>
+            e.Category == ValidationErrorCategory.Options &&
+            e.Message.Contains("IgnoreCategories") &&
+            e.Message.Contains("Typo"))).IsTrue();
+    }
+
+    [Test]
+    public async Task ValidateAsync_WithCaseInsensitiveCategoryMatch_ReturnsNoCategoryErrors()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.AddModule<CategorizedModule>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            RunOnlyCategories = ["build"],
+        });
+
+        var result = await builder.ValidateAsync();
+
+        await Assert.That(result.Errors.Any(e =>
+            e.Category == ValidationErrorCategory.Options &&
+            e.Message.Contains("categor", StringComparison.OrdinalIgnoreCase))).IsFalse();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -696,6 +696,25 @@ public class ValidationTests
     }
 
     [Test]
+    public async Task ValidateOptions_WithCaseSensitiveCategorySet_MatchesIgnoringCase()
+    {
+        IOptionsValidator validator = new OptionsValidator();
+        var options = new PipelineOptions
+        {
+            RunOnlyCategories = ["build"],
+            IgnoreCategories = ["test"],
+        };
+
+        var result = validator.ValidateOptions(
+            options,
+            new HashSet<string>(["Build", "Test"]));
+
+        await Assert.That(result.Errors.Any(error =>
+            error.Category == ValidationErrorCategory.Options &&
+            error.Message.Contains("categor", StringComparison.OrdinalIgnoreCase))).IsFalse();
+    }
+
+    [Test]
     public async Task ValidateAsync_WithSelfReferencingModule_ReturnsError()
     {
         // Arrange

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -678,6 +678,24 @@ public class ValidationTests
     }
 
     [Test]
+    public async Task ValidateOptions_WithRegisteredCategories_RejectsUnknownCategory()
+    {
+        IOptionsValidator validator = new OptionsValidator();
+        var options = new PipelineOptions
+        {
+            RunOnlyCategories = ["Typo"],
+        };
+
+        var result = validator.ValidateOptions(
+            options,
+            new HashSet<string>(["Build"], StringComparer.OrdinalIgnoreCase));
+
+        await Assert.That(result.Errors).Contains(error =>
+            error.Category == ValidationErrorCategory.Options &&
+            error.Message.Contains("Typo"));
+    }
+
+    [Test]
     public async Task ValidateAsync_WithSelfReferencingModule_ReturnsError()
     {
         // Arrange

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -14,6 +14,18 @@ namespace ModularPipelines.UnitTests.Validation;
 
 public class ValidationTests
 {
+    private sealed class LegacyOptionsValidator : IOptionsValidator
+    {
+        public int Order => 0;
+
+        public ValidationResult Validate(IServiceProvider services) => ValidationResult.Success();
+
+        public ValidationResult ValidateOptions(PipelineOptions options) =>
+            ValidationResult.WithError(new ValidationError(
+                ValidationErrorCategory.Options,
+                "legacy validator called"));
+    }
+
     // Test modules for various scenarios
     private class SimpleModule : Module<string>
     {
@@ -712,6 +724,19 @@ public class ValidationTests
         await Assert.That(result.Errors.Any(error =>
             error.Category == ValidationErrorCategory.Options &&
             error.Message.Contains("categor", StringComparison.OrdinalIgnoreCase))).IsFalse();
+    }
+
+    [Test]
+    public async Task CategoryAwareOverloadUsesLegacyValidatorImplementationByDefault()
+    {
+        IOptionsValidator validator = new LegacyOptionsValidator();
+
+        var result = validator.ValidateOptions(
+            new PipelineOptions(),
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+        await Assert.That(result.Errors).Contains(error =>
+            error.Message == "legacy validator called");
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- match `RunOnlyCategories` and `IgnoreCategories` with `StringComparer.OrdinalIgnoreCase`
- validate category conflicts case-insensitively
- reject unknown run/ignore categories and run-only filters that select zero registered modules
- normalize caller-provided category sets regardless of their comparer
- preserve source and binary-facing compatibility for existing `IOptionsValidator` implementations through a default overload
- document matching and validation behavior

## Validation

- `RunnableCategoryTests`: 5/5 passed
- `ValidationTests`: 39/39 passed
- legacy `IOptionsValidator` implementation regression passed
- scoped formatting/analyzers: clean at error severity
- `ModularPipelines.sln` Release build: 0 errors (227 existing warnings)
- Docusaurus production build: passed

Closes #3489