### PR TITLE
Mask secrets in pipeline-level logging

### DIFF
--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -5,6 +5,7 @@ using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 using ModularPipelines.Helpers;
+using ModularPipelines.Logging;
 using Spectre.Console;
 
 namespace ModularPipelines.Console;
@@ -766,15 +767,29 @@ internal sealed class BufferedLogEvent<TState>(
     Func<TState, Exception?, string> formatter,
     ISecretObfuscator secretObfuscator) : IBufferedLogEvent
 {
+    private readonly Exception? _obfuscatedException =
+        ObfuscatedLogException.Create(exception, secretObfuscator);
+
     public LogLevel Level => level;
 
     public void WriteTo(ILogger logger)
     {
+        if (obfuscatedState is TState typedState)
+        {
+            logger.Log(
+                level,
+                eventId,
+                typedState,
+                _obfuscatedException,
+                FormatTyped);
+            return;
+        }
+
         logger.Log(
             level,
             eventId,
             obfuscatedState,
-            exception,
+            _obfuscatedException,
             Format);
     }
 
@@ -787,9 +802,12 @@ internal sealed class BufferedLogEvent<TState>(
 
     private string Format(object state, Exception? logException)
     {
-        var formatted = formatter(originalState, logException);
+        var formatted = formatter(originalState, exception);
         return secretObfuscator.Obfuscate(formatted, null) ?? string.Empty;
     }
+
+    private string FormatTyped(TState state, Exception? logException)
+        => Format(state!, logException);
 
     private static string FormatLevel(LogLevel logLevel) =>
         logLevel switch

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -762,7 +762,7 @@ internal sealed class BufferedLogEvent<TState>(
     LogLevel level,
     EventId eventId,
     TState originalState,
-    object obfuscatedState,
+    object? obfuscatedState,
     Exception? exception,
     Func<TState, Exception?, string> formatter,
     ISecretObfuscator secretObfuscator) : IBufferedLogEvent
@@ -800,7 +800,7 @@ internal sealed class BufferedLogEvent<TState>(
             ? null
             : secretObfuscator.Obfuscate(exception.ToString(), null);
 
-    private string Format(object state, Exception? logException)
+    private string Format(object? state, Exception? logException)
     {
         var formatted = formatter(originalState, exception);
         return secretObfuscator.Obfuscate(formatted, null) ?? string.Empty;

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -774,6 +774,17 @@ internal sealed class BufferedLogEvent<TState>(
 
     public void WriteTo(ILogger logger)
     {
+        if (obfuscatedState is null && originalState is null)
+        {
+            logger.Log<TState>(
+                level,
+                eventId,
+                originalState,
+                _obfuscatedException,
+                FormatTyped);
+            return;
+        }
+
         if (obfuscatedState is TState typedState)
         {
             logger.Log(

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -85,14 +85,15 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
 
     private void LogDryRunCommand(CommandLoggingOptions options, string workingDirectory, string? input)
     {
-        if (!ShouldShowInput(options))
+        var logger = Logger;
+        if (!ShouldShowInput(options) || !logger.IsEnabled(LogLevel.Information))
         {
             return;
         }
 
-        Logger.LogInformation("{WorkingDirectory}> {Input} [DRY-RUN]",
+        logger.LogInformation("{WorkingDirectory}> {Input} [DRY-RUN]",
             workingDirectory,
-            input);
+            _secretObfuscator.Obfuscate(input, null));
     }
 
     private void LogOutputLine(

--- a/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
+++ b/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
@@ -46,9 +46,8 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
                 continue;
             }
 
-            var originalValue = property.Value.ToString() ?? string.Empty;
-            var obfuscatedValue = _secretObfuscator.Obfuscate(originalValue, null);
-            if (obfuscatedValue.Equals(originalValue, StringComparison.Ordinal))
+            var obfuscatedValue = ObfuscateValue(property.Value);
+            if (ReferenceEquals(obfuscatedValue, property.Value))
             {
                 continue;
             }
@@ -62,7 +61,16 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
 
     private object ObfuscateValue(object value)
     {
-        var originalValue = value.ToString() ?? string.Empty;
+        string originalValue;
+        try
+        {
+            originalValue = value.ToString() ?? string.Empty;
+        }
+        catch (Exception)
+        {
+            return value;
+        }
+
         var obfuscatedValue = _secretObfuscator.Obfuscate(originalValue, null);
         return obfuscatedValue.Equals(originalValue, StringComparison.Ordinal)
             ? value

--- a/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
+++ b/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
@@ -33,7 +33,7 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
     {
         if (state is not IReadOnlyList<KeyValuePair<string, object?>> values)
         {
-            return state;
+            return ObfuscateValue(state);
         }
 
         KeyValuePair<string, object?>[]? obfuscatedValues = null;
@@ -58,6 +58,15 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
         }
 
         return obfuscatedValues ?? state;
+    }
+
+    private object ObfuscateValue(object value)
+    {
+        var originalValue = value.ToString() ?? string.Empty;
+        var obfuscatedValue = _secretObfuscator.Obfuscate(originalValue, null);
+        return obfuscatedValue.Equals(originalValue, StringComparison.Ordinal)
+            ? value
+            : obfuscatedValue;
     }
 }
 

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -119,7 +119,9 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
                 return;
             }
 
-            var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state!);
+            var obfuscatedState = state is null
+                ? null
+                : _formattedLogValuesObfuscator.TryObfuscateValues(state);
             var logEvent = new BufferedLogEvent<TState>(
                 logLevel,
                 eventId,

--- a/src/ModularPipelines/Logging/ModuleLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/ModuleLoggerProvider.cs
@@ -20,6 +20,8 @@ internal class ModuleLoggerProvider : IInternalModuleLoggerProvider
     private readonly IServiceProvider _serviceProvider;
     private readonly IStackTraceModuleDetector _stackTraceDetector;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly ISecretObfuscator _secretObfuscator;
+    private readonly IFormattedLogValuesObfuscator _formattedLogValuesObfuscator;
     private readonly object _lock = new();
 
     private IModuleLogger? _moduleLogger;
@@ -28,11 +30,15 @@ internal class ModuleLoggerProvider : IInternalModuleLoggerProvider
     public ModuleLoggerProvider(
         IServiceProvider serviceProvider,
         IStackTraceModuleDetector stackTraceDetector,
-        ILoggerFactory loggerFactory)
+        ILoggerFactory loggerFactory,
+        ISecretObfuscator secretObfuscator,
+        IFormattedLogValuesObfuscator formattedLogValuesObfuscator)
     {
         _serviceProvider = serviceProvider;
         _stackTraceDetector = stackTraceDetector;
         _loggerFactory = loggerFactory;
+        _secretObfuscator = secretObfuscator;
+        _formattedLogValuesObfuscator = formattedLogValuesObfuscator;
     }
 
     /// <summary>
@@ -83,7 +89,10 @@ internal class ModuleLoggerProvider : IInternalModuleLoggerProvider
             {
                 // No module context - return a pipeline-level logger that doesn't create a separate output section
                 // This handles logging during initialization (e.g., GitInformation), condition evaluation, etc.
-                return _pipelineLevelLogger ??= new PipelineLevelLogger(_loggerFactory.CreateLogger("ModularPipelines.Pipeline"));
+                return _pipelineLevelLogger ??= new PipelineLevelLogger(
+                    _loggerFactory.CreateLogger("ModularPipelines.Pipeline"),
+                    _secretObfuscator,
+                    _formattedLogValuesObfuscator);
             }
 
             return _moduleLogger = GetLogger(detectedType);

--- a/src/ModularPipelines/Logging/ObfuscatedLogException.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedLogException.cs
@@ -5,6 +5,9 @@ namespace ModularPipelines.Logging;
 /// <summary>
 /// Provides downstream loggers with an exception whose public text is safe to render.
 /// </summary>
+/// <remarks>
+/// Wrapping intentionally replaces the original exception type identity.
+/// </remarks>
 internal sealed class ObfuscatedLogException : Exception
 {
     private readonly string _obfuscatedText;

--- a/src/ModularPipelines/Logging/ObfuscatedLogException.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedLogException.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using ModularPipelines.Engine;
 
 namespace ModularPipelines.Logging;
@@ -20,6 +22,7 @@ internal sealed class ObfuscatedLogException : Exception
     {
         _obfuscatedStackTrace = ObfuscateNullable(exception.StackTrace, secretObfuscator);
         _obfuscatedText = secretObfuscator.Obfuscate(exception.ToString(), null);
+        GetExceptionMethod(this) = exception.TargetSite;
         HResult = exception.HResult;
         HelpLink = ObfuscateNullable(exception.HelpLink, secretObfuscator);
         Source = ObfuscateNullable(exception.Source, secretObfuscator);
@@ -38,4 +41,8 @@ internal sealed class ObfuscatedLogException : Exception
         string? value,
         ISecretObfuscator secretObfuscator) =>
         value is null ? null : secretObfuscator.Obfuscate(value, null);
+
+    // TargetSite is non-virtual and has no public copy API; this is its .NET 10 backing field.
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_exceptionMethod")]
+    private static extern ref MethodBase? GetExceptionMethod(Exception exception);
 }

--- a/src/ModularPipelines/Logging/ObfuscatedLogException.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedLogException.cs
@@ -20,11 +20,13 @@ internal sealed class ObfuscatedLogException : Exception
 
     private ObfuscatedLogException(Exception exception, ISecretObfuscator secretObfuscator)
         : base(
-            secretObfuscator.Obfuscate(exception.Message, null),
+            GetObfuscatedMessage(exception, secretObfuscator),
             Create(exception.InnerException, secretObfuscator))
     {
-        _obfuscatedStackTrace = ObfuscateNullable(exception.StackTrace, secretObfuscator);
-        _obfuscatedText = secretObfuscator.Obfuscate(exception.ToString(), null);
+        _obfuscatedStackTrace = GetObfuscatedDiagnostic(
+            () => exception.StackTrace,
+            secretObfuscator);
+        _obfuscatedText = GetObfuscatedText(exception, secretObfuscator);
         CopyDiagnostics(this, exception, secretObfuscator);
     }
 
@@ -46,6 +48,48 @@ internal sealed class ObfuscatedLogException : Exception
         ISecretObfuscator secretObfuscator) =>
         value is null ? null : secretObfuscator.Obfuscate(value, null);
 
+    private static string GetObfuscatedMessage(
+        Exception exception,
+        ISecretObfuscator secretObfuscator)
+    {
+        try
+        {
+            return secretObfuscator.Obfuscate(exception.Message, null);
+        }
+        catch (Exception)
+        {
+            return LoggingConstants.SecretMask;
+        }
+    }
+
+    private static string GetObfuscatedText(
+        Exception exception,
+        ISecretObfuscator secretObfuscator)
+    {
+        try
+        {
+            return secretObfuscator.Obfuscate(exception.ToString(), null);
+        }
+        catch (Exception)
+        {
+            return $"{exception.GetType().FullName}: {GetObfuscatedMessage(exception, secretObfuscator)}";
+        }
+    }
+
+    private static string? GetObfuscatedDiagnostic(
+        Func<string?> getValue,
+        ISecretObfuscator secretObfuscator)
+    {
+        try
+        {
+            return ObfuscateNullable(getValue(), secretObfuscator);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
     private static void CopyDiagnostics(
         Exception destination,
         Exception source,
@@ -53,8 +97,12 @@ internal sealed class ObfuscatedLogException : Exception
     {
         TryCopyTargetSite(destination, source);
         destination.HResult = source.HResult;
-        destination.HelpLink = ObfuscateNullable(source.HelpLink, secretObfuscator);
-        destination.Source = ObfuscateNullable(source.Source, secretObfuscator);
+        destination.HelpLink = GetObfuscatedDiagnostic(
+            () => source.HelpLink,
+            secretObfuscator);
+        destination.Source = GetObfuscatedDiagnostic(
+            () => source.Source,
+            secretObfuscator);
         CopyData(destination, source, secretObfuscator);
     }
 
@@ -62,6 +110,7 @@ internal sealed class ObfuscatedLogException : Exception
     {
         if (!RuntimeFeature.IsDynamicCodeSupported)
         {
+            TryCopyNativeAotTargetSiteState(destination, source);
             return;
         }
 
@@ -72,6 +121,19 @@ internal sealed class ObfuscatedLogException : Exception
         catch (MissingFieldException)
         {
             // The private runtime field is unavailable under some runtimes.
+        }
+    }
+
+    private static void TryCopyNativeAotTargetSiteState(Exception destination, Exception source)
+    {
+        try
+        {
+            GetNativeAotStackTrace(destination) = GetNativeAotStackTrace(source)?.ToArray();
+            GetNativeAotStackTraceCount(destination) = GetNativeAotStackTraceCount(source);
+        }
+        catch (MissingFieldException)
+        {
+            // The private runtime fields are unavailable under some runtimes.
         }
     }
 
@@ -149,6 +211,13 @@ internal sealed class ObfuscatedLogException : Exception
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_exceptionMethod")]
     private static extern ref MethodBase? GetExceptionMethod(Exception exception);
 
+    // NativeAOT computes TargetSite from the first captured native stack trace entry.
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_corDbgStackTrace")]
+    private static extern ref IntPtr[]? GetNativeAotStackTrace(Exception exception);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_idxFirstFreeStackTraceEntry")]
+    private static extern ref int GetNativeAotStackTraceCount(Exception exception);
+
     private sealed class ObfuscatedAggregateLogException : AggregateException
     {
         private readonly string? _obfuscatedStackTrace;
@@ -158,11 +227,13 @@ internal sealed class ObfuscatedLogException : Exception
             AggregateException exception,
             ISecretObfuscator secretObfuscator)
             : base(
-                secretObfuscator.Obfuscate(exception.Message, null),
+                GetObfuscatedMessage(exception, secretObfuscator),
                 exception.InnerExceptions.Select(inner => Create(inner, secretObfuscator)!))
         {
-            _obfuscatedStackTrace = ObfuscateNullable(exception.StackTrace, secretObfuscator);
-            _obfuscatedText = secretObfuscator.Obfuscate(exception.ToString(), null);
+            _obfuscatedStackTrace = GetObfuscatedDiagnostic(
+                () => exception.StackTrace,
+                secretObfuscator);
+            _obfuscatedText = GetObfuscatedText(exception, secretObfuscator);
             CopyDiagnostics(this, exception, secretObfuscator);
         }
 

--- a/src/ModularPipelines/Logging/ObfuscatedLogException.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedLogException.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using ModularPipelines.Engine;
@@ -22,16 +23,17 @@ internal sealed class ObfuscatedLogException : Exception
     {
         _obfuscatedStackTrace = ObfuscateNullable(exception.StackTrace, secretObfuscator);
         _obfuscatedText = secretObfuscator.Obfuscate(exception.ToString(), null);
-        GetExceptionMethod(this) = exception.TargetSite;
-        HResult = exception.HResult;
-        HelpLink = ObfuscateNullable(exception.HelpLink, secretObfuscator);
-        Source = ObfuscateNullable(exception.Source, secretObfuscator);
+        CopyDiagnostics(this, exception, secretObfuscator);
     }
 
     public static Exception? Create(Exception? exception, ISecretObfuscator secretObfuscator)
-        => exception is null
-            ? null
-            : new ObfuscatedLogException(exception, secretObfuscator);
+        => exception switch
+        {
+            null => null,
+            AggregateException aggregateException =>
+                new ObfuscatedAggregateLogException(aggregateException, secretObfuscator),
+            _ => new ObfuscatedLogException(exception, secretObfuscator),
+        };
 
     public override string? StackTrace => _obfuscatedStackTrace;
 
@@ -42,7 +44,46 @@ internal sealed class ObfuscatedLogException : Exception
         ISecretObfuscator secretObfuscator) =>
         value is null ? null : secretObfuscator.Obfuscate(value, null);
 
+    private static void CopyDiagnostics(
+        Exception destination,
+        Exception source,
+        ISecretObfuscator secretObfuscator)
+    {
+        GetExceptionMethod(destination) = GetTargetSite(source);
+        destination.HResult = source.HResult;
+        destination.HelpLink = ObfuscateNullable(source.HelpLink, secretObfuscator);
+        destination.Source = ObfuscateNullable(source.Source, secretObfuscator);
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "TargetSite is copied as an optional diagnostic; missing trimmed metadata is acceptable.")]
+    private static MethodBase? GetTargetSite(Exception exception) => exception.TargetSite;
+
     // TargetSite is non-virtual and has no public copy API; this is its .NET 10 backing field.
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_exceptionMethod")]
     private static extern ref MethodBase? GetExceptionMethod(Exception exception);
+
+    private sealed class ObfuscatedAggregateLogException : AggregateException
+    {
+        private readonly string? _obfuscatedStackTrace;
+        private readonly string _obfuscatedText;
+
+        public ObfuscatedAggregateLogException(
+            AggregateException exception,
+            ISecretObfuscator secretObfuscator)
+            : base(
+                secretObfuscator.Obfuscate(exception.Message, null),
+                exception.InnerExceptions.Select(inner => Create(inner, secretObfuscator)!))
+        {
+            _obfuscatedStackTrace = ObfuscateNullable(exception.StackTrace, secretObfuscator);
+            _obfuscatedText = secretObfuscator.Obfuscate(exception.ToString(), null);
+            CopyDiagnostics(this, exception, secretObfuscator);
+        }
+
+        public override string? StackTrace => _obfuscatedStackTrace;
+
+        public override string ToString() => _obfuscatedText;
+    }
 }

--- a/src/ModularPipelines/Logging/ObfuscatedLogException.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedLogException.cs
@@ -10,13 +10,19 @@ namespace ModularPipelines.Logging;
 /// </remarks>
 internal sealed class ObfuscatedLogException : Exception
 {
+    private readonly string? _obfuscatedStackTrace;
     private readonly string _obfuscatedText;
 
     private ObfuscatedLogException(Exception exception, ISecretObfuscator secretObfuscator)
-        : base(secretObfuscator.Obfuscate(exception.Message, null))
+        : base(
+            secretObfuscator.Obfuscate(exception.Message, null),
+            Create(exception.InnerException, secretObfuscator))
     {
+        _obfuscatedStackTrace = ObfuscateNullable(exception.StackTrace, secretObfuscator);
         _obfuscatedText = secretObfuscator.Obfuscate(exception.ToString(), null);
         HResult = exception.HResult;
+        HelpLink = ObfuscateNullable(exception.HelpLink, secretObfuscator);
+        Source = ObfuscateNullable(exception.Source, secretObfuscator);
     }
 
     public static Exception? Create(Exception? exception, ISecretObfuscator secretObfuscator)
@@ -24,5 +30,12 @@ internal sealed class ObfuscatedLogException : Exception
             ? null
             : new ObfuscatedLogException(exception, secretObfuscator);
 
+    public override string? StackTrace => _obfuscatedStackTrace;
+
     public override string ToString() => _obfuscatedText;
+
+    private static string? ObfuscateNullable(
+        string? value,
+        ISecretObfuscator secretObfuscator) =>
+        value is null ? null : secretObfuscator.Obfuscate(value, null);
 }

--- a/src/ModularPipelines/Logging/ObfuscatedLogException.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedLogException.cs
@@ -1,6 +1,8 @@
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using ModularPipelines.Constants;
 using ModularPipelines.Engine;
 
 namespace ModularPipelines.Logging;
@@ -49,10 +51,92 @@ internal sealed class ObfuscatedLogException : Exception
         Exception source,
         ISecretObfuscator secretObfuscator)
     {
-        GetExceptionMethod(destination) = GetTargetSite(source);
+        TryCopyTargetSite(destination, source);
         destination.HResult = source.HResult;
         destination.HelpLink = ObfuscateNullable(source.HelpLink, secretObfuscator);
         destination.Source = ObfuscateNullable(source.Source, secretObfuscator);
+        CopyData(destination, source, secretObfuscator);
+    }
+
+    private static void TryCopyTargetSite(Exception destination, Exception source)
+    {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            return;
+        }
+
+        try
+        {
+            GetExceptionMethod(destination) = GetTargetSite(source);
+        }
+        catch (MissingFieldException)
+        {
+            // The private runtime field is unavailable under some runtimes.
+        }
+    }
+
+    private static void CopyData(
+        Exception destination,
+        Exception source,
+        ISecretObfuscator secretObfuscator)
+    {
+        try
+        {
+            foreach (DictionaryEntry entry in source.Data)
+            {
+                var key = SanitizeDataValue(entry.Key, secretObfuscator);
+                if (key is null)
+                {
+                    continue;
+                }
+
+                destination.Data[GetUniqueDataKey(destination.Data, key)] =
+                    SanitizeDataValue(entry.Value, secretObfuscator);
+            }
+        }
+        catch (Exception)
+        {
+            // Diagnostic data must never make logging fail.
+        }
+    }
+
+    private static object GetUniqueDataKey(IDictionary data, object key)
+    {
+        if (!data.Contains(key))
+        {
+            return key;
+        }
+
+        var baseKey = key.ToString() ?? string.Empty;
+        for (var suffix = 2; ; suffix++)
+        {
+            var candidate = $"{baseKey} ({suffix})";
+            if (!data.Contains(candidate))
+            {
+                return candidate;
+            }
+        }
+    }
+
+    private static object? SanitizeDataValue(
+        object? value,
+        ISecretObfuscator secretObfuscator)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            var text = value.ToString() ?? string.Empty;
+            var obfuscated = secretObfuscator.Obfuscate(text, null);
+            return obfuscated.Equals(text, StringComparison.Ordinal) ? value : obfuscated;
+        }
+        catch (Exception)
+        {
+            return LoggingConstants.SecretMask;
+        }
     }
 
     [UnconditionalSuppressMessage(

--- a/src/ModularPipelines/Logging/ObfuscatedLogException.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedLogException.cs
@@ -1,0 +1,25 @@
+using ModularPipelines.Engine;
+
+namespace ModularPipelines.Logging;
+
+/// <summary>
+/// Provides downstream loggers with an exception whose public text is safe to render.
+/// </summary>
+internal sealed class ObfuscatedLogException : Exception
+{
+    private readonly string _obfuscatedText;
+
+    private ObfuscatedLogException(Exception exception, ISecretObfuscator secretObfuscator)
+        : base(secretObfuscator.Obfuscate(exception.Message, null))
+    {
+        _obfuscatedText = secretObfuscator.Obfuscate(exception.ToString(), null);
+        HResult = exception.HResult;
+    }
+
+    public static Exception? Create(Exception? exception, ISecretObfuscator secretObfuscator)
+        => exception is null
+            ? null
+            : new ObfuscatedLogException(exception, secretObfuscator);
+
+    public override string ToString() => _obfuscatedText;
+}

--- a/src/ModularPipelines/Logging/PipelineLevelLogger.cs
+++ b/src/ModularPipelines/Logging/PipelineLevelLogger.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
@@ -62,6 +63,15 @@ internal sealed class PipelineLevelLogger : IModuleLogger
         where TState : notnull
     {
         var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state);
+        if (!ReferenceEquals(obfuscatedState, state)
+            && obfuscatedState is IReadOnlyList<KeyValuePair<string, object?>> obfuscatedValues
+            && state is IReadOnlyList<KeyValuePair<string, object?>>)
+        {
+            return _logger.BeginScope(new ObfuscatedScopeState(
+                obfuscatedValues,
+                _secretObfuscator.Obfuscate(state.ToString(), null)));
+        }
+
         return obfuscatedState is TState typedState
             ? _logger.BeginScope(typedState)
             : _logger.BeginScope(obfuscatedState);
@@ -71,5 +81,20 @@ internal sealed class PipelineLevelLogger : IModuleLogger
     public void Dispose()
     {
         // Nothing to dispose - the underlying logger is managed by the LoggerFactory
+    }
+
+    private sealed class ObfuscatedScopeState(
+        IReadOnlyList<KeyValuePair<string, object?>> values,
+        string formattedValue) : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        public int Count => values.Count;
+
+        public KeyValuePair<string, object?> this[int index] => values[index];
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() => values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public override string ToString() => formattedValue;
     }
 }

