### PR TITLE
Replace skipped FTP tests with loopback server

### DIFF
--- a/test/ModularPipelines.Ftp.UnitTests/Helpers/FtpTests.cs
+++ b/test/ModularPipelines.Ftp.UnitTests/Helpers/FtpTests.cs
@@ -8,45 +8,70 @@ using File = ModularPipelines.FileSystem.File;
 
 namespace ModularPipelines.Ftp.UnitTests.Helpers;
 
-[Skip("FTP tests flaky due to server load")]
 public class FtpTests : TestBase
 {
     [Test]
-    [NotInParallel(nameof(FtpTests), Order = 1)]
     public async Task Can_Download()
     {
+        await using var ftpServer = LocalFtpServer.Start();
         var ftp = await GetService<IFtp>();
 
-        var client = await ftp.GetFtpClientAsync(new FtpOptions("ftp.pureftpd.org", new NetworkCredential())
-        {
-            ClientConfigurator = client => { },
-        });
+        var client = await ftp.GetFtpClientAsync(CreateOptions(ftpServer.Port));
 
         var localPath = File.GetNewTemporaryFilePath();
 
-        var response = await client.DownloadFile(localPath, "/6jack/README.markdown");
-
-        var fileContents = await localPath.ReadAsync();
-
-        using (Assert.Multiple())
+        try
         {
-            await Assert.That(response).IsEqualTo(FtpStatus.Success);
-            await Assert.That(fileContents).StartsWith("6jack");
+            var response = await client.DownloadFile(
+                localPath,
+                LocalFtpServer.RemotePath,
+                FtpLocalExists.Overwrite);
+            var fileContents = await localPath.ReadAsync();
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(response).IsEqualTo(FtpStatus.Success);
+                await Assert.That(fileContents).IsEqualTo(LocalFtpServer.Contents);
+                await Assert.That(ftpServer.Commands).Contains(command =>
+                    command.Equals($"RETR {LocalFtpServer.RemotePath}", StringComparison.Ordinal));
+            }
+        }
+        finally
+        {
+            if (localPath.Exists)
+            {
+                localPath.Delete();
+            }
         }
     }
 
     [Test]
     public async Task Client_Is_Disposed_Properly()
     {
+        await using var ftpServer = LocalFtpServer.Start();
         var ftp = await GetService<IFtp>();
 
-        var client = await ftp.GetFtpClientAsync(new FtpOptions("ftp.pureftpd.org", new NetworkCredential())
-        {
-            ClientConfigurator = client => { },
-        });
+        var client = await ftp.GetFtpClientAsync(CreateOptions(ftpServer.Port));
         await Assert.That(client.IsDisposed).IsFalse();
 
         await Disposer.DisposeObjectAsync(ftp);
         await Assert.That(client.IsDisposed).IsTrue();
+    }
+
+    private static FtpOptions CreateOptions(int port)
+    {
+        return new FtpOptions("127.0.0.1", new NetworkCredential("user", "password"))
+        {
+            ClientConfigurator = client =>
+            {
+                client.Port = port;
+                client.Config.EncryptionMode = FtpEncryptionMode.None;
+                client.Config.DataConnectionType = FtpDataConnectionType.PASV;
+                client.Config.InternetProtocolVersions = FtpIpVersion.IPv4;
+                client.Config.ConnectTimeout = 5_000;
+                client.Config.ReadTimeout = 5_000;
+                client.Config.DataConnectionConnectTimeout = 5_000;
+            },
+        };
     }
 }

--- a/test/ModularPipelines.Ftp.UnitTests/Helpers/FtpTests.cs
+++ b/test/ModularPipelines.Ftp.UnitTests/Helpers/FtpTests.cs
@@ -2,9 +2,9 @@ using System.Net;
 using FluentFTP;
 using ModularPipelines.Ftp;
 using ModularPipelines.Ftp.Options;
+using ModularPipelines.FileSystem;
 using ModularPipelines.TestHelpers;
 using Disposer = ModularPipelines.Helpers.Disposer;
-using File = ModularPipelines.FileSystem.File;
 
 namespace ModularPipelines.Ftp.UnitTests.Helpers;
 
@@ -18,30 +18,20 @@ public class FtpTests : TestBase
 
         var client = await ftp.GetFtpClientAsync(CreateOptions(ftpServer.Port));
 
-        var localPath = File.GetNewTemporaryFilePath();
+        await using var tempFile = new TempFile();
 
-        try
-        {
-            var response = await client.DownloadFile(
-                localPath,
-                LocalFtpServer.RemotePath,
-                FtpLocalExists.Overwrite);
-            var fileContents = await localPath.ReadAsync();
+        var response = await client.DownloadFile(
+            tempFile.File,
+            LocalFtpServer.RemotePath,
+            FtpLocalExists.Overwrite);
+        var fileContents = await tempFile.File.ReadAsync();
 
-            using (Assert.Multiple())
-            {
-                await Assert.That(response).IsEqualTo(FtpStatus.Success);
-                await Assert.That(fileContents).IsEqualTo(LocalFtpServer.Contents);
-                await Assert.That(ftpServer.Commands).Contains(command =>
-                    command.Equals($"RETR {LocalFtpServer.RemotePath}", StringComparison.Ordinal));
-            }
-        }
-        finally
+        using (Assert.Multiple())
         {
-            if (localPath.Exists)
-            {
-                localPath.Delete();
-            }
+            await Assert.That(response).IsEqualTo(FtpStatus.Success);
+            await Assert.That(fileContents).IsEqualTo(LocalFtpServer.Contents);
+            await Assert.That(ftpServer.Commands).Contains(command =>
+                command.Equals($"RETR {LocalFtpServer.RemotePath}", StringComparison.Ordinal));
         }
     }
 

