### PR TITLE
Align fluent and attribute skip semantics

### DIFF
--- a/docs/docs/how-to/run-conditions.md
+++ b/docs/docs/how-to/run-conditions.md
@@ -30,9 +30,9 @@ public class DeployModule : Module<None>
 - `[RunIfAny<T1, T2>]` runs when at least one condition is `true`.
 
 Multiple condition attributes are evaluated in this order: `SkipIf`, `RunIfAll`, then
-`RunIfAny`. Attribute conditions run during module discovery and register a skipped result
-directly. Fluent `.WithSkipWhen(...)` conditions run later in the execution pipeline and invoke
-the skipped hooks and lifecycle notifications.
+`RunIfAny`. Attribute conditions and fluent `.WithSkipWhen(...)` conditions run in the same
+execution pipeline after dependency waiting. Both invoke skipped hooks and lifecycle
+notifications.
 
 Built-in platform conditions include `OnLinux`, `OnWindows`, and `OnMacOS`:
 

--- a/docs/docs/how-to/run-conditions.md
+++ b/docs/docs/how-to/run-conditions.md
@@ -34,6 +34,10 @@ Multiple condition attributes are evaluated in this order: `SkipIf`, `RunIfAll`,
 execution pipeline after dependency waiting. Both invoke skipped hooks and lifecycle
 notifications.
 
+Fluent dependencies are validated before execution conditions are evaluated. Every dependency
+declared with `DependsOn<T>()` must therefore be registered, even when an attribute condition
+will skip the consuming module on the current platform or environment.
+
 Built-in platform conditions include `OnLinux`, `OnWindows`, and `OnMacOS`:
 
 ```csharp

--- a/docs/docs/how-to/skipping.md
+++ b/docs/docs/how-to/skipping.md
@@ -9,11 +9,9 @@ sidebar_position: 7
 
 The recommended way to configure module skipping is through the `Configure()` method with the fluent builder API:
 
-Attribute conditions (`[SkipIf<T>]`, `[RunIfAll<T>]`, and `[RunIfAny<T>]`) remain supported,
-but they run during module discovery, before dependency waiting. An ignored module receives a
-skipped result directly. Fluent `.WithSkipWhen(...)` conditions run in the execution pipeline,
-where skipped hooks and lifecycle notifications are invoked. Use the fluent API when consumers
-depend on those notifications.
+Attribute conditions (`[SkipIf<T>]`, `[RunIfAll<T>]`, and `[RunIfAny<T>]`) remain supported.
+Attribute and fluent conditions run in the same execution pipeline after dependency waiting, so
+both invoke skipped hooks and lifecycle notifications.
 
 ### Simple Condition
 
@@ -103,12 +101,11 @@ public class MyModule : Module<CommandResult>
 
 ## Combining with Other Behaviors
 
-Repeated skip conditions use AND-to-skip semantics. They run in registration order, and the module
-is skipped only when every condition returns `SkipDecision.Skip`. A `SkipDecision.DoNotSkip`
-result stops evaluation and keeps the module eligible to run. When every condition skips, their
-reasons are combined.
+Repeated `WithSkipWhen` conditions use OR-to-skip semantics, matching repeated `[SkipIf<T>]`
+attributes. They run in registration order, and evaluation stops when any condition returns
+`SkipDecision.Skip`.
 
-For example, this module skips cleanup only for CI builds that are not on the main branch:
+For example, this module skips cleanup for either CI builds or non-main branches:
 
 ```csharp
 public class CleanupModule : Module<CommandResult>