--- a/src/ModularPipelines/Logging/PipelineLevelLogger.cs
+++ b/src/ModularPipelines/Logging/PipelineLevelLogger.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Console;
+using ModularPipelines.Constants;
 using ModularPipelines.Engine;
 
 namespace ModularPipelines.Logging;
@@ -69,7 +70,7 @@ internal sealed class PipelineLevelLogger : IModuleLogger
         {
             return _logger.BeginScope(new ObfuscatedScopeState(
                 obfuscatedValues,
-                _secretObfuscator.Obfuscate(state.ToString(), null)));
+                TryRenderScope(state)));
         }
 
         return obfuscatedState is TState typedState
@@ -81,6 +82,18 @@ internal sealed class PipelineLevelLogger : IModuleLogger
     public void Dispose()
     {
         // Nothing to dispose - the underlying logger is managed by the LoggerFactory
+    }
+
+    private string TryRenderScope<TState>(TState state)
+    {
+        try
+        {
+            return _secretObfuscator.Obfuscate(state?.ToString(), null);
+        }
+        catch (Exception)
+        {
+            return LoggingConstants.SecretMask;
+        }
     }
 
     private sealed class ObfuscatedScopeState(

--- a/src/ModularPipelines/Logging/PipelineLevelLogger.cs
+++ b/src/ModularPipelines/Logging/PipelineLevelLogger.cs
@@ -39,9 +39,27 @@ internal sealed class PipelineLevelLogger : IModuleLogger
             return;
         }
 
