### PR TITLE
Enable MSBuild node reuse on Windows and macOS

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -493,7 +493,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     env:
-      MSBUILDDISABLENODEREUSE: "1"
       DOTNET_gcServer: "0"
 
     # Compile only: running ModularPipelines.Build while it builds the listed solutions


### PR DESCRIPTION
## Summary
- keep MSBuild node reuse enabled for Windows and macOS compile-only jobs
- retain `MSBUILDDISABLENODEREUSE=1` on Ubuntu jobs that use it for memory control

## Validation
- workflow diff and whitespace checked
- `actionlint` was unavailable locally; GitHub Actions will validate workflow syntax

Closes #3452