@@ -127,8 +124,23 @@ public class CleanupModule : Module<CommandResult>
 }
 ```
 
-When any one of several independent predicates should be enough to skip, combine them in a single
-condition and return `SkipDecision.Skip` when their OR expression is true.
+When every condition must match before the module is skipped, group them explicitly with
+`WithSkipWhenAll`:
+
+```csharp
+protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+    .WithSkipWhenAll(
+        _ => Environment.GetEnvironmentVariable("CI") == "true"
+            ? SkipDecision.Skip("Running in CI")
+            : SkipDecision.DoNotSkip,
+        _ => Environment.GetEnvironmentVariable("DEPLOY_ENV") != "production"
+            ? SkipDecision.Skip("Not deploying to production")
+            : SkipDecision.DoNotSkip)
+    .Build();
+```
+
+Conditions inside a `WithSkipWhenAll` group use AND-to-skip semantics and combine their reasons.
+The group composes with other skip conditions using OR-to-skip semantics.
 
 ## History
 If a module was skipped, you can attempt to find its history from a previous run. See [History](storing-and-retrieving-results)

--- a/src/ModularPipelines/Attributes/OperatingSystemConditions.cs
+++ b/src/ModularPipelines/Attributes/OperatingSystemConditions.cs
@@ -29,36 +29,7 @@ internal static class OperatingSystemConditions
     /// </summary>
     public static IReadOnlyList<string> GetTargets(IConditionAttribute attribute)
     {
-        if (attribute.Logic != ConditionLogic.All)
-        {
-            return [];
-        }
-
-        var conditionTypes = attribute.GetType().GetGenericArguments();
-        if (conditionTypes.Length == 0)
-        {
-            return [];
-        }
-
-        HashSet<string>? supportedOperatingSystems = null;
-
-        foreach (var conditionType in conditionTypes)
-        {
-            var conditionOperatingSystems = GetSupportedOperatingSystems(conditionType);
-            if (conditionOperatingSystems is null)
-            {
-                return [];
-            }
-
-            if (supportedOperatingSystems is null)
-            {
-                supportedOperatingSystems = conditionOperatingSystems;
-            }
-            else
-            {
-                supportedOperatingSystems.IntersectWith(conditionOperatingSystems);
-            }
-        }
+        var supportedOperatingSystems = GetSupportedOperatingSystems(attribute);
 
         if (supportedOperatingSystems is null || supportedOperatingSystems.Count == 0)
         {
@@ -66,6 +37,34 @@ internal static class OperatingSystemConditions
         }
 
         return [CreateCapability(supportedOperatingSystems)];
+    }
+
+    /// <summary>
+    /// Returns whether all-platform attributes require mutually exclusive operating systems.
+    /// </summary>
+    public static bool HasImpossibleCombination(IEnumerable<IConditionAttribute> attributes)
+    {
+        HashSet<string>? supportedOperatingSystems = null;
+
+        foreach (var attribute in attributes)
+        {
+            var attributeOperatingSystems = GetSupportedOperatingSystems(attribute);
+            if (attributeOperatingSystems is null)
+            {
+                continue;
+            }
+
+            if (supportedOperatingSystems is null)
+            {
+                supportedOperatingSystems = attributeOperatingSystems;
+            }
+            else
+            {
+                supportedOperatingSystems.IntersectWith(attributeOperatingSystems);
+            }
+        }
+
+        return supportedOperatingSystems is { Count: 0 };
     }
 
     /// <summary>
@@ -96,6 +95,46 @@ internal static class OperatingSystemConditions
         }
 
         return capabilities;
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2067",
+        Justification = "Condition types come from RunIfAll<T> generic arguments, whose new() constraint preserves a public parameterless constructor.")]
+    private static HashSet<string>? GetSupportedOperatingSystems(IConditionAttribute attribute)
+    {
+        if (attribute.Logic != ConditionLogic.All)
+        {
+            return null;
+        }
+
+        var conditionTypes = attribute.GetType().GetGenericArguments();
+        if (conditionTypes.Length == 0)
+        {
+            return null;
+        }
+
+        HashSet<string>? supportedOperatingSystems = null;
+
+        foreach (var conditionType in conditionTypes)
+        {
+            var conditionOperatingSystems = GetSupportedOperatingSystems(conditionType);
+            if (conditionOperatingSystems is null)
+            {
+                return null;
+            }
+
+            if (supportedOperatingSystems is null)
+            {
+                supportedOperatingSystems = conditionOperatingSystems;
+            }
+            else
+            {
+                supportedOperatingSystems.IntersectWith(conditionOperatingSystems);
+            }
+        }
+
+        return supportedOperatingSystems;
     }
 
     [UnconditionalSuppressMessage(

--- a/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
@@ -61,15 +61,13 @@ public sealed class ModuleConfigurationBuilder
     /// <param name="condition">A function that receives the module context and returns a <see cref="SkipDecision"/>.</param>
     /// <returns>This builder instance for method chaining.</returns>
     /// <remarks>
-    /// Repeated conditions are evaluated in registration order and combined with AND-to-skip semantics:
-    /// the module is skipped only when every condition returns <see cref="SkipDecision.Skip(string?)"/>.
-    /// Any <see cref="SkipDecision.DoNotSkip"/> result keeps the module eligible to run.
-    /// To skip when any of several predicates matches, combine those predicates in one condition.
+    /// Repeated conditions use OR-to-skip semantics. Evaluation stops when a condition returns
+    /// <see cref="SkipDecision.Skip(string?)"/>.
     /// </remarks>
     public ModuleConfigurationBuilder WithSkipWhen(Func<IModuleContext, SkipDecision> condition)
     {
         ArgumentNullException.ThrowIfNull(condition);
-        _skipConditions.Add((context, _) => ValueTask.FromResult(condition(context)));
+        _skipConditions.Add(AdaptSkipCondition(condition));
         return this;
     }
 
@@ -79,16 +77,51 @@ public sealed class ModuleConfigurationBuilder
     /// <param name="condition">A function that receives the module context and cancellation token and returns a <see cref="SkipDecision"/>.</param>
     /// <returns>This builder instance for method chaining.</returns>
     /// <remarks>
-    /// Repeated conditions are evaluated in registration order and combined with AND-to-skip semantics:
-    /// the module is skipped only when every condition returns <see cref="SkipDecision.Skip(string?)"/>.
-    /// Any <see cref="SkipDecision.DoNotSkip"/> result keeps the module eligible to run.
-    /// To skip when any of several predicates matches, combine those predicates in one condition.
+    /// Repeated conditions use OR-to-skip semantics. Evaluation stops when a condition returns
+    /// <see cref="SkipDecision.Skip(string?)"/>.
     /// </remarks>
     public ModuleConfigurationBuilder WithSkipWhen(
         Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>> condition)
     {
         ArgumentNullException.ThrowIfNull(condition);
         _skipConditions.Add(condition);
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a synchronous group of conditions that must all return skip decisions to skip the module.
+    /// </summary>
+    /// <param name="conditions">Conditions evaluated in registration order with AND-to-skip semantics.</param>
+    /// <returns>This builder instance for method chaining.</returns>
+    /// <remarks>
+    /// Each call adds one AND group. The group composes with other skip conditions using OR-to-skip semantics.
+    /// </remarks>
+    public ModuleConfigurationBuilder WithSkipWhenAll(
+        params Func<IModuleContext, SkipDecision>[] conditions)
+    {
+        ArgumentNullException.ThrowIfNull(conditions);
+        ValidateSkipConditionGroup(conditions);
+
+        _skipConditions.Add(ComposeAllSkipConditions(
+            Array.ConvertAll(conditions, AdaptSkipCondition)));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds an asynchronous group of conditions that must all return skip decisions to skip the module.
+    /// </summary>
+    /// <param name="conditions">Conditions evaluated in registration order with AND-to-skip semantics.</param>
+    /// <returns>This builder instance for method chaining.</returns>
+    /// <remarks>
+    /// Each call adds one AND group. The group composes with other skip conditions using OR-to-skip semantics.
+    /// </remarks>
+    public ModuleConfigurationBuilder WithSkipWhenAll(
+        params Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>[] conditions)
+    {
+        ArgumentNullException.ThrowIfNull(conditions);
+        ValidateSkipConditionGroup(conditions);
+
+        _skipConditions.Add(ComposeAllSkipConditions(conditions));
         return this;
     }
 
@@ -373,6 +406,24 @@ public sealed class ModuleConfigurationBuilder
         var conditions = _skipConditions.ToArray();
         return async (context, cancellationToken) =>
         {
+            foreach (var condition in conditions)
+            {
+                var decision = await condition(context, cancellationToken).ConfigureAwait(false);
+                if (decision.ShouldSkip)
+                {
+                    return decision;
+                }
+            }
+
+            return SkipDecision.DoNotSkip;
+        };
+    }
+
+    private static Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>> ComposeAllSkipConditions(
+        IReadOnlyList<Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>> conditions)
+    {
+        return async (context, cancellationToken) =>
+        {
             List<string>? reasons = null;
 
             foreach (var condition in conditions)
@@ -391,6 +442,26 @@ public sealed class ModuleConfigurationBuilder
 
             return SkipDecision.Skip(reasons is null ? null : string.Join("; ", reasons));
         };
+    }
+
+    private static Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>> AdaptSkipCondition(
+        Func<IModuleContext, SkipDecision> condition)
+    {
+        return (context, _) => ValueTask.FromResult(condition(context));
+    }
+
+    private static void ValidateSkipConditionGroup<TCondition>(TCondition[] conditions)
+        where TCondition : Delegate
+    {
+        if (conditions.Length == 0)
+        {
+            throw new ArgumentException("At least one skip condition is required.", nameof(conditions));
+        }
+
+        if (conditions.Any(static condition => condition is null))
+        {
+            throw new ArgumentException("Skip conditions cannot contain null values.", nameof(conditions));
+        }
     }
 
     private static void ValidateModuleType(Type moduleType)

--- a/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
@@ -121,7 +121,7 @@ public sealed class ModuleConfigurationBuilder
         ArgumentNullException.ThrowIfNull(conditions);
         ValidateSkipConditionGroup(conditions);
 
-        _skipConditions.Add(ComposeAllSkipConditions(conditions));
+        _skipConditions.Add(ComposeAllSkipConditions([.. conditions]));
         return this;
     }
 

--- a/src/ModularPipelines/Engine/IModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/IModuleConditionHandler.cs
@@ -5,5 +5,9 @@ namespace ModularPipelines.Engine;
 
 internal interface IModuleConditionHandler
 {
+    Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnoreByCategory(
+        IModule module,
+        CancellationToken cancellationToken = default);
+
     Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnore(IModule module, CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Engine/ModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/ModuleConditionHandler.cs
@@ -68,6 +68,13 @@ internal class ModuleConditionHandler : IModuleConditionHandler
     {
         cancellationToken.ThrowIfCancellationRequested();
         var result = EvaluateCategoryConditions(module);
+        if (!result.ShouldIgnore
+            && IsDistributedMaster()
+            && OperatingSystemConditions.HasImpossibleCombination(GetConditionAttributes(module.GetType()).All))
+        {
+            result = (true, SkipDecision.Skip("Module requires mutually exclusive operating systems"));
+        }
+
         return Task.FromResult(result);
     }
 

--- a/src/ModularPipelines/Engine/ModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/ModuleConditionHandler.cs
@@ -62,9 +62,33 @@ internal class ModuleConditionHandler : IModuleConditionHandler
         }
     }
 
+    public Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnoreByCategory(
+        IModule module,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var result = EvaluateCategoryConditions(module);
+        return Task.FromResult(result);
+    }
+
     private async Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> EvaluateShouldIgnore(
         IModule module,
         CancellationToken cancellationToken)
+    {
+        var categoryResult = EvaluateCategoryConditions(module);
+        if (categoryResult.ShouldIgnore)
+        {
+            return categoryResult;
+        }
+
+        var moduleType = module.GetType();
+        var conditionResult = await IsRunnableCondition(moduleType, cancellationToken).ConfigureAwait(false);
+        return conditionResult.IsRunnable
+            ? (false, null)
+            : (true, conditionResult.SkipDecision);
+    }
+
+    private (bool ShouldIgnore, SkipDecision? SkipDecision) EvaluateCategoryConditions(IModule module)
     {
         var moduleType = module.GetType();
         _metadataRegistry.FinalizeMetadata(moduleType, module);
@@ -80,10 +104,7 @@ internal class ModuleConditionHandler : IModuleConditionHandler
             return (true, SkipDecision.Skip("The module was not in a runnable category"));
         }
 
-        var conditionResult = await IsRunnableCondition(moduleType, cancellationToken).ConfigureAwait(false);
-        return conditionResult.IsRunnable
-            ? (false, null)
-            : (true, conditionResult.SkipDecision);
+        return (false, null);
     }
 
     private bool IsRunnableCategory(string? category)

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -33,17 +33,20 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
     private readonly IModuleResultRepository _resultRepository;
     private readonly EngineCancellationToken _engineCancellationToken;
     private readonly IDirectHookInvoker _directHookInvoker;
+    private readonly IModuleConditionHandler _moduleConditionHandler;
     private readonly IOptions<PipelineOptions> _pipelineOptions;
 
     public ModuleExecutionPipeline(
         IModuleResultRepository resultRepository,
         EngineCancellationToken engineCancellationToken,
         IDirectHookInvoker directHookInvoker,
+        IModuleConditionHandler moduleConditionHandler,
         IOptions<PipelineOptions> pipelineOptions)
     {
         _resultRepository = resultRepository;
         _engineCancellationToken = engineCancellationToken;
         _directHookInvoker = directHookInvoker;
+        _moduleConditionHandler = moduleConditionHandler;
         _pipelineOptions = pipelineOptions;
     }
 
@@ -67,8 +70,19 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             // Setup cancellation based on AlwaysRun behavior
             SetupCancellation(config, executionContext, engineCancellationToken);
 
-            // A required dependency can skip after discovery through a fluent condition.
+            // A required dependency can skip before this module reaches its own conditions.
             var skipDecision = executionContext.SkipResult;
+            if (!skipDecision.ShouldSkip)
+            {
+                var (shouldIgnore, attributeSkipDecision) = await _moduleConditionHandler
+                    .ShouldIgnore(module, executionContext.ModuleCancellationTokenSource.Token)
+                    .ConfigureAwait(false);
+                if (shouldIgnore)
+                {
+                    skipDecision = attributeSkipDecision ?? SkipDecision.Skip("Module was ignored");
+                }
+            }
+
             if (!skipDecision.ShouldSkip && config.SkipCondition != null)
             {
                 skipDecision = await config.SkipCondition(

--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -99,7 +99,9 @@ internal class ModuleRetriever
                 continue;
             }
 
-            var (shouldIgnore, skipDecision) = await _moduleConditionHandler.ShouldIgnore(module, cancellationToken).ConfigureAwait(false);
+            var (shouldIgnore, skipDecision) = await _moduleConditionHandler
+                .ShouldIgnoreByCategory(module, cancellationToken)
+                .ConfigureAwait(false);
             if (shouldIgnore)
             {
                 modulesToIgnore.Add(new IgnoredModule(module, skipDecision ?? SkipDecision.Skip("Module was ignored")));

--- a/test/ModularPipelines.UnitTests/Attributes/LifecycleEventIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/LifecycleEventIntegrationTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Attributes.Events;
 using ModularPipelines.Configuration;
+using ModularPipelines.Conditions;
 using ModularPipelines.Context;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -52,6 +53,11 @@ public class LifecycleEventIntegrationTests : TestBase
         }
     }
 
+    public class AlwaysTrueCondition : IRunCondition
+    {
+        public Task<bool> EvaluateAsync(IPipelineContext context) => Task.FromResult(true);
+    }
+
     [LogStart]
     [LogEnd]
     public class SuccessfulModule : Module<string>
@@ -82,6 +88,19 @@ public class LifecycleEventIntegrationTests : TestBase
             .Build();
 
         protected internal override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<string?>("Should not execute");
+        }
+    }
+
+    [ModularPipelines.Attributes.SkipIf<AlwaysTrueCondition>]
+    [LogStart]
+    [LogSkipped]
+    public class AttributeSkippingModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
         {
             return Task.FromResult<string?>("Should not execute");
         }
@@ -137,5 +156,17 @@ public class LifecycleEventIntegrationTests : TestBase
         await Assert.That(result.Status).IsEqualTo(Enums.Status.Successful);
         await Assert.That(EventLog).Contains("Start:SkippingModule");
         await Assert.That(EventLog.Any(e => e.Contains("Skipped:SkippingModule:Test skip reason"))).IsTrue();
+    }
+
+    [Test]
+    public async Task AttributeSkippingModule_InvokesStartAndSkippedEvents()
+    {
+        var result = await TestPipelineHostBuilder.Create()
+            .AddModule<AttributeSkippingModule>()
+            .ExecutePipelineAsync();
+
+        await Assert.That(result.Status).IsEqualTo(Enums.Status.Successful);
+        await Assert.That(EventLog).Contains("Start:AttributeSkippingModule");
+        await Assert.That(EventLog.Any(e => e.Contains("Skipped:AttributeSkippingModule:SkipIf<AlwaysTrueCondition> returned true"))).IsTrue();
     }
 }

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
@@ -258,6 +258,30 @@ public class ModuleConfigurationTests
     }
 
     [Test]
+    public async Task WithSkipWhenAll_SnapshotsAsyncConditionGroups()
+    {
+        Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>[] conditions =
+        [
+            (_, _) => ValueTask.FromResult(SkipDecision.Skip("Original reason")),
+        ];
+        var config = ModuleConfiguration.Create()
+            .WithSkipWhenAll(conditions)
+            .Build();
+
+        conditions[0] = (_, _) => ValueTask.FromResult(SkipDecision.DoNotSkip);
+
+        var decision = await config.SkipCondition!(
+            Mock.Of<IModuleContext>(),
+            CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(decision.ShouldSkip).IsTrue();
+            await Assert.That(decision.Reason).IsEqualTo("Original reason");
+        }
+    }
+
+    [Test]
     public void WithSkipWhenAll_RejectsEmptyGroups()
     {
         var builder = ModuleConfiguration.Create();

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
@@ -92,19 +92,35 @@ public class ModuleConfigurationTests
     }
 
     [Test]
-    public async Task WithSkipWhen_RepeatedCalls_AndComposeAndShortCircuit()
+    public async Task WithSkipWhenAll_ExposesSyncAndAsyncGroups()
+    {
+        var parameterTypes = typeof(ModuleConfigurationBuilder)
+            .GetMethods()
+            .Where(method => method.Name == nameof(ModuleConfigurationBuilder.WithSkipWhenAll))
+            .Select(method => method.GetParameters().Single().ParameterType)
+            .ToArray();
+
+        await Assert.That(parameterTypes).IsEquivalentTo(
+        [
+            typeof(Func<IModuleContext, SkipDecision>[]),
+            typeof(Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>[]),
+        ]);
+    }
+
+    [Test]
+    public async Task WithSkipWhen_RepeatedCalls_OrComposeAndShortCircuit()
     {
         var evaluatedConditions = new List<string>();
         var config = ModuleConfiguration.Create()
             .WithSkipWhen(_ =>
             {
                 evaluatedConditions.Add("first");
-                return SkipDecision.DoNotSkip;
+                return SkipDecision.Skip("First reason");
             })
             .WithSkipWhen(_ =>
             {
                 evaluatedConditions.Add("second");
-                return SkipDecision.Skip("Should not be evaluated");
+                return SkipDecision.DoNotSkip;
             })
             .Build();
 
@@ -112,8 +128,26 @@ public class ModuleConfigurationTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(decision.ShouldSkip).IsFalse();
+            await Assert.That(decision.ShouldSkip).IsTrue();
+            await Assert.That(decision.Reason).IsEqualTo("First reason");
             await Assert.That(evaluatedConditions).IsEquivalentTo(["first"]);
+        }
+    }
+
+    [Test]
+    public async Task WithSkipWhen_RepeatedCalls_SkipWhenLaterConditionMatches()
+    {
+        var config = ModuleConfiguration.Create()
+            .WithSkipWhen(_ => SkipDecision.DoNotSkip)
+            .WithSkipWhen(_ => SkipDecision.Skip("Second reason"))
+            .Build();
+
+        var decision = await config.SkipCondition!(Mock.Of<IModuleContext>(), CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(decision.ShouldSkip).IsTrue();
+            await Assert.That(decision.Reason).IsEqualTo("Second reason");
         }
     }
 
@@ -179,11 +213,12 @@ public class ModuleConfigurationTests
     }
 
     [Test]
-    public async Task WithSkipWhen_AllConditionsSkip_CombinesReasons()
+    public async Task WithSkipWhenAll_AllConditionsSkip_CombinesReasons()
     {
         var config = ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("First reason"))
-            .WithSkipWhen(_ => SkipDecision.Skip("Second reason"))
+            .WithSkipWhenAll(
+                _ => SkipDecision.Skip("First reason"),
+                _ => SkipDecision.Skip("Second reason"))
             .Build();
 
         var decision = await config.SkipCondition!(Mock.Of<IModuleContext>(), CancellationToken.None);
@@ -196,13 +231,49 @@ public class ModuleConfigurationTests
     }
 
     [Test]
+    public async Task WithSkipWhenAll_StopsWhenConditionDoesNotSkip()
+    {
+        var evaluatedConditions = new List<string>();
+        var config = ModuleConfiguration.Create()
+            .WithSkipWhenAll(
+                _ =>
+                {
+                    evaluatedConditions.Add("first");
+                    return SkipDecision.DoNotSkip;
+                },
+                _ =>
+                {
+                    evaluatedConditions.Add("second");
+                    return SkipDecision.Skip("Should not be evaluated");
+                })
+            .Build();
+
+        var decision = await config.SkipCondition!(Mock.Of<IModuleContext>(), CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(decision.ShouldSkip).IsFalse();
+            await Assert.That(evaluatedConditions).IsEquivalentTo(["first"]);
+        }
+    }
+
+    [Test]
+    public void WithSkipWhenAll_RejectsEmptyGroups()
+    {
+        var builder = ModuleConfiguration.Create();
+
+        Assert.Throws<ArgumentException>(() =>
+            builder.WithSkipWhenAll(Array.Empty<Func<IModuleContext, SkipDecision>>()));
+    }
+
+    [Test]
     public async Task Build_SnapshotsSkipConditions()
     {
         var builder = ModuleConfiguration.Create()
-            .WithSkipWhen(_ => SkipDecision.Skip("First reason"));
+            .WithSkipWhen(_ => SkipDecision.DoNotSkip);
         var firstConfig = builder.Build();
 
-        builder.WithSkipWhen(_ => SkipDecision.DoNotSkip);
+        builder.WithSkipWhen(_ => SkipDecision.Skip("Second reason"));
         var secondConfig = builder.Build();
 
         var context = Mock.Of<IModuleContext>();
@@ -211,8 +282,8 @@ public class ModuleConfigurationTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(firstDecision.ShouldSkip).IsTrue();
-            await Assert.That(secondDecision.ShouldSkip).IsFalse();
+            await Assert.That(firstDecision.ShouldSkip).IsFalse();
+            await Assert.That(secondDecision.ShouldSkip).IsTrue();
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Engine/ModuleConditionHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleConditionHandlerTests.cs
@@ -97,6 +97,36 @@ public class ModuleConditionHandlerTests
     }
 
     [Test]
+    public async Task Distributed_Master_Discovery_Filters_Module_With_Contradictory_Os_Conditions()
+    {
+        var handler = CreateHandler(new DistributedOptions
+        {
+            Enabled = true,
+            InstanceIndex = 0,
+            TotalInstances = 3,
+        });
+
+        var result = await handler.ShouldIgnoreByCategory(new ContradictoryOsModule());
+
+        await Assert.That(result.ShouldIgnore).IsTrue();
+    }
+
+    [Test]
+    public async Task Distributed_Master_Discovery_Does_Not_Filter_Routable_Os_Condition()
+    {
+        var handler = CreateHandler(new DistributedOptions
+        {
+            Enabled = true,
+            InstanceIndex = 0,
+            TotalInstances = 3,
+        });
+
+        var result = await handler.ShouldIgnoreByCategory(CreateForeignOsModule());
+
+        await Assert.That(result.ShouldIgnore).IsFalse();
+    }
+
+    [Test]
     public async Task Distributed_Master_Does_Not_Filter_Unix_Condition_Group()
     {
         var handler = CreateHandler(new DistributedOptions

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -55,10 +55,15 @@ public class ModuleExecutionPipelineTests
             .ReturnsAsync((ModuleResult<int>?) null);
         using var engineCancellationToken =
             new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+        var moduleConditionHandler = new Mock<IModuleConditionHandler>();
+        moduleConditionHandler
+            .Setup(x => x.ShouldIgnore(module, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((false, null));
         var pipeline = new ModuleExecutionPipeline(
             resultRepository.Object,
             engineCancellationToken,
             directHookInvoker.Object,
+            moduleConditionHandler.Object,
             OptionsFactory.Create(new PipelineOptions()));
 
         await pipeline.ExecuteAsync(

--- a/test/ModularPipelines.UnitTests/Engine/ModuleRetrieverTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleRetrieverTests.cs
@@ -17,7 +17,7 @@ public class ModuleRetrieverTests
             .ToArray();
         var conditionHandler = new Mock<IModuleConditionHandler>();
         conditionHandler
-            .Setup(x => x.ShouldIgnore(It.IsAny<IModule>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.ShouldIgnoreByCategory(It.IsAny<IModule>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((false, null));
         var registrationEventExecutor = new Mock<IRegistrationEventExecutor>();
         registrationEventExecutor

--- a/test/ModularPipelines.UnitTests/Execution/NewRunConditionAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/NewRunConditionAttributeTests.cs
@@ -34,11 +34,19 @@ public class NewRunConditionAttributeTests : TestBase
         set => CurrentConditionState.SubsequentConditionWasEvaluated = value;
     }
 
+    private static bool DependencyWasExecuted
+    {
+        get => CurrentConditionState.DependencyWasExecuted;
+        set => CurrentConditionState.DependencyWasExecuted = value;
+    }
+
     private sealed class ConditionState
     {
         public CancellationTokenSource? CancellationTokenSource { get; set; }
 
         public bool SubsequentConditionWasEvaluated { get; set; }
+
+        public bool DependencyWasExecuted { get; set; }
     }
 
     #region Test Conditions
@@ -211,14 +219,27 @@ public class NewRunConditionAttributeTests : TestBase
         public Task<bool> EvaluateAsync(IPipelineContext context) => Task.FromResult(true);
     }
 
-    private class UnregisteredDependencyModule : SimpleTestModule<bool>
+    private class ConditionDependencyModule : SimpleTestModule<bool>
     {
-        protected override bool Result => true;
+        protected override bool Result
+        {
+            get
+            {
+                DependencyWasExecuted = true;
+                return true;
+            }
+        }
     }
 
-    [RunIfAll<AlwaysFalse>]
-    [ModularPipelines.Attributes.DependsOn<UnregisteredDependencyModule>]
-    private class SkippedModuleWithUnregisteredDependency : SimpleTestModule<bool>
+    private class DependencyCompletedCondition : IRunCondition
+    {
+        public Task<bool> EvaluateAsync(IPipelineContext context)
+            => Task.FromResult(DependencyWasExecuted);
+    }
+
+    [SkipIf<DependencyCompletedCondition>]
+    [ModularPipelines.Attributes.DependsOn<ConditionDependencyModule>]
+    private class ConditionAfterDependencyModule : SimpleTestModule<bool>
     {
         protected override bool Result => true;
     }
@@ -494,17 +515,23 @@ public class NewRunConditionAttributeTests : TestBase
     }
 
     [Test]
-    public async Task Attribute_Condition_Is_Evaluated_Before_Dependencies()
+    public async Task Attribute_Condition_Is_Evaluated_After_Dependencies()
     {
+        DependencyWasExecuted = false;
         var host = await TestPipelineHostBuilder.Create()
-            .AddModule<SkippedModuleWithUnregisteredDependency>()
+            .AddModule<ConditionDependencyModule>()
+            .AddModule<ConditionAfterDependencyModule>()
             .BuildAsync();
 
         await host.RunAsync();
 
         var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
-        var moduleResult = resultRegistry.GetResult(typeof(SkippedModuleWithUnregisteredDependency))!;
-        await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Skipped);
+        var moduleResult = resultRegistry.GetResult(typeof(ConditionAfterDependencyModule))!;
+        using (Assert.Multiple())
+        {
+            await Assert.That(DependencyWasExecuted).IsTrue();
+            await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Skipped);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Hooks/DirectModuleHooksTests.cs
+++ b/test/ModularPipelines.UnitTests/Hooks/DirectModuleHooksTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Configuration;
+using ModularPipelines.Conditions;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
 using ModularPipelines.Enums;
@@ -84,6 +85,36 @@ public class DirectModuleHooksTests : TestBase
             await Task.Yield();
             HooksCalled.Add("ExecuteAsync");
             return "Should not reach here";
+        }
+
+        protected override Task OnSkippedAsync(
+            IModuleContext context,
+            SkipDecision skipDecision,
+            CancellationToken cancellationToken)
+        {
+            HooksCalled.Add("OnSkippedAsync");
+            ReceivedSkipDecision = skipDecision;
+            return Task.CompletedTask;
+        }
+    }
+
+    private class AlwaysTrueCondition : IRunCondition
+    {
+        public Task<bool> EvaluateAsync(IPipelineContext context) => Task.FromResult(true);
+    }
+
+    [ModularPipelines.Attributes.SkipIf<AlwaysTrueCondition>]
+    private class AttributeSkippableHookTrackingModule : Module<string>
+    {
+        public List<string> HooksCalled { get; } = [];
+        public SkipDecision? ReceivedSkipDecision { get; private set; }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            HooksCalled.Add("ExecuteAsync");
+            return Task.FromResult<string?>("Should not reach here");
         }
 
         protected override Task OnSkippedAsync(
@@ -227,6 +258,18 @@ public class DirectModuleHooksTests : TestBase
         await Assert.That(module.HooksCalled).DoesNotContain("ExecuteAsync");
         await Assert.That(module.ReceivedSkipDecision).IsNotNull();
         await Assert.That(module.ReceivedSkipDecision!.Reason).IsEqualTo("Test skip reason");
+    }
+
+    [Test]
+    public async Task OnSkippedAsync_CalledWhenAttributeSkipsModule()
+    {
+        var module = await RunModule<AttributeSkippableHookTrackingModule>();
+
+        await Assert.That(module.HooksCalled).Contains("OnSkippedAsync");
+        await Assert.That(module.HooksCalled).DoesNotContain("ExecuteAsync");
+        await Assert.That(module.ReceivedSkipDecision).IsNotNull();
+        await Assert.That(module.ReceivedSkipDecision!.Reason)
+            .IsEqualTo("SkipIf<AlwaysTrueCondition> returned true");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -120,7 +120,7 @@ public class ValidationTests
     }
 
     [RunIfAll<NeverRun>]
-    private class SkippedModuleWithFluentMissingDependency : Module<string>
+    private class ExecutionSkippedModuleWithFluentMissingDependency : Module<string>
     {
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
             .DependsOn<FluentMissingDependencyModule>()
@@ -315,26 +315,21 @@ public class ValidationTests
     }
 
     [Test]
-    public async Task BuildAsync_Ignores_Fluent_Dependencies_For_Discovery_Skipped_Modules()
+    public async Task BuildAsync_Rejects_Fluent_Missing_Dependency_For_Execution_Skipped_Module()
     {
         var builder = Pipeline.CreateBuilder();
-        builder.AddModule<SkippedModuleWithFluentMissingDependency>();
+        builder.AddModule<ExecutionSkippedModuleWithFluentMissingDependency>();
 
-        await using var pipeline = await builder.BuildAsync();
-
-        await Assert.That(pipeline).IsNotNull();
+        await Assert.ThrowsAsync<PipelineValidationException>(() => builder.BuildAsync());
     }
 
     [Test]
-    public async Task ValidateAsync_Ignores_Fluent_Dependencies_For_Discovery_Skipped_Modules()
+    public async Task ValidateAsync_Rejects_Fluent_Missing_Dependency_For_Execution_Skipped_Module()
     {
         var builder = Pipeline.CreateBuilder();
-        builder.AddModule<SkippedModuleWithFluentMissingDependency>();
+        builder.AddModule<ExecutionSkippedModuleWithFluentMissingDependency>();
 
-        var result = await builder.ValidateAsync();
-
-        await Assert.That(result.Errors).DoesNotContain(error =>
-            error.Category == ValidationErrorCategory.Dependency);
+        await AssertDependencyValidationError(builder);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

- make repeated `WithSkipWhen` calls compose OR-to-skip, matching repeated `[SkipIf<T>]` attributes
- add explicit sync and async `WithSkipWhenAll(params ...)` groups for AND-to-skip behavior
- evaluate attribute conditions in the execution pipeline after dependency waiting, so attribute and fluent skips invoke the same direct hooks, lifecycle handlers, receivers, and notifications
- preserve first-class CLI module-selection skips during discovery, then apply category-only discovery skips
- update skip/run-condition documentation

## Validation

- 110/110 tests passed across configuration, attribute conditions, lifecycle events, direct hooks, retrieval, execution-pipeline, and validation coverage
- `ModularPipelines.sln` Release build passed with 0 errors (existing warnings only)
- `git diff --check` passed

Fixes #3487

## Validation behavior

Fluent dependencies are validated before execution conditions. Attribute-conditioned modules must therefore register every `DependsOn<T>()` dependency even when the condition will skip them on the current platform or environment.


### Distributed OS-routing follow-up
- Keep worker-routable OS conditions deferred while filtering impossible intersections during master discovery, before assignments are published.
- `ModuleConditionHandlerTests`: 11/11; `OperatingSystemConditionsTests`: 3/3.

