### PR TITLE
Expose typed ModuleResult variants

### DIFF
--- a/docs/docs/fundamentals.md
+++ b/docs/docs/fundamentals.md
@@ -125,9 +125,9 @@ return myModule switch
 {
     ModuleResult<MyOptionalResult>.Success { Value: var result }
         => await ProcessResult(result),
-    ModuleResult.Skipped { Decision: var skip }
+    ModuleResult<MyOptionalResult>.Skipped { Decision: var skip }
         => null,  // Module was skipped
-    ModuleResult.Failure { Exception: var ex }
+    ModuleResult<MyOptionalResult>.Failure { Exception: var ex }
         => throw new Exception("Dependency failed", ex),
     _ => null
 };

--- a/docs/docs/how-to/sharing-data.md
+++ b/docs/docs/how-to/sharing-data.md
@@ -41,9 +41,9 @@ return result switch
 {
     ModuleResult<MyResult>.Success { Value: var value }
         => await ProcessValue(value),
-    ModuleResult.Failure { Exception: var ex }
+    ModuleResult<MyResult>.Failure { Exception: var ex }
         => HandleFailure(ex),
-    ModuleResult.Skipped { Decision: var skip }
+    ModuleResult<MyResult>.Skipped { Decision: var skip }
         => HandleSkipped(skip.Reason),
     _ => null
 };

--- a/docs/docs/migrating-to-v3.md
+++ b/docs/docs/migrating-to-v3.md
@@ -562,9 +562,9 @@ public class DeployModule : Module<DeployResult>
         {
             ModuleResult<BuildOutput>.Success { Value: var output }
                 => await Deploy(output.ArtifactPath),
-            ModuleResult.Skipped { Decision: var skip }
+            ModuleResult<BuildOutput>.Skipped { Decision: var skip }
                 => null,
-            ModuleResult.Failure { Exception: var ex }
+            ModuleResult<BuildOutput>.Failure { Exception: var ex }
                 => throw new InvalidOperationException("Build failed", ex),
             _ => throw new InvalidOperationException("Unexpected result type")
         };
@@ -581,8 +581,8 @@ var buildResult = await context.GetModule<BuildModule>();
 return buildResult switch
 {
     ModuleResult<BuildOutput>.Success { Value: var output } => Process(output),
-    ModuleResult.Skipped => null,
-    ModuleResult.Failure { Exception: var ex } => throw ex,
+    ModuleResult<BuildOutput>.Skipped => null,
+    ModuleResult<BuildOutput>.Failure { Exception: var ex } => throw ex,
     _ => null
 };
 
@@ -1453,8 +1453,8 @@ var result = await context.GetModule<BuildModule>();
 return result switch
 {
     ModuleResult<BuildOutput>.Success { Value: var output } => Process(output),
-    ModuleResult.Skipped => null,
-    ModuleResult.Failure { Exception: var ex } => throw ex,
+    ModuleResult<BuildOutput>.Skipped => null,
+    ModuleResult<BuildOutput>.Failure { Exception: var ex } => throw ex,
     _ => null
 };
 

--- a/src/ModularPipelines/Engine/Execution/ModuleResultFactory.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleResultFactory.cs
@@ -109,12 +109,8 @@ internal static class ModuleResultFactory
             return skipped with { ModuleStatus = status };
         }
 
-        // For generic types (Success, FailureWrapper, SkippedWrapper), we need to use
-        // reflection to call WithStatusGeneric<T> which handles the 'with' expression.
-        // Wrapper types (FailureWrapper/SkippedWrapper) implement IFailureResult/ISkippedResult
-        // but require the generic path to maintain proper type safety. The wrapper's _inner
-        // field is private and all metadata is copied to the wrapper's own properties, so
-        // using 'with' on the wrapper correctly updates the observable ModuleStatus.
+        // Generic variants require reflection to call WithStatusGeneric<T>, which handles
+        // the 'with' expression while preserving the closed ModuleResult<T> type.
         var resultType = result.GetType();
 
         // Get the generic type argument from ModuleResult<T>

--- a/src/ModularPipelines/Models/ModuleResult.cs
+++ b/src/ModularPipelines/Models/ModuleResult.cs
@@ -68,30 +68,22 @@ public abstract record ModuleResult : IModuleResult
 
     /// <inheritdoc />
     [JsonIgnore]
