### PR TITLE
Correct pipeline result documentation examples

### DIFF
--- a/docs/docs/examples/azure-example.md
+++ b/docs/docs/examples/azure-example.md
@@ -58,7 +58,7 @@ public class ProvisionBlobStorageContainerModule : Module<BlobContainerResource>
         var blobStorageAccount = await context.GetModule<ProvisionBlobStorageAccountModule>();
 
         var blobContainerProvisionResponse = await context.Tools.Azure.Provisioner.Storage.BlobContainer(
-            blobStorageAccount.ValueOrDefault!.Id,
+            blobStorageAccount.Value.Id,
             "MyContainer",
             new BlobContainerData()
         );
@@ -82,8 +82,8 @@ public class AssignAccessToBlobStorageModule : Module<RoleAssignmentResource>
         var storageAccount = await context.GetModule<ProvisionBlobStorageAccountModule>();
 
         var roleAssignmentResource = await context.Tools.Azure.Provisioner.Security.RoleAssignment(
-            storageAccount.ValueOrDefault!.Id,
-            new RoleAssignmentCreateOrUpdateContent(WellKnownRoleDefinitions.BlobStorageOwnerDefinitionId, userAssignedIdentity.ValueOrDefault!.Data.PrincipalId!.Value)
+            storageAccount.Value.Id,
+            new RoleAssignmentCreateOrUpdateContent(WellKnownRoleDefinitions.BlobStorageOwnerDefinitionId, userAssignedIdentity.Value.Data.PrincipalId!.Value)
         );
 
         return roleAssignmentResource.Value;
@@ -112,7 +112,7 @@ public class ProvisionAzureFunction : Module<WebSiteResource>
             {
                 Identity = new ManagedServiceIdentity(ManagedServiceIdentityType.UserAssigned)
                 {
-                    UserAssignedIdentities = { { userAssignedIdentity.ValueOrDefault!.Id, new UserAssignedIdentity() } }
+                    UserAssignedIdentities = { { userAssignedIdentity.Value.Id, new UserAssignedIdentity() } }
                 },
                 SiteConfig = new SiteConfigProperties
                 {
@@ -121,12 +121,12 @@ public class ProvisionAzureFunction : Module<WebSiteResource>
                         new()
                         {
                             Name = "BlobStorageConnectionString",
-                            Value = storageAccount.ValueOrDefault!.Data.PrimaryEndpoints.BlobUri.AbsoluteUri
+                            Value = storageAccount.Value.Data.PrimaryEndpoints.BlobUri.AbsoluteUri
                         },
                         new()
                         {
                             Name = "BlobContainerName",
-                            Value = blobContainer.ValueOrDefault!.Data.Name
+                            Value = blobContainer.Value.Data.Name
                         }
                     }
                 }

--- a/docs/docs/how-to/pipeline-host.md
+++ b/docs/docs/how-to/pipeline-host.md
@@ -124,6 +124,10 @@ The pipeline follows a two-step build-then-run pattern:
 
 ```csharp
 using var builder = Pipeline.CreateBuilder(args);
+builder.ConfigurePipelineOptions(options => options with
+{
+    ThrowOnPipelineFailure = false,
+});
 builder.AddModule<MyModule>();
 
 // Step 1: Build and validate the pipeline
@@ -133,7 +137,7 @@ await using var pipeline = await builder.BuildAsync();
 var summary = await pipeline.RunAsync();
 
 // Check results
-if (summary.Status == PipelineStatus.Failed)
+if (summary.Status == ModularPipelines.Enums.Status.Failed)
 {
     Environment.Exit(1);
 }

--- a/docs/docs/how-to/pipeline-host.md
+++ b/docs/docs/how-to/pipeline-host.md
@@ -126,6 +126,7 @@ The pipeline follows a two-step build-then-run pattern:
 using var builder = Pipeline.CreateBuilder(args);
 builder.ConfigurePipelineOptions(options => options with
 {
+    ExecutionMode = ExecutionMode.WaitForAllModules,
     ThrowOnPipelineFailure = false,
 });
 builder.AddModule<MyModule>();
@@ -142,6 +143,9 @@ if (summary.Status == ModularPipelines.Enums.Status.Failed)
     Environment.Exit(1);
 }
 ```
+
+Use `WaitForAllModules` with `ThrowOnPipelineFailure = false` when you need to inspect
+the returned summary after a module fails. Fail-fast mode rethrows the module exception.
 
 `BuildAsync()` always validates the pipeline configuration before returning:
 

--- a/docs/docs/how-to/testing.md
+++ b/docs/docs/how-to/testing.md
@@ -19,6 +19,7 @@ ModularPipelines supports mocking file system operations for unit testing. All f
 ```csharp
 using Moq;
 using ModularPipelines;
+using ModularPipelines.Enums;
 using ModularPipelines.FileSystem;
 using ModularPipelines.Extensions;
 
@@ -35,13 +36,18 @@ public async Task MyModule_ReadsConfigFile()
     // Run pipeline with mock
     using var builder = Pipeline.CreateBuilder(args);
 
+    builder.ConfigurePipelineOptions(options => options with
+    {
+        ThrowOnPipelineFailure = false,
+    });
+
     builder.Services.AddSingleton<IFileSystemProvider>(mockProvider.Object);
     builder.AddModule<MyModule>();
 
     var result = await builder.ExecutePipelineAsync();
 
     // Assert results
-    Assert.That(result.Status, Is.EqualTo(PipelineStatus.Success));
+    Assert.That(result.Status, Is.EqualTo(Status.Successful));
 }
 ```
 

--- a/docs/versioned_docs/version-3.x/how-to/pipeline-host.md
+++ b/docs/versioned_docs/version-3.x/how-to/pipeline-host.md
@@ -118,6 +118,7 @@ The pipeline follows a two-step build-then-run pattern:
 
 ```csharp
 var builder = Pipeline.CreateBuilder(args);
+builder.Options.ThrowOnPipelineFailure = false;
 builder.Services.AddModule<MyModule>();
 
 // Step 1: Build the pipeline
@@ -127,7 +128,7 @@ var pipeline = builder.Build();
 var summary = await pipeline.RunAsync();
 
 // Check results
-if (summary.Status == PipelineStatus.Failed)
+if (summary.Status == ModularPipelines.Enums.Status.Failed)
 {
     Environment.Exit(1);
 }

--- a/docs/versioned_docs/version-3.x/how-to/pipeline-host.md
+++ b/docs/versioned_docs/version-3.x/how-to/pipeline-host.md
@@ -118,6 +118,7 @@ The pipeline follows a two-step build-then-run pattern:
 
 ```csharp
 var builder = Pipeline.CreateBuilder(args);
+builder.Options.ExecutionMode = ExecutionMode.WaitForAllModules;
 builder.Options.ThrowOnPipelineFailure = false;
 builder.Services.AddModule<MyModule>();
 

--- a/docs/versioned_docs/version-3.x/how-to/testing.md
+++ b/docs/versioned_docs/version-3.x/how-to/testing.md
@@ -19,6 +19,7 @@ ModularPipelines supports mocking file system operations for unit testing. All f
 ```csharp
 using Moq;
 using ModularPipelines;
+using ModularPipelines.Enums;
 using ModularPipelines.FileSystem;
 using ModularPipelines.Extensions;
 
@@ -34,6 +35,7 @@ public async Task MyModule_ReadsConfigFile()
 
     // Run pipeline with mock
     var builder = Pipeline.CreateBuilder(args);
+    builder.Options.ThrowOnPipelineFailure = false;
 
     builder.Services.AddSingleton<IFileSystemProvider>(mockProvider.Object);
     builder.Services.AddModule<MyModule>();
@@ -41,7 +43,7 @@ public async Task MyModule_ReadsConfigFile()
     var result = await builder.Build().RunAsync();
 
     // Assert results
-    Assert.That(result.Status, Is.EqualTo(PipelineStatus.Success));
+    Assert.That(result.Status, Is.EqualTo(Status.Successful));
 }
 ```
 

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -3,6 +3,7 @@ using ModularPipelines.Attributes;
 using ModularPipelines.Conditions;
 using ModularPipelines.Context;
 using ModularPipelines.DotNet.Options;
+using ModularPipelines.Enums;
 using ModularPipelines.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -35,6 +36,37 @@ public static class CurrentApiSnippets
         });
 
         return builder.ExecutePipelineAsync();
+    }
+
+    public static async Task<int> RunPipelineAndMapExitCode(string[] args)
+    {
+        using var builder = Pipeline.CreateBuilder(args);
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            ThrowOnPipelineFailure = false,
+        });
+        builder.AddModule<BuildModule>();
+
+        await using var pipeline = await builder.BuildAsync();
+        var summary = await pipeline.RunAsync();
+
+        return summary.Status == Status.Failed ? 1 : 0;
+    }
+
+    public static async Task VerifySuccessfulPipeline(string[] args)
+    {
+        using var builder = Pipeline.CreateBuilder(args);
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            ThrowOnPipelineFailure = false,
+        });
+        builder.AddModule<BuildModule>();
+
+        var result = await builder.ExecutePipelineAsync();
+        if (result.Status != Status.Successful)
+        {
+            throw new InvalidOperationException("Expected a successful pipeline.");
+        }
     }
 
     public sealed record BuildInfo(string Version, string OutputPath);
@@ -82,7 +114,7 @@ public static class CurrentApiSnippets
             CancellationToken cancellationToken)
         {
             var buildResult = await context.GetModule<BuildModule>();
-            _ = buildResult.ValueOrDefault!.OutputPath;
+            _ = buildResult.Value.OutputPath;
             return None.Value;
         }
     }
@@ -137,7 +169,7 @@ public static class CurrentApiSnippets
             CancellationToken cancellationToken)
         {
             var buildResult = await context.GetModule<BuildModule>();
-            return Path.Combine(buildResult.ValueOrDefault!.OutputPath, "artifacts");
+            return Path.Combine(buildResult.Value.OutputPath, "artifacts");
         }
     }
 }

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -43,6 +43,7 @@ public static class CurrentApiSnippets
         using var builder = Pipeline.CreateBuilder(args);
         builder.ConfigurePipelineOptions(options => options with
         {
+            ExecutionMode = ExecutionMode.WaitForAllModules,
             ThrowOnPipelineFailure = false,
         });
         builder.AddModule<BuildModule>();

--- a/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
+++ b/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
@@ -107,6 +107,10 @@ public class DocumentationSnippetTests
                 repositoryRoot,
                 "docs/docs/how-to/pipeline-host.md"))
             .ConfigureAwait(false);
+        var versionedPipelineHost = await File.ReadAllTextAsync(Path.Combine(
+                repositoryRoot,
+                "docs/versioned_docs/version-3.x/how-to/pipeline-host.md"))
+            .ConfigureAwait(false);
         var testing = await File.ReadAllTextAsync(Path.Combine(
                 repositoryRoot,
                 "docs/docs/how-to/testing.md"))
@@ -123,6 +127,9 @@ public class DocumentationSnippetTests
         await Assert.That(pipelineHost).Contains("Status.Failed");
         await Assert.That(pipelineHost).Contains("ExecutionMode = ExecutionMode.WaitForAllModules");
         await Assert.That(pipelineHost).Contains("ThrowOnPipelineFailure = false");
+        await Assert.That(versionedPipelineHost)
+            .Contains("ExecutionMode = ExecutionMode.WaitForAllModules");
+        await Assert.That(versionedPipelineHost).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(testing).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(testing).Contains("Status.Successful");
         await Assert.That(azure).DoesNotContain("ValueOrDefault!");

