### PR TITLE
Replace nested TRX test runs with fixtures

### DIFF
--- a/test/ModularPipelines.TestsForTests/global.json
+++ b/test/ModularPipelines.TestsForTests/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.302",
-    "rollForward": "latestMinor",
+    "rollForward": "latestMajor",
     "allowPrerelease": false
   },
   "test": {

--- a/test/ModularPipelines.UnitTests/Data/test-results.trx
+++ b/test/ModularPipelines.UnitTests/Data/test-results.trx
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TestRun>
+  <Results>
+    <UnitTestResult executionId="execution-pass-1" testId="test-pass-1" testName="Pass"
+      computerName="agent" duration="00:00:00.0100000" startTime="2026-07-27T12:00:00Z"
+      endTime="2026-07-27T12:00:00.0100000Z" testType="type" outcome="Passed"
+      testListId="list" relativeResultsDirectory="results/pass-1" />
+    <UnitTestResult executionId="execution-pass-2" testId="test-pass-2" testName="Pass2"
+      computerName="agent" duration="00:00:00.0100000" startTime="2026-07-27T12:00:01Z"
+      endTime="2026-07-27T12:00:01.0100000Z" testType="type" outcome="Passed"
+      testListId="list" relativeResultsDirectory="results/pass-2" />
+    <UnitTestResult executionId="execution-skip" testId="test-skip" testName="Ignore"
+      computerName="agent" duration="00:00:00" startTime="2026-07-27T12:00:02Z"
+      endTime="2026-07-27T12:00:02Z" testType="type" outcome="NotExecuted"
+      testListId="list" relativeResultsDirectory="results/skip">
+      <Output>
+        <DebugTrace>Skipped: Linux only test</DebugTrace>
+      </Output>
+    </UnitTestResult>
+    <UnitTestResult executionId="execution-fail" testId="test-fail" testName="Fail"
+      computerName="agent" duration="00:00:00.0100000" startTime="2026-07-27T12:00:03Z"
+      endTime="2026-07-27T12:00:03.0100000Z" testType="type" outcome="Failed"
+      testListId="list" relativeResultsDirectory="results/fail">
+      <Output>
+        <ErrorInfo>
+          <Message>This test is meant to fail</Message>
+          <StackTrace>at ModularPipelines.TestsForTests.Tests.Fail()</StackTrace>
+        </ErrorInfo>
+      </Output>
+    </UnitTestResult>
+  </Results>
+  <ResultSummary outcome="Failed">
+    <Counters total="4" executed="3" passed="2" failed="1" error="0"
+      timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0"
+      notRunnable="0" notExecuted="1" disconnected="0" warning="0"
+      completed="0" inProgress="0" pending="0" />
+  </ResultSummary>
+</TestRun>

--- a/test/ModularPipelines.UnitTests/Helpers/DotNetTestResultsTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DotNetTestResultsTests.cs
@@ -11,6 +11,7 @@ using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
+using ModularPipelines.TestHelpers.Assertions;
 using File = ModularPipelines.FileSystem.File;
 
 namespace ModularPipelines.UnitTests.Helpers;
@@ -18,14 +19,19 @@ namespace ModularPipelines.UnitTests.Helpers;
 [TUnit.Core.NotInParallel]
 public class DotNetTestResultsTests : TestBase
 {
+    private static readonly File TrxFixture = new(
+        Path.Combine(AppContext.BaseDirectory, "Data", "test-results.trx"));
+
     private class DotNetTestWithFailureModule : Module<CommandResult>
     {
         protected internal override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
             var repositoryInfo = await context.Git().Information.GetInfoAsync()
                 ?? throw new InvalidOperationException("Git repository information is unavailable.");
-            var testProject = repositoryInfo.Root
-                .FindFile(x => x.Name == "ModularPipelines.TestsForTests.csproj")!;
+            var testProject = repositoryInfo.Root.GetFolder("test")
+                .GetFolder("ModularPipelines.TestsForTests")
+                .GetFile("ModularPipelines.TestsForTests.csproj")
+                .AssertExists();
 
             return await context.DotNet().TestAsync(
                 new DotNetTestOptions
@@ -46,53 +52,6 @@ public class DotNetTestResultsTests : TestBase
         }
     }
 
-    private class DotNetTestWithoutFailureModule : Module<CommandResult>
-    {
-        private const string TrxFileName = "test-results.trx";
-        public static File? TrxFile { get; private set; }
-
-        protected internal override async Task<CommandResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-        {
-            var repositoryInfo = await context.Git().Information.GetInfoAsync()
-                ?? throw new InvalidOperationException("Git repository information is unavailable.");
-            var testProject = repositoryInfo.Root
-                .FindFile(x => x.Name == "ModularPipelines.TestsForTests.csproj")!;
-
-            var outputDir = testProject.Folder!.GetFolder("bin/Debug/net10.0/TestResults");
-
-            // Run all tests without filtering - the TRX file will contain all results
-            // Use Arguments with explicit -- to pass TUnit arguments correctly
-            var result = await context.DotNet().RunAsync(
-                new DotNetRunOptions
-                {
-                    Project = testProject.Path,
-                    Framework = "net10.0",
-                    Arguments =
-                    [
-                        "--",
-                        "--report-trx",
-                        "--report-trx-filename", TrxFileName,
-                    ],
-                },
-                new CommandExecutionOptions
-                {
-                    WorkingDirectory = testProject.Folder!.Path,
-                    LogSettings = new CommandLoggingOptions
-                    {
-                        Verbosity = CommandLogVerbosity.Minimal,
-                        ShowStandardOutput = false,
-                        ShowStandardError = true,
-                    },
-                    ThrowOnNonZeroExitCode = false, // Some tests intentionally fail
-                },
-                cancellationToken);
-
-            // Set the TRX file location after the test runs
-            TrxFile = new File(Path.Combine(outputDir.Path, TrxFileName));
-            return result;
-        }
-    }
-
     [Test]
     public async Task Has_Errored()
     {
@@ -100,17 +59,9 @@ public class DotNetTestResultsTests : TestBase
     }
 
     [Test]
-    public async Task Has_Not_Errored()
-    {
-        await Assert.That(async () => { await RunModule<DotNetTestWithoutFailureModule>(); })
-            .ThrowsNothing();
-    }
-
-    [Test]
     public async Task Can_Parse_Trx_Manually()
     {
-        await RunModule<DotNetTestWithoutFailureModule>();
-        var parsedResults = new TrxParser().ParseTrxContents(await DotNetTestWithoutFailureModule.TrxFile!.ReadAsync());
+        var parsedResults = new TrxParser().ParseTrxContents(await TrxFixture.ReadAsync());
 
         await Assert.That(parsedResults.UnitTestResults).Count().IsEqualTo(4);
     }
@@ -119,16 +70,14 @@ public class DotNetTestResultsTests : TestBase
     public async Task Can_Parse_Trx_Using_Helper()
     {
         var host = await TestPipelineHostBuilder.Create()
-            .AddModule<DotNetTestWithoutFailureModule>()
+            .AddModule<DotNetTestWithFailureModule>()
             .BuildAsync();
-
-        await host.RunAsync();
 
         // Get the Trx helper from a pipeline context
         // IPipelineContext is a scoped service, so we need to create a scope
         await using var scope = host.Services.CreateAsyncScope();
         var context = scope.ServiceProvider.GetRequiredService<IPipelineContext>();
-        var parsedResults = await context.Trx().ParseTrxFile(DotNetTestWithoutFailureModule.TrxFile!);
+        var parsedResults = await context.Trx().ParseTrxFile(TrxFixture);
 
         await Assert.That(parsedResults.UnitTestResults).Count().IsEqualTo(4);
     }

--- a/test/ModularPipelines.UnitTests/Helpers/DotNetTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/DotNetTests.cs
@@ -19,11 +19,10 @@ public class DotNetTests : TestBase
             var repositoryInfo = await context.Git().Information.GetInfoAsync()
                 ?? throw new InvalidOperationException("Git repository information is unavailable.");
 
-            // Use main solution explicitly - FindFile returns first match alphabetically
-            // which could be ModularPipelines.Analyzers.sln causing flaky failures
+            // Use the main solution explicitly rather than searching the repository.
             return await context.DotNet().Package.ListAsync(new DotNetPackageListOptions
             {
-                Project = repositoryInfo.Root.FindFile(x => x.Name == "ModularPipelines.sln").AssertExists(),
+                Project = repositoryInfo.Root.GetFile("ModularPipelines.sln").AssertExists(),
             }, cancellationToken: cancellationToken);
         }
     }
