### PR TITLE
Analyze only returns owned by ExecuteAsync

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
@@ -107,6 +107,11 @@ public class AsyncModuleCodeFixProvider : CodeFixProvider
         ExpressionSyntax expression,
         SemanticModel? semanticModel)
     {
+        if (expression is ThrowExpressionSyntax)
+        {
+            return expression;
+        }
+
         if (expression is InvocationExpressionSyntax invocation
             && semanticModel?.GetSymbolInfo(invocation).Symbol is IMethodSymbol
             {
@@ -121,7 +126,9 @@ public class AsyncModuleCodeFixProvider : CodeFixProvider
         }
 
         var awaitOperand = expression.WithoutTrivia();
-        if (awaitOperand is ConditionalExpressionSyntax or SwitchExpressionSyntax)
+        var parsedAwaitExpression = SyntaxFactory.ParseExpression($"await {awaitOperand}");
+        if (parsedAwaitExpression is not AwaitExpressionSyntax
+            || parsedAwaitExpression.ContainsDiagnostics)
         {
             awaitOperand = SyntaxFactory.ParenthesizedExpression(awaitOperand);
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
@@ -107,9 +107,7 @@ public class AsyncModuleCodeFixProvider : CodeFixProvider
         ExpressionSyntax expression,
         SemanticModel? semanticModel)
     {
-        if (expression is ThrowExpressionSyntax
-            || expression.IsKind(SyntaxKind.NullLiteralExpression)
-            || expression.IsKind(SyntaxKind.DefaultLiteralExpression))
+        if (IsTargetTypedReturnExpression(expression))
         {
             return expression;
         }
@@ -138,5 +136,23 @@ public class AsyncModuleCodeFixProvider : CodeFixProvider
         return SyntaxFactory
             .AwaitExpression(awaitOperand)
             .WithTriviaFrom(expression);
+    }
+
+    private static bool IsTargetTypedReturnExpression(ExpressionSyntax expression)
+    {
+        return expression switch
+        {
+            ThrowExpressionSyntax => true,
+            ParenthesizedExpressionSyntax parenthesized =>
+                IsTargetTypedReturnExpression(parenthesized.Expression),
+            ConditionalExpressionSyntax conditional =>
+                IsTargetTypedReturnExpression(conditional.WhenTrue)
+                && IsTargetTypedReturnExpression(conditional.WhenFalse),
+            SwitchExpressionSyntax switchExpression =>
+                switchExpression.Arms.All(arm =>
+                    IsTargetTypedReturnExpression(arm.Expression)),
+            _ => expression.IsKind(SyntaxKind.NullLiteralExpression)
+                 || expression.IsKind(SyntaxKind.DefaultLiteralExpression),
+        };
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
@@ -107,7 +107,9 @@ public class AsyncModuleCodeFixProvider : CodeFixProvider
         ExpressionSyntax expression,
         SemanticModel? semanticModel)
     {
-        if (expression is ThrowExpressionSyntax)
+        if (expression is ThrowExpressionSyntax
+            || expression.IsKind(SyntaxKind.NullLiteralExpression)
+            || expression.IsKind(SyntaxKind.DefaultLiteralExpression))
         {
             return expression;
         }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
@@ -64,9 +64,16 @@ public class AsyncModuleCodeFixProvider : CodeFixProvider
         // Cache the semantic model to avoid duplicate async calls
         var semanticModel = await context.Document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
+        if (methodDeclarationSyntax.ExpressionBody is { Expression: var expression })
+        {
+            editor.ReplaceNode(
+                expression,
+                RewriteReturnExpression(expression, semanticModel));
+        }
+
         foreach (var returnStatement in GetReturnStatements(methodDeclarationSyntax))
         {
-            var expressionSyntax = returnStatement.ChildNodes().OfType<ExpressionSyntax>().FirstOrDefault();
+            var expressionSyntax = returnStatement.Expression;
 
             // Skip return statements without expressions (e.g., bare "return;")
             if (expressionSyntax is null)
@@ -74,30 +81,9 @@ public class AsyncModuleCodeFixProvider : CodeFixProvider
                 continue;
             }
 
-            if (IsTaskFromResult(expressionSyntax, semanticModel))
-            {
-                var argumentList = expressionSyntax.ChildNodes().OfType<ArgumentListSyntax>().FirstOrDefault();
-                var firstArgument = argumentList?.Arguments.FirstOrDefault();
-                var firstInnerExpression = firstArgument?.Expression;
-
-                // Skip if we can't find the inner expression to unwrap
-                if (firstInnerExpression is null)
-                {
-                    continue;
-                }
-
-                var newReturnStatement = returnStatement.ReplaceNode(expressionSyntax, firstInnerExpression);
-
-                editor.ReplaceNode(returnStatement, newReturnStatement);
-
-                continue;
-            }
-
-            var awaitExpressionSyntax = SyntaxFactory.AwaitExpression(expressionSyntax).NormalizeWhitespace();
-
-            var awaitedReturnStatement = returnStatement.ReplaceNode(expressionSyntax, awaitExpressionSyntax);
-
-            editor.ReplaceNode(returnStatement, awaitedReturnStatement);
+            editor.ReplaceNode(
+                expressionSyntax,
+                RewriteReturnExpression(expressionSyntax, semanticModel));
         }
 
         return editor.GetChangedDocument();
@@ -106,35 +92,36 @@ public class AsyncModuleCodeFixProvider : CodeFixProvider
     private static ReturnStatementSyntax[] GetReturnStatements(MethodDeclarationSyntax newMethodDeclarationSyntax)
     {
         return newMethodDeclarationSyntax.Body
-                   ?.DescendantNodes()
+                   ?.DescendantNodes(ShouldDescendInto)
                    .OfType<ReturnStatementSyntax>()
                    .Reverse()
                    .ToArray()
                ?? Array.Empty<ReturnStatementSyntax>();
     }
 
-    private static bool IsTaskFromResult(ExpressionSyntax expressionSyntax, SemanticModel? semanticModel)
+    private static bool ShouldDescendInto(SyntaxNode node) =>
+        node is not AnonymousFunctionExpressionSyntax
+            and not LocalFunctionStatementSyntax;
+
+    private static ExpressionSyntax RewriteReturnExpression(
+        ExpressionSyntax expression,
+        SemanticModel? semanticModel)
     {
-        if (expressionSyntax is not InvocationExpressionSyntax invocationExpressionSyntax)
+        if (expression is InvocationExpressionSyntax invocation
+            && semanticModel?.GetSymbolInfo(invocation).Symbol is IMethodSymbol
+            {
+                Name: AnalyzerConstants.MethodNames.FromResult,
+                ContainingType.Name: AnalyzerConstants.TypeNames.Task,
+            } method
+            && method.ContainingNamespace.ToDisplayString()
+            == AnalyzerConstants.Namespaces.SystemThreadingTasks
+            && invocation.ArgumentList.Arguments.FirstOrDefault()?.Expression is { } innerExpression)
         {
-            return false;
+            return innerExpression;
         }
 
-        if (semanticModel is null)
-        {
-            return false;
-        }
-
-        var symbol = semanticModel.GetSymbolInfo(invocationExpressionSyntax).Symbol;
-
-        if (symbol is not IMethodSymbol methodSymbol)
-        {
-            return false;
-        }
-
-        return
-            methodSymbol.Name == AnalyzerConstants.MethodNames.FromResult
-            && methodSymbol.ContainingType.Name == AnalyzerConstants.TypeNames.Task
-            && methodSymbol.ContainingNamespace.ToDisplayString() == AnalyzerConstants.Namespaces.SystemThreadingTasks;
+        return SyntaxFactory
+            .AwaitExpression(expression.WithoutTrivia())
+            .WithTriviaFrom(expression);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.CodeFixes/AsyncModuleCodeFixProvider.cs
@@ -120,8 +120,14 @@ public class AsyncModuleCodeFixProvider : CodeFixProvider
             return innerExpression;
         }
 
+        var awaitOperand = expression.WithoutTrivia();
+        if (awaitOperand is ConditionalExpressionSyntax or SwitchExpressionSyntax)
+        {
+            awaitOperand = SyntaxFactory.ParenthesizedExpression(awaitOperand);
+        }
+
         return SyntaxFactory
-            .AwaitExpression(expression.WithoutTrivia())
+            .AwaitExpression(awaitOperand)
             .WithTriviaFrom(expression);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
@@ -220,38 +220,46 @@ public class Module1 : Module<string>
     [TestMethod]
     public async Task CodeFixParenthesizesConditionalExpressionBody()
     {
-        var source = $@"
-{TestSourceConstants.StandardModuleHeaderWithOptions}
-
-public class Module1 : Module<string>
-{{
-    {{|#0:protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-        => context is null ? ExecuteCommand() : ExecuteCommand();|}}
-
-    private static Task<string?> ExecuteCommand()
-        => Task.FromResult<string?>(""Foo"");
-}}
-";
-        var fixedSource = $@"
-{TestSourceConstants.StandardModuleHeaderWithOptions}
-
-public class Module1 : Module<string>
-{{
-    {{|#0:protected override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-        => await (context is null ? ExecuteCommand() : ExecuteCommand());|}}
-
-    private static Task<string?> ExecuteCommand()
-        => Task.FromResult<string?>(""Foo"");
-}}
-";
-        var expected = VerifyCS.Diagnostic(AsyncModuleAnalyzer.DiagnosticId)
-            .WithLocation(0);
-
-        await VerifyCS.VerifyCodeFixAsync(source, expected, fixedSource);
+        await VerifyExpressionBodiedCodeFixAsync(
+            "context is null ? ExecuteCommand() : ExecuteCommand()",
+            "await (context is null ? ExecuteCommand() : ExecuteCommand())");
     }
 
     [TestMethod]
     public async Task CodeFixParenthesizesSwitchExpressionBody()
+    {
+        await VerifyExpressionBodiedCodeFixAsync(
+            "context switch { null => ExecuteCommand(), _ => ExecuteCommand() }",
+            "await (context switch { null => ExecuteCommand(), _ => ExecuteCommand() })");
+    }
+
+    [TestMethod]
+    public async Task CodeFixParenthesizesCoalescingExpressionBody()
+    {
+        await VerifyExpressionBodiedCodeFixAsync(
+            "PendingTask ?? ExecuteCommand()",
+            "await (PendingTask ?? ExecuteCommand())");
+    }
+
+    [TestMethod]
+    public async Task CodeFixParenthesizesAssignmentExpressionBody()
+    {
+        await VerifyExpressionBodiedCodeFixAsync(
+            "PendingTask = ExecuteCommand()",
+            "await (PendingTask = ExecuteCommand())");
+    }
+
+    [TestMethod]
+    public async Task CodeFixPreservesThrowExpressionBody()
+    {
+        await VerifyExpressionBodiedCodeFixAsync(
+            "throw new InvalidOperationException()",
+            "throw new InvalidOperationException()");
+    }
+
+    private static async Task VerifyExpressionBodiedCodeFixAsync(
+        string expression,
+        string fixedExpression)
     {
         var source = $@"
 {TestSourceConstants.StandardModuleHeaderWithOptions}
@@ -259,7 +267,9 @@ public class Module1 : Module<string>
 public class Module1 : Module<string>
 {{
     {{|#0:protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-        => context switch {{ null => ExecuteCommand(), _ => ExecuteCommand() }};|}}
+        => {expression};|}}
+
+    private static Task<string?>? PendingTask {{ get; set; }}
 
     private static Task<string?> ExecuteCommand()
         => Task.FromResult<string?>(""Foo"");
@@ -271,7 +281,9 @@ public class Module1 : Module<string>
 public class Module1 : Module<string>
 {{
     {{|#0:protected override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-        => await (context switch {{ null => ExecuteCommand(), _ => ExecuteCommand() }});|}}
+        => {fixedExpression};|}}
+
+    private static Task<string?>? PendingTask {{ get; set; }}
 
     private static Task<string?> ExecuteCommand()
         => Task.FromResult<string?>(""Foo"");

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
@@ -257,12 +257,35 @@ public class Module1 : Module<string>
             "throw new InvalidOperationException()");
     }
 
+    [TestMethod]
+    public async Task CodeFixPreservesTargetTypedNullExpressionBody()
+    {
+        await VerifyExpressionBodiedCodeFixAsync(
+            "null",
+            "null",
+            suppressNullReturnWarning: true);
+    }
+
+    [TestMethod]
+    public async Task CodeFixPreservesTargetTypedDefaultExpressionBody()
+    {
+        await VerifyExpressionBodiedCodeFixAsync(
+            "default",
+            "default",
+            suppressNullReturnWarning: true);
+    }
+
     private static async Task VerifyExpressionBodiedCodeFixAsync(
         string expression,
-        string fixedExpression)
+        string fixedExpression,
+        bool suppressNullReturnWarning = false)
     {
+        var nullableWarningDirective = suppressNullReturnWarning
+            ? "#pragma warning disable CS8603"
+            : string.Empty;
         var source = $@"
 {TestSourceConstants.StandardModuleHeaderWithOptions}
+{nullableWarningDirective}
 
 public class Module1 : Module<string>
 {{
@@ -277,6 +300,7 @@ public class Module1 : Module<string>
 ";
         var fixedSource = $@"
 {TestSourceConstants.StandardModuleHeaderWithOptions}
+{nullableWarningDirective}
 
 public class Module1 : Module<string>
 {{

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
@@ -275,6 +275,24 @@ public class Module1 : Module<string>
             suppressNullReturnWarning: true);
     }
 
+    [TestMethod]
+    public async Task CodeFixPreservesTargetTypedConditionalExpressionBody()
+    {
+        await VerifyExpressionBodiedCodeFixAsync(
+            "context is null ? null : throw new InvalidOperationException()",
+            "context is null ? null : throw new InvalidOperationException()",
+            suppressNullReturnWarning: true);
+    }
+
+    [TestMethod]
+    public async Task CodeFixPreservesTargetTypedSwitchExpressionBody()
+    {
+        await VerifyExpressionBodiedCodeFixAsync(
+            "context switch { null => null, _ => default }",
+            "context switch { null => null, _ => default }",
+            suppressNullReturnWarning: true);
+    }
+
     private static async Task VerifyExpressionBodiedCodeFixAsync(
         string expression,
         string fixedExpression,

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
@@ -76,6 +76,32 @@ public class Module1 : Module<string>
 }}
 ";
 
+    private const string ExpressionBodiedModuleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<string>
+{{
+    {{|#0:protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        => ExecuteCommand(context);|}}
+
+    private static Task<string?> ExecuteCommand(IModuleContext context)
+        => Task.FromResult<string?>(""Foo"");
+}}
+";
+
+    private const string FixedExpressionBodiedModuleSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<string>
+{{
+    {{|#0:protected override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        => await ExecuteCommand(context);|}}
+
+    private static Task<string?> ExecuteCommand(IModuleContext context)
+        => Task.FromResult<string?>(""Foo"");
+}}
+";
+
     private const string BadModuleSource2Fixed = $@"
 {TestSourceConstants.StandardModuleHeaderWithOptions}
 
@@ -120,6 +146,50 @@ public class Module1 : Module<string>
     }
 
     [TestMethod]
+    public async Task AnalyzerIsNotTriggered_For_Returns_In_Lambdas_Or_Local_Functions()
+    {
+        var source = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<string>
+{{
+    protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        Func<string> getLambdaValue = () =>
+        {{
+            return ""lambda"";
+        }};
+
+        string GetLocalValue()
+        {{
+            return ""local"";
+        }}
+
+        return Task.FromResult<string?>(getLambdaValue() + GetLocalValue());
+    }}
+}}
+";
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
+    public async Task AnalyzerIsNotTriggered_When_Expression_Body_Uses_TaskFromResult()
+    {
+        var source = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<string>
+{{
+    protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        => Task.FromResult<string?>(""Foo"");
+}}
+";
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [TestMethod]
     public async Task CodeFixWorks()
     {
         var expected = VerifyCS.Diagnostic(AsyncModuleAnalyzer.DiagnosticId).WithLocation(0);
@@ -133,5 +203,17 @@ public class Module1 : Module<string>
         var expected = VerifyCS.Diagnostic(AsyncModuleAnalyzer.DiagnosticId).WithLocation(0);
 
         await VerifyCS.VerifyCodeFixAsync(BadModuleSource2, expected, BadModuleSource2Fixed);
+    }
+
+    [TestMethod]
+    public async Task CodeFixWorks_For_Expression_Bodied_Method()
+    {
+        var expected = VerifyCS.Diagnostic(AsyncModuleAnalyzer.DiagnosticId)
+            .WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(
+            ExpressionBodiedModuleSource,
+            expected,
+            FixedExpressionBodiedModuleSource);
     }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersAsyncModulesUnitTests.cs
@@ -216,4 +216,70 @@ public class Module1 : Module<string>
             expected,
             FixedExpressionBodiedModuleSource);
     }
+
+    [TestMethod]
+    public async Task CodeFixParenthesizesConditionalExpressionBody()
+    {
+        var source = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<string>
+{{
+    {{|#0:protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        => context is null ? ExecuteCommand() : ExecuteCommand();|}}
+
+    private static Task<string?> ExecuteCommand()
+        => Task.FromResult<string?>(""Foo"");
+}}
+";
+        var fixedSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<string>
+{{
+    {{|#0:protected override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        => await (context is null ? ExecuteCommand() : ExecuteCommand());|}}
+
+    private static Task<string?> ExecuteCommand()
+        => Task.FromResult<string?>(""Foo"");
+}}
+";
+        var expected = VerifyCS.Diagnostic(AsyncModuleAnalyzer.DiagnosticId)
+            .WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(source, expected, fixedSource);
+    }
+
+    [TestMethod]
+    public async Task CodeFixParenthesizesSwitchExpressionBody()
+    {
+        var source = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<string>
+{{
+    {{|#0:protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        => context switch {{ null => ExecuteCommand(), _ => ExecuteCommand() }};|}}
+
+    private static Task<string?> ExecuteCommand()
+        => Task.FromResult<string?>(""Foo"");
+}}
+";
+        var fixedSource = $@"
+{TestSourceConstants.StandardModuleHeaderWithOptions}
+
+public class Module1 : Module<string>
+{{
+    {{|#0:protected override async Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        => await (context switch {{ null => ExecuteCommand(), _ => ExecuteCommand() }});|}}
+
+    private static Task<string?> ExecuteCommand()
+        => Task.FromResult<string?>(""Foo"");
+}}
+";
+        var expected = VerifyCS.Diagnostic(AsyncModuleAnalyzer.DiagnosticId)
+            .WithLocation(0);
+
+        await VerifyCS.VerifyCodeFixAsync(source, expected, fixedSource);
+    }
 }

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
@@ -292,9 +292,11 @@ public class Module2 : Module<string>
             using ModularPipelines.Attributes;
 
             namespace Example;
+
             public class Dependency : Module<string>
             {
-                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
             }
 
             [DependsOn<Dependency>]
@@ -308,7 +310,8 @@ public class Module2 : Module<string>
                     }
                 }
 
-                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
             }
             """.ReplaceLineEndings("\n");
         var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId)

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AsyncModuleAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/AsyncModuleAnalyzer.cs
@@ -59,9 +59,10 @@ public class AsyncModuleAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        var returnStatementSyntaxes = methodDeclarationSyntax.Body?.DescendantNodes().OfType<ReturnStatementSyntax>().ToArray() ?? Array.Empty<ReturnStatementSyntax>();
+        var returnExpressions = GetReturnExpressions(methodDeclarationSyntax);
 
-        if (returnStatementSyntaxes.All(x => IsSynchronousObjectWrappedInTask(x, context)))
+        if (returnExpressions.All(expression =>
+                IsSynchronousObjectWrappedInTask(expression, context)))
         {
             return;
         }
@@ -69,11 +70,35 @@ public class AsyncModuleAnalyzer : DiagnosticAnalyzer
         context.ReportDiagnostic(Diagnostic.Create(Rule, context.Node.GetLocation()));
     }
 
-    private bool IsSynchronousObjectWrappedInTask(ReturnStatementSyntax returnStatementSyntax,
+    private static ExpressionSyntax[] GetReturnExpressions(
+        MethodDeclarationSyntax methodDeclaration)
+    {
+        if (methodDeclaration.ExpressionBody is { Expression: var expression })
+        {
+            return [expression];
+        }
+
+        return methodDeclaration.Body is null
+            ? []
+            :
+            [
+                .. methodDeclaration.Body
+                    .DescendantNodes(ShouldDescendInto)
+                    .OfType<ReturnStatementSyntax>()
+                    .Select(static statement => statement.Expression)
+                    .OfType<ExpressionSyntax>(),
+            ];
+    }
+
+    private static bool ShouldDescendInto(SyntaxNode node) =>
+        node is not AnonymousFunctionExpressionSyntax
+            and not LocalFunctionStatementSyntax;
+
+    private static bool IsSynchronousObjectWrappedInTask(
+        ExpressionSyntax expression,
         SyntaxNodeAnalysisContext context)
     {
-        if (returnStatementSyntax.ChildNodes().FirstOrDefault() is not InvocationExpressionSyntax
-            invocationExpressionSyntax)
+        if (expression is not InvocationExpressionSyntax invocationExpressionSyntax)
         {
             return false;
         }


### PR DESCRIPTION
## Summary
- ignore return statements inside lambdas and local functions when analyzing ExecuteAsync
- analyze expression-bodied ExecuteAsync implementations
- update the code fix to await expression bodies and avoid rewriting nested returns

## Validation
- ModularPipelines.Analyzers.sln Release build: 0 warnings, 0 errors
- ModularPipelines.Analyzers.Test: 150 passed

Closes #3509