### PR TITLE
[Automated] Update jq CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/jq.md
+++ b/docs/docs/mp-packages/cli/jq.md
@@ -7,7 +7,13 @@ title: jq CLI reference
 
 `ModularPipelines.Jq` provides strongly typed access to the `jq` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `jq` executable. Install it separately and ensure `jq` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Jq
@@ -30,7 +36,11 @@ public class RunCommandModule : Module<CommandResult>
         CancellationToken cancellationToken)
     {
         return await context.Tools.Jq.ExecuteAsync(
-            new JqExecuteOptions(),
+            new JqExecuteOptions()
+            {
+                Filter = ".",
+                InputFiles = ["input.json"],
+            },
             cancellationToken: cancellationToken);
     }
 }

--- a/src/ModularPipelines.Jq/Extensions/JqExtensions.Generated.cs
+++ b/src/ModularPipelines.Jq/Extensions/JqExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class JqExtensions
     }
 
     /// <summary>
-    /// Gets the jq service from the pipeline context.
+    /// Gets the jq service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IJq"/> service for executing jq commands.</returns>

--- a/src/ModularPipelines.Jq/Generated/Jq.CommandCoverage.json
+++ b/src/ModularPipelines.Jq/Generated/Jq.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "jq",
+  "toolVersion": "jq-1.8.2",
   "commandCount": 1,
   "commandTreeSha256": "c84d384f2a25cca2a8fde5eb61b0f81f728e5f778a232211b176ea80143877bc",
   "commands": [

--- a/src/ModularPipelines.Jq/Options/JqExecuteOptions.Generated.cs
+++ b/src/ModularPipelines.Jq/Options/JqExecuteOptions.Generated.cs
@@ -178,12 +178,6 @@ public record JqExecuteOptions : JqOptions
     public bool? ExitStatus { get; set; }
 
     /// <summary>
-    /// Open input/output streams in binary mode
-    /// </summary>
-    [CliFlag("--binary", ShortForm = "-b", PreferShortForm = true)]
-    public bool? Binary { get; set; }
-
-    /// <summary>
     /// show the version
     /// </summary>
     [CliFlag("--version", ShortForm = "-V")]
@@ -206,6 +200,12 @@ public record JqExecuteOptions : JqOptions
     /// </summary>
     [CliOption("--run-tests", ValueArity = CliOptionValueArity.Optional, Phase = CommandLinePhase.Terminal)]
     public string? RunTests { get; set; }
+
+    /// <summary>
+    /// Open input/output streams in binary mode
+    /// </summary>
+    [CliFlag("--binary", ShortForm = "-b", PreferShortForm = true)]
+    public bool? Binary { get; set; }
 
     /// <summary>
     /// Stop processing options so filters beginning with a dash are treated as positional arguments


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **jq** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- jq (jq-1.8.2): 1 commands, tree c84d384f2a25cca2a8fde5eb61b0f81f728e5f778a232211b176ea80143877bc

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator