### PR TITLE
Scope missing dependency diagnostics to modules

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/MissingDependsOnAttributeCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/MissingDependsOnAttributeCodeFixProvider.cs
@@ -36,10 +36,19 @@ public class MissingDependsOnAttributeCodeFixProvider : CodeFixProvider
         }
 
         var diagnostic = context.Diagnostics.First();
-        var diagnosticSpan = diagnostic.Location.SourceSpan;
+        if (!diagnostic.Properties.TryGetValue("ModuleDeclarationStart", out var declarationStartValue)
+            || !int.TryParse(declarationStartValue, out var declarationStart))
+        {
+            return;
+        }
 
-        // Find the type declaration identified by the diagnostic.
-        var declaration = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf().OfType<TypeDeclarationSyntax>().First();
+        // The analyzer records the enclosing module so nested helper diagnostics fix the module itself.
+        var declaration = root
+            .FindToken(declarationStart)
+            .Parent?
+            .AncestorsAndSelf()
+            .OfType<TypeDeclarationSyntax>()
+            .FirstOrDefault(typeDeclaration => typeDeclaration.SpanStart == declarationStart);
 
         if (declaration is null)
         {

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
@@ -211,6 +211,113 @@ public class Module2 : Module<string>
     }
 
     [TestMethod]
+    public async Task GetModule_Calls_In_Non_Module_Types_Are_Ignored()
+    {
+        const string source = """
+            #nullable enable
+            using System.Threading.Tasks;
+            using ModularPipelines.Context;
+            using ModularPipelines.Modules;
+
+            namespace Example;
+
+            public class Dependency : Module<string>
+            {
+                protected override Task<string?> ExecuteAsync(IModuleContext context, System.Threading.CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
+            }
+
+            public class Helper
+            {
+                public async Task UseAsync(IModuleContext context)
+                {
+                    _ = await context.GetModule<Dependency>();
+                }
+            }
+
+            public class Container
+            {
+                private class NestedHelper
+                {
+                    public async Task UseAsync(IModuleContext context)
+                    {
+                        _ = await context.GetModule<Dependency>();
+                    }
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task Nested_Helper_Code_Fix_Adds_Attribute_To_Enclosing_Module()
+    {
+        var source = """
+            #nullable enable
+            using System.Threading;
+            using System.Threading.Tasks;
+            using ModularPipelines.Context;
+            using ModularPipelines.Modules;
+
+            namespace Example;
+
+            public class Dependency : Module<string>
+            {
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
+            }
+
+            public class Consumer : Module<string>
+            {
+                private class Helper
+                {
+                    public async Task UseAsync(IModuleContext context)
+                    {
+                        _ = await {|#0:context.GetModule<Dependency>()|};
+                    }
+                }
+
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
+            }
+            """.ReplaceLineEndings("\n");
+        var fixedSource = """
+            #nullable enable
+            using System.Threading;
+            using System.Threading.Tasks;
+            using ModularPipelines.Context;
+            using ModularPipelines.Modules;
+            using ModularPipelines.Attributes;
+
+            namespace Example;
+            public class Dependency : Module<string>
+            {
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+            }
+
+            [DependsOn<Dependency>]
+            public class Consumer : Module<string>
+            {
+                private class Helper
+                {
+                    public async Task UseAsync(IModuleContext context)
+                    {
+                        _ = await context.GetModule<Dependency>();
+                    }
+                }
+
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+            }
+            """.ReplaceLineEndings("\n");
+        var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId)
+            .WithArguments("Dependency")
+            .WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(source, expected, fixedSource);
+    }
+
+    [TestMethod]
     public async Task CodeFixWorks()
     {
         var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId).WithArguments("Module1").WithLocation(0);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/MissingDependsOnAttributeAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/MissingDependsOnAttributeAnalyzer.cs
@@ -61,14 +61,16 @@ public class MissingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var classContainingGetModuleCallSyntax = GetClassDeclarationSyntax(invocationExpressionSyntax);
+        var moduleDeclaration = GetModuleDeclarationSyntax(
+            context,
+            invocationExpressionSyntax);
 
-        if (classContainingGetModuleCallSyntax is null)
+        if (moduleDeclaration is null)
         {
             return;
         }
 
-        var classSymbol = context.SemanticModel.GetDeclaredSymbol(classContainingGetModuleCallSyntax);
+        var classSymbol = context.SemanticModel.GetDeclaredSymbol(moduleDeclaration);
 
         if (classSymbol is null)
         {
@@ -83,6 +85,7 @@ public class MissingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
             {
                 ["Name"] = namedTypeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
                 ["Optional"] = IsOptionalAccessor(methodSymbol).ToString(),
+                ["ModuleDeclarationStart"] = moduleDeclaration.SpanStart.ToString(),
             }.ToImmutableDictionary();
 
             context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation(), properties, namedTypeSymbol.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
@@ -181,8 +184,15 @@ public class MissingDependsOnAttributeAnalyzer : DiagnosticAnalyzer
         => (methodSymbol.ReducedFrom ?? methodSymbol).Name
             .EndsWith(OptionalModuleAccessorSuffix, StringComparison.Ordinal);
 
-    private static ClassDeclarationSyntax? GetClassDeclarationSyntax(InvocationExpressionSyntax invocationExpressionSyntax)
+    private static TypeDeclarationSyntax? GetModuleDeclarationSyntax(
+        SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax invocationExpressionSyntax)
     {
-        return invocationExpressionSyntax.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
+        return invocationExpressionSyntax
+            .Ancestors()
+            .OfType<TypeDeclarationSyntax>()
+            .FirstOrDefault(declaration => context.SemanticModel
+                .GetDeclaredSymbol(declaration, context.CancellationToken)
+                .IsModule(context.Compilation));
     }
 }


### PR DESCRIPTION
## Summary
- ignore GetModule calls in standalone and nested non-module helpers
- walk outward to the nearest enclosing module for nested helper calls
- target the enclosing module in the code fix via diagnostic metadata

## Validation
- ModularPipelines.Analyzers.sln Release build: 0 warnings, 0 errors
- ModularPipelines.Analyzers.Test: 149 passed

Closes #3507