### PR TITLE
Isolate artifact lifecycle test paths

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
@@ -292,9 +292,11 @@ public class Module2 : Module<string>
             using ModularPipelines.Attributes;
 
             namespace Example;
+
             public class Dependency : Module<string>
             {
-                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
             }
 
             [DependsOn<Dependency>]
@@ -308,7 +310,8 @@ public class Module2 : Module<string>
                     }
                 }
 
-                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
             }
             """.ReplaceLineEndings("\n");
         var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId)

--- a/src/ModularPipelines/Distributed/Artifacts/ArtifactLifecycleManager.cs
+++ b/src/ModularPipelines/Distributed/Artifacts/ArtifactLifecycleManager.cs
@@ -15,6 +15,7 @@ internal class ArtifactLifecycleManager
     private readonly IDistributedArtifactStore _store;
     private readonly ArtifactOptions _options;
     private readonly ILogger<ArtifactLifecycleManager> _logger;
+    private readonly string _workingDirectory;
 
     /// <summary>
     /// Tracks completed and in-flight restores keyed by "{producerType}:{artifactName}:{normalizedRestorePath}".
@@ -26,10 +27,20 @@ internal class ArtifactLifecycleManager
         IDistributedArtifactStore store,
         IOptions<ArtifactOptions> options,
         ILogger<ArtifactLifecycleManager> logger)
+        : this(store, options, logger, Directory.GetCurrentDirectory())
+    {
+    }
+
+    internal ArtifactLifecycleManager(
+        IDistributedArtifactStore store,
+        IOptions<ArtifactOptions> options,
+        ILogger<ArtifactLifecycleManager> logger,
+        string workingDirectory)
     {
         _store = store;
         _options = options.Value;
         _logger = logger;
+        _workingDirectory = Path.GetFullPath(workingDirectory);
     }
 
     /// <summary>
@@ -148,7 +159,7 @@ internal class ArtifactLifecycleManager
         foreach (var attr in attributes)
         {
             var producerTypeName = attr.ProducerModule.FullName!;
-            var restorePath = attr.RestorePath ?? Directory.GetCurrentDirectory();
+            var restorePath = attr.RestorePath ?? _workingDirectory;
             await DownloadConsumedArtifactsForPathAsync(producerTypeName, attr.ArtifactName, restorePath, moduleType, cancellationToken);
         }
     }
@@ -165,14 +176,14 @@ internal class ArtifactLifecycleManager
         Type consumerModuleType,
         CancellationToken cancellationToken)
     {
-        var normalizedPath = Path.GetFullPath(restorePath);
+        var normalizedPath = ResolvePath(restorePath);
         var restoreKey = $"{producerTypeName}:{artifactName}:{normalizedPath}";
 
         // Use CancellationToken.None for the shared download so one caller's cancellation
         // doesn't abort the download for other modules consuming the same artifact.
         var lazyTask = _completedRestores.GetOrAdd(
             restoreKey,
-            _ => new Lazy<Task>(() => RestoreArtifactAsync(producerTypeName, artifactName, restorePath, consumerModuleType, CancellationToken.None)));
+            _ => new Lazy<Task>(() => RestoreArtifactAsync(producerTypeName, artifactName, normalizedPath, consumerModuleType, CancellationToken.None)));
 
         try
         {
@@ -237,8 +248,10 @@ internal class ArtifactLifecycleManager
     /// Resolves a path pattern to concrete paths. Supports simple glob patterns.
     /// Returns a list of matched files/directories.
     /// </summary>
-    internal static IReadOnlyList<string> ResolvePathPattern(string pathPattern)
+    internal IReadOnlyList<string> ResolvePathPattern(string pathPattern)
     {
+        pathPattern = ResolvePath(pathPattern);
+
         // If the path exists directly, return it
         if (Directory.Exists(pathPattern) || File.Exists(pathPattern))
         {
@@ -281,4 +294,7 @@ internal class ArtifactLifecycleManager
         var dirMatches = Directory.GetDirectories(baseDir, searchPattern, SearchOption.AllDirectories);
         return dirMatches;
     }
+
+    private string ResolvePath(string path) =>
+        Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(_workingDirectory, path));
 }

--- a/test/ModularPipelines.Distributed.UnitTests/Artifacts/ArtifactLifecycleManagerTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Artifacts/ArtifactLifecycleManagerTests.cs
@@ -40,6 +40,13 @@ public class ArtifactLifecycleManagerTests
     [Test]
     public async Task UploadProducedArtifacts_Scans_Attributes()
     {
+        var workingDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"artifact-upload-test-{Guid.NewGuid():N}");
+        var artifactDirectory = Path.Combine(workingDirectory, "test-output");
+        Directory.CreateDirectory(artifactDirectory);
+        File.WriteAllText(Path.Combine(artifactDirectory, "test.txt"), "hello");
+
         var mockStore = new Mock<IDistributedArtifactStore>();
         var expectedRef = new ArtifactReference("id1", "build-output", typeof(ProducerModule).FullName!, 100, "application/octet-stream", DateTimeOffset.UtcNow);
         mockStore
@@ -48,32 +55,23 @@ public class ArtifactLifecycleManagerTests
 
         var options = Microsoft.Extensions.Options.Options.Create(new ArtifactOptions());
         var logger = Mock.Of<ILogger<ArtifactLifecycleManager>>();
-        var manager = new ArtifactLifecycleManager(mockStore.Object, options, logger);
-
-        // Create a temporary directory to match the path pattern
-        var tempDir = Path.Combine(Path.GetTempPath(), "test-output");
-        Directory.CreateDirectory(tempDir);
-        File.WriteAllText(Path.Combine(tempDir, "test.txt"), "hello");
+        var manager = new ArtifactLifecycleManager(
+            mockStore.Object,
+            options,
+            logger,
+            workingDirectory);
 
         try
         {
-            // Change to temp parent so "test-output" resolves
-            var originalDir = Directory.GetCurrentDirectory();
-            Directory.SetCurrentDirectory(Path.GetTempPath());
-            try
-            {
-                var refs = await manager.UploadProducedArtifactsAsync(typeof(ProducerModule), CancellationToken.None);
-                await Assert.That(refs.Count).IsEqualTo(1);
-                await Assert.That(refs[0].Name).IsEqualTo("build-output");
-            }
-            finally
-            {
-                Directory.SetCurrentDirectory(originalDir);
-            }
+            var refs = await manager.UploadProducedArtifactsAsync(
+                typeof(ProducerModule),
+                CancellationToken.None);
+            await Assert.That(refs.Count).IsEqualTo(1);
+            await Assert.That(refs[0].Name).IsEqualTo("build-output");
         }
         finally
         {
-            Directory.Delete(tempDir, true);
+            Directory.Delete(workingDirectory, true);
         }
     }
 
@@ -95,6 +93,10 @@ public class ArtifactLifecycleManagerTests
     [Test]
     public async Task DownloadConsumedArtifacts_Scans_ConsumesAttribute()
     {
+        var workingDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"artifact-download-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workingDirectory);
         var mockStore = new Mock<IDistributedArtifactStore>();
         var artifactRef = new ArtifactReference("id1", "build-output", typeof(ProducerModule).FullName!, 100, "application/octet-stream", DateTimeOffset.UtcNow);
 
@@ -108,12 +110,25 @@ public class ArtifactLifecycleManagerTests
 
         var options = Microsoft.Extensions.Options.Options.Create(new ArtifactOptions());
         var logger = Mock.Of<ILogger<ArtifactLifecycleManager>>();
-        var manager = new ArtifactLifecycleManager(mockStore.Object, options, logger);
+        var manager = new ArtifactLifecycleManager(
+            mockStore.Object,
+            options,
+            logger,
+            workingDirectory);
 
-        await manager.DownloadConsumedArtifactsAsync(typeof(ConsumerModule), CancellationToken.None);
+        try
+        {
+            await manager.DownloadConsumedArtifactsAsync(
+                typeof(ConsumerModule),
+                CancellationToken.None);
 
-        mockStore.Verify(s => s.ListArtifactsAsync(typeof(ProducerModule).FullName!, It.IsAny<CancellationToken>()), Times.Once);
-        mockStore.Verify(s => s.DownloadAsync(artifactRef, It.IsAny<CancellationToken>()), Times.Once);
+            mockStore.Verify(s => s.ListArtifactsAsync(typeof(ProducerModule).FullName!, It.IsAny<CancellationToken>()), Times.Once);
+            mockStore.Verify(s => s.DownloadAsync(artifactRef, It.IsAny<CancellationToken>()), Times.Once);
+        }
+        finally
+        {
+            Directory.Delete(workingDirectory, true);
+        }
     }
 
     [Test]


### PR DESCRIPTION
Closes #3520

- resolve relative artifact paths against an immutable working root
- inject GUID-scoped roots in upload/download lifecycle tests
- remove process-wide current-directory mutation and leaked restore output

Validation:
- ArtifactLifecycleManagerTests: 7/7 passed
- ModularPipelines.sln Release build: 0 warnings, 0 errors