--- a/test/ModularPipelines.Ftp.UnitTests/Helpers/LocalFtpServer.cs
+++ b/test/ModularPipelines.Ftp.UnitTests/Helpers/LocalFtpServer.cs
@@ -1,0 +1,181 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace ModularPipelines.Ftp.UnitTests.Helpers;
+
+internal sealed class LocalFtpServer : IAsyncDisposable
+{
+    public const string RemotePath = "/fixture.txt";
+    public const string Contents = "local FTP fixture\r\n";
+
+    private static readonly byte[] ContentBytes = Encoding.UTF8.GetBytes(Contents);
+    private readonly CancellationTokenSource _cancellationTokenSource = new(TimeSpan.FromSeconds(15));
+    private readonly ConcurrentQueue<string> _commands = new();
+    private readonly TcpListener _listener;
+    private readonly Task _serverTask;
+    private TcpListener? _dataListener;
+
+    private LocalFtpServer()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        _serverTask = RunAsync(_cancellationTokenSource.Token);
+    }
+
+    public int Port => ((IPEndPoint) _listener.LocalEndpoint).Port;
+
+    public IReadOnlyCollection<string> Commands => _commands.ToArray();
+
+    public static LocalFtpServer Start() => new();
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cancellationTokenSource.CancelAsync();
+        _dataListener?.Stop();
+        _listener.Stop();
+        await _serverTask;
+        _cancellationTokenSource.Dispose();
+    }
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                using var client = await _listener.AcceptTcpClientAsync(cancellationToken);
+                await ServeClientAsync(client, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (SocketException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task ServeClientAsync(TcpClient client, CancellationToken cancellationToken)
+    {
+        await using var stream = client.GetStream();
+        using var reader = new StreamReader(stream, Encoding.ASCII);
+        await using var writer = new StreamWriter(stream, Encoding.ASCII)
+        {
+            AutoFlush = true,
+            NewLine = "\r\n",
+        };
+
+        await writer.WriteLineAsync("220 localhost FTP ready");
+
+        while (await reader.ReadLineAsync(cancellationToken) is { } command)
+        {
+            _commands.Enqueue(command);
+            var separator = command.IndexOf(' ');
+            var verb = (separator < 0 ? command : command[..separator]).ToUpperInvariant();
+            var argument = separator < 0 ? string.Empty : command[(separator + 1)..];
+
+            switch (verb)
+            {
+                case "USER":
+                    await writer.WriteLineAsync("331 Password required");
+                    break;
+                case "PASS":
+                    await writer.WriteLineAsync("230 Logged on");
+                    break;
+                case "FEAT":
+                    await writer.WriteLineAsync("211-Extensions supported:");
+                    await writer.WriteLineAsync(" EPSV");
+                    await writer.WriteLineAsync(" MDTM");
+                    await writer.WriteLineAsync(" SIZE");
+                    await writer.WriteLineAsync(" UTF8");
+                    await writer.WriteLineAsync("211 End");
+                    break;
+                case "SYST":
+                    await writer.WriteLineAsync("215 UNIX Type: L8");
+                    break;
+                case "PWD":
+                    await writer.WriteLineAsync("257 \"/\" is current directory");
+                    break;
+                case "TYPE":
+                case "OPTS":
+                case "NOOP":
+                    await writer.WriteLineAsync("200 Command okay");
+                    break;
+                case "SIZE":
+                    await writer.WriteLineAsync(argument == RemotePath
+                        ? $"213 {ContentBytes.Length}"
+                        : "550 File unavailable");
+                    break;
+                case "MDTM":
+                    await writer.WriteLineAsync(argument == RemotePath
+                        ? "213 20260101000000"
+                        : "550 File unavailable");
+                    break;
+                case "REST":
+                    await writer.WriteLineAsync("350 Restart position accepted");
+                    break;
+                case "PASV":
+                    await StartPassiveListenerAsync(writer, extended: false);
+                    break;
+                case "EPSV":
+                    await StartPassiveListenerAsync(writer, extended: true);
+                    break;
+                case "RETR":
+                    await SendFileAsync(writer, argument, cancellationToken);
+                    break;
+                case "AUTH":
+                    await writer.WriteLineAsync("502 TLS not supported");
+                    break;
+                case "QUIT":
+                    await writer.WriteLineAsync("221 Bye");
+                    return;
+                default:
+                    await writer.WriteLineAsync("200 Command okay");
+                    break;
+            }
+        }
+    }
+
+    private async Task StartPassiveListenerAsync(StreamWriter writer, bool extended)
+    {
+        _dataListener?.Stop();
+        _dataListener = new TcpListener(IPAddress.Loopback, 0);
+        _dataListener.Start();
+        var port = ((IPEndPoint) _dataListener.LocalEndpoint).Port;
+
+        await writer.WriteLineAsync(extended
+            ? $"229 Entering Extended Passive Mode (|||{port}|)"
+            : $"227 Entering Passive Mode (127,0,0,1,{port / 256},{port % 256})");
+    }
+
+    private async Task SendFileAsync(
+        StreamWriter writer,
+        string remotePath,
+        CancellationToken cancellationToken)
+    {
+        if (remotePath != RemotePath)
+        {
+            await writer.WriteLineAsync("550 File unavailable");
+            return;
+        }
+
+        if (_dataListener is null)
+        {
+            await writer.WriteLineAsync("425 Use PASV or EPSV first");
+            return;
+        }
+
+        await writer.WriteLineAsync("150 Opening binary data connection");
+        using var dataClient = await _dataListener.AcceptTcpClientAsync(cancellationToken);
+        await using (var dataStream = dataClient.GetStream())
+        {
+            await dataStream.WriteAsync(ContentBytes, cancellationToken);
+        }
+
+        _dataListener.Stop();
+        _dataListener = null;
+        await writer.WriteLineAsync("226 Transfer complete");
+    }
+}

--- a/test/ModularPipelines.Ftp.UnitTests/Helpers/LocalFtpServer.cs
+++ b/test/ModularPipelines.Ftp.UnitTests/Helpers/LocalFtpServer.cs
@@ -16,7 +16,6 @@ internal sealed class LocalFtpServer : IAsyncDisposable
     private readonly ConcurrentQueue<string> _commands = new();
     private readonly TcpListener _listener;
     private readonly Task _serverTask;
-    private TcpListener? _dataListener;
 
     private LocalFtpServer()
     {
@@ -34,7 +33,6 @@ internal sealed class LocalFtpServer : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         await _cancellationTokenSource.CancelAsync();
-        _dataListener?.Stop();
         _listener.Stop();
         await _serverTask;
         await Task.WhenAll(_clientTasks);
@@ -88,6 +86,7 @@ internal sealed class LocalFtpServer : IAsyncDisposable
             AutoFlush = true,
             NewLine = "\r\n",
         };
+        using var session = new FtpSession(writer);
 
         await writer.WriteLineAsync("220 localhost FTP ready");
 
@@ -139,13 +138,13 @@ internal sealed class LocalFtpServer : IAsyncDisposable
                     await writer.WriteLineAsync("350 Restart position accepted");
                     break;
                 case "PASV":
-                    await StartPassiveListenerAsync(writer, extended: false);
+                    await session.StartPassiveListenerAsync(extended: false);
                     break;
                 case "EPSV":
-                    await StartPassiveListenerAsync(writer, extended: true);
+                    await session.StartPassiveListenerAsync(extended: true);
                     break;
                 case "RETR":
-                    await SendFileAsync(writer, argument, cancellationToken);
+                    await session.SendFileAsync(argument, cancellationToken);
                     break;
                 case "AUTH":
                     await writer.WriteLineAsync("502 TLS not supported");
@@ -160,44 +159,48 @@ internal sealed class LocalFtpServer : IAsyncDisposable
         }
     }
 
