### PR TITLE
Demote expected module skip logs

### DIFF
--- a/src/ModularPipelines/Engine/DependencySkipDecisionFactory.cs
+++ b/src/ModularPipelines/Engine/DependencySkipDecisionFactory.cs
@@ -6,6 +6,7 @@ internal static class DependencySkipDecisionFactory
 {
     private const string DependencyReasonPrefix = "Required dependency '";
     private const string DependencyReasonSeparator = " was skipped: ";
+    private const string DependencyReasonSuffix = "' was skipped";
 
     public static SkipDecision Create(
         IReadOnlyList<(Type ModuleType, SkipDecision? SkipDecision)> skippedDependencies)
@@ -37,7 +38,9 @@ internal static class DependencySkipDecisionFactory
                 StringComparison.Ordinal);
             if (separatorIndex < 0)
             {
-                break;
+                return reason.EndsWith(DependencyReasonSuffix, StringComparison.Ordinal)
+                    ? null
+                    : reason;
             }
 
             reason = reason[(separatorIndex + DependencyReasonSeparator.Length)..];

--- a/src/ModularPipelines/Engine/DependencySkipDecisionFactory.cs
+++ b/src/ModularPipelines/Engine/DependencySkipDecisionFactory.cs
@@ -4,13 +4,16 @@ namespace ModularPipelines.Engine;
 
 internal static class DependencySkipDecisionFactory
 {
+    private const string DependencyReasonPrefix = "Required dependency '";
+    private const string DependencyReasonSeparator = " was skipped: ";
+
     public static SkipDecision Create(
         IReadOnlyList<(Type ModuleType, SkipDecision? SkipDecision)> skippedDependencies)
     {
         if (skippedDependencies.Count == 1)
         {
             var dependency = skippedDependencies[0];
-            var dependencyReason = dependency.SkipDecision?.Reason;
+            var dependencyReason = GetRootReason(dependency.SkipDecision?.Reason);
             var reasonSuffix = string.IsNullOrWhiteSpace(dependencyReason)
                 ? string.Empty
                 : $": {dependencyReason}";
@@ -22,5 +25,24 @@ internal static class DependencySkipDecisionFactory
             ", ",
             skippedDependencies.Select(dependency => $"'{dependency.ModuleType.Name}'"));
         return SkipDecision.Skip($"Required dependencies {dependencyNames} were skipped");
+    }
+
+    private static string? GetRootReason(string? reason)
+    {
+        while (reason?.StartsWith(DependencyReasonPrefix, StringComparison.Ordinal) == true)
+        {
+            var separatorIndex = reason.IndexOf(
+                DependencyReasonSeparator,
+                DependencyReasonPrefix.Length,
+                StringComparison.Ordinal);
+            if (separatorIndex < 0)
+            {
+                break;
+            }
+
+            reason = reason[(separatorIndex + DependencyReasonSeparator.Length)..];
+        }
+
+        return reason;
     }
 }

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -498,7 +498,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             Status.Successful => LogLevel.Information,
             Status.Failed => LogLevel.Error,
             Status.TimedOut => LogLevel.Error,
-            Status.Skipped => LogLevel.Warning,
+            Status.Skipped => LogLevel.Information,
             Status.Unknown => LogLevel.Error,
             Status.IgnoredFailure => LogLevel.Warning,
             Status.PipelineTerminated => LogLevel.Error,

--- a/test/ModularPipelines.UnitTests/Engine/DependencySkipDecisionFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencySkipDecisionFactoryTests.cs
@@ -19,6 +19,22 @@ public class DependencySkipDecisionFactoryTests
             "Required dependency 'IntermediateDependency' was skipped: Disabled by configuration");
     }
 
+    [Test]
+    [Arguments(null)]
+    [Arguments("   ")]
+    public async Task Create_CollapsesNestedDependencyReasonsWithoutRootCause(string? rootReason)
+    {
+        var rootDecision = SkipDecision.Skip(rootReason);
+        var intermediateDecision = DependencySkipDecisionFactory.Create(
+            [(typeof(RootDependency), rootDecision)]);
+
+        var decision = DependencySkipDecisionFactory.Create(
+            [(typeof(IntermediateDependency), intermediateDecision)]);
+
+        await Assert.That(decision.Reason).IsEqualTo(
+            "Required dependency 'IntermediateDependency' was skipped");
+    }
+
     private sealed class RootDependency
     {
     }

