### PR TITLE
Include integration tests in tool solutions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,10 @@ and analyzers only). Each tool/CLI integration has its **own** solution next to 
 pwsh scripts/Invoke-AgentDotNet.ps1 -SingleNode `
   -DotNetArguments @('build', 'ModularPipelines.sln', '-c', 'Release')
 
+# Core build including ModularPipelines.UnitTests
+pwsh scripts/Invoke-AgentDotNet.ps1 -SingleNode `
+  -DotNetArguments @('build', 'ModularPipelines.Tests.slnf', '-c', 'Release')
+
 # Tool-specific build
 pwsh scripts/Invoke-AgentDotNet.ps1 -SingleNode `
   -DotNetArguments @(
@@ -51,8 +55,11 @@ pwsh scripts/Invoke-AgentDotNet.ps1 -SingleNode `
 # framework, Cmd, source generator, and analyzers only.
 dotnet build ModularPipelines.sln -c Release
 
+# Build the core library and its unit-test project without building the full solution.
+dotnet build ModularPipelines.Tests.slnf -c Release
+
 # Working on a tool/CLI integration? Build that tool's own solution.
-# (Most tool integrations have auto-generated options - see the code generation notes below.)
+# It includes the tool's matching unit-test project when one exists.
 dotnet build src/ModularPipelines.Docker/ModularPipelines.Docker.sln -c Release
 
 # Other solutions - only when working on those areas.
@@ -73,9 +80,11 @@ dotnet build ModularPipelines.Analyzers.sln -c Release
 
 Every tool/CLI integration (Docker, DotNet, Git, Helm, Terraform, Azure, AWS, etc.) is a
 separate package whose options are largely auto-generated, and each has its own
