### PR TITLE
Add non-generic Module base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,13 @@ public class BuildModule : Module<BuildInfo>
 
 // PublishModule retrieves and uses it
 [DependsOn<BuildModule>]
-public class PublishModule : Module<None>
+public class PublishModule : Module
 {
-    protected override async Task<None> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
         var buildResult = await context.GetModule<BuildModule>();
         var outputPath = buildResult.Value.OutputPath; // Throws with module context if unavailable
         // Publish using the build output...
-        return None.Value;
     }
 }
 ```

--- a/README_Template.md
+++ b/README_Template.md
@@ -86,14 +86,13 @@ public class BuildModule : Module<BuildInfo>
 
 // PublishModule retrieves and uses it
 [DependsOn<BuildModule>]
-public class PublishModule : Module<None>
+public class PublishModule : Module
 {
-    protected override async Task<None> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
         var buildResult = await context.GetModule<BuildModule>();
         var outputPath = buildResult.Value.OutputPath; // Throws with module context if unavailable
         // Publish using the build output...
-        return None.Value;
     }
 }
 ```

--- a/docs/docs/how-to/defining-modules.md
+++ b/docs/docs/how-to/defining-modules.md
@@ -24,22 +24,22 @@ public class FindAFileModule : Module<FileInfo>
 
 ### Modules Without Return Values
 
-For modules that perform actions without returning meaningful data, use `Module<None>`:
+For modules that perform actions without returning meaningful data, use the non-generic `Module`:
 
 ```csharp
-public class CleanupModule : Module<None>
+public class CleanupModule : Module
 {
-    protected override async Task<None> ExecuteAsync(
+    protected override Task ExecuteAsync(
         IModuleContext context, CancellationToken cancellationToken)
     {
         var folder = context.Files.GetFolder("./temp");
         folder.Delete();
-        return None.Value;
+        return Task.CompletedTask;
     }
 }
 ```
 
-For synchronous operations, use `SyncModule<None>`:
+For synchronous operations, `SyncModule<None>` remains available:
 
 ```csharp
 public class LoggingModule : SyncModule<None>
@@ -53,7 +53,8 @@ public class LoggingModule : SyncModule<None>
 }
 ```
 
-The `None` struct represents the absence of a value. It is semantically equivalent to `null`, meaning `None.Value.Equals(null)` returns `true`.
+The pipeline represents a non-generic module's successful result internally with `None.Value`.
+You only need to return that sentinel yourself when using `SyncModule<None>`.
 
 ## Configuring Module Behavior
 

--- a/docs/docs/how-to/execution-and-dependencies.md
+++ b/docs/docs/how-to/execution-and-dependencies.md
@@ -13,7 +13,7 @@ These can chain together as appropriate. And it'll detect if two modules depend 
 
 ```csharp
 [DependsOn<Module1>] // F#: [<DependsOn(typeof<Module1>)>]
-public class Module2 : Module<None>
+public class Module2 : Module
 {
     ...
 }

--- a/docs/docs/how-to/run-conditions.md
+++ b/docs/docs/how-to/run-conditions.md
@@ -22,7 +22,7 @@ Apply the condition with an attribute that states its intent:
 
 ```csharp
 [RunIfAll<ServiceIsAvailable>]
-public class DeployModule : Module<None>
+public class DeployModule : Module
 ```
 
 - `[SkipIf<T>]` skips when the condition is `true`.
@@ -42,7 +42,7 @@ Built-in platform conditions include `OnLinux`, `OnWindows`, and `OnMacOS`:
 
 ```csharp
 [RunIfAll<OnLinux>]
