### PR TITLE
Fix Chocolatey and nvm installer execution

### DIFF
--- a/src/ModularPipelines/Context/PredefinedInstallers.cs
+++ b/src/ModularPipelines/Context/PredefinedInstallers.cs
@@ -90,11 +90,10 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
     /// <inheritdoc/>
     public virtual async Task<CommandResult> ChocolateyAsync()
     {
-        return await _command.ExecuteCommandLineToolAsync(new GenericCommandLineToolOptions("cmd")
+        var result = await _command.ExecuteCommandLineToolAsync(new GenericCommandLineToolOptions("powershell.exe")
         {
             Arguments =
             [
-                @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe",
                 "-NoProfile",
                 "-InputFormat",
                 "None",
@@ -102,11 +101,14 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
                 "Bypass",
                 "-Command",
                 "[System.Net.ServicePointManager]::SecurityProtocol = 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))",
-                "&&",
-                "SET",
-                "PATH=%PATH%;%ALLUSERSPROFILE%\\chocolatey\\bin"
             ],
         }).ConfigureAwait(false);
+
+        var allUsersProfile = _environmentVariables.GetEnvironmentVariable("ALLUSERSPROFILE")
+                              ?? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
+        _environmentVariables.AddToPath(Path.Combine(allUsersProfile, "chocolatey", "bin"));
+
+        return result;
     }
 
     /// <inheritdoc/>
@@ -136,7 +138,7 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
     /// <inheritdoc/>
     public async Task<File?> Nvm(string? version = null)
     {
-        if (OperatingSystem.IsWindows())
+        if (_environmentContext.OperatingSystem == OperatingSystemIdentifier.Windows)
         {
             var nvmWindowsUrl = $"https://github.com/coreybutler/nvm-windows/releases/download/{Versions.NvmWindows}/nvm-noinstall.zip";
             var zipFile = await _downloader.DownloadFileAsync(
@@ -170,11 +172,6 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
 
         await _bash.FromFileAsync(new BashFileOptions(bashScript)).ConfigureAwait(false);
 
-        await _bash.CommandAsync(new BashCommandOptions("export NVM_DIR=\"$HOME/.nvm\"")).ConfigureAwait(false);
-        await _bash.CommandAsync(new BashCommandOptions("[ -s \"$NVM_DIR/nvm.sh\" ] && \\. \"$NVM_DIR/nvm.sh\"")).ConfigureAwait(false);
-        await _bash.CommandAsync(new BashCommandOptions("[ -s \"$NVM_DIR/bash_completion\" ] && \\. \"$NVM_DIR/bash_completion\"")).ConfigureAwait(false);
-        await _bash.CommandAsync(new BashCommandOptions("source ~/.bashrc")).ConfigureAwait(false);
-
         var nvmDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nvm");
         return new File(nvmDir);
     }
@@ -186,7 +183,7 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
 
         await Nvm().ConfigureAwait(false);
 
-        if (OperatingSystem.IsWindows())
+        if (_environmentContext.OperatingSystem == OperatingSystemIdentifier.Windows)
         {
             // Windows: CliWrap handles argument escaping automatically via WithArguments()
             return await _command.ExecuteCommandLineToolAsync(new GenericCommandLineToolOptions("nvm")
@@ -197,7 +194,9 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
 
         // Linux/Mac: Use shell escaping since BashCommandOptions uses string interpolation.
         var escapedVersion = ShellArgumentEscaper.Escape(version);
-        return await _bash.CommandAsync(new BashCommandOptions($"nvm install {escapedVersion}")).ConfigureAwait(false);
+        return await _bash.CommandAsync(new BashCommandOptions(
+            $"export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && nvm install {escapedVersion}"))
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/test/ModularPipelines.UnitTests/Helpers/PredefinedInstallersTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/PredefinedInstallersTests.cs
@@ -1,0 +1,141 @@
+using ModularPipelines.Context;
+using ModularPipelines.Context.Domains.Environment;
+using ModularPipelines.Context.Domains.Files;
+using ModularPipelines.Context.Domains.Installers;
+using ModularPipelines.Context.Domains.Network;
+using ModularPipelines.Context.Domains.Shell;
+using ModularPipelines.FileSystem;
+using ModularPipelines.Models;
+using ModularPipelines.Options;
+using Moq;
+using File = ModularPipelines.FileSystem.File;
+
+namespace ModularPipelines.UnitTests.Helpers;
+
+public class PredefinedInstallersTests
+{
+    [Test]
+    public async Task Chocolatey_Runs_PowerShell_Directly_And_Adds_Install_Directory_To_Path()
+    {
+        const string allUsersProfile = @"C:\ProgramData";
+        CommandLineToolOptions? capturedOptions = null;
+        var result = CreateResult();
+        var command = new Mock<ICommandContext>();
+        command.Setup(context => context.ExecuteCommandLineToolAsync(
+                It.IsAny<CommandLineToolOptions>(),
+                It.IsAny<CommandExecutionOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<CommandLineToolOptions, CommandExecutionOptions?, CancellationToken>(
+                (options, _, _) => capturedOptions = options)
+            .ReturnsAsync(result);
+        var environmentVariables = new Mock<IEnvironmentVariablesContext>();
+        environmentVariables.Setup(context => context.GetEnvironmentVariable(
+                "ALLUSERSPROFILE",
+                EnvironmentVariableTarget.Process))
+            .Returns(allUsersProfile);
+        var installer = CreateInstaller(
+            command.Object,
+            Mock.Of<IEnvironmentContext>(),
+            Mock.Of<IDownloaderContext>(),
+            Mock.Of<IBashContext>(),
+            environmentVariables.Object);
+
+        var actualResult = await installer.ChocolateyAsync();
+
+        var options = (GenericCommandLineToolOptions) capturedOptions!;
+        var arguments = options.Arguments!.ToArray();
+        using (Assert.Multiple())
+        {
+            await Assert.That(actualResult).IsSameReferenceAs(result);
+            await Assert.That(options.Tool).IsEqualTo("powershell.exe");
+            await Assert.That(arguments).Contains("-Command");
+            await Assert.That(arguments).DoesNotContain("&&");
+            await Assert.That(arguments).DoesNotContain("SET");
+        }
+
+        environmentVariables.Verify(context => context.AddToPath(
+            Path.Combine(allUsersProfile, "chocolatey", "bin"),
+            EnvironmentVariableTarget.Process), Times.Once);
+    }
+
+    [Test]
+    public async Task Node_On_Unix_Sources_Nvm_And_Installs_In_One_Bash_Process()
+    {
+        var result = CreateResult();
+        BashCommandOptions? capturedOptions = null;
+        var environment = new Mock<IEnvironmentContext>();
+        environment.SetupGet(context => context.OperatingSystem).Returns(OperatingSystemIdentifier.Linux);
+        var downloadedScript = new File(Path.Combine(Path.GetTempPath(), "nvm-install.sh"));
+        var downloader = new Mock<IDownloaderContext>();
+        downloader.Setup(context => context.DownloadFileAsync(
+                It.IsAny<DownloadFileOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(downloadedScript);
+        var bash = new Mock<IBashContext>();
+        bash.Setup(context => context.FromFileAsync(
+                It.IsAny<BashFileOptions>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+        bash.Setup(context => context.CommandAsync(
+                It.IsAny<BashCommandOptions>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<BashCommandOptions, CancellationToken>((options, _) => capturedOptions = options)
+            .ReturnsAsync(result);
+        var installer = CreateInstaller(
+            Mock.Of<ICommandContext>(),
+            environment.Object,
+            downloader.Object,
+            bash.Object,
+            Mock.Of<IEnvironmentVariablesContext>());
+
+        var actualResult = await installer.NodeAsync("lts/iron");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(actualResult).IsSameReferenceAs(result);
+            await Assert.That(capturedOptions!.Command).IsEqualTo(
+                "export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && nvm install 'lts/iron'");
+        }
+
+        bash.Verify(context => context.FromFileAsync(
+            It.Is<BashFileOptions>(options => options.FilePath == downloadedScript.Path),
+            It.IsAny<CancellationToken>()), Times.Once);
+        bash.Verify(context => context.CommandAsync(
+            It.IsAny<BashCommandOptions>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static PredefinedInstallers CreateInstaller(
+        ICommandContext command,
+        IEnvironmentContext environment,
+        IDownloaderContext downloader,
+        IBashContext bash,
+        IEnvironmentVariablesContext environmentVariables)
+    {
+        return new PredefinedInstallers(
+            command,
+            environment,
+            downloader,
+            Mock.Of<IMacInstallerContext>(),
+            Mock.Of<IWindowsInstallerContext>(),
+            Mock.Of<ILinuxInstallerContext>(),
+            bash,
+            Mock.Of<IZipContext>(),
+            environmentVariables);
+    }
+
+    private static CommandResult CreateResult()
+    {
+        var timestamp = DateTimeOffset.UtcNow;
+        return new CommandResult(
+            "installer",
+            Environment.CurrentDirectory,
+            string.Empty,
+            string.Empty,
+            new Dictionary<string, string?>(),
+            timestamp,
+            timestamp,
+            TimeSpan.Zero,
+            0);
+    }
+}


### PR DESCRIPTION
## Summary
- invoke Chocolatey's install script through powershell.exe directly
- append the resolved Chocolatey bin directory to the parent process PATH after success
- source nvm and install Node in one Bash process on Unix
- use injected OS context so both platform paths are deterministic and testable

## Validation
- PredefinedInstallersTests: 2/2 passed
- ModularPipelines.sln Release build: 0 warnings, 0 errors
- touched files pass whitespace and warning-analyzer verification

Fixes #3473