-        var obfuscatedState = state is null
-            ? null
-            : _formattedLogValuesObfuscator.TryObfuscateValues(state);
+        object? obfuscatedState;
+        try
+        {
+            obfuscatedState = state is null
+                ? null
+                : _formattedLogValuesObfuscator.TryObfuscateValues(state);
+        }
+        catch (Exception)
+        {
+            new BufferedLogEvent<string>(
+                    logLevel,
+                    eventId,
+                    LoggingConstants.SecretMask,
+                    LoggingConstants.SecretMask,
+                    exception,
+                    static (message, _) => message,
+                    _secretObfuscator)
+                .WriteTo(_logger);
+            return;
+        }
+
         new BufferedLogEvent<TState>(
                 logLevel,
                 eventId,

--- a/src/ModularPipelines/Logging/PipelineLevelLogger.cs
+++ b/src/ModularPipelines/Logging/PipelineLevelLogger.cs
@@ -32,6 +32,11 @@ internal sealed class PipelineLevelLogger : IModuleLogger
     /// <inheritdoc />
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
+        if (!IsEnabled(logLevel))
+        {
+            return;
+        }
+
         var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state!);
         new BufferedLogEvent<TState>(
                 logLevel,

--- a/src/ModularPipelines/Logging/PipelineLevelLogger.cs
+++ b/src/ModularPipelines/Logging/PipelineLevelLogger.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Console;
+using ModularPipelines.Engine;
 
 namespace ModularPipelines.Logging;
 
@@ -14,16 +16,32 @@ namespace ModularPipelines.Logging;
 internal sealed class PipelineLevelLogger : IModuleLogger
 {
     private readonly ILogger _logger;
+    private readonly ISecretObfuscator _secretObfuscator;
+    private readonly IFormattedLogValuesObfuscator _formattedLogValuesObfuscator;
 
-    public PipelineLevelLogger(ILogger logger)
+    public PipelineLevelLogger(
+        ILogger logger,
+        ISecretObfuscator secretObfuscator,
+        IFormattedLogValuesObfuscator formattedLogValuesObfuscator)
     {
         _logger = logger;
+        _secretObfuscator = secretObfuscator;
+        _formattedLogValuesObfuscator = formattedLogValuesObfuscator;
     }
 
     /// <inheritdoc />
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
-        _logger.Log(logLevel, eventId, state, exception, formatter);
+        var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state!);
+        new BufferedLogEvent<TState>(
+                logLevel,
+                eventId,
+                state,
+                obfuscatedState,
+                exception,
+                formatter,
+                _secretObfuscator)
+            .WriteTo(_logger);
     }
 
     /// <inheritdoc />