-`src/ModularPipelines.<Tool>/ModularPipelines.<Tool>.sln`. Build the specific tool
-solution when working on it. `ModularPipelines.All.sln` exists for CI's full build only —
-see the caution above; agents should not build it.
+`src/ModularPipelines.<Tool>/ModularPipelines.<Tool>.sln`. Each tool solution includes
+its matching unit-test project when one exists. Build the specific tool solution when
+working on it. `ModularPipelines.Tests.slnf` provides the equivalent test-building loop
+for the lightweight core. `ModularPipelines.All.sln` exists for CI's full build only — see
+the caution above; agents should not build it.
 
 ### Running Tests
 ```powershell

--- a/ModularPipelines.Tests.slnf
+++ b/ModularPipelines.Tests.slnf
@@ -1,0 +1,8 @@
+{
+  "solution": {
+    "path": "ModularPipelines.All.sln",
+    "projects": [
+      "test\\ModularPipelines.UnitTests\\ModularPipelines.UnitTests.csproj"
+    ]
+  }
+}

--- a/src/ModularPipelines.AmazonWebServices/ModularPipelines.AmazonWebServices.sln
+++ b/src/ModularPipelines.AmazonWebServices/ModularPipelines.AmazonWebServices.sln
@@ -8,23 +8,74 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.AmazonWebS
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.AmazonWebServices.UnitTests", "..\..\test\ModularPipelines.AmazonWebServices.UnitTests\ModularPipelines.AmazonWebServices.UnitTests.csproj", "{7DB3301D-A0C2-46A1-8497-06A80109F20E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500} = {2F3EEFC9-4D3A-4394-96C9-BE42F65F30D6}
-		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834} = {2F3EEFC9-4D3A-4394-96C9-BE42F65F30D6}
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Debug|x64.Build.0 = Debug|Any CPU
+		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Debug|x86.Build.0 = Debug|Any CPU
 		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Release|x64.ActiveCfg = Release|Any CPU
+		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Release|x64.Build.0 = Release|Any CPU
+		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Release|x86.ActiveCfg = Release|Any CPU
+		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500}.Release|x86.Build.0 = Release|Any CPU
 		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Debug|x64.Build.0 = Debug|Any CPU
+		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Debug|x86.Build.0 = Debug|Any CPU
 		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Release|x64.ActiveCfg = Release|Any CPU
+		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Release|x64.Build.0 = Release|Any CPU
+		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Release|x86.ActiveCfg = Release|Any CPU
+		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834}.Release|x86.Build.0 = Release|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Debug|x64.Build.0 = Debug|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Debug|x86.Build.0 = Debug|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Release|x64.ActiveCfg = Release|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Release|x64.Build.0 = Release|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Release|x86.ActiveCfg = Release|Any CPU
+		{7DB3301D-A0C2-46A1-8497-06A80109F20E}.Release|x86.Build.0 = Release|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Debug|x64.Build.0 = Debug|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Debug|x86.Build.0 = Debug|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Release|x64.ActiveCfg = Release|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Release|x64.Build.0 = Release|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Release|x86.ActiveCfg = Release|Any CPU
+		{D4EAD397-6BCC-4C8D-82A2-08F175E08CC8}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{E70B7189-9A0B-4D16-BA46-D7D1EA2D4500} = {2F3EEFC9-4D3A-4394-96C9-BE42F65F30D6}
+		{B777CDA3-D4E6-4ECC-9D95-4F0C64408834} = {2F3EEFC9-4D3A-4394-96C9-BE42F65F30D6}
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Ansible/ModularPipelines.Ansible.sln
+++ b/src/ModularPipelines.Ansible/ModularPipelines.Ansible.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Ansible", "ModularPipelines.Ansible.csproj", "{5DC40C77-BD7C-5166-8C4B-C396928B5597}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Ansible.UnitTests", "..\..\test\ModularPipelines.Ansible.UnitTests\ModularPipelines.Ansible.UnitTests.csproj", "{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5DC40C77-BD7C-5166-8C4B-C396928B5597}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Debug|x64.Build.0 = Debug|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Debug|x86.Build.0 = Debug|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Release|x64.ActiveCfg = Release|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Release|x64.Build.0 = Release|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Release|x86.ActiveCfg = Release|Any CPU
+		{5FCC975F-95E9-42BD-9B7D-6789EEE70B63}.Release|x86.Build.0 = Release|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Debug|x64.Build.0 = Debug|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Debug|x86.Build.0 = Debug|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Release|Any CPU.Build.0 = Release|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Release|x64.ActiveCfg = Release|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Release|x64.Build.0 = Release|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Release|x86.ActiveCfg = Release|Any CPU
+		{746A45AE-1E1E-4EA9-A589-C9D5C97A9492}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.ArgoCd/ModularPipelines.ArgoCd.sln
+++ b/src/ModularPipelines.ArgoCd/ModularPipelines.ArgoCd.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.ArgoCd", "ModularPipelines.ArgoCd.csproj", "{A95D9426-5EB7-568B-B438-A9F7D2ACF74F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.ArgoCd.UnitTests", "..\..\test\ModularPipelines.ArgoCd.UnitTests\ModularPipelines.ArgoCd.UnitTests.csproj", "{379CDC86-97C3-40D5-801E-1415B149AB8F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{B52256BE-44A6-41D4-BAC7-55D16077DB29}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{A95D9426-5EB7-568B-B438-A9F7D2ACF74F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Debug|x64.Build.0 = Debug|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Debug|x86.Build.0 = Debug|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Release|x64.ActiveCfg = Release|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Release|x64.Build.0 = Release|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Release|x86.ActiveCfg = Release|Any CPU
+		{379CDC86-97C3-40D5-801E-1415B149AB8F}.Release|x86.Build.0 = Release|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Debug|x64.Build.0 = Debug|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Debug|x86.Build.0 = Debug|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Release|x64.ActiveCfg = Release|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Release|x64.Build.0 = Release|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Release|x86.ActiveCfg = Release|Any CPU
+		{B52256BE-44A6-41D4-BAC7-55D16077DB29}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Buildah/ModularPipelines.Buildah.sln
+++ b/src/ModularPipelines.Buildah/ModularPipelines.Buildah.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Buildah", "ModularPipelines.Buildah.csproj", "{D96FA246-C1E2-53F4-979C-628A7B92C40D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Buildah.UnitTests", "..\..\test\ModularPipelines.Buildah.UnitTests\ModularPipelines.Buildah.UnitTests.csproj", "{5D144099-9A3F-467A-9DC8-CA5B22186CA7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{D7D496AB-26F1-4497-8103-3D1577B59411}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D96FA246-C1E2-53F4-979C-628A7B92C40D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Debug|x64.Build.0 = Debug|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Debug|x86.Build.0 = Debug|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Release|x64.ActiveCfg = Release|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Release|x64.Build.0 = Release|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Release|x86.ActiveCfg = Release|Any CPU
+		{5D144099-9A3F-467A-9DC8-CA5B22186CA7}.Release|x86.Build.0 = Release|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Debug|x64.Build.0 = Debug|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Debug|x86.Build.0 = Debug|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Release|x64.ActiveCfg = Release|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Release|x64.Build.0 = Release|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Release|x86.ActiveCfg = Release|Any CPU
+		{D7D496AB-26F1-4497-8103-3D1577B59411}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Chocolatey/ModularPipelines.Chocolatey.sln
+++ b/src/ModularPipelines.Chocolatey/ModularPipelines.Chocolatey.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Chocolatey", "ModularPipelines.Chocolatey.csproj", "{570BC4EA-8425-5985-B584-DA5D0A691EA0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Chocolatey.UnitTests", "..\..\test\ModularPipelines.Chocolatey.UnitTests\ModularPipelines.Chocolatey.UnitTests.csproj", "{E9BDA05F-487C-4436-ADC9-E0049250D7BD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{570BC4EA-8425-5985-B584-DA5D0A691EA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Debug|x64.Build.0 = Debug|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Debug|x86.Build.0 = Debug|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Release|x64.ActiveCfg = Release|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Release|x64.Build.0 = Release|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Release|x86.ActiveCfg = Release|Any CPU
+		{E9BDA05F-487C-4436-ADC9-E0049250D7BD}.Release|x86.Build.0 = Release|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Debug|x64.Build.0 = Debug|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Debug|x86.Build.0 = Debug|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Release|x64.ActiveCfg = Release|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Release|x64.Build.0 = Release|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Release|x86.ActiveCfg = Release|Any CPU
+		{8DA4FEDA-8DF4-499F-BA8E-41E22A65C98D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Cosign/ModularPipelines.Cosign.sln
+++ b/src/ModularPipelines.Cosign/ModularPipelines.Cosign.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Cosign", "ModularPipelines.Cosign.csproj", "{E8E3D5CE-4CC1-5881-ACC4-7E24B3174F40}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Cosign.UnitTests", "..\..\test\ModularPipelines.Cosign.UnitTests\ModularPipelines.Cosign.UnitTests.csproj", "{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E8E3D5CE-4CC1-5881-ACC4-7E24B3174F40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Debug|x64.Build.0 = Debug|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Debug|x86.Build.0 = Debug|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Release|x64.ActiveCfg = Release|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Release|x64.Build.0 = Release|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Release|x86.ActiveCfg = Release|Any CPU
+		{AB8641E0-D8FB-4A8E-9500-1FD2D7CE8ACA}.Release|x86.Build.0 = Release|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Debug|x64.Build.0 = Debug|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Debug|x86.Build.0 = Debug|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Release|x64.ActiveCfg = Release|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Release|x64.Build.0 = Release|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Release|x86.ActiveCfg = Release|Any CPU
+		{C3C2F3BE-0725-4E3A-B1B8-A41A3192FC41}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Docker/ModularPipelines.Docker.sln
+++ b/src/ModularPipelines.Docker/ModularPipelines.Docker.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Docker", "ModularPipelines.Docker.csproj", "{6CBA5884-0003-5633-8F48-8BC1DAEDCF2A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Docker.UnitTests", "..\..\test\ModularPipelines.Docker.UnitTests\ModularPipelines.Docker.UnitTests.csproj", "{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{6DB095D3-FF35-409C-AB30-8D1B660D35ED}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6CBA5884-0003-5633-8F48-8BC1DAEDCF2A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Debug|x64.Build.0 = Debug|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Debug|x86.Build.0 = Debug|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Release|x64.ActiveCfg = Release|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Release|x64.Build.0 = Release|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Release|x86.ActiveCfg = Release|Any CPU
+		{115C5283-C2B2-43AA-AAB3-B8BBE333D4EB}.Release|x86.Build.0 = Release|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Debug|x64.Build.0 = Debug|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Debug|x86.Build.0 = Debug|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Release|x64.ActiveCfg = Release|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Release|x64.Build.0 = Release|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Release|x86.ActiveCfg = Release|Any CPU
+		{6DB095D3-FF35-409C-AB30-8D1B660D35ED}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.DotNet/ModularPipelines.DotNet.sln
+++ b/src/ModularPipelines.DotNet/ModularPipelines.DotNet.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.DotNet", "ModularPipelines.DotNet.csproj", "{934A4F06-FFC0-513E-A79F-711A872D912E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.DotNet.UnitTests", "..\..\test\ModularPipelines.DotNet.UnitTests\ModularPipelines.DotNet.UnitTests.csproj", "{8CC65C7B-1AE0-458F-A454-135BE5CB738D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{9A502F84-ECC5-4C0E-91AF-F66330F9B487}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{934A4F06-FFC0-513E-A79F-711A872D912E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Debug|x64.Build.0 = Debug|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Debug|x86.Build.0 = Debug|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Release|x64.ActiveCfg = Release|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Release|x64.Build.0 = Release|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Release|x86.ActiveCfg = Release|Any CPU
+		{8CC65C7B-1AE0-458F-A454-135BE5CB738D}.Release|x86.Build.0 = Release|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Debug|x64.Build.0 = Debug|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Debug|x86.Build.0 = Debug|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Release|x64.ActiveCfg = Release|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Release|x64.Build.0 = Release|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Release|x86.ActiveCfg = Release|Any CPU
+		{9A502F84-ECC5-4C0E-91AF-F66330F9B487}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Eksctl/ModularPipelines.Eksctl.sln
+++ b/src/ModularPipelines.Eksctl/ModularPipelines.Eksctl.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Eksctl", "ModularPipelines.Eksctl.csproj", "{37A49B57-7FC7-568C-855C-F34EF74CFDF5}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Eksctl.UnitTests", "..\..\test\ModularPipelines.Eksctl.UnitTests\ModularPipelines.Eksctl.UnitTests.csproj", "{F12F9617-6459-43B9-9B0B-953731935EB8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{E639F99C-21F2-47EE-A330-DC53F797CACB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{37A49B57-7FC7-568C-855C-F34EF74CFDF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Debug|x64.Build.0 = Debug|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Debug|x86.Build.0 = Debug|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Release|x64.ActiveCfg = Release|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Release|x64.Build.0 = Release|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Release|x86.ActiveCfg = Release|Any CPU
+		{F12F9617-6459-43B9-9B0B-953731935EB8}.Release|x86.Build.0 = Release|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Debug|x64.Build.0 = Debug|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Debug|x86.Build.0 = Debug|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Release|x64.ActiveCfg = Release|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Release|x64.Build.0 = Release|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Release|x86.ActiveCfg = Release|Any CPU
+		{E639F99C-21F2-47EE-A330-DC53F797CACB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Email/ModularPipelines.Email.sln
+++ b/src/ModularPipelines.Email/ModularPipelines.Email.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Email", "ModularPipelines.Email.csproj", "{C15A4964-F6B2-52CA-A2B0-7C18BB00FED6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Email.UnitTests", "..\..\test\ModularPipelines.Email.UnitTests\ModularPipelines.Email.UnitTests.csproj", "{4BF31E9E-E642-4F09-A057-580EC77C5A5F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{A353EAC3-65A9-4708-A2EB-854F75697F32}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C15A4964-F6B2-52CA-A2B0-7C18BB00FED6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Debug|x64.Build.0 = Debug|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Debug|x86.Build.0 = Debug|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Release|x64.ActiveCfg = Release|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Release|x64.Build.0 = Release|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Release|x86.ActiveCfg = Release|Any CPU
+		{4BF31E9E-E642-4F09-A057-580EC77C5A5F}.Release|x86.Build.0 = Release|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Debug|x64.Build.0 = Debug|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Debug|x86.Build.0 = Debug|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Release|x64.ActiveCfg = Release|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Release|x64.Build.0 = Release|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Release|x86.ActiveCfg = Release|Any CPU
+		{A353EAC3-65A9-4708-A2EB-854F75697F32}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Flux/ModularPipelines.Flux.sln
+++ b/src/ModularPipelines.Flux/ModularPipelines.Flux.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Flux", "ModularPipelines.Flux.csproj", "{BBFC4328-B494-56B6-AF3F-AB0173EB362A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Flux.UnitTests", "..\..\test\ModularPipelines.Flux.UnitTests\ModularPipelines.Flux.UnitTests.csproj", "{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{BBFC4328-B494-56B6-AF3F-AB0173EB362A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Debug|x64.Build.0 = Debug|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Debug|x86.Build.0 = Debug|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Release|x64.ActiveCfg = Release|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Release|x64.Build.0 = Release|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Release|x86.ActiveCfg = Release|Any CPU
+		{43DBC78B-BE91-48EA-B936-E94BBF2D29AE}.Release|x86.Build.0 = Release|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Debug|x64.Build.0 = Debug|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Debug|x86.Build.0 = Debug|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Release|x64.ActiveCfg = Release|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Release|x64.Build.0 = Release|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Release|x86.ActiveCfg = Release|Any CPU
+		{20921A6F-679C-41F9-9AD9-B8A6C7C5DFF7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Flyway/ModularPipelines.Flyway.sln
+++ b/src/ModularPipelines.Flyway/ModularPipelines.Flyway.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Flyway", "ModularPipelines.Flyway.csproj", "{1E6325D8-E46F-57E1-B645-110EAAAAB5B7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Flyway.UnitTests", "..\..\test\ModularPipelines.Flyway.UnitTests\ModularPipelines.Flyway.UnitTests.csproj", "{6120FBD6-D7EE-4067-A655-B89C5DA32327}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{9378AE18-9C13-41E2-8A5F-944322BEDC62}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1E6325D8-E46F-57E1-B645-110EAAAAB5B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Debug|x64.Build.0 = Debug|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Debug|x86.Build.0 = Debug|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Release|x64.ActiveCfg = Release|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Release|x64.Build.0 = Release|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Release|x86.ActiveCfg = Release|Any CPU
+		{6120FBD6-D7EE-4067-A655-B89C5DA32327}.Release|x86.Build.0 = Release|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Debug|x64.Build.0 = Debug|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Debug|x86.Build.0 = Debug|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Release|x64.ActiveCfg = Release|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Release|x64.Build.0 = Release|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Release|x86.ActiveCfg = Release|Any CPU
+		{9378AE18-9C13-41E2-8A5F-944322BEDC62}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Ftp/ModularPipelines.Ftp.sln
+++ b/src/ModularPipelines.Ftp/ModularPipelines.Ftp.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Ftp", "ModularPipelines.Ftp.csproj", "{6C8DD210-26ED-5697-813A-8094482A4F8F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Ftp.UnitTests", "..\..\test\ModularPipelines.Ftp.UnitTests\ModularPipelines.Ftp.UnitTests.csproj", "{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6C8DD210-26ED-5697-813A-8094482A4F8F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Debug|x64.Build.0 = Debug|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Debug|x86.Build.0 = Debug|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Release|x64.ActiveCfg = Release|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Release|x64.Build.0 = Release|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Release|x86.ActiveCfg = Release|Any CPU
+		{9293B5BF-7DAC-407A-8033-6CBE553CCDDB}.Release|x86.Build.0 = Release|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Debug|x64.Build.0 = Debug|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Debug|x86.Build.0 = Debug|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Release|x64.ActiveCfg = Release|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Release|x64.Build.0 = Release|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Release|x86.ActiveCfg = Release|Any CPU
+		{BC470872-BEA6-449D-9DF8-FAC76F6BEE3D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Git/ModularPipelines.Git.sln
+++ b/src/ModularPipelines.Git/ModularPipelines.Git.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Git", "ModularPipelines.Git.csproj", "{E7FC3BA0-4AB9-5365-AB3E-C83C21ADEE51}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Git.UnitTests", "..\..\test\ModularPipelines.Git.UnitTests\ModularPipelines.Git.UnitTests.csproj", "{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E7FC3BA0-4AB9-5365-AB3E-C83C21ADEE51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Debug|x64.Build.0 = Debug|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Debug|x86.Build.0 = Debug|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Release|x64.ActiveCfg = Release|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Release|x64.Build.0 = Release|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Release|x86.ActiveCfg = Release|Any CPU
+		{7283C73A-7EA5-4943-A15A-2A440EC2E9E9}.Release|x86.Build.0 = Release|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Debug|x64.Build.0 = Debug|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Debug|x86.Build.0 = Debug|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Release|x64.ActiveCfg = Release|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Release|x64.Build.0 = Release|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Release|x86.ActiveCfg = Release|Any CPU
+		{65DD8048-D72A-459E-AF5C-2CA18F26DEAA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.GitHub/ModularPipelines.GitHub.sln
+++ b/src/ModularPipelines.GitHub/ModularPipelines.GitHub.sln
@@ -1,4 +1,5 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -8,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\Modu
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Git", "..\ModularPipelines.Git\ModularPipelines.Git.csproj", "{E7FC3BA0-4AB9-5365-AB3E-C83C21ADEE51}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.GitHub.UnitTests", "..\..\test\ModularPipelines.GitHub.UnitTests\ModularPipelines.GitHub.UnitTests.csproj", "{87008B63-60D9-450F-BD62-716B0E768858}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{2A23051C-99C1-4733-B780-4C40744D5603}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -16,9 +21,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E2C8B22D-FDB7-5A5C-B4F7-55333DBEFB81}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -57,7 +59,32 @@ Global
 		{E7FC3BA0-4AB9-5365-AB3E-C83C21ADEE51}.Release|x64.Build.0 = Release|Any CPU
 		{E7FC3BA0-4AB9-5365-AB3E-C83C21ADEE51}.Release|x86.ActiveCfg = Release|Any CPU
 		{E7FC3BA0-4AB9-5365-AB3E-C83C21ADEE51}.Release|x86.Build.0 = Release|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Debug|x64.Build.0 = Debug|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Debug|x86.Build.0 = Debug|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Release|x64.ActiveCfg = Release|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Release|x64.Build.0 = Release|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Release|x86.ActiveCfg = Release|Any CPU
+		{87008B63-60D9-450F-BD62-716B0E768858}.Release|x86.Build.0 = Release|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Debug|x64.Build.0 = Debug|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Debug|x86.Build.0 = Debug|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Release|x64.ActiveCfg = Release|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Release|x64.Build.0 = Release|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Release|x86.ActiveCfg = Release|Any CPU
+		{2A23051C-99C1-4733-B780-4C40744D5603}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Go/ModularPipelines.Go.sln
+++ b/src/ModularPipelines.Go/ModularPipelines.Go.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Go", "ModularPipelines.Go.csproj", "{39C5159D-63AB-5AEE-A2FA-1C9CD61B7C88}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Go.UnitTests", "..\..\test\ModularPipelines.Go.UnitTests\ModularPipelines.Go.UnitTests.csproj", "{524E7856-7BB6-421F-B3FA-FD140D2841DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{39C5159D-63AB-5AEE-A2FA-1C9CD61B7C88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Debug|x64.Build.0 = Debug|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Debug|x86.Build.0 = Debug|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Release|x64.ActiveCfg = Release|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Release|x64.Build.0 = Release|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{524E7856-7BB6-421F-B3FA-FD140D2841DC}.Release|x86.Build.0 = Release|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Debug|x64.Build.0 = Debug|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Debug|x86.Build.0 = Debug|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Release|x64.ActiveCfg = Release|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Release|x64.Build.0 = Release|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Release|x86.ActiveCfg = Release|Any CPU
+		{49FA01A6-D1FF-4983-A8AA-7F6F44A7A7EE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Google/ModularPipelines.Google.sln
+++ b/src/ModularPipelines.Google/ModularPipelines.Google.sln
@@ -4,19 +4,70 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Google", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{303E4137-9F93-47D0-9819-93BB2C5A7314}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Google.UnitTests", "..\..\test\ModularPipelines.Google.UnitTests\ModularPipelines.Google.UnitTests.csproj", "{583E33E0-D9E6-4356-AA8E-905158A349E7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Debug|x64.Build.0 = Debug|Any CPU
+		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Debug|x86.Build.0 = Debug|Any CPU
 		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Release|x64.ActiveCfg = Release|Any CPU
+		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Release|x64.Build.0 = Release|Any CPU
+		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Release|x86.ActiveCfg = Release|Any CPU
+		{1576A946-DA14-47F9-A529-DCC32EFDA6AB}.Release|x86.Build.0 = Release|Any CPU
 		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Debug|x64.Build.0 = Debug|Any CPU
+		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Debug|x86.Build.0 = Debug|Any CPU
 		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Release|Any CPU.Build.0 = Release|Any CPU
+		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Release|x64.ActiveCfg = Release|Any CPU
+		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Release|x64.Build.0 = Release|Any CPU
+		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Release|x86.ActiveCfg = Release|Any CPU
+		{303E4137-9F93-47D0-9819-93BB2C5A7314}.Release|x86.Build.0 = Release|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Debug|x64.Build.0 = Debug|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Debug|x86.Build.0 = Debug|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Release|x64.ActiveCfg = Release|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Release|x64.Build.0 = Release|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Release|x86.ActiveCfg = Release|Any CPU
+		{583E33E0-D9E6-4356-AA8E-905158A349E7}.Release|x86.Build.0 = Release|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Debug|x86.Build.0 = Debug|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Release|x64.Build.0 = Release|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C76E309-8A70-4B9C-A166-1E7BF847ABD7}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Grype/ModularPipelines.Grype.sln
+++ b/src/ModularPipelines.Grype/ModularPipelines.Grype.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Grype", "ModularPipelines.Grype.csproj", "{36B12094-1398-55AF-92CD-283EC2E34674}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Grype.UnitTests", "..\..\test\ModularPipelines.Grype.UnitTests\ModularPipelines.Grype.UnitTests.csproj", "{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{36B12094-1398-55AF-92CD-283EC2E34674}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Debug|x64.Build.0 = Debug|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Debug|x86.Build.0 = Debug|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Release|x64.ActiveCfg = Release|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Release|x64.Build.0 = Release|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Release|x86.ActiveCfg = Release|Any CPU
+		{FD77860F-36F1-4B82-A347-FE4DE3EBDE9A}.Release|x86.Build.0 = Release|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Debug|x64.Build.0 = Debug|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Debug|x86.Build.0 = Debug|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Release|x64.ActiveCfg = Release|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Release|x64.Build.0 = Release|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Release|x86.ActiveCfg = Release|Any CPU
+		{D88CA4E0-BF91-4004-BD7A-96B78544B6BC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Hadolint/ModularPipelines.Hadolint.sln
+++ b/src/ModularPipelines.Hadolint/ModularPipelines.Hadolint.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Hadolint", "ModularPipelines.Hadolint.csproj", "{F443D995-4FBD-59FF-B820-8A6E0B48C1DC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Hadolint.UnitTests", "..\..\test\ModularPipelines.Hadolint.UnitTests\ModularPipelines.Hadolint.UnitTests.csproj", "{3B72117B-8F49-46ED-8192-06982319BF6D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F443D995-4FBD-59FF-B820-8A6E0B48C1DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Debug|x64.Build.0 = Debug|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Debug|x86.Build.0 = Debug|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Release|x64.ActiveCfg = Release|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Release|x64.Build.0 = Release|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Release|x86.ActiveCfg = Release|Any CPU
+		{3B72117B-8F49-46ED-8192-06982319BF6D}.Release|x86.Build.0 = Release|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Debug|x64.Build.0 = Debug|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Debug|x86.Build.0 = Debug|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Release|x64.ActiveCfg = Release|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Release|x64.Build.0 = Release|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Release|x86.ActiveCfg = Release|Any CPU
+		{AA6FE328-0B5A-42BE-86F2-7F0B084C5F20}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Helm/ModularPipelines.Helm.sln
+++ b/src/ModularPipelines.Helm/ModularPipelines.Helm.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Helm", "ModularPipelines.Helm.csproj", "{43546E5F-829E-5388-9779-AB6A2A8807B3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Helm.UnitTests", "..\..\test\ModularPipelines.Helm.UnitTests\ModularPipelines.Helm.UnitTests.csproj", "{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{D3870D46-8F2B-48EF-9CF0-6891D72B7591}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{43546E5F-829E-5388-9779-AB6A2A8807B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Debug|x64.Build.0 = Debug|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Debug|x86.Build.0 = Debug|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Release|x64.ActiveCfg = Release|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Release|x64.Build.0 = Release|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Release|x86.ActiveCfg = Release|Any CPU
+		{D849EF01-BC0F-4F6E-BB21-E0A87BEEC659}.Release|x86.Build.0 = Release|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Debug|x64.Build.0 = Debug|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Debug|x86.Build.0 = Debug|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Release|x64.ActiveCfg = Release|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Release|x64.Build.0 = Release|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Release|x86.ActiveCfg = Release|Any CPU
+		{D3870D46-8F2B-48EF-9CF0-6891D72B7591}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Homebrew/ModularPipelines.Homebrew.sln
+++ b/src/ModularPipelines.Homebrew/ModularPipelines.Homebrew.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Homebrew", "ModularPipelines.Homebrew.csproj", "{C597B09B-F45B-519B-8F89-A7A7E1C2430E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Homebrew.UnitTests", "..\..\test\ModularPipelines.Homebrew.UnitTests\ModularPipelines.Homebrew.UnitTests.csproj", "{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{F4DE320B-968C-426A-AB9E-74ABD45057D6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C597B09B-F45B-519B-8F89-A7A7E1C2430E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Debug|x64.Build.0 = Debug|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Debug|x86.Build.0 = Debug|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Release|x64.ActiveCfg = Release|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Release|x64.Build.0 = Release|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Release|x86.ActiveCfg = Release|Any CPU
+		{BD0E2DE1-FF0E-4CF9-A98A-36FE323CCDA8}.Release|x86.Build.0 = Release|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Debug|x64.Build.0 = Debug|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Debug|x86.Build.0 = Debug|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Release|x64.ActiveCfg = Release|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Release|x64.Build.0 = Release|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Release|x86.ActiveCfg = Release|Any CPU
+		{F4DE320B-968C-426A-AB9E-74ABD45057D6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Java/ModularPipelines.Java.sln
+++ b/src/ModularPipelines.Java/ModularPipelines.Java.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Java", "ModularPipelines.Java.csproj", "{E230ABCC-32F8-5177-A10B-1985D483206D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Java.UnitTests", "..\..\test\ModularPipelines.Java.UnitTests\ModularPipelines.Java.UnitTests.csproj", "{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{169B1D74-6B8F-4E53-820F-606354436839}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E230ABCC-32F8-5177-A10B-1985D483206D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Debug|x64.Build.0 = Debug|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Debug|x86.Build.0 = Debug|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Release|x64.ActiveCfg = Release|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Release|x64.Build.0 = Release|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Release|x86.ActiveCfg = Release|Any CPU
+		{4BFA7F6B-C968-41BF-916C-CFAFEA04D998}.Release|x86.Build.0 = Release|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Debug|x64.Build.0 = Debug|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Debug|x86.Build.0 = Debug|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Release|Any CPU.Build.0 = Release|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Release|x64.ActiveCfg = Release|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Release|x64.Build.0 = Release|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Release|x86.ActiveCfg = Release|Any CPU
+		{169B1D74-6B8F-4E53-820F-606354436839}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Jq/ModularPipelines.Jq.sln
+++ b/src/ModularPipelines.Jq/ModularPipelines.Jq.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Jq", "ModularPipelines.Jq.csproj", "{0782DEA4-5BF9-5C04-B6EC-C3FBF815F028}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Jq.UnitTests", "..\..\test\ModularPipelines.Jq.UnitTests\ModularPipelines.Jq.UnitTests.csproj", "{7222E9A0-9869-49BD-A87C-5C954763C994}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{06866830-1CB2-4DC0-8F9B-3919BEA223D7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0782DEA4-5BF9-5C04-B6EC-C3FBF815F028}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Debug|x64.Build.0 = Debug|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Debug|x86.Build.0 = Debug|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Release|x64.ActiveCfg = Release|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Release|x64.Build.0 = Release|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Release|x86.ActiveCfg = Release|Any CPU
+		{7222E9A0-9869-49BD-A87C-5C954763C994}.Release|x86.Build.0 = Release|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Debug|x64.Build.0 = Debug|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Debug|x86.Build.0 = Debug|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Release|x64.ActiveCfg = Release|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Release|x64.Build.0 = Release|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Release|x86.ActiveCfg = Release|Any CPU
+		{06866830-1CB2-4DC0-8F9B-3919BEA223D7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Kind/ModularPipelines.Kind.sln
+++ b/src/ModularPipelines.Kind/ModularPipelines.Kind.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Kind", "ModularPipelines.Kind.csproj", "{08ACEF93-EBE0-5A50-89A6-DCD9AD3AFFA3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Kind.UnitTests", "..\..\test\ModularPipelines.Kind.UnitTests\ModularPipelines.Kind.UnitTests.csproj", "{897E1D14-209F-4EF6-A77F-312B35134953}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{08ACEF93-EBE0-5A50-89A6-DCD9AD3AFFA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Debug|x64.Build.0 = Debug|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Debug|x86.Build.0 = Debug|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Release|Any CPU.Build.0 = Release|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Release|x64.ActiveCfg = Release|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Release|x64.Build.0 = Release|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Release|x86.ActiveCfg = Release|Any CPU
+		{897E1D14-209F-4EF6-A77F-312B35134953}.Release|x86.Build.0 = Release|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Debug|x64.Build.0 = Debug|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Debug|x86.Build.0 = Debug|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Release|x64.ActiveCfg = Release|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Release|x64.Build.0 = Release|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Release|x86.ActiveCfg = Release|Any CPU
+		{40DDAE7D-0BDA-4C21-A0E0-3782F5516BF8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Kubernetes/ModularPipelines.Kubernetes.sln
+++ b/src/ModularPipelines.Kubernetes/ModularPipelines.Kubernetes.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Kubernetes", "ModularPipelines.Kubernetes.csproj", "{6B0BC007-693A-5B1F-8CA5-4538A3DCC9CD}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Kubernetes.UnitTests", "..\..\test\ModularPipelines.Kubernetes.UnitTests\ModularPipelines.Kubernetes.UnitTests.csproj", "{EB3675C3-AD28-4584-BFBB-C2E0027A5416}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{2DAC88D7-FDA4-411C-BF14-66391480D4B3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6B0BC007-693A-5B1F-8CA5-4538A3DCC9CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Debug|x64.Build.0 = Debug|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Debug|x86.Build.0 = Debug|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Release|x64.ActiveCfg = Release|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Release|x64.Build.0 = Release|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Release|x86.ActiveCfg = Release|Any CPU
+		{EB3675C3-AD28-4584-BFBB-C2E0027A5416}.Release|x86.Build.0 = Release|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Debug|x64.Build.0 = Debug|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Debug|x86.Build.0 = Debug|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Release|x64.ActiveCfg = Release|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Release|x64.Build.0 = Release|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Release|x86.ActiveCfg = Release|Any CPU
+		{2DAC88D7-FDA4-411C-BF14-66391480D4B3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Liquibase/ModularPipelines.Liquibase.sln
+++ b/src/ModularPipelines.Liquibase/ModularPipelines.Liquibase.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Liquibase", "ModularPipelines.Liquibase.csproj", "{747E4575-D861-586D-8363-5A4387118FC3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Liquibase.UnitTests", "..\..\test\ModularPipelines.Liquibase.UnitTests\ModularPipelines.Liquibase.UnitTests.csproj", "{ACFD6DD5-7102-4E56-8507-4B9326D7A692}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{6C003FE7-DCA3-4574-86D4-878F2D42B059}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{747E4575-D861-586D-8363-5A4387118FC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Debug|x64.Build.0 = Debug|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Debug|x86.Build.0 = Debug|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Release|x64.ActiveCfg = Release|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Release|x64.Build.0 = Release|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Release|x86.ActiveCfg = Release|Any CPU
+		{ACFD6DD5-7102-4E56-8507-4B9326D7A692}.Release|x86.Build.0 = Release|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Debug|x64.Build.0 = Debug|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Debug|x86.Build.0 = Debug|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Release|x64.ActiveCfg = Release|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Release|x64.Build.0 = Release|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Release|x86.ActiveCfg = Release|Any CPU
+		{6C003FE7-DCA3-4574-86D4-878F2D42B059}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Minikube/ModularPipelines.Minikube.sln
+++ b/src/ModularPipelines.Minikube/ModularPipelines.Minikube.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Minikube", "ModularPipelines.Minikube.csproj", "{8AACFAAB-D363-5D5A-BDA4-ED54FAFEB1CA}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Minikube.UnitTests", "..\..\test\ModularPipelines.Minikube.UnitTests\ModularPipelines.Minikube.UnitTests.csproj", "{09D391AB-6AB3-4929-8723-447AFE61299B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{056EED49-1956-45B5-B70A-16EE7CC725A0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8AACFAAB-D363-5D5A-BDA4-ED54FAFEB1CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Debug|x64.Build.0 = Debug|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Debug|x86.Build.0 = Debug|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Release|x64.ActiveCfg = Release|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Release|x64.Build.0 = Release|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Release|x86.ActiveCfg = Release|Any CPU
+		{09D391AB-6AB3-4929-8723-447AFE61299B}.Release|x86.Build.0 = Release|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Debug|x64.Build.0 = Debug|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Debug|x86.Build.0 = Debug|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Release|x64.ActiveCfg = Release|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Release|x64.Build.0 = Release|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Release|x86.ActiveCfg = Release|Any CPU
+		{056EED49-1956-45B5-B70A-16EE7CC725A0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.NerdbankGitVersioning/ModularPipelines.NerdbankGitVersioning.sln
+++ b/src/ModularPipelines.NerdbankGitVersioning/ModularPipelines.NerdbankGitVersioning.sln
@@ -7,6 +7,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.NerdbankGi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{45738E8A-AD9F-4EEA-A082-C895578F78F0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.NerdbankGitVersioning.UnitTests", "..\..\test\ModularPipelines.NerdbankGitVersioning.UnitTests\ModularPipelines.NerdbankGitVersioning.UnitTests.csproj", "{DED82B37-94DE-4316-BB8E-13F33C8E053F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +45,30 @@ Global
 		{45738E8A-AD9F-4EEA-A082-C895578F78F0}.Release|x64.Build.0 = Release|Any CPU
 		{45738E8A-AD9F-4EEA-A082-C895578F78F0}.Release|x86.ActiveCfg = Release|Any CPU
 		{45738E8A-AD9F-4EEA-A082-C895578F78F0}.Release|x86.Build.0 = Release|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Debug|x64.Build.0 = Debug|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Debug|x86.Build.0 = Debug|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Release|x64.ActiveCfg = Release|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Release|x64.Build.0 = Release|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Release|x86.ActiveCfg = Release|Any CPU
+		{DED82B37-94DE-4316-BB8E-13F33C8E053F}.Release|x86.Build.0 = Release|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Debug|x64.Build.0 = Debug|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Debug|x86.Build.0 = Debug|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Release|x64.ActiveCfg = Release|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Release|x64.Build.0 = Release|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Release|x86.ActiveCfg = Release|Any CPU
+		{40EE9088-B6AF-4F13-8CD5-CC013E1A8EF9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ModularPipelines.Newman/ModularPipelines.Newman.sln
+++ b/src/ModularPipelines.Newman/ModularPipelines.Newman.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Newman", "ModularPipelines.Newman.csproj", "{6945107C-8159-5EB3-A1D6-C4370E01048D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Newman.UnitTests", "..\..\test\ModularPipelines.Newman.UnitTests\ModularPipelines.Newman.UnitTests.csproj", "{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{61ACB9AE-C525-4789-AA82-FE59055D7B3C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{6945107C-8159-5EB3-A1D6-C4370E01048D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Debug|x64.Build.0 = Debug|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Debug|x86.Build.0 = Debug|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Release|x64.ActiveCfg = Release|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Release|x64.Build.0 = Release|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Release|x86.ActiveCfg = Release|Any CPU
+		{E6C0BF7A-47C9-41D4-B63C-C2F2D8732DBF}.Release|x86.Build.0 = Release|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Debug|x64.Build.0 = Debug|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Debug|x86.Build.0 = Debug|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Release|x64.ActiveCfg = Release|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Release|x64.Build.0 = Release|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Release|x86.ActiveCfg = Release|Any CPU
+		{61ACB9AE-C525-4789-AA82-FE59055D7B3C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Node/ModularPipelines.Node.sln
+++ b/src/ModularPipelines.Node/ModularPipelines.Node.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Node", "ModularPipelines.Node.csproj", "{7D349091-7ED4-5D33-963D-C3CE2809B809}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Node.UnitTests", "..\..\test\ModularPipelines.Node.UnitTests\ModularPipelines.Node.UnitTests.csproj", "{691C669A-3168-4856-A261-61B53894FC57}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{7D349091-7ED4-5D33-963D-C3CE2809B809}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Debug|x64.Build.0 = Debug|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Debug|x86.Build.0 = Debug|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Release|x64.ActiveCfg = Release|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Release|x64.Build.0 = Release|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Release|x86.ActiveCfg = Release|Any CPU
+		{691C669A-3168-4856-A261-61B53894FC57}.Release|x86.Build.0 = Release|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Debug|x64.Build.0 = Debug|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Debug|x86.Build.0 = Debug|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Release|x64.ActiveCfg = Release|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Release|x64.Build.0 = Release|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Release|x86.ActiveCfg = Release|Any CPU
+		{3FB8F8FE-B2E4-4DC5-BEA4-3C1CBFC9FE85}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Packer/ModularPipelines.Packer.sln
+++ b/src/ModularPipelines.Packer/ModularPipelines.Packer.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Packer", "ModularPipelines.Packer.csproj", "{D453D233-1EFC-5CB3-987B-719A5AA6FA90}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Packer.UnitTests", "..\..\test\ModularPipelines.Packer.UnitTests\ModularPipelines.Packer.UnitTests.csproj", "{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{F33242ED-B75F-4BF7-8A77-B2E002F527EA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D453D233-1EFC-5CB3-987B-719A5AA6FA90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Debug|x64.Build.0 = Debug|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Debug|x86.Build.0 = Debug|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Release|x64.ActiveCfg = Release|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Release|x64.Build.0 = Release|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Release|x86.ActiveCfg = Release|Any CPU
+		{8A77A4DD-B41C-4E50-A563-23EEB5486BAB}.Release|x86.Build.0 = Release|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Debug|x64.Build.0 = Debug|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Debug|x86.Build.0 = Debug|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Release|x64.ActiveCfg = Release|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Release|x64.Build.0 = Release|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Release|x86.ActiveCfg = Release|Any CPU
+		{F33242ED-B75F-4BF7-8A77-B2E002F527EA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Podman/ModularPipelines.Podman.sln
+++ b/src/ModularPipelines.Podman/ModularPipelines.Podman.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Podman", "ModularPipelines.Podman.csproj", "{D08B6E30-914A-593B-AB40-6F345BDBE348}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Podman.UnitTests", "..\..\test\ModularPipelines.Podman.UnitTests\ModularPipelines.Podman.UnitTests.csproj", "{CD6717B7-DD95-40ED-A494-C58312BC51D1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{D08B6E30-914A-593B-AB40-6F345BDBE348}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Debug|x64.Build.0 = Debug|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Debug|x86.Build.0 = Debug|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Release|x64.ActiveCfg = Release|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Release|x64.Build.0 = Release|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Release|x86.ActiveCfg = Release|Any CPU
+		{CD6717B7-DD95-40ED-A494-C58312BC51D1}.Release|x86.Build.0 = Release|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Debug|x64.Build.0 = Debug|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Debug|x86.Build.0 = Debug|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Release|x64.ActiveCfg = Release|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Release|x64.Build.0 = Release|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Release|x86.ActiveCfg = Release|Any CPU
+		{1B9E86EB-48D8-4B0B-964B-086F9D5FE2BE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Pulumi/ModularPipelines.Pulumi.sln
+++ b/src/ModularPipelines.Pulumi/ModularPipelines.Pulumi.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Pulumi", "ModularPipelines.Pulumi.csproj", "{28E8AF10-B92B-5FB0-99EF-39F424BDD4A2}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Pulumi.UnitTests", "..\..\test\ModularPipelines.Pulumi.UnitTests\ModularPipelines.Pulumi.UnitTests.csproj", "{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{F396B1FB-FF53-469D-999C-3E9952F886AD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{28E8AF10-B92B-5FB0-99EF-39F424BDD4A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Debug|x64.Build.0 = Debug|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Debug|x86.Build.0 = Debug|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Release|x64.ActiveCfg = Release|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Release|x64.Build.0 = Release|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Release|x86.ActiveCfg = Release|Any CPU
+		{AD1DDFDD-6427-4778-B0DC-8668F56DF4D6}.Release|x86.Build.0 = Release|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Debug|x64.Build.0 = Debug|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Debug|x86.Build.0 = Debug|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Release|x64.ActiveCfg = Release|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Release|x64.Build.0 = Release|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Release|x86.ActiveCfg = Release|Any CPU
+		{F396B1FB-FF53-469D-999C-3E9952F886AD}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Python/ModularPipelines.Python.sln
+++ b/src/ModularPipelines.Python/ModularPipelines.Python.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Python", "ModularPipelines.Python.csproj", "{5B59B045-F7CE-5AF0-8FE8-21FEEB50965B}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Python.UnitTests", "..\..\test\ModularPipelines.Python.UnitTests\ModularPipelines.Python.UnitTests.csproj", "{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{75770AB3-661C-4B96-AC0F-8D14879D405D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{5B59B045-F7CE-5AF0-8FE8-21FEEB50965B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Debug|x64.Build.0 = Debug|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Debug|x86.Build.0 = Debug|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Release|x64.ActiveCfg = Release|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Release|x64.Build.0 = Release|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Release|x86.ActiveCfg = Release|Any CPU
+		{69B0C0E3-971A-420C-885C-4DEB86A2ACB6}.Release|x86.Build.0 = Release|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Debug|x64.Build.0 = Debug|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Debug|x86.Build.0 = Debug|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Release|x64.ActiveCfg = Release|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Release|x64.Build.0 = Release|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Release|x86.ActiveCfg = Release|Any CPU
+		{75770AB3-661C-4B96-AC0F-8D14879D405D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Rust/ModularPipelines.Rust.sln
+++ b/src/ModularPipelines.Rust/ModularPipelines.Rust.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Rust", "ModularPipelines.Rust.csproj", "{ED6D58DC-8C86-5F79-8F93-BEB8C83BB3E7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Rust.UnitTests", "..\..\test\ModularPipelines.Rust.UnitTests\ModularPipelines.Rust.UnitTests.csproj", "{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{D0F8066A-41A0-474D-9F02-816B37E9BFF3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{ED6D58DC-8C86-5F79-8F93-BEB8C83BB3E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Debug|x64.Build.0 = Debug|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Debug|x86.Build.0 = Debug|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Release|x64.ActiveCfg = Release|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Release|x64.Build.0 = Release|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Release|x86.ActiveCfg = Release|Any CPU
+		{EA053DCE-9685-4EBA-9548-B869FAB6C1E5}.Release|x86.Build.0 = Release|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Debug|x64.Build.0 = Debug|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Debug|x86.Build.0 = Debug|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Release|x64.ActiveCfg = Release|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Release|x64.Build.0 = Release|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Release|x86.ActiveCfg = Release|Any CPU
+		{D0F8066A-41A0-474D-9F02-816B37E9BFF3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Shellcheck/ModularPipelines.Shellcheck.sln
+++ b/src/ModularPipelines.Shellcheck/ModularPipelines.Shellcheck.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Shellcheck", "ModularPipelines.Shellcheck.csproj", "{93C1CE92-6326-5AEF-B810-1A9B9688762E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Shellcheck.UnitTests", "..\..\test\ModularPipelines.Shellcheck.UnitTests\ModularPipelines.Shellcheck.UnitTests.csproj", "{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{93C1CE92-6326-5AEF-B810-1A9B9688762E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Debug|x64.Build.0 = Debug|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Debug|x86.Build.0 = Debug|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Release|x64.ActiveCfg = Release|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Release|x64.Build.0 = Release|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Release|x86.ActiveCfg = Release|Any CPU
+		{AADA0977-F8D4-4C7E-AF7E-09C98FD7DC4B}.Release|x86.Build.0 = Release|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Debug|x64.Build.0 = Debug|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Debug|x86.Build.0 = Debug|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Release|x64.ActiveCfg = Release|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Release|x64.Build.0 = Release|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Release|x86.ActiveCfg = Release|Any CPU
+		{E64D243B-944A-4F7D-8758-C34CEA3B0ECC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Skopeo/ModularPipelines.Skopeo.sln
+++ b/src/ModularPipelines.Skopeo/ModularPipelines.Skopeo.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Skopeo", "ModularPipelines.Skopeo.csproj", "{CC2530F8-185A-5E59-AC6B-B91A6FB1BB53}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Skopeo.UnitTests", "..\..\test\ModularPipelines.Skopeo.UnitTests\ModularPipelines.Skopeo.UnitTests.csproj", "{CACE8CBB-216F-469F-8971-1C84CD4290C0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{CC2530F8-185A-5E59-AC6B-B91A6FB1BB53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Debug|x64.Build.0 = Debug|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Debug|x86.Build.0 = Debug|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Release|x64.ActiveCfg = Release|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Release|x64.Build.0 = Release|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Release|x86.ActiveCfg = Release|Any CPU
+		{CACE8CBB-216F-469F-8971-1C84CD4290C0}.Release|x86.Build.0 = Release|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Debug|x64.Build.0 = Debug|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Debug|x86.Build.0 = Debug|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Release|x64.ActiveCfg = Release|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Release|x64.Build.0 = Release|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Release|x86.ActiveCfg = Release|Any CPU
+		{16C253E3-E92A-4C22-A1B4-FD9F71663BD1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Snyk/ModularPipelines.Snyk.sln
+++ b/src/ModularPipelines.Snyk/ModularPipelines.Snyk.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Snyk", "ModularPipelines.Snyk.csproj", "{16B5A360-EB01-5468-8DFB-195A1FA69DC1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Snyk.UnitTests", "..\..\test\ModularPipelines.Snyk.UnitTests\ModularPipelines.Snyk.UnitTests.csproj", "{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{B8CA6993-DAD4-4451-8B5F-0405755DB566}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{16B5A360-EB01-5468-8DFB-195A1FA69DC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Debug|x64.Build.0 = Debug|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Debug|x86.Build.0 = Debug|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Release|x64.ActiveCfg = Release|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Release|x64.Build.0 = Release|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Release|x86.ActiveCfg = Release|Any CPU
+		{E1AA0116-F364-4C6F-BFEC-AFE4F661C928}.Release|x86.Build.0 = Release|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Debug|x64.Build.0 = Debug|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Debug|x86.Build.0 = Debug|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Release|x64.ActiveCfg = Release|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Release|x64.Build.0 = Release|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Release|x86.ActiveCfg = Release|Any CPU
+		{B8CA6993-DAD4-4451-8B5F-0405755DB566}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.SonarScanner/ModularPipelines.SonarScanner.sln
+++ b/src/ModularPipelines.SonarScanner/ModularPipelines.SonarScanner.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.SonarScanner", "ModularPipelines.SonarScanner.csproj", "{593DDB38-16DE-5DF1-A844-1A850F1A26CB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.SonarScanner.UnitTests", "..\..\test\ModularPipelines.SonarScanner.UnitTests\ModularPipelines.SonarScanner.UnitTests.csproj", "{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{03591169-91AF-47AE-AE49-00D9188DAA46}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{593DDB38-16DE-5DF1-A844-1A850F1A26CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Debug|x64.Build.0 = Debug|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Debug|x86.Build.0 = Debug|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Release|x64.ActiveCfg = Release|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Release|x64.Build.0 = Release|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Release|x86.ActiveCfg = Release|Any CPU
+		{50D8A1B8-8FD4-47F3-AD19-B50E1D57C3AD}.Release|x86.Build.0 = Release|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Debug|x64.Build.0 = Debug|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Debug|x86.Build.0 = Debug|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Release|x64.ActiveCfg = Release|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Release|x64.Build.0 = Release|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Release|x86.ActiveCfg = Release|Any CPU
+		{03591169-91AF-47AE-AE49-00D9188DAA46}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Syft/ModularPipelines.Syft.sln
+++ b/src/ModularPipelines.Syft/ModularPipelines.Syft.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Syft", "ModularPipelines.Syft.csproj", "{194E678E-A76F-5F95-983B-B3B1F1B30832}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Syft.UnitTests", "..\..\test\ModularPipelines.Syft.UnitTests\ModularPipelines.Syft.UnitTests.csproj", "{68D8EDAC-ECBD-42D5-9090-12E552D6A566}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{194E678E-A76F-5F95-983B-B3B1F1B30832}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Debug|x64.Build.0 = Debug|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Debug|x86.Build.0 = Debug|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Release|x64.ActiveCfg = Release|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Release|x64.Build.0 = Release|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Release|x86.ActiveCfg = Release|Any CPU
+		{68D8EDAC-ECBD-42D5-9090-12E552D6A566}.Release|x86.Build.0 = Release|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Debug|x64.Build.0 = Debug|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Debug|x86.Build.0 = Debug|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Release|x64.ActiveCfg = Release|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Release|x64.Build.0 = Release|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Release|x86.ActiveCfg = Release|Any CPU
+		{5D01B1F7-AF6A-4A21-88C4-638C69FD9AEA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Terraform/ModularPipelines.Terraform.sln
+++ b/src/ModularPipelines.Terraform/ModularPipelines.Terraform.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Terraform", "ModularPipelines.Terraform.csproj", "{81F893BE-917B-53E0-9ED6-7810CB3E50C3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Terraform.UnitTests", "..\..\test\ModularPipelines.Terraform.UnitTests\ModularPipelines.Terraform.UnitTests.csproj", "{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{3A6D299E-59F0-4062-A406-9191EF6BD701}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{81F893BE-917B-53E0-9ED6-7810CB3E50C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Debug|x64.Build.0 = Debug|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Debug|x86.Build.0 = Debug|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Release|x64.ActiveCfg = Release|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Release|x64.Build.0 = Release|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Release|x86.ActiveCfg = Release|Any CPU
+		{8A41071B-ACFE-4F18-BBED-E4E6BA30B9F5}.Release|x86.Build.0 = Release|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Debug|x64.Build.0 = Debug|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Debug|x86.Build.0 = Debug|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Release|x64.ActiveCfg = Release|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Release|x64.Build.0 = Release|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Release|x86.ActiveCfg = Release|Any CPU
+		{3A6D299E-59F0-4062-A406-9191EF6BD701}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Trivy/ModularPipelines.Trivy.sln
+++ b/src/ModularPipelines.Trivy/ModularPipelines.Trivy.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Trivy", "ModularPipelines.Trivy.csproj", "{E1397E08-F3F7-5C99-BF77-85117F8AC65D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Trivy.UnitTests", "..\..\test\ModularPipelines.Trivy.UnitTests\ModularPipelines.Trivy.UnitTests.csproj", "{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{EB2EC222-E927-45C5-B85F-C31F5568ABDE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E1397E08-F3F7-5C99-BF77-85117F8AC65D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Debug|x64.Build.0 = Debug|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Debug|x86.Build.0 = Debug|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Release|x64.ActiveCfg = Release|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Release|x64.Build.0 = Release|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Release|x86.ActiveCfg = Release|Any CPU
+		{D8BFA6C4-4B12-4F67-9DB3-4D963E8FB433}.Release|x86.Build.0 = Release|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Debug|x64.Build.0 = Debug|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Debug|x86.Build.0 = Debug|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Release|x64.ActiveCfg = Release|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Release|x64.Build.0 = Release|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Release|x86.ActiveCfg = Release|Any CPU
+		{EB2EC222-E927-45C5-B85F-C31F5568ABDE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Vault/ModularPipelines.Vault.sln
+++ b/src/ModularPipelines.Vault/ModularPipelines.Vault.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Vault", "ModularPipelines.Vault.csproj", "{522D2B7A-A7C2-5E59-899D-07541A9039C7}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Vault.UnitTests", "..\..\test\ModularPipelines.Vault.UnitTests\ModularPipelines.Vault.UnitTests.csproj", "{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{2F8B9955-3A4B-4555-A34D-150A76135727}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{522D2B7A-A7C2-5E59-899D-07541A9039C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Debug|x64.Build.0 = Debug|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Debug|x86.Build.0 = Debug|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Release|x64.ActiveCfg = Release|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Release|x64.Build.0 = Release|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Release|x86.ActiveCfg = Release|Any CPU
+		{2235F9CB-013A-4FF9-8D92-C3C8A97C7349}.Release|x86.Build.0 = Release|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Debug|x64.Build.0 = Debug|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Debug|x86.Build.0 = Debug|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Release|x64.ActiveCfg = Release|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Release|x64.Build.0 = Release|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Release|x86.ActiveCfg = Release|Any CPU
+		{2F8B9955-3A4B-4555-A34D-150A76135727}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.WinGet/ModularPipelines.WinGet.sln
+++ b/src/ModularPipelines.WinGet/ModularPipelines.WinGet.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.WinGet", "ModularPipelines.WinGet.csproj", "{813CE2C6-5C89-5F6D-A707-D9639DE2128E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.WinGet.UnitTests", "..\..\test\ModularPipelines.WinGet.UnitTests\ModularPipelines.WinGet.UnitTests.csproj", "{7BB279AC-C149-47F0-8B3A-77648F14B84D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{813CE2C6-5C89-5F6D-A707-D9639DE2128E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Debug|x64.Build.0 = Debug|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Debug|x86.Build.0 = Debug|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Release|x64.ActiveCfg = Release|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Release|x64.Build.0 = Release|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Release|x86.ActiveCfg = Release|Any CPU
+		{7BB279AC-C149-47F0-8B3A-77648F14B84D}.Release|x86.Build.0 = Release|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Debug|x64.Build.0 = Debug|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Debug|x86.Build.0 = Debug|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Release|x64.Build.0 = Release|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Release|x86.ActiveCfg = Release|Any CPU
+		{F15432EE-5DEE-4F57-9BA1-4C4AD339C87B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Yarn/ModularPipelines.Yarn.sln
+++ b/src/ModularPipelines.Yarn/ModularPipelines.Yarn.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Yarn", "ModularPipelines.Yarn.csproj", "{234A2A8F-7C7F-519B-AD71-F1E4E7F46BD4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Yarn.UnitTests", "..\..\test\ModularPipelines.Yarn.UnitTests\ModularPipelines.Yarn.UnitTests.csproj", "{FB09C39B-35AB-4F80-8AB0-355210CFD953}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{E19B2177-66F9-4E8C-A497-6292FB863921}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{234A2A8F-7C7F-519B-AD71-F1E4E7F46BD4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Debug|x64.Build.0 = Debug|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Debug|x86.Build.0 = Debug|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Release|x64.ActiveCfg = Release|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Release|x64.Build.0 = Release|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Release|x86.ActiveCfg = Release|Any CPU
+		{FB09C39B-35AB-4F80-8AB0-355210CFD953}.Release|x86.Build.0 = Release|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Debug|x64.Build.0 = Debug|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Debug|x86.Build.0 = Debug|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Release|x64.ActiveCfg = Release|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Release|x64.Build.0 = Release|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Release|x86.ActiveCfg = Release|Any CPU
+		{E19B2177-66F9-4E8C-A497-6292FB863921}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/src/ModularPipelines.Yq/ModularPipelines.Yq.sln
+++ b/src/ModularPipelines.Yq/ModularPipelines.Yq.sln
@@ -1,10 +1,15 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Yq", "ModularPipelines.Yq.csproj", "{E7EC36AE-70F4-5C29-A779-8A597126E00F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines", "..\ModularPipelines\ModularPipelines.csproj", "{913CAEF5-F03A-5911-BCFD-11F3066DAC19}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.Yq.UnitTests", "..\..\test\ModularPipelines.Yq.UnitTests\ModularPipelines.Yq.UnitTests.csproj", "{E6F384DD-9C57-480D-9672-3D49224AE794}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ModularPipelines.TestHelpers", "..\..\test\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj", "{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -14,9 +19,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E7EC36AE-70F4-5C29-A779-8A597126E00F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -43,7 +45,32 @@ Global
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x64.Build.0 = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.ActiveCfg = Release|Any CPU
 		{913CAEF5-F03A-5911-BCFD-11F3066DAC19}.Release|x86.Build.0 = Release|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Debug|x64.Build.0 = Debug|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Debug|x86.Build.0 = Debug|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Release|x64.ActiveCfg = Release|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Release|x64.Build.0 = Release|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Release|x86.ActiveCfg = Release|Any CPU
+		{E6F384DD-9C57-480D-9672-3D49224AE794}.Release|x86.Build.0 = Release|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Debug|x64.Build.0 = Debug|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Debug|x86.Build.0 = Debug|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Release|x64.ActiveCfg = Release|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Release|x64.Build.0 = Release|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Release|x86.ActiveCfg = Release|Any CPU
+		{F27EF5F9-E9DE-4F66-9FFA-E7BB95F5C705}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add each matching integration test project and TestHelpers to 46 tool-specific solutions
- add ModularPipelines.Tests.slnf for lightweight core-test validation without expanding the core solution
- document the new test filter and keep agent guidance away from ModularPipelines.All.sln

## Validation
- matching source/test audit: 52/52 represented, 0 missing
- ModularPipelines.Tests.slnf Release build: 0 warnings, 0 errors
- Docker tool solution Release build: 0 warnings, 0 errors and includes Docker.UnitTests + TestHelpers

Closes #3525