### PR TITLE
[Automated] Update grype CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/grype.md
+++ b/docs/docs/mp-packages/cli/grype.md
@@ -7,7 +7,13 @@ title: grype CLI reference
 
 `ModularPipelines.Grype` provides strongly typed access to the `grype` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `grype` executable. Install it separately and ensure `grype` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Grype
@@ -17,29 +23,17 @@ Resolve the service with `context.Tools.Grype`. For projects older than C# 14, i
 
 ## Module example
 
-```csharp
-using ModularPipelines.Context;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-using ModularPipelines.Grype.Options;
+Resolve the service in a module, then select a command from the table below. A runnable example is omitted when no command has complete safety metadata:
 
-public class RunCommandModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult?> ExecuteAsync(
-        IModuleContext context,
-        CancellationToken cancellationToken)
-    {
-        return await context.Tools.Grype.ExplainAsync(
-            new GrypeExplainOptions(),
-            cancellationToken: cancellationToken);
-    }
-}
+```csharp
+var grype = context.Tools.Grype;
 ```
 
 ## Commands
 
 | CLI command | Options record |
 | --- | --- |
+| `grype db` | `GrypeDbOptions` |
 | `grype db check` | `GrypeDbCheckOptions` |
 | `grype db delete` | `GrypeDbDeleteOptions` |
 | `grype db diff` | `GrypeDbDiffOptions` |

--- a/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
+++ b/src/ModularPipelines.Grype/Extensions/GrypeExtensions.Generated.cs
@@ -34,7 +34,7 @@ public static class GrypeExtensions
     }
 
     /// <summary>
-    /// Gets the grype service from the pipeline context.
+    /// Gets the grype service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGrype"/> service for executing grype commands.</returns>

--- a/src/ModularPipelines.Grype/Generated/Grype.CommandCoverage.json
+++ b/src/ModularPipelines.Grype/Generated/Grype.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "grype",
+  "toolVersion": "grype 0.116.1",
   "commandCount": 12,
   "commandTreeSha256": "b45d7527254e3df6ad584cc8896f94ed1d24e359389729d279639a4563ceb40c",
   "commands": [

--- a/src/ModularPipelines.Grype/Options/GrypeDbDiffOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeDbDiffOptions.Generated.cs
@@ -18,7 +18,9 @@ namespace ModularPipelines.Grype.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("db", "diff")]
-public record GrypeDbDiffOptions : GrypeOptions
+public record GrypeDbDiffOptions(
+    [property: CliArgument(0)] string OldDbUrlOrPath
+) : GrypeOptions
 {
     /// <summary>
     /// help for diff
@@ -67,5 +69,11 @@ public record GrypeDbDiffOptions : GrypeOptions
     /// </summary>
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
+
+    /// <summary>
+    /// The new_db_url_or_path operand.
+    /// </summary>
+    [CliArgument(1)]
+    public string? NewDbUrlOrPath { get; set; }
 
 }

--- a/src/ModularPipelines.Grype/Options/GrypeDbImportOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeDbImportOptions.Generated.cs
@@ -18,7 +18,9 @@ namespace ModularPipelines.Grype.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("db", "import")]
-public record GrypeDbImportOptions : GrypeOptions
+public record GrypeDbImportOptions(
+    [property: CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)] string File
+) : GrypeOptions
 {
     /// <summary>
     /// help for import

--- a/src/ModularPipelines.Grype/Options/GrypeDbOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeDbOptions.Generated.cs
@@ -50,4 +50,10 @@ public record GrypeDbOptions : GrypeOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Grype/Options/GrypeDbSearchOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeDbSearchOptions.Generated.cs
@@ -116,4 +116,10 @@ public record GrypeDbSearchOptions : GrypeOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
+    /// <summary>
+    /// The command operand.
+    /// </summary>
+    [CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)]
+    public string? Command { get; set; }
+
 }

--- a/src/ModularPipelines.Grype/Options/GrypeDbSearchVulnOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeDbSearchVulnOptions.Generated.cs
@@ -18,7 +18,9 @@ namespace ModularPipelines.Grype.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("db", "search", "vuln")]
-public record GrypeDbSearchVulnOptions : GrypeOptions
+public record GrypeDbSearchVulnOptions(
+    [property: CliArgument(0, Placement = ArgumentPlacement.BeforeOptions)] IEnumerable<string> Id
+) : GrypeOptions
 {
     /// <summary>
     /// only show vulnerabilities with the given fix state (fixed, not-fixed, unknown, wont-fix)

--- a/src/ModularPipelines.Grype/Options/GrypeExplainOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeExplainOptions.Generated.cs
@@ -56,4 +56,10 @@ public record GrypeExplainOptions : GrypeOptions
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
 
+    /// <summary>
+    /// The VULNERABILITY ID operand.
+    /// </summary>
+    [CliArgument(0)]
+    public string? VulnerabilityId { get; set; }
+
 }

--- a/src/ModularPipelines.Grype/Options/GrypeOptions.Generated.cs
+++ b/src/ModularPipelines.Grype/Options/GrypeOptions.Generated.cs
@@ -19,6 +19,7 @@ namespace ModularPipelines.Grype.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliTool("grype")]
+[CliGlobalOptions]
 public abstract record GrypeOptions : CommandLineToolOptions
 {
 }

--- a/src/ModularPipelines.Grype/Services/GrypeDb.Generated.cs
+++ b/src/ModularPipelines.Grype/Services/GrypeDb.Generated.cs
@@ -94,11 +94,11 @@ public class GrypeDb : IGrypeDb
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> DiffAsync(
-        GrypeDbDiffOptions? options = null,
+        GrypeDbDiffOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GrypeDbDiffOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>
@@ -109,11 +109,11 @@ public class GrypeDb : IGrypeDb
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> ImportAsync(
-        GrypeDbImportOptions? options = null,
+        GrypeDbImportOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GrypeDbImportOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.Grype/Services/GrypeDbSearch.Generated.cs
+++ b/src/ModularPipelines.Grype/Services/GrypeDbSearch.Generated.cs
@@ -32,6 +32,21 @@ public class GrypeDbSearch
     #region Commands
 
     /// <summary>
+    /// Search the DB for vulnerabilities or affected packages
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public virtual async Task<CommandResult> ExecuteAsync(
+        GrypeDbSearchOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GrypeDbSearchOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <summary>
     /// Search for vulnerabilities within the DB (supports DB schema v6+ only)
     /// </summary>
     /// <param name="options">The command options.</param>
@@ -39,11 +54,11 @@ public class GrypeDbSearch
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> VulnAsync(
-        GrypeDbSearchVulnOptions? options = null,
+        GrypeDbSearchVulnOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new GrypeDbSearchVulnOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     #endregion

--- a/src/ModularPipelines.Grype/Services/IGrypeDb.Generated.cs
+++ b/src/ModularPipelines.Grype/Services/IGrypeDb.Generated.cs
@@ -15,6 +15,9 @@ namespace ModularPipelines.Grype.Services;
 /// <summary>
 /// grype db commands.
 /// </summary>
+/// <remarks>
+/// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
+/// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public interface IGrypeDb
 {
@@ -30,10 +33,7 @@ public interface IGrypeDb
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(
-        GrypeDbOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(GrypeDbOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Check to see if there is a database update available
@@ -42,10 +42,7 @@ public interface IGrypeDb
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> CheckAsync(
-        GrypeDbCheckOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> CheckAsync(GrypeDbCheckOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Delete the vulnerability database
@@ -54,10 +51,7 @@ public interface IGrypeDb
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DeleteAsync(
-        GrypeDbDeleteOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> DeleteAsync(GrypeDbDeleteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Diff two databases, showing packages with added, removed, and modified vulnerability matches
@@ -66,10 +60,7 @@ public interface IGrypeDb
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DiffAsync(
-        GrypeDbDiffOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> DiffAsync(GrypeDbDiffOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// import a vulnerability database archive from a local FILE or URL.
@@ -78,10 +69,7 @@ public interface IGrypeDb
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ImportAsync(
-        GrypeDbImportOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ImportAsync(GrypeDbImportOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List all DBs available according to the listing URL
@@ -90,10 +78,7 @@ public interface IGrypeDb
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ListAsync(
-        GrypeDbListOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ListAsync(GrypeDbListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// List vulnerability providers that are in the database
@@ -102,10 +87,7 @@ public interface IGrypeDb
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ProvidersAsync(
-        GrypeDbProvidersOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ProvidersAsync(GrypeDbProvidersOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Display database status and metadata
@@ -114,10 +96,7 @@ public interface IGrypeDb
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> StatusAsync(
-        GrypeDbStatusOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> StatusAsync(GrypeDbStatusOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Download and install the latest vulnerability database
@@ -126,9 +105,6 @@ public interface IGrypeDb
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateAsync(
-        GrypeDbUpdateOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> UpdateAsync(GrypeDbUpdateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **grype** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- grype (grype 0.116.1): 12 commands, tree b45d7527254e3df6ad584cc8896f94ed1d24e359389729d279639a4563ceb40c

## Verification
- [x] Solution builds successfully
- API compatibility gate: **failure**

---
🤖 Generated with ModularPipelines.OptionsGenerator