### PR TITLE
[Automated] Update choco CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/choco.md
+++ b/docs/docs/mp-packages/cli/choco.md
@@ -7,7 +7,13 @@ title: choco CLI reference
 
 `ModularPipelines.Chocolatey` provides strongly typed access to the `choco` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `choco` executable. Install it separately and ensure `choco` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Chocolatey
@@ -17,23 +23,10 @@ Resolve the service with `context.Tools.Choco`. For projects older than C# 14, i
 
 ## Module example
 
-```csharp
-using ModularPipelines.Context;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-using ModularPipelines.Chocolatey.Options;
+Resolve the service in a module, then select a command from the table below. A runnable example is omitted when no command has complete safety metadata:
 
-public class RunCommandModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult?> ExecuteAsync(
-        IModuleContext context,
-        CancellationToken cancellationToken)
-    {
-        return await context.Tools.Choco.ApikeyAsync(
-            new ChocoApikeyOptions(),
-            cancellationToken: cancellationToken);
-    }
-}
+```csharp
+var choco = context.Tools.Choco;
 ```
 
 ## Commands

--- a/src/ModularPipelines.Chocolatey/Extensions/ChocoExtensions.Generated.cs
+++ b/src/ModularPipelines.Chocolatey/Extensions/ChocoExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class ChocoExtensions
     }
 
     /// <summary>
-    /// Gets the choco service from the pipeline context.
+    /// Gets the choco service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IChoco"/> service for executing choco commands.</returns>

--- a/src/ModularPipelines.Chocolatey/Generated/Choco.CommandCoverage.json
+++ b/src/ModularPipelines.Chocolatey/Generated/Choco.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "choco",
+  "toolVersion": "2.7.3",
   "commandCount": 27,
   "commandTreeSha256": "dbe8fe8a94432faaf1b5dd5f654b165f5722a9fd59318ccb9d8ce3681cafb72c",
   "commands": [

--- a/src/ModularPipelines.Chocolatey/Options/ChocoOptions.Generated.cs
+++ b/src/ModularPipelines.Chocolatey/Options/ChocoOptions.Generated.cs
@@ -19,6 +19,7 @@ namespace ModularPipelines.Chocolatey.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliTool("choco")]
+[CliGlobalOptions]
 public abstract record ChocoOptions : CommandLineToolOptions
 {
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **choco** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- choco (2.7.3): 27 commands, tree dbe8fe8a94432faaf1b5dd5f654b165f5722a9fd59318ccb9d8ce3681cafb72c

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator