### PR TITLE
Fix failed module progress completion

### DIFF
--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -264,12 +264,17 @@ internal class ModuleRunner : IModuleRunner
                 _resultRegistry.RegisterResult(moduleType, result);
             }
 
-            // Invoke OnModuleFailed lifecycle event
-            await _lifecycleEventInvoker.InvokeFailedEventAsync(lifecycleContext, ex).ConfigureAwait(false);
+            try
+            {
+                // Invoke OnModuleFailed lifecycle event
+                await _lifecycleEventInvoker.InvokeFailedEventAsync(lifecycleContext, ex).ConfigureAwait(false);
 
-            await _pipelineSetupExecutor.OnModuleFailureAsync(moduleState).ConfigureAwait(false);
-
-            await _mediator.Publish(new ModuleCompletedNotification(moduleState, false)).ConfigureAwait(false);
+                await _pipelineSetupExecutor.OnModuleFailureAsync(moduleState).ConfigureAwait(false);
+            }
+            finally
+            {
+                await _mediator.Publish(new ModuleCompletedNotification(moduleState, false)).ConfigureAwait(false);
+            }
 
             throw;
         }

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -269,6 +269,8 @@ internal class ModuleRunner : IModuleRunner
 
             await _pipelineSetupExecutor.OnModuleFailureAsync(moduleState).ConfigureAwait(false);
 
+            await _mediator.Publish(new ModuleCompletedNotification(moduleState, false)).ConfigureAwait(false);
+
             throw;
         }
         finally

--- a/test/ModularPipelines.UnitTests/Engine/FailedModuleNotificationTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/FailedModuleNotificationTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context;
 using ModularPipelines.Events;
 using ModularPipelines.Exceptions;
+using ModularPipelines.Interfaces;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
 using Moq;
@@ -35,6 +36,34 @@ public class FailedModuleNotificationTests
             It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Test]
+    public async Task Failed_Module_Publishes_Completion_When_Failure_Receiver_Throws()
+    {
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(x => x.Publish(
+                It.IsAny<ModuleCompletedNotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        await Assert.That(async () =>
+                await TestPipelineHostBuilder.Create()
+                    .ConfigureServices((_, services) =>
+                    {
+                        services.AddSingleton(mediator.Object);
+                        services.AddSingleton<IModuleEventReceiver, ThrowingFailureReceiver>();
+                    })
+                    .AddModule<FailingModule>()
+                    .ExecutePipelineAsync())
+            .Throws<InvalidOperationException>();
+
+        mediator.Verify(x => x.Publish(
+            It.Is<ModuleCompletedNotification>(notification =>
+                notification.ModuleState.ModuleType == typeof(FailingModule)
+                && !notification.IsSuccessful),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     private sealed class FailingModule : Module<bool>
     {
         protected internal override Task<bool> ExecuteAsync(
@@ -42,6 +71,14 @@ public class FailedModuleNotificationTests
             CancellationToken cancellationToken)
         {
             return Task.FromException<bool>(new InvalidOperationException("Expected test failure"));
+        }
+    }
+
+    private sealed class ThrowingFailureReceiver : IModuleEventReceiver
+    {
+        public Task OnModuleFailureAsync(IModuleHookContext context)
+        {
+            return Task.FromException(new InvalidOperationException("Expected receiver failure"));
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/FailedModuleNotificationTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/FailedModuleNotificationTests.cs
@@ -1,0 +1,47 @@
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Context;
+using ModularPipelines.Events;
+using ModularPipelines.Exceptions;
+using ModularPipelines.Modules;
+using ModularPipelines.TestHelpers;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+public class FailedModuleNotificationTests
+{
+    [Test]
+    public async Task Failed_Module_Publishes_Unsuccessful_Completion_Notification()
+    {
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(x => x.Publish(
+                It.IsAny<ModuleCompletedNotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+
+        await Assert.That(async () =>
+                await TestPipelineHostBuilder.Create()
+                    .ConfigureServices((_, services) => services.AddSingleton(mediator.Object))
+                    .AddModule<FailingModule>()
+                    .ExecutePipelineAsync())
+            .Throws<ModuleFailedException>();
+
+        mediator.Verify(x => x.Publish(
+            It.Is<ModuleCompletedNotification>(notification =>
+                notification.ModuleState.ModuleType == typeof(FailingModule)
+                && !notification.IsSuccessful),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private sealed class FailingModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromException<bool>(new InvalidOperationException("Expected test failure"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- publish an unsuccessful `ModuleCompletedNotification` after failed-module lifecycle hooks
- cover the failure path with a focused mediator regression test

## Validation
- `FailedModuleNotificationTests`: 1 passed
- `ModularPipelines.sln` Release build: 0 warnings, 0 errors
- changed-file whitespace verification: passed
- full solution info-level format verification remains blocked by pre-existing diagnostics in unrelated files

Closes #3459