-    public Exception? ExceptionOrDefault => this switch
-    {
-        Failure f => f.Exception,
-        IFailureResult => GetExceptionFromWrapper(),
-        _ => null,
-    };
+    public Exception? ExceptionOrDefault =>
+        this is Failure failure ? failure.Exception : GetExceptionFromWrapper();
 
     /// <inheritdoc />
     [JsonIgnore]
-    public SkipDecision? SkipDecisionOrDefault => this switch
-    {
-        Skipped sk => sk.Decision,
-        ISkippedResult => GetSkipDecisionFromWrapper(),
-        _ => null,
-    };
+    public SkipDecision? SkipDecisionOrDefault =>
+        this is Skipped skipped ? skipped.Decision : GetSkipDecisionFromWrapper();
 
     /// <summary>
-    /// Gets the exception from a failure wrapper. Override in derived classes.
+    /// Gets the exception from a typed failure variant. Override in derived classes.
     /// </summary>
     /// <returns>The wrapped exception, or <c>null</c>.</returns>
     protected virtual Exception? GetExceptionFromWrapper() => null;
 
     /// <summary>
-    /// Gets the skip decision from a skipped wrapper. Override in derived classes.
+    /// Gets the skip decision from a typed skipped variant. Override in derived classes.
     /// </summary>
     /// <returns>The wrapped skip decision, or <c>null</c>.</returns>
     protected virtual SkipDecision? GetSkipDecisionFromWrapper() => null;
@@ -191,29 +183,15 @@ public abstract record ModuleResult : IModuleResult
 }
 
 /// <summary>
-/// Marker interface for failure results to enable pattern matching across generic types.
-/// </summary>
-internal interface IFailureResult
-{
-}
-
-/// <summary>
-/// Marker interface for skipped results to enable pattern matching across generic types.
-/// </summary>
-internal interface ISkippedResult
-{
-}
-
-/// <summary>
 /// Represents the result of a module execution as a discriminated union.
 /// Use pattern matching to handle Success, Failure, and Skipped cases.
 /// </summary>
 /// <typeparam name="T">The type of value returned on success.</typeparam>
 /// <remarks>
 /// <para>
-/// The type parameter T is only used by the <see cref="Success"/> variant.
-/// <see cref="ModuleResult.Failure"/> and <see cref="ModuleResult.Skipped"/> are non-generic
-/// and shared across all ModuleResult&lt;T&gt; types.
+/// The nested <see cref="Success"/>, <see cref="Failure"/>, and <see cref="Skipped"/>
+/// variants provide the canonical pattern-matching surface for a typed result.
+/// Non-generic failure and skipped results are converted to these variants at typed boundaries.
 /// </para>
 /// </remarks>
 /// <example>
@@ -224,10 +202,10 @@ internal interface ISkippedResult
 ///     case ModuleResult&lt;string&gt;.Success { Value: var value }:
 ///         Console.WriteLine($"Got: {value}");
 ///         break;
-///     case ModuleResult.Failure { Exception: var ex }:
+///     case ModuleResult&lt;string&gt;.Failure { Exception: var ex }:
 ///         Console.WriteLine($"Failed: {ex.Message}");
 ///         break;
-///     case ModuleResult.Skipped { Decision: var skip }:
+///     case ModuleResult&lt;string&gt;.Skipped { Decision: var skip }:
 ///         Console.WriteLine($"Skipped: {skip.Reason}");
 ///         break;
 /// }
@@ -283,8 +261,6 @@ public abstract record ModuleResult<T> : ModuleResult
             Success s => onSuccess(s.Value),
             Failure f => onFailure(f.Exception),
             Skipped sk => onSkipped(sk.Decision),
-            FailureWrapper fw => onFailure(fw.Exception),
-            SkippedWrapper sw => onSkipped(sw.Decision),
             _ => throw new InvalidOperationException("Unknown result type"),
         };
 
@@ -310,16 +286,10 @@ public abstract record ModuleResult<T> : ModuleResult
             case Skipped sk:
                 onSkipped(sk.Decision);
                 break;