@@ -36,7 +54,10 @@ internal sealed class PipelineLevelLogger : IModuleLogger
     public IDisposable? BeginScope<TState>(TState state)
         where TState : notnull
     {
-        return _logger.BeginScope(state);
+        var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state);
+        return obfuscatedState is TState typedState
+            ? _logger.BeginScope(typedState)
+            : _logger.BeginScope(obfuscatedState);
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Logging/PipelineLevelLogger.cs
+++ b/src/ModularPipelines/Logging/PipelineLevelLogger.cs
@@ -63,16 +63,7 @@ internal sealed class PipelineLevelLogger : IModuleLogger
     public IDisposable? BeginScope<TState>(TState state)
         where TState : notnull
     {
-        var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state);
-        if (!ReferenceEquals(obfuscatedState, state)
-            && obfuscatedState is IReadOnlyList<KeyValuePair<string, object?>> obfuscatedValues
-            && state is IReadOnlyList<KeyValuePair<string, object?>>)
-        {
-            return _logger.BeginScope(new ObfuscatedScopeState(
-                obfuscatedValues,
-                TryRenderScope(state)));
-        }
-
+        var obfuscatedState = TryObfuscateScopeState(state);
         return obfuscatedState is TState typedState
             ? _logger.BeginScope(typedState)
             : _logger.BeginScope(obfuscatedState);
