### PR TITLE
Preserve formatting in DependsOn code fix

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/Extensions/SyntaxNodeExtensions.cs
@@ -25,8 +25,18 @@ internal static class SyntaxNodeExtensions
             return documentRoot;
         }
 
-        var usingDirective = SyntaxFactory.UsingDirective(
-            SyntaxFactory.ParseName(namespaceName));
+        var endOfLine = compilationUnitSyntax
+            .DescendantTrivia()
+            .FirstOrDefault(trivia => trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            .ToFullString();
+        if (string.IsNullOrEmpty(endOfLine))
+        {
+            endOfLine = Environment.NewLine;
+        }
+
+        var usingDirective = SyntaxFactory
+            .UsingDirective(SyntaxFactory.ParseName(namespaceName))
+            .WithTrailingTrivia(SyntaxFactory.EndOfLine(endOfLine));
         var conditionalMatch = compilationUnitSyntax.Usings
             .FirstOrDefault(item =>
                 item.Alias is null

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/MissingDependsOnAttributeCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/MissingDependsOnAttributeCodeFixProvider.cs
@@ -84,15 +84,18 @@ public class MissingDependsOnAttributeCodeFixProvider : CodeFixProvider
                     CreateDependsOnAttribute(name, syntaxTree!, isOptional)))
             .NormalizeWhitespace(eol: endOfLine)
             .WithTrailingTrivia(SyntaxFactory.EndOfLine(endOfLine));
+        var leadingTrivia = typeDecl.AttributeLists.Count == 0
+            ? typeDecl.GetLeadingTrivia()
+            : typeDecl.AttributeLists.Last().GetLeadingTrivia();
+        var indentation = SyntaxFactory.TriviaList(
+            leadingTrivia
+                .Reverse()
+                .TakeWhile(static trivia => trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+                .Reverse());
+        attribute = attribute.WithLeadingTrivia(
+            typeDecl.AttributeLists.Count == 0 ? leadingTrivia : indentation);
         if (typeDecl.AttributeLists.Count == 0)
         {
-            var leadingTrivia = typeDecl.GetLeadingTrivia();
-            var indentation = SyntaxFactory.TriviaList(
-                leadingTrivia
-                    .Reverse()
-                    .TakeWhile(static trivia => trivia.IsKind(SyntaxKind.WhitespaceTrivia))
-                    .Reverse());
-            attribute = attribute.WithLeadingTrivia(leadingTrivia);
             typeDecl = typeDecl.WithLeadingTrivia(indentation);
         }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/MissingDependsOnAttributeCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/MissingDependsOnAttributeCodeFixProvider.cs
@@ -78,16 +78,30 @@ public class MissingDependsOnAttributeCodeFixProvider : CodeFixProvider
             endOfLine = Environment.NewLine;
         }
 
-        var attributes = typeDecl.AttributeLists.Add(
-            SyntaxFactory.AttributeList(SyntaxFactory.SingletonSeparatedList(CreateDependsOnAttribute(name, syntaxTree!, isOptional)))
-                .WithTrailingTrivia(SyntaxFactory.EndOfLine(endOfLine))
-                .NormalizeWhitespace(eol: endOfLine));
+        var originalTypeDecl = typeDecl;
+        var attribute = SyntaxFactory.AttributeList(
+                SyntaxFactory.SingletonSeparatedList(
+                    CreateDependsOnAttribute(name, syntaxTree!, isOptional)))
+            .NormalizeWhitespace(eol: endOfLine)
+            .WithTrailingTrivia(SyntaxFactory.EndOfLine(endOfLine));
+        if (typeDecl.AttributeLists.Count == 0)
+        {
+            var leadingTrivia = typeDecl.GetLeadingTrivia();
+            var indentation = SyntaxFactory.TriviaList(
+                leadingTrivia
+                    .Reverse()
+                    .TakeWhile(static trivia => trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+                    .Reverse());
+            attribute = attribute.WithLeadingTrivia(leadingTrivia);
+            typeDecl = typeDecl.WithLeadingTrivia(indentation);
+        }
+
+        var attributes = typeDecl.AttributeLists.Add(attribute);
 
         return document.WithSyntaxRoot(
             documentRoot
-                .ReplaceNode(typeDecl, typeDecl.WithAttributeLists(attributes).WithTrailingTrivia(SyntaxFactory.EndOfLine(endOfLine)))
+                .ReplaceNode(originalTypeDecl, typeDecl.WithAttributeLists(attributes))
                 .AddUsings()
-                .NormalizeWhitespace(eol: endOfLine)
         );
     }
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
@@ -76,7 +76,8 @@ public class Module2 : Module<IDictionary<string, object>>
     }
 }";
 
