### PR TITLE
Add typed module registration handles

### DIFF
--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -26,6 +26,9 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     internal const string PipelineBuilderExtensionsFullName =
         "ModularPipelines.Extensions.PipelineBuilderExtensions";
 
+    internal const string ModuleRegistrationNamespace = "ModularPipelines";
+    internal const string ModuleRegistrationTypeName = "ModuleRegistration";
+
     private static readonly DiagnosticDescriptor SkippedModuleRuntimeMetadata =
         GeneratorDiagnostics.SkippedModuleRuntimeMetadata;
 
@@ -163,8 +166,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     {
         if (context.Node is not InvocationExpressionSyntax invocation
             || context.SemanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method
-            || (method.ReducedFrom ?? method).ContainingType.ToDisplayString()
-            != PipelineBuilderExtensionsFullName
+            || !IsModuleRegistrationMethod(method)
             || method.TypeArguments.Length != 1
             || method.TypeArguments[0] is not INamedTypeSymbol type
             || !type.IsGenericType
@@ -203,8 +205,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     {
         if (context.Node is not InvocationExpressionSyntax invocation
             || context.SemanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method
-            || (method.ReducedFrom ?? method).ContainingType.ToDisplayString()
-            != PipelineBuilderExtensionsFullName
+            || !IsModuleRegistrationMethod(method)
             || method.TypeArguments.Length != 1
             || method.TypeArguments[0] is not ITypeParameterSymbol typeParameter)
         {
@@ -221,8 +222,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
     {
         if (context.Node is not InvocationExpressionSyntax invocation
             || context.SemanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method
-            || (method.ReducedFrom ?? method).ContainingType.ToDisplayString()
-            != PipelineBuilderExtensionsFullName
+            || !IsModuleRegistrationMethod(method)
             || method.TypeArguments.Length != 1
             || method.TypeArguments[0] is not INamedTypeSymbol type
             || !ImplementsModule(type, context.SemanticModel.Compilation)
@@ -234,6 +234,15 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         return new NonConcreteModuleRegistrationInfo(
             type.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
             invocation.GetLocation());
+    }
+
+    private static bool IsModuleRegistrationMethod(IMethodSymbol method)
+    {
+        var containingType = (method.ReducedFrom ?? method).ContainingType.OriginalDefinition;
+        return containingType.ToDisplayString() == PipelineBuilderExtensionsFullName
+               || (containingType.Name == ModuleRegistrationTypeName
+                   && containingType.Arity == 1
+                   && containingType.ContainingNamespace.ToDisplayString() == ModuleRegistrationNamespace);
     }
 
     private static bool IsCandidate(SyntaxNode node)

--- a/src/ModularPipelines/Builders/ModuleRegistration.cs
+++ b/src/ModularPipelines/Builders/ModuleRegistration.cs
@@ -20,7 +20,7 @@ namespace ModularPipelines;
 /// Represents a module registration and provides metadata configuration for that module.
 /// </summary>
 /// <typeparam name="TModule">The registered module type.</typeparam>
-public sealed class ModuleRegistration<TModule> : IDisposable
+public sealed class ModuleRegistration<TModule>
     where TModule : class, IModule
 {
     private readonly Type _moduleType;
@@ -343,11 +343,6 @@ public sealed class ModuleRegistration<TModule> : IDisposable
     /// </summary>
     /// <returns>The validation result.</returns>
     public Task<ValidationResult> ValidateAsync() => Builder.ValidateAsync();
-
-    /// <summary>
-    /// Releases resources owned by the pipeline builder.
-    /// </summary>
-    public void Dispose() => Builder.Dispose();
 
     /// <summary>
     /// Converts a module registration back to its pipeline builder.

--- a/src/ModularPipelines/Builders/ModuleRegistration.cs
+++ b/src/ModularPipelines/Builders/ModuleRegistration.cs
@@ -1,0 +1,361 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Caching;
+using ModularPipelines.Engine;
+using ModularPipelines.Extensions;
+using ModularPipelines.Interfaces;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+using ModularPipelines.Requirements;
+using ModularPipelines.Validation;
+
+namespace ModularPipelines;
+
+/// <summary>
+/// Represents a module registration and provides metadata configuration for that module.
+/// </summary>
+/// <typeparam name="TModule">The registered module type.</typeparam>
+public sealed class ModuleRegistration<TModule> : IDisposable
+    where TModule : class, IModule
+{
+    private readonly Type _moduleType;
+
+    internal ModuleRegistration(PipelineBuilder builder, Type moduleType)
+    {
+        Builder = builder;
+        _moduleType = moduleType;
+    }
+
+    /// <summary>
+    /// Gets the pipeline builder associated with this registration.
+    /// </summary>
+    public PipelineBuilder Builder { get; }
+
+    /// <summary>
+    /// Gets the service collection for registering application services.
+    /// </summary>
+    public IServiceCollection Services => Builder.Services;
+
+    /// <summary>
+    /// Gets the configuration manager for adding and reading configuration.
+    /// </summary>
+    public ConfigurationManager Configuration => Builder.Configuration;
+
+    /// <summary>
+    /// Gets the current immutable pipeline options snapshot.
+    /// </summary>
+    public PipelineOptions Options => Builder.Options;
+
+    /// <summary>
+    /// Gets the host environment information.
+    /// </summary>
+    public IHostEnvironment Environment => Builder.Environment;
+
+    /// <summary>
+    /// Adds tags to the registered module.
+    /// </summary>
+    /// <param name="tags">The tags to add.</param>
+    /// <returns>This registration for chaining.</returns>
+    public ModuleRegistration<TModule> WithTags(params string[] tags)
+    {
+        Builder.Services.Configure<ModuleRegistrationOptions>(options => options.AddTags(_moduleType, tags));
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the category of the registered module.
+    /// </summary>
+    /// <param name="category">The category to set.</param>
+    /// <returns>This registration for chaining.</returns>
+    public ModuleRegistration<TModule> WithCategory(string category)
+    {
+        Builder.Services.Configure<ModuleRegistrationOptions>(options => options.SetCategory(_moduleType, category));
+        return this;
+    }
+
+    /// <summary>
+    /// Adds another module to the pipeline.
+    /// </summary>
+    /// <typeparam name="TNextModule">The type of module to add.</typeparam>
+    /// <returns>The new module registration.</returns>
+#pragma warning disable MPG0013 // The concrete type is supplied by the caller of this forwarding method.
+    public ModuleRegistration<TNextModule> AddModule<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TNextModule>()
+        where TNextModule : class, IModule
+        => Builder.AddModule<TNextModule>();
+#pragma warning restore MPG0013
+
+    /// <summary>
+    /// Adds another pre-created module instance to the pipeline.
+    /// </summary>
+    /// <param name="module">The module instance to add.</param>
+    /// <typeparam name="TNextModule">The type of module to add.</typeparam>
+    /// <returns>The new module registration.</returns>
+#pragma warning disable MPG0013 // The concrete type is supplied by the caller of this forwarding method.
+    public ModuleRegistration<TNextModule> AddModule<TNextModule>(TNextModule module)
+        where TNextModule : class, IModule
+        => Builder.AddModule(module);
+#pragma warning restore MPG0013
+
+    /// <summary>
+    /// Adds another module to the pipeline using a factory method.
+    /// </summary>
+    /// <param name="factory">A factory method for creating the module.</param>
+    /// <typeparam name="TNextModule">The type of module to add.</typeparam>
+    /// <returns>The new module registration.</returns>
+#pragma warning disable MPG0013 // The concrete type is supplied by the caller of this forwarding method.
+    public ModuleRegistration<TNextModule> AddModule<TNextModule>(Func<IServiceProvider, TNextModule> factory)
+        where TNextModule : class, IModule
+        => Builder.AddModule(factory);
+#pragma warning restore MPG0013
+
+    /// <summary>
+    /// Adds multiple module types to the pipeline.
+    /// </summary>
+    /// <param name="moduleTypes">The module types to add.</param>
+    /// <returns>The pipeline builder.</returns>
+    [RequiresUnreferencedCode(
+        "Runtime type module registration relies on reflection. Use AddModule<TModule>() for trim-safe registration.")]
+    [RequiresDynamicCode(
+        "Runtime type module registration may require runtime code generation. Use AddModule<TModule>() for Native AOT.")]
+    public PipelineBuilder AddModules(params Type[] moduleTypes) => Builder.AddModules(moduleTypes);
+
+    /// <summary>
+    /// Adds all modules from the assembly containing the specified type.
+    /// </summary>
+    /// <typeparam name="T">Any type from the assembly to scan.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    [RequiresUnreferencedCode("Module discovery scans all types in an assembly.")]
+    public PipelineBuilder AddModulesFromAssemblyContainingType<T>()
+        => Builder.AddModulesFromAssemblyContainingType<T>();
+
+    /// <summary>
+    /// Adds all modules from an assembly.
+    /// </summary>
+    /// <param name="assembly">The assembly to scan.</param>
+    /// <returns>The pipeline builder.</returns>
+    [RequiresUnreferencedCode("Module discovery scans all types in an assembly.")]
+    public PipelineBuilder AddModulesFromAssembly(Assembly assembly)
+        => Builder.AddModulesFromAssembly(assembly);
+
+    /// <summary>
+    /// Adds a requirement to the pipeline.
+    /// </summary>
+    /// <typeparam name="TRequirement">The type of requirement to add.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder AddRequirement<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TRequirement>()
+        where TRequirement : class, IPipelineRequirement
+        => Builder.AddRequirement<TRequirement>();
+
+    /// <summary>
+    /// Adds a requirement to the pipeline using a factory method.
+    /// </summary>
+    /// <param name="factory">A factory method for creating the requirement.</param>
+    /// <typeparam name="TRequirement">The type of requirement to add.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder AddRequirement<TRequirement>(Func<IServiceProvider, TRequirement> factory)
+        where TRequirement : class, IPipelineRequirement
+        => Builder.AddRequirement(factory);
+
+    /// <summary>
+    /// Adds a requirement instance to the pipeline.
+    /// </summary>
+    /// <param name="requirement">The requirement instance to add.</param>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder AddRequirement(IPipelineRequirement requirement)
+        => Builder.AddRequirement(requirement);
+
+    /// <summary>
+    /// Adds global hooks to run before or after all modules execute.
+    /// </summary>
+    /// <typeparam name="TGlobalSetup">The hook type.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder AddPipelineGlobalHooks<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TGlobalSetup>()
+        where TGlobalSetup : class, IPipelineGlobalHooks
+        => Builder.AddPipelineGlobalHooks<TGlobalSetup>();
+
+    /// <summary>
+    /// Adds a global receiver for module lifecycle events.
+    /// </summary>
+    /// <typeparam name="TReceiver">The receiver type.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder AddModuleEventReceiver<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TReceiver>()
+        where TReceiver : class, IModuleEventReceiver
+        => Builder.AddModuleEventReceiver<TReceiver>();
+
+    /// <summary>
+    /// Configures services for the pipeline.
+    /// </summary>
+    /// <param name="configureServices">The service configuration action.</param>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder ConfigureServices(Action<IServiceCollection> configureServices)
+        => Builder.ConfigureServices(configureServices);
+
+    /// <summary>
+    /// Configures services for the pipeline with builder context.
+    /// </summary>
+    /// <param name="configureServices">The service configuration action.</param>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder ConfigureServices(Action<PipelineBuilder, IServiceCollection> configureServices)
+        => Builder.ConfigureServices(configureServices);
+
+    /// <summary>
+    /// Adds a custom result repository.
+    /// </summary>
+    /// <typeparam name="TRepository">The repository type.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    [RequiresUnreferencedCode("Result history resolves module result types through reflection.")]
+    [RequiresDynamicCode("Result history creates generic delegates for runtime module result types.")]
+    public PipelineBuilder AddResultsRepository<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TRepository>()
+        where TRepository : class, IModuleResultRepository
+        => Builder.AddResultsRepository<TRepository>();
+
+    /// <summary>
+    /// Enables fingerprint-based incremental module caching.
+    /// </summary>
+    /// <param name="configure">Optional cache configuration.</param>
+    /// <typeparam name="TStore">The cache storage backend.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder AddModuleCache<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TStore>(
+        Action<ModuleCacheOptions>? configure = null)
+        where TStore : class, IModuleCacheStore
+        => Builder.AddModuleCache<TStore>(configure);
+
+    /// <summary>
+    /// Configures pipeline options.
+    /// </summary>
+    /// <param name="configureOptions">The options transformation.</param>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder ConfigurePipelineOptions(Func<PipelineOptions, PipelineOptions> configureOptions)
+        => Builder.ConfigurePipelineOptions(configureOptions);
+
+    /// <summary>
+    /// Configures pipeline options with builder context.
+    /// </summary>
+    /// <param name="configureOptions">The options transformation.</param>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder ConfigurePipelineOptions(
+        Func<PipelineBuilder, PipelineOptions, PipelineOptions> configureOptions)
+        => Builder.ConfigurePipelineOptions(configureOptions);
+
+    /// <summary>
+    /// Adds a custom module estimated time provider.
+    /// </summary>
+    /// <typeparam name="TProvider">The provider type.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder AddModuleEstimatedTimeProvider<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TProvider>()
+        where TProvider : class, IModuleEstimatedTimeProvider
+        => Builder.AddModuleEstimatedTimeProvider<TProvider>();
+
+    /// <summary>
+    /// Adds a pipeline file writer.
+    /// </summary>
+    /// <typeparam name="TWriter">The writer type.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder AddPipelineFileWriter<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TWriter>()
+        where TWriter : class, IBuildSystemPipelineFileWriter
+        => Builder.AddPipelineFileWriter<TWriter>();
+
+    /// <summary>
+    /// Adds a singleton service implementation.
+    /// </summary>
+    /// <typeparam name="TService">The service type.</typeparam>
+    /// <typeparam name="TImplementation">The implementation type.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder AddSingleton<
+        TService,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>()
+        where TService : class
+        where TImplementation : class, TService
+        => Builder.AddSingleton<TService, TImplementation>();
+
+    /// <summary>
+    /// Adds a singleton service instance.
+    /// </summary>
+    /// <param name="implementationInstance">The service instance.</param>
+    /// <typeparam name="TService">The service type.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder AddSingleton<TService>(TService implementationInstance)
+        where TService : class
+        => Builder.AddSingleton(implementationInstance);
+
+    /// <summary>
+    /// Configures options for the pipeline.
+    /// </summary>
+    /// <param name="configureOptions">The configuration action.</param>
+    /// <typeparam name="TOptions">The options type.</typeparam>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder Configure<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TOptions>(
+        Action<TOptions> configureOptions)
+        where TOptions : class
+        => Builder.Configure(configureOptions);
+
+    /// <summary>
+    /// Builds and executes the pipeline.
+    /// </summary>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <returns>A summary of the pipeline execution results.</returns>
+    public Task<PipelineSummary> ExecutePipelineAsync(CancellationToken cancellationToken = default)
+        => Builder.ExecutePipelineAsync(cancellationToken);
+
+    /// <summary>
+    /// Sets the minimum pipeline log level.
+    /// </summary>
+    /// <param name="logLevel">The minimum log level.</param>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder SetLogLevel(LogLevel logLevel) => Builder.SetLogLevel(logLevel);
+
+    /// <summary>
+    /// Runs only modules in the specified categories.
+    /// </summary>
+    /// <param name="categories">The categories to run.</param>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder RunCategories(params string[] categories) => Builder.RunCategories(categories);
+
+    /// <summary>
+    /// Ignores modules in the specified categories.
+    /// </summary>
+    /// <param name="categories">The categories to ignore.</param>
+    /// <returns>The pipeline builder.</returns>
+    public PipelineBuilder IgnoreCategories(params string[] categories) => Builder.IgnoreCategories(categories);
+
+    /// <summary>
+    /// Builds and validates the pipeline.
+    /// </summary>
+    /// <returns>The pipeline.</returns>
+    public Task<IPipeline> BuildAsync() => Builder.BuildAsync();
+
+    /// <summary>
+    /// Validates the pipeline configuration.
+    /// </summary>
+    /// <returns>The validation result.</returns>
+    public Task<ValidationResult> ValidateAsync() => Builder.ValidateAsync();
+
+    /// <summary>
+    /// Releases resources owned by the pipeline builder.
+    /// </summary>
+    public void Dispose() => Builder.Dispose();
+
+    /// <summary>
+    /// Converts a module registration back to its pipeline builder.
+    /// </summary>
+    /// <param name="registration">The module registration.</param>
+    public static implicit operator PipelineBuilder(ModuleRegistration<TModule> registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+        return registration.Builder;
+    }
+}

--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -21,15 +21,14 @@ public static class PipelineBuilderExtensions
     /// </summary>
     /// <param name="builder">The pipeline builder.</param>
     /// <typeparam name="TModule">The type of Module to add.</typeparam>
-    /// <returns>The same builder instance for chaining.</returns>
-    public static PipelineBuilder AddModule<
+    /// <returns>A typed registration handle for configuring module metadata.</returns>
+    public static ModuleRegistration<TModule> AddModule<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TModule>(
         this PipelineBuilder builder)
         where TModule : class, IModule
     {
         builder.Services.AddModule<TModule>();
-        builder.LastRegisteredModuleType = typeof(TModule);
-        return builder;
+        return new ModuleRegistration<TModule>(builder, typeof(TModule));
     }
 
     /// <summary>
@@ -38,13 +37,12 @@ public static class PipelineBuilderExtensions
     /// <param name="builder">The pipeline builder.</param>
     /// <param name="module">The module instance to add.</param>
     /// <typeparam name="TModule">The type of Module to add.</typeparam>
-    /// <returns>The same builder instance for chaining.</returns>
-    public static PipelineBuilder AddModule<TModule>(this PipelineBuilder builder, TModule module)
+    /// <returns>A typed registration handle for configuring module metadata.</returns>
+    public static ModuleRegistration<TModule> AddModule<TModule>(this PipelineBuilder builder, TModule module)
         where TModule : class, IModule
     {
         builder.Services.AddModule(module);
-        builder.LastRegisteredModuleType = typeof(TModule);
-        return builder;
+        return new ModuleRegistration<TModule>(builder, module.GetType());
     }
 
     /// <summary>
@@ -53,13 +51,12 @@ public static class PipelineBuilderExtensions
     /// <param name="builder">The pipeline builder.</param>
     /// <param name="factory">A factory method for creating the module.</param>
     /// <typeparam name="TModule">The type of Module to add.</typeparam>
-    /// <returns>The same builder instance for chaining.</returns>
-    public static PipelineBuilder AddModule<TModule>(this PipelineBuilder builder, Func<IServiceProvider, TModule> factory)
+    /// <returns>A typed registration handle for configuring module metadata.</returns>
+    public static ModuleRegistration<TModule> AddModule<TModule>(this PipelineBuilder builder, Func<IServiceProvider, TModule> factory)
         where TModule : class, IModule
     {
         builder.Services.AddModule(factory);
-        builder.LastRegisteredModuleType = typeof(TModule);
-        return builder;
+        return new ModuleRegistration<TModule>(builder, typeof(TModule));
     }
 
     /// <summary>
@@ -80,7 +77,6 @@ public static class PipelineBuilderExtensions
         {
             ValidateModuleType(moduleType);
             builder.Services.AddModule(moduleType);
-            builder.LastRegisteredModuleType = moduleType;
         }
 
         return builder;
@@ -109,33 +105,6 @@ public static class PipelineBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(assembly);
         builder.Services.AddModulesFromAssembly(assembly);
-        builder.LastRegisteredModuleType = null;
-        return builder;
-    }
-
-    /// <summary>
-    /// Adds tags to the most recently registered module.
-    /// </summary>
-    /// <param name="builder">The pipeline builder.</param>
-    /// <param name="tags">The tags to add.</param>
-    /// <returns>The same builder instance for chaining.</returns>
-    public static PipelineBuilder WithTags(this PipelineBuilder builder, params string[] tags)
-    {
-        var moduleType = GetLastRegisteredModuleType(builder);
-        builder.Services.Configure<ModuleRegistrationOptions>(options => options.AddTags(moduleType, tags));
-        return builder;
-    }
-
-    /// <summary>
-    /// Sets the category of the most recently registered module.
-    /// </summary>
-    /// <param name="builder">The pipeline builder.</param>
-    /// <param name="category">The category to set.</param>
-    /// <returns>The same builder instance for chaining.</returns>
-    public static PipelineBuilder WithCategory(this PipelineBuilder builder, string category)
-    {
-        var moduleType = GetLastRegisteredModuleType(builder);
-        builder.Services.Configure<ModuleRegistrationOptions>(options => options.SetCategory(moduleType, category));
         return builder;
     }
 
@@ -413,13 +382,6 @@ public static class PipelineBuilderExtensions
     {
         builder.Services.Configure(configureOptions);
         return builder;
-    }
-
-    private static Type GetLastRegisteredModuleType(PipelineBuilder builder)
-    {
-        return builder.LastRegisteredModuleType
-               ?? throw new InvalidOperationException(
-                   "Module metadata must follow an AddModule call.");
     }
 
     private static void ValidateModuleType(Type moduleType)

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -40,8 +40,6 @@ public sealed class PipelineBuilder : IDisposable
     private readonly PipelineCommandLineOptions _commandLineOptions;
     private PipelineOptions _options;
 
-    internal Type? LastRegisteredModuleType { get; set; }
-
     internal PipelineBuilder(string[]? args)
         : this(new PipelineBuilderOptions { Args = args })
     {

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -305,6 +305,70 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
+    public async Task Chained_Registration_Handles_Are_Recognized()
+    {
+        var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """
+            namespace ModularPipelines
+            {
+                public sealed class PipelineBuilder;
+
+                public sealed class ModuleRegistration<TModule>
+                    where TModule : class, Modules.IModule
+                {
+                    public ModuleRegistration<TNextModule> AddModule<TNextModule>()
+                        where TNextModule : class, Modules.IModule => new();
+                }
+            }
+
+            namespace ModularPipelines.Extensions
+            {
+                public static class PipelineBuilderExtensions
+                {
+                    public static ModularPipelines.ModuleRegistration<TModule> AddModule<TModule>(
+                        this ModularPipelines.PipelineBuilder builder)
+                        where TModule : class, ModularPipelines.Modules.IModule => new();
+                }
+            }
+
+            namespace Consumer
+            {
+                using ModularPipelines.Extensions;
+
+                public sealed class StarterModule : ModularPipelines.Modules.Module<string>;
+                public sealed class GenericModule<T> : ModularPipelines.Modules.Module<T>;
+
+                public static class Registration
+                {
+                    public static void Configure(ModularPipelines.PipelineBuilder builder)
+                    {
+                        builder.AddModule<StarterModule>()
+                            .AddModule<GenericModule<string>>()
+                            .AddModule<ModularPipelines.Modules.IModule>();
+                    }
+
+                    public static void Register<TModule>(ModularPipelines.PipelineBuilder builder)
+                        where TModule : class, ModularPipelines.Modules.IModule
+                    {
+                        builder.AddModule<StarterModule>().AddModule<TModule>();
+                    }
+                }
+            }
+            """);
+
+        var generated = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated)
+                .Contains("CreateRegistration<global::Consumer.GenericModule<string>, string>");
+            await Assert.That(result.Diagnostics.Count(diagnostic => diagnostic.Id == "MPG0013"))
+                .IsEqualTo(1);
+            await Assert.That(result.Diagnostics.Count(diagnostic => diagnostic.Id == "MPG0015"))
+                .IsEqualTo(1);
+        }
+    }
+
+    [Test]
     public async Task Inferred_Closed_Generic_Registrations_Are_Emitted()
     {
         var result = GeneratorTestHarness.Run(new ModuleMetadataGenerator(), TestInfrastructure, """

--- a/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
@@ -24,6 +24,15 @@ public class PipelineBuilderRegistrationTests
         protected override bool Result => true;
     }
 
+    private abstract class TestModuleBase : SimpleTestModule<bool>
+    {
+    }
+
+    private sealed class DerivedTestModule : TestModuleBase
+    {
+        protected override bool Result => true;
+    }
+
     private sealed class TestAssembly(
         AssemblyName assemblyName,
         params AssemblyName[] referencedAssemblies) : Assembly
@@ -38,25 +47,36 @@ public class PipelineBuilderRegistrationTests
     }
 
     [Test]
-    public async Task AddModule_ReturnsSamePipelineBuilder()
+    public async Task AddModule_ReturnsTypedRegistrationConvertibleToBuilder()
     {
         var builder = TestPipelineHostBuilder.Create();
 
         var result = builder.AddModule<TestModuleA>();
+        PipelineBuilder convertedBuilder = result;
 
-        await Assert.That(result).IsSameReferenceAs(builder);
+        await Assert.That(result).IsTypeOf<ModuleRegistration<TestModuleA>>();
+        await Assert.That(convertedBuilder).IsSameReferenceAs(builder);
     }
 
     [Test]
-    public async Task RegistrationApi_UsesOnlyPipelineBuilder()
+    public async Task RegistrationApi_UsesTypedHandlesOnlyForAddModule()
     {
         var addMethods = typeof(PipelineBuilderExtensions)
             .GetMethods()
             .Where(method => method.IsPublic && method.Name.StartsWith("Add", StringComparison.Ordinal))
             .ToList();
+        var addModuleMethods = addMethods
+            .Where(method => method.Name == nameof(PipelineBuilderExtensions.AddModule))
+            .ToList();
+        var otherAddMethods = addMethods.Except(addModuleMethods).ToList();
 
-        await Assert.That(addMethods).IsNotEmpty();
-        await Assert.That(addMethods.All(method => method.ReturnType == typeof(PipelineBuilder))).IsTrue();
+        await Assert.That(addModuleMethods.Count).IsEqualTo(3);
+        await Assert.That(addModuleMethods.All(method =>
+            method.ReturnType.IsGenericType
+            && method.ReturnType.GetGenericTypeDefinition() == typeof(ModuleRegistration<>))).IsTrue();
+        await Assert.That(otherAddMethods.All(method => method.ReturnType == typeof(PipelineBuilder))).IsTrue();
+        await Assert.That(typeof(PipelineBuilderExtensions).GetMethods()
+            .Any(method => method.Name is "WithTags" or "WithCategory")).IsFalse();
         await Assert.That(typeof(ServiceCollectionExtensions).IsPublic).IsFalse();
     }
 
@@ -237,6 +257,23 @@ public class PipelineBuilderRegistrationTests
     }
 
     [Test]
+    public async Task InstanceMetadata_UsesConcreteRuntimeType()
+    {
+        TestModuleBase module = new DerivedTestModule();
+        var builder = TestPipelineHostBuilder.Create();
+
+#pragma warning disable MPG0015 // Verifies metadata for a legal registration through an abstract static type.
+        builder.AddModule(module).WithCategory("TestCategory");
+#pragma warning restore MPG0015
+
+        using var provider = builder.Services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<ModuleRegistrationOptions>>().Value;
+
+        await Assert.That(options.Categories.ContainsKey(typeof(TestModuleBase))).IsFalse();
+        await Assert.That(options.Categories[typeof(DerivedTestModule)]).IsEqualTo("TestCategory");
+    }
+
+    [Test]
     public async Task ModuleMetadata_CanChainAcrossModules()
     {
         var builder = TestPipelineHostBuilder.Create()
@@ -256,12 +293,20 @@ public class PipelineBuilderRegistrationTests
     }
 
     [Test]
-    public async Task ModuleMetadata_RequiresPriorModule()
+    public async Task ModuleMetadata_HandlesCanBeConfiguredOutOfOrder()
     {
         var builder = TestPipelineHostBuilder.Create();
+        var firstRegistration = builder.AddModule<TestModuleA>();
+        var secondRegistration = builder.AddModule<TestModuleB>();
 
-        await Assert.That(() => builder.WithTags("tag"))
-            .Throws<InvalidOperationException>();
+        secondRegistration.WithTags("second");
+        firstRegistration.WithTags("first");
+
+        using var provider = builder.Services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<ModuleRegistrationOptions>>().Value;
+
+        await Assert.That(options.Tags[typeof(TestModuleA)]).IsEquivalentTo(["first"]);
+        await Assert.That(options.Tags[typeof(TestModuleB)]).IsEquivalentTo(["second"]);
     }
 
     [Test]


### PR DESCRIPTION
Closes #3494

## Summary

- return `ModuleRegistration<TModule>` from typed `AddModule` overloads
- bind tags and categories to explicit registration handles, including concrete runtime instance types
- remove `LastRegisteredModuleType` and builder-level metadata extensions
- preserve existing fluent builder chains through facade forwarding and implicit builder conversion
- cover out-of-order handle configuration and runtime-type metadata

## Validation

- core solution build: passed, 0 warnings
- `PipelineBuilderRegistrationTests`: 19/19 passed

The unit-test project currently needs the one-line `RunnableModule` constructor fix from #3638 to compile; that fix was applied only for local validation and is not included here.