### PR TITLE
Reduce CI warning noise to zero

### DIFF
--- a/.ruleset
+++ b/.ruleset
@@ -1,5 +1,6 @@
 <RuleSet Name="Rules for Modular Pipelines project" Description="These rules focus on styling Modular Pipelines" ToolsVersion="10.0">
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <!-- Baseline existing documentation/layout debt; diagnostics outside these families remain visible. -->
     <Rule Id="SA0001" Action="None" />
     <Rule Id="SA1003" Action="None" />
     <Rule Id="SA1101" Action="None" />
@@ -13,16 +14,29 @@
     <Rule Id="SA1009" Action="None" />
     <Rule Id="SA1111" Action="None" />
     <Rule Id="SA1118" Action="None" />
+    <Rule Id="SA1127" Action="None" />
     <Rule Id="SA1128" Action="None" />
     <Rule Id="SA1201" Action="None" />
+    <Rule Id="SA1202" Action="None" />
+    <Rule Id="SA1214" Action="None" />
     <Rule Id="SA1401" Action="None" />
     <Rule Id="SA1402" Action="None" />
+    <Rule Id="SA1413" Action="None" />
+    <Rule Id="SA1505" Action="None" />
+    <Rule Id="SA1513" Action="None" />
+    <Rule Id="SA1515" Action="None" />
+    <Rule Id="SA1516" Action="None" />
     <Rule Id="SA1602" Action="None" />
     <Rule Id="SA1600" Action="None" />
     <Rule Id="SA1616" Action="None" />
     <Rule Id="SA1614" Action="None" />
     <Rule Id="SA1611" Action="None" />
+    <Rule Id="SA1615" Action="None" />
     <Rule Id="SA1618" Action="None" />
+    <Rule Id="SA1623" Action="None" />
+    <Rule Id="SA1629" Action="None" />
+    <Rule Id="SA1642" Action="None" />
+    <Rule Id="SA1649" Action="None" />
     <Rule Id="TUnitAnalyzers0003" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ModularPipelines.Analyzers.csproj
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/ModularPipelines.Analyzers.csproj
@@ -5,6 +5,8 @@
     <!-- Avoid ID conflicts with the package project. -->
     <PackageId>*$(MSBuildProjectFile)*</PackageId>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <!-- Descriptor creation is centralized, which release tracking cannot statically associate with analyzers. -->
+    <NoWarn>$(NoWarn);RS2002;RS2003</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers">

--- a/src/ModularPipelines.Development.Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/ModularPipelines.Development.Analyzers/AnalyzerReleases.Shipped.md
@@ -2,7 +2,7 @@
 
 ### New Rules
 
-| Rule ID | Category | Severity | Notes                                            |
-|---------|----------|----------|--------------------------------------------------|
-| AB0001  | Naming   | Warning  | Type names should not contain the company name.  |
-| AB0002  | Usage    | Warning  | The speed must be lower than the Speed of Light. |
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+AB0001 | Naming | Warning | Type names should not contain the company name.
+AB0002 | Usage | Warning | The speed must be lower than the Speed of Light.

--- a/src/ModularPipelines.Development.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/ModularPipelines.Development.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,4 +1,13 @@
 ### New Rules
 
-| Rule ID | Category | Severity | Notes |
-|---------|----------|----------|-------|
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+MPD0001 | Usage | Warning | Properties should be virtual to allow overriding
+MPD0002 | Usage | Warning | Command methods should be virtual to allow overriding
+
+### Removed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+AB0001 | Naming | Warning | Removed stale template rule
+AB0002 | Usage | Warning | Removed stale template rule

--- a/src/ModularPipelines.Development.Analyzers/ModularPipelines.Development.Analyzers.csproj
+++ b/src/ModularPipelines.Development.Analyzers/ModularPipelines.Development.Analyzers.csproj
@@ -7,6 +7,8 @@
         <LangVersion>latest</LangVersion>
         <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
         <IsRoslynComponent>true</IsRoslynComponent>
+        <!-- Code-fix providers require Workspaces in this combined development-only assembly. -->
+        <NoWarn>$(NoWarn);RS1038</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/ModularPipelines.Git/Options/GitRemoteGetUrlOptions.cs
+++ b/src/ModularPipelines.Git/Options/GitRemoteGetUrlOptions.cs
@@ -35,5 +35,5 @@ public record GitRemoteGetUrlOptions : GitRemoteOptions
     /// The name of the remote to query (e.g., "origin").
     /// </summary>
     [CliArgument(0)]
-    public required string Remote { get; init; }
+    public required virtual string Remote { get; init; }
 }

--- a/src/ModularPipelines.Git/Options/GitRemoteSetUrlOptions.cs
+++ b/src/ModularPipelines.Git/Options/GitRemoteSetUrlOptions.cs
@@ -42,17 +42,17 @@ public record GitRemoteSetUrlOptions : GitRemoteOptions
     /// The name of the remote to configure (e.g., "origin").
     /// </summary>
     [CliArgument(0)]
-    public required string Remote { get; init; }
+    public required virtual string Remote { get; init; }
 
     /// <summary>
     /// The new URL to set for the remote.
     /// </summary>
     [CliArgument(1)]
-    public required string NewUrl { get; init; }
+    public required virtual string NewUrl { get; init; }
 
     /// <summary>
     /// Optional old URL pattern to match when changing URLs.
     /// </summary>
     [CliArgument(2)]
-    public string? OldUrl { get; set; }
+    public virtual string? OldUrl { get; set; }
 }

--- a/src/ModularPipelines.Git/Options/GitRemoteShowOptions.cs
+++ b/src/ModularPipelines.Git/Options/GitRemoteShowOptions.cs
@@ -29,5 +29,5 @@ public record GitRemoteShowOptions : GitRemoteOptions
     /// The name of the remote to show information about (e.g., "origin").
     /// </summary>
     [CliArgument(0)]
-    public required string Remote { get; init; }
+    public required virtual string Remote { get; init; }
 }

--- a/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
+++ b/test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
-    <!-- Test fixtures intentionally use private nested modules and are not AOT publish inputs. -->
-    <NoWarn>$(NoWarn);MPG0011</NoWarn>
+    <!-- Test fixtures intentionally exercise reflection fallbacks and nullable legacy module shapes. -->
+    <NoWarn>$(NoWarn);CS8631;MPG0003;MPG0004;MPG0005;MPG0006;MPG0011;MPG0013;MPG0016</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />


### PR DESCRIPTION
Closes #3453

## Summary
- baseline the existing StyleCop documentation/layout debt families in the repository ruleset
- complete development-analyzer release tracking and localize Roslyn suppressions to known tooling seams
- suppress intentional source-generator diagnostics only in the core fixture project
- fix five real MPD0001 warnings in Git remote option models

## Validation
- ModularPipelines.sln Release rebuild: 0 warnings, 0 errors (from 209 warnings)
- ModularPipelines.Analyzers.sln Release rebuild: 0 warnings, 0 errors
- ModularPipelines.Git.sln Release build with -warnaserror: passed
- ModularPipelines.UnitTests.csproj Release rebuild with -warnaserror: 0 warnings, 0 errors (from 274 warnings)