@@ -82,6 +73,29 @@ internal sealed class PipelineLevelLogger : IModuleLogger
     public void Dispose()
     {
         // Nothing to dispose - the underlying logger is managed by the LoggerFactory
+    }
+
+    private object TryObfuscateScopeState<TState>(TState state)
+        where TState : notnull
+    {
+        try
+        {
+            var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state);
+            if (!ReferenceEquals(obfuscatedState, state)
+                && obfuscatedState is IReadOnlyList<KeyValuePair<string, object?>> obfuscatedValues
+                && state is IReadOnlyList<KeyValuePair<string, object?>>)
+            {
+                return new ObfuscatedScopeState(
+                    obfuscatedValues,
+                    TryRenderScope(state));
+            }
+
+            return obfuscatedState;
+        }
+        catch (Exception)
+        {
+            return LoggingConstants.SecretMask;
+        }
     }
 
     private string TryRenderScope<TState>(TState state)

--- a/src/ModularPipelines/Logging/PipelineLevelLogger.cs
+++ b/src/ModularPipelines/Logging/PipelineLevelLogger.cs
@@ -37,7 +37,9 @@ internal sealed class PipelineLevelLogger : IModuleLogger
             return;
         }
 
-        var obfuscatedState = _formattedLogValuesObfuscator.TryObfuscateValues(state!);
+        var obfuscatedState = state is null
+            ? null
+            : _formattedLogValuesObfuscator.TryObfuscateValues(state);
         new BufferedLogEvent<TState>(
                 logLevel,
                 eventId,

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -36,6 +36,35 @@ public class CommandLoggerTests : TestBase
     }
 
     [Test]
+    public async Task Masks_Secret_Values_From_Dry_Run_Command()
+    {
+        const string secret = "dry-run-command-secret";
+        var file = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N") + ".txt");
+        var result = await GetService<ICommandContext>((_, collection) =>
+        {
+            collection.Configure<LoggerFilterOptions>(options => options.MinLevel = LogLevel.Information);
+            collection.AddLogging(builder => builder.AddFile(file));
+        });
+
+        await result.T.ExecuteCommandLineToolAsync(
+            new SecretCommandOptions { Secret = secret },
+            new CommandExecutionOptions
+            {
+                InternalDryRun = true,
+                LogSettings = new CommandLoggingOptions
+                {
+                    ShowCommandArguments = true,
+                },
+            });
+        await result.Host.DisposeAsync();
+
+        var logFile = await File.ReadAllTextAsync(file);
+        await Assert.That(logFile).Contains("[DRY-RUN]");
+        await Assert.That(logFile).DoesNotContain(secret);
+        await Assert.That(logFile).Contains("********");
+    }
+
+    [Test]
     public async Task OutputLoggingManipulator_Does_Not_Change_Command_Result()
     {
         const string rawOutput = "raw-output";

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -313,7 +313,7 @@ public class CommandLoggerTests : TestBase
     }
 
     [Test]
-    public async Task Fast_Command_Logs_Complete_Output_When_Result_Is_Truncated()
+    public async Task Command_Logs_Complete_Output_When_Result_Is_Truncated()
     {
         const string output = "complete-output";
         var file = await RunPowershellCommandWithLoggingOptions(
@@ -322,7 +322,7 @@ public class CommandLoggerTests : TestBase
             maxCapturedOutputLength: 4);
 
         var logFile = await File.ReadAllTextAsync(file);
-        await Assert.That(logFile).Contains($"→ {output}");
+        await Assert.That(Regex.Matches(logFile, $"(?:→|↳) {output}").Count).IsEqualTo(1);
         await Assert.That(logFile).DoesNotContain("truncated");
     }
 

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -551,7 +551,7 @@ public class ModuleOutputBufferTests
         var writer = new StringWriter();
         var loggerControl = new SynchronousLoggerControl(writer);
         var fallbackLogger = new RecordingLogger();
-        var logException = new InvalidOperationException("structured failure");
+        var logException = new InvalidOperationException("structured secret failure");
         var buffer = CreateBufferWithStructuredLog(
             TimeSpan.FromMilliseconds(50),
             "structured secret",
@@ -595,11 +595,12 @@ public class ModuleOutputBufferTests
         await Assert.That(output).Contains("[WARN] structured ***");
         await Assert.That(output).DoesNotContain("structured secret");
         await Assert.That(output).Contains(nameof(InvalidOperationException));
-        await Assert.That(output).Contains("structured failure");
+        await Assert.That(output).Contains("structured *** failure");
         await Assert.That(output).Contains("direct output");
         await Assert.That(loggerControl.LogCallCount).IsEqualTo(0);
         await Assert.That(fallbackLogger.Entries).HasSingleItem();
-        await Assert.That(fallbackLogger.Entries[0].Exception).IsSameReferenceAs(logException);
+        await Assert.That(fallbackLogger.Entries[0].Exception).IsNotSameReferenceAs(logException);
+        await Assert.That(fallbackLogger.Entries[0].Exception?.ToString()).DoesNotContain("secret");
         await Assert.That(buffer.HasOutput).IsFalse();
     }
 

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -180,6 +180,24 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task BufferedLogEvent_PreservesGenericTypeForNullState()
+    {
+        var logger = new RecordingLogger();
+        var logEvent = new BufferedLogEvent<string?>(
+            LogLevel.Information,
+            default,
+            null,
+            null,
+            null,
+            static (state, _) => state ?? "null-state",
+            new PassthroughSecretObfuscator());
+
+        logEvent.WriteTo(logger);
+
+        await Assert.That(logger.StateTypes).HasSingleItem().And.IsEquivalentTo([typeof(string)]);
+    }
+
+    [Test]
     public async Task ConsoleOutputAddedAfterCompletion_IsRetained()
     {
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
@@ -760,6 +778,8 @@ public class ModuleOutputBufferTests
     {
         public List<(string Message, Exception? Exception)> Entries { get; } = [];
 
+        public List<Type> StateTypes { get; } = [];
+
         public Exception? LogException { get; set; }
 
         public IDisposable? BeginScope<TState>(TState state)
@@ -780,6 +800,7 @@ public class ModuleOutputBufferTests
                 throw LogException;
             }
 
+            StateTypes.Add(typeof(TState));
             Entries.Add((formatter(state, exception), exception));
         }
     }

--- a/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
@@ -108,4 +108,24 @@ public class FormattedLogValuesObfuscatorTests
 
         await Assert.That(obfuscatedState).IsEqualTo("Value: ********");
     }