-            case FailureWrapper fw:
-                onFailure(fw.Exception);
-                break;
-            case SkippedWrapper sw:
-                onSkipped(sw.Decision);
-                break;
         }
     }
 
-    // === Generic discriminated variant ===
+    // === Generic discriminated variants ===
 
     /// <summary>
     /// Represents a successful module execution with a value.
@@ -327,75 +297,59 @@ public abstract record ModuleResult<T> : ModuleResult
     /// <param name="Value">The value produced by the module, which may be <c>null</c>.</param>
     public sealed record Success(T? Value) : ModuleResult<T>;
 
+    /// <summary>
+    /// Represents a failed module execution with an exception.
+    /// </summary>
+    /// <param name="Exception">The exception that caused the failure.</param>
+    public new sealed record Failure(Exception Exception) : ModuleResult<T>
+    {
+        /// <inheritdoc />
+        protected override Exception? GetExceptionFromWrapper() => Exception;
+    }
+
+    /// <summary>
+    /// Represents a skipped module execution.
+    /// </summary>
+    /// <param name="Decision">The skip decision containing the reason.</param>
+    public new sealed record Skipped(SkipDecision Decision) : ModuleResult<T>
+    {
+        /// <inheritdoc />
+        protected override SkipDecision? GetSkipDecisionFromWrapper() => Decision;
+    }
+
     // === Implicit conversions from non-generic Failure/Skipped ===
 
     /// <summary>
     /// Implicitly converts a non-generic <see cref="ModuleResult.Failure"/> to <see cref="ModuleResult{T}"/>.
     /// </summary>
     /// <param name="failure">The failure result to convert.</param>
-    public static implicit operator ModuleResult<T>(Failure failure) => new FailureWrapper(failure);
+    public static implicit operator ModuleResult<T>(ModuleResult.Failure failure) =>
+        new Failure(failure.Exception)
+        {
+            ModuleName = failure.ModuleName,
+            ModuleTypeName = failure.ModuleTypeName,
+            ModuleDuration = failure.ModuleDuration,
+            ModuleStart = failure.ModuleStart,
+            ModuleEnd = failure.ModuleEnd,
+            ModuleStatus = failure.ModuleStatus,
+            ModuleType = failure.ModuleType,
+        };
 
     /// <summary>
     /// Implicitly converts a non-generic <see cref="ModuleResult.Skipped"/> to <see cref="ModuleResult{T}"/>.
     /// </summary>
     /// <param name="skipped">The skipped result to convert.</param>
-    public static implicit operator ModuleResult<T>(Skipped skipped) => new SkippedWrapper(skipped);
-
-    /// <summary>
-    /// Wrapper that allows non-generic Failure to be used as ModuleResult&lt;T&gt;.
-    /// </summary>
-    internal sealed record FailureWrapper : ModuleResult<T>, IFailureResult
-    {
-        private readonly Failure _inner;
-
-        [SetsRequiredMembers]
-        internal FailureWrapper(Failure inner)
+    public static implicit operator ModuleResult<T>(ModuleResult.Skipped skipped) =>
+        new Skipped(skipped.Decision)
         {
-            _inner = inner;
-            ModuleName = inner.ModuleName;
-            ModuleDuration = inner.ModuleDuration;
-            ModuleStart = inner.ModuleStart;
-            ModuleEnd = inner.ModuleEnd;
-            ModuleStatus = inner.ModuleStatus;
-            ModuleType = inner.ModuleType;
-        }
-
-        /// <summary>
-        /// Gets the wrapped exception.
-        /// </summary>
-        public Exception Exception => _inner.Exception;
-
-        /// <inheritdoc />
-        protected override Exception? GetExceptionFromWrapper() => Exception;
-    }
-
-    /// <summary>
-    /// Wrapper that allows non-generic Skipped to be used as ModuleResult&lt;T&gt;.
-    /// </summary>
-    internal sealed record SkippedWrapper : ModuleResult<T>, ISkippedResult
-    {
-        private readonly Skipped _inner;
-
-        [SetsRequiredMembers]
-        internal SkippedWrapper(Skipped inner)
-        {
-            _inner = inner;
-            ModuleName = inner.ModuleName;
-            ModuleDuration = inner.ModuleDuration;
-            ModuleStart = inner.ModuleStart;
-            ModuleEnd = inner.ModuleEnd;
-            ModuleStatus = inner.ModuleStatus;
-            ModuleType = inner.ModuleType;
-        }
-
-        /// <summary>
-        /// Gets the wrapped skip decision.
-        /// </summary>
-        public SkipDecision Decision => _inner.Decision;
-
-        /// <inheritdoc />
-        protected override SkipDecision? GetSkipDecisionFromWrapper() => Decision;
-    }
+            ModuleName = skipped.ModuleName,
+            ModuleTypeName = skipped.ModuleTypeName,
+            ModuleDuration = skipped.ModuleDuration,
+            ModuleStart = skipped.ModuleStart,
+            ModuleEnd = skipped.ModuleEnd,
+            ModuleStatus = skipped.ModuleStatus,
+            ModuleType = skipped.ModuleType,
+        };
 
     // === Internal factory methods ===
     internal static Success CreateSuccess(T? value, ModuleExecutionContext ctx)
