### PR TITLE
Flow cancellation through Git repository discovery

### DIFF
--- a/src/ModularPipelines.Git/Attributes/BranchConditionHelper.cs
+++ b/src/ModularPipelines.Git/Attributes/BranchConditionHelper.cs
@@ -15,9 +15,10 @@ internal static class BranchConditionHelper
     internal static async Task<bool> CheckBranchMatches(
         IPipelineContext pipelineContext,
         string expectedBranchName,
-        string logMessageFormat)
+        string logMessageFormat,
+        CancellationToken cancellationToken = default)
     {
-        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync().ConfigureAwait(false);
+        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync(cancellationToken).ConfigureAwait(false);
         var currentBranchName = repositoryInfo?.BranchName;
         pipelineContext.Logger.LogDebug(logMessageFormat, GetDisplayBranchName(currentBranchName), expectedBranchName);
         return currentBranchName == expectedBranchName;
@@ -29,9 +30,10 @@ internal static class BranchConditionHelper
     internal static async Task<bool> CheckBranchStartsWith(
         IPipelineContext pipelineContext,
         string expectedPrefix,
-        string logMessageFormat)
+        string logMessageFormat,
+        CancellationToken cancellationToken = default)
     {
-        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync().ConfigureAwait(false);
+        var repositoryInfo = await pipelineContext.Git().Information.GetInfoAsync(cancellationToken).ConfigureAwait(false);
         var currentBranchName = repositoryInfo?.BranchName;
         pipelineContext.Logger.LogDebug(logMessageFormat, GetDisplayBranchName(currentBranchName), expectedPrefix);
         return currentBranchName?.StartsWith(expectedPrefix) ?? false;

--- a/src/ModularPipelines.Git/Attributes/RunIfBranchAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunIfBranchAttribute.cs
@@ -24,9 +24,15 @@ public class RunIfBranchAttribute : Attribute, IGroupedConditionAttribute
 
     public Task<bool> EvaluateAsync(IPipelineContext pipelineContext)
     {
+        return EvaluateAsync(pipelineContext, default);
+    }
+
+    public Task<bool> EvaluateAsync(IPipelineContext pipelineContext, CancellationToken cancellationToken)
+    {
         return BranchConditionHelper.CheckBranchMatches(
             pipelineContext,
             BranchName,
-            "Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}");
+            "Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}",
+            cancellationToken);
     }
 }

--- a/src/ModularPipelines.Git/Attributes/RunIfBranchStartsWithAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunIfBranchStartsWithAttribute.cs
@@ -24,9 +24,15 @@ public class RunIfBranchStartsWithAttribute : Attribute, IGroupedConditionAttrib
 
     public Task<bool> EvaluateAsync(IPipelineContext pipelineContext)
     {
+        return EvaluateAsync(pipelineContext, default);
+    }
+
+    public Task<bool> EvaluateAsync(IPipelineContext pipelineContext, CancellationToken cancellationToken)
+    {
         return BranchConditionHelper.CheckBranchStartsWith(
             pipelineContext,
             BranchNamePrefix,
-            "Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}");
+            "Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}",
+            cancellationToken);
     }
 }

--- a/src/ModularPipelines.Git/Attributes/RunOnlyIfBranchStartsWithAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunOnlyIfBranchStartsWithAttribute.cs
@@ -22,9 +22,15 @@ public class RunOnlyIfBranchStartsWithAttribute : Attribute, IConditionAttribute
 
     public Task<bool> EvaluateAsync(IPipelineContext pipelineContext)
     {
+        return EvaluateAsync(pipelineContext, default);
+    }
+
+    public Task<bool> EvaluateAsync(IPipelineContext pipelineContext, CancellationToken cancellationToken)
+    {
         return BranchConditionHelper.CheckBranchStartsWith(
             pipelineContext,
             BranchNamePrefix,
-            "Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}");
+            "Current Branch: {CurrentBranch} | Can run if starts with: {ExpectedPrefix}",
+            cancellationToken);
     }
 }