+
+    [Test]
+    public async Task TryObfuscateValues_PreservesStateWhenToStringThrows()
+    {
+        var state = new ThrowingToStringState();
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object)
+            .TryObfuscateValues(state);
+
+        await Assert.That(obfuscatedState).IsSameReferenceAs(state);
+        secretObfuscator.Verify(
+            x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()),
+            Times.Never);
+    }
+
+    private sealed class ThrowingToStringState
+    {
+        public override string ToString() => throw new InvalidOperationException("Cannot format state.");
+    }
 }

--- a/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
@@ -92,4 +92,20 @@ public class FormattedLogValuesObfuscatorTests
 
         await Assert.That(properties["ModuleName"]).IsEqualTo("********");
     }
+
+    [Test]
+    public async Task TryObfuscateValues_MasksUnstructuredState()
+    {
+        const string secret = "plain-state-secret";
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) =>
+                (value ?? string.Empty).Replace(secret, "********", StringComparison.Ordinal));
+
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object)
+            .TryObfuscateValues($"Value: {secret}");
+
+        await Assert.That(obfuscatedState).IsEqualTo("Value: ********");
+    }
 }

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -279,6 +279,19 @@ public class PipelineLevelLoggerTests
         await Assert.That(underlyingLogger.Scope?.ToString()).IsEqualTo(LoggingConstants.SecretMask);
     }
 
+    [Test]
+    public async Task BeginScope_GuardsHostileStructuredTraversal()
+    {
+        var underlyingLogger = new RecordingLogger();
+        var pipelineLevelLogger = CreateLogger(underlyingLogger);
+
+        await Assert.That(
+                () => pipelineLevelLogger.BeginScope(new ThrowingCountStructuredScopeState()))
+            .ThrowsNothing();
+
+        await Assert.That(underlyingLogger.Scope).IsEqualTo(LoggingConstants.SecretMask);
+    }
+
     private static PipelineLevelLogger CreateLogger(
         ILogger logger,
         Func<string?, string>? obfuscate = null)
@@ -326,6 +339,20 @@ public class PipelineLevelLoggerTests
             GetEnumerator();
 
         public override string ToString() => throw new InvalidOperationException("Cannot format scope.");
+    }
+
+    private sealed class ThrowingCountStructuredScopeState
+        : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        public int Count => throw new InvalidOperationException("Cannot count scope values.");
+
+        public KeyValuePair<string, object?> this[int index] =>
+            throw new InvalidOperationException("Cannot read scope value.");
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() =>
+            throw new InvalidOperationException("Cannot enumerate scope values.");
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 
     private sealed class ThrowingToStringValue

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -143,6 +143,35 @@ public class PipelineLevelLoggerTests
     }
 
     [Test]
+    public async Task Log_PreservesSanitizedExceptionDiagnostics()
+    {
+        const string secret = "pipeline-secret";
+        var underlyingLogger = new RecordingLogger();
+        var innerException = new ArgumentException($"Inner: {secret}");
+        var originalException = CaptureException(
+            new InvalidOperationException($"Outer: {secret}", innerException));
+        originalException.HelpLink = $"https://example.invalid/{secret}";
+        originalException.Source = $"source-{secret}";
+        var pipelineLevelLogger = CreateLogger(
+            underlyingLogger,
+            value => value?.Replace(secret, "********", StringComparison.Ordinal) ?? string.Empty);
+
+        pipelineLevelLogger.LogError(originalException, "Failure");
+
+        var exception = underlyingLogger.Exception;
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception?.StackTrace).Contains(nameof(CaptureException));
+            await Assert.That(exception?.StackTrace).DoesNotContain(secret);
+            await Assert.That(exception?.InnerException).IsNotNull();
+            await Assert.That(exception?.InnerException?.Message).IsEqualTo("Inner: ********");
+            await Assert.That(exception?.InnerException).IsNotSameReferenceAs(innerException);
+            await Assert.That(exception?.HelpLink).IsEqualTo("https://example.invalid/********");
+            await Assert.That(exception?.Source).IsEqualTo("source-********");
+        }
+    }
+
+    [Test]
     public async Task BeginScope_ObfuscatesStateBeforeDelegating()
     {
         const string secret = "scope-secret";
@@ -187,6 +216,18 @@ public class PipelineLevelLoggerTests
             logger,
             secretObfuscator.Object,
             new FormattedLogValuesObfuscator(secretObfuscator.Object));
+    }
+
+    private static Exception CaptureException(Exception exception)
+    {
+        try
+        {
+            throw exception;
+        }
+        catch (Exception captured)
+        {
+            return captured;
+        }
     }
 
     private sealed class RecordingLogger : ILogger

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -156,6 +156,24 @@ public class PipelineLevelLoggerTests
         await Assert.That(underlyingLogger.Scope?.ToString()).IsEqualTo("Scope: ********");
     }
 
+    [Test]
+    public async Task BeginScope_PreservesStructuredFormattedRenderingAfterObfuscation()
+    {
+        const string secret = "scope-secret";
+        var underlyingLogger = new RecordingLogger();
+        var pipelineLevelLogger = CreateLogger(
+            underlyingLogger,
+            value => value?.Replace(secret, "********", StringComparison.Ordinal) ?? string.Empty);
+
+        pipelineLevelLogger.BeginScope("Token {Token}", secret);
+
+        await Assert.That(underlyingLogger.Scope?.ToString()).IsEqualTo("Token ********");
+        var structuredScope = underlyingLogger.Scope
+            as IReadOnlyList<KeyValuePair<string, object?>>;
+        await Assert.That(structuredScope).IsNotNull();
+        await Assert.That(structuredScope![0].Value?.ToString()).IsEqualTo("********");
+    }
+
     private static PipelineLevelLogger CreateLogger(
         ILogger logger,
         Func<string?, string>? obfuscate = null)

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -61,6 +61,26 @@ public class PipelineLevelLoggerTests
     }
 
     [Test]
+    public async Task Log_PreservesNullState()
+    {
+        var underlyingLogger = new RecordingLogger();
+        var pipelineLevelLogger = CreateLogger(underlyingLogger);
+
+        pipelineLevelLogger.Log<string?>(
+            LogLevel.Information,
+            new EventId(2, "NullState"),
+            null,
+            null,
+            static (state, _) => state ?? "null-state");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(underlyingLogger.State).IsNull();
+            await Assert.That(underlyingLogger.Message).IsEqualTo("null-state");
+        }
+    }
+
+    [Test]
     public async Task IsEnabled_DelegatesToUnderlyingLogger()
     {
         // Arrange

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Constants;
 using ModularPipelines.Engine;
@@ -180,6 +181,25 @@ public class PipelineLevelLoggerTests
     }
 
     [Test]
