### PR TITLE
[Automated] Update hadolint CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/hadolint.md
+++ b/docs/docs/mp-packages/cli/hadolint.md
@@ -7,7 +7,13 @@ title: hadolint CLI reference
 
 `ModularPipelines.Hadolint` provides strongly typed access to the `hadolint` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `hadolint` executable. Install it separately and ensure `hadolint` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Hadolint
@@ -17,23 +23,10 @@ Resolve the service with `context.Tools.Hadolint`. For projects older than C# 14
 
 ## Module example
 
-```csharp
-using ModularPipelines.Context;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-using ModularPipelines.Hadolint.Options;
+Resolve the service in a module, then select a command from the table below. A runnable example is omitted when no command has complete safety metadata:
 
-public class RunCommandModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult?> ExecuteAsync(
-        IModuleContext context,
-        CancellationToken cancellationToken)
-    {
-        return await context.Tools.Hadolint.ExecuteAsync(
-            new HadolintExecuteOptions(),
-            cancellationToken: cancellationToken);
-    }
-}
+```csharp
+var hadolint = context.Tools.Hadolint;
 ```
 
 ## Commands

--- a/src/ModularPipelines.Hadolint/Enums/HadolintFailureThreshold.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Enums/HadolintFailureThreshold.Generated.cs
@@ -17,20 +17,20 @@ namespace ModularPipelines.Hadolint.Enums;
 public enum HadolintFailureThreshold
 {
     [EnumValue("error")]
-    Error,
+    Error = 0,
 
     [EnumValue("warning")]
-    Warning,
+    Warning = 1,
 
     [EnumValue("info")]
-    Info,
+    Info = 2,
 
     [EnumValue("style")]
-    Style,
+    Style = 3,
 
     [EnumValue("ignore")]
-    Ignore,
+    Ignore = 4,
 
     [EnumValue("none")]
-    None
+    None = 5
 }

--- a/src/ModularPipelines.Hadolint/Enums/HadolintFormat.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Enums/HadolintFormat.Generated.cs
@@ -17,32 +17,32 @@ namespace ModularPipelines.Hadolint.Enums;
 public enum HadolintFormat
 {
     [EnumValue("tty")]
-    Tty,
+    Tty = 0,
 
     [EnumValue("json")]
-    Json,
+    Json = 1,
 
     [EnumValue("checkstyle")]
-    Checkstyle,
+    Checkstyle = 2,
 
     [EnumValue("codeclimate")]
-    Codeclimate,
+    Codeclimate = 3,
 
     [EnumValue("gitlab_codeclimate")]
-    GitlabCodeclimate,
+    GitlabCodeclimate = 4,
 
     [EnumValue("gnu")]
-    Gnu,
+    Gnu = 5,
 
     [EnumValue("codacy")]
-    Codacy,
+    Codacy = 6,
 
     [EnumValue("sonarqube")]
-    Sonarqube,
+    Sonarqube = 7,
 
     [EnumValue("sarif")]
-    Sarif,
+    Sarif = 8,
 
     [EnumValue("junit")]
-    Junit
+    Junit = 9
 }

--- a/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Extensions/HadolintExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class HadolintExtensions
     }
 
     /// <summary>
-    /// Gets the hadolint service from the pipeline context.
+    /// Gets the hadolint service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IHadolint"/> service for executing hadolint commands.</returns>

--- a/src/ModularPipelines.Hadolint/Generated/Hadolint.CommandCoverage.json
+++ b/src/ModularPipelines.Hadolint/Generated/Hadolint.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "hadolint",
+  "toolVersion": "Haskell Dockerfile Linter 2.15.1",
   "commandCount": 1,
   "commandTreeSha256": "aeb27eae3024b418e56e8f019f96d51b3a9c807828bc0b65fc1c600d24a325b5",
   "commands": [

--- a/src/ModularPipelines.Hadolint/Options/HadolintExecuteOptions.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Options/HadolintExecuteOptions.Generated.cs
@@ -40,10 +40,16 @@ public record HadolintExecuteOptions : HadolintOptions
     public string? Config { get; set; }
 
     /// <summary>
-    /// The file path referenced in the generated report. This only applies for the 'checkstyle' format and is useful when running Hadolint with Docker to set the correct file path.
+    /// The file path referenced in the generated report. This only applies for the 'checkstyle', 'codeclimate', 'sonarqube', 'junit' and 'gitlab_codeclimate' formats and is useful when running Hadolint with Docker to set the correct file path.
     /// </summary>
     [CliOption("--file-path-in-report")]
     public string? FilePathInReport { get; set; }
+
+    /// <summary>
+    /// Output destination file
+    /// </summary>
+    [CliOption("--output", ShortForm = "-o")]
+    public string? Output { get; set; }
 
     /// <summary>
     /// Don't exit with a failure status code when any rule is violated
@@ -64,7 +70,7 @@ public record HadolintExecuteOptions : HadolintOptions
     public bool? Verbose { get; set; }
 
     /// <summary>
-    /// The output format for the results [tty | json | checkstyle | codeclimate | gitlab_codeclimate | gnu | codacy | sonarqube | sarif] (default: tty)
+    /// The output format for the results [tty | json | checkstyle | codeclimate | gitlab_codeclimate | gnu | codacy | sonarqube | sarif | junit] (default: tty)
     /// </summary>
     [CliOption("--format", ShortForm = "-f")]
     public HadolintFormat? Format { get; set; }

--- a/src/ModularPipelines.Hadolint/Options/HadolintOptions.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Options/HadolintOptions.Generated.cs
@@ -19,6 +19,7 @@ namespace ModularPipelines.Hadolint.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliTool("hadolint")]
+[CliGlobalOptions]
 public abstract record HadolintOptions : CommandLineToolOptions
 {
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **hadolint** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- hadolint (Haskell Dockerfile Linter 2.15.1): 1 commands, tree aeb27eae3024b418e56e8f019f96d51b3a9c807828bc0b65fc1c600d24a325b5

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator