### PR TITLE
Detect derived secret attributes in generated metadata

### DIFF
--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -201,16 +201,15 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     continue;
                 }
 
-                var secretAttribute = FindAttribute(
-                    property,
-                    attribute => IsAttribute(attribute, SecretValueAttributeFullName));
+                var secretAttribute = FindAttribute(property, IsSecretAttribute);
                 if (secretAttribute is null)
                 {
                     continue;
                 }
 
                 hasAttributes = true;
-                if (!IsPropertyAccessible(property, currentAssembly))
+                if (!IsAttribute(secretAttribute, SecretValueAttributeFullName)
+                    || !IsPropertyAccessible(property, currentAssembly))
                 {
                     isComplete = false;
                     continue;
@@ -500,6 +499,10 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         var name = attribute.AttributeClass?.ToDisplayString();
         return name == CliArgumentAttributeFullName || name == CliFlagAttributeFullName || name == CliOptionAttributeFullName;
     }
+
+    private static bool IsSecretAttribute(AttributeData attribute) =>
+        attribute.AttributeClass is { } attributeClass
+        && InheritsFrom(attributeClass, SecretValueAttributeFullName);
 
     private static bool IsAttribute(AttributeData attribute, string fullName) =>
         attribute.AttributeClass?.ToDisplayString() == fullName;

--- a/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
@@ -16,7 +16,7 @@ public class IncompleteMetadataDiagnosticTests
             public sealed class CliOptionAttribute(string name) : System.Attribute;
 
             [System.AttributeUsage(System.AttributeTargets.Property)]
-            public sealed class SecretValueAttribute(params string[] keys) : System.Attribute;
+            public class SecretValueAttribute(params string[] keys) : System.Attribute;
         }
         """;
 
@@ -65,6 +65,42 @@ public class IncompleteMetadataDiagnosticTests
             result,
             "MPG0004",
             "global::Secrets");
+    }
+
+    [Test]
+    public async Task Derived_Secret_Attribute_Marks_Metadata_Incomplete()
+    {
+        var result = GeneratorTestRunner.Run(
+            new CommandOptionsGenerator(),
+            CommandInfrastructure,
+            """
+            public sealed class NamedSecretAttribute
+                : ModularPipelines.Attributes.SecretValueAttribute
+            {
+                public NamedSecretAttribute() : base("password")
+                {
+                }
+            }
+
+            public sealed class Secrets
+            {
+                [ModularPipelines.Attributes.SecretValue]
+                public string Token { get; } = "";
+
+                [NamedSecret]
+                public string Password { get; } = "";
+            }
+            """);
+
+        await AssertIncompleteDiagnostic(
+            result,
+            "MPG0004",
+            "global::Secrets");
+
+        var generatedSource = result.GeneratedTrees.Single().ToString();
+        await Assert.That(generatedSource).Contains("new(\"Token\"");
+        await Assert.That(generatedSource).DoesNotContain("new(\"Password\"");
+        await Assert.That(generatedSource).Contains("isComplete: false");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- recognize SecretValueAttribute subclasses during secret metadata analysis
- mark derived-attribute metadata incomplete so runtime reflection preserves subclass constructor semantics
- add direct-plus-derived regression coverage for generated fallback metadata

## Validation
- IncompleteMetadataDiagnosticTests: 11/11 passed
- ModularPipelines.sln Release build: 0 warnings, 0 errors
- touched-file whitespace verification passed
- full source-generator test project exceeded the mandated 2 GB local guard (exit 137); CI will run that scope

Closes #3505