-    private async Task StartPassiveListenerAsync(StreamWriter writer, bool extended)
+    private sealed class FtpSession(StreamWriter writer) : IDisposable
     {
-        _dataListener?.Stop();
-        _dataListener = new TcpListener(IPAddress.Loopback, 0);
-        _dataListener.Start();
-        var port = ((IPEndPoint) _dataListener.LocalEndpoint).Port;
+        private TcpListener? _dataListener;
 
-        await writer.WriteLineAsync(extended
-            ? $"229 Entering Extended Passive Mode (|||{port}|)"
-            : $"227 Entering Passive Mode (127,0,0,1,{port / 256},{port % 256})");
-    }
-
-    private async Task SendFileAsync(
-        StreamWriter writer,
-        string remotePath,
-        CancellationToken cancellationToken)
-    {
-        if (remotePath != RemotePath)
+        public async Task StartPassiveListenerAsync(bool extended)
         {
-            await writer.WriteLineAsync("550 File unavailable");
-            return;
+            _dataListener?.Stop();
+            _dataListener = new TcpListener(IPAddress.Loopback, 0);
+            _dataListener.Start();
+            var port = ((IPEndPoint) _dataListener.LocalEndpoint).Port;
+
+            await writer.WriteLineAsync(extended
+                ? $"229 Entering Extended Passive Mode (|||{port}|)"
+                : $"227 Entering Passive Mode (127,0,0,1,{port / 256},{port % 256})");
         }
 
-        if (_dataListener is null)
+        public async Task SendFileAsync(string remotePath, CancellationToken cancellationToken)
         {
-            await writer.WriteLineAsync("425 Use PASV or EPSV first");
-            return;
+            if (remotePath != RemotePath)
+            {
+                await writer.WriteLineAsync("550 File unavailable");
+                return;
+            }
+
+            if (_dataListener is null)
+            {
+                await writer.WriteLineAsync("425 Use PASV or EPSV first");
+                return;
+            }
+
+            await writer.WriteLineAsync("150 Opening binary data connection");
+            using var dataClient = await _dataListener.AcceptTcpClientAsync(cancellationToken);
+            await using (var dataStream = dataClient.GetStream())
+            {
+                await dataStream.WriteAsync(ContentBytes, cancellationToken);
+            }
+
+            _dataListener.Stop();
+            _dataListener = null;
+            await writer.WriteLineAsync("226 Transfer complete");
         }
 
-        await writer.WriteLineAsync("150 Opening binary data connection");
-        using var dataClient = await _dataListener.AcceptTcpClientAsync(cancellationToken);
-        await using (var dataStream = dataClient.GetStream())
-        {
-            await dataStream.WriteAsync(ContentBytes, cancellationToken);
-        }
-
-        _dataListener.Stop();
-        _dataListener = null;
-        await writer.WriteLineAsync("226 Transfer complete");
+        public void Dispose() => _dataListener?.Stop();
     }
 }