@@ -413,22 +367,40 @@ public abstract record ModuleResult<T> : ModuleResult
         };
     }
 
-    internal static new FailureWrapper CreateFailure(Exception exception, ModuleExecutionContext ctx)
+    internal static new Failure CreateFailure(Exception exception, ModuleExecutionContext ctx)
     {
-        var failure = ModuleResult.CreateFailure(exception, ctx);
-        return new FailureWrapper(failure);
+        var (start, end, duration) = GetTimingInfo(ctx);
+        return new Failure(exception)
+        {
+            ModuleName = ctx.ModuleType.Name,
+            ModuleTypeName = ctx.ModuleType.FullName,
+            ModuleDuration = duration,
+            ModuleStart = start,
+            ModuleEnd = end,
+            ModuleStatus = ctx.Status,
+            ModuleType = ctx.ModuleType,
+        };
     }
 
-    internal static new SkippedWrapper CreateSkipped(SkipDecision decision, ModuleExecutionContext ctx)
+    internal static new Skipped CreateSkipped(SkipDecision decision, ModuleExecutionContext ctx)
     {
-        var skipped = ModuleResult.CreateSkipped(decision, ctx);
-        return new SkippedWrapper(skipped);
+        var (start, end, duration) = GetTimingInfo(ctx);
+        return new Skipped(decision)
+        {
+            ModuleName = ctx.ModuleType.Name,
+            ModuleTypeName = ctx.ModuleType.FullName,
+            ModuleDuration = duration,
+            ModuleStart = start,
+            ModuleEnd = end,
+            ModuleStatus = ctx.Status,
+            ModuleType = ctx.ModuleType,
+        };
     }
 
     /// <inheritdoc />
     protected override object? GetValueOrDefault() => ValueOrDefault;
 
-    // Prevent external inheritance - only Success, FailureWrapper, SkippedWrapper are valid
+    // Prevent external inheritance - only Success, Failure, and Skipped are valid
     private protected ModuleResult()
     {
     }
@@ -878,7 +850,7 @@ internal sealed class ModuleResultJsonConverter<T> : JsonConverter<ModuleResult<
                 ModuleStatus = moduleStatus,
             },
             "Failure" => exception is not null
-                ? new ModuleResult<T>.FailureWrapper(new ModuleResult.Failure(exception)
+                ? new ModuleResult<T>.Failure(exception)
                 {
                     ModuleName = moduleName,
                     ModuleTypeName = moduleTypeName,
@@ -886,10 +858,10 @@ internal sealed class ModuleResultJsonConverter<T> : JsonConverter<ModuleResult<
                     ModuleStart = moduleStart,
                     ModuleEnd = moduleEnd,
                     ModuleStatus = moduleStatus,
-                })
+                }
                 : throw new JsonException("Failure result requires an Exception property in the JSON."),
             "Skipped" => skipDecision is not null
-                ? new ModuleResult<T>.SkippedWrapper(new ModuleResult.Skipped(skipDecision)
+                ? new ModuleResult<T>.Skipped(skipDecision)
                 {
                     ModuleName = moduleName,
                     ModuleTypeName = moduleTypeName,
@@ -897,7 +869,7 @@ internal sealed class ModuleResultJsonConverter<T> : JsonConverter<ModuleResult<
                     ModuleStart = moduleStart,
                     ModuleEnd = moduleEnd,
                     ModuleStatus = moduleStatus,
-                })
+                }
                 : throw new JsonException("Skipped result requires a Decision property in the JSON."),
             _ => throw new JsonException($"Unknown discriminator: {discriminator}"),
         };
