### PR TITLE
Log command headers before process output

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -119,11 +119,13 @@ internal sealed class Command : ICommandContext
         var standardError = string.Empty;
 
         var inputToLog = GetInputToLog(command, execOpts);
-        _commandLogger.LogCommandStart(
-            options,
-            execOpts,
-            inputToLog,
-            command.WorkingDirPath);
+        var loggingFailures = new DeferredCommandLoggingFailures();
+        loggingFailures.Capture(
+            () => _commandLogger.LogCommandStart(
+                options,
+                execOpts,
+                inputToLog,
+                command.WorkingDirPath));
 
         // Only create timeout token if ExecutionTimeout is specified to avoid unnecessary allocations
         using var timeoutCancellationToken = CreateTimeoutCancellationToken(execOpts);
@@ -182,8 +184,7 @@ internal sealed class Command : ICommandContext
                 standardOutput = standardOutputBuffer.ToString();
                 standardError = standardErrorBuffer.ToString();
 
-                var failure = CombineWithCompletionFailure(
-                    e,
+                loggingFailures.Capture(
                     () => LogCommandCompletion(
                         options,
                         execOpts,
@@ -196,6 +197,7 @@ internal sealed class Command : ICommandContext
                         completeStandardErrorBuffer,
                         deferredOutputLogger,
                         command.WorkingDirPath));
+                var failure = loggingFailures.CombineWith(e);
 
                 throw new CommandException(
                     CreateFailureResult(
@@ -218,8 +220,7 @@ internal sealed class Command : ICommandContext
                 standardOutput = standardOutputBuffer.ToString();
                 standardError = standardErrorBuffer.ToString();
 
-                var failure = CombineWithCompletionFailure(
-                    e,
+                loggingFailures.Capture(
                     () => LogCommandCompletion(
                         options,
                         execOpts,
@@ -232,6 +233,7 @@ internal sealed class Command : ICommandContext
                         completeStandardErrorBuffer,
                         deferredOutputLogger,
                         command.WorkingDirPath));
+                var failure = loggingFailures.CombineWith(e);
 
                 if (ShouldPreserveCallerCancellation(e, failure, cancellationToken))
                 {
@@ -259,9 +261,8 @@ internal sealed class Command : ICommandContext
                 standardOutput,
                 standardError);
 
-            try
-            {
-                LogCommandCompletion(
+            loggingFailures.Capture(
+                () => LogCommandCompletion(
                     options,
                     execOpts,
                     inputToLog,
@@ -272,13 +273,12 @@ internal sealed class Command : ICommandContext
                     completeStandardOutputBuffer,
                     completeStandardErrorBuffer,
                     deferredOutputLogger,
-                    command.WorkingDirPath);
-            }
-            catch (Exception completionFailure) when (commandFailure is not null)
+                    command.WorkingDirPath));
+            if (commandFailure is not null && loggingFailures.HasFailures)
             {
                 throw new CommandException(
                     commandFailure.Result,
-                    new AggregateException(commandFailure, completionFailure));
+                    loggingFailures.CombineWith(commandFailure));
             }
 
             if (commandFailure is not null)
@@ -286,22 +286,8 @@ internal sealed class Command : ICommandContext
                 throw commandFailure;
             }
 
+            loggingFailures.Throw();
             return new CommandResult(command, result, standardOutput, standardError);
-        }
-    }
-
-    private static Exception CombineWithCompletionFailure(
-        Exception executionFailure,
-        Action complete)
-    {
-        try
-        {
-            complete();
-            return executionFailure;
-        }
-        catch (Exception completionFailure)
-        {
-            return new AggregateException(executionFailure, completionFailure);
         }
     }
 

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -119,6 +119,11 @@ internal sealed class Command : ICommandContext
         var standardError = string.Empty;
 
         var inputToLog = GetInputToLog(command, execOpts);
+        _commandLogger.LogCommandStart(
+            options,
+            execOpts,
+            inputToLog,
+            command.WorkingDirPath);
 
         // Only create timeout token if ExecutionTimeout is specified to avoid unnecessary allocations
         using var timeoutCancellationToken = CreateTimeoutCancellationToken(execOpts);
