### PR TITLE
[Automated] Update cargo CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/cargo.md
+++ b/docs/docs/mp-packages/cli/cargo.md
@@ -7,7 +7,13 @@ title: cargo CLI reference
 
 `ModularPipelines.Rust` provides strongly typed access to the `cargo` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `cargo` executable. Install it separately and ensure `cargo` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Rust
@@ -30,7 +36,7 @@ public class RunCommandModule : Module<CommandResult>
         CancellationToken cancellationToken)
     {
         return await context.Tools.Cargo.CheckAsync(
-            new CargoCheckOptions
+            new CargoCheckOptions()
             {
                 Quiet = true,
             },

--- a/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
+++ b/src/ModularPipelines.Rust/Extensions/CargoExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class CargoExtensions
     }
 
     /// <summary>
-    /// Gets the cargo service from the pipeline context.
+    /// Gets the cargo service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ICargo"/> service for executing cargo commands.</returns>

--- a/src/ModularPipelines.Rust/Generated/Cargo.CommandCoverage.json
+++ b/src/ModularPipelines.Rust/Generated/Cargo.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "cargo",
+  "toolVersion": "cargo 1.97.1 (c980f4866 2026-06-30)",
   "commandCount": 16,
   "commandTreeSha256": "f8b1c0ec09c6f1a8fbc12f34c9e244131aa2869c068c7f752c8da91976b1ec19",
   "commands": [

--- a/src/ModularPipelines.Rust/Options/CargoAddOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoAddOptions.Generated.cs
@@ -19,6 +19,8 @@ namespace ModularPipelines.Rust.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("add")]
-public record CargoAddOptions : CargoOptions
+public record CargoAddOptions(
+    [property: CliArgument(0)] IEnumerable<string> DepVersion
+) : CargoOptions
 {
 }

--- a/src/ModularPipelines.Rust/Options/CargoBenchOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoBenchOptions.Generated.cs
@@ -63,4 +63,16 @@ public record CargoBenchOptions : CargoOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
+    /// <summary>
+    /// The BENCHNAME operand.
+    /// </summary>
+    [CliArgument(0)]
+    public string? Benchname { get; set; }
+
+    /// <summary>
+    /// The [ARGS] operand.
+    /// </summary>
+    [CliArgument(1, PrependOptionTerminator = true)]
+    public IEnumerable<string>? Args { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Options/CargoInitOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoInitOptions.Generated.cs
@@ -81,4 +81,10 @@ public record CargoInitOptions : CargoOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
+    /// <summary>
+    /// The PATH operand.
+    /// </summary>
+    [CliArgument(0)]
+    public string? Path { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Options/CargoInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoInstallOptions.Generated.cs
@@ -135,4 +135,10 @@ public record CargoInstallOptions : CargoOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
+    /// <summary>
+    /// The [CRATE[@&lt;VER&gt;]] operand.
+    /// </summary>
+    [CliArgument(0)]
+    public IEnumerable<string>? CrateVer { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Options/CargoNewOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoNewOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Rust.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("new")]
-public record CargoNewOptions : CargoOptions
+public record CargoNewOptions(
+    [property: CliArgument(0)] string Path
+) : CargoOptions
 {
     /// <summary>
     /// Initialize a new repository for the given version control system,

--- a/src/ModularPipelines.Rust/Options/CargoOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoOptions.Generated.cs
@@ -19,6 +19,7 @@ namespace ModularPipelines.Rust.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliTool("cargo")]
+[CliGlobalOptions]
 public abstract record CargoOptions : CommandLineToolOptions
 {
 }

--- a/src/ModularPipelines.Rust/Options/CargoRemoveOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoRemoveOptions.Generated.cs
@@ -19,7 +19,9 @@ namespace ModularPipelines.Rust.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("remove")]
-public record CargoRemoveOptions : CargoOptions
+public record CargoRemoveOptions(
+    [property: CliArgument(0)] IEnumerable<string> DepId
+) : CargoOptions
 {
     /// <summary>
     /// Don't actually write the manifest

--- a/src/ModularPipelines.Rust/Options/CargoRunOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoRunOptions.Generated.cs
@@ -51,4 +51,10 @@ public record CargoRunOptions : CargoOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
+    /// <summary>
+    /// The [ARGS] operand.
+    /// </summary>
+    [CliArgument(0)]
+    public IEnumerable<string>? Args { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Options/CargoSearchOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoSearchOptions.Generated.cs
@@ -63,4 +63,10 @@ public record CargoSearchOptions : CargoOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
+    /// <summary>
+    /// The [QUERY] operand.
+    /// </summary>
+    [CliArgument(0)]
+    public IEnumerable<string>? Query { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Options/CargoTestOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoTestOptions.Generated.cs
@@ -69,4 +69,16 @@ public record CargoTestOptions : CargoOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
+    /// <summary>
+    /// The TESTNAME operand.
+    /// </summary>
+    [CliArgument(0)]
+    public string? Testname { get; set; }
+
+    /// <summary>
+    /// The [ARGS] operand.
+    /// </summary>
+    [CliArgument(1, PrependOptionTerminator = true)]
+    public IEnumerable<string>? Args { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Options/CargoUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoUninstallOptions.Generated.cs
@@ -51,4 +51,10 @@ public record CargoUninstallOptions : CargoOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
+    /// <summary>
+    /// The [SPEC] operand.
+    /// </summary>
+    [CliArgument(0)]
+    public IEnumerable<string>? Spec { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Options/CargoUpdateOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoUpdateOptions.Generated.cs
@@ -69,4 +69,10 @@ public record CargoUpdateOptions : CargoOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
+    /// <summary>
+    /// The [SPEC] operand.
+    /// </summary>
+    [CliArgument(0)]
+    public IEnumerable<string>? Spec { get; set; }
+
 }

--- a/src/ModularPipelines.Rust/Services/Cargo.Generated.cs
+++ b/src/ModularPipelines.Rust/Services/Cargo.Generated.cs
@@ -33,11 +33,11 @@ internal partial class Cargo : ICargo
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> AddAsync(
-        CargoAddOptions? options = null,
+        CargoAddOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new CargoAddOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -105,11 +105,11 @@ internal partial class Cargo : ICargo
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> NewAsync(
-        CargoNewOptions? options = null,
+        CargoNewOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new CargoNewOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -123,11 +123,11 @@ internal partial class Cargo : ICargo
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> RemoveAsync(
-        CargoRemoveOptions? options = null,
+        CargoRemoveOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new CargoRemoveOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines.Rust/Services/ICargo.Generated.cs
+++ b/src/ModularPipelines.Rust/Services/ICargo.Generated.cs
@@ -27,7 +27,7 @@ public partial interface ICargo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> AddAsync(CargoAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> AddAsync(CargoAddOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Execute all benchmarks of a local package
@@ -99,7 +99,7 @@ public partial interface ICargo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> NewAsync(CargoNewOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> NewAsync(CargoNewOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Upload a package to the registry
@@ -117,7 +117,7 @@ public partial interface ICargo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RemoveAsync(CargoRemoveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> RemoveAsync(CargoRemoveOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Run a binary or example of the local package


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **cargo** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- cargo (cargo 1.97.1 (c980f4866 2026-06-30)): 16 commands, tree f8b1c0ec09c6f1a8fbc12f34c9e244131aa2869c068c7f752c8da91976b1ec19

## Verification
- [x] Solution builds successfully
- API compatibility gate: **failure**

---
🤖 Generated with ModularPipelines.OptionsGenerator