### PR TITLE
Add first-class pipeline CLI options

### DIFF
--- a/docs/docs/how-to/command-line.md
+++ b/docs/docs/how-to/command-line.md
@@ -1,0 +1,80 @@
+---
+title: Command Line
+sidebar_position: 2
+---
+
+# Command Line
+
+Pass the application's `args` to `Pipeline.CreateBuilder(args)` to enable the
+built-in pipeline command line:
+
+```csharp
+using var builder = Pipeline.CreateBuilder(args);
+
+builder
+    .AddModule<BuildModule>()
+    .AddModule<TestModule>()
+    .AddModule<DeployModule>();
+
+await builder.ExecutePipelineAsync();
+```
+
+## Options
+
+| Option | Behavior |
+| --- | --- |
+| `--list-modules` | Lists registered modules, categories, and direct dependencies without executing modules. |
+| `--module <name>` | Runs a module and its transitive dependency closure. Repeat the option or separate names with commas. |
+| `--skip-module <name>` | Excludes a module. Repeat the option or separate names with commas. |
+| `--categories <name>` | Runs modules in the specified categories. Repeat the option or separate names with commas. |
+| `--ignore-categories <name>` | Excludes modules in the specified categories. Repeat the option or separate names with commas. |
+| `--validate` | Validates pipeline configuration without executing modules. |
+
+Module names are matched case-insensitively. A simple type name, full type name,
+or assembly-qualified type name can be used. If a simple name matches multiple
+registered modules, use a full type name.
+
+For example:
+
+```shell
+dotnet run -- --module TestModule
+dotnet run -- --module BuildModule,TestModule --skip-module SlowTestModule
+dotnet run -- --categories Test --ignore-categories Integration
+dotnet run -- --list-modules
+dotnet run -- --validate
+```
+
+Explicit skips and category filters still apply to targeted dependency closures.
+If a required dependency is skipped, the existing dependency skip behavior also
+skips modules that require it.
+
+Arguments that ModularPipelines does not recognize continue to the .NET host and
+configuration providers.
+
+## Programmatic Selection
+
+Use `PipelineOptions` when the selection does not come from command-line
+arguments:
+
+```csharp
+builder.ConfigurePipelineOptions(options => options with
+{
+    TargetModules = [nameof(TestModule)],
+    SkippedModules = [nameof(SlowTestModule)],
+});
+```
+
+`TargetModules` includes each selected module's transitive dependency closure.
+
+## Disable Built-In Parsing
+
+To forward every argument to host configuration, disable pipeline command-line
+options:
+
+```csharp
+using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+{
+    Args = args,
+    EnableCommandLineOptions = false,
+});
+```

