### PR TITLE
[Automated] Update syft CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/syft.md
+++ b/docs/docs/mp-packages/cli/syft.md
@@ -7,7 +7,13 @@ title: syft CLI reference
 
 `ModularPipelines.Syft` provides strongly typed access to the `syft` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `syft` executable. Install it separately and ensure `syft` is available on `PATH`.
+
+See the [syft installation guide](https://oss.anchore.com/docs/installation/syft/).
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Syft
@@ -17,23 +23,10 @@ Resolve the service with `context.Tools.Syft`. For projects older than C# 14, im
 
 ## Module example
 
-```csharp
-using ModularPipelines.Context;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-using ModularPipelines.Syft.Options;
+Resolve the service in a module, then select a command from the table below. A runnable example is omitted when no command has complete safety metadata:
 
-public class RunCommandModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult?> ExecuteAsync(
-        IModuleContext context,
-        CancellationToken cancellationToken)
-    {
-        return await context.Tools.Syft.AttestAsync(
-            new SyftAttestOptions("value"),
-            cancellationToken: cancellationToken);
-    }
-}
+```csharp
+var syft = context.Tools.Syft;
 ```
 
 ## Commands
@@ -41,7 +34,9 @@ public class RunCommandModule : Module<CommandResult>
 | CLI command | Options record |
 | --- | --- |
 | `syft attest` | `SyftAttestOptions` |
+| `syft cataloger` | `SyftCatalogerOptions` |
 | `syft cataloger list` | `SyftCatalogerListOptions` |
+| `syft config` | `SyftConfigOptions` |
 | `syft config locations` | `SyftConfigLocationsOptions` |
 | `syft convert` | `SyftConvertOptions` |
 | `syft login` | `SyftLoginOptions` |

--- a/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
+++ b/src/ModularPipelines.Syft/Extensions/SyftExtensions.Generated.cs
@@ -35,7 +35,7 @@ public static class SyftExtensions
     }
 
     /// <summary>
-    /// Gets the syft service from the pipeline context.
+    /// Gets the syft service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISyft"/> service for executing syft commands.</returns>

--- a/src/ModularPipelines.Syft/Generated/Syft.CommandCoverage.json
+++ b/src/ModularPipelines.Syft/Generated/Syft.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "syft",
+  "toolVersion": "syft 1.50.0",
   "commandCount": 8,
   "commandTreeSha256": "312b56070505f8e9227e5762adaba7ae25213d326283923b5592ce0281c0c868",
   "commands": [

--- a/src/ModularPipelines.Syft/Options/SyftAttestOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftAttestOptions.Generated.cs
@@ -19,7 +19,7 @@ namespace ModularPipelines.Syft.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("attest")]
 public record SyftAttestOptions(
-    [property: CliArgument(1, Placement = ArgumentPlacement.BeforeOptions)] string Image
+    [property: CliArgument(1)] string Image
 ) : SyftOptions
 {
     /// <summary>
@@ -136,7 +136,10 @@ public record SyftAttestOptions(
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
-    [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]
+    /// <summary>
+    /// The FORMAT operand.
+    /// </summary>
+    [CliArgument(0)]
     public string? Format { get; set; }
 
 }

--- a/src/ModularPipelines.Syft/Options/SyftCatalogerListOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftCatalogerListOptions.Generated.cs
@@ -74,7 +74,4 @@ public record SyftCatalogerListOptions : SyftOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
-    [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]
-    public string? Options { get; set; }
-
 }

--- a/src/ModularPipelines.Syft/Options/SyftCatalogerOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftCatalogerOptions.Generated.cs
@@ -50,4 +50,10 @@ public record SyftCatalogerOptions : SyftOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Syft/Options/SyftConfigOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftConfigOptions.Generated.cs
@@ -56,4 +56,10 @@ public record SyftConfigOptions : SyftOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Syft/Options/SyftConvertOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftConvertOptions.Generated.cs
@@ -68,10 +68,16 @@ public record SyftConvertOptions : SyftOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
+    /// <summary>
+    /// The SOURCE-SBOM operand.
+    /// </summary>
     [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]
     public string? SourceSbom { get; set; }
 
-    [CliArgument(1, Placement = ArgumentPlacement.BeforeOptions)]
+    /// <summary>
+    /// The FORMAT operand.
+    /// </summary>
+    [CliArgument(0)]
     public string? Format { get; set; }
 
 }

--- a/src/ModularPipelines.Syft/Options/SyftLoginOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftLoginOptions.Generated.cs
@@ -69,10 +69,10 @@ public record SyftLoginOptions : SyftOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
-    [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]
-    public string? Options { get; set; }
-
-    [CliArgument(1, Placement = ArgumentPlacement.BeforeOptions)]
+    /// <summary>
+    /// The SERVER operand.
+    /// </summary>
+    [CliArgument(0)]
     public string? Server { get; set; }
 
 }

--- a/src/ModularPipelines.Syft/Options/SyftOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftOptions.Generated.cs
@@ -19,6 +19,7 @@ namespace ModularPipelines.Syft.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliTool("syft")]
+[CliGlobalOptions]
 public abstract record SyftOptions : CommandLineToolOptions
 {
 }

--- a/src/ModularPipelines.Syft/Options/SyftScanOptions.Generated.cs
+++ b/src/ModularPipelines.Syft/Options/SyftScanOptions.Generated.cs
@@ -140,6 +140,9 @@ public record SyftScanOptions : SyftOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
+    /// <summary>
+    /// The SOURCE operand.
+    /// </summary>
     [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]
     public string? Source { get; set; }
 

--- a/src/ModularPipelines.Syft/Services/ISyftCataloger.Generated.cs
+++ b/src/ModularPipelines.Syft/Services/ISyftCataloger.Generated.cs
@@ -15,6 +15,9 @@ namespace ModularPipelines.Syft.Services;
 /// <summary>
 /// syft cataloger commands.
 /// </summary>
+/// <remarks>
+/// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
+/// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public interface ISyftCataloger
 {
@@ -25,10 +28,7 @@ public interface ISyftCataloger
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(
-        SyftCatalogerOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(SyftCatalogerOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List available catalogers
@@ -37,9 +37,6 @@ public interface ISyftCataloger
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ListAsync(
-        SyftCatalogerListOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ListAsync(SyftCatalogerListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
 }

--- a/src/ModularPipelines.Syft/Services/ISyftConfig.Generated.cs
+++ b/src/ModularPipelines.Syft/Services/ISyftConfig.Generated.cs
@@ -15,6 +15,9 @@ namespace ModularPipelines.Syft.Services;
 /// <summary>
 /// syft config commands.
 /// </summary>
+/// <remarks>
+/// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
+/// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public interface ISyftConfig
 {
@@ -25,10 +28,7 @@ public interface ISyftConfig
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(
-        SyftConfigOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(SyftConfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// shows all locations and the order in which syft will look for a configuration file
@@ -37,9 +37,6 @@ public interface ISyftConfig
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> LocationsAsync(
-        SyftConfigLocationsOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> LocationsAsync(SyftConfigLocationsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **syft** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- syft (syft 1.50.0): 8 commands, tree 312b56070505f8e9227e5762adaba7ae25213d326283923b5592ce0281c0c868

## Verification
- [x] Solution builds successfully
- API compatibility gate: **failure**

---
🤖 Generated with ModularPipelines.OptionsGenerator