+    public async Task Log_GuardsHostileExceptionDiagnostics()
+    {
+        var underlyingLogger = new RecordingLogger();
+        var pipelineLevelLogger = CreateLogger(underlyingLogger);
+
+        await Assert.That(
+                () => pipelineLevelLogger.LogError(new ThrowingDiagnosticException(), "Failure"))
+            .ThrowsNothing();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(underlyingLogger.Exception?.Message)
+                .IsEqualTo(LoggingConstants.SecretMask);
+            await Assert.That(underlyingLogger.Exception?.ToString())
+                .Contains(nameof(ThrowingDiagnosticException));
+        }
+    }
+
+    [Test]
     public async Task Log_PreservesEverySanitizedAggregateExceptionBranch()
     {
         const string secret = "pipeline-secret";
@@ -311,6 +331,30 @@ public class PipelineLevelLoggerTests
     private sealed class ThrowingToStringValue
     {
         public override string ToString() => throw new InvalidOperationException("Cannot format value.");
+    }
+
+    private sealed class ThrowingDiagnosticException : Exception
+    {
+        public override string Message => throw new InvalidOperationException("Cannot read message.");
+
+        public override IDictionary Data => throw new InvalidOperationException("Cannot read data.");
+
+        public override string? HelpLink
+        {
+            get => throw new InvalidOperationException("Cannot read help link.");
+            set => base.HelpLink = value;
+        }
+
+        public override string? Source
+        {
+            get => throw new InvalidOperationException("Cannot read source.");
+            set => base.Source = value;
+        }
+
+        public override string? StackTrace =>
+            throw new InvalidOperationException("Cannot read stack trace.");
+
+        public override string ToString() => throw new InvalidOperationException("Cannot format exception.");
     }
 
     private sealed class RecordingLogger : ILogger

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Constants;
 using ModularPipelines.Engine;
 using ModularPipelines.Logging;
 using Moq;
@@ -152,6 +153,9 @@ public class PipelineLevelLoggerTests
             new InvalidOperationException($"Outer: {secret}", innerException));
         originalException.HelpLink = $"https://example.invalid/{secret}";
         originalException.Source = $"source-{secret}";
+        originalException.Data[$"key-{secret}"] = $"value-{secret}";
+        originalException.Data["number"] = 42;
+        originalException.Data["hostile"] = new ThrowingToStringValue();
         var pipelineLevelLogger = CreateLogger(
             underlyingLogger,
             value => value?.Replace(secret, "********", StringComparison.Ordinal) ?? string.Empty);
@@ -169,6 +173,9 @@ public class PipelineLevelLoggerTests
             await Assert.That(exception?.InnerException).IsNotSameReferenceAs(innerException);
             await Assert.That(exception?.HelpLink).IsEqualTo("https://example.invalid/********");
             await Assert.That(exception?.Source).IsEqualTo("source-********");
+            await Assert.That(exception?.Data["key-********"]).IsEqualTo("value-********");
+            await Assert.That(exception?.Data["number"]).IsEqualTo(42);
+            await Assert.That(exception?.Data["hostile"]).IsEqualTo(LoggingConstants.SecretMask);
         }
     }
 
@@ -233,6 +240,25 @@ public class PipelineLevelLoggerTests
         await Assert.That(structuredScope![0].Value?.ToString()).IsEqualTo("********");
     }
 
+    [Test]
+    public async Task BeginScope_PreservesStructuredStateWhenRenderingThrows()
+    {
+        const string secret = "scope-secret";
+        var underlyingLogger = new RecordingLogger();
+        var pipelineLevelLogger = CreateLogger(
+            underlyingLogger,
+            value => value?.Replace(secret, "********", StringComparison.Ordinal) ?? string.Empty);
+        var state = new ThrowingStructuredScopeState("Token", secret);
+
+        await Assert.That(() => pipelineLevelLogger.BeginScope(state)).ThrowsNothing();
+
+        var structuredScope = underlyingLogger.Scope
+            as IReadOnlyList<KeyValuePair<string, object?>>;
+        await Assert.That(structuredScope).IsNotNull();
+        await Assert.That(structuredScope![0].Value).IsEqualTo("********");
+        await Assert.That(underlyingLogger.Scope?.ToString()).IsEqualTo(LoggingConstants.SecretMask);
+    }
+
     private static PipelineLevelLogger CreateLogger(
         ILogger logger,
         Func<string?, string>? obfuscate = null)
@@ -258,6 +284,33 @@ public class PipelineLevelLoggerTests
         {
             return captured;
         }
+    }
+
+    private sealed class ThrowingStructuredScopeState(
+        string key,
+        object? value) : IReadOnlyList<KeyValuePair<string, object?>>
+    {
+        private readonly KeyValuePair<string, object?>[] _values =
+        [
+            new(key, value),
+        ];
+
+        public int Count => _values.Length;
+
+        public KeyValuePair<string, object?> this[int index] => _values[index];
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() =>
+            ((IEnumerable<KeyValuePair<string, object?>>) _values).GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
+            GetEnumerator();
+
+        public override string ToString() => throw new InvalidOperationException("Cannot format scope.");
+    }
+
+    private sealed class ThrowingToStringValue
+    {
+        public override string ToString() => throw new InvalidOperationException("Cannot format value.");
     }
 
     private sealed class RecordingLogger : ILogger

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Engine;
 using ModularPipelines.Logging;
 using Moq;
 
@@ -14,7 +15,7 @@ public class PipelineLevelLoggerTests
     {
         // Arrange
         var mockLogger = new Mock<ILogger>();
-        var pipelineLevelLogger = new PipelineLevelLogger(mockLogger.Object);
+        var pipelineLevelLogger = CreateLogger(mockLogger.Object);
         var eventId = new EventId(1, "TestEvent");
         const string message = "Test message";
 
@@ -37,7 +38,7 @@ public class PipelineLevelLoggerTests
         var mockLogger = new Mock<ILogger>();
         mockLogger.Setup(x => x.IsEnabled(LogLevel.Warning)).Returns(true);
         mockLogger.Setup(x => x.IsEnabled(LogLevel.Trace)).Returns(false);
-        var pipelineLevelLogger = new PipelineLevelLogger(mockLogger.Object);
+        var pipelineLevelLogger = CreateLogger(mockLogger.Object);
 
         // Act & Assert
         await Assert.That(pipelineLevelLogger.IsEnabled(LogLevel.Warning)).IsTrue();
@@ -51,7 +52,7 @@ public class PipelineLevelLoggerTests
         var mockLogger = new Mock<ILogger>();
         var expectedScope = new Mock<IDisposable>();
         mockLogger.Setup(x => x.BeginScope("test scope")).Returns(expectedScope.Object);
-        var pipelineLevelLogger = new PipelineLevelLogger(mockLogger.Object);
+        var pipelineLevelLogger = CreateLogger(mockLogger.Object);
 
         // Act
         var scope = pipelineLevelLogger.BeginScope("test scope");
@@ -65,9 +66,91 @@ public class PipelineLevelLoggerTests
     {
         // Arrange
         var mockLogger = new Mock<ILogger>();
-        var pipelineLevelLogger = new PipelineLevelLogger(mockLogger.Object);
+        var pipelineLevelLogger = CreateLogger(mockLogger.Object);
 
         // Act & Assert - should not throw
         pipelineLevelLogger.Dispose();
+    }
+
+    [Test]
+    public async Task Log_ObfuscatesStateMessageAndExceptionBeforeDelegating()
+    {
+        const string secret = "pipeline-secret";
+        var underlyingLogger = new RecordingLogger();
+        var originalException = new InvalidOperationException($"Failure: {secret}");
+        var pipelineLevelLogger = CreateLogger(
+            underlyingLogger,
+            value => value?.Replace(secret, "********", StringComparison.Ordinal) ?? string.Empty);
+
+        pipelineLevelLogger.LogError(
+            originalException,
+            "Token {Token}",
+            secret);
+
+        await Assert.That(underlyingLogger.State?.ToString()).DoesNotContain(secret);
+        await Assert.That(underlyingLogger.Message).DoesNotContain(secret);
+        await Assert.That(underlyingLogger.Exception).IsNotSameReferenceAs(originalException);
+        await Assert.That(underlyingLogger.Exception?.ToString()).DoesNotContain(secret);
+    }
+
+    [Test]
+    public async Task BeginScope_ObfuscatesStateBeforeDelegating()
+    {
+        const string secret = "scope-secret";
+        var underlyingLogger = new RecordingLogger();
+        var pipelineLevelLogger = CreateLogger(
+            underlyingLogger,
+            value => value?.Replace(secret, "********", StringComparison.Ordinal) ?? string.Empty);
+
+        pipelineLevelLogger.BeginScope($"Scope: {secret}");
+
+        await Assert.That(underlyingLogger.Scope?.ToString()).IsEqualTo("Scope: ********");
+    }
+
+    private static PipelineLevelLogger CreateLogger(
+        ILogger logger,
+        Func<string?, string>? obfuscate = null)
+    {
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) => obfuscate?.Invoke(value) ?? value ?? string.Empty);
+
+        return new PipelineLevelLogger(
+            logger,
+            secretObfuscator.Object,
+            new FormattedLogValuesObfuscator(secretObfuscator.Object));
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public object? State { get; private set; }
+
+        public object? Scope { get; private set; }
+
+        public string? Message { get; private set; }
+
+        public Exception? Exception { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull
+        {
+            Scope = state;
+            return null;
+        }
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            State = state;
+            Exception = exception;
+            Message = formatter(state, exception);
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -15,6 +15,7 @@ public class PipelineLevelLoggerTests
     {
         // Arrange
         var mockLogger = new Mock<ILogger>();
+        mockLogger.Setup(x => x.IsEnabled(LogLevel.Information)).Returns(true);
         var pipelineLevelLogger = CreateLogger(mockLogger.Object);
         var eventId = new EventId(1, "TestEvent");
         const string message = "Test message";
@@ -29,6 +30,34 @@ public class PipelineLevelLoggerTests
             message,
             null,
             It.IsAny<Func<string, Exception?, string>>()), Times.Once);