--- a/src/ModularPipelines.Git/Attributes/RunOnlyOnBranchAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/RunOnlyOnBranchAttribute.cs
@@ -22,9 +22,15 @@ public class RunOnlyOnBranchAttribute : Attribute, IConditionAttribute
 
     public Task<bool> EvaluateAsync(IPipelineContext pipelineContext)
     {
+        return EvaluateAsync(pipelineContext, default);
+    }
+
+    public Task<bool> EvaluateAsync(IPipelineContext pipelineContext, CancellationToken cancellationToken)
+    {
         return BranchConditionHelper.CheckBranchMatches(
             pipelineContext,
             BranchName,
-            "Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}");
+            "Current Branch: {CurrentBranch} | Can run on: {ExpectedBranch}",
+            cancellationToken);
     }
 }

--- a/src/ModularPipelines.Git/Attributes/SkipIfBranchAttribute.cs
+++ b/src/ModularPipelines.Git/Attributes/SkipIfBranchAttribute.cs
@@ -20,11 +20,17 @@ public class SkipIfBranchAttribute : Attribute, IConditionAttribute
         BranchName = branchName;
     }
 
-    public async Task<bool> EvaluateAsync(IPipelineContext pipelineContext)
+    public Task<bool> EvaluateAsync(IPipelineContext pipelineContext)
     {
-        return await BranchConditionHelper.CheckBranchMatches(
+        return EvaluateAsync(pipelineContext, default);
+    }
+
+    public Task<bool> EvaluateAsync(IPipelineContext pipelineContext, CancellationToken cancellationToken)
+    {
+        return BranchConditionHelper.CheckBranchMatches(
             pipelineContext,
             BranchName,
-            "Current Branch: {CurrentBranch} | Will skip on: {SkipBranch}").ConfigureAwait(false);
+            "Current Branch: {CurrentBranch} | Will skip on: {SkipBranch}",
+            cancellationToken);
     }
 }

--- a/src/ModularPipelines.Git/GitCommandRunner.cs
+++ b/src/ModularPipelines.Git/GitCommandRunner.cs
@@ -18,7 +18,16 @@ public class GitCommandRunner : IGitCommandRunner
     }
 
     /// <inheritdoc />
-    public async Task<string> RunCommands(CommandExecutionOptions? commandEnvironmentOptions, params string?[] commands)
+    public Task<string> RunCommands(CommandExecutionOptions? commandEnvironmentOptions, params string?[] commands)
+    {
+        return RunCommands(commandEnvironmentOptions, default, commands);
+    }
+
+    /// <inheritdoc />
+    public async Task<string> RunCommands(
+        CommandExecutionOptions? commandEnvironmentOptions,
+        CancellationToken cancellationToken,
+        params string?[] commands)
     {
         commandEnvironmentOptions ??= new CommandExecutionOptions();
 
@@ -29,19 +38,31 @@ public class GitCommandRunner : IGitCommandRunner
             LogSettings = CommandLoggingOptions.Silent,
         };
 
-        var commandResult = await _context.Shell.Command.ExecuteCommandLineToolAsync(commandLineToolOptions, executionOptions).ConfigureAwait(false);
+        var commandResult = await _context.Shell.Command.ExecuteCommandLineToolAsync(
+            commandLineToolOptions,
+            executionOptions,
+            cancellationToken).ConfigureAwait(false);
 
         return commandResult.StandardOutput.Trim();
     }
 
     /// <inheritdoc />