--- a/test/ModularPipelines.UnitTests/Engine/DependencySkipDecisionFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencySkipDecisionFactoryTests.cs
@@ -1,0 +1,29 @@
+using ModularPipelines.Engine;
+using ModularPipelines.Models;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class DependencySkipDecisionFactoryTests
+{
+    [Test]
+    public async Task Create_CollapsesNestedDependencyReasonsToRootCause()
+    {
+        var rootDecision = SkipDecision.Skip("Disabled by configuration");
+        var intermediateDecision = DependencySkipDecisionFactory.Create(
+            [(typeof(RootDependency), rootDecision)]);
+
+        var decision = DependencySkipDecisionFactory.Create(
+            [(typeof(IntermediateDependency), intermediateDecision)]);
+
+        await Assert.That(decision.Reason).IsEqualTo(
+            "Required dependency 'IntermediateDependency' was skipped: Disabled by configuration");
+    }
+
+    private sealed class RootDependency
+    {
+    }
+
+    private sealed class IntermediateDependency
+    {
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -1,7 +1,10 @@
+using Microsoft.Extensions.Logging;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Execution;
+using ModularPipelines.Enums;
+using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -75,5 +78,58 @@ public class ModuleExecutionPipelineTests
         var linkedCancellationTokenSource = executionContext.ModuleCancellationTokenSource;
         Assert.Throws<ObjectDisposedException>(() => _ = originalCancellationTokenSource.Token);
         Assert.Throws<ObjectDisposedException>(() => _ = linkedCancellationTokenSource.Token);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_LogsExpectedSkipStatusAsInformation()
+    {
+        var module = new SuccessfulModule();
+        var executionContext = new ModuleExecutionContext<int>(module, module.GetType());
+        var logger = new Mock<IModuleLogger>();
+        var services = new Mock<IServicesContext>();
+        services.SetupGet(x => x.Options).Returns(new PipelineOptions());
+        var moduleContext = new Mock<IModuleContext>();
+        moduleContext.SetupGet(x => x.Logger).Returns(logger.Object);
+        moduleContext.SetupGet(x => x.Services).Returns(services.Object);
+
+        var resultRepository = new Mock<IModuleResultRepository>();
+        resultRepository.SetupGet(x => x.IsEnabled).Returns(false);
+        var skipDecision = SkipDecision.Skip("Configured skip");
+        var directHookInvoker = new Mock<IDirectHookInvoker>();
+        directHookInvoker
+            .Setup(x => x.InvokeSkippedAsync(
+                module,
+                moduleContext.Object,
+                skipDecision,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        using var engineCancellationToken =
+            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+        var moduleConditionHandler = new Mock<IModuleConditionHandler>();
+        moduleConditionHandler
+            .Setup(x => x.ShouldIgnore(module, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((true, skipDecision));
+        var pipeline = new ModuleExecutionPipeline(
+            resultRepository.Object,
+            engineCancellationToken,
+            directHookInvoker.Object,
+            moduleConditionHandler.Object,
+            OptionsFactory.Create(new PipelineOptions()));
+
+        await pipeline.ExecuteAsync(
+            module,
+            executionContext,
+            moduleContext.Object,
+            CancellationToken.None);
+
+        var expectedMessage = StatusDisplayProvider.FormatStatusMessage(
+            nameof(SuccessfulModule),
+            Status.Skipped);
+        logger.Verify(x => x.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((state, _) => state.ToString() == expectedMessage),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
     }
 }


### PR DESCRIPTION
## Summary
- log expected module skips at information level instead of warning
- collapse transitive dependency-skip messages to the root reason
- cover skip severity and nested-cascade behavior with regression tests

## Validation
- 2/2 ModuleExecutionPipelineTests passed
- 9/9 CategoryFilterDependencyTests passed
- focused dependency skip test passed
- ModularPipelines.sln Release build passed
- scoped format verification passed

Closes #3551