### PR TITLE
Restore source generator incremental caching

### DIFF
--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -47,7 +47,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 static (_, _) => true,
                 static (generatorContext, _) => GetTypeCandidate(generatorContext))
             .Where(static item => item is not null)
-            .Select(static (item, _) => item!);
+            .Select(static (item, _) => item!)
+            .WithComparer(TypeMetadataCandidateComparer.Instance);
 
         var candidates = typeCandidates.Collect().Combine(secretCandidates.Collect());
         context.RegisterSourceOutput(candidates, static (sourceContext, candidateGroups) =>

--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -53,9 +53,11 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         var candidates = context.SyntaxProvider.ForAttributeWithMetadataName(
                 IntegrationAttributeFullName,
                 static (node, _) => node is MethodDeclarationSyntax,
-                static (generatorContext, _) => GetCandidate(generatorContext));
-        var referencedToolProperties = context.CompilationProvider.Select(
-            static (compilation, _) => GetReferencedToolProperties(compilation));
+                static (generatorContext, _) => GetCandidate(generatorContext))
+            .WithComparer(IntegrationCandidateComparer.Instance);
+        var referencedToolProperties = context.MetadataReferencesProvider
+            .Collect()
+            .Select(static (references, _) => GetReferencedToolProperties(references));
 
         context.RegisterSourceOutput(
             candidates
@@ -130,8 +132,11 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
     }
 
     private static EquatableArray<ReferencedToolProperty> GetReferencedToolProperties(
-        Compilation compilation)
+        ImmutableArray<MetadataReference> references)
     {
+        var compilation = CSharpCompilation.Create(
+            "ModularPipelines.ReferencedToolProperties",
+            references: references);
         return compilation.References
             .Select(compilation.GetAssemblyOrModuleSymbol)
             .OfType<IAssemblySymbol>()
@@ -478,6 +483,34 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         string GeneratedTypeName,
         string MethodName,
         Location Location);
+
+    private sealed class IntegrationCandidateComparer : IEqualityComparer<IntegrationCandidate>
+    {
+        public static IntegrationCandidateComparer Instance { get; } = new();
+
+        public bool Equals(IntegrationCandidate? x, IntegrationCandidate? y) =>
+            ReferenceEquals(x, y)
+            || (x is not null
+                && y is not null
+                && EqualityComparer<IntegrationRegistration?>.Default.Equals(
+                    x.Registration,
+                    y.Registration)
+                && x.ToolProperties.Equals(y.ToolProperties)
+                && StringComparer.Ordinal.Equals(x.GeneratedTypeName, y.GeneratedTypeName)
+                && StringComparer.Ordinal.Equals(x.MethodName, y.MethodName)
+                && (x.Registration is not null || x.Location.Equals(y.Location)));
+
+        public int GetHashCode(IntegrationCandidate obj)
+        {
+            var hashCode = obj.Registration?.GetHashCode() ?? 0;
+            hashCode = (hashCode * 397) ^ obj.ToolProperties.GetHashCode();
+            hashCode = (hashCode * 397) ^ StringComparer.Ordinal.GetHashCode(obj.GeneratedTypeName);
+            hashCode = (hashCode * 397) ^ StringComparer.Ordinal.GetHashCode(obj.MethodName);
+            return obj.Registration is null
+                ? (hashCode * 397) ^ obj.Location.GetHashCode()
+                : hashCode;
+        }
+    }
 
     private sealed record IntegrationRegistration(string TypeName, string MethodName);
 

--- a/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModuleMetadataGenerator.cs
@@ -50,13 +50,15 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             .CreateSyntaxProvider(
                 static (node, _) => IsCandidate(node),
                 static (generatorContext, _) => GetModuleMetadata(generatorContext))