@@ -916,10 +888,8 @@ internal sealed class ModuleResultJsonConverter<T> : JsonConverter<ModuleResult<
         var discriminator = value switch
         {
             ModuleResult<T>.Success => "Success",
-            ModuleResult<T>.FailureWrapper => "Failure",
-            ModuleResult<T>.SkippedWrapper => "Skipped",
-            ModuleResult.Failure => "Failure",
-            ModuleResult.Skipped => "Skipped",
+            ModuleResult<T>.Failure => "Failure",
+            ModuleResult<T>.Skipped => "Skipped",
             _ => throw new JsonException("Unknown ModuleResult type"),
         };
         writer.WriteString("$type", discriminator);
@@ -945,19 +915,11 @@ internal sealed class ModuleResultJsonConverter<T> : JsonConverter<ModuleResult<
                 writer.WritePropertyName("Value");
                 JsonSerializer.Serialize(writer, success.Value, options);
                 break;
-            case ModuleResult<T>.FailureWrapper failureWrapper:
-                writer.WritePropertyName("Exception");
-                ExceptionConverter.Write(writer, failureWrapper.Exception, options);
-                break;
-            case ModuleResult<T>.SkippedWrapper skippedWrapper:
-                writer.WritePropertyName("Decision");
-                JsonSerializer.Serialize(writer, skippedWrapper.Decision, options);
-                break;
-            case ModuleResult.Failure failure:
+            case ModuleResult<T>.Failure failure:
                 writer.WritePropertyName("Exception");
                 ExceptionConverter.Write(writer, failure.Exception, options);
                 break;
-            case ModuleResult.Skipped skipped:
+            case ModuleResult<T>.Skipped skipped:
                 writer.WritePropertyName("Decision");
                 JsonSerializer.Serialize(writer, skipped.Decision, options);
                 break;

--- a/src/ModularPipelines/Models/ModuleResult.cs
+++ b/src/ModularPipelines/Models/ModuleResult.cs
@@ -299,12 +299,14 @@ public abstract record ModuleResult<T> : ModuleResult
     /// Represents a successful module execution with a value.
     /// </summary>
     /// <param name="Value">The value produced by the module, which may be <c>null</c>.</param>
+    [JsonConverter(typeof(ModuleResultJsonConverterFactory))]
     public sealed record Success(T? Value) : ModuleResult<T>;
 
     /// <summary>
     /// Represents a failed module execution with an exception.
     /// </summary>
     /// <param name="Exception">The exception that caused the failure.</param>
+    [JsonConverter(typeof(ModuleResultJsonConverterFactory))]
     public new sealed record Failure(Exception Exception) : ModuleResult<T>
     {
         /// <inheritdoc />
@@ -315,6 +317,7 @@ public abstract record ModuleResult<T> : ModuleResult
     /// Represents a skipped module execution.
     /// </summary>
     /// <param name="Decision">The skip decision containing the reason.</param>
+    [JsonConverter(typeof(ModuleResultJsonConverterFactory))]
     public new sealed record Skipped(SkipDecision Decision) : ModuleResult<T>
     {
         /// <inheritdoc />
@@ -573,23 +576,23 @@ internal sealed class ModuleResultJsonConverterFactory : JsonConverterFactory
             return new ModuleResultNonGenericJsonConverter();
         }
 
-        // For generic types, get the type argument
-        Type valueType;
         if (typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(ModuleResult<>))
         {
-            valueType = typeToConvert.GetGenericArguments()[0];
-        }
-        else if (typeToConvert.DeclaringType?.IsGenericType == true)
-        {
-            valueType = typeToConvert.DeclaringType.GetGenericArguments()[0];
-        }
-        else
-        {
-            return null;
+            var valueType = typeToConvert.GetGenericArguments()[0];
+            var converterType = typeof(ModuleResultJsonConverter<>).MakeGenericType(valueType);
+            return (JsonConverter?) Activator.CreateInstance(converterType);
         }
 
-        var converterType = typeof(ModuleResultJsonConverter<>).MakeGenericType(valueType);
-        return (JsonConverter?) Activator.CreateInstance(converterType);
+        if (typeToConvert.IsGenericType &&
+            typeToConvert.DeclaringType?.IsGenericType == true)
+        {
+            var valueType = typeToConvert.GetGenericArguments()[0];
+            var converterType = typeof(ModuleResultVariantJsonConverter<,>)
+                .MakeGenericType(valueType, typeToConvert);
+            return (JsonConverter?) Activator.CreateInstance(converterType);
+        }
+
+        return null;
     }
 }
 
