### PR TITLE
[Automated] Update sonar-scanner CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/sonar-scanner.md
+++ b/docs/docs/mp-packages/cli/sonar-scanner.md
@@ -7,7 +7,17 @@ title: sonar-scanner CLI reference
 
 `ModularPipelines.SonarScanner` provides strongly typed access to the `sonar-scanner` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `sonar-scanner` executable. Install it separately and ensure `sonar-scanner` is available on `PATH`.
+
+The generation workflow is pinned to `sonar-scanner` version `8.0.1.6346`.
+
+See the [sonar-scanner installation guide](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner).
+
+The generator workflow downloads the Linux x64 SonarScanner CLI distribution.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.SonarScanner
@@ -17,23 +27,10 @@ Resolve the service with `context.Tools.SonarScanner`. For projects older than C
 
 ## Module example
 
-```csharp
-using ModularPipelines.Context;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-using ModularPipelines.SonarScanner.Options;
+Resolve the service in a module, then select a command from the table below. A runnable example is omitted when no command has complete safety metadata:
 
-public class RunCommandModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult?> ExecuteAsync(
-        IModuleContext context,
-        CancellationToken cancellationToken)
-    {
-        return await context.Tools.SonarScanner.ExecuteAsync(
-            new SonarScannerExecuteOptions(),
-            cancellationToken: cancellationToken);
-    }
-}
+```csharp
+var sonarScanner = context.Tools.SonarScanner;
 ```
 
 ## Commands

--- a/src/ModularPipelines.SonarScanner/Extensions/SonarScannerExtensions.Generated.cs
+++ b/src/ModularPipelines.SonarScanner/Extensions/SonarScannerExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class SonarScannerExtensions
     }
 
     /// <summary>
-    /// Gets the sonar-scanner service from the pipeline context.
+    /// Gets the sonar-scanner service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ISonarScanner"/> service for executing sonar-scanner commands.</returns>

--- a/src/ModularPipelines.SonarScanner/Generated/SonarScanner.CommandCoverage.json
+++ b/src/ModularPipelines.SonarScanner/Generated/SonarScanner.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "sonar-scanner",
+  "toolVersion": "03:13:24.882 INFO  Scanner configuration file: /home/runner/work/_temp/cli-tools/sonar-scanner-8.0.1.6346-linux-x64/conf/sonar-scanner.properties 03:13:24.887 INFO  Project root configuration file: NONE 03:13:24.917 INFO  SonarScanner CLI 8.0.1.6346 03:13:24.928 INFO  Linux 6.17.0-1020-azure amd64",
   "commandCount": 1,
   "commandTreeSha256": "944baa3accf9323dfebdf2c80745c343a30dd6bbb1b9ea867489959c12c680be",
   "commands": [

--- a/src/ModularPipelines.SonarScanner/Options/SonarScannerOptions.Generated.cs
+++ b/src/ModularPipelines.SonarScanner/Options/SonarScannerOptions.Generated.cs
@@ -19,6 +19,7 @@ namespace ModularPipelines.SonarScanner.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliTool("sonar-scanner")]
+[CliGlobalOptions]
 public abstract record SonarScannerOptions : CommandLineToolOptions
 {
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **sonar-scanner** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- sonar-scanner (03:13:24.882 INFO  Scanner configuration file: /home/runner/work/_temp/cli-tools/sonar-scanner-8.0.1.6346-linux-x64/conf/sonar-scanner.properties 03:13:24.887 INFO  Project root configuration file: NONE 03:13:24.917 INFO  SonarScanner CLI 8.0.1.6346 03:13:24.928 INFO  Linux 6.17.0-1020-azure amd64): 1 commands, tree 944baa3accf9323dfebdf2c80745c343a30dd6bbb1b9ea867489959c12c680be

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator