### PR TITLE
Run module continuations asynchronously

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutionContext.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionContext.cs
@@ -27,7 +27,8 @@ namespace ModularPipelines.Engine;
 /// </remarks>
 internal class ModuleExecutionContext : IModuleExecutionContext
 {
-    private readonly TaskCompletionSource<IModuleResult> _resultSource = new();
+    private readonly TaskCompletionSource<IModuleResult> _resultSource =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public ModuleExecutionContext(IModule module, Type moduleType)
     {
@@ -171,7 +172,8 @@ internal class ModuleExecutionContext : IModuleExecutionContext
 /// </summary>
 internal class ModuleExecutionContext<T> : ModuleExecutionContext
 {
-    private readonly TaskCompletionSource<ModuleResult<T>> _typedResultSource = new();
+    private readonly TaskCompletionSource<ModuleResult<T>> _typedResultSource =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     public ModuleExecutionContext(Module<T> module, Type moduleType)
         : base(module, moduleType)

--- a/src/ModularPipelines/Engine/ModuleExecutionContext.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionContext.cs
@@ -13,7 +13,7 @@ namespace ModularPipelines.Engine;
 /// <para>
 /// This class implements the separation of concerns between:
 /// - What a module IS (the <see cref="Module{T}"/> implementation)
-/// - How a module is EXECUTED (this context class)
+/// - How a module is EXECUTED (this context class).
 /// </para>
 /// <para>
 /// The module itself remains a clean, stateless definition of work to do.

--- a/src/ModularPipelines/Modules/Module.cs
+++ b/src/ModularPipelines/Modules/Module.cs
@@ -68,7 +68,8 @@ public abstract class Module<T> : IModule, ITaggedModule
             LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
-    internal TaskCompletionSource<ModuleResult<T>> CompletionSource { get; } = new();
+    internal TaskCompletionSource<ModuleResult<T>> CompletionSource { get; } =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     /// <inheritdoc />
     Task<IModuleResult> IModule.ResultTask => CompletionSource.Task.ContinueWith(

--- a/test/ModularPipelines.UnitTests/Engine/TaskCompletionSourceTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/TaskCompletionSourceTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Context;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Scheduling;
 using ModularPipelines.Models;
@@ -12,12 +13,37 @@ namespace ModularPipelines.UnitTests.Engine;
 [TUnit.Core.NotInParallel]
 public class TaskCompletionSourceTests
 {
+    private sealed class TestModule : Module<int>
+    {
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(1);
+    }
+
     [Test]
     public async Task ModuleState_CompletionSource_RunsContinuationsAsynchronously()
     {
         var state = new ModuleState(Mock.Of<IModule>(), typeof(IModule));
 
         await Assert.That(RunsContinuationsAsynchronously(state.CompletionSource.Task)).IsTrue();
+    }
+
+    [Test]
+    public async Task ModuleAndExecutionContext_CompletionSources_RunContinuationsAsynchronously()
+    {
+        var module = new TestModule();
+        var context = new ModuleExecutionContext<int>(module, module.GetType());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(RunsContinuationsAsynchronously(module.CompletionSource.Task))
+                .IsTrue();
+            await Assert.That(RunsContinuationsAsynchronously(context.ExecutionTask))
+                .IsTrue();
+            await Assert.That(RunsContinuationsAsynchronously(context.TypedExecutionTask))
+                .IsTrue();
+        }
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- run `Module<T>` result continuations asynchronously
- run typed and untyped `ModuleExecutionContext` continuations asynchronously
- add regression coverage for all three completion sources

## Validation
- `TaskCompletionSourceTests`: 5/5 passed
- `ModularPipelines.sln` Release build passed

Closes #3460