### PR TITLE
Fix POSIX escaping for installer paths

### DIFF
--- a/src/ModularPipelines/Context/FileInstaller.cs
+++ b/src/ModularPipelines/Context/FileInstaller.cs
@@ -1,5 +1,6 @@
 using ModularPipelines.Context.Domains.Network;
 using ModularPipelines.Context.Domains.Shell;
+using ModularPipelines.Helpers.Internal;
 using ModularPipelines.Models;
 using ModularPipelines.Options;
 
@@ -30,8 +31,8 @@ public class FileInstaller : IFileInstaller
             }, null, cancellationToken).ConfigureAwait(false);
         }
 
-        var escapedPath = options.Path.Replace("'", "'\''");
-        await _bash.CommandAsync(new BashCommandOptions($"chmod u+x '{escapedPath}'"), cancellationToken).ConfigureAwait(false);
+        var escapedPath = ShellArgumentEscaper.Escape(options.Path);
+        await _bash.CommandAsync(new BashCommandOptions($"chmod u+x {escapedPath}"), cancellationToken).ConfigureAwait(false);
 
         return await _bash.FromFileAsync(new BashFileOptions(options.Path), cancellationToken).ConfigureAwait(false);
     }

--- a/src/ModularPipelines/Context/PredefinedInstallers.cs
+++ b/src/ModularPipelines/Context/PredefinedInstallers.cs
@@ -6,6 +6,7 @@ using ModularPipelines.Context.Domains.Installers;
 using ModularPipelines.Context.Domains.Network;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.FileSystem;
+using ModularPipelines.Helpers.Internal;
 using ModularPipelines.Models;
 using ModularPipelines.Options;
 using ModularPipelines.Options.Linux;
@@ -195,8 +196,7 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
         }
 
         // Linux/Mac: Use shell escaping since BashCommandOptions uses string interpolation.
-        // The validation regex ensures no single quotes in version, making this escaping safe.
-        var escapedVersion = EscapeShellArgument(version);
+        var escapedVersion = ShellArgumentEscaper.Escape(version);
         return await _bash.CommandAsync(new BashCommandOptions($"nvm install {escapedVersion}")).ConfigureAwait(false);
     }
 
@@ -218,18 +218,6 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
                 "Expected formats: --lts, --latest, v18.0.0, 18.0.0, lts/*, node, system, or similar.",
                 nameof(version));
         }
-    }
-
-    /// <summary>
-    /// Escapes a string for safe use as a shell argument.
-    /// </summary>
-    /// <param name="argument">The argument to escape.</param>
-    /// <returns>The escaped argument wrapped in single quotes.</returns>
-    private static string EscapeShellArgument(string argument)
-    {
-        // Single-quote the argument and escape any embedded single quotes
-        // by ending the quote, adding an escaped quote, and starting a new quote
-        return "'" + argument.Replace("'", "'\\''") + "'";
     }
 
     // Matches valid nvm version formats:

--- a/src/ModularPipelines/Helpers/Internal/ShellArgumentEscaper.cs
+++ b/src/ModularPipelines/Helpers/Internal/ShellArgumentEscaper.cs
@@ -1,0 +1,7 @@
+namespace ModularPipelines.Helpers.Internal;
+
+internal static class ShellArgumentEscaper
+{
+    public static string Escape(string argument) =>
+        "'" + argument.Replace("'", "'\\''", StringComparison.Ordinal) + "'";
+}

--- a/test/ModularPipelines.UnitTests/Helpers/FileInstallerTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/FileInstallerTests.cs
@@ -1,0 +1,63 @@
+using ModularPipelines.Context;
+using ModularPipelines.Context.Domains.Network;
+using ModularPipelines.Context.Domains.Shell;
+using ModularPipelines.Models;
+using ModularPipelines.Options;
+using ModularPipelines.UnitTests.Attributes;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Helpers;
+
+public class FileInstallerTests
+{
+    [Test]
+    [LinuxOnlyTest]
+    public async Task EscapesPathForMakeExecutableCommand()
+    {
+        const string path = "/tmp/it's ready.sh";
+        BashCommandOptions? chmodOptions = null;
+        BashFileOptions? scriptOptions = null;
+        var result = CreateResult();
+        var bash = new Mock<IBashContext>();
+        bash.Setup(context => context.CommandAsync(
+                It.IsAny<BashCommandOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<BashCommandOptions, CancellationToken>(
+                (options, _) => chmodOptions = options)
+            .ReturnsAsync(result);
+        bash.Setup(context => context.FromFileAsync(
+                It.IsAny<BashFileOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<BashFileOptions, CancellationToken>(
+                (options, _) => scriptOptions = options)
+            .ReturnsAsync(result);
+        var installer = new FileInstaller(
+            Mock.Of<ICommandContext>(),
+            Mock.Of<IDownloaderContext>(),
+            bash.Object);
+
+        await installer.InstallFromFileAsync(new InstallerOptions(path));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(chmodOptions?.Command)
+                .IsEqualTo("chmod u+x '/tmp/it'\\''s ready.sh'");
+            await Assert.That(scriptOptions?.FilePath).IsEqualTo(path);
+        }
+    }
+
+    private static CommandResult CreateResult()
+    {
+        var timestamp = DateTimeOffset.UtcNow;
+        return new CommandResult(
+            "bash",
+            Environment.CurrentDirectory,
+            string.Empty,
+            string.Empty,
+            new Dictionary<string, string?>(),
+            timestamp,
+            timestamp,
+            TimeSpan.Zero,
+            0);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Helpers/ShellArgumentEscaperTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/ShellArgumentEscaperTests.cs
@@ -1,0 +1,14 @@
+using ModularPipelines.Helpers.Internal;
+
+namespace ModularPipelines.UnitTests.Helpers;
+
+public class ShellArgumentEscaperTests
+{
+    [Test]
+    public async Task EscapesEmbeddedSingleQuotes()
+    {
+        var escaped = ShellArgumentEscaper.Escape("/tmp/it's ready.sh");
+
+        await Assert.That(escaped).IsEqualTo("'/tmp/it'\\''s ready.sh'");
+    }
+}


### PR DESCRIPTION
## Summary
- generate valid POSIX single-quoted installer paths
- share shell argument escaping with the existing nvm path
- keep Bash file paths raw for structured argv handling

## Test plan
- [x] ShellArgumentEscaperTests (1 passed)
- [x] FileInstallerTests compiles; Linux behavior case skipped locally on Windows
- [x] ModularPipelines.sln Release build
- [x] dotnet format for changed files

Closes #3474