### PR TITLE
[Automated] Update yq CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/yq.md
+++ b/docs/docs/mp-packages/cli/yq.md
@@ -7,7 +7,13 @@ title: yq CLI reference
 
 `ModularPipelines.Yq` provides strongly typed access to the `yq` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `yq` executable. Install it separately and ensure `yq` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Yq
@@ -17,23 +23,10 @@ Resolve the service with `context.Tools.Yq`. For projects older than C# 14, impo
 
 ## Module example
 
-```csharp
-using ModularPipelines.Context;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-using ModularPipelines.Yq.Options;
+Resolve the service in a module, then select a command from the table below. A runnable example is omitted when no command has complete safety metadata:
 
-public class RunCommandModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult?> ExecuteAsync(
-        IModuleContext context,
-        CancellationToken cancellationToken)
-    {
-        return await context.Tools.Yq.EvalAllAsync(
-            new YqEvalAllOptions(),
-            cancellationToken: cancellationToken);
-    }
-}
+```csharp
+var yq = context.Tools.Yq;
 ```
 
 ## Commands

--- a/src/ModularPipelines.Yq/Extensions/YqExtensions.Generated.cs
+++ b/src/ModularPipelines.Yq/Extensions/YqExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class YqExtensions
     }
 
     /// <summary>
-    /// Gets the yq service from the pipeline context.
+    /// Gets the yq service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IYq"/> service for executing yq commands.</returns>

--- a/src/ModularPipelines.Yq/Generated/Yq.CommandCoverage.json
+++ b/src/ModularPipelines.Yq/Generated/Yq.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "yq",
+  "toolVersion": "yq (https://github.com/mikefarah/yq/) version v4.53.3",
   "commandCount": 2,
   "commandTreeSha256": "328b5b077fb40b3d69b15529bbcc453b6d65385140018db3cd2467f0e69454ee",
   "commands": [

--- a/src/ModularPipelines.Yq/Options/YqEvalAllOptions.Generated.cs
+++ b/src/ModularPipelines.Yq/Options/YqEvalAllOptions.Generated.cs
@@ -162,7 +162,7 @@ public record YqEvalAllOptions : YqOptions
     /// pretty print, shorthand for '... style = ""'
     /// </summary>
     [CliFlag("--prettyPrint", ShortForm = "-P")]
-    public bool? Prettyprint { get; set; }
+    public bool? PrettyPrint { get; set; }
 
     /// <summary>
     /// use [x] in array paths (e.g. for SpringBoot)
@@ -228,7 +228,7 @@ public record YqEvalAllOptions : YqOptions
     /// unwrap scalar, print the value with no quotes, colours or comments. Defaults to true for yaml (default true)
     /// </summary>
     [CliOption("--unwrapScalar", ShortForm = "-r", Format = OptionFormat.EqualsSeparated)]
-    public bool? Unwrapscalar { get; set; }
+    public bool? UnwrapScalar { get; set; }
 
     /// <summary>
     /// verbose mode
@@ -301,5 +301,11 @@ public record YqEvalAllOptions : YqOptions
     /// </summary>
     [CliFlag("--yaml-fix-merge-anchor-to-spec")]
     public bool? YamlFixMergeAnchorToSpec { get; set; }
+
+    /// <summary>
+    /// The [yaml_file1] operand.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.BeforeOptions)]
+    public IEnumerable<string>? YamlFile1 { get; set; }
 
 }

--- a/src/ModularPipelines.Yq/Options/YqEvalOptions.Generated.cs
+++ b/src/ModularPipelines.Yq/Options/YqEvalOptions.Generated.cs
@@ -162,7 +162,7 @@ public record YqEvalOptions : YqOptions
     /// pretty print, shorthand for '... style = ""'
     /// </summary>
     [CliFlag("--prettyPrint", ShortForm = "-P")]
-    public bool? Prettyprint { get; set; }
+    public bool? PrettyPrint { get; set; }
 
     /// <summary>
     /// use [x] in array paths (e.g. for SpringBoot)
@@ -228,7 +228,7 @@ public record YqEvalOptions : YqOptions
     /// unwrap scalar, print the value with no quotes, colours or comments. Defaults to true for yaml (default true)
     /// </summary>
     [CliOption("--unwrapScalar", ShortForm = "-r", Format = OptionFormat.EqualsSeparated)]
-    public bool? Unwrapscalar { get; set; }
+    public bool? UnwrapScalar { get; set; }
 
     /// <summary>
     /// verbose mode
@@ -301,5 +301,11 @@ public record YqEvalOptions : YqOptions
     /// </summary>
     [CliFlag("--yaml-fix-merge-anchor-to-spec")]
     public bool? YamlFixMergeAnchorToSpec { get; set; }
+
+    /// <summary>
+    /// The [yaml_file1] operand.
+    /// </summary>
+    [CliArgument(1, Placement = ArgumentPlacement.BeforeOptions)]
+    public IEnumerable<string>? YamlFile1 { get; set; }
 
 }

--- a/src/ModularPipelines.Yq/Options/YqOptions.Generated.cs
+++ b/src/ModularPipelines.Yq/Options/YqOptions.Generated.cs
@@ -19,6 +19,7 @@ namespace ModularPipelines.Yq.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliTool("yq")]
+[CliGlobalOptions]
 public abstract record YqOptions : CommandLineToolOptions
 {
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **yq** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- yq (yq (https://github.com/mikefarah/yq/) version v4.53.3): 2 commands, tree 328b5b077fb40b3d69b15529bbcc453b6d65385140018db3cd2467f0e69454ee

## Verification
- [x] Solution builds successfully
- API compatibility gate: **failure**

---
🤖 Generated with ModularPipelines.OptionsGenerator