-    private const string FixedModuleSource = @"#nullable enable
+    private const string FixedModuleSource = @"
+#nullable enable
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -87,6 +88,7 @@ using ModularPipelines.Modules;
 using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Examples.Modules;
+
 public class Module1 : Module<IDictionary<string, object>>
 {
     protected override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -157,8 +159,7 @@ public class Module2 : Module<IDictionary<string, object>>
                 "[DependsOn<Module1>(Optional = true)]\n    public class Module2 : Module<string>")
             .Replace(
                 "{|#0:context.GetModule1ModuleIfRegistered()|}",
-                "context.GetModule1ModuleIfRegistered()")
-            .TrimStart();
+                "context.GetModule1ModuleIfRegistered()");
         var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId).WithArguments("Module1").WithLocation(0);
 
         await VerifyCS.VerifyCodeFixAsync(source, expected, fixedSource);
@@ -219,6 +220,74 @@ public class Module2 : Module<string>
             BadModuleSource.ReplaceLineEndings("\n"),
             expected,
             FixedModuleSource.ReplaceLineEndings("\n"));
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Preserves_Unrelated_Formatting()
+    {
+        var source = """
+            #nullable enable
+            using System.Threading;
+            using System.Threading.Tasks;
+            using ModularPipelines.Context;
+            using ModularPipelines.Modules;
+
+            namespace Example;
+
+            public class Dependency : Module<string>
+            {
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
+            }
+
+
+            // Keep this comment and the unusual token spacing below.
+            public   class Consumer : Module<string>
+            {
+                private const string Alignment = "keep";       // aligned comment
+
+                protected override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                {
+                    var dependency = await {|#0:context.GetModule<Dependency>()|}; // trailing comment
+                    return Alignment;
+                }
+            }
+            """.ReplaceLineEndings("\n");
+        var fixedSource = """
+            #nullable enable
+            using System.Threading;
+            using System.Threading.Tasks;
+            using ModularPipelines.Context;
+            using ModularPipelines.Modules;
+            using ModularPipelines.Attributes;
+
+            namespace Example;
+
+            public class Dependency : Module<string>
+            {
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
+            }
+
+
+            // Keep this comment and the unusual token spacing below.
+            [DependsOn<Dependency>]
+            public   class Consumer : Module<string>
+            {
+                private const string Alignment = "keep";       // aligned comment
+
+                protected override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                {
+                    var dependency = await context.GetModule<Dependency>(); // trailing comment
+                    return Alignment;
+                }
+            }
+            """.ReplaceLineEndings("\n");
+        var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithArguments("Dependency")
+            .WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(source, expected, fixedSource);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
@@ -291,6 +291,70 @@ public class Module2 : Module<string>
     }
 
     [TestMethod]
+    public async Task CodeFix_Indents_Attribute_Appended_To_Existing_List()
+    {
+        var source = """
+            #nullable enable
+            using System.Threading;
+            using System.Threading.Tasks;
+            using ModularPipelines.Context;
+            using ModularPipelines.Modules;
+
+            namespace Example
+            {
+                public class Dependency : Module<string>
+                {
+                    protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                        => Task.FromResult<string?>(null);
+                }
+
+                [System.Obsolete]
+                public class Consumer : Module<string>
+                {
+                    protected override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    {
+                        var dependency = await {|#0:context.GetModule<Dependency>()|};
+                        return null;
+                    }
+                }
+            }
+            """.ReplaceLineEndings("\n");
+        var fixedSource = """
+            #nullable enable
+            using System.Threading;
+            using System.Threading.Tasks;
+            using ModularPipelines.Context;
+            using ModularPipelines.Modules;
+            using ModularPipelines.Attributes;
+
+            namespace Example
+            {
+                public class Dependency : Module<string>
+                {
+                    protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                        => Task.FromResult<string?>(null);
+                }
+
+                [System.Obsolete]
+                [DependsOn<Dependency>]
+                public class Consumer : Module<string>
+                {
+                    protected override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    {
+                        var dependency = await context.GetModule<Dependency>();
+                        return null;
+                    }
+                }
+            }
+            """.ReplaceLineEndings("\n");
+        var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithArguments("Dependency")
+            .WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(source, expected, fixedSource);
+    }
+
+    [TestMethod]
     public async Task OptionalCodeFixWorks()
     {
         var source = BadModuleSource

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
@@ -355,6 +355,56 @@ public class Module2 : Module<string>
     }
 
     [TestMethod]
+    public async Task CodeFix_Separates_Inserted_Using_When_Source_Has_No_Usings()
+    {
+        var source = """
+            #nullable enable
+            namespace Example;
+
+            public class Dependency : ModularPipelines.Modules.Module<string>
+            {
+                protected override System.Threading.Tasks.Task<string?> ExecuteAsync(ModularPipelines.Context.IModuleContext context, System.Threading.CancellationToken cancellationToken)
+                    => System.Threading.Tasks.Task.FromResult<string?>(null);
+            }
+
+            public class Consumer : ModularPipelines.Modules.Module<string>
+            {
+                protected override async System.Threading.Tasks.Task<string?> ExecuteAsync(ModularPipelines.Context.IModuleContext context, System.Threading.CancellationToken cancellationToken)
+                {
+                    var dependency = await {|#0:context.GetModule<Dependency>()|};
+                    return null;
+                }
+            }
+            """.ReplaceLineEndings("\n");
+        var fixedSource = """
+            using ModularPipelines.Attributes;
+            #nullable enable
+            namespace Example;
+
+            public class Dependency : ModularPipelines.Modules.Module<string>
+            {
+                protected override System.Threading.Tasks.Task<string?> ExecuteAsync(ModularPipelines.Context.IModuleContext context, System.Threading.CancellationToken cancellationToken)
+                    => System.Threading.Tasks.Task.FromResult<string?>(null);
+            }
+
+            [DependsOn<Dependency>]
+            public class Consumer : ModularPipelines.Modules.Module<string>
+            {
+                protected override async System.Threading.Tasks.Task<string?> ExecuteAsync(ModularPipelines.Context.IModuleContext context, System.Threading.CancellationToken cancellationToken)
+                {
+                    var dependency = await context.GetModule<Dependency>();
+                    return null;
+                }
+            }
+            """.ReplaceLineEndings("\n");
+        var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithArguments("Dependency")
+            .WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(source, expected, fixedSource);
+    }
+
+    [TestMethod]
     public async Task OptionalCodeFixWorks()
     {
         var source = BadModuleSource


### PR DESCRIPTION
Closes #3510

## Summary
- stop normalizing the entire compilation unit when adding `DependsOn`
- move existing declaration trivia onto the inserted attribute while preserving indentation and trailing trivia
- update expectations and add byte-sensitive coverage for blank lines, token spacing, and comments

## Validation
- guarded Release build: `ModularPipelines.Analyzers.sln` (0 warnings, 0 errors)
- `ModularPipelinesAnalyzersUnitTests`: 10/10 passed