--- a/docs/docs/how-to/pipeline-host.md
+++ b/docs/docs/how-to/pipeline-host.md
@@ -28,6 +28,9 @@ builder
 await builder.ExecutePipelineAsync();
 ```
 
+Passing `args` also enables the [built-in pipeline command line](command-line.md)
+for listing, selecting, skipping, and validating modules.
+
 ## Configuration
 
 Add configuration sources directly via the `Configuration` property:

--- a/src/ModularPipelines/CommandLine/PipelineCommand.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommand.cs
@@ -1,0 +1,8 @@
+namespace ModularPipelines.PipelineCli;
+
+internal enum PipelineCommand
+{
+    Run,
+    ListModules,
+    Validate,
+}

--- a/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
@@ -1,5 +1,6 @@
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using Spectre.Console;
@@ -11,6 +12,8 @@ internal sealed class PipelineCommandHandler(
     IEnumerable<IModule> modules,
     IDependencyChainProvider dependencyChainProvider,
     IRegistrationEventExecutor registrationEventExecutor,
+    IModuleDependencyRegistry dependencyRegistry,
+    IModuleMetadataRegistry metadataRegistry,
     IConsoleWriter consoleWriter)
 {
     private readonly IReadOnlyList<IModule> _modules = modules
@@ -24,10 +27,10 @@ internal sealed class PipelineCommandHandler(
             case PipelineCommand.Run:
                 return null;
             case PipelineCommand.ListModules:
-                await registrationEventExecutor.InvokeRegistrationEventsAsync(_modules).ConfigureAwait(false);
-                cancellationToken.ThrowIfCancellationRequested();
+                await FinalizeModulesAsync(cancellationToken).ConfigureAwait(false);
                 return ListModules();
             case PipelineCommand.Validate:
+                await FinalizeModulesAsync(cancellationToken).ConfigureAwait(false);
                 return ReportSuccessfulValidation();
             default:
                 throw new ArgumentOutOfRangeException(nameof(commandLineOptions));
@@ -36,7 +39,6 @@ internal sealed class PipelineCommandHandler(
 
     private PipelineSummary ListModules()
     {
-        dependencyChainProvider.Initialize(_modules);
         var table = new Table
         {
             Border = TableBorder.Rounded,
@@ -56,12 +58,20 @@ internal sealed class PipelineCommandHandler(
                 .ToArray();
             table.AddRow(
                 Markup.Escape(moduleType.FullName ?? moduleType.Name),
-                Markup.Escape(model.Module.Configuration.Category ?? string.Empty),
+                Markup.Escape(metadataRegistry.GetCategory(moduleType) ?? string.Empty),
                 Markup.Escape(string.Join(", ", dependencies)));
         }
 
         consoleWriter.Write(table);
         return CreateSummary();
+    }
+
+    private async Task FinalizeModulesAsync(CancellationToken cancellationToken)
+    {
+        await registrationEventExecutor.InvokeRegistrationEventsAsync(_modules).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        ModuleDependencyValidator.Validate(_modules, dependencyRegistry, metadataRegistry);
+        dependencyChainProvider.Initialize(_modules);
     }
 
     private PipelineSummary ReportSuccessfulValidation()

--- a/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
@@ -1,0 +1,83 @@
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using Spectre.Console;
+
+namespace ModularPipelines.PipelineCli;
+
+internal sealed class PipelineCommandHandler(
+    PipelineCommandLineOptions commandLineOptions,
+    IEnumerable<IModule> modules,
+    IDependencyChainProvider dependencyChainProvider,
+    IRegistrationEventExecutor registrationEventExecutor,
+    IConsoleWriter consoleWriter)
+{
+    private readonly IReadOnlyList<IModule> _modules = modules
+        .Distinct<IModule>(ReferenceEqualityComparer.Instance)
+        .ToArray();
+
+    public async Task<PipelineSummary?> TryExecuteAsync(CancellationToken cancellationToken)
+    {
+        switch (commandLineOptions.Command)
+        {
+            case PipelineCommand.Run:
+                return null;
+            case PipelineCommand.ListModules:
+                await registrationEventExecutor.InvokeRegistrationEventsAsync(_modules).ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                return ListModules();
+            case PipelineCommand.Validate:
+                return ReportSuccessfulValidation();
+            default:
+                throw new ArgumentOutOfRangeException(nameof(commandLineOptions));
+        }
+    }
+
+    private PipelineSummary ListModules()
+    {
+        dependencyChainProvider.Initialize(_modules);
+        var table = new Table
+        {
+            Border = TableBorder.Rounded,
+            Title = new TableTitle("[bold]Pipeline modules[/]"),
+        };
+        table.AddColumn("[bold]Module[/]");
+        table.AddColumn("[bold]Category[/]");
+        table.AddColumn("[bold]Dependencies[/]");
+
+        foreach (var model in dependencyChainProvider.ModuleDependencyModels
+                     .OrderBy(model => model.Module.GetType().FullName, StringComparer.Ordinal))
+        {
+            var moduleType = model.Module.GetType();
+            var dependencies = model.IsDependentOn
+                .Select(dependency => dependency.Module.GetType().Name)
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+            table.AddRow(
+                Markup.Escape(moduleType.FullName ?? moduleType.Name),
+                Markup.Escape(model.Module.Configuration.Category ?? string.Empty),
+                Markup.Escape(string.Join(", ", dependencies)));
+        }
+
+        consoleWriter.Write(table);
+        return CreateSummary();
+    }
+
+    private PipelineSummary ReportSuccessfulValidation()
+    {
+        consoleWriter.LogToConsole("[green]Pipeline validation succeeded.[/]");
+        return CreateSummary();
+    }
+
+    private PipelineSummary CreateSummary()
+    {
+        var now = DateTimeOffset.UtcNow;
+        return new PipelineSummary(
+            _modules,
+            [],
+            TimeSpan.Zero,
+            now,
+            now);
+    }
+}

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineOptions.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineOptions.cs
@@ -1,0 +1,18 @@
+namespace ModularPipelines.PipelineCli;
+
+internal sealed record PipelineCommandLineOptions(
+    PipelineCommand Command,
+    IReadOnlyList<string> HostArguments,
+    IReadOnlyList<string> TargetModules,
+    IReadOnlyList<string> SkippedModules,
+    IReadOnlyList<string> RunOnlyCategories,
+    IReadOnlyList<string> IgnoreCategories)
+{
+    public static PipelineCommandLineOptions Empty { get; } = new(
+        PipelineCommand.Run,
+        [],
+        [],
+        [],
+        [],
+        []);
+}

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
@@ -84,8 +84,9 @@ internal static class PipelineCommandLineParser
             return false;
         }
 
-        var values = value
-            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        var values = IsAssemblyQualifiedModuleName(option, value)
+            ? [value.Trim()]
+            : value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
         if (values.Length == 0)
         {
             throw new ArgumentException($"Command-line option '{option}' requires a non-empty value.", nameof(arguments));
@@ -93,6 +94,23 @@ internal static class PipelineCommandLineParser
 
         destination.AddRange(values);
         return true;
+    }
+
+    private static bool IsAssemblyQualifiedModuleName(string option, string value)
+    {
+        if (!option.Equals(ModuleOption, StringComparison.OrdinalIgnoreCase)
+            && !option.Equals(SkipModuleOption, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return value.Split(',').Skip(1).Any(static part =>
+        {
+            var component = part.TrimStart();
+            return component.StartsWith("Version=", StringComparison.OrdinalIgnoreCase)
+                   || component.StartsWith("Culture=", StringComparison.OrdinalIgnoreCase)
+                   || component.StartsWith("PublicKeyToken=", StringComparison.OrdinalIgnoreCase);
+        });
     }
 
     private static PipelineCommand SetCommand(

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
@@ -1,0 +1,114 @@
+namespace ModularPipelines.PipelineCli;
+
+internal static class PipelineCommandLineParser
+{
+    private const string ListModulesOption = "--list-modules";
+    private const string ValidateOption = "--validate";
+    private const string ModuleOption = "--module";
+    private const string SkipModuleOption = "--skip-module";
+    private const string CategoriesOption = "--categories";
+    private const string IgnoreCategoriesOption = "--ignore-categories";
+
+    public static PipelineCommandLineOptions Parse(IReadOnlyList<string>? arguments)
+    {
+        if (arguments is null || arguments.Count == 0)
+        {
+            return PipelineCommandLineOptions.Empty;
+        }
+
+        var command = PipelineCommand.Run;
+        var hostArguments = new List<string>();
+        var targetModules = new List<string>();
+        var skippedModules = new List<string>();
+        var runOnlyCategories = new List<string>();
+        var ignoreCategories = new List<string>();
+
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            var argument = arguments[index];
+            if (argument.Equals(ListModulesOption, StringComparison.OrdinalIgnoreCase))
+            {
+                command = SetCommand(command, PipelineCommand.ListModules, argument);
+                continue;
+            }
+
+            if (argument.Equals(ValidateOption, StringComparison.OrdinalIgnoreCase))
+            {
+                command = SetCommand(command, PipelineCommand.Validate, argument);
+                continue;
+            }
+
+            if (TryReadValues(arguments, ref index, ModuleOption, targetModules)
+                || TryReadValues(arguments, ref index, SkipModuleOption, skippedModules)
+                || TryReadValues(arguments, ref index, CategoriesOption, runOnlyCategories)
+                || TryReadValues(arguments, ref index, IgnoreCategoriesOption, ignoreCategories))
+            {
+                continue;
+            }
+
+            hostArguments.Add(argument);
+        }
+
+        return new PipelineCommandLineOptions(
+            command,
+            hostArguments,
+            Distinct(targetModules),
+            Distinct(skippedModules),
+            Distinct(runOnlyCategories),
+            Distinct(ignoreCategories));
+    }
+
+    private static bool TryReadValues(
+        IReadOnlyList<string> arguments,
+        ref int index,
+        string option,
+        List<string> destination)
+    {
+        var argument = arguments[index];
+        string? value = null;
+        if (argument.Equals(option, StringComparison.OrdinalIgnoreCase))
+        {
+            if (++index >= arguments.Count || arguments[index].StartsWith("--", StringComparison.Ordinal))
+            {
+                throw new ArgumentException($"Command-line option '{option}' requires a value.", nameof(arguments));
+            }
+
+            value = arguments[index];
+        }
+        else if (argument.StartsWith($"{option}=", StringComparison.OrdinalIgnoreCase))
+        {
+            value = argument[(option.Length + 1)..];
+        }
+        else
+        {
+            return false;
+        }
+
+        var values = value
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        if (values.Length == 0)
+        {
+            throw new ArgumentException($"Command-line option '{option}' requires a non-empty value.", nameof(arguments));
+        }
+
+        destination.AddRange(values);
+        return true;
+    }
+
+    private static PipelineCommand SetCommand(
+        PipelineCommand current,
+        PipelineCommand requested,
+        string option)
+    {
+        if (current != PipelineCommand.Run && current != requested)
+        {
+            throw new ArgumentException(
+                $"Command-line option '{option}' cannot be combined with another pipeline command.");
+        }
+
+        return requested;
+    }
+
+    private static IReadOnlyList<string> Distinct(IEnumerable<string> values) =>
+        values.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+}

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -37,6 +37,7 @@ using ModularPipelines.Interfaces;
 using ModularPipelines.Logging;
 using ModularPipelines.Options;
 using ModularPipelines.Options.Validators;
+using ModularPipelines.PipelineCli;
 using ModularPipelines.Validation;
 using Spectre.Console;
 
@@ -90,6 +91,7 @@ internal static class DependencyInjectionSetup
     private static void RegisterBundledServices(IServiceCollection services)
     {
         services
+            .AddSingleton<PipelineCommandHandler>()
             .Configure<PipelineOptions>(_ => { })
             .Configure<SchedulerOptions>(_ => { })
             .Configure<ConcurrencyOptions>(_ => { })
@@ -350,6 +352,7 @@ internal static class DependencyInjectionSetup
             .AddSingleton<IPipelineValidationService, PipelineValidationService>()
             .AddSingleton<IPipelineValidator, OptionsValidator>()
             .AddSingleton<IPipelineValidator, DependencyValidator>()
+            .AddSingleton<IPipelineValidator, ModuleSelectionValidator>()
             .AddSingleton<IPipelineValidator, ModuleConfigurationValidator>();
     }
 

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -90,6 +90,8 @@ internal static class DependencyInjectionSetup
     /// </summary>
     private static void RegisterBundledServices(IServiceCollection services)
     {
+        services.TryAddSingleton(PipelineCommandLineOptions.Empty);
+
         services
             .AddSingleton<PipelineCommandHandler>()
             .Configure<PipelineOptions>(_ => { })

--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -1,12 +1,14 @@
 using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using EnumerableAsyncProcessor.Extensions;
+using Microsoft.Extensions.Options;
 using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 
 namespace ModularPipelines.Engine;
 
@@ -17,6 +19,8 @@ internal class ModuleRetriever
     private readonly ISafeModuleEstimatedTimeProvider _estimatedTimeProvider;
     private readonly IModuleDependencyRegistry _dependencyRegistry;
     private readonly IModuleMetadataRegistry _metadataRegistry;
+    private readonly IDependencyChainProvider _dependencyChainProvider;
+    private readonly IOptions<PipelineOptions> _pipelineOptions;
     private readonly List<IModule> _modules;
     private Task<OrganizedModules>? _cached;
 
@@ -26,7 +30,9 @@ internal class ModuleRetriever
         IEnumerable<IModule> modules,
         ISafeModuleEstimatedTimeProvider estimatedTimeProvider,
         IModuleDependencyRegistry dependencyRegistry,
-        IModuleMetadataRegistry metadataRegistry
+        IModuleMetadataRegistry metadataRegistry,
+        IDependencyChainProvider dependencyChainProvider,
+        IOptions<PipelineOptions> pipelineOptions
     )
     {
         _moduleConditionHandler = moduleConditionHandler;
@@ -34,6 +40,8 @@ internal class ModuleRetriever
         _estimatedTimeProvider = estimatedTimeProvider;
         _dependencyRegistry = dependencyRegistry;
         _metadataRegistry = metadataRegistry;
+        _dependencyChainProvider = dependencyChainProvider;
+        _pipelineOptions = pipelineOptions;
 
         // Defend against direct service registrations that repeat one module instance.
         // The module object still represents one execution.
@@ -65,6 +73,10 @@ internal class ModuleRetriever
 
         // Dynamic dependencies and metadata must be registered before conditions and cascade skipping are evaluated.
         await _registrationEventExecutor.InvokeRegistrationEventsAsync(_modules).ConfigureAwait(false);
+        var moduleSelection = ModuleSelection.Create(
+            _modules,
+            _dependencyChainProvider,
+            _pipelineOptions.Value);
 
         var modulesToIgnore = new List<IgnoredModule>();
         var modulesToProcess = new List<IModule>();
@@ -72,6 +84,12 @@ internal class ModuleRetriever
         foreach (var module in _modules)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (moduleSelection.GetSkipDecision(module) is { } selectionSkipDecision)
+            {
+                modulesToIgnore.Add(new IgnoredModule(module, selectionSkipDecision));
+                continue;
+            }
+
             var (shouldIgnore, skipDecision) = await _moduleConditionHandler.ShouldIgnore(module, cancellationToken).ConfigureAwait(false);
             if (shouldIgnore)
             {

--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -62,6 +62,15 @@ internal class ModuleRetriever
         return (await DiscoverModules(cancellationToken, cascadeSkippedDependencies: true).ConfigureAwait(false)).RunnableModules;
     }
 
+    internal async Task ValidateSelectionAsync()
+    {
+        await _registrationEventExecutor.InvokeRegistrationEventsAsync(_modules).ConfigureAwait(false);
+        _ = ModuleSelection.Create(
+            _modules,
+            _dependencyChainProvider,
+            _pipelineOptions.Value);
+    }
+
     private async Task<DiscoveredModules> DiscoverModules(
         CancellationToken cancellationToken,
         bool cascadeSkippedDependencies)

--- a/src/ModularPipelines/Engine/ModuleSelection.cs
+++ b/src/ModularPipelines/Engine/ModuleSelection.cs
@@ -1,0 +1,104 @@
+using ModularPipelines.Exceptions;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Engine;
+
+internal sealed class ModuleSelection
+{
+    private readonly IReadOnlySet<Type>? _targetTypes;
+    private readonly IReadOnlySet<Type> _skippedTypes;
+
+    private ModuleSelection(IReadOnlySet<Type>? targetTypes, IReadOnlySet<Type> skippedTypes)
+    {
+        _targetTypes = targetTypes;
+        _skippedTypes = skippedTypes;
+    }
+
+    public static ModuleSelection Create(
+        IReadOnlyList<IModule> modules,
+        IDependencyChainProvider dependencyChainProvider,
+        PipelineOptions options)
+    {
+        if (options.TargetModules is not { Count: > 0 }
+            && options.SkippedModules is not { Count: > 0 })
+        {
+            return new ModuleSelection(null, new HashSet<Type>());
+        }
+
+        dependencyChainProvider.Initialize(modules);
+        var models = dependencyChainProvider.ModuleDependencyModels;
+        var skippedTypes = ResolveNames(options.SkippedModules, models, "skip");
+        var targetModels = ResolveModels(options.TargetModules, models, "target");
+        IReadOnlySet<Type>? targetTypes = targetModels.Count == 0
+            ? null
+            : targetModels
+                .SelectMany(model => model.AllDescendantDependenciesAndSelf())
+                .Select(model => model.Module.GetType())
+                .ToHashSet();
+
+        return new ModuleSelection(targetTypes, skippedTypes);
+    }
+
+    public SkipDecision? GetSkipDecision(IModule module)
+    {
+        var moduleType = module.GetType();
+        if (_skippedTypes.Contains(moduleType))
+        {
+            return SkipDecision.Skip($"Module '{moduleType.Name}' was skipped by pipeline selection");
+        }
+
+        return _targetTypes is not null && !_targetTypes.Contains(moduleType)
+            ? SkipDecision.Skip($"Module '{moduleType.Name}' was not in the targeted dependency closure")
+            : null;
+    }
+
+    private static IReadOnlySet<Type> ResolveNames(
+        IReadOnlyList<string>? names,
+        IReadOnlyList<ModuleDependencyModel> models,
+        string selectionKind) =>
+        ResolveModels(names, models, selectionKind)
+            .Select(model => model.Module.GetType())
+            .ToHashSet();
+
+    private static IReadOnlyList<ModuleDependencyModel> ResolveModels(
+        IReadOnlyList<string>? names,
+        IReadOnlyList<ModuleDependencyModel> models,
+        string selectionKind)
+    {
+        if (names is null || names.Count == 0)
+        {
+            return [];
+        }
+
+        var resolved = new List<ModuleDependencyModel>();
+        foreach (var name in names)
+        {
+            var matches = models
+                .Where(model => Matches(model.Module.GetType(), name))
+                .ToArray();
+            if (matches.Length == 0)
+            {
+                throw new ModuleSelectionException(
+                    $"Pipeline {selectionKind} module '{name}' is not registered.");
+            }
+
+            if (matches.Length > 1)
+            {
+                throw new ModuleSelectionException(
+                    $"Pipeline {selectionKind} module name '{name}' is ambiguous. "
+                    + $"Use a full type name: {string.Join(", ", matches.Select(model => model.Module.GetType().FullName))}.");
+            }
+
+            resolved.Add(matches[0]);
+        }
+
+        return resolved.Distinct().ToArray();
+    }
+
+    private static bool Matches(Type moduleType, string name) =>
+        name.Equals(moduleType.Name, StringComparison.OrdinalIgnoreCase)
+        || name.Equals(moduleType.FullName, StringComparison.OrdinalIgnoreCase)
+        || name.Equals(moduleType.AssemblyQualifiedName, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/ModularPipelines/Exceptions/ModuleSelectionException.cs
+++ b/src/ModularPipelines/Exceptions/ModuleSelectionException.cs
@@ -1,0 +1,3 @@
+namespace ModularPipelines.Exceptions;
+
+internal sealed class ModuleSelectionException(string message) : PipelineException(message);

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -51,6 +51,8 @@ public record PipelineOptions
 {
     private IReadOnlyList<string>? _runOnlyCategories;
     private IReadOnlyList<string>? _ignoreCategories;
+    private IReadOnlyList<string>? _targetModules;
+    private IReadOnlyList<string>? _skippedModules;
     private CommandExecutionOptions? _defaultExecutionOptions;
 
     /// <summary>
@@ -82,6 +84,30 @@ public record PipelineOptions
     {
         get => _ignoreCategories;
         init => _ignoreCategories = value is null
+            ? null
+            : Array.AsReadOnly(value.ToArray());
+    }
+
+    /// <summary>
+    /// Gets module names to execute with their transitive dependency closures.
+    /// Names may be simple, full, or assembly-qualified module type names.
+    /// </summary>
+    public IReadOnlyList<string>? TargetModules
+    {
+        get => _targetModules;
+        init => _targetModules = value is null
+            ? null
+            : Array.AsReadOnly(value.ToArray());
+    }
+
+    /// <summary>
+    /// Gets module names to exclude from execution.
+    /// Names may be simple, full, or assembly-qualified module type names.
+    /// </summary>
+    public IReadOnlyList<string>? SkippedModules
+    {
+        get => _skippedModules;
+        init => _skippedModules = value is null
             ? null
             : Array.AsReadOnly(value.ToArray());
     }

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -18,6 +18,7 @@ using ModularPipelines.Distributed.Worker;
 using ModularPipelines.Engine;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Options;
+using ModularPipelines.PipelineCli;
 using ModularPipelines.Plugins;
 using ModularPipelines.Validation;
 
@@ -36,6 +37,7 @@ public sealed class PipelineBuilder : IDisposable
     private readonly ServiceCollection _services;
     private readonly ConfigurationManager _configuration;
     private readonly PipelineHostEnvironment _environment;
+    private readonly PipelineCommandLineOptions _commandLineOptions;
     private PipelineOptions _options;
 
     internal Type? LastRegisteredModuleType { get; set; }
@@ -49,21 +51,33 @@ public sealed class PipelineBuilder : IDisposable
     {
         ArgumentNullException.ThrowIfNull(options);
 
-        var args = options.Args?.ToArray();
+        _commandLineOptions = options.EnableCommandLineOptions
+            ? PipelineCommandLineParser.Parse(options.Args)
+            : PipelineCommandLineOptions.Empty with
+            {
+                HostArguments = options.Args?.ToArray() ?? [],
+            };
+        var args = _commandLineOptions.HostArguments.ToArray();
         _services = new ServiceCollection();
         _configuration = new ConfigurationManager();
-        _options = new PipelineOptions();
+        _options = new PipelineOptions
+        {
+            TargetModules = NullIfEmpty(_commandLineOptions.TargetModules),
+            SkippedModules = NullIfEmpty(_commandLineOptions.SkippedModules),
+            RunOnlyCategories = NullIfEmpty(_commandLineOptions.RunOnlyCategories),
+            IgnoreCategories = NullIfEmpty(_commandLineOptions.IgnoreCategories),
+        };
 
         _hostBuilder = Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args);
 
         // Add default configuration sources
         _configuration.AddEnvironmentVariables();
-        if (args is not null)
+        if (args.Length > 0)
         {
             _configuration.AddCommandLine(args);
         }
 
-        _environment = CreateHostEnvironment(options);
+        _environment = CreateHostEnvironment(options, args);
         _hostBuilder.UseEnvironment(_environment.EnvironmentName);
         _hostBuilder.UseContentRoot(_environment.ContentRootPath);
 
@@ -253,13 +267,15 @@ public sealed class PipelineBuilder : IDisposable
                ?? Task.FromResult(ValidationResult.Success());
     }
 
-    private static PipelineHostEnvironment CreateHostEnvironment(PipelineBuilderOptions options)
+    private static PipelineHostEnvironment CreateHostEnvironment(
+        PipelineBuilderOptions options,
+        IReadOnlyList<string> hostArguments)
     {
         var hostConfiguration = new ConfigurationManager();
         hostConfiguration.AddEnvironmentVariables(prefix: "DOTNET_");
-        if (options.Args is not null)
+        if (hostArguments.Count > 0)
         {
-            hostConfiguration.AddCommandLine([.. options.Args]);
+            hostConfiguration.AddCommandLine([.. hostArguments]);
         }
 
         var environmentName = FirstNonEmpty(
@@ -290,6 +306,9 @@ public sealed class PipelineBuilder : IDisposable
     {
         return candidates.FirstOrDefault(static value => !string.IsNullOrEmpty(value)) ?? fallback;
     }
+
+    private static IReadOnlyList<string>? NullIfEmpty(IReadOnlyList<string> values) =>
+        values.Count == 0 ? null : values;
 
     private async Task<IPipeline> BuildPipelineAsync()
     {
@@ -322,6 +341,7 @@ public sealed class PipelineBuilder : IDisposable
             ActivateDistributedModeIfConfigured(services);
 
             services
+                .AddSingleton(_commandLineOptions)
                 .AddSingleton(_options)
                 .AddTransient<IOptionsFactory<PipelineOptions>, PipelineOptionsFactory>();
 

--- a/src/ModularPipelines/PipelineBuilderOptions.cs
+++ b/src/ModularPipelines/PipelineBuilderOptions.cs
@@ -11,6 +11,12 @@ public class PipelineBuilderOptions
     public IReadOnlyList<string>? Args { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether ModularPipelines should consume its first-class
+    /// command-line options. Disable this to forward every argument directly to host configuration.
+    /// </summary>
+    public bool EnableCommandLineOptions { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the application name.
     /// </summary>
     public string? ApplicationName { get; set; }

--- a/src/ModularPipelines/PipelineImpl.cs
+++ b/src/ModularPipelines/PipelineImpl.cs
@@ -10,6 +10,7 @@ using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.PipelineCli;
 
 namespace ModularPipelines;
 
@@ -70,6 +71,13 @@ internal sealed class PipelineImpl : IPipeline
     /// <inheritdoc />
     public async Task<PipelineSummary> RunAsync(CancellationToken cancellationToken = default)
     {
+        if (await Services.GetRequiredService<PipelineCommandHandler>()
+                .TryExecuteAsync(cancellationToken)
+                .ConfigureAwait(false) is { } commandResult)
+        {
+            return commandResult;
+        }
+
         return await Services.GetRequiredService<IExecutionOrchestrator>()
             .ExecuteAsync(cancellationToken)
             .ConfigureAwait(false);

--- a/src/ModularPipelines/Validation/ModuleSelectionValidator.cs
+++ b/src/ModularPipelines/Validation/ModuleSelectionValidator.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ModularPipelines.Engine;
+using ModularPipelines.Exceptions;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Validation;
+
+internal sealed class ModuleSelectionValidator(IOptions<PipelineOptions> options) : IPipelineValidator
+{
+    public int Order => 250;
+
+    public ValidationResult Validate(IServiceProvider services) =>
+        ValidateAsync(services).GetAwaiter().GetResult();
+
+    public async Task<ValidationResult> ValidateAsync(IServiceProvider services)
+    {
+        if (options.Value.TargetModules?.Count is not > 0
+            && options.Value.SkippedModules?.Count is not > 0)
+        {
+            return ValidationResult.Success();
+        }
+
+        try
+        {
+            await services.GetRequiredService<ModuleRetriever>()
+                .GetRunnableModulesForValidation()
+                .ConfigureAwait(false);
+            return ValidationResult.Success();
+        }
+        catch (ModuleSelectionException exception)
+        {
+            return ValidationResult.WithError(new ValidationError(
+                ValidationErrorCategory.ModuleConfiguration,
+                exception.Message));
+        }
+    }
+}

--- a/src/ModularPipelines/Validation/ModuleSelectionValidator.cs
+++ b/src/ModularPipelines/Validation/ModuleSelectionValidator.cs
@@ -24,7 +24,7 @@ internal sealed class ModuleSelectionValidator(IOptions<PipelineOptions> options
         try
         {
             await services.GetRequiredService<ModuleRetriever>()
-                .GetRunnableModulesForValidation()
+                .ValidateSelectionAsync()
                 .ConfigureAwait(false);
             return ValidationResult.Success();
         }

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -1,9 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Attributes;
+using ModularPipelines.Attributes.Events;
 using ModularPipelines.Context;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
+using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace ModularPipelines.UnitTests.PipelineCli;
 
@@ -14,6 +18,31 @@ public class PipelineCommandLineTests
     private static int _targetExecutions;
     private static int _unrelatedExecutions;
     private static int _categoryExecutions;
+
+    private sealed class CapturingConsoleWriter : IConsoleWriter
+    {
+        public IRenderable? Renderable { get; private set; }
+
+        public void LogToConsole(string value)
+        {
+        }
+
+        public void Write(IRenderable renderable)
+        {
+            Renderable = renderable;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class AddRegistrationDependencyAttribute(Type dependencyType)
+        : Attribute, IModuleRegistrationEventReceiver
+    {
+        public Task OnRegistrationAsync(IModuleRegistrationContext context)
+        {
+            context.AddDependency(dependencyType);
+            return Task.CompletedTask;
+        }
+    }
 
     private sealed class DependencyModule : Module<string>
     {
@@ -47,6 +76,23 @@ public class PipelineCommandLineTests
             Interlocked.Increment(ref _unrelatedExecutions);
             return Task.FromResult<string?>("unrelated");
         }
+    }
+
+    private sealed class UnregisteredModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("unregistered");
+    }
+
+    [AddRegistrationDependency(typeof(UnregisteredModule))]
+    private sealed class InvalidDynamicDependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("invalid");
     }
 
     [ModuleCategory("selected")]
@@ -215,6 +261,38 @@ public class PipelineCommandLineTests
             await Assert.That(_targetExecutions).IsEqualTo(0);
             await Assert.That(_unrelatedExecutions).IsEqualTo(0);
         }
+    }
+
+    [Test]
+    public async Task ValidateCommandChecksRegistrationTimeDependencies()
+    {
+        using var builder = Pipeline.CreateBuilder(["--validate"]);
+        builder.AddModule<InvalidDynamicDependencyModule>();
+
+        await Assert.ThrowsAsync<ModuleNotRegisteredException>(
+            () => builder.ExecutePipelineAsync());
+    }
+
+    [Test]
+    public async Task ListModulesUsesFinalizedFluentCategory()
+    {
+        var consoleWriter = new CapturingConsoleWriter();
+        using var builder = Pipeline.CreateBuilder(["--list-modules"]);
+        builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
+        builder.AddModule<UnrelatedModule>().WithCategory("configured-category");
+
+        await builder.ExecutePipelineAsync();
+
+        using var output = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(output),
+        });
+        console.Write(consoleWriter.Renderable!);
+
+        await Assert.That(output.ToString()).Contains("configured-category");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Attributes;
 using ModularPipelines.Attributes.Events;
+using ModularPipelines.Conditions;
 using ModularPipelines.Context;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
@@ -18,6 +19,7 @@ public class PipelineCommandLineTests
     private static int _targetExecutions;
     private static int _unrelatedExecutions;
     private static int _categoryExecutions;
+    private static int _conditionEvaluations;
 
     private sealed class CapturingConsoleWriter : IConsoleWriter
     {
@@ -107,6 +109,24 @@ public class PipelineCommandLineTests
         }
     }
 
+    private sealed class TrackingCondition : IRunCondition
+    {
+        public Task<bool> EvaluateAsync(IPipelineContext context)
+        {
+            Interlocked.Increment(ref _conditionEvaluations);
+            return Task.FromResult(true);
+        }
+    }
+
+    [RunIfAll<TrackingCondition>]
+    private sealed class ConditionalModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("conditional");
+    }
+
     [Before(Test)]
     public void ResetCounters()
     {
@@ -114,6 +134,7 @@ public class PipelineCommandLineTests
         _targetExecutions = 0;
         _unrelatedExecutions = 0;
         _categoryExecutions = 0;
+        _conditionEvaluations = 0;
     }
 
     [Test]
@@ -217,6 +238,37 @@ public class PipelineCommandLineTests
                 .IsEquivalentTo(["Build", "Test"]);
             await Assert.That(builder.Options.IgnoreCategories)
                 .IsEquivalentTo(["Integration"]);
+        }
+    }
+
+    [Test]
+    public async Task AssemblyQualifiedModuleNameIsPreserved()
+    {
+        using var builder = CreateExecutionBuilder(
+            ["--module", typeof(TargetModule).AssemblyQualifiedName!]);
+
+        await builder.ExecutePipelineAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(_dependencyExecutions).IsEqualTo(1);
+            await Assert.That(_targetExecutions).IsEqualTo(1);
+            await Assert.That(_unrelatedExecutions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task SelectionValidationDoesNotEvaluateRunConditions()
+    {
+        using var builder = Pipeline.CreateBuilder(["--module", nameof(ConditionalModule)]);
+        builder.AddModule<ConditionalModule>();
+
+        var result = await builder.ValidateAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.IsValid).IsTrue();
+            await Assert.That(_conditionEvaluations).IsEqualTo(0);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -1,0 +1,235 @@
+using ModularPipelines.Attributes;
+using ModularPipelines.Context;
+using ModularPipelines.Exceptions;
+using ModularPipelines.Extensions;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.UnitTests.PipelineCli;
+
+[TUnit.Core.NotInParallel(nameof(PipelineCommandLineTests))]
+public class PipelineCommandLineTests
+{
+    private static int _dependencyExecutions;
+    private static int _targetExecutions;
+    private static int _unrelatedExecutions;
+    private static int _categoryExecutions;
+
+    private sealed class DependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _dependencyExecutions);
+            return Task.FromResult<string?>("dependency");
+        }
+    }
+
+    [ModularPipelines.Attributes.DependsOn<DependencyModule>]
+    private sealed class TargetModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _targetExecutions);
+            return Task.FromResult<string?>("target");
+        }
+    }
+
+    private sealed class UnrelatedModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _unrelatedExecutions);
+            return Task.FromResult<string?>("unrelated");
+        }
+    }
+
+    [ModuleCategory("selected")]
+    private sealed class SelectedCategoryModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _categoryExecutions);
+            return Task.FromResult<string?>("selected");
+        }
+    }
+
+    [Before(Test)]
+    public void ResetCounters()
+    {
+        _dependencyExecutions = 0;
+        _targetExecutions = 0;
+        _unrelatedExecutions = 0;
+        _categoryExecutions = 0;
+    }
+
+    [Test]
+    public async Task ModuleOptionRunsTargetAndDependencyClosure()
+    {
+        using var builder = CreateExecutionBuilder(["--module", nameof(TargetModule)]);
+
+        await builder.ExecutePipelineAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(_dependencyExecutions).IsEqualTo(1);
+            await Assert.That(_targetExecutions).IsEqualTo(1);
+            await Assert.That(_unrelatedExecutions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task ProgrammaticTargetModulesRunsDependencyClosure()
+    {
+        using var builder = CreateExecutionBuilder();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            TargetModules = [nameof(TargetModule)],
+        });
+
+        await builder.ExecutePipelineAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(_dependencyExecutions).IsEqualTo(1);
+            await Assert.That(_targetExecutions).IsEqualTo(1);
+            await Assert.That(_unrelatedExecutions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task SkipModuleOptionExcludesNamedModule()
+    {
+        using var builder = CreateExecutionBuilder(["--skip-module", nameof(UnrelatedModule)]);
+
+        await builder.ExecutePipelineAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(_dependencyExecutions).IsEqualTo(1);
+            await Assert.That(_targetExecutions).IsEqualTo(1);
+            await Assert.That(_unrelatedExecutions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task CategoriesOptionBindsExistingPipelineOption()
+    {
+        using var builder = Pipeline.CreateBuilder(["--categories", "selected"]);
+        builder.AddModule<SelectedCategoryModule>();
+        builder.AddModule<UnrelatedModule>();
+
+        await builder.ExecutePipelineAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(builder.Options.RunOnlyCategories).IsEquivalentTo(["selected"]);
+            await Assert.That(_categoryExecutions).IsEqualTo(1);
+            await Assert.That(_unrelatedExecutions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task UnknownArgumentsStillFlowToHostConfiguration()
+    {
+        using var builder = Pipeline.CreateBuilder(
+        [
+            "--module", nameof(TargetModule),
+            "--custom-setting", "custom-value",
+        ]);
+
+        await Assert.That(builder.Options.TargetModules).IsEquivalentTo([nameof(TargetModule)]);
+        await Assert.That(builder.Configuration["custom-setting"]).IsEqualTo("custom-value");
+    }
+
+    [Test]
+    public async Task RepeatedCommaSeparatedAndEqualsValuesAreParsed()
+    {
+        using var builder = Pipeline.CreateBuilder(
+        [
+            "--module", "FirstModule,SecondModule",
+            "--module=ThirdModule",
+            "--skip-module=SkippedModule",
+            "--categories", "Build,Test",
+            "--ignore-categories=Integration",
+        ]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(builder.Options.TargetModules)
+                .IsEquivalentTo(["FirstModule", "SecondModule", "ThirdModule"]);
+            await Assert.That(builder.Options.SkippedModules)
+                .IsEquivalentTo(["SkippedModule"]);
+            await Assert.That(builder.Options.RunOnlyCategories)
+                .IsEquivalentTo(["Build", "Test"]);
+            await Assert.That(builder.Options.IgnoreCategories)
+                .IsEquivalentTo(["Integration"]);
+        }
+    }
+
+    [Test]
+    public async Task CommandLineParsingCanBeDisabled()
+    {
+        using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+        {
+            Args = ["--module", "forwarded-value"],
+            EnableCommandLineOptions = false,
+        });
+
+        await Assert.That(builder.Options.TargetModules).IsNull();
+        await Assert.That(builder.Configuration["module"]).IsEqualTo("forwarded-value");
+    }
+
+    [Test]
+    public async Task UnknownTargetProducesValidationError()
+    {
+        using var builder = CreateExecutionBuilder(["--module", "MissingModule"]);
+
+        var exception = await Assert.ThrowsAsync<PipelineValidationException>(
+            () => builder.ExecutePipelineAsync());
+
+        await Assert.That(exception!.ValidationResult.Errors.Any(
+            error => error.Message.Contains("MissingModule", StringComparison.Ordinal))).IsTrue();
+    }
+
+    [Test]
+    [Arguments("--list-modules")]
+    [Arguments("--validate")]
+    public async Task InformationalCommandsDoNotExecuteModules(string command)
+    {
+        using var builder = CreateExecutionBuilder([command]);
+
+        var summary = await builder.ExecutePipelineAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(summary.Results).IsEmpty();
+            await Assert.That(_dependencyExecutions).IsEqualTo(0);
+            await Assert.That(_targetExecutions).IsEqualTo(0);
+            await Assert.That(_unrelatedExecutions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task PipelineCommandsAreMutuallyExclusive()
+    {
+        await Assert.That(() => Pipeline.CreateBuilder(["--list-modules", "--validate"]))
+            .Throws<ArgumentException>();
+    }
+
+    private static PipelineBuilder CreateExecutionBuilder(string[]? arguments = null)
+    {
+        var builder = Pipeline.CreateBuilder(arguments);
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<TargetModule>();
+        builder.AddModule<UnrelatedModule>();
+        return builder;
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/DependencyInjectionTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyInjectionTests.cs
@@ -74,10 +74,12 @@ public class DependencyInjectionTests
 
         DependencyInjectionSetup.Initialize(serviceCollection);
 
-        serviceCollection.BuildServiceProvider(new ServiceProviderOptions
+        using var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions
         {
             ValidateScopes = true,
             ValidateOnBuild = true,
         });
+
+        serviceProvider.GetRequiredService<global::ModularPipelines.PipelineCli.PipelineCommandHandler>();
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleRetrieverTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleRetrieverTests.cs
@@ -2,6 +2,7 @@ using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 using Moq;
 
 namespace ModularPipelines.UnitTests.Engine;
@@ -47,7 +48,9 @@ public class ModuleRetrieverTests
             modules,
             estimatedTimeProvider.Object,
             Mock.Of<IModuleDependencyRegistry>(),
-            Mock.Of<IModuleMetadataRegistry>());
+            Mock.Of<IModuleMetadataRegistry>(),
+            Mock.Of<IDependencyChainProvider>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()));
 
         var organizedModulesTask = retriever.GetOrganizedModules();
         var allStartedBeforeRelease = await Task.WhenAny(


### PR DESCRIPTION
## Summary
- add built-in `--list-modules`, `--module`, `--skip-module`, category, and `--validate` options
- execute targeted modules with their transitive dependency closure while preserving skip/category behavior
- preserve assembly-qualified module names and keep validation free of execution-time condition evaluation
- forward unknown arguments to host configuration and provide an opt-out
- expose programmatic module targeting and document the CLI

## Validation
- `PipelineCommandLineTests`: 15 passed
- `DependencyInjectionTests`: 3 passed
- `ModuleRetrieverTests`: 1 passed
- `ModularPipelines.sln` Release build: 0 errors (227 existing analyzer warnings)
- Docusaurus production build: passed (existing documentation warnings)

Closes #3537