### PR TITLE
Assert rendered pipeline progress

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
@@ -292,9 +292,11 @@ public class Module2 : Module<string>
             using ModularPipelines.Attributes;
 
             namespace Example;
+
             public class Dependency : Module<string>
             {
-                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
             }
 
             [DependsOn<Dependency>]
@@ -308,7 +310,8 @@ public class Module2 : Module<string>
                     }
                 }
 
-                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
             }
             """.ReplaceLineEndings("\n");
         var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId)

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -288,7 +288,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         }
 
         // Start the progress display
-        session.Start();
+        await session.StartAsync().ConfigureAwait(false);
 
         return session;
     }

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -51,6 +51,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     private readonly ISpectreConsoleLoggerControl _loggerControl;
     private readonly INonSpectreLoggerFactory _nonSpectreLoggerFactory;
     private readonly ISpectreLoggerFilter _spectreLoggerFilter;
+    private readonly IAnsiConsole _ansiConsole;
     private TextWriter? _originalConsoleOut;
     private TextWriter? _originalConsoleError;
     private IAnsiConsole? _originalAnsiConsole;
@@ -73,7 +74,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         IOutputCoordinator outputCoordinator,
         ISpectreConsoleLoggerControl loggerControl,
         INonSpectreLoggerFactory nonSpectreLoggerFactory,
-        ISpectreLoggerFilter spectreLoggerFilter)
+        ISpectreLoggerFilter spectreLoggerFilter,
+        IAnsiConsole ansiConsole)
     {
         _formatterProvider = formatterProvider;
         _resultsPrinter = resultsPrinter;
@@ -87,6 +89,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         _loggerControl = loggerControl;
         _nonSpectreLoggerFactory = nonSpectreLoggerFactory;
         _spectreLoggerFilter = spectreLoggerFilter;
+        _ansiConsole = ansiConsole;
         _unattributedBuffer = new ModuleOutputBuffer(
             "Pipeline",
             typeof(void),
@@ -120,10 +123,15 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
 
                 // Configure Spectre.Console to use the REAL console directly
                 // This bypasses our interception for progress rendering
-                var configuredAnsiConsole = AnsiConsole.Create(
-                    CreateAnsiConsoleSettings(_originalConsoleOut, _buildSystemDetector.IsKnownBuildAgent));
+                var configuredAnsiConsole = UsesGlobalAnsiConsole
+                    ? AnsiConsole.Create(
+                        CreateAnsiConsoleSettings(_originalConsoleOut, _buildSystemDetector.IsKnownBuildAgent))
+                    : _ansiConsole;
                 configuredAnsiConsole.Profile.Capabilities.Interactive = _options.Value.ShowProgressInConsole;
-                AnsiConsole.Console = configuredAnsiConsole;
+                if (UsesGlobalAnsiConsole)
+                {
+                    AnsiConsole.Console = configuredAnsiConsole;
+                }
 
                 // Configure console width for CI environments
                 // Spectre.Console defaults to 80 characters when it can't detect terminal width,
@@ -160,7 +168,10 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                 // Restore original streams on failure
                 System.Console.SetOut(originalOut);
                 System.Console.SetError(originalError);
-                AnsiConsole.Console = originalAnsi;
+                if (UsesGlobalAnsiConsole)
+                {
+                    AnsiConsole.Console = originalAnsi;
+                }
 
                 _originalConsoleOut = null;
                 _originalConsoleError = null;
@@ -198,7 +209,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                 System.Console.SetError(_originalConsoleError);
             }
 
-            if (_originalAnsiConsole != null)
+            if (UsesGlobalAnsiConsole && _originalAnsiConsole != null)
             {
                 AnsiConsole.Console = _originalAnsiConsole;
             }
@@ -267,6 +278,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                 modules,
                 _options,
                 _loggerFactory,
+                _ansiConsole,
                 cancellationToken);
 
             // Wire up the progress controller for output coordination
@@ -538,6 +550,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         return settings;
     }
 
+    private bool UsesGlobalAnsiConsole => ReferenceEquals(_ansiConsole, DelegatingAnsiConsole.Instance);
+
     private async Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync(OutputFlushKind flushKind)
     {
         var populatedBeforeFlush = _moduleBuffers.Values
@@ -653,13 +667,13 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         if (configuredWidth.HasValue)
         {
             // User explicitly configured a width
-            AnsiConsole.Console.Profile.Width = configuredWidth.Value;
+            _ansiConsole.Profile.Width = configuredWidth.Value;
         }
         else if (_buildSystemDetector.IsKnownBuildAgent)
         {
             // Running in a known CI environment - use expanded width
             // CI environments typically don't have a TTY, causing Spectre.Console to default to 80 chars
-            AnsiConsole.Console.Profile.Width = DefaultCiConsoleWidth;
+            _ansiConsole.Profile.Width = DefaultCiConsoleWidth;
         }
 
         // Otherwise, leave Spectre.Console's auto-detected width (works well for local terminals)

--- a/src/ModularPipelines/Console/ProgressSession.cs
+++ b/src/ModularPipelines/Console/ProgressSession.cs
@@ -40,6 +40,7 @@ internal class ProgressSession : IProgressSession, IProgressController
     private readonly ILogger _logger;
     private readonly IAnsiConsole _ansiConsole;
     private readonly CancellationTokenSource _progressLoopCancellationTokenSource;
+    private readonly TaskCompletionSource _started = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private readonly ConcurrentDictionary<IModule, ProgressTask> _moduleTasks = new();
     private readonly ConcurrentDictionary<SubModuleBase, ProgressTask> _subModuleTasks = new();
@@ -80,17 +81,22 @@ internal class ProgressSession : IProgressSession, IProgressController
     /// <summary>
     /// Starts the progress display loop.
     /// </summary>
-    public void Start()
+    public Task StartAsync()
     {
         lock (_progressLock)
         {
-            if (_progressLoopTask is not null || _disposeTask is not null)
+            if (_disposeTask is not null)
             {
-                return;
+                return Task.CompletedTask;
             }
 
-            _totalModuleCount = _modules.RunnableModules.Count;
-            _progressLoopTask = RunProgressLoopAsync();
+            if (_progressLoopTask is null)
+            {
+                _totalModuleCount = _modules.RunnableModules.Count;
+                _progressLoopTask = RunProgressLoopAsync();
+            }
+
+            return _started.Task;
         }
     }
 
@@ -125,10 +131,16 @@ internal class ProgressSession : IProgressSession, IProgressController
                     // Register all pending modules upfront so users can see what's coming
                     RegisterPendingModules(ctx);
 
+                    ctx.Refresh();
+                    _started.TrySetResult();
+
                     // Keep alive until all modules complete or cancellation
                     while (!ctx.IsFinished)
                     {
-                        cancellationToken.ThrowIfCancellationRequested();
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            break;
+                        }
 
                         // Check pause state and prepare for refresh
                         bool shouldRefresh;
@@ -174,6 +186,10 @@ internal class ProgressSession : IProgressSession, IProgressController
                                     _refreshCompleted = null;
                                 }
                             }
+                            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                            {
+                                break;
+                            }
                         }
                         else if (shouldRefresh)
                         {
@@ -197,7 +213,14 @@ internal class ProgressSession : IProgressSession, IProgressController
                             }
                         }
 
-                        await Task.Delay(RefreshInterval, cancellationToken).ConfigureAwait(false);
+                        try
+                        {
+                            await Task.Delay(RefreshInterval, cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                        {
+                            break;
+                        }
                     }
                 })
                 .ConfigureAwait(false);
@@ -209,6 +232,10 @@ internal class ProgressSession : IProgressSession, IProgressController
         catch (Exception)
         {
             // Suppress exceptions from progress display
+        }
+        finally
+        {
+            _started.TrySetResult();
         }
     }
 

--- a/src/ModularPipelines/Console/ProgressSession.cs
+++ b/src/ModularPipelines/Console/ProgressSession.cs
@@ -38,6 +38,7 @@ internal class ProgressSession : IProgressSession, IProgressController
     private readonly OrganizedModules _modules;
     private readonly IOptions<PipelineOptions> _options;
     private readonly ILogger _logger;
+    private readonly IAnsiConsole _ansiConsole;
     private readonly CancellationTokenSource _progressLoopCancellationTokenSource;
 
     private readonly ConcurrentDictionary<IModule, ProgressTask> _moduleTasks = new();
@@ -64,12 +65,14 @@ internal class ProgressSession : IProgressSession, IProgressController
         OrganizedModules modules,
         IOptions<PipelineOptions> options,
         ILoggerFactory loggerFactory,
+        IAnsiConsole ansiConsole,
         CancellationToken cancellationToken)
     {
         _coordinator = coordinator;
         _modules = modules;
         _options = options;
         _logger = loggerFactory.CreateLogger<ProgressSession>();
+        _ansiConsole = ansiConsole;
         _progressLoopCancellationTokenSource =
             CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
     }
@@ -96,7 +99,7 @@ internal class ProgressSession : IProgressSession, IProgressController
         var cancellationToken = _progressLoopCancellationTokenSource.Token;
         try
         {
-            await AnsiConsole.Progress()
+            await _ansiConsole.Progress()
                 .AutoRefresh(false) // Disable auto-refresh so we can pause rendering during output writes
                 .AutoClear(false)
                 .HideCompleted(false)

--- a/src/ModularPipelines/Console/ProgressSession.cs
+++ b/src/ModularPipelines/Console/ProgressSession.cs
@@ -222,6 +222,11 @@ internal class ProgressSession : IProgressSession, IProgressController
                             break;
                         }
                     }
+
+                    // Render state changes made immediately before disposal. The periodic
+                    // loop may be cancelled before its next scheduled refresh.
+                    UpdateProgressTickers();
+                    ctx.Refresh();
                 })
                 .ConfigureAwait(false);
         }
@@ -557,7 +562,6 @@ internal class ProgressSession : IProgressSession, IProgressController
 
     private async Task DisposeCoreAsync()
     {
-        _progressLoopCancellationTokenSource.Cancel();
         TaskCompletionSource? refreshCompletion;
 
         // Signal resume in case we're disposed while paused
@@ -600,6 +604,10 @@ internal class ProgressSession : IProgressSession, IProgressController
 
             _progressTickers.Clear();
         }
+
+        // Cancel only after terminal task state is recorded so the progress loop's
+        // final refresh renders those changes before its live callback exits.
+        _progressLoopCancellationTokenSource.Cancel();
 
         if (_progressLoopTask is not null)
         {

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -191,6 +191,7 @@ internal static class DependencyInjectionSetup
             .AddSingleton<IPrimaryExceptionContainer, PrimaryExceptionContainer>()
             .AddSingleton<ISecondaryExceptionContainer, SecondaryExceptionContainer>()
             .AddSingleton<IExceptionRethrowService, ExceptionRethrowService>()
+            .AddSingleton<IAnsiConsole>(DelegatingAnsiConsole.Instance)
 
             // Console coordinator - single point of control for all console output
             .AddSingleton<Console.ConsoleCoordinator>()

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -179,6 +179,9 @@ internal static class DependencyInjectionSetup
     /// </summary>
     private static void RegisterLoggingAndConsoleServices(IServiceCollection services)
     {
+        services.AddOptions<SpectreConsoleLoggerOptions>()
+            .Configure<IAnsiConsole>((options, console) => options.Console = console);
+
         services
             .AddSingleton(TimeProvider.System)
             .AddSingleton<IExceptionOutputFormatter, SpectreExceptionFormatter>()

--- a/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
@@ -205,6 +205,7 @@ public class ConsoleCoordinatorTests
             outputCoordinator,
             Mock.Of<ISpectreConsoleLoggerControl>(),
             nonSpectreLoggerFactory.Object,
-            spectreLoggerFilter.Object);
+            spectreLoggerFilter.Object,
+            DelegatingAnsiConsole.Instance);
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ProgressSessionTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ProgressSessionTests.cs
@@ -2,18 +2,57 @@ using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Console;
+using ModularPipelines.Context;
 using ModularPipelines.Engine;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
+using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using Moq;
+using Spectre.Console;
 
 namespace ModularPipelines.UnitTests.Console;
 
 [TUnit.Core.NotInParallel]
 public class ProgressSessionTests
 {
+    [Test]
+    public async Task StartAsync_Renders_Pipeline_And_Module_Rows()
+    {
+        using var output = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = ColorSystemSupport.Standard,
+            Interactive = InteractionSupport.Yes,
+            Out = new AnsiConsoleOutput(output),
+        });
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        var coordinator = CreateCoordinator(outputCoordinator.Object, console);
+        var module = new RenderingModule();
+        var organizedModules = new OrganizedModules(
+            [new RunnableModule(module, TimeSpan.Zero, [])],
+            []);
+        await using var session = new ProgressSession(
+            coordinator,
+            organizedModules,
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
+            NullLoggerFactory.Instance,
+            console,
+            CancellationToken.None);
+
+        await session.StartAsync();
+        var moduleState = new ModuleState(module, module.GetType());
+        session.OnModuleStarted(moduleState, TimeSpan.Zero);
+        session.OnModuleCompleted(moduleState, true);
+        await session.DisposeAsync();
+
+        var renderedProgress = output.ToString();
+        await Assert.That(renderedProgress).Contains("Pipeline");
+        await Assert.That(renderedProgress).Contains("Rendering");
+    }
+
     [Test]
     public async Task PauseAsync_CompletesImmediatelyWhenNoRefreshIsActive()
     {
@@ -33,7 +72,9 @@ public class ProgressSessionTests
         await session.ResumeAsync();
     }
 
-    private static ConsoleCoordinator CreateCoordinator(IOutputCoordinator outputCoordinator)
+    private static ConsoleCoordinator CreateCoordinator(
+        IOutputCoordinator outputCoordinator,
+        IAnsiConsole? console = null)
     {
         var secretProvider = new Mock<ISecretProvider>();
         secretProvider.SetupGet(provider => provider.Secrets).Returns([]);
@@ -63,6 +104,16 @@ public class ProgressSessionTests
             Mock.Of<ISpectreConsoleLoggerControl>(),
             nonSpectreLoggerFactory.Object,
             spectreLoggerFilter.Object,
-            DelegatingAnsiConsole.Instance);
+            console ?? DelegatingAnsiConsole.Instance);
+    }
+
+    private sealed class RenderingModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ProgressSessionTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ProgressSessionTests.cs
@@ -24,6 +24,7 @@ public class ProgressSessionTests
             new OrganizedModules([], []),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
             NullLoggerFactory.Instance,
+            DelegatingAnsiConsole.Instance,
             CancellationToken.None);
 
         var pauseTask = session.PauseAsync();
@@ -61,6 +62,7 @@ public class ProgressSessionTests
             outputCoordinator,
             Mock.Of<ISpectreConsoleLoggerControl>(),
             nonSpectreLoggerFactory.Object,
-            spectreLoggerFilter.Object);
+            spectreLoggerFilter.Object,
+            DelegatingAnsiConsole.Instance);
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/PipelineProgressTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineProgressTests.cs
@@ -12,6 +12,7 @@ using Spectre.Console;
 
 namespace ModularPipelines.UnitTests.Engine;
 
+[TUnit.Core.NotInParallel]
 public class PipelineProgressTests
 {
     private class Module1 : Module<bool>
@@ -125,9 +126,5 @@ public class PipelineProgressTests
                     .AddModule<Module7>()
                     .ExecutePipelineAsync()).
             Throws<ModuleFailedException>();
-
-        var renderedProgress = output.ToString();
-        await Assert.That(renderedProgress).Contains("Pipeline:");
-        await Assert.That(renderedProgress).Contains($"{nameof(Module1)}:");
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/PipelineProgressTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineProgressTests.cs
@@ -12,24 +12,8 @@ using Spectre.Console;
 
 namespace ModularPipelines.UnitTests.Engine;
 
-[TUnit.Core.NotInParallel]
 public class PipelineProgressTests
 {
-    private static bool _originalInteractive;
-
-    [Before(Class)]
-    public static void Setup()
-    {
-        _originalInteractive = AnsiConsole.Profile.Capabilities.Interactive;
-        AnsiConsole.Profile.Capabilities.Interactive = true;
-    }
-
-    [After(Class)]
-    public static void CleanUp()
-    {
-        AnsiConsole.Profile.Capabilities.Interactive = _originalInteractive;
-    }
-
     private class Module1 : Module<bool>
     {
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -112,14 +96,24 @@ public class PipelineProgressTests
         }
     }
 
-    [Test, Retry(5)]
+    [Test]
     public async Task Can_Show_Progress()
     {
+        using var output = new StringWriter();
+        var console = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Interactive = InteractionSupport.Yes,
+            Out = new AnsiConsoleOutput(output),
+        });
+
         await Assert.That(async () =>
                 await TestPipelineHostBuilder.Create()
+                    .ConfigureServices((_, services) => services.AddSingleton<IAnsiConsole>(console))
                     .ConfigurePipelineOptions((_, options) => options with
                     {
-                        PrintResults = true,
+                        PrintResults = false,
                         ShowProgressInConsole = true,
                     })
                     .AddModule<Module1>()
@@ -131,5 +125,9 @@ public class PipelineProgressTests
                     .AddModule<Module7>()
                     .ExecutePipelineAsync()).
             Throws<ModuleFailedException>();
+
+        var renderedProgress = output.ToString();
+        await Assert.That(renderedProgress).Contains("Pipeline:");
+        await Assert.That(renderedProgress).Contains($"{nameof(Module1)}:");
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
@@ -13,6 +13,22 @@ namespace ModularPipelines.UnitTests.Logging;
 public class SpectreConsoleLoggerTests
 {
     [Test]
+    public async Task Configuration_Uses_Registered_Console()
+    {
+        var console = Mock.Of<IAnsiConsole>();
+        var services = new ServiceCollection();
+        DependencyInjectionSetup.Initialize(services);
+        services.AddSingleton(console);
+        await using var provider = services.BuildServiceProvider();
+
+        var options = provider
+            .GetRequiredService<Microsoft.Extensions.Options.IOptions<SpectreConsoleLoggerOptions>>()
+            .Value;
+
+        await Assert.That(options.Console).IsSameReferenceAs(console);
+    }
+
+    [Test]
     public async Task Configuration_Uses_Synchronous_Output()
     {
         var options = new SpectreConsoleLoggerOptions();


### PR DESCRIPTION
## Summary
- inject one DI-resolved `IAnsiConsole` into progress rendering and MEL.Spectre logging
- await the initial progress refresh and end cancellation normally so live output is retained
- replace retry-based integration coverage with deterministic component rendering assertions
- retain nonparallel isolation for process-global `System.Console` redirection

## Validation
- `ProgressSessionTests`: 2/2
- `SpectreConsoleLoggerTests`: 6/6
- `Can_Show_Progress`: passed normally and with `GITHUB_ACTIONS=true`
- `ModularPipelines.sln` Release build: 0 warnings, 0 errors
- changed-file whitespace verification: passed

Fixes #3523