### PR TITLE
[Automated] Update mvn CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/mvn.md
+++ b/docs/docs/mp-packages/cli/mvn.md
@@ -7,7 +7,13 @@ title: mvn CLI reference
 
 `ModularPipelines.Java` provides strongly typed access to the `mvn` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `mvn` executable. Install it separately and ensure `mvn` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Java
@@ -17,23 +23,10 @@ Resolve the service with `context.Tools.Maven`. For projects older than C# 14, i
 
 ## Module example
 
-```csharp
-using ModularPipelines.Context;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-using ModularPipelines.Java.Options;
+Resolve the service in a module, then select a command from the table below. A runnable example is omitted when no command has complete safety metadata:
 
-public class RunCommandModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult?> ExecuteAsync(
-        IModuleContext context,
-        CancellationToken cancellationToken)
-    {
-        return await context.Tools.Maven.ExecuteAsync(
-            new MavenExecuteOptions(),
-            cancellationToken: cancellationToken);
-    }
-}
+```csharp
+var maven = context.Tools.Maven;
 ```
 
 ## Commands

--- a/src/ModularPipelines.Java/Enums/MavenColor.Generated.cs
+++ b/src/ModularPipelines.Java/Enums/MavenColor.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Java.Enums;
 public enum MavenColor
 {
     [EnumValue("auto")]
-    Auto,
+    Auto = 0,
 
     [EnumValue("always")]
-    Always,
+    Always = 1,
 
     [EnumValue("never")]
-    Never
+    Never = 2
 }

--- a/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
+++ b/src/ModularPipelines.Java/Extensions/MavenExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class MavenExtensions
     }
 
     /// <summary>
-    /// Gets the mvn service from the pipeline context.
+    /// Gets the mvn service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IMaven"/> service for executing mvn commands.</returns>

--- a/src/ModularPipelines.Java/Generated/Maven.CommandCoverage.json
+++ b/src/ModularPipelines.Java/Generated/Maven.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "mvn",
+  "toolVersion": "Apache Maven 3.9.16 (2bdd9fddda4b155ebf8000e807eb73fd829a51d5) Maven home: /home/runner/work/_temp/cli-tools/apache-maven-3.9.16 Java version: 17.0.19, vendor: Eclipse Adoptium, runtime: /usr/lib/jvm/temurin-17-jdk-amd64 Default locale: en, platform encoding: UTF-8 OS name: \u0022linux\u0022, version: \u00226.17.0-1020-azure\u0022, arch: \u0022amd64\u0022, family: \u0022unix\u0022",
   "commandCount": 1,
   "commandTreeSha256": "77b009e6e3fcca705290e093300672ab0c85c6661417cced8369040f3290be3f",
   "commands": [

--- a/src/ModularPipelines.Java/Options/MavenOptions.Generated.cs
+++ b/src/ModularPipelines.Java/Options/MavenOptions.Generated.cs
@@ -19,6 +19,7 @@ namespace ModularPipelines.Java.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliTool("mvn")]
+[CliGlobalOptions]
 public abstract record MavenOptions : CommandLineToolOptions
 {
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **mvn** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- mvn (Apache Maven 3.9.16 (2bdd9fddda4b155ebf8000e807eb73fd829a51d5) Maven home: /home/runner/work/_temp/cli-tools/apache-maven-3.9.16 Java version: 17.0.19, vendor: Eclipse Adoptium, runtime: /usr/lib/jvm/temurin-17-jdk-amd64 Default locale: en, platform encoding: UTF-8 OS name: "linux", version: "6.17.0-1020-azure", arch: "amd64", family: "unix"): 1 commands, tree 77b009e6e3fcca705290e093300672ab0c85c6661417cced8369040f3290be3f

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator