### PR TITLE
Remove unused dynamic scheduler insertion

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersUnitTests.cs
@@ -292,9 +292,11 @@ public class Module2 : Module<string>
             using ModularPipelines.Attributes;
 
             namespace Example;
+
             public class Dependency : Module<string>
             {
-                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
             }
 
             [DependsOn<Dependency>]
@@ -308,7 +310,8 @@ public class Module2 : Module<string>
                     }
                 }
 
-                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken) => Task.FromResult<string?>(null);
+                protected override Task<string?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+                    => Task.FromResult<string?>(null);
             }
             """.ReplaceLineEndings("\n");
         var expected = VerifyCS.Diagnostic(MissingDependsOnAttributeAnalyzer.DiagnosticId)

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -28,7 +28,6 @@ internal class ModuleScheduler : IModuleScheduler
     private readonly IModuleConstraintEvaluator _constraintEvaluator;
     private readonly ISchedulerStatusReporter _statusReporter;
     private readonly ConcurrentDictionary<Type, ModuleState> _moduleStates;
-    private readonly Dictionary<Type, HashSet<Type>> _dependencyGraph;
     private readonly HashSet<ModuleState> _queuedModules;
     private readonly HashSet<ModuleState> _executingModules;
     private readonly ModuleStateQueries _stateQueries;
@@ -65,7 +64,6 @@ internal class ModuleScheduler : IModuleScheduler
         _constraintEvaluator = constraintEvaluator;
         _statusReporter = statusReporter;
         _moduleStates = new ConcurrentDictionary<Type, ModuleState>();
-        _dependencyGraph = new Dictionary<Type, HashSet<Type>>();
         _queuedModules = new HashSet<ModuleState>();
         _executingModules = new HashSet<ModuleState>();
         _stateQueries = new ModuleStateQueries(_moduleStates);
@@ -127,116 +125,6 @@ internal class ModuleScheduler : IModuleScheduler
             "Initialized {Count} modules for scheduling with total of {DependencyCount} dependencies",
             _moduleStates.Count,
             _moduleStates.Values.Sum(x => x.UnresolvedDependencies.Count));
-    }
-
-    /// <summary>
-    /// Adds a new module dynamically (e.g., SubModule discovered during execution).
-    /// </summary>
-    public void AddModule(IModule module)
-    {
-        ArgumentNullException.ThrowIfNull(module);
-
-        if (IsDisposed)
-        {
-            return;
-        }
-
-        var moduleType = module.GetType();
-        ModuleState state;
-
-        // Track unregistered dependencies for logging outside lock
-        List<Type>? unregisteredDependencies = null;
-
-        _stateLock.EnterWriteLock();
-        try
-        {
-            if (_moduleStates.ContainsKey(moduleType))
-            {
-                return;
-            }
-
-            state = new ModuleState(module, moduleType);
-            _metadataRegistry.FinalizeMetadata(moduleType, module);
-
-            var availableModuleTypes = _moduleStates.Keys.Append(moduleType).ToArray();
-            var newModuleDependencies = ModuleDependencyResolver.GetAllDependencies(
-                module,
-                availableModuleTypes,
-                _dependencyRegistry,
-                _metadataRegistry).ToArray();
-            var (newlyAvailableDependenciesByType, selectorDependents) =
-                ResolveNewlyAvailableDependencies(moduleType);
-
-            var newModuleDependencyTypes = newModuleDependencies
-                .Select(dependency => dependency.DependencyType)
-                .ToHashSet();
-
-            ValidateNoDynamicCycle(
-                moduleType,
-                newModuleDependencyTypes,
-                newlyAvailableDependenciesByType.Keys);
-
-            foreach (var (dependencyType, optional) in newModuleDependencies)
-            {
-                ModuleStateDependencyInitializer.Record(state, dependencyType, optional);
-            }
-
-            _moduleStates[moduleType] = state;
-            _stateCounters.AddPendingModule();
-            _dependencyGraph[moduleType] = newModuleDependencyTypes;
-
-            foreach (var selectorDependent in selectorDependents)
-            {
-                _dependencyGraph[selectorDependent].Add(moduleType);
-            }
-
-            foreach (var (existingModuleType, optional) in newlyAvailableDependenciesByType)
-            {
-                var existingState = _moduleStates[existingModuleType];
-                if (existingState.State == ModuleExecutionState.Pending)
-                {
-                    ModuleStateDependencyInitializer.Record(existingState, moduleType, optional);
-                    LinkDependencyState(existingState, moduleType, optional);
-                }
-            }
-
-            foreach (var (dependencyType, optional) in newModuleDependencies)
-            {
-                LinkDependencyState(state, dependencyType, optional);
-            }
-
-            foreach (var (dependencyType, ignoreIfNotRegistered) in newModuleDependencies)
-            {
-                if (!_moduleStates.ContainsKey(dependencyType) && !ignoreIfNotRegistered)
-                {
-                    unregisteredDependencies ??= new List<Type>();
-                    unregisteredDependencies.Add(dependencyType);
-                }
-            }
-        }
-        finally
-        {
-            _stateLock.ExitWriteLock();
-        }
-
-        // Logging outside lock
-        if (unregisteredDependencies != null)
-        {
-            foreach (var dependencyType in unregisteredDependencies)
-            {
-                _logger.LogWarning(
-                    "Dynamically added module {ModuleName} depends on {DependencyName} which is not registered",
-                    moduleType.Name,
-                    dependencyType.Name);
-            }
-        }
-
-        _logger.LogDebug(
-            "Dynamically added module {ModuleName} with {DependencyCount} dependencies",
-            moduleType.Name,
-            state.UnresolvedDependencies.Count);
-
-        _schedulerNotification.Release();
     }
 
     /// <summary>
@@ -363,42 +251,6 @@ internal class ModuleScheduler : IModuleScheduler
         _schedulerNotification.Release();
     }
 
-    private (
-        Dictionary<Type, bool> DependenciesByType,
-        HashSet<Type> SelectorDependents) ResolveNewlyAvailableDependencies(Type moduleType)
-    {
-        var dependenciesByType = new Dictionary<Type, bool>();
-        var selectorDependents = new HashSet<Type>();
-
-        foreach (var existingModuleType in _moduleStates.Keys)
-        {
-            var existingState = _moduleStates[existingModuleType];
-            bool? isOptional = existingState.Dependencies.TryGetValue(moduleType, out var declaredOptional)
-                ? declaredOptional
-                : null;
-
-            var selectorDependencies = ModuleDependencyResolver.GetSelectorDependencies(
-                    existingModuleType,
-                    [moduleType],
-                    _metadataRegistry)
-                .ToArray();
-
-            if (selectorDependencies.Length > 0)
-            {
-                selectorDependents.Add(existingModuleType);
-                isOptional = (isOptional ?? true)
-                             && selectorDependencies.All(dependency => dependency.Optional);
-            }
-
-            if (isOptional is not null)
-            {
-                dependenciesByType[existingModuleType] = isOptional.Value;
-            }
-        }
-
-        return (dependenciesByType, selectorDependents);
-    }
-
     private void AddModuleStates(IEnumerable<IModule> modules)
     {
         foreach (var module in modules)
@@ -485,10 +337,6 @@ internal class ModuleScheduler : IModuleScheduler
             availableModuleTypes,
             _dependencyRegistry,
             _metadataRegistry);
-        _dependencyGraph[state.ModuleType] = dependencies
-            .Select(dependency => dependency.DependencyType)
-            .ToHashSet();
-
         foreach (var (dependencyType, optional) in dependencies)
         {
             LinkDependencyState(state, dependencyType, optional);
@@ -518,95 +366,6 @@ internal class ModuleScheduler : IModuleScheduler
                 state.ModuleType.Name,
                 dependencyType.Name);
         }
-    }
-
-    private void ValidateNoDynamicCycle(
-        Type moduleType,
-        IReadOnlySet<Type> newModuleDependencies,
-        IEnumerable<Type> newlyAvailableDependentTypes)
-    {
-        if (newModuleDependencies.Contains(moduleType))
-        {
-            ThrowDependencyCollision([moduleType, moduleType]);
-        }
-
-        var pendingDependents = newlyAvailableDependentTypes
-            .Where(type => _moduleStates[type].State == ModuleExecutionState.Pending)
-            .ToHashSet();
-        if (pendingDependents.Count == 0)
-        {
-            return;
-        }
-
-        var parentByType = new Dictionary<Type, Type?>
-        {
-            [moduleType] = null,
-        };
-
-        var modulesToVisit = new Stack<Type>();
-        modulesToVisit.Push(moduleType);
-
-        while (modulesToVisit.TryPop(out var currentType))
-        {
-            foreach (var dependencyType in GetPendingDependencies(currentType, moduleType, newModuleDependencies))
-            {
-                if (!parentByType.TryAdd(dependencyType, currentType))
-                {
-                    continue;
-                }
-
-                if (pendingDependents.Contains(dependencyType))
-                {
-                    ThrowDependencyCollision(BuildDynamicCycle(moduleType, dependencyType, parentByType));
-                }
-
-                modulesToVisit.Push(dependencyType);
-            }
-        }
-    }
-
-    private IEnumerable<Type> GetPendingDependencies(
-        Type currentType,
-        Type addedModuleType,
-        IReadOnlySet<Type> newModuleDependencies)
-    {
-        var dependencies = currentType == addedModuleType
-            ? newModuleDependencies
-            : _moduleStates[currentType].State == ModuleExecutionState.Pending
-                ? _dependencyGraph[currentType]
-                : [];
-
-        return dependencies.Where(dependencyType =>
-            dependencyType != addedModuleType
-            && _moduleStates.TryGetValue(dependencyType, out var dependencyState)
-            && dependencyState.State != ModuleExecutionState.Completed);
-    }
-
-    private static Type[] BuildDynamicCycle(
-        Type moduleType,
-        Type dependentType,
-        IReadOnlyDictionary<Type, Type?> parentByType)
-    {
-        var pathFromModule = new Stack<Type>();
-        var currentType = (Type?) dependentType;
-
-        while (currentType is not null && currentType != moduleType)
-        {
-            pathFromModule.Push(currentType);
-            currentType = parentByType[currentType];
-        }
-
-        return [dependentType, moduleType, .. pathFromModule];
-    }
-
-    private static void ThrowDependencyCollision(IReadOnlyList<Type> cycle)
-    {
-        var formattedCycle = cycle.Select(type => type.Name).ToArray();
-        formattedCycle[0] = $"**{formattedCycle[0]}**";
-        formattedCycle[^1] = $"**{formattedCycle[^1]}**";
-
-        throw new DependencyCollisionException(
-            $"Dependency collision detected: {string.Join(" -> ", formattedCycle)}");
     }
 
     private async Task RunSchedulerLoopAsync(CancellationToken cancellationToken)

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging.Abstractions;
-using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Attributes;
@@ -14,10 +13,6 @@ namespace ModularPipelines.UnitTests.Engine;
 
 public class ModuleSchedulerDynamicCycleTests
 {
-    private abstract class DynamicBaseModule : Module<string>
-    {
-    }
-
     [ModularPipelines.Attributes.DependsOn<DynamicModule>(Optional = true)]
     private class ExistingModule : Module<string>
     {
@@ -34,40 +29,6 @@ public class ModuleSchedulerDynamicCycleTests
             CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DynamicModule));
     }
 
-    [ModularPipelines.Attributes.DependsOnAllModulesInheritingFrom<DynamicBaseModule>]
-    private class ExistingPredicateModule : Module<string>
-    {
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(ExistingPredicateModule));
-    }
-
-    [ModularPipelines.Attributes.DependsOn<ExistingPredicateModule>]
-    private class DynamicPredicateModule : DynamicBaseModule
-    {
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DynamicPredicateModule));
-    }
-
-    private class IndependentDynamicModule : DynamicBaseModule
-    {
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(IndependentDynamicModule));
-    }
-
-    private class FluentExistingModule : Module<string>
-    {
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOn<IndependentDynamicModule>()
-            .Build();
-
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(FluentExistingModule));
-    }
-
     private class CompletedDependencyModule : Module<string>
     {
         protected internal override Task<string?> ExecuteAsync(
@@ -81,111 +42,6 @@ public class ModuleSchedulerDynamicCycleTests
         protected internal override Task<string?> ExecuteAsync(
             IModuleContext context,
             CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DeferredConstraintModule));
-    }
-
-    private class ConditionalExistingModule : Module<string>
-    {
-        public bool IncludeDependency { get; set; } = true;
-
-        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
-            .DependsOnIf<CompletedDependencyModule>(IncludeDependency)
-            .Build();
-
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(ConditionalExistingModule));
-    }
-
-    [ModularPipelines.Attributes.DependsOn<CompletedDependencyModule>]
-    private class LateDynamicModule : Module<string>
-    {
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(LateDynamicModule));
-    }
-
-    private sealed class CountingDependsOnAttribute : ModularPipelines.Attributes.DependsOnBaseAttribute
-    {
-        public static int EvaluationCount;
-
-        public override bool ShouldDependOn(Type candidateModule, IDependencyContext context)
-        {
-            Interlocked.Increment(ref EvaluationCount);
-            return candidateModule == typeof(IndependentDynamicModule);
-        }
-    }
-
-    [CountingDependsOn]
-    private class CountingPredicateModule : Module<string>
-    {
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(CountingPredicateModule));
-    }
-
-    private class ExistingCandidateOne : Module<string>
-    {
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(ExistingCandidateOne));
-    }
-
-    private class ExistingCandidateTwo : Module<string>
-    {
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(ExistingCandidateTwo));
-    }
-
-    [ModularPipelines.Attributes.DependsOn<DeepDynamicModule>(Optional = true)]
-    private class DeepExistingModule : Module<string>
-    {
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DeepExistingModule));
-    }
-
-    [ModularPipelines.Attributes.DependsOn<DeepExistingModule>]
-    private class DeepMiddleModule : Module<string>
-    {
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DeepMiddleModule));
-    }
-
-    [ModularPipelines.Attributes.DependsOn<DeepMiddleModule>]
-    private class DeepDynamicModule : Module<string>
-    {
-        protected internal override Task<string?> ExecuteAsync(
-            IModuleContext context,
-            CancellationToken cancellationToken) => Task.FromResult<string?>(nameof(DeepDynamicModule));
-    }
-
-    [Test]
-    public async Task AddModule_WhenModuleIntroducesCycle_ThrowsAndRollsBack()
-    {
-        using var scheduler = CreateScheduler();
-        scheduler.InitializeModules([new ExistingModule()]);
-
-        await Assert.That(() => scheduler.AddModule(new DynamicModule()))
-            .Throws<DependencyCollisionException>()
-            .And.HasMessageEqualTo(
-                "Dependency collision detected: **ExistingModule** -> DynamicModule -> **ExistingModule**");
-        await Assert.That(scheduler.GetModuleState(typeof(DynamicModule))).IsNull();
-    }
-
-    [Test]
-    public async Task AddModule_WhenModuleClosesLongCycle_ThrowsAndRollsBack()
-    {
-        using var scheduler = CreateScheduler();
-        scheduler.InitializeModules([new DeepExistingModule(), new DeepMiddleModule()]);
-
-        await Assert.That(() => scheduler.AddModule(new DeepDynamicModule()))
-            .Throws<DependencyCollisionException>()
-            .And.HasMessageEqualTo(
-                "Dependency collision detected: **DeepExistingModule** -> " +
-                "DeepDynamicModule -> DeepMiddleModule -> **DeepExistingModule**");
-        await Assert.That(scheduler.GetModuleState(typeof(DeepDynamicModule))).IsNull();
     }
 
     [Test]
@@ -309,124 +165,6 @@ public class ModuleSchedulerDynamicCycleTests
             await Assert.That(moduleState.State).IsEqualTo(ModuleExecutionState.Completed);
             await Assert.That(started).IsFalse();
         }
-    }
-
-    [Test]
-    public async Task AddModule_WhenExistingPredicateCreatesCycle_ThrowsAndRollsBack()
-    {
-        using var scheduler = CreateScheduler();
-        scheduler.InitializeModules([new ExistingPredicateModule()]);
-
-        await Assert.That(() => scheduler.AddModule(new DynamicPredicateModule()))
-            .Throws<DependencyCollisionException>();
-        await Assert.That(scheduler.GetModuleState(typeof(DynamicPredicateModule))).IsNull();
-        await Assert.That(scheduler.GetModuleState(typeof(ExistingPredicateModule))!.Dependencies
-            .ContainsKey(typeof(DynamicPredicateModule))).IsFalse();
-    }
-
-    [Test]
-    [Arguments(false)]
-    [Arguments(true)]
-    public async Task AddModule_DoesNotChangeActiveModuleDependencies(bool executing)
-    {
-        using var scheduler = CreateScheduler();
-        scheduler.InitializeModules([new ExistingPredicateModule()]);
-        var existingState = scheduler.GetModuleState(typeof(ExistingPredicateModule))!;
-        existingState.State = executing ? ModuleExecutionState.Executing : ModuleExecutionState.Queued;
-
-        scheduler.AddModule(new DynamicPredicateModule());
-
-        await Assert.That(existingState.Dependencies.ContainsKey(typeof(DynamicPredicateModule))).IsFalse();
-        await Assert.That(existingState.UnresolvedDependencies).DoesNotContain(typeof(DynamicPredicateModule));
-        await Assert.That(scheduler.GetModuleState(typeof(DynamicPredicateModule))!.UnresolvedDependencies)
-            .Contains(typeof(ExistingPredicateModule));
-    }
-
-    [Test]
-    public async Task AddModule_WhenDependencyAlreadyCompleted_IsReady()
-    {
-        using var scheduler = CreateScheduler();
-        scheduler.InitializeModules([new CompletedDependencyModule()]);
-        scheduler.MarkModuleCompleted(typeof(CompletedDependencyModule), success: true);
-
-        scheduler.AddModule(new LateDynamicModule());
-
-        var state = scheduler.GetModuleState(typeof(LateDynamicModule));
-        await Assert.That(state).IsNotNull();
-        await Assert.That(state!.UnresolvedDependencies).IsEmpty();
-        await Assert.That(state.IsReadyToExecute).IsTrue();
-    }
-
-    [Test]
-    public async Task AddModule_DoesNotCreateCycleThroughCompletedDependent()
-    {
-        using var scheduler = CreateScheduler();
-        scheduler.InitializeModules([new ExistingModule()]);
-        scheduler.MarkModuleCompleted(typeof(ExistingModule), success: true);
-
-        scheduler.AddModule(new DynamicModule());
-
-        var state = scheduler.GetModuleState(typeof(DynamicModule));
-        await Assert.That(state).IsNotNull();
-        await Assert.That(state!.IsReadyToExecute).IsTrue();
-    }
-
-    [Test]
-    public async Task AddModule_ReconcilesExistingPredicateDependencies()
-    {
-        using var scheduler = CreateScheduler();
-        scheduler.InitializeModules([new ExistingPredicateModule()]);
-        var existingState = scheduler.GetModuleState(typeof(ExistingPredicateModule))!;
-        var dependencySnapshot = existingState.Dependencies;
-
-        scheduler.AddModule(new IndependentDynamicModule());
-
-        await Assert.That(dependencySnapshot.ContainsKey(typeof(IndependentDynamicModule))).IsFalse();
-        await Assert.That(existingState.Dependencies.ContainsKey(typeof(IndependentDynamicModule))).IsTrue();
-        await Assert.That(existingState.UnresolvedDependencies).Contains(typeof(IndependentDynamicModule));
-    }
-
-    [Test]
-    public async Task AddModule_ReconcilesExistingFluentDependencies()
-    {
-        using var scheduler = CreateScheduler();
-        scheduler.InitializeModules([new FluentExistingModule()]);
-
-        scheduler.AddModule(new IndependentDynamicModule());
-
-        var existingState = scheduler.GetModuleState(typeof(FluentExistingModule));
-        await Assert.That(existingState).IsNotNull();
-        await Assert.That(existingState!.UnresolvedDependencies).Contains(typeof(IndependentDynamicModule));
-    }
-
-    [Test]
-    public async Task AddModule_PreservesInitiallyDeclaredConditionalDependency()
-    {
-        var conditionalModule = new ConditionalExistingModule();
-        using var scheduler = CreateScheduler();
-        scheduler.InitializeModules([new CompletedDependencyModule(), conditionalModule]);
-        conditionalModule.IncludeDependency = false;
-
-        scheduler.AddModule(new IndependentDynamicModule());
-
-        var state = scheduler.GetModuleState(typeof(ConditionalExistingModule));
-        await Assert.That(state).IsNotNull();
-        await Assert.That(state!.UnresolvedDependencies).Contains(typeof(CompletedDependencyModule));
-    }
-
-    [Test]
-    public async Task AddModule_EvaluatesExistingSelectorsOnlyForNewModule()
-    {
-        using var scheduler = CreateScheduler();
-        scheduler.InitializeModules(
-            [new CountingPredicateModule(), new ExistingCandidateOne(), new ExistingCandidateTwo()]);
-        CountingDependsOnAttribute.EvaluationCount = 0;
-
-        scheduler.AddModule(new IndependentDynamicModule());
-
-        await Assert.That(CountingDependsOnAttribute.EvaluationCount).IsEqualTo(1);
-        await Assert.That(scheduler.GetModuleState(typeof(CountingPredicateModule))!.UnresolvedDependencies)
-            .Contains(typeof(IndependentDynamicModule));
     }
 
     private static ModuleScheduler CreateScheduler(


### PR DESCRIPTION
## Summary
- remove the unused `ModuleScheduler.AddModule` mutation path
- delete orphaned dynamic dependency reconciliation and cycle-graph helpers
- remove tests that exercised only the unreachable API while retaining scheduler deadlock/state coverage

## Validation
- remaining scheduler suites: 8/8 passed
- `ModularPipelines.sln` Release build: 0 warnings, 0 errors
- changed-file whitespace verification passed

Closes #3463