@@ -37,7 +36,10 @@ public class DotNetTests : TestBase
 
             return await context.DotNet().FormatAsync(new DotNetFormatOptions
             {
-                ProjectSolution = repositoryInfo.Root.FindFile(x => x.Name.Contains("TestsForTests")).AssertExists(),
+                ProjectSolution = repositoryInfo.Root.GetFolder("test")
+                    .GetFolder("ModularPipelines.TestsForTests")
+                    .GetFile("ModularPipelines.TestsForTests.csproj")
+                    .AssertExists(),
             }, cancellationToken: cancellationToken);
         }
     }

--- a/test/ModularPipelines.UnitTests/Models/TrxParsingTests.cs
+++ b/test/ModularPipelines.UnitTests/Models/TrxParsingTests.cs
@@ -1,108 +1,29 @@
-using Microsoft.Extensions.DependencyInjection;
-using ModularPipelines.Context;
 using ModularPipelines.DotNet;
 using ModularPipelines.DotNet.Enums;
-using ModularPipelines.DotNet.Extensions;
-using ModularPipelines.DotNet.Options;
 using ModularPipelines.DotNet.Parsers.Trx;
-using ModularPipelines.Engine;
-using ModularPipelines.Extensions;
-using ModularPipelines.Git.Extensions;
-using ModularPipelines.Models;
-using ModularPipelines.Options;
-using ModularPipelines.Modules;
-using ModularPipelines.TestHelpers;
 
 namespace ModularPipelines.UnitTests.Models;
 