--- a/test/ModularPipelines.Ftp.UnitTests/Helpers/LocalFtpServer.cs
+++ b/test/ModularPipelines.Ftp.UnitTests/Helpers/LocalFtpServer.cs
@@ -12,6 +12,7 @@ internal sealed class LocalFtpServer : IAsyncDisposable
 
     private static readonly byte[] ContentBytes = Encoding.UTF8.GetBytes(Contents);
     private readonly CancellationTokenSource _cancellationTokenSource = new(TimeSpan.FromSeconds(15));
+    private readonly ConcurrentBag<Task> _clientTasks = [];
     private readonly ConcurrentQueue<string> _commands = new();
     private readonly TcpListener _listener;
     private readonly Task _serverTask;
@@ -26,7 +27,7 @@ internal sealed class LocalFtpServer : IAsyncDisposable
 
     public int Port => ((IPEndPoint) _listener.LocalEndpoint).Port;
 
-    public IReadOnlyCollection<string> Commands => _commands.ToArray();
+    public IReadOnlyCollection<string> Commands => [.. _commands];
 
     public static LocalFtpServer Start() => new();
 
@@ -36,6 +37,7 @@ internal sealed class LocalFtpServer : IAsyncDisposable
         _dataListener?.Stop();
         _listener.Stop();
         await _serverTask;
+        await Task.WhenAll(_clientTasks);
         _cancellationTokenSource.Dispose();
     }
 
@@ -45,8 +47,8 @@ internal sealed class LocalFtpServer : IAsyncDisposable
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                using var client = await _listener.AcceptTcpClientAsync(cancellationToken);
-                await ServeClientAsync(client, cancellationToken);
+                var client = await _listener.AcceptTcpClientAsync(cancellationToken);
+                _clientTasks.Add(ServeClientSafelyAsync(client, cancellationToken));
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -54,6 +56,26 @@ internal sealed class LocalFtpServer : IAsyncDisposable
         }
         catch (SocketException) when (cancellationToken.IsCancellationRequested)
         {
+        }
+    }
+
+    private async Task ServeClientSafelyAsync(TcpClient client, CancellationToken cancellationToken)
+    {
+        using (client)
+        {
+            try
+            {
+                await ServeClientAsync(client, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (IOException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (SocketException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
         }
     }
 

--- a/test/ModularPipelines.Ftp.UnitTests/Helpers/LocalFtpServer.cs
+++ b/test/ModularPipelines.Ftp.UnitTests/Helpers/LocalFtpServer.cs
@@ -11,7 +11,7 @@ internal sealed class LocalFtpServer : IAsyncDisposable
     public const string Contents = "local FTP fixture\r\n";
 
     private static readonly byte[] ContentBytes = Encoding.UTF8.GetBytes(Contents);
-    private readonly CancellationTokenSource _cancellationTokenSource = new(TimeSpan.FromSeconds(15));
+    private readonly CancellationTokenSource _cancellationTokenSource = new();
     private readonly ConcurrentBag<Task> _clientTasks = [];
     private readonly ConcurrentQueue<string> _commands = new();
     private readonly TcpListener _listener;


### PR DESCRIPTION
Closes #3529.

## Summary
- replace the permanently skipped public-server tests with a loopback FTP stub
- exercise FluentFTP `AutoConnect`, passive-mode download, and response content
- verify `IFtp` disposes tracked clients
- remove external network/server-load dependence and clean temporary output

## Validation
- focused FtpTests: 2/2 passed
- FTP integration Release build: 0 warnings, 0 errors
- test-project whitespace verification passed