-    public async Task<string?> RunCommandsOrNull(CommandExecutionOptions? commandEnvironmentOptions, params string?[] commands)
+    public Task<string?> RunCommandsOrNull(CommandExecutionOptions? commandEnvironmentOptions, params string?[] commands)
+    {
+        return RunCommandsOrNull(commandEnvironmentOptions, default, commands);
+    }
+
+    /// <inheritdoc />
+    public async Task<string?> RunCommandsOrNull(
+        CommandExecutionOptions? commandEnvironmentOptions,
+        CancellationToken cancellationToken,
+        params string?[] commands)
     {
         try
         {
-            return await RunCommands(commandEnvironmentOptions, commands).ConfigureAwait(false);
+            return await RunCommands(commandEnvironmentOptions, cancellationToken, commands).ConfigureAwait(false);
         }
-        catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
+        catch (Exception ex) when (ex is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
         {
             _logger.LogDebug(ex, "Git command failed: {Commands}", string.Join(" ", commands.Where(c => c != null)));
             return null;

--- a/src/ModularPipelines.Git/GitInformation.cs
+++ b/src/ModularPipelines.Git/GitInformation.cs
@@ -14,7 +14,9 @@ internal class GitInformation : IGitInformation
 {
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly IGitCommitMapper _gitCommitMapper;
-    private readonly Lazy<Task<GitRepositoryInfo?>> _repositoryInfo;
+    private readonly SemaphoreSlim _repositoryInfoLock = new(1, 1);
+    private GitRepositoryInfo? _repositoryInfo;
+    private bool _repositoryInfoLoaded;
 
     public GitInformation(
         IServiceScopeFactory serviceScopeFactory,
@@ -22,12 +24,31 @@ internal class GitInformation : IGitInformation
     {
         _serviceScopeFactory = serviceScopeFactory;
         _gitCommitMapper = gitCommitMapper;
-        _repositoryInfo = new Lazy<Task<GitRepositoryInfo?>>(
-            LoadInfoAsync,
-            LazyThreadSafetyMode.ExecutionAndPublication);
     }
 
-    public Task<GitRepositoryInfo?> GetInfoAsync() => _repositoryInfo.Value;
+    public async Task<GitRepositoryInfo?> GetInfoAsync(CancellationToken cancellationToken = default)
+    {
+        if (Volatile.Read(ref _repositoryInfoLoaded))
+        {
+            return _repositoryInfo;
+        }
+
+        await _repositoryInfoLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!_repositoryInfoLoaded)
+            {
+                _repositoryInfo = await LoadInfoAsync(cancellationToken).ConfigureAwait(false);
+                Volatile.Write(ref _repositoryInfoLoaded, true);
+            }
+
+            return _repositoryInfo;
+        }
+        finally
+        {
+            _repositoryInfoLock.Release();
+        }
+    }
 
     public IAsyncEnumerable<GitCommit> Commits(
         GitOptions? options = null,
@@ -49,6 +70,7 @@ internal class GitInformation : IGitInformation
         {
             var output = await gitCommandRunner.RunCommandsOrNull(
                 null,
+                cancellationToken,
                 "log",
                 branch,
                 $"--skip={index}",
@@ -65,7 +87,7 @@ internal class GitInformation : IGitInformation
         }
     }
 
-    private async Task<GitRepositoryInfo?> LoadInfoAsync()
+    private async Task<GitRepositoryInfo?> LoadInfoAsync(CancellationToken cancellationToken)
     {
         await using var scope = _serviceScopeFactory.CreateAsyncScope();
         var logger = scope.ServiceProvider.GetRequiredService<ILogger<GitInformation>>();
@@ -74,7 +96,8 @@ internal class GitInformation : IGitInformation
         var root = await GetOutput(
             command,
             logger,
-            new GitRevParseOptions { ShowToplevel = true }).ConfigureAwait(false);
+            new GitRevParseOptions { ShowToplevel = true },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(root))
         {
@@ -84,29 +107,35 @@ internal class GitInformation : IGitInformation
         var branchName = GetOutput(
             command,
             logger,
-            new GitBranchOptions { ShowCurrent = true });
-        var defaultBranchName = GetDefaultBranchName(command, logger);
+            new GitBranchOptions { ShowCurrent = true },
+            cancellationToken: cancellationToken);
+        var defaultBranchName = GetDefaultBranchName(command, logger, cancellationToken);
         var lastCommitSha = GetOutput(
             command,
             logger,
-            new GitRevParseOptions { Committish = "HEAD" });
+            new GitRevParseOptions { Committish = "HEAD" },
+            cancellationToken: cancellationToken);
         var lastCommitShortSha = GetOutput(
             command,
             logger,
-            new GitRevParseOptions { Short = true, Committish = "HEAD" });
+            new GitRevParseOptions { Short = true, Committish = "HEAD" },
+            cancellationToken: cancellationToken);
         var tag = GetOutput(
             command,
             logger,
-            new GitDescribeOptions { Tags = true });
+            new GitDescribeOptions { Tags = true },
+            cancellationToken: cancellationToken);
         var commitCount = GetOutput(
             command,
             logger,
-            new GitRevListOptions { Count = true, Ref = "HEAD" });
+            new GitRevListOptions { Count = true, Ref = "HEAD" },
+            cancellationToken: cancellationToken);
         var lastCommitTimestamp = GetOutput(
             command,
             logger,
-            new GitLogOptions { Format = GitConstants.AuthorTimestampFormat, MaxCount = "1" });
-        var previousCommit = GetPreviousCommit(gitCommandRunner);
+            new GitLogOptions { Format = GitConstants.AuthorTimestampFormat, MaxCount = "1" },
+            cancellationToken: cancellationToken);
+        var previousCommit = GetPreviousCommit(gitCommandRunner, cancellationToken);
 
         await Task.WhenAll(
             branchName,
@@ -131,11 +160,18 @@ internal class GitInformation : IGitInformation
         };
     }
 