-public class TrxParsingTests : TestBase
+public class TrxParsingTests
 {
+    private static readonly string TrxFixturePath = Path.Combine(
+        AppContext.BaseDirectory,
+        "Data",
+        "test-results.trx");
+
     [Test]
-    public async Task ParsesSkippedTestReason()
+    public async Task Parses_Skipped_Test_Reason()
     {
-        const string trx = """
-                           <TestRun>
-                             <Results>
-                               <UnitTestResult executionId="execution" testId="test" testName="Skipped_Test"
-                                 computerName="agent" duration="00:00:00" startTime="2026-07-27T12:00:00Z"
-                                 endTime="2026-07-27T12:00:00Z" testType="type" outcome="NotExecuted"
-                                 testListId="list" relativeResultsDirectory="results">
-                                 <Output>
-                                   <DebugTrace>Skipped: Linux only test</DebugTrace>
-                                 </Output>
-                               </UnitTestResult>
-                             </Results>
-                             <ResultSummary outcome="Completed">
-                               <Counters total="1" executed="0" passed="0" failed="0" error="0"
-                                 timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0"
-                                 notRunnable="0" notExecuted="1" disconnected="0" warning="0"
-                                 completed="0" inProgress="0" pending="0" />
-                             </ResultSummary>
-                           </TestRun>
-                           """;
+        var result = await ParseFixture();
 
-        var result = new TrxParser().ParseTrxContents(trx);
-
-        await Assert.That(result.UnitTestResults.Single().Output?.DebugTrace)
+        await Assert.That(result.UnitTestResults.Single(x => x.Outcome == TestOutcome.NotExecuted).Output?.DebugTrace)
             .IsEqualTo("Skipped: Linux only test");
     }
 
-    public class NUnitModule : Module<DotNetTestResult>
-    {
-        public DotNetTestResult? LastResult { get; private set; }
-
-        protected internal override async Task<DotNetTestResult?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-        {
-            var repositoryInfo = await context.Git().Information.GetInfoAsync()
-                ?? throw new InvalidOperationException("Git repository information is unavailable.");
-            var testProject = repositoryInfo.Root
-                .FindFile(x => x.Name == "ModularPipelines.TestsForTests.csproj")!;
-
-            // Create a temp directory for test results
-            var resultsDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(resultsDirectory);
-
-            const string trxFileName = "test-results.trx";
-
-            await context.DotNet().TestAsync(
-                new DotNetTestOptions
-                {
-                    Framework = "net10.0",
-                    ResultsDirectory = resultsDirectory,
-                    Arguments = ["--report-trx", "--report-trx-filename", trxFileName]
-                },
-                new CommandExecutionOptions
-                {
-                    WorkingDirectory = testProject.Folder!.Path,
-                    ThrowOnNonZeroExitCode = false,
-                    LogSettings = new CommandLoggingOptions
-                    {
-                        Verbosity = CommandLogVerbosity.Minimal,
-                        ShowStandardOutput = false,
-                        ShowStandardError = true,
-                    },
-                },
-                cancellationToken);
-
-            var trxFilePath = Path.Combine(resultsDirectory, trxFileName);
-            var trxContents = await System.IO.File.ReadAllTextAsync(trxFilePath, cancellationToken);
-
-            LastResult = new TrxParser().ParseTrxContents(trxContents);
-            return LastResult;
-        }
-    }
-
     [Test]
-    public async Task NUnit()
+    public async Task Parses_Mixed_Test_Outcomes()
     {
-        var host = await TestPipelineHostBuilder.Create()
-            .AddModule<NUnitModule>()
-            .BuildAsync();
-
-        await host.RunAsync();
-
-        var module = host.Services.GetServices<IModule>().OfType<NUnitModule>().First();
-        var testResult = module.LastResult!;
+        var testResult = await ParseFixture();
 
         await Assert.That(testResult.Successful).IsFalse();
 
@@ -114,5 +35,11 @@ public class TrxParsingTests : TestBase
 
         await Assert.That(testResult.UnitTestResults.Where(x => x.Outcome == TestOutcome.Passed))
             .Count().IsEqualTo(2);
+    }
+
+    private static async Task<DotNetTestResult> ParseFixture()
+    {
+        var contents = await System.IO.File.ReadAllTextAsync(TrxFixturePath);
+        return new TrxParser().ParseTrxContents(contents);
     }
 }


### PR DESCRIPTION
## Summary
- check in a deterministic TRX fixture covering passed, failed, skipped, and errored outcomes
- make parser tests consume the fixture instead of spawning nested dotnet test processes
- keep one focused nested failure run for the behavior that requires a real CommandResult
- use direct project paths and allow the test fixture project to roll forward to the installed SDK

## Validation
- TrxParsingTests: 2/2
- DotNetTestResultsTests: 3/3

Closes #3524