### PR TITLE
Fix compilation regressions from module scheduling changes

### DIFF
--- a/src/ModularPipelines.Testing/ModuleTester.cs
+++ b/src/ModularPipelines.Testing/ModuleTester.cs
@@ -1,3 +1,4 @@
+using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -176,7 +177,15 @@ public class ModuleTestBuilder<TModule>
 
         var pipelineContext = pipeline.Services.GetRequiredService<IPipelineContext>();
         var logger = GetModuleLogger(pipeline.Services);
-        var moduleContext = new ModuleContext(pipelineContext, module, executionContext, logger);
+        var mediator = pipeline.Services.GetRequiredService<IMediator>();
+        var estimatedTimeProvider = pipeline.Services.GetRequiredService<ISafeModuleEstimatedTimeProvider>();
+        var moduleContext = new ModuleContext(
+            pipelineContext,
+            module,
+            executionContext,
+            logger,
+            mediator,
+            estimatedTimeProvider);
         var executionPipeline = pipeline.Services.GetRequiredService<IModuleExecutionPipeline>();
         var executor = ModuleExecutionDelegateFactory.GetExecutor(module.ResultType);
 

--- a/test/ModularPipelines.UnitTests/Console/ProgressSessionTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ProgressSessionTests.cs
@@ -32,7 +32,7 @@ public class ProgressSessionTests
         var coordinator = CreateCoordinator(outputCoordinator.Object, console);
         var module = new RenderingModule();
         var organizedModules = new OrganizedModules(
-            [new RunnableModule(module, TimeSpan.Zero, [])],
+            [new RunnableModule(module, TimeSpan.Zero)],
             []);
         await using var session = new ProgressSession(
             coordinator,


### PR DESCRIPTION
## Summary

- remove the stale third `RunnableModule` constructor argument in `ProgressSessionTests`
- provide `IMediator` and `ISafeModuleEstimatedTimeProvider` when `ModuleTester` creates `ModuleContext`
- restore compilation after #3614 changed both internal constructor shapes

## Validation

- core unit test project build: passed with 0 warnings after the progress fix
- `ProgressSessionTests`: 2/2 passed
- `ModularPipelines.Testing.sln` build: passed with 0 warnings
- `ModularPipelines.Testing.UnitTests`: 72/72 passed