@@ -930,5 +933,30 @@ internal sealed class ModuleResultJsonConverter<T> : JsonConverter<ModuleResult<
         }
 
         writer.WriteEndObject();
+    }
+}
+
+/// <summary>
+/// Adapts the canonical generic converter to a concrete nested result variant.
+/// </summary>
+internal sealed class ModuleResultVariantJsonConverter<T, TVariant> : JsonConverter<TVariant>
+    where TVariant : ModuleResult<T>
+{
+    private static readonly ModuleResultJsonConverter<T> Converter = new();
+
+    public override TVariant? Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        return (TVariant?) Converter.Read(ref reader, typeToConvert, options);
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        TVariant value,
+        JsonSerializerOptions options)
+    {
+        Converter.Write(writer, value, options);
     }
 }

--- a/src/ModularPipelines/Models/ModuleResult.cs
+++ b/src/ModularPipelines/Models/ModuleResult.cs
@@ -68,25 +68,23 @@ public abstract record ModuleResult : IModuleResult
 
     /// <inheritdoc />
     [JsonIgnore]
-    public Exception? ExceptionOrDefault =>
-        this is Failure failure ? failure.Exception : GetExceptionFromWrapper();
+    public Exception? ExceptionOrDefault => GetExceptionCore();
 
     /// <inheritdoc />
     [JsonIgnore]
-    public SkipDecision? SkipDecisionOrDefault =>
-        this is Skipped skipped ? skipped.Decision : GetSkipDecisionFromWrapper();
+    public SkipDecision? SkipDecisionOrDefault => GetSkipDecisionCore();
 
     /// <summary>
-    /// Gets the exception from a typed failure variant. Override in derived classes.
+    /// Gets the exception from a failure variant. Override in derived classes.
     /// </summary>
-    /// <returns>The wrapped exception, or <c>null</c>.</returns>
-    protected virtual Exception? GetExceptionFromWrapper() => null;
+    /// <returns>The exception, or <c>null</c>.</returns>
+    protected virtual Exception? GetExceptionCore() => null;
 
     /// <summary>
-    /// Gets the skip decision from a typed skipped variant. Override in derived classes.
+    /// Gets the skip decision from a skipped variant. Override in derived classes.
     /// </summary>
-    /// <returns>The wrapped skip decision, or <c>null</c>.</returns>
-    protected virtual SkipDecision? GetSkipDecisionFromWrapper() => null;
+    /// <returns>The skip decision, or <c>null</c>.</returns>
+    protected virtual SkipDecision? GetSkipDecisionCore() => null;
 
     // === Internal: Module type tracking ===
 
@@ -110,6 +108,9 @@ public abstract record ModuleResult : IModuleResult
     {
         /// <inheritdoc />
         protected override object? GetValueOrDefault() => null;
+
+        /// <inheritdoc />
+        protected override Exception? GetExceptionCore() => Exception;
     }
 
     /// <summary>
@@ -124,6 +125,9 @@ public abstract record ModuleResult : IModuleResult
     {
         /// <inheritdoc />
         protected override object? GetValueOrDefault() => null;
+
+        /// <inheritdoc />
+        protected override SkipDecision? GetSkipDecisionCore() => Decision;
     }
 
     // === Internal factory methods for non-generic results ===
@@ -304,7 +308,7 @@ public abstract record ModuleResult<T> : ModuleResult
     public new sealed record Failure(Exception Exception) : ModuleResult<T>
     {
         /// <inheritdoc />
-        protected override Exception? GetExceptionFromWrapper() => Exception;
+        protected override Exception? GetExceptionCore() => Exception;
     }
 
     /// <summary>
