### PR TITLE
Preserve HTTP content headers across retries

### DIFF
--- a/src/ModularPipelines/Http/ResilienceHttpHandler.cs
+++ b/src/ModularPipelines/Http/ResilienceHttpHandler.cs
@@ -36,17 +36,15 @@ internal class ResilienceHttpHandler : DelegatingHandler
 
         // Buffer content upfront if present, so it can be reused across retries
         byte[]? contentBytes = null;
-        string? contentType = null;
         if (request.Content != null)
         {
             contentBytes = await request.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
-            contentType = request.Content.Headers.ContentType?.ToString();
         }
 
         var retryPolicy = BuildRetryPolicy(options);
 
         return await retryPolicy.ExecuteAsync(
-            async ct => await base.SendAsync(CloneRequest(request, contentBytes, contentType), ct).ConfigureAwait(false),
+            async ct => await base.SendAsync(CloneRequest(request, contentBytes), ct).ConfigureAwait(false),
             cancellationToken).ConfigureAwait(false);
     }
 
@@ -131,8 +129,7 @@ internal class ResilienceHttpHandler : DelegatingHandler
     /// </summary>
     /// <param name="original">The original request to clone.</param>
     /// <param name="contentBytes">Pre-buffered content bytes, or null if no content.</param>
-    /// <param name="contentType">The content type header value, or null if no content.</param>
-    private static HttpRequestMessage CloneRequest(HttpRequestMessage original, byte[]? contentBytes, string? contentType)
+    private static HttpRequestMessage CloneRequest(HttpRequestMessage original, byte[]? contentBytes)
     {
         var clone = new HttpRequestMessage(original.Method, original.RequestUri)
         {
@@ -146,9 +143,9 @@ internal class ResilienceHttpHandler : DelegatingHandler
         if (contentBytes != null)
         {
             clone.Content = new ByteArrayContent(contentBytes);
-            if (!string.IsNullOrEmpty(contentType))
+            foreach (var header in original.Content!.Headers)
             {
-                clone.Content.Headers.TryAddWithoutValidation("Content-Type", contentType);
+                clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
             }
         }
 

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -680,6 +680,57 @@ public class HttpTests : TestBase
     }
 
     [Test]
+    public async Task ResilienceHandler_PreservesContentHeadersAcrossAttempts()
+    {
+        var innerHandler = new SequenceResponseHandler(
+            new HttpResponseMessage(HttpStatusCode.ServiceUnavailable),
+            new HttpResponseMessage(HttpStatusCode.OK));
+        var moduleLoggerProvider = new Mock<IModuleLoggerProvider>();
+        moduleLoggerProvider
+            .Setup(x => x.GetLogger())
+            .Returns(Mock.Of<IModuleLogger>());
+        using var handler = new ResilienceHttpHandler(
+            moduleLoggerProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+            {
+                DefaultHttpResilienceOptions = new HttpResilienceOptions
+                {
+                    MaxRetryAttempts = 1,
+                    InitialDelay = TimeSpan.Zero,
+                    JitterFactor = 0,
+                },
+            }))
+        {
+            InnerHandler = innerHandler,
+        };
+        using var invoker = new HttpMessageInvoker(handler);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "https://example.test/upload")
+        {
+            Content = new ByteArrayContent([1, 2, 3]),
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        request.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")
+        {
+            FileName = "artifact.bin",
+        };
+        request.Content.Headers.ContentEncoding.Add("gzip");
+        request.Content.Headers.ContentLanguage.Add("en-GB");
+        request.Content.Headers.ContentMD5 = [1, 2, 3, 4];
+        request.Content.Headers.TryAddWithoutValidation("X-Content-Metadata", ["first", "second"]);
+        var expectedHeaders = SnapshotContentHeaders(request);
+
+        using var response = await invoker.SendAsync(request, CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(innerHandler.ContentHeaderSnapshots).Count().IsEqualTo(2);
+            await Assert.That(innerHandler.ContentHeaderSnapshots[0]).IsEquivalentTo(expectedHeaders);
+            await Assert.That(innerHandler.ContentHeaderSnapshots[1]).IsEquivalentTo(expectedHeaders);
+        }
+    }
+
+    [Test]
     public async Task PublicApi_DoesNotExposeRawHttpClients()
     {
         var rawClientMembers = typeof(IHttpContext)
@@ -820,6 +871,16 @@ public class HttpTests : TestBase
             await Assert.That(indexOfDuration).IsLessThan(indexOfResponse);
         }
     }
+
+    private static string[] SnapshotContentHeaders(HttpRequestMessage request) =>
+        request.Content?.Headers
+            .Where(static header => !header.Key.Equals(
+                "Content-Length",
+                StringComparison.OrdinalIgnoreCase))
+            .OrderBy(static header => header.Key, StringComparer.OrdinalIgnoreCase)
+            .Select(static header => $"{header.Key}:{string.Join("|", header.Value)}")
+            .ToArray()
+        ?? [];
 
     private sealed class ImmediateResponseHandler(
         HttpContent content,
@@ -1025,10 +1086,13 @@ public class HttpTests : TestBase
     {
         public int CallCount { get; private set; }
 
+        public List<string[]> ContentHeaderSnapshots { get; } = [];
+
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
+            ContentHeaderSnapshots.Add(SnapshotContentHeaders(request));
             return Task.FromResult(responses[CallCount++]);
         }
     }


### PR DESCRIPTION
Closes #3475

## Summary
- copy every caller-supplied content header onto buffered retry requests
- preserve custom and standard headers across the initial attempt and retries
- add regression coverage for disposition, encoding, language, MD5, content type, and custom metadata

## Validation
- guarded Release build: `test/ModularPipelines.UnitTests/ModularPipelines.UnitTests.csproj`
- `HttpTests`: 39/39 passed