-    private static async Task<string?> GetDefaultBranchName(ICommandContext command, ILogger logger)
+    private static async Task<string?> GetDefaultBranchName(
+        ICommandContext command,
+        ILogger logger,
+        CancellationToken cancellationToken)
     {
         try
         {
-            var output = await GetOutput(command, logger, new GitRemoteShowOptions { Remote = "origin" }).ConfigureAwait(false);
+            var output = await GetOutput(
+                command,
+                logger,
+                new GitRemoteShowOptions { Remote = "origin" },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
             if (output == null)
             {
                 return null;
@@ -145,7 +181,7 @@ internal class GitInformation : IGitInformation
                 .FirstOrDefault(x => x.StartsWith("HEAD branch:"))
                 ?.Split("HEAD branch: ")[1];
         }
-        catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
+        catch (Exception ex) when (ex is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
         {
             // Fallback: If 'git remote show origin' fails (e.g., no remote configured, network issues,
             // or shallow clone), try parsing origin/HEAD reference instead. This provides a best-effort
@@ -158,13 +194,18 @@ internal class GitInformation : IGitInformation
             }, new CommandExecutionOptions
             {
                 ThrowOnNonZeroExitCode = false,
-            }).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
 
             return output?.Replace("origin/", string.Empty);
         }
     }
 
-    private static async Task<string?> GetOutput(ICommandContext command, ILogger logger, GitOptions gitOptions, CommandExecutionOptions? executionOptions = null)
+    private static async Task<string?> GetOutput(
+        ICommandContext command,
+        ILogger logger,
+        GitOptions gitOptions,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
     {
         try
         {
@@ -175,19 +216,21 @@ internal class GitInformation : IGitInformation
                 // These are internal one-time setup commands that don't need to be logged
                 LogSettings = CommandLoggingOptions.Silent,
             };
-            var result = await command.ExecuteCommandLineToolAsync(gitOptions, options).ConfigureAwait(false);
+            var result = await command.ExecuteCommandLineToolAsync(gitOptions, options, cancellationToken).ConfigureAwait(false);
             return result.StandardOutput.Trim();
         }
-        catch (Exception exception) when (exception is not (OutOfMemoryException or StackOverflowException))
+        catch (Exception exception) when (exception is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
         {
             logger.LogDebug(exception, "Error running Git command");
             return null;
         }
     }
 
-    private async Task<GitCommit?> GetPreviousCommit(IGitCommandRunner gitCommandRunner)
+    private async Task<GitCommit?> GetPreviousCommit(
+        IGitCommandRunner gitCommandRunner,
+        CancellationToken cancellationToken)
     {
-        var output = await gitCommandRunner.RunCommandsOrNull(null, "log", "--skip=0", "-1",
+        var output = await gitCommandRunner.RunCommandsOrNull(null, cancellationToken, "log", "--skip=0", "-1",
             $"--format={GitConstants.CommitLogFormat}").ConfigureAwait(false);
 
         return string.IsNullOrWhiteSpace(output) ? null : _gitCommitMapper.Map(output);

--- a/src/ModularPipelines.Git/IGitCommandRunner.cs
+++ b/src/ModularPipelines.Git/IGitCommandRunner.cs
@@ -17,10 +17,42 @@ public interface IGitCommandRunner
     Task<string> RunCommands(CommandExecutionOptions? commandEnvironmentOptions, params string?[] commands);
 
     /// <summary>
+    /// Executes git commands and returns the trimmed standard output.
+    /// </summary>
+    /// <param name="commandEnvironmentOptions">Optional command environment configuration.</param>
+    /// <param name="cancellationToken">The token used to cancel command execution.</param>
+    /// <param name="commands">Git command arguments to execute.</param>
+    /// <returns>The trimmed standard output from the git command.</returns>
+    Task<string> RunCommands(
+        CommandExecutionOptions? commandEnvironmentOptions,
+        CancellationToken cancellationToken,
+        params string?[] commands)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return RunCommands(commandEnvironmentOptions, commands);
+    }
+
+    /// <summary>
     /// Executes git commands and returns the trimmed standard output, or null if the command fails.
     /// </summary>
     /// <param name="commandEnvironmentOptions">Optional command environment configuration.</param>
     /// <param name="commands">Git command arguments to execute.</param>
     /// <returns>The trimmed standard output from the git command, or null if the command failed.</returns>
     Task<string?> RunCommandsOrNull(CommandExecutionOptions? commandEnvironmentOptions, params string?[] commands);
+
+    /// <summary>
+    /// Executes git commands and returns the trimmed standard output, or null if the command fails.
+    /// </summary>
+    /// <param name="commandEnvironmentOptions">Optional command environment configuration.</param>
+    /// <param name="cancellationToken">The token used to cancel command execution.</param>
+    /// <param name="commands">Git command arguments to execute.</param>
+    /// <returns>The trimmed standard output from the git command, or null if the command failed.</returns>
+    Task<string?> RunCommandsOrNull(
+        CommandExecutionOptions? commandEnvironmentOptions,
+        CancellationToken cancellationToken,
+        params string?[] commands)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return RunCommandsOrNull(commandEnvironmentOptions, commands);
+    }
 }

--- a/src/ModularPipelines.Git/IGitInformation.cs
+++ b/src/ModularPipelines.Git/IGitInformation.cs
@@ -5,12 +5,29 @@ namespace ModularPipelines.Git;
 
 public interface IGitInformation
 {
-    Task<GitRepositoryInfo?> GetInfoAsync();
+    /// <summary>
+    /// Gets cached information about the current Git repository.
+    /// </summary>
+    /// <param name="cancellationToken">The token used to cancel repository discovery.</param>
+    /// <returns>The repository information, or <see langword="null" /> when Git information is unavailable.</returns>
+    Task<GitRepositoryInfo?> GetInfoAsync(CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Enumerates commits from the current branch.
+    /// </summary>
+    /// <remarks>
+    /// Async-enumerable methods omit the <c>Async</c> suffix because enumeration is asynchronous at the call site.
+    /// </remarks>
     IAsyncEnumerable<GitCommit> Commits(
         GitOptions? options = null,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Enumerates commits from the specified branch.
+    /// </summary>
+    /// <remarks>
+    /// Async-enumerable methods omit the <c>Async</c> suffix because enumeration is asynchronous at the call site.
+    /// </remarks>
     IAsyncEnumerable<GitCommit> Commits(
         string? branch,
         GitOptions? options = null,

--- a/test/ModularPipelines.UnitTests/Attributes/BranchConditionLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/BranchConditionLoggingTests.cs
@@ -33,7 +33,7 @@ public class BranchConditionLoggingTests
         var logger = new Mock<IModuleLogger>();
         logger.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(true);
         var gitInformation = new Mock<IGitInformation>();
-        gitInformation.Setup(x => x.GetInfoAsync())
+        gitInformation.Setup(x => x.GetInfoAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GitRepositoryInfo(
                 new ModularPipelines.FileSystem.Folder(TestContext.WorkingDirectory)));
         var git = Mock.Of<IGit>(x => x.Information == gitInformation.Object);
@@ -51,5 +51,29 @@ public class BranchConditionLoggingTests
 
         await Assert.That(result).IsFalse();
         await Assert.That(logMessage).IsEqualTo("Current Branch: (detached) | Can run on: main");
+    }
+
+    [Test]
+    public async Task RunIfBranch_Propagates_Cancellation_Token()
+    {
+        var gitInformation = new Mock<IGitInformation>();
+        gitInformation.Setup(x => x.GetInfoAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GitRepositoryInfo(
+                new ModularPipelines.FileSystem.Folder(TestContext.WorkingDirectory)));
+        var git = Mock.Of<IGit>(x => x.Information == gitInformation.Object);
+        var services = new Mock<IServicesContext>();
+        services.Setup(x => x.Get<IGit>()).Returns(git);
+        var logger = Mock.Of<IModuleLogger>();
+        var context = Mock.Of<IPipelineContext>(x =>
+            x.Logger == logger &&
+            x.Services == services.Object);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await new RunIfBranchAttribute("main")
+            .EvaluateAsync(context, cancellationTokenSource.Token);
+
+        gitInformation.Verify(
+            x => x.GetInfoAsync(cancellationTokenSource.Token),
+            Times.Once);
     }
 }

--- a/test/ModularPipelines.UnitTests/Context/GitInformationTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/GitInformationTests.cs
@@ -4,6 +4,7 @@ using ModularPipelines.Context.Domains.Shell;
 using Moq;
 using ModularPipelines.Git;
 using ModularPipelines.Git.Extensions;
+using ModularPipelines.Models;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 
@@ -50,6 +51,66 @@ public class GitInformationTests : TestBase
             services.AddSingleton<ICommandContext>(command.Object));
 
         await Assert.That(await result.T.GetInfoAsync()).IsNull();
+        await result.Host.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Cancelled_Load_Is_Not_Cached()
+    {
+        var command = new Mock<ICommandContext>();
+        var observedToken = default(CancellationToken);
+        command.Setup(x => x.ExecuteCommandLineToolAsync(
+                It.IsAny<CommandLineToolOptions>(),
+                It.IsAny<CommandExecutionOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<CommandLineToolOptions, CommandExecutionOptions?, CancellationToken>(
+                (_, _, cancellationToken) =>
+                {
+                    observedToken = cancellationToken;
+                    return Task.FromException<CommandResult>(new OperationCanceledException(cancellationToken));
+                });
+        var result = await GetService<IGitInformation>((_, services) =>
+            services.AddSingleton<ICommandContext>(command.Object));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            async () => await result.T.GetInfoAsync(cancellationTokenSource.Token));
+        await Assert.That(observedToken).IsEqualTo(cancellationTokenSource.Token);
+
+        command.Setup(x => x.ExecuteCommandLineToolAsync(
+                It.IsAny<CommandLineToolOptions>(),
+                It.IsAny<CommandExecutionOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("git unavailable"));
+
+        await Assert.That(await result.T.GetInfoAsync()).IsNull();
+        await result.Host.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Commits_Propagates_Cancellation_Token()
+    {
+        var observedToken = default(CancellationToken);
+        var runner = new Mock<IGitCommandRunner>();
+        runner.Setup(x => x.RunCommandsOrNull(
+                It.IsAny<CommandExecutionOptions?>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?[]>()))
+            .Returns<CommandExecutionOptions?, CancellationToken, string?[]>(
+                (_, cancellationToken, _) =>
+                {
+                    observedToken = cancellationToken;
+                    return Task.FromResult<string?>(null);
+                });
+        var result = await GetService<IGitInformation>((_, services) =>
+            services.AddSingleton(runner.Object));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await foreach (var _ in result.T.Commits(cancellationToken: cancellationTokenSource.Token))
+        {
+        }
+
+        await Assert.That(observedToken).IsEqualTo(cancellationTokenSource.Token);
         await result.Host.DisposeAsync();
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleConditionHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleConditionHandlerTests.cs
@@ -165,7 +165,7 @@ public class ModuleConditionHandlerTests
     public async Task Mandatory_Branch_Condition_Is_Not_Overridden_By_Optional_Alternative()
     {
         var gitInformation = new Mock<IGitInformation>();
-        gitInformation.Setup(x => x.GetInfoAsync())
+        gitInformation.Setup(x => x.GetInfoAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new GitRepositoryInfo(
                 new ModularPipelines.FileSystem.Folder(TestContext.WorkingDirectory))
             {


### PR DESCRIPTION
## Summary
- add an optional cancellation token to IGitInformation.GetInfoAsync and propagate it through repository discovery
- preserve cancellation across cached-load retries, commit enumeration, and branch conditions
- document the IAsyncEnumerable naming convention for Commits

## Validation
- ModularPipelines.Git solution Release build: 0 warnings, 0 errors
- GitInformationTests: 5/5
- BranchConditionLoggingTests: 3/3

Closes #3497