@@ -314,7 +318,7 @@ public abstract record ModuleResult<T> : ModuleResult
     public new sealed record Skipped(SkipDecision Decision) : ModuleResult<T>
     {
         /// <inheritdoc />
-        protected override SkipDecision? GetSkipDecisionFromWrapper() => Decision;
+        protected override SkipDecision? GetSkipDecisionCore() => Decision;
     }
 
     // === Implicit conversions from non-generic Failure/Skipped ===

--- a/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Master/DistributedModuleExecutorTests.cs
@@ -288,7 +288,7 @@ public class DistributedModuleExecutorTests
             coordinator: noDequeue,
             resultCollector: resultCollector);
 
-        // Create a properly-typed failure result (FailureWrapper<SimpleResult>)
+        // Create a properly typed failure result.
         var failureResult = CreateTypedFailureResult(module, new InvalidOperationException("Worker error"));
         var serialized = serializer.Serialize(
             failureResult,

--- a/test/ModularPipelines.UnitTests/Modules/ModuleResultContractTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/ModuleResultContractTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using ModularPipelines.Context;
 using ModularPipelines.Distributed;
 using ModularPipelines.Enums;
@@ -38,6 +39,97 @@ public class ModuleResultContractTests
         {
             await Assert.That(hasValue).IsFalse();
             await Assert.That(value).IsEqualTo(default);
+        }
+    }
+
+    [Test]
+    public async Task Generic_Failure_Can_Be_Pattern_Matched()
+    {
+        ModuleResult<int> result = CreateFailure();
+
+        var message = result switch
+        {
+            ModuleResult<int>.Failure { Exception: var exception } => exception.Message,
+            _ => null,
+        };
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result).IsTypeOf<ModuleResult<int>.Failure>();
+            await Assert.That(message).IsEqualTo("Failed");
+            await Assert.That(result.ExceptionOrDefault?.Message).IsEqualTo("Failed");
+            await Assert.That(result.ModuleTypeName).IsEqualTo(typeof(IntModule).FullName);
+        }
+    }
+
+    [Test]
+    public async Task Generic_Skipped_Can_Be_Pattern_Matched()
+    {
+        var decision = SkipDecision.Skip("Not needed");
+        ModuleResult<int> result = new ModuleResult.Skipped(decision)
+        {
+            ModuleName = nameof(IntModule),
+            ModuleTypeName = typeof(IntModule).FullName,
+            ModuleDuration = TimeSpan.Zero,
+            ModuleStart = DateTimeOffset.UtcNow,
+            ModuleEnd = DateTimeOffset.UtcNow,
+            ModuleStatus = Status.Skipped,
+        };
+
+        var reason = result switch
+        {
+            ModuleResult<int>.Skipped { Decision: var skip } => skip.Reason,
+            _ => null,
+        };
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result).IsTypeOf<ModuleResult<int>.Skipped>();
+            await Assert.That(reason).IsEqualTo("Not needed");
+            await Assert.That(result.SkipDecisionOrDefault).IsEqualTo(decision);
+            await Assert.That(result.ModuleTypeName).IsEqualTo(typeof(IntModule).FullName);
+        }
+    }
+
+    [Test]
+    public async Task Generic_Failure_RoundTrips_Through_Json()
+    {
+        ModuleResult<int> result = CreateFailure();
+
+        var json = JsonSerializer.Serialize(result);
+        var deserialized = JsonSerializer.Deserialize<ModuleResult<int>>(json);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(deserialized).IsTypeOf<ModuleResult<int>.Failure>();
+            await Assert.That(deserialized!.ExceptionOrDefault?.Message).IsEqualTo("Failed");
+            await Assert.That(deserialized.ModuleName).IsEqualTo(nameof(IntModule));
+            await Assert.That(deserialized.ModuleTypeName).IsEqualTo(typeof(IntModule).FullName);
+        }
+    }
+
+    [Test]
+    public async Task Generic_Skipped_RoundTrips_Through_Json()
+    {
+        ModuleResult<int> result = new ModuleResult<int>.Skipped(SkipDecision.Skip("Not needed"))
+        {
+            ModuleName = nameof(IntModule),
+            ModuleTypeName = typeof(IntModule).FullName,
+            ModuleDuration = TimeSpan.Zero,
+            ModuleStart = DateTimeOffset.UtcNow,
+            ModuleEnd = DateTimeOffset.UtcNow,
+            ModuleStatus = Status.Skipped,
+        };
+
+        var json = JsonSerializer.Serialize(result);
+        var deserialized = JsonSerializer.Deserialize<ModuleResult<int>>(json);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(deserialized).IsTypeOf<ModuleResult<int>.Skipped>();
+            await Assert.That(deserialized!.SkipDecisionOrDefault?.Reason).IsEqualTo("Not needed");
+            await Assert.That(deserialized.ModuleName).IsEqualTo(nameof(IntModule));
+            await Assert.That(deserialized.ModuleTypeName).IsEqualTo(typeof(IntModule).FullName);
         }
     }
 