+    }
+
+    [Test]
+    public void Log_DoesNotObfuscateWhenDisabled()
+    {
+        var mockLogger = new Mock<ILogger>();
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        var pipelineLevelLogger = new PipelineLevelLogger(
+            mockLogger.Object,
+            secretObfuscator.Object,
+            new FormattedLogValuesObfuscator(secretObfuscator.Object));
+
+        pipelineLevelLogger.LogError(
+            new InvalidOperationException("secret"),
+            "Token {Token}",
+            "secret");
+
+        secretObfuscator.Verify(
+            x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()),
+            Times.Never);
+        mockLogger.Verify(
+            x => x.Log(
+                It.IsAny<LogLevel>(),
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Never);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -200,6 +200,27 @@ public class PipelineLevelLoggerTests
     }
 
     [Test]
+    public async Task Log_GuardsHostileStructuredTraversal()
+    {
+        var underlyingLogger = new RecordingLogger();
+        var pipelineLevelLogger = CreateLogger(underlyingLogger);
+
+        await Assert.That(() => pipelineLevelLogger.Log(
+                LogLevel.Information,
+                new EventId(3, "HostileState"),
+                new ThrowingCountStructuredState(),
+                null,
+                static (_, _) => throw new InvalidOperationException("Cannot format state.")))
+            .ThrowsNothing();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(underlyingLogger.State).IsEqualTo(LoggingConstants.SecretMask);
+            await Assert.That(underlyingLogger.Message).IsEqualTo(LoggingConstants.SecretMask);
+        }
+    }
+
+    [Test]
     public async Task Log_PreservesEverySanitizedAggregateExceptionBranch()
     {
         const string secret = "pipeline-secret";
@@ -286,7 +307,7 @@ public class PipelineLevelLoggerTests
         var pipelineLevelLogger = CreateLogger(underlyingLogger);
 
         await Assert.That(
-                () => pipelineLevelLogger.BeginScope(new ThrowingCountStructuredScopeState()))
+                () => pipelineLevelLogger.BeginScope(new ThrowingCountStructuredState()))
             .ThrowsNothing();
 
         await Assert.That(underlyingLogger.Scope).IsEqualTo(LoggingConstants.SecretMask);
@@ -341,7 +362,7 @@ public class PipelineLevelLoggerTests
         public override string ToString() => throw new InvalidOperationException("Cannot format scope.");
     }
 
-    private sealed class ThrowingCountStructuredScopeState
+    private sealed class ThrowingCountStructuredState
         : IReadOnlyList<KeyValuePair<string, object?>>
     {
         public int Count => throw new InvalidOperationException("Cannot count scope values.");

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -173,6 +173,35 @@ public class PipelineLevelLoggerTests
     }
 
     [Test]
+    public async Task Log_PreservesEverySanitizedAggregateExceptionBranch()
+    {
+        const string secret = "pipeline-secret";
+        var underlyingLogger = new RecordingLogger();
+        var firstException = new InvalidOperationException($"First: {secret}");
+        var secondException = new ArgumentException($"Second: {secret}");
+        var originalException = new AggregateException(
+            $"Aggregate: {secret}",
+            firstException,
+            secondException);
+        var pipelineLevelLogger = CreateLogger(
+            underlyingLogger,
+            value => value?.Replace(secret, "********", StringComparison.Ordinal) ?? string.Empty);
+
+        pipelineLevelLogger.LogError(originalException, "Failure");
+
+        var aggregateException = underlyingLogger.Exception as AggregateException;
+        using (Assert.Multiple())
+        {
+            await Assert.That(aggregateException).IsNotNull();
+            await Assert.That(aggregateException!.InnerExceptions).Count().IsEqualTo(2);
+            await Assert.That(aggregateException.InnerExceptions[0].Message).IsEqualTo("First: ********");
+            await Assert.That(aggregateException.InnerExceptions[1].Message).IsEqualTo("Second: ********");
+            await Assert.That(aggregateException.InnerExceptions[0]).IsNotSameReferenceAs(firstException);
+            await Assert.That(aggregateException.InnerExceptions[1]).IsNotSameReferenceAs(secondException);
+        }
+    }
+
+    [Test]
     public async Task BeginScope_ObfuscatesStateBeforeDelegating()
     {
         const string secret = "scope-secret";

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -163,6 +163,7 @@ public class PipelineLevelLoggerTests
         {
             await Assert.That(exception?.StackTrace).Contains(nameof(CaptureException));
             await Assert.That(exception?.StackTrace).DoesNotContain(secret);
+            await Assert.That(exception?.TargetSite).IsEqualTo(originalException.TargetSite);
             await Assert.That(exception?.InnerException).IsNotNull();
             await Assert.That(exception?.InnerException?.Message).IsEqualTo("Inner: ********");
             await Assert.That(exception?.InnerException).IsNotSameReferenceAs(innerException);


### PR DESCRIPTION
## Summary
- mask dry-run command inputs before logging
- apply structured-state and scope masking to pipeline-level logs
- replace raw exceptions with obfuscated downstream-safe exceptions

## Test plan
- [x] focused logging tests (89 passed)
- [x] `ModularPipelines.sln` Release build (0 errors)
- [x] touched-file whitespace verification

Closes #3476