--- a/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
+++ b/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
@@ -35,6 +35,7 @@ public class DocumentationSnippetTests
                 .ConfigureAwait(false);
 
             await Assert.That(contents).DoesNotContain("PipelineHostBuilder.Create()");
+            await Assert.That(contents).DoesNotContain("PipelineStatus");
             await Assert.That(contents).DoesNotContain("ExecuteAsync(IPipelineContext");
             await Assert.That(contents).DoesNotContain("await GetModule<");
 
@@ -96,6 +97,40 @@ public class DocumentationSnippetTests
 
             await Assert.That(readme).DoesNotContain("ExecuteModuleAsync(");
         }
+    }
+
+    [Test]
+    public async Task Pipeline_Status_Documentation_Matches_Compiled_Current_Api_Shape()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var pipelineHost = await File.ReadAllTextAsync(Path.Combine(
+                repositoryRoot,
+                "docs/docs/how-to/pipeline-host.md"))
+            .ConfigureAwait(false);
+        var testing = await File.ReadAllTextAsync(Path.Combine(
+                repositoryRoot,
+                "docs/docs/how-to/testing.md"))
+            .ConfigureAwait(false);
+        var azure = await File.ReadAllTextAsync(Path.Combine(
+                repositoryRoot,
+                "docs/docs/examples/azure-example.md"))
+            .ConfigureAwait(false);
+        var compiledFixture = await File.ReadAllTextAsync(Path.Combine(
+                repositoryRoot,
+                "test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs"))
+            .ConfigureAwait(false);
+
+        await Assert.That(pipelineHost).Contains("Status.Failed");
+        await Assert.That(pipelineHost).Contains("ThrowOnPipelineFailure = false");
+        await Assert.That(testing).Contains("ThrowOnPipelineFailure = false");
+        await Assert.That(testing).Contains("Status.Successful");
+        await Assert.That(azure).DoesNotContain("ValueOrDefault!");
+        await Assert.That(azure).Contains(".Value.");
+
+        await Assert.That(compiledFixture).Contains("Status.Failed");
+        await Assert.That(compiledFixture).Contains("ThrowOnPipelineFailure = false");
+        await Assert.That(compiledFixture).Contains("Status.Successful");
+        await Assert.That(compiledFixture).Contains("buildResult.Value.OutputPath");
     }
 
     private static string FindRepositoryRoot()

--- a/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
+++ b/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
@@ -121,6 +121,7 @@ public class DocumentationSnippetTests
             .ConfigureAwait(false);
 
         await Assert.That(pipelineHost).Contains("Status.Failed");
+        await Assert.That(pipelineHost).Contains("ExecutionMode = ExecutionMode.WaitForAllModules");
         await Assert.That(pipelineHost).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(testing).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(testing).Contains("Status.Successful");
@@ -128,6 +129,7 @@ public class DocumentationSnippetTests
         await Assert.That(azure).Contains(".Value.");
 
         await Assert.That(compiledFixture).Contains("Status.Failed");
+        await Assert.That(compiledFixture).Contains("ExecutionMode = ExecutionMode.WaitForAllModules");
         await Assert.That(compiledFixture).Contains("ThrowOnPipelineFailure = false");
         await Assert.That(compiledFixture).Contains("Status.Successful");
         await Assert.That(compiledFixture).Contains("buildResult.Value.OutputPath");


### PR DESCRIPTION
## Summary

- replace stale `PipelineStatus` examples with `ModularPipelines.Enums.Status`
- keep failure-status checks reachable by disabling `ThrowOnPipelineFailure`
- use required dependency `.Value` in the current Azure example
- compile and contract-test the documented API shapes

## Validation

- `DocumentationSnippetTests`: 4/4 passed
- scoped `dotnet format whitespace --verify-no-changes`
- `npm run build --prefix docs`

Closes #3498