@@ -84,6 +176,7 @@ public class ModuleResultContractTests
         return new ModuleResult.Failure(new InvalidOperationException("Failed"))
         {
             ModuleName = nameof(IntModule),
+            ModuleTypeName = typeof(IntModule).FullName,
             ModuleDuration = TimeSpan.Zero,
             ModuleStart = DateTimeOffset.UtcNow,
             ModuleEnd = DateTimeOffset.UtcNow,

--- a/test/ModularPipelines.UnitTests/Modules/ModuleResultContractTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/ModuleResultContractTests.cs
@@ -134,6 +134,37 @@ public class ModuleResultContractTests
     }
 
     [Test]
+    public async Task Concrete_Generic_Failure_Serializes_Through_Json()
+    {
+        var result = (ModuleResult<int>.Failure) CreateFailure();
+
+        var json = JsonSerializer.Serialize(result);
+        var deserialized = JsonSerializer.Deserialize<ModuleResult<int>>(json);
+
+        await Assert.That(deserialized).IsTypeOf<ModuleResult<int>.Failure>();
+        await Assert.That(deserialized!.ExceptionOrDefault?.Message).IsEqualTo("Failed");
+    }
+
+    [Test]
+    public async Task Concrete_Generic_Skipped_Serializes_Through_Json()
+    {
+        var result = new ModuleResult<int>.Skipped(SkipDecision.Skip("Not needed"))
+        {
+            ModuleName = nameof(IntModule),
+            ModuleDuration = TimeSpan.Zero,
+            ModuleStart = DateTimeOffset.UtcNow,
+            ModuleEnd = DateTimeOffset.UtcNow,
+            ModuleStatus = Status.Skipped,
+        };
+
+        var json = JsonSerializer.Serialize(result);
+        var deserialized = JsonSerializer.Deserialize<ModuleResult<int>>(json);
+
+        await Assert.That(deserialized).IsTypeOf<ModuleResult<int>.Skipped>();
+        await Assert.That(deserialized!.SkipDecisionOrDefault?.Reason).IsEqualTo("Not needed");
+    }
+
+    [Test]
     public async Task NullSuccess_TryGetValue_ReturnsTrue()
     {
         ModuleResult<string> result = new ModuleResult<string>.Success(null)


### PR DESCRIPTION
Closes #3485

## Summary
- add public `ModuleResult<T>.Failure` and `.Skipped` canonical variants
- preserve non-generic variants through implicit typed conversion
- update JSON/factory handling and current documentation
- remove internal wrappers and marker interfaces

## Validation
- `ModuleResultContractTests`: 7/7
- `ModuleResultSerializerTests`: 2/2
- `ResultsRepositoryTests`: 2/2
- `IgnoredModuleResultRegistrarTests`: 1/1
- `ModuleHistoryTests`: 14/14
- core Release build: 0 errors (227 pre-existing warnings)
- docs production build passed
- `dotnet-inspect` confirms expected public types and no wrappers
- `git diff --check` passed

### Concrete-variant serialization follow-up
- Extracts the closed value type from the constructed nested variant rather than its open declaring type.
- Adds subtype-compatible converter adapters and annotates `Success`, `Failure`, and `Skipped`, so direct concrete serialization uses the canonical polymorphic JSON shape.
- Concrete failure/skipped round-trip regressions included; `ModuleResultContractTests`: 9/9 passing; whitespace formatter clean.
