### PR TITLE
Modernize the pipeline template entry point

### DIFF
--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -9,9 +9,7 @@ using TemplatePipeline.Settings;
 var pipelineDirectory = PipelineProjectDirectory.Find();
 Environment.CurrentDirectory = pipelineDirectory;
 
-// PipelineBuilder became disposable in v4; retain compatibility with earlier package versions.
-var builder = Pipeline.CreateBuilder(args);
-using var builderLifetime = ((object)builder) as IDisposable;
+using var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
     .AddJsonFile(Path.Combine(pipelineDirectory, "appsettings.json"), optional: false)


### PR DESCRIPTION
Closes #3496.

## Summary
- use `using var builder = Pipeline.CreateBuilder(args)` in the shipped template
- remove the cross-version `object`/`IDisposable` compatibility cast
- retain the already-modern `context.Tools.DotNet` module API

## Validation
- `ModularPipelines.Templates.slnx` Release build: 0 warnings, 0 errors
- template NuGet pack succeeded
- inspected packed `Program.cs` and version-substituted `Directory.Packages.props`