-            .SelectMany(static (metadata, _) => metadata);
+            .SelectMany(static (metadata, _) => metadata)
+            .WithComparer(ModuleMetadataInfoComparer.Instance);
 
         var registeredClosedGenericModules = context.SyntaxProvider
             .CreateSyntaxProvider(
                 static (node, _) => IsModuleRegistrationCandidate(node),
                 static (generatorContext, _) => GetRegisteredModuleMetadata(generatorContext))
-            .SelectMany(static (metadata, _) => metadata);
+            .SelectMany(static (metadata, _) => metadata)
+            .WithComparer(ModuleMetadataInfoComparer.Instance);
 
         var genericModuleRegistrations = context.SyntaxProvider
             .CreateSyntaxProvider(
@@ -74,12 +76,16 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             .Collect()
             .Combine(registeredClosedGenericModules.Collect())
             .Select(static (input, _) => input.Left.AddRange(input.Right));
+        var compilationMetadata = context.CompilationProvider.Select(
+            static (compilation, _) => new CompilationMetadata(
+                compilation.AssemblyName,
+                compilation.GetTypeByMetadataName(ModuleInterfaceFullName) is not null));
 
         context.RegisterSourceOutput(
-            context.CompilationProvider.Combine(allModules),
+            compilationMetadata.Combine(allModules),
             static (sourceContext, input) =>
             {
-                if (input.Left.GetTypeByMetadataName(ModuleInterfaceFullName) is not null)
+                if (input.Left.HasModuleInterface)
                 {
                     foreach (var skipped in input.Right
                                  .Where(static module => !module.CanEmit)
@@ -278,7 +284,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                     GetModuleResultTypeName(type),
                     false,
                     invocation.GetLocation(),
-                    [],
+                    ImmutableArray<DependencyMetadataInfo>.Empty,
                     false,
                     false,
                     true,
@@ -322,7 +328,7 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
                     GetModuleResultTypeName(dependency),
                     false,
                     GetDependencyLocation(type, dependency),
-                    [],
+                    ImmutableArray<DependencyMetadataInfo>.Empty,
                     false,
                     false,
                     true,
@@ -381,9 +387,10 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
             GetModuleResultTypeName(type),
             IsTypeAccessible(type, currentAssembly),
             type.Locations.FirstOrDefault(static location => location.IsInSource),
-            [.. dependencies
+            dependencies
                 .OrderBy(static dependency => dependency.TypeName, StringComparer.Ordinal)
-                .ThenBy(static dependency => dependency.Optional)],
+                .ThenBy(static dependency => dependency.Optional)
+                .ToImmutableArray(),
             dependenciesComplete,
             isPartial,
             false,
@@ -728,11 +735,58 @@ public sealed class ModuleMetadataGenerator : IIncrementalGenerator
         string? ResultTypeName,
         bool CanEmit,
         Location? Location,
-        ImmutableArray<DependencyMetadataInfo> Dependencies,
+        EquatableArray<DependencyMetadataInfo> Dependencies,
         bool DependenciesComplete,
         bool IsPartial,
         bool IsExternalRegistration,
         Location? SelectorDependencyLocation);
+
+    private sealed class ModuleMetadataInfoComparer : IEqualityComparer<ModuleMetadataInfo>
+    {
+        public static ModuleMetadataInfoComparer Instance { get; } = new();
+
+        public bool Equals(ModuleMetadataInfo? x, ModuleMetadataInfo? y) =>
+            ReferenceEquals(x, y)
+            || (x is not null
+                && y is not null
+                && StringComparer.Ordinal.Equals(x.TypeName, y.TypeName)
+                && StringComparer.Ordinal.Equals(x.ResultTypeName, y.ResultTypeName)
+                && x.CanEmit == y.CanEmit
+                && x.Dependencies.Equals(y.Dependencies)
+                && x.DependenciesComplete == y.DependenciesComplete
+                && x.IsPartial == y.IsPartial
+                && x.IsExternalRegistration == y.IsExternalRegistration
+                && LocationsEqualWhenRequired(x, y));
+
+        public int GetHashCode(ModuleMetadataInfo obj)
+        {
+            var hashCode = StringComparer.Ordinal.GetHashCode(obj.TypeName);
+            hashCode = (hashCode * 397) ^ (obj.ResultTypeName is null
+                ? 0
+                : StringComparer.Ordinal.GetHashCode(obj.ResultTypeName));
+            hashCode = (hashCode * 397) ^ obj.CanEmit.GetHashCode();
+            hashCode = (hashCode * 397) ^ obj.Dependencies.GetHashCode();
+            hashCode = (hashCode * 397) ^ obj.DependenciesComplete.GetHashCode();
+            hashCode = (hashCode * 397) ^ obj.IsPartial.GetHashCode();
+            hashCode = (hashCode * 397) ^ obj.IsExternalRegistration.GetHashCode();
+            if (!obj.CanEmit || obj.IsPartial)
+            {
+                hashCode = (hashCode * 397) ^ (obj.Location?.GetHashCode() ?? 0);
+            }
+
+            return obj.SelectorDependencyLocation is null
+                ? hashCode
+                : (hashCode * 397) ^ obj.SelectorDependencyLocation.GetHashCode();
+        }
+
+        private static bool LocationsEqualWhenRequired(
+            ModuleMetadataInfo x,
+            ModuleMetadataInfo y) =>
+            ((x.CanEmit && !x.IsPartial) || Equals(x.Location, y.Location))
+            && Equals(x.SelectorDependencyLocation, y.SelectorDependencyLocation);
+    }
+
+    private sealed record CompilationMetadata(string? AssemblyName, bool HasModuleInterface);
 
     private sealed record DependencyMetadataInfo(
         string TypeName,

--- a/test/ModularPipelines.SourceGenerator.UnitTests/GeneratorTestHarness.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/GeneratorTestHarness.cs
@@ -73,12 +73,20 @@ internal static class GeneratorTestHarness
                 trackIncrementalGeneratorSteps: true));
 
         driver = driver.RunGenerators(compilation);
-        driver = driver.RunGenerators(compilation);
+        var sourceTree = compilation.SyntaxTrees.Last();
+        var equivalentSourceTree = CSharpSyntaxTree.ParseText(
+            sourceTree.GetText().ToString() + Environment.NewLine,
+            (CSharpParseOptions) sourceTree.Options);
+        var equivalentCompilation = compilation.ReplaceSyntaxTree(
+            sourceTree,
+            equivalentSourceTree);
+        ThrowForCompilationErrors(equivalentCompilation);
+        driver = driver.RunGenerators(equivalentCompilation);
 
         return driver.GetRunResult();
     }
 
-    public static bool HasCachedOutput(GeneratorDriverRunResult result)
+    public static bool HasCachedOrUnchangedOutput(GeneratorDriverRunResult result)
     {
         var outputReasons = result.Results.Single().TrackedOutputSteps.Values
             .SelectMany(static steps => steps)
@@ -87,7 +95,9 @@ internal static class GeneratorTestHarness
             .ToArray();
 
         return outputReasons.Length > 0
-               && outputReasons.All(static reason => reason == IncrementalStepRunReason.Cached);
+               && outputReasons.All(static reason => reason is
+                   IncrementalStepRunReason.Cached
+                   or IncrementalStepRunReason.Unchanged);
     }
 
     private static CSharpCompilation CreateCompilation(string infrastructure, string source)

--- a/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
@@ -68,6 +68,23 @@ public class IncompleteMetadataDiagnosticTests
     }
 
     [Test]
+    public async Task Equivalent_Secret_Compilation_Uses_Incremental_Cache()
+    {
+        var result = GeneratorTestHarness.RunTwiceWithStepTracking(
+            new CommandOptionsGenerator(),
+            CommandInfrastructure,
+            """
+            public sealed class Secrets
+            {
+                [ModularPipelines.Attributes.SecretValue]
+                public string Token { get; } = "";
+            }
+            """);
+
+        await Assert.That(GeneratorTestHarness.HasCachedOrUnchangedOutput(result)).IsTrue();
+    }
+
+    [Test]
     public async Task Derived_Secret_Attribute_Marks_Metadata_Incomplete()
     {
         var result = GeneratorTestRunner.Run(

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
@@ -542,7 +542,7 @@ public class ModularPipelinesIntegrationGeneratorTests
     }
 
     [Test]
-    public async Task Unchanged_Compilation_Uses_Incremental_Cache()
+    public async Task Equivalent_Compilation_Uses_Incremental_Cache()
     {
         var result = GeneratorTestHarness.RunTwiceWithStepTracking(
             new ModularPipelinesIntegrationGenerator(),
@@ -560,7 +560,7 @@ public class ModularPipelinesIntegrationGeneratorTests
             }
             """);
 
-        await Assert.That(GeneratorTestHarness.HasCachedOutput(result)).IsTrue();
+        await Assert.That(GeneratorTestHarness.HasCachedOrUnchangedOutput(result)).IsTrue();
     }
 
     private static GeneratorDriverRunResult RunGenerator(

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleExtensionsGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleExtensionsGeneratorTests.cs
@@ -95,7 +95,7 @@ public class ModuleExtensionsGeneratorTests
     }
 
     [Test]
-    public async Task Unchanged_Compilation_Uses_Incremental_Cache()
+    public async Task Equivalent_Compilation_Uses_Incremental_Cache()
     {
         var result = GeneratorTestHarness.RunTwiceWithStepTracking(
             new ModuleExtensionsGenerator(),
@@ -107,6 +107,6 @@ public class ModuleExtensionsGeneratorTests
             }
             """);
 
-        await Assert.That(GeneratorTestHarness.HasCachedOutput(result)).IsTrue();
+        await Assert.That(GeneratorTestHarness.HasCachedOrUnchangedOutput(result)).IsTrue();
     }
 }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModuleMetadataGeneratorTests.cs
@@ -741,7 +741,7 @@ public class ModuleMetadataGeneratorTests
     }
 
     [Test]
-    public async Task Unchanged_Compilation_Uses_Incremental_Cache()
+    public async Task Equivalent_Compilation_Uses_Incremental_Cache()
     {
         var result = GeneratorTestHarness.RunTwiceWithStepTracking(
             new ModuleMetadataGenerator(),
@@ -749,11 +749,14 @@ public class ModuleMetadataGeneratorTests
             """
             namespace Consumer
             {
+                public sealed class DependencyModule : ModularPipelines.Modules.Module<string>;
+
+                [ModularPipelines.Attributes.DependsOn<DependencyModule>]
                 public sealed class BuildModule : ModularPipelines.Modules.Module<string>;
             }
             """);
 
-        await Assert.That(GeneratorTestHarness.HasCachedOutput(result)).IsTrue();
+        await Assert.That(GeneratorTestHarness.HasCachedOrUnchangedOutput(result)).IsTrue();
     }
 
     private static int CountOccurrences(string source, string value)


### PR DESCRIPTION
## Summary
- compare module, integration, and secret metadata by semantic value
- keep raw compilations out of source-output pipelines and cache referenced assembly metadata by reference set
- exercise incremental generators with an equivalent replacement syntax tree

## Validation
- source-generator unit-test project build: 0 warnings, 0 errors
- ModuleMetadataGeneratorTests: 22 passed
- ModularPipelinesIntegrationGeneratorTests: 16 passed
- IncompleteMetadataDiagnosticTests: 12 passed
- ModuleExtensionsGeneratorTests: 5 passed
- dotnet format verification passed
- full source-generator suite exceeded the agent guard's 2 GB process-tree limit; relevant classes passed separately

Closes #3506