@@ -945,7 +950,7 @@ internal sealed class Command : ICommandContext
     {
         var deferredOutput = deferredOutputLogger?.Complete();
         var hasStreamedOutput = deferredOutput?.HasStreamedOutput == true;
-        _commandLogger.Log(
+        _commandLogger.LogCommandCompletion(
             options,
             executionOptions,
             input,

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -120,12 +120,6 @@ internal sealed class Command : ICommandContext
 
         var inputToLog = GetInputToLog(command, execOpts);
         var loggingFailures = new DeferredCommandLoggingFailures();
-        loggingFailures.Capture(
-            () => _commandLogger.LogCommandStart(
-                options,
-                execOpts,
-                inputToLog,
-                command.WorkingDirPath));
 
         // Only create timeout token if ExecutionTimeout is specified to avoid unnecessary allocations
         using var timeoutCancellationToken = CreateTimeoutCancellationToken(execOpts);
@@ -140,6 +134,12 @@ internal sealed class Command : ICommandContext
 
         var registration = linkedCancellationToken.Token.Register(
             () => ScheduleForcefulCancellation(forcefulCancellationToken, execOpts.GracefulShutdownTimeout));
+        loggingFailures.Capture(
+            () => _commandLogger.LogCommandStart(
+                options,
+                execOpts,
+                inputToLog,
+                command.WorkingDirPath));
         await using (registration.ConfigureAwait(false))
         {
             CliWrap.CommandResult result;

--- a/src/ModularPipelines/Context/LoggingCommandLineExecutor.cs
+++ b/src/ModularPipelines/Context/LoggingCommandLineExecutor.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
@@ -46,25 +47,50 @@ internal sealed class LoggingCommandLineExecutor : ICommandLineExecutor
     {
         var workingDirectory = options?.WorkingDirectory ?? Environment.CurrentDirectory;
         var inputToLog = GetInputToLog(commandLine, options);
-        _commandLogger.LogCommandStart(
-            options: null,
-            execOpts: options,
-            inputToLog: inputToLog,
-            commandWorkingDirPath: workingDirectory);
+        var stopwatch = Stopwatch.StartNew();
+        var loggingFailures = new DeferredCommandLoggingFailures();
+        loggingFailures.Capture(
+            () => _commandLogger.LogCommandStart(
+                options: null,
+                execOpts: options,
+                inputToLog: inputToLog,
+                commandWorkingDirPath: workingDirectory));
 
-        var result = await _inner.ExecuteAsync(commandLine, options, cancellationToken).ConfigureAwait(false);
+        CommandResult result;
+        try
+        {
+            result = await _inner.ExecuteAsync(commandLine, options, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception executionFailure)
+        {
+            loggingFailures.Capture(
+                () => LogCompletion(
+                    options,
+                    inputToLog,
+                    workingDirectory,
+                    exitCode: -1,
+                    runTime: stopwatch.Elapsed,
+                    standardOutput: string.Empty,
+                    standardError: executionFailure.Message));
 
-        // Delegate to CommandLogger for consistent logging across all command execution paths
-        _commandLogger.LogCommandCompletion(
-            options: null, // Raw command line execution doesn't use CommandLineToolOptions
-            execOpts: options,
-            inputToLog: inputToLog,
-            exitCode: result.ExitCode,
-            runTime: result.Duration,
-            standardOutput: result.StandardOutput,
-            standardError: result.StandardError,
-            commandWorkingDirPath: workingDirectory);
+            if (!loggingFailures.HasFailures)
+            {
+                throw;
+            }
 
+            throw loggingFailures.CombineWith(executionFailure);
+        }
+
+        loggingFailures.Capture(
+            () => LogCompletion(
+                options,
+                inputToLog,
+                workingDirectory,
+                result.ExitCode,
+                result.Duration,
+                result.StandardOutput,
+                result.StandardError));
+        loggingFailures.Throw();
         return result;
     }
 
@@ -74,5 +100,25 @@ internal sealed class LoggingCommandLineExecutor : ICommandLineExecutor
         return options?.InputLoggingManipulator is not null
             ? options.InputLoggingManipulator(input)
             : input;
+    }
+
+    private void LogCompletion(
+        CommandExecutionOptions? options,
+        string inputToLog,
+        string workingDirectory,
+        int exitCode,
+        TimeSpan runTime,
+        string standardOutput,
+        string standardError)
+    {
+        _commandLogger.LogCommandCompletion(
+            options: null,
+            execOpts: options,
+            inputToLog: inputToLog,
+            exitCode: exitCode,
+            runTime: runTime,
+            standardOutput: standardOutput,
+            standardError: standardError,
+            commandWorkingDirPath: workingDirectory);
     }
 }

--- a/src/ModularPipelines/Context/LoggingCommandLineExecutor.cs
+++ b/src/ModularPipelines/Context/LoggingCommandLineExecutor.cs
@@ -26,7 +26,7 @@ internal sealed class LoggingCommandLineExecutor : ICommandLineExecutor
     private readonly ICommandLogger _commandLogger;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="LoggingCommandLineExecutor"/> class.
+    /// Initialises a new instance of the <see cref="LoggingCommandLineExecutor"/> class.
     /// </summary>
     /// <param name="inner">The inner executor to wrap.</param>
     /// <param name="commandLogger">The command logger for consistent logging.</param>
@@ -46,11 +46,16 @@ internal sealed class LoggingCommandLineExecutor : ICommandLineExecutor
     {
         var workingDirectory = options?.WorkingDirectory ?? Environment.CurrentDirectory;
         var inputToLog = GetInputToLog(commandLine, options);
+        _commandLogger.LogCommandStart(
+            options: null,
+            execOpts: options,
+            inputToLog: inputToLog,
+            commandWorkingDirPath: workingDirectory);
 
         var result = await _inner.ExecuteAsync(commandLine, options, cancellationToken).ConfigureAwait(false);
 
         // Delegate to CommandLogger for consistent logging across all command execution paths
-        _commandLogger.Log(
+        _commandLogger.LogCommandCompletion(
             options: null, // Raw command line execution doesn't use CommandLineToolOptions
             execOpts: options,
             inputToLog: inputToLog,

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -27,6 +27,85 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
 
     private ILogger Logger => _moduleLoggerProvider.GetLogger();
 
+    public void LogCommandStart(
+        CommandLineToolOptions? options,
+        CommandExecutionOptions? execOpts,
+        string? inputToLog,
+        string commandWorkingDirPath)
+    {
+        var effectiveOptions = GetEffectiveLoggingOptions(options, execOpts);
+        if (effectiveOptions.Verbosity == CommandLogVerbosity.Silent)
+        {
+            return;
+        }
+
+        if (execOpts?.InternalDryRun == true)
+        {
+            LogDryRunCommand(effectiveOptions, commandWorkingDirPath, inputToLog);
+            return;
+        }
+
+        var obfuscatedInput = ShouldShowInput(effectiveOptions)
+            ? _secretObfuscator.Obfuscate(inputToLog, null)
+            : LoggingConstants.CommandMask;
+        Logger.LogInformation(
+            "{WorkingDirectory}> {Input}",
+            commandWorkingDirPath,
+            obfuscatedInput);
+    }
+
+    public void LogCommandCompletion(
+        CommandLineToolOptions? options,
+        CommandExecutionOptions? execOpts,
+        string? inputToLog,
+        int? exitCode,
+        TimeSpan? runTime,
+        string standardOutput,
+        string standardError,
+        string commandWorkingDirPath)
+    {
+        var effectiveOptions = GetEffectiveLoggingOptions(options, execOpts);
+        if (effectiveOptions.Verbosity == CommandLogVerbosity.Silent
+            || execOpts?.InternalDryRun == true)
+        {
+            return;
+        }
+
+        var standardOutputToLog = execOpts?.OutputLoggingManipulator is not null
+            ? execOpts.OutputLoggingManipulator(standardOutput)
+            : standardOutput;
+        var standardErrorToLog = execOpts?.OutputLoggingManipulator is not null
+            ? execOpts.OutputLoggingManipulator(standardError)
+            : standardError;
+        var trimmedOutput = standardOutputToLog.Trim();
+        var isSuccess = exitCode == 0;
+
+        if (isSuccess && ShouldInlineOutput(effectiveOptions, trimmedOutput))
+        {
+            Logger.LogInformation(
+                "  → {CommandOutput}",
+                _secretObfuscator.Obfuscate(trimmedOutput, null));
+        }
+        else
+        {
+            LogCapturedOutput(effectiveOptions, trimmedOutput, wasInlined: false);
+        }
+
+        LogCapturedError(effectiveOptions, standardErrorToLog, exitCode);
+
+        var commandStatus = BuildCommandStatus(effectiveOptions, isSuccess, exitCode, runTime);
+        if (string.IsNullOrEmpty(commandStatus)
+            && effectiveOptions.Verbosity >= CommandLogVerbosity.Normal)
+        {
+            commandStatus = isSuccess ? "✓" : "✗";
+        }
+
+        if (!string.IsNullOrEmpty(commandStatus))
+        {
+            Logger.LogInformation("{CommandStatus}", commandStatus.TrimStart());
+        }
+    }
+
     public void Log(
         CommandLineToolOptions? options,
         CommandExecutionOptions? execOpts,

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -71,39 +71,15 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
             return;
         }
 
-        var standardOutputToLog = execOpts?.OutputLoggingManipulator is not null
-            ? execOpts.OutputLoggingManipulator(standardOutput)
-            : standardOutput;
-        var standardErrorToLog = execOpts?.OutputLoggingManipulator is not null
-            ? execOpts.OutputLoggingManipulator(standardError)
-            : standardError;
-        var trimmedOutput = standardOutputToLog.Trim();
+        var (outputToLog, errorToLog) = ManipulateOutput(
+            execOpts?.OutputLoggingManipulator,
+            standardOutput,
+            standardError);
         var isSuccess = exitCode == 0;
 
-        if (isSuccess && ShouldInlineOutput(effectiveOptions, trimmedOutput))
-        {
-            Logger.LogInformation(
-                "  → {CommandOutput}",
-                _secretObfuscator.Obfuscate(trimmedOutput, null));
-        }
-        else
-        {
-            LogCapturedOutput(effectiveOptions, trimmedOutput, wasInlined: false);
-        }
-
-        LogCapturedError(effectiveOptions, standardErrorToLog, exitCode);
-
-        var commandStatus = BuildCommandStatus(effectiveOptions, isSuccess, exitCode, runTime);
-        if (string.IsNullOrEmpty(commandStatus)
-            && effectiveOptions.Verbosity >= CommandLogVerbosity.Normal)
-        {
-            commandStatus = isSuccess ? "✓" : "✗";
-        }
-
-        if (!string.IsNullOrEmpty(commandStatus))
-        {
-            Logger.LogInformation("{CommandStatus}", commandStatus.TrimStart());
-        }
+        LogCapturedOutput(effectiveOptions, outputToLog.Trim(), isSuccess);
+        LogCapturedError(effectiveOptions, errorToLog, exitCode);
+        LogCommandStatus(effectiveOptions, isSuccess, exitCode, runTime);
     }
 
     public void Log(
@@ -198,6 +174,19 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
                && options.ShowStandardOutput;
     }
 
+    private static (string Output, string Error) ManipulateOutput(
+        Func<string, string>? manipulator,
+        string standardOutput,
+        string standardError)
+    {
+        if (manipulator is null)
+        {
+            return (standardOutput, standardError);
+        }
+
+        return (manipulator(standardOutput), manipulator(standardError));
+    }
+
     private static string BuildCommandStatus(
         CommandLoggingOptions options,
         bool isSuccess,
@@ -235,10 +224,17 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
     private void LogCapturedOutput(
         CommandLoggingOptions options,
         string output,
-        bool wasInlined)
+        bool isSuccess)
     {
-        if (wasInlined
-            || string.IsNullOrWhiteSpace(output)
+        if (isSuccess && ShouldInlineOutput(options, output))
+        {
+            Logger.LogInformation(
+                "  → {CommandOutput}",
+                _secretObfuscator.Obfuscate(output, null));
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(output)
             || options.Verbosity < CommandLogVerbosity.Normal
             || !options.ShowStandardOutput)
         {
@@ -262,6 +258,25 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
         }
 
         Logger.LogWarning("  ✗ {CommandError}", _secretObfuscator.Obfuscate(error, null));
+    }
+
+    private void LogCommandStatus(
+        CommandLoggingOptions options,
+        bool isSuccess,
+        int? exitCode,
+        TimeSpan? runTime)
+    {
+        var commandStatus = BuildCommandStatus(options, isSuccess, exitCode, runTime);
+        if (string.IsNullOrEmpty(commandStatus)
+            && options.Verbosity >= CommandLogVerbosity.Normal)
+        {
+            commandStatus = isSuccess ? "✓" : "✗";
+        }
+
+        if (!string.IsNullOrEmpty(commandStatus))
+        {
+            Logger.LogInformation("{CommandStatus}", commandStatus.TrimStart());
+        }
     }
 
     private static bool ShouldShowInput(CommandLoggingOptions options)

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -79,7 +79,7 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
 
         LogCapturedOutput(effectiveOptions, outputToLog.Trim(), isSuccess);
         LogCapturedError(effectiveOptions, errorToLog, exitCode);
-        LogCommandStatus(effectiveOptions, isSuccess, exitCode, runTime);
+        LogCommandStatus(effectiveOptions, inputToLog, isSuccess, exitCode, runTime);
     }
 
     public void Log(
@@ -262,6 +262,7 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
 
     private void LogCommandStatus(
         CommandLoggingOptions options,
+        string? inputToLog,
         bool isSuccess,
         int? exitCode,
         TimeSpan? runTime)
@@ -275,7 +276,13 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
 
         if (!string.IsNullOrEmpty(commandStatus))
         {
-            Logger.LogInformation("{CommandStatus}", commandStatus.TrimStart());
+            var obfuscatedInput = ShouldShowInput(options)
+                ? _secretObfuscator.Obfuscate(inputToLog, null)
+                : LoggingConstants.CommandMask;
+            Logger.LogInformation(
+                "{CommandStatus} {Input}",
+                commandStatus.TrimStart(),
+                obfuscatedInput);
         }
     }
 

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -116,23 +116,16 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
         string standardError,
         string commandWorkingDirPath)
     {
-        // Determine effective logging options
-        var effectiveOptions = GetEffectiveLoggingOptions(options, execOpts);
-
-        // Silent = no logging at all
-        if (effectiveOptions.Verbosity == CommandLogVerbosity.Silent)
-        {
-            return;
-        }
-
-        if (execOpts?.InternalDryRun == true)
-        {
-            LogDryRunCommand(effectiveOptions, commandWorkingDirPath, inputToLog);
-            return;
-        }
-
-        // Use compact logging format for cleaner output
-        LogCompact(effectiveOptions, execOpts, commandWorkingDirPath, inputToLog, exitCode, runTime, standardOutput, standardError);
+        LogCommandStart(options, execOpts, inputToLog, commandWorkingDirPath);
+        LogCommandCompletion(
+            options,
+            execOpts,
+            inputToLog,
+            exitCode,
+            runTime,
+            standardOutput,
+            standardError,
+            commandWorkingDirPath);
     }
 
     void ICommandOutputLogger.LogStandardOutputLine(
@@ -194,51 +187,6 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
         Logger.LogInformation(
             isError ? "  ↳ {CommandError}" : "  ↳ {CommandOutput}",
             obfuscatedOutput);
-    }
-
-    private void LogCompact(
-        CommandLoggingOptions options,
-        CommandExecutionOptions? execOpts,
-        string workingDirectory,
-        string? input,
-        int? exitCode,
-        TimeSpan? runTime,
-        string standardOutput,
-        string standardError)
-    {
-        var isSuccess = exitCode == 0;
-        var obfuscatedInput = ShouldShowInput(options)
-            ? _secretObfuscator.Obfuscate(input, null)
-            : LoggingConstants.CommandMask;
-
-        var commandMessage = new StringBuilder();
-        commandMessage.Append(workingDirectory);
-        commandMessage.Append("> ");
-        commandMessage.Append(obfuscatedInput);
-
-        var standardOutputToLog = execOpts?.OutputLoggingManipulator is not null
-            ? execOpts.OutputLoggingManipulator(standardOutput)
-            : standardOutput;
-        var standardErrorToLog = execOpts?.OutputLoggingManipulator is not null
-            ? execOpts.OutputLoggingManipulator(standardError)
-            : standardError;
-
-        var trimmedOutput = standardOutputToLog.Trim();
-        var hasShortOutput = ShouldInlineOutput(options, trimmedOutput);
-        var hasInlineOutput = hasShortOutput && isSuccess;
-        var inlineOutput = hasInlineOutput
-            ? $" → {_secretObfuscator.Obfuscate(trimmedOutput, null)}"
-            : string.Empty;
-        var commandStatus = BuildCommandStatus(options, isSuccess, exitCode, runTime);
-
-        Logger.LogInformation(
-            "{CommandMessage}{CommandOutput}{CommandStatus}",
-            commandMessage.ToString(),
-            inlineOutput,
-            commandStatus);
-
-        LogCapturedOutput(options, trimmedOutput, hasInlineOutput);
-        LogCapturedError(options, standardErrorToLog, exitCode);
     }
 
     private static bool ShouldInlineOutput(CommandLoggingOptions options, string output)

--- a/src/ModularPipelines/Logging/DeferredCommandLoggingFailures.cs
+++ b/src/ModularPipelines/Logging/DeferredCommandLoggingFailures.cs
@@ -1,0 +1,40 @@
+using System.Runtime.ExceptionServices;
+
+namespace ModularPipelines.Logging;
+
+internal sealed class DeferredCommandLoggingFailures
+{
+    private readonly List<Exception> _failures = [];
+
+    public bool HasFailures => _failures.Count > 0;
+
+    public void Capture(Action log)
+    {
+        try
+        {
+            log();
+        }
+        catch (Exception exception)
+        {
+            _failures.Add(exception);
+        }
+    }
+
+    public Exception CombineWith(Exception primaryFailure) =>
+        _failures.Count == 0
+            ? primaryFailure
+            : new AggregateException([primaryFailure, .. _failures]);
+
+    public void Throw()
+    {
+        if (_failures.Count == 1)
+        {
+            ExceptionDispatchInfo.Capture(_failures[0]).Throw();
+        }
+
+        if (_failures.Count > 1)
+        {
+            throw new AggregateException(_failures);
+        }
+    }
+}

--- a/src/ModularPipelines/Logging/ICommandLogger.cs
+++ b/src/ModularPipelines/Logging/ICommandLogger.cs
@@ -18,7 +18,54 @@ namespace ModularPipelines.Logging;
 public interface ICommandLogger
 {
     /// <summary>
-    /// Logs the details of a command execution.
+    /// Logs a command immediately before execution starts.
+    /// </summary>
+    /// <param name="options">The command line tool options used for execution. Can be null for raw command line execution.</param>
+    /// <param name="execOpts">The command execution options containing logging settings.</param>
+    /// <param name="inputToLog">The input command to log.</param>
+    /// <param name="commandWorkingDirPath">The working directory where the command will execute.</param>
+    void LogCommandStart(
+        CommandLineToolOptions? options,
+        CommandExecutionOptions? execOpts,
+        string? inputToLog,
+        string commandWorkingDirPath)
+    {
+    }
+
+    /// <summary>
+    /// Logs command output and status after execution finishes.
+    /// </summary>
+    /// <param name="options">The command line tool options used for execution. Can be null for raw command line execution.</param>
+    /// <param name="execOpts">The command execution options containing logging settings.</param>
+    /// <param name="inputToLog">The input command to log.</param>
+    /// <param name="exitCode">The exit code returned by the command.</param>
+    /// <param name="runTime">The time taken to execute the command.</param>
+    /// <param name="standardOutput">The standard output from the command.</param>
+    /// <param name="standardError">The standard error from the command.</param>
+    /// <param name="commandWorkingDirPath">The working directory where the command executed.</param>
+    void LogCommandCompletion(
+        CommandLineToolOptions? options,
+        CommandExecutionOptions? execOpts,
+        string? inputToLog,
+        int? exitCode,
+        TimeSpan? runTime,
+        string standardOutput,
+        string standardError,
+        string commandWorkingDirPath)
+    {
+        Log(
+            options,
+            execOpts,
+            inputToLog,
+            exitCode,
+            runTime,
+            standardOutput,
+            standardError,
+            commandWorkingDirPath);
+    }
+
+    /// <summary>
+    /// Logs the details of a completed command execution.
     /// </summary>
     /// <param name="options">The command line tool options used for execution. Can be null for raw command line execution.</param>
     /// <param name="execOpts">The command execution options containing logging settings. Logging behavior is controlled via <see cref="CommandExecutionOptions.LogSettings"/>.</param>

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -339,6 +339,54 @@ public class CommandLoggerTests : TestBase
     }
 
     [Test]
+    public async Task Command_Header_Precedes_Streamed_Output_And_Completion()
+    {
+        var marker = $"ordered-output-{Guid.NewGuid():N}";
+        var file = await RunPowershellCommandWithLoggingOptions(
+            $"Write-Output '{marker}'; Start-Sleep -Milliseconds 750",
+            new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Detailed });
+
+        var logFile = await File.ReadAllTextAsync(file);
+        var headerIndex = logFile.IndexOf(
+            $"{Environment.CurrentDirectory}> pwsh",
+            StringComparison.Ordinal);
+        var outputIndex = logFile.IndexOf($"↳ {marker}", StringComparison.Ordinal);
+        var completionIndex = logFile.LastIndexOf("✓ [", StringComparison.Ordinal);
+
+        await Assert.That(headerIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(outputIndex).IsGreaterThan(headerIndex);
+        await Assert.That(completionIndex).IsGreaterThan(outputIndex);
+
+        var lines = logFile.Split(Environment.NewLine);
+        var headerLine = lines.Single(line =>
+            line.Contains($"{Environment.CurrentDirectory}> pwsh", StringComparison.Ordinal));
+        var completionLine = lines.Last(line =>
+            line.Contains("✓ [", StringComparison.Ordinal));
+        await Assert.That(headerLine).DoesNotContain("✓");
+        await Assert.That(completionLine).DoesNotContain("pwsh");
+    }
+
+    [Test]
+    public async Task Failed_Command_Logs_Error_Before_Completion()
+    {
+        var marker = $"ordered-error-{Guid.NewGuid():N}";
+        var file = await RunPowershellCommandWithLoggingOptions(
+            $"[Console]::Error.WriteLine('{marker}'); Start-Sleep -Milliseconds 750; exit 7",
+            new CommandLoggingOptions { Verbosity = CommandLogVerbosity.Detailed });
+
+        var logFile = await File.ReadAllTextAsync(file);
+        var headerIndex = logFile.IndexOf(
+            $"{Environment.CurrentDirectory}> pwsh",
+            StringComparison.Ordinal);
+        var errorIndex = logFile.IndexOf($"↳ {marker}", StringComparison.Ordinal);
+        var completionIndex = logFile.LastIndexOf("✗ [", StringComparison.Ordinal);
+
+        await Assert.That(headerIndex).IsGreaterThanOrEqualTo(0);
+        await Assert.That(errorIndex).IsGreaterThan(headerIndex);
+        await Assert.That(completionIndex).IsGreaterThan(errorIndex);
+    }
+
+    [Test]
     public async Task Command_Output_Is_Logged_Before_Command_Completes()
     {
         var marker = $"live-output-{Guid.NewGuid():N}";

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -363,7 +363,7 @@ public class CommandLoggerTests : TestBase
         var completionLine = lines.Last(line =>
             line.Contains("✓ [", StringComparison.Ordinal));
         await Assert.That(headerLine).DoesNotContain("✓");
-        await Assert.That(completionLine).DoesNotContain("pwsh");
+        await Assert.That(completionLine).Contains("pwsh");
     }
 
     [Test]
@@ -444,6 +444,42 @@ public class CommandLoggerTests : TestBase
         await Assert.That(exception.InnerExceptions[0]).IsTypeOf<InvalidOperationException>();
         await Assert.That(exception.InnerExceptions[0].Message).IsEqualTo("Logging failed.");
         await Assert.That(loggingProvider.ThrowCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task HeaderLoggingFailureDoesNotPreventCommandExecution()
+    {
+        var marker = $"header-failure-{Guid.NewGuid():N}";
+        var sideEffectFile = Path.Combine(
+            TestContext.WorkingDirectory,
+            Guid.NewGuid().ToString("N") + ".txt");
+        using var loggingProvider =
+            new SelectiveThrowingLoggerProvider($"{Environment.CurrentDirectory}> {marker}");
+        var (commandContext, _) = await GetService<ICommandContext>((_, collection) =>
+        {
+            collection.Configure<LoggerFilterOptions>(
+                options => options.MinLevel = LogLevel.Information);
+            collection.AddLogging(builder => builder.AddProvider(loggingProvider));
+        });
+
+        var exception = await Assert.ThrowsAsync<AggregateException>(() =>
+            commandContext.ExecuteCommandLineToolAsync(
+                new PowershellScriptOptions(
+                    $"[System.IO.File]::WriteAllText('{sideEffectFile}', 'executed')"),
+                new CommandExecutionOptions
+                {
+                    InputLoggingManipulator = _ => marker,
+                }));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Flatten().InnerExceptions)
+                .Contains(failure =>
+                    failure is InvalidOperationException
+                    && failure.Message == "Logging failed.");
+            await Assert.That(await File.ReadAllTextAsync(sideEffectFile)).IsEqualTo("executed");
+            await Assert.That(loggingProvider.ThrowCount).IsEqualTo(1);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -483,6 +483,33 @@ public class CommandLoggerTests : TestBase
     }
 
     [Test]
+    public async Task InvalidExecutionTimeoutDoesNotLogCommandStart()
+    {
+        var marker = $"invalid-timeout-{Guid.NewGuid():N}";
+        var file = Path.Combine(
+            TestContext.WorkingDirectory,
+            Guid.NewGuid().ToString("N") + ".txt");
+        var result = await GetService<ICommandContext>((_, collection) =>
+        {
+            collection.Configure<LoggerFilterOptions>(
+                options => options.MinLevel = LogLevel.Information);
+            collection.AddLogging(builder => builder.AddFile(file));
+        });
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            result.T.ExecuteCommandLineToolAsync(
+                new PowershellScriptOptions("Write-Output 'not-executed'"),
+                new CommandExecutionOptions
+                {
+                    ExecutionTimeout = TimeSpan.FromMilliseconds(-2),
+                    InputLoggingManipulator = _ => marker,
+                }));
+        await result.Host.DisposeAsync();
+
+        await Assert.That(await File.ReadAllTextAsync(file)).DoesNotContain(marker);
+    }
+
+    [Test]
     public async Task Deferred_Logging_Failure_After_NonZero_Exit_Preserves_Command_Failure()
     {
         var marker = $"throwing-failure-output-{Guid.NewGuid():N}";

--- a/test/ModularPipelines.UnitTests/Context/LoggingCommandLineExecutorTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/LoggingCommandLineExecutorTests.cs
@@ -1,0 +1,140 @@
+using ModularPipelines.Context;
+using ModularPipelines.Logging;
+using ModularPipelines.Models;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.UnitTests.Context;
+
+public class LoggingCommandLineExecutorTests
+{
+    [Test]
+    public async Task InnerFailureStillLogsCompletion()
+    {
+        var expectedException = new InvalidOperationException("Execution failed.");
+        var logger = new RecordingCommandLogger();
+        var executor = new LoggingCommandLineExecutor(
+            new StubCommandLineExecutor(
+                (_, _, _) => Task.FromException<CommandResult>(expectedException)),
+            logger);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => executor.ExecuteAsync(new CommandLine("tool", [])));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception).IsSameReferenceAs(expectedException);
+            await Assert.That(logger.Events).Count().IsEqualTo(2);
+            await Assert.That(logger.Events[0]).IsEqualTo("start");
+            await Assert.That(logger.Events[1]).IsEqualTo("completion");
+            await Assert.That(logger.CompletionExitCode).IsEqualTo(-1);
+            await Assert.That(logger.CompletionError).IsEqualTo(expectedException.Message);
+        }
+    }
+
+    [Test]
+    public async Task StartLoggingFailureDoesNotPreventExecution()
+    {
+        var expectedException = new InvalidOperationException("Logging failed.");
+        var executed = false;
+        var logger = new RecordingCommandLogger
+        {
+            StartFailure = expectedException,
+        };
+        var result = CreateResult();
+        var executor = new LoggingCommandLineExecutor(
+            new StubCommandLineExecutor((_, _, _) =>
+            {
+                executed = true;
+                return Task.FromResult(result);
+            }),
+            logger);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => executor.ExecuteAsync(new CommandLine("tool", [])));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(executed).IsTrue();
+            await Assert.That(exception).IsSameReferenceAs(expectedException);
+            await Assert.That(logger.Events).Count().IsEqualTo(2);
+            await Assert.That(logger.Events[1]).IsEqualTo("completion");
+        }
+    }
+
+    private static CommandResult CreateResult()
+    {
+        var timestamp = DateTimeOffset.UtcNow;
+        return new CommandResult(
+            "tool",
+            Environment.CurrentDirectory,
+            string.Empty,
+            string.Empty,
+            new Dictionary<string, string?>(),
+            timestamp,
+            timestamp,
+            TimeSpan.Zero,
+            0);
+    }
+
+    private sealed class StubCommandLineExecutor(
+        Func<CommandLine, CommandExecutionOptions?, CancellationToken, Task<CommandResult>> execute)
+        : ICommandLineExecutor
+    {
+        public Task<CommandResult> ExecuteAsync(
+            CommandLine commandLine,
+            CommandExecutionOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            execute(commandLine, options, cancellationToken);
+    }
+
+    private sealed class RecordingCommandLogger : ICommandLogger
+    {
+        public List<string> Events { get; } = [];
+
+        public Exception? StartFailure { get; init; }
+
+        public int? CompletionExitCode { get; private set; }
+
+        public string? CompletionError { get; private set; }
+
+        public void LogCommandStart(
+            CommandLineToolOptions? options,
+            CommandExecutionOptions? execOpts,
+            string? inputToLog,
+            string commandWorkingDirPath)
+        {
+            Events.Add("start");
+            if (StartFailure is not null)
+            {
+                throw StartFailure;
+            }
+        }
+
+        public void LogCommandCompletion(
+            CommandLineToolOptions? options,
+            CommandExecutionOptions? execOpts,
+            string? inputToLog,
+            int? exitCode,
+            TimeSpan? runTime,
+            string standardOutput,
+            string standardError,
+            string commandWorkingDirPath)
+        {
+            Events.Add("completion");
+            CompletionExitCode = exitCode;
+            CompletionError = standardError;
+        }
+
+        public void Log(
+            CommandLineToolOptions? options,
+            CommandExecutionOptions? execOpts,
+            string? inputToLog,
+            int? exitCode,
+            TimeSpan? runTime,
+            string standardOutput,
+            string standardError,
+            string commandWorkingDirPath)
+        {
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
@@ -87,8 +87,9 @@ public class SpectreConsoleLoggerTests
             string.Empty,
             "C:\\repo");
 
-        await Assert.That(logger.Properties["CommandOutput"]?.ToString()).Contains("short output");
-        await Assert.That(logger.Properties["CommandMessage"]?.ToString()).DoesNotContain("short output");
+        var outputEntry = logger.Entries.Single(properties => properties.ContainsKey("CommandOutput"));
+        await Assert.That(outputEntry["CommandOutput"]?.ToString()).Contains("short output");
+        await Assert.That(outputEntry.Values.Select(x => x?.ToString())).DoesNotContain("tool --version");
     }
 
     [Test]
@@ -154,8 +155,7 @@ public class SpectreConsoleLoggerTests
 
     private sealed class CapturingModuleLogger : IModuleLogger
     {
-        public IReadOnlyDictionary<string, object?> Properties { get; private set; }
-            = new Dictionary<string, object?>();
+        public List<IReadOnlyDictionary<string, object?>> Entries { get; } = [];
 
         public void Log<TState>(
             LogLevel logLevel,
@@ -169,7 +169,7 @@ public class SpectreConsoleLoggerTests
                 throw new InvalidOperationException("Expected structured log state.");
             }
 
-            Properties = properties.ToDictionary(x => x.Key, x => x.Value);
+            Entries.Add(properties.ToDictionary(x => x.Key, x => x.Value));
         }
 
         public bool IsEnabled(LogLevel logLevel) => true;


### PR DESCRIPTION
## Summary
- log each command header immediately before execution starts
- emit buffered/streamed output after the header and a concise completion status last
- preserve custom `ICommandLogger` compatibility through default lifecycle hooks
- cover success and failure ordering with regression tests

## Validation
- 48 `CommandLoggerTests` passed with coverage
- warning-level analyzer gate passed for changed files
- whitespace verification passed
- guarded Release build of `ModularPipelines.sln` passed with 0 warnings/errors

Closes #3550