### PR TITLE
Fix Git commit log parsing

### DIFF
--- a/src/ModularPipelines.Git/GitCommitMapper.cs
+++ b/src/ModularPipelines.Git/GitCommitMapper.cs
@@ -1,19 +1,23 @@
+using System.Globalization;
 using ModularPipelines.Git.Models;
 
 namespace ModularPipelines.Git;
 
 public class GitCommitMapper : IGitCommitMapper
 {
-    private const int ExpectedLineCount = 10;
+    private const int ExpectedFieldCount = 10;
 
     public GitCommit Map(string commandLineOutput)
     {
-        var lines = commandLineOutput.Split(GitConstants.DotNetLineSeparator, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
+        var lines = commandLineOutput
+            .Split(GitConstants.DotNetLineSeparator, StringSplitOptions.None)
+            .Select(x => x.Trim())
+            .ToArray();
 
-        if (lines.Count < ExpectedLineCount)
+        if (lines.Length != ExpectedFieldCount)
         {
             throw new ArgumentException(
-                $"Git commit output is malformed. Expected at least {ExpectedLineCount} lines but received {lines.Count}. " +
+                $"Git commit output is malformed. Expected exactly {ExpectedFieldCount} fields but received {lines.Length}. " +
                 $"Output: {commandLineOutput}",
                 nameof(commandLineOutput));
         }
@@ -24,13 +28,13 @@ public class GitCommitMapper : IGitCommitMapper
             {
                 Name = lines[0],
                 Email = lines[1],
-                Date = DateTime.Parse(lines[2]),
+                Date = ParseDate(lines[2]),
             },
             Committer = new GitAuthor
             {
                 Name = lines[3],
                 Email = lines[4],
-                Date = DateTime.Parse(lines[5]),
+                Date = ParseDate(lines[5]),
             },
             Hash = new GitHash
             {
@@ -43,5 +47,10 @@ public class GitCommitMapper : IGitCommitMapper
                 Body = lines[9],
             },
         };
+    }
+
+    private static DateTime ParseDate(string value)
+    {
+        return DateTimeOffset.Parse(value, CultureInfo.InvariantCulture).UtcDateTime;
     }
 }

--- a/src/ModularPipelines.Git/GitConstants.cs
+++ b/src/ModularPipelines.Git/GitConstants.cs
@@ -15,9 +15,9 @@ internal static class GitConstants
     /// Using %B would duplicate the subject in the body field.
     /// </remarks>
     public const string CommitLogFormat =
-        $"'%aN {GitEscapedLineSeparator} %aE {GitEscapedLineSeparator} %aI {GitEscapedLineSeparator} " +
+        $"%aN {GitEscapedLineSeparator} %aE {GitEscapedLineSeparator} %aI {GitEscapedLineSeparator} " +
         $"%cN {GitEscapedLineSeparator} %cE {GitEscapedLineSeparator} %cI {GitEscapedLineSeparator} " +
-        $"%H {GitEscapedLineSeparator} %h {GitEscapedLineSeparator} %s {GitEscapedLineSeparator} %b'";
+        $"%H {GitEscapedLineSeparator} %h {GitEscapedLineSeparator} %s {GitEscapedLineSeparator} %b";
 
     /// <summary>
     /// Git format specifier for Unix timestamp of author date.

--- a/test/ModularPipelines.Git.UnitTests/GitCommandsTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitCommandsTests.cs
@@ -1,0 +1,49 @@
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Git.UnitTests;
+
+public class GitCommandsTests
+{
+    [Test]
+    public async Task Commits_Uses_Unquoted_Pretty_Format()
+    {
+        var runner = new RecordingGitCommandRunner(string.Join(
+            "%\n%",
+            "Author",
+            "author@example.com",
+            "2026-07-31T13:00:45Z",
+            "Committer",
+            "committer@example.com",
+            "2026-07-31T12:15:30Z",
+            "0123456789abcdef0123456789abcdef01234567",
+            "0123456",
+            "Subject",
+            string.Empty));
+        var commands = new GitCommands(null!, runner, new GitCommitMapper());
+
+        await foreach (var _ in commands.CommitsAsync())
+        {
+            break;
+        }
+
+        var formatArgument = runner.Commands!.Single(command => command?.StartsWith("--format=", StringComparison.Ordinal) == true);
+        await Assert.That(formatArgument).StartsWith("--format=%aN");
+        await Assert.That(formatArgument).DoesNotContain("'");
+    }
+
+    private sealed class RecordingGitCommandRunner(string output) : IGitCommandRunner
+    {
+        public string?[]? Commands { get; private set; }
+
+        public Task<string> RunCommands(CommandExecutionOptions? commandEnvironmentOptions, params string?[] commands)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<string?> RunCommandsOrNull(CommandExecutionOptions? commandEnvironmentOptions, params string?[] commands)
+        {
+            Commands = commands;
+            return Task.FromResult<string?>(output);
+        }
+    }
+}

