### PR TITLE
Observe abandoned task faults

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -167,6 +167,7 @@ internal class ModuleExecutor : IModuleExecutor
         finally
         {
             EnsureCancellation(cancellationTokenSource);
+            TaskObservation.ObserveFault(schedulerTask);
         }
 
         try

--- a/src/ModularPipelines/Helpers/TaskObservation.cs
+++ b/src/ModularPipelines/Helpers/TaskObservation.cs
@@ -1,0 +1,13 @@
+namespace ModularPipelines.Helpers;
+
+internal static class TaskObservation
+{
+    public static void ObserveFault(Task task)
+    {
+        _ = task.ContinueWith(
+            static faultedTask => _ = faultedTask.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
+    }
+}

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -104,13 +104,16 @@ internal static class TimeoutHelper
             var tcs = new TaskCompletionSource<T>(
                 TaskCreationOptions.RunContinuationsAsynchronously);
             using var reg = cancellationToken.Register(
-                static state => ((TaskCompletionSource<T>)state!).TrySetCanceled(),
+                static state => ((TaskCompletionSource<T>) state!).TrySetCanceled(),
                 tcs);
 
-            // await await: first gets winning task, then awaits it
-            // (propagates result or exception)
-            var winningResult = await await Task.WhenAny(task, tcs.Task)
-                .ConfigureAwait(false);
+            var fastPathWinner = await Task.WhenAny(task, tcs.Task).ConfigureAwait(false);
+            if (fastPathWinner != task)
+            {
+                TaskObservation.ObserveFault(task);
+            }
+
+            var winningResult = await fastPathWinner.ConfigureAwait(false);
             return TimeoutExecutionResult<T>.Success(winningResult, stopwatch.Elapsed);
         }
 
@@ -125,7 +128,7 @@ internal static class TimeoutHelper
         var cancelledTcs = new TaskCompletionSource<T>(
             TaskCreationOptions.RunContinuationsAsynchronously);
         using var registration = timeoutCts.Token.Register(
-            static state => ((TaskCompletionSource<T>)state!)
+            static state => ((TaskCompletionSource<T>) state!)
                 .TrySetCanceled(),
             cancelledTcs);
 
@@ -142,6 +145,7 @@ internal static class TimeoutHelper
             // Determine if it was external cancellation or timeout
             if (cancellationToken.IsCancellationRequested)
             {
+                TaskObservation.ObserveFault(executionTask);
                 throw new OperationCanceledException(cancellationToken);
             }
 
@@ -160,6 +164,7 @@ internal static class TimeoutHelper
             {
                 // Task still didn't complete - definitely not respecting the token
                 taskRespondedDuringGrace = false;
+                TaskObservation.ObserveFault(executionTask);
             }
             catch (OperationCanceledException)
             {

--- a/test/ModularPipelines.UnitTests/Engine/TaskCompletionSourceTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/TaskCompletionSourceTests.cs
@@ -1,11 +1,19 @@
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
+using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Engine.Execution;
 using ModularPipelines.Engine.Scheduling;
+using ModularPipelines.Exceptions;
+using ModularPipelines.Helpers;
+using ModularPipelines.Interfaces;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 using Moq;
 
 namespace ModularPipelines.UnitTests.Engine;
@@ -75,12 +83,59 @@ public class TaskCompletionSourceTests
             () => CreateFaultedSubModuleCompletion(expectedException));
     }
 
+    [Test]
+    public async Task TimeoutHelper_FastCancellation_ObservesAbandonedFault()
+    {
+        var expectedException = new InvalidOperationException(Guid.NewGuid().ToString());
+
+        await AssertNoUnobservedTaskException(
+            expectedException,
+            () => CreateFastCancellationFaultAsync(expectedException));
+    }
+
+    [Test]
+    public async Task TimeoutHelper_ExternalCancellation_ObservesAbandonedFault()
+    {
+        var expectedException = new InvalidOperationException(Guid.NewGuid().ToString());
+
+        await AssertNoUnobservedTaskException(
+            expectedException,
+            () => CreateExternalCancellationFaultAsync(expectedException));
+    }
+
+    [Test]
+    public async Task TimeoutHelper_GraceExpiry_ObservesAbandonedFault()
+    {
+        var expectedException = new InvalidOperationException(Guid.NewGuid().ToString());
+
+        await AssertNoUnobservedTaskException(
+            expectedException,
+            () => CreateGraceExpiryFaultAsync(expectedException));
+    }
+
+    [Test]
+    public async Task ModuleExecutor_WorkerFault_ObservesAbandonedSchedulerFault()
+    {
+        var expectedException = new InvalidOperationException(Guid.NewGuid().ToString());
+
+        await AssertNoUnobservedTaskException(
+            expectedException,
+            () => CreateAbandonedSchedulerFaultAsync(expectedException));
+    }
+
     private static bool RunsContinuationsAsynchronously(Task task) =>
         task.CreationOptions.HasFlag(TaskCreationOptions.RunContinuationsAsynchronously);
 
+    private static Task AssertNoUnobservedTaskException(
+        Exception expectedException,
+        Func<WeakReference> createFaultedOwner) =>
+        AssertNoUnobservedTaskException(
+            expectedException,
+            () => Task.FromResult(createFaultedOwner()));
+
     private static async Task AssertNoUnobservedTaskException(
         Exception expectedException,
-        Func<WeakReference> createFaultedOwner)
+        Func<Task<WeakReference>> createFaultedOwner)
     {
         var exceptionObservedByFinalizer = 0;
 
@@ -96,13 +151,14 @@ public class TaskCompletionSourceTests
         TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
         try
         {
-            var ownerReference = createFaultedOwner();
+            var ownerReference = await createFaultedOwner();
 
             for (var attempt = 0; attempt < 10 && ownerReference.IsAlive; attempt++)
             {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
                 GC.Collect();
+                await Task.Yield();
             }
 
             await Assert.That(ownerReference.IsAlive).IsFalse();
@@ -169,5 +225,109 @@ public class TaskCompletionSourceTests
         }
 
         return new WeakReference(tracker);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task<WeakReference> CreateFastCancellationFaultAsync(Exception exception)
+    {
+        var abandonedTaskSource = new TaskCompletionSource<int>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var invocation = TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            _ => abandonedTaskSource.Task,
+            timeout: null,
+            cancellationTokenSource.Token);
+
+        cancellationTokenSource.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await invocation);
+        abandonedTaskSource.SetException(exception);
+
+        return new WeakReference(abandonedTaskSource.Task);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task<WeakReference> CreateExternalCancellationFaultAsync(Exception exception)
+    {
+        var abandonedTaskSource = new TaskCompletionSource<int>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var invocation = TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            _ => abandonedTaskSource.Task,
+            TimeSpan.FromMinutes(1),
+            cancellationTokenSource.Token);
+
+        cancellationTokenSource.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await invocation);
+        abandonedTaskSource.SetException(exception);
+
+        return new WeakReference(abandonedTaskSource.Task);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task<WeakReference> CreateGraceExpiryFaultAsync(Exception exception)
+    {
+        var abandonedTaskSource = new TaskCompletionSource<int>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            _ => abandonedTaskSource.Task,
+            TimeSpan.FromMilliseconds(1),
+            CancellationToken.None);
+
+        await Assert.That(result.TimedOut).IsTrue();
+        await Assert.That(result.WasCancellationTokenRespected).IsFalse();
+        abandonedTaskSource.SetException(exception);
+
+        return new WeakReference(abandonedTaskSource.Task);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task<WeakReference> CreateAbandonedSchedulerFaultAsync(Exception exception)
+    {
+        var workerException = new DependencyCollisionException("Worker fault");
+        var readyModules = Channel.CreateUnbounded<ModuleState>();
+        readyModules.Writer.Complete(workerException);
+        var schedulerTaskSource = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler.SetupGet(x => x.ReadyModules).Returns(readyModules.Reader);
+        scheduler.Setup(x => x.RunSchedulerAsync(It.IsAny<CancellationToken>()))
+            .Returns(schedulerTaskSource.Task);
+        scheduler.Setup(x => x.CancelPendingModules(false)).Returns([]);
+        var schedulerFactory = new Mock<IModuleSchedulerFactory>();
+        schedulerFactory.Setup(x => x.Create()).Returns(scheduler.Object);
+        var alwaysRunHandler = new Mock<IAlwaysRunHandler>();
+        alwaysRunHandler
+            .Setup(x => x.WaitForAlwaysRunModulesAsync(
+                scheduler.Object,
+                It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(Task.CompletedTask);
+        var registrationEventExecutor = new Mock<IRegistrationEventExecutor>();
+        registrationEventExecutor
+            .Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IReadOnlyList<IModule>>()))
+            .Returns(Task.CompletedTask);
+        var parallelLimitProvider = new Mock<IParallelLimitProvider>();
+        parallelLimitProvider.Setup(x => x.GetMaxDegreeOfParallelism()).Returns(1);
+        var executor = new ModuleExecutor(
+            schedulerFactory.Object,
+            Mock.Of<IModuleRunner>(),
+            alwaysRunHandler.Object,
+            Mock.Of<IModuleResultRegistrar>(),
+            Mock.Of<IModuleResultRegistry>(),
+            parallelLimitProvider.Object,
+            registrationEventExecutor.Object,
+            Mock.Of<IMetricsCollector>(),
+            new ModuleDependencyRegistry(),
+            new ModuleMetadataRegistry(
+                Microsoft.Extensions.Options.Options.Create(new ModuleRegistrationOptions()),
+                new ModuleAttributeEventService()),
+            Mock.Of<ISecondaryExceptionContainer>(),
+            Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
+            NullLogger<ModuleExecutor>.Instance);
+
+        await Assert.ThrowsAsync<DependencyCollisionException>(
+            async () => await executor.ExecuteAsync([new TestModule()]));
+        schedulerTaskSource.SetException(exception);
+
+        return new WeakReference(schedulerTaskSource.Task);
     }
 }


### PR DESCRIPTION
## Summary
- attach fault-only observers when `TimeoutHelper` abandons work after cancellation or timeout grace expiry
- observe the scheduler task when worker execution exits before reaching its normal await
- cover fast cancellation, external cancellation, grace expiry, and scheduler abandonment with finalizer-based regression tests

## Validation
- `TaskCompletionSourceTests`: 9/9 passed
- `ModuleTimeoutTests`: 12/12 passed
- `ModuleExecutorLoggingTests`: 13/13 passed
- `ModularPipelines.sln` Release build: 0 warnings, 0 errors
- changed-file whitespace verification passed

Closes #3461