### PR TITLE
Resolve Windows scripts from the working directory

### DIFF
--- a/src/ModularPipelines/Helpers/Internal/CliCommandFactory.cs
+++ b/src/ModularPipelines/Helpers/Internal/CliCommandFactory.cs
@@ -13,7 +13,10 @@ internal static class CliCommandFactory
         CommandExecutionOptions? executionOptions = null)
     {
         var argumentList = arguments.ToList();
-        var commandScript = ResolveWindowsCommandScript(tool, executionOptions?.EnvironmentVariables);
+        var commandScript = ResolveWindowsCommandScript(
+            tool,
+            executionOptions?.WorkingDirectory,
+            executionOptions?.EnvironmentVariables);
         if (commandScript is null)
         {
             return ApplyEnvironmentVariables(
@@ -71,6 +74,7 @@ internal static class CliCommandFactory
 
     private static string? ResolveWindowsCommandScript(
         string tool,
+        string? workingDirectory,
         IEnumerable<KeyValuePair<string, string?>>? environmentVariables)
     {
         var path = GetEnvironmentVariable(environmentVariables, "PATH")
@@ -79,7 +83,7 @@ internal static class CliCommandFactory
             ?? Environment.GetEnvironmentVariable("PATHEXT");
         var resolvedCommand = WindowsCommandResolver.Resolve(
             tool,
-            Environment.CurrentDirectory,
+            workingDirectory ?? Environment.CurrentDirectory,
             path,
             pathExtensions);
 

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -227,7 +227,7 @@ public class CommandTests : TestBase
         }
 
         var tempDirectory = Path.Combine(Path.GetTempPath(), "mp runtime command tests", Guid.NewGuid().ToString("N"));
-        var scriptDirectory = Path.Combine(Environment.CurrentDirectory, $"mp-runtime-relative-{Guid.NewGuid():N}");
+        var scriptDirectory = Path.Combine(tempDirectory, "scripts");
         Directory.CreateDirectory(tempDirectory);
         Directory.CreateDirectory(scriptDirectory);
         var scriptPath = Path.Combine(scriptDirectory, "mp-runtime-relative-test.cmd");
@@ -236,13 +236,11 @@ public class CommandTests : TestBase
         {
             await File.WriteAllTextAsync(scriptPath, "@echo off\r\necho %CD%\r\n");
             var command = await GetService<ICommandContext>();
-            var relativeToolPath = Path.ChangeExtension(
-                Path.GetRelativePath(Environment.CurrentDirectory, scriptPath),
-                null);
+            var relativeToolPath = Path.ChangeExtension(Path.Combine("scripts", "mp-runtime-relative-test.cmd"), null);
 
             var resolvedScript = WindowsCommandResolver.Resolve(
                 relativeToolPath,
-                Environment.CurrentDirectory,
+                tempDirectory,
                 pathExtensions: ".COM;.EXE;.BAT;.CMD",
                 isWindows: true);
 
@@ -265,12 +263,11 @@ public class CommandTests : TestBase
         finally
         {
             Directory.Delete(tempDirectory, recursive: true);
-            Directory.Delete(scriptDirectory, recursive: true);
         }
     }
 
     [Test]
-    public async Task ExecuteCommandLineToolAsync_Resolves_Relative_Path_Entries_Before_Changing_Working_Directory()
+    public async Task ExecuteCommandLineToolAsync_Resolves_Relative_Path_Entries_From_Working_Directory()
     {
         if (!OperatingSystem.IsWindows())
         {
@@ -279,7 +276,7 @@ public class CommandTests : TestBase
 
         var workingDirectory = Path.Combine(Path.GetTempPath(), "mp runtime command tests", Guid.NewGuid().ToString("N"));
         var relativeScriptDirectory = $"mp-runtime-path-{Guid.NewGuid():N}";
-        var scriptDirectory = Path.Combine(Environment.CurrentDirectory, relativeScriptDirectory);
+        var scriptDirectory = Path.Combine(workingDirectory, relativeScriptDirectory);
         Directory.CreateDirectory(workingDirectory);
         Directory.CreateDirectory(scriptDirectory);
         var scriptPath = Path.Combine(scriptDirectory, "mp-runtime-path-test.cmd");
@@ -308,7 +305,6 @@ public class CommandTests : TestBase
         finally
         {
             Directory.Delete(workingDirectory, recursive: true);
-            Directory.Delete(scriptDirectory, recursive: true);
         }
     }
 


### PR DESCRIPTION
## Summary
- resolve Windows command scripts relative to CommandExecutionOptions.WorkingDirectory
- interpret relative PATH entries from the configured process directory
- update relative script regression tests to require working-directory resolution

## Validation
- CommandTests: 16/16 passed
- ModularPipelines.sln Release build: 0 warnings, 0 errors

Fixes #3472