--- a/test/ModularPipelines.Git.UnitTests/GitCommitMapperTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitCommitMapperTests.cs
@@ -1,0 +1,77 @@
+namespace ModularPipelines.Git.UnitTests;
+
+public class GitCommitMapperTests
+{
+    private const string Separator = "%\n%";
+
+    private readonly GitCommitMapper _mapper = new();
+
+    [Test]
+    public async Task Maps_Commit_Fields_And_Normalizes_Date_Offsets()
+    {
+        var output = JoinFields(
+            "Author Name",
+            "author@example.com",
+            "2026-07-31T18:30:45+05:30",
+            "Committer Name",
+            "committer@example.com",
+            "2026-07-31T08:15:30-04:00",
+            "0123456789abcdef0123456789abcdef01234567",
+            "0123456",
+            "Commit subject",
+            "Commit body\nwith another line");
+
+        var commit = _mapper.Map(output);
+
+        await Assert.That(commit.Author!.Name).IsEqualTo("Author Name");
+        await Assert.That(commit.Author.Email).IsEqualTo("author@example.com");
+        await Assert.That(commit.Author.Date).IsEqualTo(new DateTime(2026, 7, 31, 13, 0, 45, DateTimeKind.Utc));
+        await Assert.That(commit.Committer!.Name).IsEqualTo("Committer Name");
+        await Assert.That(commit.Committer.Email).IsEqualTo("committer@example.com");
+        await Assert.That(commit.Committer.Date).IsEqualTo(new DateTime(2026, 7, 31, 12, 15, 30, DateTimeKind.Utc));
+        await Assert.That(commit.Hash!.Long).IsEqualTo("0123456789abcdef0123456789abcdef01234567");
+        await Assert.That(commit.Hash.Short).IsEqualTo("0123456");
+        await Assert.That(commit.Message!.Subject).IsEqualTo("Commit subject");
+        await Assert.That(commit.Message.Body).IsEqualTo("Commit body\nwith another line");
+    }
+
+    [Test]
+    public async Task Preserves_Empty_Fields_Without_Shifting_Later_Values()
+    {
+        var output = JoinFields(
+            "Author Name",
+            string.Empty,
+            "2026-07-31T13:00:45Z",
+            "Committer Name",
+            "committer@example.com",
+            "2026-07-31T12:15:30Z",
+            "0123456789abcdef0123456789abcdef01234567",
+            "0123456",
+            "Commit subject",
+            string.Empty);
+
+        var commit = _mapper.Map(output);
+
+        await Assert.That(commit.Author!.Email).IsEmpty();
+        await Assert.That(commit.Committer!.Name).IsEqualTo("Committer Name");
+        await Assert.That(commit.Message!.Subject).IsEqualTo("Commit subject");
+        await Assert.That(commit.Message.Body).IsEmpty();
+    }
+
+    [Test]
+    [Arguments(9)]
+    [Arguments(11)]
+    public async Task Rejects_Unexpected_Field_Count(int fieldCount)
+    {
+        var output = string.Join(Separator, Enumerable.Repeat("value", fieldCount));
+
+        var exception = Assert.Throws<ArgumentException>(() => _mapper.Map(output));
+
+        await Assert.That(exception.Message).Contains("Expected exactly 10 fields");
+    }
+
+    private static string JoinFields(params string[] fields)
+    {
+        return string.Join(Separator, fields);
+    }
+}


### PR DESCRIPTION
## Summary
- remove shell quoting from the argv-based git pretty format
- preserve empty commit fields and reject malformed field counts
- parse ISO author/committer timestamps invariantly and normalize their offsets to UTC
- add mapper and command-format regressions

## Validation
- ModularPipelines.Git.UnitTests: 7/7 passed
- ModularPipelines.Git.sln Release build: 0 warnings, 0 errors
- touched source and test files pass dotnet format verification
- live git-log format check: 10 fields, no literal boundary quotes

Fixes #3470