-public class LinuxModule : Module<None>
+public class LinuxModule : Module
 ```
 
 One-off conditions can use `Configure().WithSkipWhen(...)`.

--- a/src/ModularPipelines/Models/None.cs
+++ b/src/ModularPipelines/Models/None.cs
@@ -5,8 +5,9 @@ namespace ModularPipelines.Models;
 /// </summary>
 /// <remarks>
 /// This is similar to <c>void</c> but can be used as a generic type parameter.
-/// Use <see cref="Modules.Module{T}"/> with <see cref="None"/> for modules that perform
-/// actions without returning results.
+/// The non-generic <see cref="Modules.Module"/> uses <see cref="None"/> internally for modules
+/// that perform actions without returning results. Use <see cref="Modules.SyncModule{T}"/> with
+/// <see cref="None"/> for synchronous modules without a result value.
 /// </remarks>
 public readonly struct None : IEquatable<None>, IEquatable<None?>
 {

--- a/src/ModularPipelines/Modules/Module.cs
+++ b/src/ModularPipelines/Modules/Module.cs
@@ -34,6 +34,9 @@ namespace ModularPipelines.Modules;
 /// Dependencies can be declared through <see cref="Configure"/> or statically via
 /// <see cref="Attributes.DependsOnAttribute"/> attributes.
 /// </para>
+/// <para>
+/// Inherit from the non-generic <see cref="Module"/> when the module does not return a value.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code>

--- a/src/ModularPipelines/Modules/NonGenericModule.cs
+++ b/src/ModularPipelines/Modules/NonGenericModule.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel;
+using ModularPipelines.Context;
+using ModularPipelines.Models;
+
+namespace ModularPipelines.Modules;
+
+/// <summary>
+/// A pipeline module that performs work without returning a value.
+/// </summary>
+/// <remarks>
+/// Use <see cref="Module"/> for cleanup, notification, publishing, and other operations
+/// where dependent modules do not need a result value.
+/// </remarks>
+/// <example>
+/// <code>
+/// public class CleanupModule : Module
+/// {
+///     protected override Task ExecuteAsync(
+///         IModuleContext context,
+///         CancellationToken cancellationToken)
+///     {
+///         context.Files.GetFolder("./temp").Delete();
+///         return Task.CompletedTask;
+///     }
+/// }
+/// </code>
+/// </example>
+public abstract class Module : NonGenericModuleAdapter
+{
+    /// <summary>
+    /// Executes the module's core logic.
+    /// </summary>
+    /// <param name="context">The module context providing access to pipeline services.</param>
+    /// <param name="cancellationToken">A token that is cancelled if the pipeline fails or the module times out.</param>
+    /// <returns>A task representing the operation.</returns>
+    protected abstract new Task ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    protected sealed override Task ExecuteWithoutResultAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken) =>
+        ExecuteAsync(context, cancellationToken);
+}
+
+/// <summary>
+/// Infrastructure adapter for non-generic modules.
+/// </summary>
+/// <remarks>Inherit from <see cref="Module"/> instead.</remarks>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public abstract class NonGenericModuleAdapter : Module<None>
+{
+    /// <summary>
+    /// Executes the non-generic module implementation.
+    /// </summary>
+    protected abstract Task ExecuteWithoutResultAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken);
+
+    /// <inheritdoc />
+    protected internal sealed override async Task<None> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        await ExecuteWithoutResultAsync(context, cancellationToken).ConfigureAwait(false);
+        return None.Value;
+    }
+}

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -108,15 +108,14 @@ public static class CurrentApiSnippets
     }
 
     [DependsOn<BuildModule>]
-    public sealed class PublishModule : Module<None>
+    public sealed class PublishModule : Module
     {
-        protected override async Task<None> ExecuteAsync(
+        protected override async Task ExecuteAsync(
             IModuleContext context,
             CancellationToken cancellationToken)
         {
             var buildResult = await context.GetModule<BuildModule>();
             _ = buildResult.Value.OutputPath;
-            return None.Value;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
+++ b/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
@@ -71,9 +71,8 @@ public class DocumentationSnippetTests
         var repositoryRoot = FindRepositoryRoot();
         string[] currentApiShape =
         [
-            "PublishModule : Module<None>",
-            "protected override async Task<None> ExecuteAsync(",
-            "return None.Value;",
+            "PublishModule : Module",
+            "protected override async Task ExecuteAsync(",
         ];
         var compiledFixture = await File.ReadAllTextAsync(Path.Combine(
                 repositoryRoot,

--- a/test/ModularPipelines.UnitTests/Modules/ExecutionApiSurfaceTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/ExecutionApiSurfaceTests.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
+using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using PipelineModule = ModularPipelines.Modules.Module;
 
 namespace ModularPipelines.UnitTests.Modules;
 
@@ -12,6 +14,12 @@ public class ExecutionApiSurfaceTests
         var moduleExecuteAsync = typeof(Module<>).GetMethod(
             "ExecuteAsync",
             BindingFlags.Instance | BindingFlags.NonPublic);
+        var nonGenericModuleExecuteAsync = typeof(PipelineModule).GetMethod(
+            "ExecuteAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+        var nonGenericAdapterExecuteAsync = typeof(NonGenericModuleAdapter).GetMethod(
+            "ExecuteAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
         var syncModuleMethods = typeof(SyncModule<>).GetMethods(
             BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
         var syncExecute = syncModuleMethods.SingleOrDefault(static method => method.Name == "Execute");
@@ -25,10 +33,17 @@ public class ExecutionApiSurfaceTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(assembly.GetType("ModularPipelines.Modules.Module")).IsNull();
+            await Assert.That(assembly.GetType("ModularPipelines.Modules.Module")).IsEqualTo(typeof(PipelineModule));
             await Assert.That(assembly.GetType("ModularPipelines.Modules.SyncModule")).IsNull();
             await Assert.That(moduleExecuteAsync).IsNotNull();
             await Assert.That(moduleExecuteAsync!.IsAbstract).IsTrue();
+            await Assert.That(nonGenericModuleExecuteAsync).IsNotNull();
+            await Assert.That(nonGenericModuleExecuteAsync!.IsAbstract).IsTrue();
+            await Assert.That(nonGenericModuleExecuteAsync.ReturnType).IsEqualTo(typeof(Task));
+            await Assert.That(nonGenericAdapterExecuteAsync).IsNotNull();
+            await Assert.That(nonGenericAdapterExecuteAsync!.IsFinal).IsTrue();
+            await Assert.That(nonGenericAdapterExecuteAsync.ReturnType).IsEqualTo(typeof(Task<None>));
+            await Assert.That(typeof(Module<None>).IsAssignableFrom(typeof(PipelineModule))).IsTrue();
             await Assert.That(syncExecute).IsNotNull();
             await Assert.That(syncExecute!.IsAbstract).IsTrue();
             await Assert.That(duplicateSyncHooks).IsEmpty();

--- a/test/ModularPipelines.UnitTests/Modules/NonGenericModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/NonGenericModuleTests.cs
@@ -1,0 +1,40 @@
+using ModularPipelines.Context;
+using ModularPipelines.Enums;
+using ModularPipelines.Interfaces;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.TestHelpers;
+
+namespace ModularPipelines.UnitTests.Modules;
+
+public class NonGenericModuleTests : TestBase
+{
+    [Test]
+    public async Task Executes_And_Produces_None_Result()
+    {
+        var module = await RunModule<TestModule>();
+        var result = await module;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(module.ExecutionCount).IsEqualTo(1);
+            await Assert.That(result.ModuleStatus).IsEqualTo(Status.Successful);
+            await Assert.That(result.ValueOrDefault).IsEqualTo(None.Value);
+            await Assert.That(((IModule) module).ResultType).IsEqualTo(typeof(None));
+        }
+    }
+
+    private sealed class TestModule : Module
+    {
+        public int ExecutionCount { get; private set; }
+
+        protected override async Task ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            cancellationToken.ThrowIfCancellationRequested();
+            ExecutionCount++;
+        }
+    }
+}


### PR DESCRIPTION
Closes #3492.

## Summary

- add a non-generic `Module` base for modules that return no meaningful value
- expose `protected abstract Task ExecuteAsync(IModuleContext, CancellationToken)` to module authors
- seal the infrastructure adapter that awaits the operation and returns `None.Value` to the existing `Module<None>` engine path
- migrate README, compiled snippets, and current how-to docs away from `Module<None>` for asynchronous void modules
- retain `SyncModule<None>` for synchronous void modules

## Design

C# cannot overload methods by return type alone, so a hidden `NonGenericModuleAdapter : Module<None>` owns the sealed `Task<None>` bridge while `Module` exposes the user-facing `Task ExecuteAsync` override. Generic `Module<T>` keeps its abstract compile-time contract unchanged.

## Validation

- `ModularPipelines.sln` Release build: passed, 0 warnings/errors
- `ModularPipelines.UnitTests` Release build: passed, 0 warnings/errors
- `NonGenericModuleTests`: 1/1 passed
- `ExecutionApiSurfaceTests`: 1/1 passed
- `DocumentationSnippetTests`: 4/4 passed