### PR TITLE
Restore submodule progress and timing

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
@@ -291,9 +291,11 @@ public class Module2 : Module<string>
             using ModularPipelines.Attributes;
 
             namespace Example;
+
             public class Dependency : Module<string>
             {
-                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
             }
 
             [DependsOn<Dependency>]
@@ -307,7 +309,8 @@ public class Module2 : Module<string>
                     }
                 }
 
-                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
             }
             """.ReplaceLineEndings("\n");
         var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId)

--- a/src/ModularPipelines/Context/ModuleContext.cs
+++ b/src/ModularPipelines/Context/ModuleContext.cs
@@ -26,6 +26,7 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
     private readonly IModuleLogger _logger;
     private readonly IMediator _mediator;
     private readonly ISafeModuleEstimatedTimeProvider _estimatedTimeProvider;
+    private readonly Lazy<Task<SubModuleEstimation[]>> _subModuleEstimations;
 
     public ModuleContext(
         IPipelineContext pipelineContext,
@@ -42,6 +43,7 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
         _logger = logger;
         _mediator = mediator;
         _estimatedTimeProvider = estimatedTimeProvider;
+        _subModuleEstimations = new Lazy<Task<SubModuleEstimation[]>>(LoadSubModuleEstimationsAsync);
     }
 
     #region IModuleContext specific methods
@@ -108,9 +110,7 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
     {
         var moduleType = _currentModule.GetType();
         var tracker = new SubModuleTracker(name, moduleType);
-        var estimates = await _estimatedTimeProvider
-            .GetSubModuleEstimatedTimesAsync(moduleType)
-            .ConfigureAwait(false);
+        var estimates = await _subModuleEstimations.Value.ConfigureAwait(false);
         var estimatedDuration = estimates
             .FirstOrDefault(x => string.Equals(x.SubModuleName, name, StringComparison.Ordinal))
             ?.EstimatedDuration ?? DefaultSubModuleEstimatedDuration;
@@ -137,6 +137,15 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
                 new SubModuleCompletedNotification(_currentModule, tracker, isSuccessful))
                 .ConfigureAwait(false);
         }
+    }
+
+    private async Task<SubModuleEstimation[]> LoadSubModuleEstimationsAsync()
+    {
+        var estimates = await _estimatedTimeProvider
+            .GetSubModuleEstimatedTimesAsync(_currentModule.GetType())
+            .ConfigureAwait(false);
+
+        return estimates.ToArray();
     }
 
     #endregion

--- a/src/ModularPipelines/Context/ModuleContext.cs
+++ b/src/ModularPipelines/Context/ModuleContext.cs
@@ -1,6 +1,9 @@
+using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context.Domains;
 using ModularPipelines.Engine;
+using ModularPipelines.Enums;
+using ModularPipelines.Events;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
@@ -14,23 +17,31 @@ namespace ModularPipelines.Context;
 /// </summary>
 internal class ModuleContext : IModuleContext, IInternalPipelineContext
 {
+    private static readonly TimeSpan DefaultSubModuleEstimatedDuration = TimeSpan.FromMinutes(2);
+
     private readonly IPipelineContext _pipelineContext;
     private readonly IInternalPipelineContext _internalContext;
     private readonly IModule _currentModule;
     private readonly ModuleExecutionContext _executionContext;
     private readonly IModuleLogger _logger;
+    private readonly IMediator _mediator;
+    private readonly ISafeModuleEstimatedTimeProvider _estimatedTimeProvider;
 
     public ModuleContext(
         IPipelineContext pipelineContext,
         IModule currentModule,
         ModuleExecutionContext executionContext,
-        IModuleLogger logger)
+        IModuleLogger logger,
+        IMediator mediator,
+        ISafeModuleEstimatedTimeProvider estimatedTimeProvider)
     {
         _pipelineContext = pipelineContext;
         _internalContext = (IInternalPipelineContext) pipelineContext;
         _currentModule = currentModule;
         _executionContext = executionContext;
         _logger = logger;
+        _mediator = mediator;
+        _estimatedTimeProvider = estimatedTimeProvider;
     }
 
     #region IModuleContext specific methods
@@ -84,18 +95,48 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
         return _executionContext.MatrixTarget;
     }
 
-    public async Task<T> SubModule<T>(string name, Func<Task<T>> action)
-    {
-        var tracker = new SubModuleTracker(name, _currentModule.GetType());
-        _executionContext.SubModules.Add(tracker);
-        return await tracker.ExecuteAsync(action).ConfigureAwait(false);
-    }
+    public Task<T> SubModule<T>(string name, Func<Task<T>> action) => ExecuteSubModule(name, action);
 
-    public async Task SubModule(string name, Func<Task> action)
+    public Task SubModule(string name, Func<Task> action) =>
+        ExecuteSubModule(name, async () =>
+        {
+            await action().ConfigureAwait(false);
+            return 0;
+        });
+
+    private async Task<T> ExecuteSubModule<T>(string name, Func<Task<T>> action)
     {
-        var tracker = new SubModuleTracker(name, _currentModule.GetType());
-        _executionContext.SubModules.Add(tracker);
-        await tracker.ExecuteAsync(action).ConfigureAwait(false);
+        var moduleType = _currentModule.GetType();
+        var tracker = new SubModuleTracker(name, moduleType);
+        var estimates = await _estimatedTimeProvider
+            .GetSubModuleEstimatedTimesAsync(moduleType)
+            .ConfigureAwait(false);
+        var estimatedDuration = estimates
+            .FirstOrDefault(x => string.Equals(x.SubModuleName, name, StringComparison.Ordinal))
+            ?.EstimatedDuration ?? DefaultSubModuleEstimatedDuration;
+
+        await _mediator.Publish(
+            new SubModuleCreatedNotification(_currentModule, tracker, estimatedDuration))
+            .ConfigureAwait(false);
+
+        try
+        {
+            return await tracker.ExecuteAsync(action).ConfigureAwait(false);
+        }
+        finally
+        {
+            var isSuccessful = tracker.Status == Status.Successful;
+            if (isSuccessful)
+            {
+                await _estimatedTimeProvider.SaveSubModuleTimeAsync(
+                    moduleType,
+                    new SubModuleEstimation(name, tracker.Duration)).ConfigureAwait(false);
+            }
+
+            await _mediator.Publish(
+                new SubModuleCompletedNotification(_currentModule, tracker, isSuccessful))
+                .ConfigureAwait(false);
+        }
     }
 
     #endregion

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -149,7 +149,13 @@ internal class ModuleRunner : IModuleRunner
         var executionContext = CreateExecutionContext(module, moduleType);
         ApplyDependencySkip(moduleState, executionContext);
         var logger = GetModuleLogger(scopedServiceProvider, moduleType);
-        var moduleContext = new ModuleContext(pipelineContext, module, executionContext, logger);
+        var moduleContext = new ModuleContext(
+            pipelineContext,
+            module,
+            executionContext,
+            logger,
+            _mediator,
+            _moduleEstimatedTimeProvider);
 
         // Start Activity for distributed tracing (Phase 1: alongside AsyncLocal for compatibility)
         using var activity = ModuleActivityTracing.StartModuleActivity(moduleType);

--- a/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
+++ b/src/ModularPipelines/Engine/FileSystemModuleEstimatedTimeProvider.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using EnumerableAsyncProcessor.Extensions;
 using ModularPipelines.Models;
 
@@ -5,6 +6,8 @@ namespace ModularPipelines.Engine;
 
 internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvider
 {
+    private const string EncodedSubModuleNamePrefix = "B64-";
+
     private static readonly TimeSpan CacheRetention = TimeSpan.FromDays(90);
     private static readonly TimeSpan IndexRefreshInterval = TimeSpan.FromMinutes(1);
 
@@ -62,7 +65,8 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
                         return null;
                     }
 
-                    var name = fileNameWithoutExtension[(subIndex + 5)..]; // 5 = length of "-Sub-"
+                    var encodedName = fileNameWithoutExtension[(subIndex + 5)..]; // 5 = length of "-Sub-"
+                    var name = DecodeSubModuleName(encodedName);
                     var time = await GetEstimatedTimeAsync(file.FullName).ConfigureAwait(false);
                     return new SubModuleEstimation(name, time);
                 }
@@ -79,9 +83,12 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
 
     public async Task SaveSubModuleTimeAsync(Type moduleType, SubModuleEstimation subModuleEstimation)
     {
-        var fileName = $"Mod-{GetModuleName(moduleType)}-Sub-{subModuleEstimation.SubModuleName}.txt";
+        var moduleName = GetModuleName(moduleType);
+        var encodedSubModuleName = EncodeSubModuleName(subModuleEstimation.SubModuleName);
+        var fileName = $"Mod-{moduleName}-Sub-{encodedSubModuleName}.txt";
 
         await SaveModuleTimeAsync(subModuleEstimation.EstimatedDuration, fileName).ConfigureAwait(false);
+        DeleteLegacySubModuleFile(moduleName, subModuleEstimation.SubModuleName, fileName);
 
         lock (_subModuleIndexLock)
         {
@@ -168,6 +175,52 @@ internal class FileSystemModuleEstimatedTimeProvider : IModuleEstimatedTimeProvi
     }
 
     private static string GetModuleName(Type moduleType) => moduleType.FullName ?? moduleType.Name;
+
+    private static string EncodeSubModuleName(string name)
+    {
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(name))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+
+        return $"{EncodedSubModuleNamePrefix}{base64}";
+    }
+
+    private static string DecodeSubModuleName(string name)
+    {
+        if (!name.StartsWith(EncodedSubModuleNamePrefix, StringComparison.Ordinal))
+        {
+            return name;
+        }
+
+        var base64 = name[EncodedSubModuleNamePrefix.Length..]
+            .Replace('-', '+')
+            .Replace('_', '/');
+        base64 = base64.PadRight(base64.Length + ((4 - (base64.Length % 4)) % 4), '=');
+
+        try
+        {
+            return Encoding.UTF8.GetString(Convert.FromBase64String(base64));
+        }
+        catch (FormatException)
+        {
+            return name;
+        }
+    }
+
+    private void DeleteLegacySubModuleFile(string moduleName, string subModuleName, string encodedFileName)
+    {
+        var legacyFileName = $"Mod-{moduleName}-Sub-{subModuleName}.txt";
+        if (legacyFileName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
+            || legacyFileName.Contains('/')
+            || legacyFileName.Contains('\\')
+            || string.Equals(legacyFileName, encodedFileName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        TryDelete(new FileInfo(Path.Combine(_directory, legacyFileName)));
+    }
 
     private static void TryDelete(FileInfo file)
     {

--- a/src/ModularPipelines/Engine/ModuleExecutionContext.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionContext.cs
@@ -36,7 +36,6 @@ internal class ModuleExecutionContext : IModuleExecutionContext
         ModuleType = moduleType;
         Stopwatch = new Stopwatch();
         ModuleCancellationTokenSource = new CancellationTokenSource();
-        SubModules = new List<SubModuleTracker>();
     }
 
     /// <summary>
@@ -92,11 +91,6 @@ internal class ModuleExecutionContext : IModuleExecutionContext
     /// to combine external and engine-level cancellation.
     /// </remarks>
     public CancellationTokenSource ModuleCancellationTokenSource { get; set; }
-
-    /// <summary>
-    /// Gets the list of sub-module trackers.
-    /// </summary>
-    public List<SubModuleTracker> SubModules { get; }
 
     /// <summary>
     /// Gets or sets the matrix target value for this module instance, if it was expanded via MatrixTargetAttribute.
@@ -251,8 +245,6 @@ internal interface IModuleExecutionContext
     Stopwatch Stopwatch { get; }
 
     CancellationTokenSource ModuleCancellationTokenSource { get; set; }
-
-    List<SubModuleTracker> SubModules { get; }
 
     Task<IModuleResult> ExecutionTask { get; }
 

--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Runtime.CompilerServices;
 using EnumerableAsyncProcessor.Extensions;
 using Microsoft.Extensions.Options;
@@ -140,9 +139,7 @@ internal class ModuleRetriever
             {
                 var estimatedTime = await _estimatedTimeProvider.GetModuleEstimatedTimeAsync(module.GetType());
 
-                var subModules = await _estimatedTimeProvider.GetSubModuleEstimatedTimesAsync(module.GetType());
-
-                return new RunnableModule(module, estimatedTime, subModules.ToImmutableList());
+                return new RunnableModule(module, estimatedTime);
             })
             .ProcessInParallel();
 

--- a/src/ModularPipelines/Engine/SubModuleTracker.cs
+++ b/src/ModularPipelines/Engine/SubModuleTracker.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using ModularPipelines.Enums;
+using ModularPipelines.Modules;
 
 namespace ModularPipelines.Engine;
 
@@ -12,45 +13,14 @@ namespace ModularPipelines.Engine;
 /// This class is internal because it is only used within the engine infrastructure
 /// and is not intended for direct use by external consumers.
 /// </remarks>
-internal class SubModuleTracker
+internal sealed class SubModuleTracker : SubModuleBase
 {
     private readonly Stopwatch _stopwatch = new();
 
     public SubModuleTracker(string name, Type parentModuleType)
+        : base(parentModuleType, name)
     {
-        Name = name;
-        ParentModuleType = parentModuleType;
     }
-
-    /// <summary>
-    /// Gets the name of this sub-operation.
-    /// </summary>
-    public string Name { get; }
-
-    /// <summary>
-    /// Gets the type of the parent module.
-    /// </summary>
-    public Type ParentModuleType { get; }
-
-    /// <summary>
-    /// Gets the current status.
-    /// </summary>
-    public Status Status { get; private set; } = Status.NotYetStarted;
-
-    /// <summary>
-    /// Gets when the sub-operation started.
-    /// </summary>
-    public DateTimeOffset StartTime { get; private set; }
-
-    /// <summary>
-    /// Gets when the sub-operation ended.
-    /// </summary>
-    public DateTimeOffset EndTime { get; private set; }
-
-    /// <summary>
-    /// Gets the duration of the sub-operation.
-    /// </summary>
-    public TimeSpan Duration { get; private set; }
 
     /// <summary>
     /// Executes an action and tracks its progress.

--- a/src/ModularPipelines/Models/RunnableModule.cs
+++ b/src/ModularPipelines/Models/RunnableModule.cs
@@ -2,4 +2,4 @@ using ModularPipelines.Modules;
 
 namespace ModularPipelines.Models;
 
-internal record RunnableModule(IModule Module, TimeSpan EstimatedDuration, ICollection<SubModuleEstimation> SubModuleEstimations);
+internal record RunnableModule(IModule Module, TimeSpan EstimatedDuration);

--- a/src/ModularPipelines/Modules/SubModuleBase.cs
+++ b/src/ModularPipelines/Modules/SubModuleBase.cs
@@ -8,8 +8,6 @@ internal abstract class SubModuleBase
 
     public string Name { get; }
 
-    public abstract Task CallbackTask { get; }
-
     internal Status Status { get; set; } = Status.NotYetStarted;
 
     internal TimeSpan Duration { get; set; }

--- a/test/ModularPipelines.UnitTests/Context/ModuleContextSubModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ModuleContextSubModuleTests.cs
@@ -1,0 +1,112 @@
+using Mediator;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Events;
+using ModularPipelines.Logging;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Context;
+
+public class ModuleContextSubModuleTests
+{
+    [Test]
+    public async Task SubModule_PublishesLifecycleAndSavesDuration()
+    {
+        var module = Mock.Of<IModule>();
+        var executionContext = new ModuleExecutionContext(module, module.GetType());
+        var mediator = new Mock<IMediator>();
+        var estimatedTimeProvider = new Mock<ISafeModuleEstimatedTimeProvider>();
+        var expectedEstimate = TimeSpan.FromSeconds(12);
+        SubModuleCreatedNotification? created = null;
+        SubModuleCompletedNotification? completed = null;
+        SubModuleEstimation? saved = null;
+
+        mediator
+            .Setup(x => x.Publish(It.IsAny<SubModuleCreatedNotification>(), It.IsAny<CancellationToken>()))
+            .Callback<SubModuleCreatedNotification, CancellationToken>((notification, _) => created = notification)
+            .Returns(ValueTask.CompletedTask);
+        mediator
+            .Setup(x => x.Publish(It.IsAny<SubModuleCompletedNotification>(), It.IsAny<CancellationToken>()))
+            .Callback<SubModuleCompletedNotification, CancellationToken>((notification, _) => completed = notification)
+            .Returns(ValueTask.CompletedTask);
+        estimatedTimeProvider
+            .Setup(x => x.GetSubModuleEstimatedTimesAsync(module.GetType()))
+            .ReturnsAsync([new SubModuleEstimation("Compile", expectedEstimate)]);
+        estimatedTimeProvider
+            .Setup(x => x.SaveSubModuleTimeAsync(module.GetType(), It.IsAny<SubModuleEstimation>()))
+            .Callback<Type, SubModuleEstimation>((_, estimation) => saved = estimation)
+            .Returns(Task.CompletedTask);
+        var context = CreateContext(module, executionContext, mediator.Object, estimatedTimeProvider.Object);
+
+        var result = await context.SubModule("Compile", () => Task.FromResult(42));
+
+        await Assert.That(result).IsEqualTo(42);
+        await Assert.That(created).IsNotNull();
+        await Assert.That(created!.ParentModule).IsSameReferenceAs(module);
+        await Assert.That(created.SubModule.Name).IsEqualTo("Compile");
+        await Assert.That(created.EstimatedDuration).IsEqualTo(expectedEstimate);
+        await Assert.That(completed).IsNotNull();
+        await Assert.That(completed!.SubModule).IsSameReferenceAs(created.SubModule);
+        await Assert.That(completed.IsSuccessful).IsTrue();
+        await Assert.That(saved).IsNotNull();
+        await Assert.That(saved!.SubModuleName).IsEqualTo("Compile");
+        await Assert.That(saved.EstimatedDuration).IsEqualTo(created.SubModule.Duration);
+    }
+
+    [Test]
+    public async Task SubModule_FailurePublishesCompletionWithoutSavingDuration()
+    {
+        var module = Mock.Of<IModule>();
+        var executionContext = new ModuleExecutionContext(module, module.GetType());
+        var mediator = new Mock<IMediator>();
+        var estimatedTimeProvider = new Mock<ISafeModuleEstimatedTimeProvider>();
+        var expectedException = new InvalidOperationException("Submodule failed");
+        SubModuleCreatedNotification? created = null;
+        SubModuleCompletedNotification? completed = null;
+
+        mediator
+            .Setup(x => x.Publish(It.IsAny<SubModuleCreatedNotification>(), It.IsAny<CancellationToken>()))
+            .Callback<SubModuleCreatedNotification, CancellationToken>((notification, _) => created = notification)
+            .Returns(ValueTask.CompletedTask);
+        mediator
+            .Setup(x => x.Publish(It.IsAny<SubModuleCompletedNotification>(), It.IsAny<CancellationToken>()))
+            .Callback<SubModuleCompletedNotification, CancellationToken>((notification, _) => completed = notification)
+            .Returns(ValueTask.CompletedTask);
+        estimatedTimeProvider
+            .Setup(x => x.GetSubModuleEstimatedTimesAsync(module.GetType()))
+            .ReturnsAsync([]);
+        var context = CreateContext(module, executionContext, mediator.Object, estimatedTimeProvider.Object);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => context.SubModule<int>("Fail", () => Task.FromException<int>(expectedException)));
+
+        await Assert.That(exception).IsSameReferenceAs(expectedException);
+        await Assert.That(created).IsNotNull();
+        await Assert.That(created!.EstimatedDuration).IsEqualTo(TimeSpan.FromMinutes(2));
+        await Assert.That(completed).IsNotNull();
+        await Assert.That(completed!.IsSuccessful).IsFalse();
+        estimatedTimeProvider.Verify(
+            x => x.SaveSubModuleTimeAsync(It.IsAny<Type>(), It.IsAny<SubModuleEstimation>()),
+            Times.Never);
+    }
+
+    private static ModuleContext CreateContext(
+        IModule module,
+        ModuleExecutionContext executionContext,
+        IMediator mediator,
+        ISafeModuleEstimatedTimeProvider estimatedTimeProvider)
+    {
+        var pipelineContext = new Mock<IPipelineContext>();
+        pipelineContext.As<IInternalPipelineContext>();
+
+        return new ModuleContext(
+            pipelineContext.Object,
+            module,
+            executionContext,
+            Mock.Of<IModuleLogger>(),
+            mediator,
+            estimatedTimeProvider);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Context/ModuleContextSubModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ModuleContextSubModuleTests.cs
@@ -92,6 +92,37 @@ public class ModuleContextSubModuleTests
             Times.Never);
     }
 
+    [Test]
+    public async Task SubModule_LoadsEstimatesOncePerModuleExecution()
+    {
+        var module = Mock.Of<IModule>();
+        var executionContext = new ModuleExecutionContext(module, module.GetType());
+        var mediator = new Mock<IMediator>();
+        var estimatedTimeProvider = new Mock<ISafeModuleEstimatedTimeProvider>();
+
+        mediator
+            .Setup(x => x.Publish(It.IsAny<SubModuleCreatedNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+        mediator
+            .Setup(x => x.Publish(It.IsAny<SubModuleCompletedNotification>(), It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+        estimatedTimeProvider
+            .Setup(x => x.GetSubModuleEstimatedTimesAsync(module.GetType()))
+            .ReturnsAsync([]);
+        estimatedTimeProvider
+            .Setup(x => x.SaveSubModuleTimeAsync(module.GetType(), It.IsAny<SubModuleEstimation>()))
+            .Returns(Task.CompletedTask);
+        var context = CreateContext(module, executionContext, mediator.Object, estimatedTimeProvider.Object);
+
+        await Task.WhenAll(
+            context.SubModule("First", () => Task.CompletedTask),
+            context.SubModule("Second", () => Task.CompletedTask));
+
+        estimatedTimeProvider.Verify(
+            x => x.GetSubModuleEstimatedTimesAsync(module.GetType()),
+            Times.Once);
+    }
+
     private static ModuleContext CreateContext(
         IModule module,
         ModuleExecutionContext executionContext,

--- a/test/ModularPipelines.UnitTests/Engine/FileSystemModuleEstimatedTimeProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/FileSystemModuleEstimatedTimeProviderTests.cs
@@ -93,6 +93,46 @@ public class FileSystemModuleEstimatedTimeProviderTests
     }
 
     [Test]
+    public async Task SaveSubModuleTime_EncodesUnsafeNameAndRestoresOriginalName()
+    {
+        await RunWithTemporaryDirectoryAsync(async directory =>
+        {
+            const string subModuleName = "Build src/api:release";
+            var duration = TimeSpan.FromSeconds(3);
+            var provider = CreateProvider(directory);
+
+            await provider.SaveSubModuleTimeAsync(
+                typeof(PrefixModule),
+                new SubModuleEstimation(subModuleName, duration));
+            var estimations = (await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModule))).ToArray();
+
+            await Assert.That(Directory.GetFiles(directory)).HasSingleItem();
+            await Assert.That(estimations).HasSingleItem();
+            await Assert.That(estimations[0].SubModuleName).IsEqualTo(subModuleName);
+            await Assert.That(estimations[0].EstimatedDuration).IsEqualTo(duration);
+        });
+    }
+
+    [Test]
+    public async Task SaveSubModuleTime_ReplacesLegacyFileForSameName()
+    {
+        await RunWithTemporaryDirectoryAsync(async directory =>
+        {
+            WriteEstimation(directory, typeof(PrefixModule), "legacy", TimeSpan.FromSeconds(1));
+            var provider = CreateProvider(directory);
+
+            await provider.SaveSubModuleTimeAsync(
+                typeof(PrefixModule),
+                new SubModuleEstimation("legacy", TimeSpan.FromSeconds(2)));
+            var estimations = (await provider.GetSubModuleEstimatedTimesAsync(typeof(PrefixModule))).ToArray();
+
+            await Assert.That(Directory.GetFiles(directory)).HasSingleItem();
+            await Assert.That(estimations).HasSingleItem();
+            await Assert.That(estimations[0].EstimatedDuration).IsEqualTo(TimeSpan.FromSeconds(2));
+        });
+    }
+
+    [Test]
     public async Task GetSubModuleEstimatedTimes_RefreshesExpiredDirectoryIndex()
     {
         await RunWithTemporaryDirectoryAsync(async directory =>

--- a/test/ModularPipelines.UnitTests/Engine/IgnoredModuleResultRegistrarTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/IgnoredModuleResultRegistrarTests.cs
@@ -33,7 +33,7 @@ public class IgnoredModuleResultRegistrarTests
             var dependency = new ForeignOperatingSystemModule();
             var dependent = new CrossPlatformDependentModule();
             var organizedModules = new OrganizedModules(
-                [new RunnableModule(dependent, TimeSpan.Zero, [])],
+                [new RunnableModule(dependent, TimeSpan.Zero)],
                 [new IgnoredModule(dependency, SkipDecision.Skip("Unavailable on this worker"))]);
             var contextProvider = new Mock<IPipelineContextProvider>();
             contextProvider


### PR DESCRIPTION
## Summary
- publish submodule created/completed notifications around `IModuleContext.SubModule` execution
- load persisted submodule estimates at execution time and save successful durations
- make `SubModuleTracker` the progress lifecycle object and remove dead execution-context/startup estimate storage
- add focused success and failure lifecycle regression coverage

## Validation
- `ModuleContextSubModuleTests`: 2/2 passed
- affected existing suites: 23/23 passed
- `ModularPipelines.sln` Release build: 0 warnings, 0 errors
- changed-file whitespace verification passed

Closes #3462