### PR TITLE
Add dependency graph export

### DIFF
--- a/docs/docs/how-to/execution-and-dependencies.md
+++ b/docs/docs/how-to/execution-and-dependencies.md
@@ -42,6 +42,44 @@ public class Module2 : Module<string>
 }
 ```
 
+## Exporting the Dependency Graph
+
+Export the resolved graph without executing modules from the command line:
+
+```bash
+dotnet run -- --graph mermaid dependency-graph.mmd
+dotnet run -- --graph dot dependency-graph.dot
+dotnet run -- --graph json dependency-graph.json
+```
+
+The path is optional. The defaults are `dependency-graph.mmd`, `dependency-graph.dot`,
+and `dependency-graph.json`. Graph nodes include the module category, estimated duration,
+and skip status. Conditions that require runtime results or asynchronous work are shown as
+unresolved. Edges point from each dependency to the module that depends on it.
+
+Paths containing a directory separator can include `=` directly. For an ambiguous filename
+containing `=`, use the explicit path option so it is not treated as host configuration:
+
+```bash
+dotnet run -- --graph json --graph-path branch=main.json
+```
+
+You can also export programmatically:
+
+```csharp
+using ModularPipelines.Enums;
+
+using var builder = Pipeline.CreateBuilder(args);
+builder.AddModule<Module2>();
+
+await builder.ExportDependencyGraphAsync(
+    DependencyGraphFormat.Mermaid,
+    "dependency-graph.mmd");
+```
+
+When the `ModularPipelines.GitHub` integration writes `GITHUB_STEP_SUMMARY`, it includes
+the Mermaid dependency flowchart alongside the run Gantt and result table.
+
 ### Auto-Registration
 
 When you declare a required dependency, you don't need to explicitly register it:

--- a/src/ModularPipelines.GitHub/GitHubMarkdownSummaryGenerator.cs
+++ b/src/ModularPipelines.GitHub/GitHubMarkdownSummaryGenerator.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using ModularPipelines.Context;
+using ModularPipelines.Engine;
 using ModularPipelines.Enums;
 using ModularPipelines.Interfaces;
 using ModularPipelines.Logging;
@@ -12,49 +13,95 @@ internal class GitHubMarkdownSummaryGenerator : IPipelineGlobalHooks
     private const long MaxFileSizeInBytes = 1 * 1024 * 1024; // 1MB
 
     private readonly ISummaryLogger _summaryLogger;
+    private readonly IDependencyGraphExporter _dependencyGraphExporter;
 
-    public GitHubMarkdownSummaryGenerator(ISummaryLogger summaryLogger)
+    public GitHubMarkdownSummaryGenerator(
+        ISummaryLogger summaryLogger,
+        IDependencyGraphExporter dependencyGraphExporter)
     {
         _summaryLogger = summaryLogger;
+        _dependencyGraphExporter = dependencyGraphExporter;
     }
 
-    public Task OnStartAsync(IPipelineContext pipelineContext)
+    public Task OnPipelineStartAsync(IPipelineContext pipelineContext)
     {
         return Task.CompletedTask;
     }
 
-    public async Task OnEndAsync(IPipelineContext pipelineContext, PipelineSummary pipelineSummary)
+    public async Task OnPipelineEndAsync(
+        IPipelineContext pipelineContext,
+        PipelineSummary pipelineSummary)
     {
-        var mermaid = GenerateMermaidSummary(pipelineSummary);
-        var table = GenerateTableSummary(pipelineSummary);
-        var exception = GetException(pipelineSummary);
-
-        var stepSummaryVariable = pipelineContext.Environment.Variables.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
-
+        var stepSummaryVariable = pipelineContext.Environment.Variables
+            .GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
         if (string.IsNullOrEmpty(stepSummaryVariable))
         {
             return;
         }
 
-        await WriteFile(pipelineContext, stepSummaryVariable, mermaid, table, exception);
+        var mermaid = GenerateMermaidSummary(pipelineSummary);
+        var dependencyGraph = await GenerateDependencyGraphAsync(pipelineSummary).ConfigureAwait(false);
+        var table = GenerateTableSummary(pipelineSummary);
+        var exception = GetException(pipelineSummary);
+
+        await WriteFile(
+            pipelineContext,
+            stepSummaryVariable,
+            dependencyGraph,
+            mermaid,
+            table,
+            exception);
     }
 
-    private async Task WriteFile(IPipelineContext pipelineContext, string stepSummaryVariable, string mermaid,
-        string table, string exception)
+    private async Task WriteFile(
+        IPipelineContext pipelineContext,
+        string stepSummaryVariable,
+        string dependencyGraph,
+        string mermaid,
+        string table,
+        string exception)
     {
         var fileInfo = pipelineContext.Files.GetFile(stepSummaryVariable);
         var currentFileSize = fileInfo.Exists ? fileInfo.Length : 0;
-        var contents = $"{mermaid}\n\n{table}\n\n{_summaryLogger.GetOutput()}{exception}";
-        long newContentSize = Encoding.UTF8.GetByteCount(contents);
-        var newSize = currentFileSize + newContentSize;
+        var existingSummary = $"{mermaid}\n\n{table}\n\n{_summaryLogger.GetOutput()}{exception}";
+        var contents = SelectContentsToAppend(currentFileSize, dependencyGraph, existingSummary);
 
-        if (newSize > MaxFileSizeInBytes)
+        if (contents is null)
         {
             System.Console.WriteLine("Appending to the GitHub Step Summary would exceed the 1MB file size limit.");
             return;
         }
 
         await pipelineContext.Files.GetFile(stepSummaryVariable).AppendAsync(contents);
+    }
+
+    private static string? SelectContentsToAppend(
+        long currentFileSize,
+        string dependencyGraph,
+        string existingSummary)
+    {
+        if (currentFileSize + Encoding.UTF8.GetByteCount(existingSummary) > MaxFileSizeInBytes)
+        {
+            return null;
+        }
+
+        var contentsWithGraph = $"{dependencyGraph}\n\n{existingSummary}";
+        return currentFileSize + Encoding.UTF8.GetByteCount(contentsWithGraph) <= MaxFileSizeInBytes
+            ? contentsWithGraph
+            : existingSummary;
+    }
+
+    private async Task<string> GenerateDependencyGraphAsync(PipelineSummary pipelineSummary)
+    {
+        var graph = await _dependencyGraphExporter
+            .RenderSummaryAsync(DependencyGraphFormat.Mermaid, pipelineSummary)
+            .ConfigureAwait(false);
+        return $"""
+               ### Dependency Graph
+               ```mermaid
+               {graph}
+               ```
+               """;
     }
 
     private static string GetException(PipelineSummary pipelineSummary)

--- a/src/ModularPipelines/Attributes/DependsOnModulesInCategoryAttribute.cs
+++ b/src/ModularPipelines/Attributes/DependsOnModulesInCategoryAttribute.cs
@@ -12,7 +12,7 @@ namespace ModularPipelines.Attributes;
 /// </code>
 /// </example>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-public sealed class DependsOnModulesInCategoryAttribute : DependsOnBaseAttribute
+public sealed class DependsOnModulesInCategoryAttribute : PlanningSafeDependsOnBaseAttribute
 {
     /// <summary>
     /// Gets the category to match.

--- a/src/ModularPipelines/Attributes/DependsOnModulesWithAttributeAttribute.cs
+++ b/src/ModularPipelines/Attributes/DependsOnModulesWithAttributeAttribute.cs
@@ -13,7 +13,7 @@ namespace ModularPipelines.Attributes;
 /// </code>
 /// </example>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-public sealed class DependsOnModulesWithAttributeAttribute<TAttribute> : DependsOnBaseAttribute
+public sealed class DependsOnModulesWithAttributeAttribute<TAttribute> : PlanningSafeDependsOnBaseAttribute
     where TAttribute : Attribute
 {
     /// <inheritdoc />

--- a/src/ModularPipelines/Attributes/DependsOnModulesWithTagAttribute.cs
+++ b/src/ModularPipelines/Attributes/DependsOnModulesWithTagAttribute.cs
@@ -12,7 +12,7 @@ namespace ModularPipelines.Attributes;
 /// </code>
 /// </example>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-public sealed class DependsOnModulesWithTagAttribute : DependsOnBaseAttribute
+public sealed class DependsOnModulesWithTagAttribute : PlanningSafeDependsOnBaseAttribute
 {
     /// <summary>
     /// Gets the tag to match.

--- a/src/ModularPipelines/Attributes/EnvironmentVariableConditionAttributes.cs
+++ b/src/ModularPipelines/Attributes/EnvironmentVariableConditionAttributes.cs
@@ -6,7 +6,7 @@ namespace ModularPipelines.Attributes;
 /// Runs a module when an environment variable is set or equals an expected value.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-public sealed class RunIfEnvironmentVariableAttribute : RunIfAllAttribute
+public sealed class RunIfEnvironmentVariableAttribute : RunIfAllAttribute, IPlanningConditionAttribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="RunIfEnvironmentVariableAttribute"/> class.
@@ -44,7 +44,7 @@ public sealed class RunIfEnvironmentVariableAttribute : RunIfAllAttribute
 /// Skips a module when an environment variable is set or equals an expected value.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-public sealed class SkipIfEnvironmentVariableAttribute : SkipIfAttribute
+public sealed class SkipIfEnvironmentVariableAttribute : SkipIfAttribute, IPlanningConditionAttribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SkipIfEnvironmentVariableAttribute"/> class.
@@ -82,7 +82,7 @@ public sealed class SkipIfEnvironmentVariableAttribute : SkipIfAttribute
 /// Runs a module when an environment variable is not set.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-public sealed class RunIfEnvironmentVariableUnsetAttribute : RunIfAllAttribute
+public sealed class RunIfEnvironmentVariableUnsetAttribute : RunIfAllAttribute, IPlanningConditionAttribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="RunIfEnvironmentVariableUnsetAttribute"/> class.
@@ -111,7 +111,7 @@ public sealed class RunIfEnvironmentVariableUnsetAttribute : RunIfAllAttribute
 /// Skips a module when an environment variable is not set.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-public sealed class SkipIfEnvironmentVariableUnsetAttribute : SkipIfAttribute
+public sealed class SkipIfEnvironmentVariableUnsetAttribute : SkipIfAttribute, IPlanningConditionAttribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SkipIfEnvironmentVariableUnsetAttribute"/> class.

--- a/src/ModularPipelines/Attributes/Events/IPlanningSafeModuleRegistrationEventReceiver.cs
+++ b/src/ModularPipelines/Attributes/Events/IPlanningSafeModuleRegistrationEventReceiver.cs
@@ -1,0 +1,10 @@
+namespace ModularPipelines.Attributes.Events;
+
+/// <summary>
+/// Marks a module registration receiver as safe to invoke during dependency graph planning.
+/// </summary>
+/// <remarks>
+/// Planning occurs before pipeline startup and the receiver is invoked again during execution.
+/// Implementations must therefore be deterministic, idempotent, and free of external side effects.
+/// </remarks>
+public interface IPlanningSafeModuleRegistrationEventReceiver : IModuleRegistrationEventReceiver;

--- a/src/ModularPipelines/Attributes/IConditionAttribute.cs
+++ b/src/ModularPipelines/Attributes/IConditionAttribute.cs
@@ -37,3 +37,5 @@ public interface IConditionAttribute
     /// </summary>
     string ConditionNames { get; }
 }
+
+internal interface IPlanningConditionAttribute : IConditionAttribute;

--- a/src/ModularPipelines/Attributes/IPlanningSafeDependencySelector.cs
+++ b/src/ModularPipelines/Attributes/IPlanningSafeDependencySelector.cs
@@ -1,0 +1,10 @@
+namespace ModularPipelines.Attributes;
+
+/// <summary>
+/// Marks a dependency-selector attribute as safe to construct during dependency graph planning.
+/// </summary>
+/// <remarks>
+/// Implement this interface only when construction is deterministic, idempotent, and free of
+/// observable side effects. Built-in selectors are trusted without this marker.
+/// </remarks>
+public interface IPlanningSafeDependencySelector;

--- a/src/ModularPipelines/Attributes/OperatingSystemConditionAttributes.cs
+++ b/src/ModularPipelines/Attributes/OperatingSystemConditionAttributes.cs
@@ -7,7 +7,7 @@ namespace ModularPipelines.Attributes;
 /// Runs a module on any of the selected operating systems.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-public sealed class RunIfOperatingSystemAttribute : RunIfAllAttribute, IOperatingSystemConditionAttribute
+public sealed class RunIfOperatingSystemAttribute : RunIfAllAttribute, IOperatingSystemConditionAttribute, IPlanningConditionAttribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="RunIfOperatingSystemAttribute"/> class.
@@ -36,7 +36,7 @@ public sealed class RunIfOperatingSystemAttribute : RunIfAllAttribute, IOperatin
 /// Skips a module on any of the selected operating systems.
 /// </summary>
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
-public sealed class SkipIfOperatingSystemAttribute : SkipIfAttribute, IOperatingSystemConditionAttribute
+public sealed class SkipIfOperatingSystemAttribute : SkipIfAttribute, IOperatingSystemConditionAttribute, IPlanningConditionAttribute
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="SkipIfOperatingSystemAttribute"/> class.

--- a/src/ModularPipelines/Attributes/OperatingSystemConditions.cs
+++ b/src/ModularPipelines/Attributes/OperatingSystemConditions.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using ModularPipelines.Conditions;
+using ModularPipelines.Engine.Attributes;
 
 namespace ModularPipelines.Attributes;
 
@@ -48,6 +50,38 @@ internal static class OperatingSystemConditions
     public static bool HasImpossibleCombination(IEnumerable<IConditionAttribute> attributes)
     {
         HashSet<string>? supportedOperatingSystems = null;
+
+        foreach (var attribute in attributes)
+        {
+            var attributeOperatingSystems = GetSupportedOperatingSystems(attribute);
+            if (attributeOperatingSystems is null)
+            {
+                continue;
+            }
+
+            if (supportedOperatingSystems is null)
+            {
+                supportedOperatingSystems = attributeOperatingSystems;
+            }
+            else
+            {
+                supportedOperatingSystems.IntersectWith(attributeOperatingSystems);
+            }
+        }
+
+        return supportedOperatingSystems is { Count: 0 };
+    }
+
+    /// <summary>
+    /// Returns whether declared all-platform attributes require mutually exclusive operating systems
+    /// without constructing condition attributes.
+    /// </summary>
+    public static bool HasImpossibleCombination(Type moduleType)
+    {
+        HashSet<string>? supportedOperatingSystems = null;
+        var attributes = CustomAttributeMetadata.GetApplicable(
+            moduleType,
+            static type => typeof(RunIfAllAttribute).IsAssignableFrom(type));
 
         foreach (var attribute in attributes)
         {
@@ -148,6 +182,61 @@ internal static class OperatingSystemConditions
         }
 
         return supportedOperatingSystems;
+    }
+
+    private static HashSet<string>? GetSupportedOperatingSystems(CustomAttributeData attribute)
+    {
+        if (attribute.AttributeType == typeof(RunIfOperatingSystemAttribute))
+        {
+            return GetOperatingSystemsFromConstructor(attribute);
+        }
+
+        var conditionTypes = attribute.AttributeType.GetGenericArguments();
+        if (conditionTypes.Length == 0)
+        {
+            return null;
+        }
+
+        HashSet<string>? supportedOperatingSystems = null;
+        foreach (var conditionType in conditionTypes)
+        {
+            var operatingSystem = GetOperatingSystem(conditionType);
+            if (operatingSystem is null)
+            {
+                return null;
+            }
+
+            if (supportedOperatingSystems is null)
+            {
+                supportedOperatingSystems = new HashSet<string>(
+                    [operatingSystem],
+                    StringComparer.OrdinalIgnoreCase);
+            }
+            else
+            {
+                supportedOperatingSystems.IntersectWith([operatingSystem]);
+            }
+        }
+
+        return supportedOperatingSystems;
+    }
+
+    private static HashSet<string>? GetOperatingSystemsFromConstructor(CustomAttributeData attribute)
+    {
+        if (attribute.ConstructorArguments is not [{ Value: IReadOnlyCollection<CustomAttributeTypedArgument> values }])
+        {
+            return null;
+        }
+
+        var operatingSystems = values
+            .Select(static value => value.Value is null
+                ? OperatingSystemIdentifier.Unknown
+                : (OperatingSystemIdentifier) Enum.ToObject(typeof(OperatingSystemIdentifier), value.Value))
+            .Select(GetOperatingSystem)
+            .ToArray();
+        return operatingSystems.Length == 0 || operatingSystems.Any(static value => value is null)
+            ? null
+            : new HashSet<string>(operatingSystems!, StringComparer.OrdinalIgnoreCase);
     }
 
     [UnconditionalSuppressMessage(

--- a/src/ModularPipelines/Attributes/PlanningSafeDependsOnBaseAttribute.cs
+++ b/src/ModularPipelines/Attributes/PlanningSafeDependsOnBaseAttribute.cs
@@ -1,0 +1,10 @@
+namespace ModularPipelines.Attributes;
+
+/// <summary>
+/// Base class for dependency predicates that are safe to evaluate during graph planning.
+/// </summary>
+/// <remarks>
+/// Planning-safe predicates must be deterministic and free of observable side effects.
+/// Predicates derived directly from <see cref="DependsOnBaseAttribute"/> are deferred until runtime.
+/// </remarks>
+public abstract class PlanningSafeDependsOnBaseAttribute : DependsOnBaseAttribute;

--- a/src/ModularPipelines/Attributes/PlanningSafeDependsOnBaseAttribute.cs
+++ b/src/ModularPipelines/Attributes/PlanningSafeDependsOnBaseAttribute.cs
@@ -5,6 +5,10 @@ namespace ModularPipelines.Attributes;
 /// </summary>
 /// <remarks>
 /// Planning-safe predicates must be deterministic and free of observable side effects.
+/// During graph planning, predicates can inspect tags, categories, and attribute presence.
+/// Reading values from other custom attributes is unavailable because doing so can invoke
+/// arbitrary attribute constructors. Such access fails graph export rather than omitting
+/// a dependency that may be present at runtime.
 /// Predicates derived directly from <see cref="DependsOnBaseAttribute"/> are deferred until runtime.
 /// </remarks>
 public abstract class PlanningSafeDependsOnBaseAttribute : DependsOnBaseAttribute;

--- a/src/ModularPipelines/CommandLine/PipelineCommand.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommand.cs
@@ -7,4 +7,5 @@ internal enum PipelineCommand
     DryRun,
     ListModules,
     Validate,
+    ExportGraph,
 }

--- a/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
@@ -14,6 +14,7 @@ internal sealed class PipelineCommandHandler(
     IRegistrationEventExecutor registrationEventExecutor,
     IModuleDependencyRegistry dependencyRegistry,
     IModuleMetadataRegistry metadataRegistry,
+    IDependencyGraphExporter dependencyGraphExporter,
     IConsoleWriter consoleWriter)
 {
     private readonly IReadOnlyList<IModule> _modules = modules
@@ -33,9 +34,25 @@ internal sealed class PipelineCommandHandler(
             case PipelineCommand.Validate:
                 await FinalizeModulesAsync(cancellationToken).ConfigureAwait(false);
                 return ReportSuccessfulValidation();
+            case PipelineCommand.ExportGraph:
+                await ExportGraphAsync(cancellationToken).ConfigureAwait(false);
+                return CreateSummary();
             default:
                 throw new ArgumentOutOfRangeException(nameof(commandLineOptions));
         }
+    }
+
+    private async Task ExportGraphAsync(CancellationToken cancellationToken)
+    {
+        await dependencyGraphExporter.ExportAsync(
+                commandLineOptions.GraphFormat
+                ?? throw new InvalidOperationException("A dependency graph format is required."),
+                commandLineOptions.GraphPath
+                ?? throw new InvalidOperationException("A dependency graph path is required."),
+                cancellationToken)
+            .ConfigureAwait(false);
+        consoleWriter.LogToConsole(
+            $"Dependency graph written to {Path.GetFullPath(commandLineOptions.GraphPath)}");
     }
 
     private PipelineSummary ListModules()

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineHelp.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineHelp.cs
@@ -15,6 +15,8 @@ internal static class PipelineCommandLineHelp
           --skip-module <name>[,<name>...] Exclude selected modules.
           --categories <name>[,<name>...]  Run selected categories.
           --ignore-categories <name>[,<name>...] Exclude selected categories.
+          --graph <mermaid|dot|json> [path] Export the dependency graph.
+          --graph-path <path>              Set the graph output path explicitly.
           --                             Forward all remaining arguments to host configuration.
 
         Options accepting values may be repeated or written as --option=value.

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineOptions.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineOptions.cs
@@ -1,3 +1,5 @@
+using ModularPipelines.Enums;
+
 namespace ModularPipelines.PipelineCli;
 
 internal sealed record PipelineCommandLineOptions(
@@ -7,7 +9,9 @@ internal sealed record PipelineCommandLineOptions(
     IReadOnlyList<string> TargetModules,
     IReadOnlyList<string> SkippedModules,
     IReadOnlyList<string> RunOnlyCategories,
-    IReadOnlyList<string> IgnoreCategories)
+    IReadOnlyList<string> IgnoreCategories,
+    DependencyGraphFormat? GraphFormat,
+    string? GraphPath)
 {
     public static PipelineCommandLineOptions Empty { get; } = new(
         PipelineCommand.Run,
@@ -16,5 +20,7 @@ internal sealed record PipelineCommandLineOptions(
         [],
         [],
         [],
-        []);
+        [],
+        null,
+        null);
 }

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
@@ -1,3 +1,5 @@
+using ModularPipelines.Enums;
+
 namespace ModularPipelines.PipelineCli;
 
 internal static class PipelineCommandLineParser
@@ -12,6 +14,8 @@ internal static class PipelineCommandLineParser
     private const string SkipModuleOption = "--skip-module";
     private const string CategoriesOption = "--categories";
     private const string IgnoreCategoriesOption = "--ignore-categories";
+    private const string GraphOption = "--graph";
+    private const string GraphPathOption = "--graph-path";
 
     private static readonly string[] KnownLongOptions =
     [
@@ -19,10 +23,13 @@ internal static class PipelineCommandLineParser
         ListModulesOption,
         ValidateOption,
         DryRunOption,
+        NoCacheOption,
         ModuleOption,
         SkipModuleOption,
         CategoriesOption,
         IgnoreCategoriesOption,
+        GraphOption,
+        GraphPathOption,
     ];
 
     private static readonly string[] FlagOptions =
@@ -31,7 +38,18 @@ internal static class PipelineCommandLineParser
         ListModulesOption,
         ValidateOption,
         DryRunOption,
+        NoCacheOption,
     ];
+
+    private static readonly IReadOnlyDictionary<string, PipelineCommand> CommandOptions =
+        new Dictionary<string, PipelineCommand>(StringComparer.OrdinalIgnoreCase)
+        {
+            [HelpOption] = PipelineCommand.Help,
+            [ShortHelpOption] = PipelineCommand.Help,
+            [ListModulesOption] = PipelineCommand.ListModules,
+            [ValidateOption] = PipelineCommand.Validate,
+            [DryRunOption] = PipelineCommand.DryRun,
+        };
 
     public static PipelineCommandLineOptions Parse(IReadOnlyList<string>? arguments)
     {
@@ -40,76 +58,244 @@ internal static class PipelineCommandLineParser
             return PipelineCommandLineOptions.Empty;
         }
 
-        var command = PipelineCommand.Run;
-        var disableModuleCache = false;
-        var hostArguments = new List<string>();
-        var targetModules = new List<string>();
-        var skippedModules = new List<string>();
-        var runOnlyCategories = new List<string>();
-        var ignoreCategories = new List<string>();
+        var state = ParseArguments(arguments);
 
-        for (var index = 0; index < arguments.Count; index++)
+        if (state.GraphPath is not null && state.GraphFormat is null)
         {
-            var argument = arguments[index];
-            if (argument == "--")
-            {
-                hostArguments.AddRange(arguments.Skip(index + 1));
-                break;
-            }
+            throw new ArgumentException(
+                $"Command-line option '{GraphPathOption}' requires '{GraphOption}'.",
+                nameof(arguments));
+        }
 
-            if (argument.Equals(HelpOption, StringComparison.OrdinalIgnoreCase)
-                || argument.Equals(ShortHelpOption, StringComparison.OrdinalIgnoreCase))
-            {
-                command = SetCommand(command, PipelineCommand.Help, argument);
-                continue;
-            }
-
-            if (argument.Equals(ListModulesOption, StringComparison.OrdinalIgnoreCase))
-            {
-                command = SetCommand(command, PipelineCommand.ListModules, argument);
-                continue;
-            }
-
-            if (argument.Equals(ValidateOption, StringComparison.OrdinalIgnoreCase))
-            {
-                command = SetCommand(command, PipelineCommand.Validate, argument);
-                continue;
-            }
-
-            if (argument.Equals(DryRunOption, StringComparison.OrdinalIgnoreCase))
-            {
-                command = SetCommand(command, PipelineCommand.DryRun, argument);
-                continue;
-            }
-
-            if (argument.Equals(NoCacheOption, StringComparison.OrdinalIgnoreCase))
-            {
-                disableModuleCache = true;
-                continue;
-            }
-
-            if (TryReadValues(arguments, ref index, ModuleOption, targetModules)
-                || TryReadValues(arguments, ref index, SkipModuleOption, skippedModules)
-                || TryReadValues(arguments, ref index, CategoriesOption, runOnlyCategories)
-                || TryReadValues(arguments, ref index, IgnoreCategoriesOption, ignoreCategories))
-            {
-                continue;
-            }
-
-            ThrowForLikelyPipelineOptionTypo(argument);
-
-            hostArguments.Add(argument);
+        if (state.GraphFormat is { } resolvedGraphFormat)
+        {
+            state.GraphPath ??= GetDefaultGraphPath(resolvedGraphFormat);
         }
 
         return new PipelineCommandLineOptions(
-            command,
-            disableModuleCache,
-            hostArguments,
-            Distinct(targetModules),
-            Distinct(skippedModules),
-            Distinct(runOnlyCategories),
-            Distinct(ignoreCategories));
+            state.Command,
+            state.DisableModuleCache,
+            state.HostArguments,
+            Distinct(state.TargetModules),
+            Distinct(state.SkippedModules),
+            Distinct(state.RunOnlyCategories),
+            Distinct(state.IgnoreCategories),
+            state.GraphFormat,
+            state.GraphPath);
     }
+
+    private static ParsingState ParseArguments(IReadOnlyList<string> arguments)
+    {
+        var state = new ParsingState();
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            if (arguments[index] == "--")
+            {
+                state.HostArguments.AddRange(arguments.Skip(index + 1));
+                break;
+            }
+
+            ParseArgument(arguments, ref index, state);
+        }
+
+        return state;
+    }
+
+    private static void ParseArgument(
+        IReadOnlyList<string> arguments,
+        ref int index,
+        ParsingState state)
+    {
+        var argument = arguments[index];
+        if (TrySetCommand(argument, state))
+        {
+            return;
+        }
+
+        if (TryParseGraph(arguments, ref index, state))
+        {
+            return;
+        }
+
+        if (TryReadGraphPath(arguments, ref index, out var parsedExplicitGraphPath))
+        {
+            state.GraphPath = SetGraphPath(state.GraphPath, parsedExplicitGraphPath);
+            return;
+        }
+
+        if (argument.Equals(NoCacheOption, StringComparison.OrdinalIgnoreCase))
+        {
+            state.DisableModuleCache = true;
+            return;
+        }
+
+        if (TryReadValues(arguments, ref index, ModuleOption, state.TargetModules)
+            || TryReadValues(arguments, ref index, SkipModuleOption, state.SkippedModules)
+            || TryReadValues(arguments, ref index, CategoriesOption, state.RunOnlyCategories)
+            || TryReadValues(arguments, ref index, IgnoreCategoriesOption, state.IgnoreCategories))
+        {
+            return;
+        }
+
+        ThrowForLikelyPipelineOptionTypo(argument);
+        state.HostArguments.Add(argument);
+    }
+
+    private static bool TrySetCommand(string argument, ParsingState state)
+    {
+        if (!CommandOptions.TryGetValue(argument, out var command))
+        {
+            return false;
+        }
+
+        state.Command = SetCommand(state.Command, command, argument);
+        return true;
+    }
+
+    private static bool TryParseGraph(
+        IReadOnlyList<string> arguments,
+        ref int index,
+        ParsingState state)
+    {
+        var argument = arguments[index];
+        if (!TryReadGraph(arguments, ref index, out var graphFormat, out var graphPath))
+        {
+            return false;
+        }
+
+        if (state.GraphFormat is not null)
+        {
+            throw new ArgumentException(
+                $"Command-line option '{GraphOption}' cannot be specified more than once.",
+                nameof(arguments));
+        }
+
+        state.Command = SetCommand(state.Command, PipelineCommand.ExportGraph, argument);
+        state.GraphFormat = graphFormat;
+        if (graphPath is not null)
+        {
+            state.GraphPath = SetGraphPath(state.GraphPath, graphPath);
+        }
+
+        return true;
+    }
+
+    private static bool TryReadGraph(
+        IReadOnlyList<string> arguments,
+        ref int index,
+        out DependencyGraphFormat format,
+        out string? path)
+    {
+        var argument = arguments[index];
+        string? value;
+        if (argument.Equals(GraphOption, StringComparison.OrdinalIgnoreCase))
+        {
+            if (++index >= arguments.Count || arguments[index].StartsWith("--", StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    $"Command-line option '{GraphOption}' requires mermaid, dot, or json.",
+                    nameof(arguments));
+            }
+
+            value = arguments[index];
+        }
+        else if (argument.StartsWith($"{GraphOption}=", StringComparison.OrdinalIgnoreCase))
+        {
+            value = argument[(GraphOption.Length + 1)..];
+        }
+        else
+        {
+            format = default;
+            path = null;
+            return false;
+        }
+
+        if (value.Equals("mermaid", StringComparison.OrdinalIgnoreCase))
+        {
+            format = DependencyGraphFormat.Mermaid;
+        }
+        else if (value.Equals("dot", StringComparison.OrdinalIgnoreCase))
+        {
+            format = DependencyGraphFormat.Dot;
+        }
+        else if (value.Equals("json", StringComparison.OrdinalIgnoreCase))
+        {
+            format = DependencyGraphFormat.Json;
+        }
+        else
+        {
+            throw new ArgumentException(
+                $"Unsupported dependency graph format '{value}'. Use mermaid, dot, or json.",
+                nameof(arguments));
+        }
+
+        path = index + 1 < arguments.Count
+               && IsGraphPath(arguments[index + 1])
+            ? arguments[++index]
+            : null;
+        return true;
+    }
+
+    private static bool IsGraphPath(string argument) =>
+        !argument.StartsWith("--", StringComparison.Ordinal)
+        && (!argument.Contains('=')
+            || argument.Contains(Path.DirectorySeparatorChar)
+            || argument.Contains(Path.AltDirectorySeparatorChar));
+
+    private static bool TryReadGraphPath(
+        IReadOnlyList<string> arguments,
+        ref int index,
+        out string path)
+    {
+        var argument = arguments[index];
+        if (argument.Equals(GraphPathOption, StringComparison.OrdinalIgnoreCase))
+        {
+            if (++index >= arguments.Count || arguments[index].StartsWith("--", StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    $"Command-line option '{GraphPathOption}' requires a path.",
+                    nameof(arguments));
+            }
+
+            path = arguments[index];
+            return true;
+        }
+
+        if (argument.StartsWith($"{GraphPathOption}=", StringComparison.OrdinalIgnoreCase))
+        {
+            path = argument[(GraphPathOption.Length + 1)..];
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException(
+                    $"Command-line option '{GraphPathOption}' requires a path.",
+                    nameof(arguments));
+            }
+
+            return true;
+        }
+
+        path = string.Empty;
+        return false;
+    }
+
+    private static string SetGraphPath(string? current, string requested)
+    {
+        if (current is not null)
+        {
+            throw new ArgumentException("A dependency graph path can only be specified once.");
+        }
+
+        return requested;
+    }
+
+    private static string GetDefaultGraphPath(DependencyGraphFormat format) =>
+        format switch
+        {
+            DependencyGraphFormat.Mermaid => "dependency-graph.mmd",
+            DependencyGraphFormat.Dot => "dependency-graph.dot",
+            DependencyGraphFormat.Json => "dependency-graph.json",
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, null),
+        };
 
     private static bool TryReadValues(
         IReadOnlyList<string> arguments,
@@ -178,6 +364,27 @@ internal static class PipelineCommandLineParser
         }
 
         return requested;
+    }
+
+    private sealed class ParsingState
+    {
+        public PipelineCommand Command { get; set; } = PipelineCommand.Run;
+
+        public bool DisableModuleCache { get; set; }
+
+        public List<string> HostArguments { get; } = [];
+
+        public List<string> TargetModules { get; } = [];
+
+        public List<string> SkippedModules { get; } = [];
+
+        public List<string> RunOnlyCategories { get; } = [];
+
+        public List<string> IgnoreCategories { get; } = [];
+
+        public DependencyGraphFormat? GraphFormat { get; set; }
+
+        public string? GraphPath { get; set; }
     }
 
     private static IReadOnlyList<string> Distinct(IEnumerable<string> values) =>

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
@@ -237,7 +237,7 @@ internal static class PipelineCommandLineParser
     }
 
     private static bool IsGraphPath(string argument) =>
-        !argument.StartsWith("--", StringComparison.Ordinal)
+        !argument.StartsWith('-')
         && (!argument.Contains('=')
             || argument.Contains(Path.DirectorySeparatorChar)
             || argument.Contains(Path.AltDirectorySeparatorChar));

--- a/src/ModularPipelines/Conditions/IPlanningRunCondition.cs
+++ b/src/ModularPipelines/Conditions/IPlanningRunCondition.cs
@@ -1,0 +1,10 @@
+namespace ModularPipelines.Conditions;
+
+/// <summary>
+/// Marks a run condition as safe to evaluate while constructing a dependency-graph plan.
+/// </summary>
+/// <remarks>
+/// Planning conditions must be side-effect free and must not perform blocking work or remote I/O.
+/// Conditions without this marker remain unresolved until pipeline execution.
+/// </remarks>
+public interface IPlanningRunCondition : IRunCondition;

--- a/src/ModularPipelines/Conditions/IsCI.cs
+++ b/src/ModularPipelines/Conditions/IsCI.cs
@@ -20,7 +20,7 @@ namespace ModularPipelines.Conditions;
 /// </code>
 /// </example>
 [ExcludeFromCodeCoverage]
-public sealed class IsCI : IRunCondition
+public sealed class IsCI : IPlanningRunCondition
 {
     /// <inheritdoc />
     public Task<bool> EvaluateAsync(IPipelineContext context)

--- a/src/ModularPipelines/Conditions/IsLocal.cs
+++ b/src/ModularPipelines/Conditions/IsLocal.cs
@@ -19,7 +19,7 @@ namespace ModularPipelines.Conditions;
 /// </code>
 /// </example>
 [ExcludeFromCodeCoverage]
-public sealed class IsLocal : IRunCondition
+public sealed class IsLocal : IPlanningRunCondition
 {
     /// <inheritdoc />
     public Task<bool> EvaluateAsync(IPipelineContext context)

--- a/src/ModularPipelines/Conditions/OnLinux.cs
+++ b/src/ModularPipelines/Conditions/OnLinux.cs
@@ -13,7 +13,7 @@ namespace ModularPipelines.Conditions;
 /// </code>
 /// </example>
 [ExcludeFromCodeCoverage]
-public sealed class OnLinux : IRunCondition
+public sealed class OnLinux : IPlanningRunCondition
 {
     /// <inheritdoc />
     public Task<bool> EvaluateAsync(IPipelineContext context)

--- a/src/ModularPipelines/Conditions/OnMacOS.cs
+++ b/src/ModularPipelines/Conditions/OnMacOS.cs
@@ -13,7 +13,7 @@ namespace ModularPipelines.Conditions;
 /// </code>
 /// </example>
 [ExcludeFromCodeCoverage]
-public sealed class OnMacOS : IRunCondition
+public sealed class OnMacOS : IPlanningRunCondition
 {
     /// <inheritdoc />
     public Task<bool> EvaluateAsync(IPipelineContext context)

--- a/src/ModularPipelines/Conditions/OnUnix.cs
+++ b/src/ModularPipelines/Conditions/OnUnix.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.Conditions;
 /// </code>
 /// </example>
 [ExcludeFromCodeCoverage]
-public sealed class OnUnix : ConditionGroup
+public sealed class OnUnix : ConditionGroup, IPlanningRunCondition
 {
     /// <inheritdoc />
     public override IReadOnlyList<IRunCondition> Conditions => [new OnLinux(), new OnMacOS()];

--- a/src/ModularPipelines/Conditions/OnWindows.cs
+++ b/src/ModularPipelines/Conditions/OnWindows.cs
@@ -13,7 +13,7 @@ namespace ModularPipelines.Conditions;
 /// </code>
 /// </example>
 [ExcludeFromCodeCoverage]
-public sealed class OnWindows : IRunCondition
+public sealed class OnWindows : IPlanningRunCondition
 {
     /// <inheritdoc />
     public Task<bool> EvaluateAsync(IPipelineContext context)

--- a/src/ModularPipelines/Configuration/ModuleConfiguration.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfiguration.cs
@@ -57,6 +57,8 @@ public sealed class ModuleConfiguration
 
     internal Func<IModuleContext, CancellationToken, ValueTask<SkipDecision?>>? PlanningSkipCondition { get; init; }
 
+    internal Func<IModuleContext, CancellationToken, ValueTask<SkipDecision?>>? SynchronousPlanningSkipCondition { get; init; }
+
     /// <summary>
     /// Gets the timeout duration for module execution.
     /// </summary>

--- a/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
@@ -37,6 +37,7 @@ internal static class ModuleConfigurationAttributeAdapter
         {
             SkipCondition = configured.SkipCondition,
             PlanningSkipCondition = configured.PlanningSkipCondition,
+            SynchronousPlanningSkipCondition = configured.SynchronousPlanningSkipCondition,
             Timeout = configured.Timeout,
             RetryConfiguration = configured.RetryConfiguration,
             AdvancedRetryPolicyFactory = configured.AdvancedRetryPolicyFactory,

--- a/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
@@ -37,6 +37,7 @@ internal static class ModuleConfigurationAttributeAdapter
         {
             SkipCondition = configured.SkipCondition,
             PlanningSkipCondition = configured.PlanningSkipCondition,
+            SynchronousPlanningSkipCondition = configured.SynchronousPlanningSkipCondition,
             Timeout = configured.Timeout,
             RetryConfiguration = configured.RetryConfiguration,
             ResilienceShieldFactory = configured.ResilienceShieldFactory,

--- a/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
@@ -40,6 +40,7 @@ public sealed class ModuleConfigurationBuilder
     private readonly List<DeclaredDependency> _dependencies = [];
     private readonly List<Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>> _skipConditions = [];
     private readonly List<Func<IModuleContext, CancellationToken, ValueTask<SkipDecision?>>> _planningSkipConditions = [];
+    private readonly List<Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>> _synchronousPlanningSkipConditions = [];
     private readonly List<string> _cacheKeyParts = [];
     private readonly HashSet<string> _cacheEnvironmentVariables = [with(StringComparer.Ordinal)];
     private string? _cacheAssemblyVersionKey;
@@ -48,6 +49,7 @@ public sealed class ModuleConfigurationBuilder
     private Func<IModuleContext, IAsyncPolicy>? _advancedRetryPolicyFactory;
     private Func<IModuleContext, Exception, Task<bool>>? _ignoreFailuresCondition;
     private bool _alwaysRun;
+    private bool _hasAsyncSkipCondition;
     private string[]? _parallelConstraintKeys;
     private ModulePriority? _priority;
     private ExecutionType? _executionType;
@@ -75,6 +77,7 @@ public sealed class ModuleConfigurationBuilder
         var adaptedCondition = AdaptSkipCondition(condition);
         _skipConditions.Add(adaptedCondition);
         _planningSkipConditions.Add(AdaptPlanningSkipCondition(adaptedCondition));
+        AddSynchronousPlanningSkipCondition(adaptedCondition);
         return this;
     }
 
@@ -93,6 +96,7 @@ public sealed class ModuleConfigurationBuilder
         ArgumentNullException.ThrowIfNull(condition);
         _skipConditions.Add(condition);
         _planningSkipConditions.Add(AdaptPlanningSkipCondition(condition));
+        _hasAsyncSkipCondition = true;
         return this;
     }
 
@@ -111,8 +115,10 @@ public sealed class ModuleConfigurationBuilder
         ValidateSkipConditionGroup(conditions);
 
         var adaptedConditions = Array.ConvertAll(conditions, AdaptSkipCondition);
-        _skipConditions.Add(ComposeAllSkipConditions(adaptedConditions));
+        var composedCondition = ComposeAllSkipConditions(adaptedConditions);
+        _skipConditions.Add(composedCondition);
         _planningSkipConditions.Add(ComposeAllPlanningSkipConditions(adaptedConditions));
+        AddSynchronousPlanningSkipCondition(composedCondition);
         return this;
     }
 
@@ -132,6 +138,7 @@ public sealed class ModuleConfigurationBuilder
 
         _skipConditions.Add(ComposeAllSkipConditions([.. conditions]));
         _planningSkipConditions.Add(ComposeAllPlanningSkipConditions(conditions));
+        _hasAsyncSkipCondition = true;
         return this;
     }
 
@@ -430,6 +437,7 @@ public sealed class ModuleConfigurationBuilder
         {
             SkipCondition = ComposeSkipConditions(),
             PlanningSkipCondition = ComposePlanningSkipConditions(),
+            SynchronousPlanningSkipCondition = ComposeSynchronousPlanningSkipConditions(),
             Timeout = _timeout,
             RetryConfiguration = _retryConfiguration,
             AdvancedRetryPolicyFactory = _advancedRetryPolicyFactory,
@@ -454,14 +462,18 @@ public sealed class ModuleConfigurationBuilder
         return this;
     }
 
-    private Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>? ComposeSkipConditions()
+    private Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>? ComposeSkipConditions() =>
+        ComposeSkipConditions(_skipConditions);
+
+    private static Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>? ComposeSkipConditions(
+        IReadOnlyCollection<Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>> skipConditions)
     {
-        if (_skipConditions.Count == 0)
+        if (skipConditions.Count == 0)
         {
             return null;
         }
 
-        var conditions = _skipConditions.ToArray();
+        var conditions = skipConditions.ToArray();
         return async (context, cancellationToken) =>
         {
             foreach (var condition in conditions)
@@ -501,6 +513,28 @@ public sealed class ModuleConfigurationBuilder
 
             return hasUnknownDecision ? null : SkipDecision.DoNotSkip;
         };
+    }
+
+    private Func<IModuleContext, CancellationToken, ValueTask<SkipDecision?>>? ComposeSynchronousPlanningSkipConditions()
+    {
+        var condition = ComposeSkipConditions(_synchronousPlanningSkipConditions);
+        if (condition is null)
+        {
+            return null;
+        }
+
+        var hasAsyncSkipCondition = _hasAsyncSkipCondition;
+        return async (context, cancellationToken) =>
+        {
+            var decision = await condition(context, cancellationToken).ConfigureAwait(false);
+            return decision.ShouldSkip || !hasAsyncSkipCondition ? decision : null;
+        };
+    }
+
+    private void AddSynchronousPlanningSkipCondition(
+        Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>> condition)
+    {
+        _synchronousPlanningSkipConditions.Add(condition);
     }
 
     private static Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>> ComposeAllSkipConditions(

--- a/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
@@ -40,6 +40,7 @@ public sealed class ModuleConfigurationBuilder
     private readonly List<DeclaredDependency> _dependencies = [];
     private readonly List<Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>> _skipConditions = [];
     private readonly List<Func<IModuleContext, CancellationToken, ValueTask<SkipDecision?>>> _planningSkipConditions = [];
+    private readonly List<Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>> _synchronousPlanningSkipConditions = [];
     private readonly List<string> _cacheKeyParts = [];
     private readonly HashSet<string> _cacheEnvironmentVariables = [with(StringComparer.Ordinal)];
     private string? _cacheAssemblyVersionKey;
@@ -48,6 +49,7 @@ public sealed class ModuleConfigurationBuilder
     private Func<IModuleContext, Shield>? _resilienceShieldFactory;
     private Func<IModuleContext, Exception, Task<bool>>? _ignoreFailuresCondition;
     private bool _alwaysRun;
+    private bool _hasAsyncSkipCondition;
     private string[]? _parallelConstraintKeys;
     private ModulePriority? _priority;
     private ExecutionType? _executionType;
@@ -75,6 +77,7 @@ public sealed class ModuleConfigurationBuilder
         var adaptedCondition = AdaptSkipCondition(condition);
         _skipConditions.Add(adaptedCondition);
         _planningSkipConditions.Add(AdaptPlanningSkipCondition(adaptedCondition));
+        AddSynchronousPlanningSkipCondition(adaptedCondition);
         return this;
     }
 
@@ -93,6 +96,7 @@ public sealed class ModuleConfigurationBuilder
         ArgumentNullException.ThrowIfNull(condition);
         _skipConditions.Add(condition);
         _planningSkipConditions.Add(AdaptPlanningSkipCondition(condition));
+        _hasAsyncSkipCondition = true;
         return this;
     }
 
@@ -111,8 +115,10 @@ public sealed class ModuleConfigurationBuilder
         ValidateSkipConditionGroup(conditions);
 
         var adaptedConditions = Array.ConvertAll(conditions, AdaptSkipCondition);
-        _skipConditions.Add(ComposeAllSkipConditions(adaptedConditions));
+        var composedCondition = ComposeAllSkipConditions(adaptedConditions);
+        _skipConditions.Add(composedCondition);
         _planningSkipConditions.Add(ComposeAllPlanningSkipConditions(adaptedConditions));
+        AddSynchronousPlanningSkipCondition(composedCondition);
         return this;
     }
 
@@ -132,6 +138,7 @@ public sealed class ModuleConfigurationBuilder
 
         _skipConditions.Add(ComposeAllSkipConditions([.. conditions]));
         _planningSkipConditions.Add(ComposeAllPlanningSkipConditions(conditions));
+        _hasAsyncSkipCondition = true;
         return this;
     }
 
@@ -430,6 +437,7 @@ public sealed class ModuleConfigurationBuilder
         {
             SkipCondition = ComposeSkipConditions(),
             PlanningSkipCondition = ComposePlanningSkipConditions(),
+            SynchronousPlanningSkipCondition = ComposeSynchronousPlanningSkipConditions(),
             Timeout = _timeout,
             RetryConfiguration = _retryConfiguration,
             ResilienceShieldFactory = _resilienceShieldFactory,
@@ -454,14 +462,18 @@ public sealed class ModuleConfigurationBuilder
         return this;
     }
 
-    private Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>? ComposeSkipConditions()
+    private Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>? ComposeSkipConditions() =>
+        ComposeSkipConditions(_skipConditions);
+
+    private static Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>? ComposeSkipConditions(
+        IReadOnlyCollection<Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>>> skipConditions)
     {
-        if (_skipConditions.Count == 0)
+        if (skipConditions.Count == 0)
         {
             return null;
         }
 
-        var conditions = _skipConditions.ToArray();
+        var conditions = skipConditions.ToArray();
         return async (context, cancellationToken) =>
         {
             foreach (var condition in conditions)
@@ -501,6 +513,28 @@ public sealed class ModuleConfigurationBuilder
 
             return hasUnknownDecision ? null : SkipDecision.DoNotSkip;
         };
+    }
+
+    private Func<IModuleContext, CancellationToken, ValueTask<SkipDecision?>>? ComposeSynchronousPlanningSkipConditions()
+    {
+        var condition = ComposeSkipConditions(_synchronousPlanningSkipConditions);
+        if (condition is null)
+        {
+            return null;
+        }
+
+        var hasAsyncSkipCondition = _hasAsyncSkipCondition;
+        return async (context, cancellationToken) =>
+        {
+            var decision = await condition(context, cancellationToken).ConfigureAwait(false);
+            return decision.ShouldSkip || !hasAsyncSkipCondition ? decision : null;
+        };
+    }
+
+    private void AddSynchronousPlanningSkipCondition(
+        Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>> condition)
+    {
+        _synchronousPlanningSkipConditions.Add(condition);
     }
 
     private static Func<IModuleContext, CancellationToken, ValueTask<SkipDecision>> ComposeAllSkipConditions(

--- a/src/ModularPipelines/Context/ModuleContext.cs
+++ b/src/ModularPipelines/Context/ModuleContext.cs
@@ -91,6 +91,7 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
                 "A module cannot depend on its own result.");
         }
 
+        EnsureModuleResultAccessAllowed(moduleType);
         return _internalContext.GetModule<TModule>();
     }
 

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -233,6 +233,11 @@ internal static class DependencyInjectionSetup
             .AddSingleton<IUnusedModuleDetector, UnusedModuleDetector>()
             .AddSingleton<IDependencyCollisionDetector, DependencyCollisionDetector>()
             .AddSingleton<IDependencyPrinter, DependencyPrinter>()
+            .AddSingleton<PipelineExecutionState>()
+            .AddSingleton<ModuleDiscoveryPlanner>()
+            .AddSingleton<DependencyGraphExporter>()
+            .AddSingleton<IDependencyGraphExporter>(provider =>
+                provider.GetRequiredService<DependencyGraphExporter>())
             .AddSingleton<IDependencyTreeFormatter, DependencyTreeFormatter>();
     }
 

--- a/src/ModularPipelines/Engine/Attributes/CustomAttributeMetadata.cs
+++ b/src/ModularPipelines/Engine/Attributes/CustomAttributeMetadata.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace ModularPipelines.Engine.Attributes;
+
+internal static class CustomAttributeMetadata
+{
+    public static IReadOnlyList<CustomAttributeData> GetApplicable(
+        Type type,
+        Func<Type, bool> predicate)
+    {
+        var result = new List<CustomAttributeData>();
+        var inheritedNonMultipleTypes = new HashSet<Type>();
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            foreach (var data in current.CustomAttributes.Where(data => predicate(data.AttributeType)))
+            {
+                var usage = data.AttributeType.GetCustomAttribute<AttributeUsageAttribute>(inherit: true);
+                if (current != type && !(usage?.Inherited ?? true))
+                {
+                    continue;
+                }
+
+                if (!(usage?.AllowMultiple ?? false)
+                    && !inheritedNonMultipleTypes.Add(data.AttributeType))
+                {
+                    continue;
+                }
+
+                result.Add(data);
+            }
+        }
+
+        return result;
+    }
+
+    public static T Create<T>(CustomAttributeData data)
+    {
+        var constructorArguments = data.ConstructorArguments
+            .Select(ConvertArgument)
+            .ToArray();
+        var attribute = (T) data.Constructor.Invoke(constructorArguments);
+        foreach (var namedArgument in data.NamedArguments)
+        {
+            var value = ConvertArgument(namedArgument.TypedValue);
+            if (namedArgument.IsField)
+            {
+                ((FieldInfo) namedArgument.MemberInfo).SetValue(attribute, value);
+            }
+            else
+            {
+                ((PropertyInfo) namedArgument.MemberInfo).SetValue(attribute, value);
+            }
+        }
+
+        return attribute;
+    }
+
+    [UnconditionalSuppressMessage(
+        "Aot",
+        "IL3050",
+        Justification = "Attribute array types are statically present in the inspected custom-attribute metadata.")]
+    private static object? ConvertArgument(CustomAttributeTypedArgument argument)
+    {
+        if (argument.Value is IReadOnlyCollection<CustomAttributeTypedArgument> values
+            && argument.ArgumentType.GetElementType() is { } elementType)
+        {
+            var array = Array.CreateInstance(elementType, values.Count);
+            var index = 0;
+            foreach (var value in values)
+            {
+                array.SetValue(ConvertArgument(value), index++);
+            }
+
+            return array;
+        }
+
+        return argument.ArgumentType.IsEnum && argument.Value is not null
+            ? Enum.ToObject(argument.ArgumentType, argument.Value)
+            : argument.Value;
+    }
+}

--- a/src/ModularPipelines/Engine/Attributes/IModuleAttributeEventService.cs
+++ b/src/ModularPipelines/Engine/Attributes/IModuleAttributeEventService.cs
@@ -11,6 +11,10 @@ internal interface IModuleAttributeEventService
 
     IReadOnlyList<IModuleRegistrationEventReceiver> GetRegistrationReceivers(Type moduleType);
 
+    IReadOnlyList<IModuleRegistrationEventReceiver> GetPlanningRegistrationReceivers(Type moduleType);
+
+    IReadOnlyList<Attribute> GetPlanningAttributes(Type moduleType);
+
     IReadOnlyList<IModuleReadyHandler> GetReadyHandlers(Type moduleType);
 
     IReadOnlyList<IModuleStartHandler> GetStartHandlers(Type moduleType);

--- a/src/ModularPipelines/Engine/Attributes/ModuleAttributeEventService.cs
+++ b/src/ModularPipelines/Engine/Attributes/ModuleAttributeEventService.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using ModularPipelines.Attributes.Events;
+using ModularPipelines.Exceptions;
 
 namespace ModularPipelines.Engine.Attributes;
 
@@ -14,12 +16,114 @@ namespace ModularPipelines.Engine.Attributes;
 internal class ModuleAttributeEventService : IModuleAttributeEventService
 {
     private readonly ConcurrentDictionary<Type, Lazy<AttributeHandlerCache>> _cache = new();
+    private readonly ConcurrentDictionary<Type, Lazy<PlanningAttributeCache>> _planningCache = new();
 
     public IReadOnlyList<Attribute> GetAttributes(Type moduleType)
         => GetCache(moduleType).Attributes;
 
     public IReadOnlyList<IModuleRegistrationEventReceiver> GetRegistrationReceivers(Type moduleType)
         => GetCache(moduleType).RegistrationReceivers;
+
+    public IReadOnlyList<IModuleRegistrationEventReceiver> GetPlanningRegistrationReceivers(Type moduleType)
+        => GetPlanningCache(moduleType).RegistrationReceivers;
+
+    public IReadOnlyList<Attribute> GetPlanningAttributes(Type moduleType)
+        => GetPlanningCache(moduleType).Attributes;
+
+    private PlanningAttributeCache GetPlanningCache(Type moduleType)
+        => _planningCache.GetOrAdd(
+            moduleType,
+            static type => new Lazy<PlanningAttributeCache>(
+                () => DiscoverPlanningAttributes(type),
+                LazyThreadSafetyMode.ExecutionAndPublication)).Value;
+
+    private static PlanningAttributeCache DiscoverPlanningAttributes(Type moduleType)
+    {
+        var receiverData = CustomAttributeMetadata.GetApplicable(
+            moduleType,
+            static type => typeof(IModuleRegistrationEventReceiver).IsAssignableFrom(type));
+        if (receiverData.Count == 0)
+        {
+            return new PlanningAttributeCache([], []);
+        }
+
+        var deferredReceiverTypes = receiverData
+            .Select(static data => data.AttributeType)
+            .Where(static type => !typeof(IPlanningSafeModuleRegistrationEventReceiver).IsAssignableFrom(type))
+            .Distinct()
+            .ToArray();
+        if (deferredReceiverTypes.Length > 0)
+        {
+            throw new PipelineException(
+                $"Cannot export a resolved dependency graph because {moduleType.FullName} has "
+                + "registration receivers that are not planning-safe: "
+                + string.Join(", ", deferredReceiverTypes.Select(static type => type.FullName))
+                + $". Implement {nameof(IPlanningSafeModuleRegistrationEventReceiver)} only when "
+                + "the receiver is deterministic, idempotent, and free of external side effects.");
+        }
+
+        var attributeData = CustomAttributeMetadata.GetApplicable(moduleType, static _ => true);
+        var attributes = attributeData.Select(CreatePlanningAttribute).ToArray();
+        var receivers = attributes.OfType<IModuleRegistrationEventReceiver>().ToList();
+        return new PlanningAttributeCache(attributes, SortByPriority(receivers));
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2072",
+        Justification = "The exact attribute type is preserved by the custom-attribute metadata being inspected.")]
+    private static Attribute CreatePlanningAttribute(CustomAttributeData data)
+    {
+        if (typeof(IPlanningSafeModuleRegistrationEventReceiver).IsAssignableFrom(data.AttributeType)
+            || data.AttributeType.Assembly == typeof(ModuleAttributeEventService).Assembly)
+        {
+            return CustomAttributeMetadata.Create<Attribute>(data);
+        }
+
+        if (!IsCompilerMetadataAttribute(data.AttributeType)
+            && (data.ConstructorArguments.Count > 0
+            || data.NamedArguments.Count > 0
+            || HasInstanceState(data.AttributeType)))
+        {
+            throw new PipelineException(
+                $"Cannot export a resolved dependency graph because {data.AttributeType.FullName} is a stateful "
+                + "companion to a planning-safe registration receiver. Planning cannot construct arbitrary "
+                + "companion attributes. Use a stateless marker attribute or move the required state onto the "
+                + $"{nameof(IPlanningSafeModuleRegistrationEventReceiver)} attribute.");
+        }
+
+        return (Attribute) RuntimeHelpers.GetUninitializedObject(data.AttributeType);
+    }
+
+    private static bool IsCompilerMetadataAttribute(Type attributeType)
+        => attributeType.Namespace == typeof(CompilerGeneratedAttribute).Namespace;
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2070",
+        Justification = "Planning inspects module attribute types that are already preserved by custom-attribute metadata.")]
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2075",
+        Justification = "Planning inspects module attribute types that are already preserved by custom-attribute metadata.")]
+    private static bool HasInstanceState(Type attributeType)
+    {
+        for (var current = attributeType; current != typeof(Attribute); current = current.BaseType)
+        {
+            if (current is null)
+            {
+                return true;
+            }
+
+            if (current.GetFields(
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly).Length > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     public IReadOnlyList<IModuleReadyHandler> GetReadyHandlers(Type moduleType)
         => GetCache(moduleType).ReadyHandlers;
@@ -144,4 +248,8 @@ internal class ModuleAttributeEventService : IModuleAttributeEventService
         IReadOnlyList<IModuleEndHandler> EndHandlers,
         IReadOnlyList<IModuleFailureHandler> FailureHandlers,
         IReadOnlyList<IModuleSkippedHandler> SkippedHandlers);
+
+    private sealed record PlanningAttributeCache(
+        IReadOnlyList<Attribute> Attributes,
+        IReadOnlyList<IModuleRegistrationEventReceiver> RegistrationReceivers);
 }

--- a/src/ModularPipelines/Engine/Attributes/RegistrationEventExecutor.cs
+++ b/src/ModularPipelines/Engine/Attributes/RegistrationEventExecutor.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using ModularPipelines.Attributes.Events;
 using ModularPipelines.Context;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Modules;
@@ -18,6 +19,7 @@ internal class RegistrationEventExecutor : IRegistrationEventExecutor
     private readonly IModuleMetadataRegistry _metadataRegistry;
     private readonly IConfiguration _configuration;
     private readonly IHostEnvironment _environment;
+    private readonly bool _planningSafeOnly;
     private Task? _invocationTask;
     private HashSet<Type>? _registeredModuleTypes;
 
@@ -28,6 +30,25 @@ internal class RegistrationEventExecutor : IRegistrationEventExecutor
         IModuleMetadataRegistry metadataRegistry,
         IConfiguration configuration,
         IHostEnvironment environment)
+        : this(
+            attributeEventService,
+            attributeEventInvoker,
+            dependencyRegistry,
+            metadataRegistry,
+            configuration,
+            environment,
+            planningSafeOnly: false)
+    {
+    }
+
+    internal RegistrationEventExecutor(
+        IModuleAttributeEventService attributeEventService,
+        IAttributeEventInvoker attributeEventInvoker,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
+        IConfiguration configuration,
+        IHostEnvironment environment,
+        bool planningSafeOnly)
     {
         _attributeEventService = attributeEventService;
         _attributeEventInvoker = attributeEventInvoker;
@@ -35,6 +56,7 @@ internal class RegistrationEventExecutor : IRegistrationEventExecutor
         _metadataRegistry = metadataRegistry;
         _configuration = configuration;
         _environment = environment;
+        _planningSafeOnly = planningSafeOnly;
     }
 
     public Task InvokeRegistrationEventsAsync(IEnumerable<IModule> modules)
@@ -76,16 +98,18 @@ internal class RegistrationEventExecutor : IRegistrationEventExecutor
         foreach (var module in modules)
         {
             var moduleType = module.GetType();
-            var receivers = _attributeEventService.GetRegistrationReceivers(moduleType);
+            var receivers = GetRegistrationReceivers(moduleType);
 
-            if (receivers.Count == 0)
+            if (receivers.Length == 0)
             {
                 continue;
             }
 
             var context = new ModuleRegistrationContext(
                 moduleType,
-                _attributeEventService.GetAttributes(moduleType),
+                _planningSafeOnly
+                    ? _attributeEventService.GetPlanningAttributes(moduleType)
+                    : _attributeEventService.GetAttributes(moduleType),
                 _configuration,
                 _environment,
                 registeredModuleTypes,
@@ -94,5 +118,13 @@ internal class RegistrationEventExecutor : IRegistrationEventExecutor
 
             await _attributeEventInvoker.InvokeRegistrationReceiversAsync(receivers, context).ConfigureAwait(false);
         }
+    }
+
+    private IModuleRegistrationEventReceiver[] GetRegistrationReceivers(Type moduleType)
+    {
+        var receivers = _planningSafeOnly
+            ? _attributeEventService.GetPlanningRegistrationReceivers(moduleType)
+            : _attributeEventService.GetRegistrationReceivers(moduleType);
+        return [.. receivers];
     }
 }

--- a/src/ModularPipelines/Engine/Dependencies/ModuleMetadataRegistry.cs
+++ b/src/ModularPipelines/Engine/Dependencies/ModuleMetadataRegistry.cs
@@ -17,10 +17,16 @@ internal class ModuleMetadataRegistry : IModuleMetadataRegistry
     private readonly ConcurrentDictionary<Type, Lazy<ModuleMetadata>> _finalizedMetadata = new();
     private readonly ConcurrentDictionary<(Type ModuleType, Type AttributeType), Attribute[]> _attributesByType = new();
     private readonly IModuleAttributeEventService _attributeEventService;
+    private readonly bool _planningSafeOnly;
 
-    public ModuleMetadataRegistry(IModuleAttributeEventService attributeEventService)
+    internal bool PlanningSafeOnly => _planningSafeOnly;
+
+    public ModuleMetadataRegistry(
+        IModuleAttributeEventService attributeEventService,
+        bool planningSafeOnly = false)
     {
         _attributeEventService = attributeEventService;
+        _planningSafeOnly = planningSafeOnly;
     }
 
     public void SetMetadata(Type moduleType, string key, object value)
@@ -59,7 +65,12 @@ internal class ModuleMetadataRegistry : IModuleMetadataRegistry
     /// <inheritdoc />
     public bool HasAttribute<TAttribute>(Type moduleType)
         where TAttribute : Attribute
-        => GetCachedAttributes(moduleType, typeof(TAttribute)).Length > 0;
+        => _planningSafeOnly
+            ? CustomAttributeMetadata.GetApplicable(
+                    moduleType,
+                    typeof(TAttribute).IsAssignableFrom)
+                .Count > 0
+            : GetCachedAttributes(moduleType, typeof(TAttribute)).Length > 0;
 
     /// <inheritdoc />
     public TAttribute? GetAttribute<TAttribute>(Type moduleType)
@@ -100,9 +111,15 @@ internal class ModuleMetadataRegistry : IModuleMetadataRegistry
     {
         return _attributesByType.GetOrAdd(
             (moduleType, attributeType),
-            key => _attributeEventService.GetAttributes(key.ModuleType)
-                .Where(key.AttributeType.IsInstanceOfType)
-                .ToArray());
+            key => _planningSafeOnly
+                ? CustomAttributeMetadata.GetApplicable(
+                        key.ModuleType,
+                        key.AttributeType.IsAssignableFrom)
+                    .Select(CustomAttributeMetadata.Create<Attribute>)
+                    .ToArray()
+                : _attributeEventService.GetAttributes(key.ModuleType)
+                    .Where(key.AttributeType.IsInstanceOfType)
+                    .ToArray());
     }
 
     internal sealed record ModuleMetadata(FrozenSet<string> Tags, string? Category);

--- a/src/ModularPipelines/Engine/Dependencies/ModuleMetadataRegistry.cs
+++ b/src/ModularPipelines/Engine/Dependencies/ModuleMetadataRegistry.cs
@@ -76,6 +76,7 @@ internal class ModuleMetadataRegistry : IModuleMetadataRegistry
     public TAttribute? GetAttribute<TAttribute>(Type moduleType)
         where TAttribute : Attribute
     {
+        EnsureAttributeValuesAvailable(typeof(TAttribute));
         var attributes = GetCachedAttributes(moduleType, typeof(TAttribute));
         return attributes.Length switch
         {
@@ -89,7 +90,10 @@ internal class ModuleMetadataRegistry : IModuleMetadataRegistry
     /// <inheritdoc />
     public IEnumerable<TAttribute> GetAttributes<TAttribute>(Type moduleType)
         where TAttribute : Attribute
-        => GetCachedAttributes(moduleType, typeof(TAttribute)).Cast<TAttribute>();
+    {
+        EnsureAttributeValuesAvailable(typeof(TAttribute));
+        return GetCachedAttributes(moduleType, typeof(TAttribute)).Cast<TAttribute>();
+    }
 
     private ModuleMetadata CreateMetadata(Type moduleType, IModule instance)
     {
@@ -122,5 +126,19 @@ internal class ModuleMetadataRegistry : IModuleMetadataRegistry
                     .ToArray());
     }
 
+    private void EnsureAttributeValuesAvailable(Type attributeType)
+    {
+        if (_planningSafeOnly
+            && attributeType != typeof(ModuleTagAttribute)
+            && attributeType != typeof(ModuleCategoryAttribute))
+        {
+            throw new PlanningMetadataValueUnavailableException(attributeType);
+        }
+    }
+
     internal sealed record ModuleMetadata(FrozenSet<string> Tags, string? Category);
 }
+
+internal sealed class PlanningMetadataValueUnavailableException(Type attributeType)
+    : InvalidOperationException(
+        $"Attribute values for '{attributeType.Name}' are unavailable during dependency graph planning.");

--- a/src/ModularPipelines/Engine/DependencyChainProvider.cs
+++ b/src/ModularPipelines/Engine/DependencyChainProvider.cs
@@ -8,15 +8,20 @@ internal class DependencyChainProvider : IDependencyChainProvider
 {
     private readonly IModuleMetadataRegistry _metadataRegistry;
     private readonly IModuleDependencyRegistry _dependencyRegistry;
+    private readonly bool _planningSafeOnly;
+
+    public bool IsInitialized { get; private set; }
 
     public IReadOnlyList<ModuleDependencyModel> ModuleDependencyModels { get; private set; } = [];
 
     public DependencyChainProvider(
         IModuleMetadataRegistry metadataRegistry,
-        IModuleDependencyRegistry dependencyRegistry)
+        IModuleDependencyRegistry dependencyRegistry,
+        bool planningSafeOnly = false)
     {
         _metadataRegistry = metadataRegistry;
         _dependencyRegistry = dependencyRegistry;
+        _planningSafeOnly = planningSafeOnly;
     }
 
     public void Initialize(IReadOnlyList<IModule> modules)
@@ -30,6 +35,7 @@ internal class DependencyChainProvider : IDependencyChainProvider
         }
 
         ModuleDependencyModels = Detect(modules.Select(x => new ModuleDependencyModel(x)).ToArray());
+        IsInitialized = true;
     }
 
     private ModuleDependencyModel[] Detect(ModuleDependencyModel[] allModules)
@@ -73,9 +79,12 @@ internal class DependencyChainProvider : IDependencyChainProvider
             moduleDependencyModel.Module,
             availableModuleTypes,
             _dependencyRegistry,
-            dependencyContext: _metadataRegistry);
+            dependencyContext: _metadataRegistry,
+            planningSafeOnly: _planningSafeOnly);
 
-        foreach (var (dependencyType, _) in dependencies)
+        foreach (var dependencyType in dependencies
+                     .Select(dependency => dependency.DependencyType)
+                     .Distinct())
         {
             if (moduleModelsByType.TryGetValue(dependencyType, out var dependencyModel))
             {

--- a/src/ModularPipelines/Engine/DependencyGraphExporter.cs
+++ b/src/ModularPipelines/Engine/DependencyGraphExporter.cs
@@ -1,0 +1,702 @@
+using System.Text;
+using System.Text.Json;
+using Mediator;
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Context;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Engine.Execution;
+using ModularPipelines.Engine.Executors;
+using ModularPipelines.Enums;
+using ModularPipelines.Logging;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.Engine;
+
+internal sealed class DependencyGraphExporter(
+    ModuleRetriever moduleRetriever,
+    ModuleDiscoveryPlanner moduleDiscoveryPlanner,
+    IDependencyChainProvider dependencyChainProvider,
+    IModuleMetadataRegistry metadataRegistry,
+    IModuleConditionHandler moduleConditionHandler,
+    IServiceProvider serviceProvider,
+    ISafeModuleEstimatedTimeProvider estimatedTimeProvider,
+    IMediator mediator,
+    PipelineExecutionState pipelineExecutionState,
+    IIgnoredModuleResultRegistrar ignoredModuleResultRegistrar) :
+    IDependencyGraphExporter
+{
+    public async Task<string> RenderAsync(
+        DependencyGraphFormat format,
+        CancellationToken cancellationToken = default)
+    {
+        using var exportLease = pipelineExecutionState.EnterGraphExport();
+        return await RenderBeforeExecutionAsync(format, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<string> RenderSummaryAsync(
+        DependencyGraphFormat format,
+        PipelineSummary pipelineSummary,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(pipelineSummary);
+        var graph = await CreateGraphAsync(pipelineSummary, cancellationToken).ConfigureAwait(false);
+        return Render(format, graph);
+    }
+
+    private static string Render(
+        DependencyGraphFormat format,
+        DependencyGraphDocument graph)
+    {
+        return format switch
+        {
+            DependencyGraphFormat.Mermaid => RenderMermaid(graph),
+            DependencyGraphFormat.Dot => RenderDot(graph),
+            DependencyGraphFormat.Json => RenderJson(graph),
+            _ => throw new ArgumentOutOfRangeException(nameof(format), format, null),
+        };
+    }
+
+    public async Task ExportAsync(
+        DependencyGraphFormat format,
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        using var exportLease = pipelineExecutionState.EnterGraphExport();
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var fullPath = Path.GetFullPath(path);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var contents = await RenderBeforeExecutionAsync(format, cancellationToken).ConfigureAwait(false);
+        await File.WriteAllTextAsync(fullPath, contents, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<string> RenderBeforeExecutionAsync(
+        DependencyGraphFormat format,
+        CancellationToken cancellationToken)
+    {
+        var graph = await CreateGraphAsync(cancellationToken).ConfigureAwait(false);
+        return Render(format, graph);
+    }
+
+    private async Task<DependencyGraphDocument> CreateGraphAsync(
+        CancellationToken cancellationToken)
+    {
+        var planningDiscovery = await moduleDiscoveryPlanner
+            .DiscoverAsync(cancellationToken)
+            .ConfigureAwait(false);
+        DependencyGraphDocument graph;
+        try
+        {
+            graph = await CreateGraphDocumentAsync(planningDiscovery, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception graphException)
+            when (graphException is not (OutOfMemoryException or StackOverflowException))
+        {
+            try
+            {
+                await planningDiscovery.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (Exception cleanupException)
+                when (cleanupException is not (OutOfMemoryException or StackOverflowException))
+            {
+                throw new AggregateException(
+                    "Dependency graph creation and planning cleanup both failed.",
+                    graphException,
+                    cleanupException);
+            }
+
+            throw;
+        }
+
+        await planningDiscovery.DisposeAsync().ConfigureAwait(false);
+        return graph;
+    }
+
+    private async Task<DependencyGraphDocument> CreateGraphDocumentAsync(
+        PlannedModuleDiscovery planningDiscovery,
+        CancellationToken cancellationToken)
+    {
+        var organizedModules = planningDiscovery.OrganizedModules;
+        var ignoredModuleResolution = await ignoredModuleResultRegistrar
+            .ResolveIgnoredModuleResultsAsync(
+                organizedModules,
+                planningDiscovery.DependencyRegistry,
+                planningDiscovery.MetadataRegistry,
+                planningDiscovery.OriginalModules,
+                cancellationToken)
+            .ConfigureAwait(false);
+        organizedModules = ignoredModuleResolution.OrganizedModules;
+        ValidateRunnableModules(
+            organizedModules,
+            ignoredModuleResolution.UsedHistoryModuleTypes,
+            planningDiscovery.DependencyRegistry,
+            planningDiscovery.MetadataRegistry);
+        var ignoredBeforeRunConditions = organizedModules.IgnoredModules
+            .Select(ignored => ignored.Module)
+            .ToHashSet<IModule>(ReferenceEqualityComparer.Instance);
+        var conditionResolution = await ApplyRunConditionsAsync(
+                organizedModules,
+                planningDiscovery.MetadataRegistry,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var runConditionHistoryTypes = await ignoredModuleResultRegistrar
+            .ResolveHistoryModuleTypesAsync(
+                conditionResolution.OrganizedModules.IgnoredModules
+                    .Select(ignored => ignored.Module)
+                    .Where(module => !ignoredBeforeRunConditions.Contains(module)),
+                planningDiscovery.OriginalModules,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var usedHistoryModuleTypes = ignoredModuleResolution.UsedHistoryModuleTypes
+            .Concat(runConditionHistoryTypes)
+            .ToHashSet();
+        var historyResolvedModuleTypes = ignoredModuleResolution.OrganizedModules.IgnoredModules
+            .Select(ignored => ignored.Module.GetType())
+            .Concat(conditionResolution.OrganizedModules.IgnoredModules
+                .Select(ignored => ignored.Module.GetType()))
+            .ToHashSet();
+        var skipResolution = await CascadeRunConditionSkipsAsync(
+                conditionResolution.OrganizedModules,
+                usedHistoryModuleTypes,
+                historyResolvedModuleTypes,
+                planningDiscovery.OriginalModules,
+                planningDiscovery.DependencyRegistry,
+                planningDiscovery.MetadataRegistry,
+                cancellationToken)
+            .ConfigureAwait(false);
+        organizedModules = skipResolution.OrganizedModules;
+        planningDiscovery.DependencyChainProvider.Initialize(organizedModules.AllModules);
+        var models = planningDiscovery.DependencyChainProvider.ModuleDependencyModels
+            .OrderBy(model => GetModuleFullName(model.Module), StringComparer.Ordinal)
+            .ToArray();
+        var unresolvedSkipDecisions = PropagateUnresolvedSkipDecisions(
+            models,
+            conditionResolution.UnresolvedSkipDecisionTypes,
+            skipResolution.SkippedModuleTypes,
+            planningDiscovery.DependencyRegistry,
+            planningDiscovery.MetadataRegistry);
+        var ignoredModules = organizedModules.IgnoredModules.ToDictionary(
+            ignored => ignored.Module.GetType());
+        var states = models.ToDictionary(
+            model => model.Module.GetType(),
+            model =>
+            {
+                var moduleType = model.Module.GetType();
+                ignoredModules.TryGetValue(moduleType, out var ignored);
+                return skipResolution.SkippedModuleTypes.Contains(moduleType)
+                    ? new GraphNodeExecutionState(true, ignored?.SkipDecision.Reason)
+                    : unresolvedSkipDecisions.Contains(moduleType)
+                        ? new GraphNodeExecutionState(null, null)
+                        : new GraphNodeExecutionState(false, null);
+            });
+
+        return CreateDocument(
+            organizedModules,
+            models,
+            states,
+            planningDiscovery.MetadataRegistry);
+    }
+
+    private async Task<DependencyGraphDocument> CreateGraphAsync(
+        PipelineSummary pipelineSummary,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var organizedModules = await moduleRetriever
+            .GetOrganizedModules(cancellationToken)
+            .ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!dependencyChainProvider.IsInitialized)
+        {
+            dependencyChainProvider.Initialize(organizedModules.AllModules);
+        }
+
+        var models = dependencyChainProvider.ModuleDependencyModels
+            .OrderBy(model => GetModuleFullName(model.Module), StringComparer.Ordinal)
+            .ToArray();
+        var uniqueModelTypeNames = models
+            .Select(model => model.Module.GetType())
+            .Where(static type => type.FullName is not null)
+            .GroupBy(static type => type.FullName!, StringComparer.Ordinal)
+            .Where(static group => group.Count() == 1)
+            .Select(static group => group.Key)
+            .ToHashSet(StringComparer.Ordinal);
+        var resultsByType = pipelineSummary.Results
+            .OfType<ModuleResult>()
+            .Where(static result => result.ModuleType is not null)
+            .GroupBy(static result => result.ModuleType!)
+            .ToDictionary(static group => group.Key, static group => group.First());
+        var deserializedResultsByTypeName = pipelineSummary.Results
+            .OfType<ModuleResult>()
+            .Where(static result => result.ModuleType is null
+                                    && result.ModuleTypeName is not null)
+            .GroupBy(static result => result.ModuleTypeName!, StringComparer.Ordinal)
+            .Where(static group => group.Count() == 1)
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.Single(),
+                StringComparer.Ordinal);
+        var states = models.ToDictionary(
+            model => model.Module.GetType(),
+            model =>
+            {
+                var moduleType = model.Module.GetType();
+                resultsByType.TryGetValue(moduleType, out var result);
+                if (result is null
+                    && moduleType.FullName is { } moduleTypeName
+                    && uniqueModelTypeNames.Contains(moduleTypeName))
+                {
+                    deserializedResultsByTypeName.TryGetValue(moduleTypeName, out result);
+                }
+
+                return new GraphNodeExecutionState(
+                    result?.ModuleStatus == Status.Skipped,
+                    result?.SkipDecisionOrDefault?.Reason);
+            });
+
+        return CreateDocument(organizedModules, models, states, metadataRegistry);
+    }
+
+    private static DependencyGraphDocument CreateDocument(
+        OrganizedModules organizedModules,
+        IReadOnlyList<ModuleDependencyModel> models,
+        IReadOnlyDictionary<Type, GraphNodeExecutionState> states,
+        IModuleMetadataRegistry graphMetadataRegistry)
+    {
+        var estimatedDurations = organizedModules.RunnableModules.ToDictionary(
+            runnable => runnable.Module.GetType(),
+            runnable => runnable.EstimatedDuration);
+        var identifiers = models
+            .Select((model, index) => (model.Module, Identifier: $"n{index}"))
+            .ToDictionary(item => item.Module.GetType(), item => item.Identifier);
+        var nodes = models.Select(model =>
+        {
+            var moduleType = model.Module.GetType();
+            estimatedDurations.TryGetValue(moduleType, out var estimatedDuration);
+            var state = states[moduleType];
+            return new DependencyGraphNode(
+                identifiers[moduleType],
+                moduleType.Name,
+                GetModuleFullName(model.Module),
+                graphMetadataRegistry.GetCategory(moduleType),
+                state.Skipped,
+                state.SkipReason,
+                estimatedDuration);
+        }).ToArray();
+        var edges = models
+            .SelectMany(dependent => dependent.IsDependentOn.Select(dependency =>
+                new DependencyGraphEdge(
+                    identifiers[dependency.Module.GetType()],
+                    identifiers[dependent.Module.GetType()])))
+            .OrderBy(edge => edge.From, StringComparer.Ordinal)
+            .ThenBy(edge => edge.To, StringComparer.Ordinal)
+            .ToArray();
+
+        return new DependencyGraphDocument(nodes, edges);
+    }
+
+    private async Task<RunConditionSkipResolution> CascadeRunConditionSkipsAsync(
+        OrganizedModules organizedModules,
+        HashSet<Type> usedHistoryModuleTypes,
+        HashSet<Type> historyResolvedModuleTypes,
+        IReadOnlyDictionary<IModule, IModule> originalModules,
+        IModuleDependencyRegistry graphDependencyRegistry,
+        IModuleMetadataRegistry graphMetadataRegistry,
+        CancellationToken cancellationToken)
+    {
+        var skippedModuleTypes = new HashSet<Type>();
+        var cascadeResult = await DependencySkipCascade.ApplyAsync(
+                [.. organizedModules.AllModules],
+                organizedModules.RunnableModules.Select(runnable => (IModule) runnable.Module),
+                organizedModules.IgnoredModules,
+                graphDependencyRegistry,
+                graphMetadataRegistry,
+                async pendingIgnoredModules =>
+                {
+                    var unresolvedModules = pendingIgnoredModules
+                        .Select(ignored => ignored.Module)
+                        .Where(module => historyResolvedModuleTypes.Add(module.GetType()))
+                        .ToArray();
+                    if (unresolvedModules.Length > 0)
+                    {
+                        var resolvedHistoryModuleTypes = await ignoredModuleResultRegistrar
+                            .ResolveHistoryModuleTypesAsync(
+                                unresolvedModules,
+                                originalModules,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                        cancellationToken.ThrowIfCancellationRequested();
+                        usedHistoryModuleTypes.UnionWith(resolvedHistoryModuleTypes);
+                    }
+
+                    foreach (var ignoredModule in pendingIgnoredModules)
+                    {
+                        var moduleType = ignoredModule.Module.GetType();
+                        if (!usedHistoryModuleTypes.Contains(moduleType))
+                        {
+                            skippedModuleTypes.Add(moduleType);
+                        }
+                    }
+                },
+                skippedModuleTypes.Contains,
+                cancellationToken)
+            .ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        var remainingModules = cascadeResult.RunnableModules.ToHashSet<IModule>(
+            ReferenceEqualityComparer.Instance);
+
+        return new RunConditionSkipResolution(
+            new OrganizedModules(
+                [.. organizedModules.RunnableModules.Where(runnable => remainingModules.Contains(runnable.Module))],
+                cascadeResult.IgnoredModules),
+            skippedModuleTypes);
+    }
+
+    private async Task<RunConditionResolution> ApplyRunConditionsAsync(
+        OrganizedModules organizedModules,
+        IModuleMetadataRegistry graphMetadataRegistry,
+        CancellationToken cancellationToken)
+    {
+        var runnableModules = new List<RunnableModule>();
+        var ignoredModules = organizedModules.IgnoredModules.ToList();
+        var unresolvedSkipDecisionTypes = new HashSet<Type>();
+        foreach (var runnableModule in organizedModules.RunnableModules)
+        {
+            var ignoredModule = await EvaluateRunConditionsAsync(
+                    runnableModule.Module,
+                    graphMetadataRegistry,
+                    unresolvedSkipDecisionTypes,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (ignoredModule is not null)
+            {
+                ignoredModules.Add(ignoredModule);
+            }
+            else
+            {
+                runnableModules.Add(runnableModule);
+            }
+        }
+
+        return new RunConditionResolution(
+            new OrganizedModules(runnableModules, ignoredModules),
+            unresolvedSkipDecisionTypes);
+    }
+
+    private async Task<IgnoredModule?> EvaluateRunConditionsAsync(
+        IModule module,
+        IModuleMetadataRegistry graphMetadataRegistry,
+        ISet<Type> unresolvedSkipDecisionTypes,
+        CancellationToken cancellationToken)
+    {
+        var conditionResult = await moduleConditionHandler
+            .ShouldIgnoreForGraphPlanning(module, graphMetadataRegistry, cancellationToken)
+            .ConfigureAwait(false);
+        if (conditionResult.ShouldIgnore)
+        {
+            return new IgnoredModule(
+                module,
+                conditionResult.SkipDecision ?? SkipDecision.Skip("Module was ignored"));
+        }
+
+        if (!conditionResult.IsResolved)
+        {
+            unresolvedSkipDecisionTypes.Add(module.GetType());
+        }
+
+        if (module.Configuration.SkipCondition is null)
+        {
+            return null;
+        }
+
+        var skipDecision = await EvaluateConfiguredSkipConditionAsync(module, cancellationToken)
+            .ConfigureAwait(false);
+        if (skipDecision is null)
+        {
+            unresolvedSkipDecisionTypes.Add(module.GetType());
+            return null;
+        }
+
+        return skipDecision.ShouldSkip ? new IgnoredModule(module, skipDecision) : null;
+    }
+
+    private async Task<SkipDecision?> EvaluateConfiguredSkipConditionAsync(
+        IModule module,
+        CancellationToken cancellationToken)
+    {
+        await using var scope = serviceProvider.CreateAsyncScope();
+        var scopedServices = scope.ServiceProvider;
+        var configuration = module.Configuration;
+        var executionContext = ExecutionContextFactory.Create(module, module.GetType());
+        try
+        {
+            var moduleContext = new ModuleContext(
+                scopedServices.GetRequiredService<IPipelineContext>(),
+                module,
+                executionContext,
+                scopedServices.GetRequiredService<IInternalModuleLoggerProvider>().GetLogger(module.GetType()),
+                mediator,
+                estimatedTimeProvider,
+                moduleResultAccessAllowed: false);
+            try
+            {
+                using var planningResultAccess = PlanningModuleResultAccess.Enter();
+                var planningCondition = configuration.SynchronousPlanningSkipCondition;
+                return planningCondition is null
+                    ? null
+                    : await planningCondition(moduleContext, cancellationToken).ConfigureAwait(false);
+            }
+            catch (PlanningModuleResultUnavailableException)
+            {
+                return null;
+            }
+        }
+        finally
+        {
+            executionContext.ModuleCancellationTokenSource.Dispose();
+        }
+    }
+
+    private static HashSet<Type> PropagateUnresolvedSkipDecisions(
+        IReadOnlyList<ModuleDependencyModel> models,
+        IReadOnlySet<Type> initiallyUnresolvedTypes,
+        IReadOnlySet<Type> skippedModuleTypes,
+        IModuleDependencyRegistry graphDependencyRegistry,
+        IModuleMetadataRegistry graphMetadataRegistry)
+    {
+        var unresolvedTypes = initiallyUnresolvedTypes
+            .Where(type => !skippedModuleTypes.Contains(type))
+            .ToHashSet();
+        var availableModuleTypes = models.Select(model => model.Module.GetType()).ToArray();
+        var changed = true;
+        while (changed)
+        {
+            changed = false;
+            foreach (var model in models.Where(model =>
+                         !skippedModuleTypes.Contains(model.Module.GetType())))
+            {
+                var moduleType = model.Module.GetType();
+                if (unresolvedTypes.Contains(moduleType))
+                {
+                    continue;
+                }
+
+                var dependsOnUnresolved = ModuleDependencyResolver
+                    .GetAllDependencies(
+                        model.Module,
+                        availableModuleTypes,
+                        graphDependencyRegistry,
+                        graphMetadataRegistry)
+                    .Any(dependency => !dependency.Optional
+                                       && unresolvedTypes.Contains(dependency.DependencyType));
+                if (dependsOnUnresolved)
+                {
+                    changed = unresolvedTypes.Add(moduleType) || changed;
+                }
+            }
+        }
+
+        return unresolvedTypes;
+    }
+
+    private static void ValidateRunnableModules(
+        OrganizedModules organizedModules,
+        IReadOnlySet<Type> usedHistoryModuleTypes,
+        IModuleDependencyRegistry graphDependencyRegistry,
+        IModuleMetadataRegistry graphMetadataRegistry)
+    {
+        var runnableModules = organizedModules.RunnableModules
+            .Select(runnableModule => (IModule) runnableModule.Module)
+            .Concat(organizedModules.IgnoredModules
+                .Select(ignoredModule => ignoredModule.Module)
+                .Where(module => usedHistoryModuleTypes.Contains(module.GetType())))
+            .ToList();
+
+        ModuleDependencyValidator.Validate(
+            runnableModules,
+            graphDependencyRegistry,
+            graphMetadataRegistry,
+            usedHistoryModuleTypes);
+    }
+
+    private static string RenderMermaid(DependencyGraphDocument graph)
+    {
+        var builder = new StringBuilder("flowchart TD");
+        foreach (var node in graph.Nodes)
+        {
+            builder.AppendLine();
+            builder.Append("    ").Append(node.Id).Append("[\"")
+                .Append(BuildLabel(node, "<br/>", EscapeMermaid))
+                .Append("\"]");
+        }
+
+        foreach (var edge in graph.Edges)
+        {
+            builder.AppendLine();
+            builder.Append("    ").Append(edge.From).Append(" --> ").Append(edge.To);
+        }
+
+        if (graph.Nodes.Any(node => node.Skipped is true))
+        {
+            builder.AppendLine();
+            builder.AppendLine("    classDef skipped fill:#616161,color:#fff,stroke:#424242,stroke-dasharray: 5 5");
+            builder.Append("    class ")
+                .AppendJoin(',', graph.Nodes.Where(node => node.Skipped is true).Select(node => node.Id))
+                .Append(" skipped");
+        }
+
+        return builder.ToString();
+    }
+
+    private static string RenderDot(DependencyGraphDocument graph)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("digraph ModularPipelines {");
+        builder.AppendLine("    rankdir=LR;");
+        foreach (var node in graph.Nodes)
+        {
+            builder.Append("    ").Append(node.Id)
+                .Append(" [label=\"")
+                .Append(BuildLabel(node, "\\n", EscapeDot))
+                .Append('"');
+            if (node.Skipped is true)
+            {
+                builder.Append(", style=\"filled,dashed\", fillcolor=\"#616161\", fontcolor=\"white\"");
+            }
+
+            builder.AppendLine("];");
+        }
+
+        foreach (var edge in graph.Edges)
+        {
+            builder.Append("    ").Append(edge.From).Append(" -> ").Append(edge.To).AppendLine(";");
+        }
+
+        builder.Append('}');
+        return builder.ToString();
+    }
+
+    private static string RenderJson(DependencyGraphDocument graph)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+        writer.WriteStartObject();
+        writer.WriteStartArray("nodes");
+        foreach (var node in graph.Nodes)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("id", node.Id);
+            writer.WriteString("name", node.Name);
+            writer.WriteString("fullName", node.FullName);
+            writer.WriteString("category", node.Category);
+            if (node.Skipped.HasValue)
+            {
+                writer.WriteBoolean("skipped", node.Skipped.Value);
+            }
+            else
+            {
+                writer.WriteNull("skipped");
+            }
+            writer.WriteString("skipReason", node.SkipReason);
+            writer.WriteString("estimatedDuration", node.EstimatedDuration.ToString("c"));
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+        writer.WriteStartArray("edges");
+        foreach (var edge in graph.Edges)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("from", edge.From);
+            writer.WriteString("to", edge.To);
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+        writer.Flush();
+        return Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static string BuildLabel(
+        DependencyGraphNode node,
+        string separator,
+        Func<string, string> escape)
+    {
+        var parts = new List<string> { node.Name };
+        if (!string.IsNullOrWhiteSpace(node.Category))
+        {
+            parts.Add($"Category: {node.Category}");
+        }
+
+        if (node.EstimatedDuration > TimeSpan.Zero)
+        {
+            parts.Add($"Estimated: {node.EstimatedDuration:c}");
+        }
+
+        if (node.Skipped is true)
+        {
+            parts.Add(string.IsNullOrWhiteSpace(node.SkipReason)
+                ? "Skipped"
+                : $"Skipped: {node.SkipReason}");
+        }
+        else if (node.Skipped is null)
+        {
+            parts.Add("Skip status: unresolved");
+        }
+
+        return string.Join(separator, parts.Select(escape));
+    }
+
+    private static string EscapeMermaid(string value) =>
+        value.Replace("&", "&amp;", StringComparison.Ordinal)
+            .Replace("\"", "&quot;", StringComparison.Ordinal)
+            .Replace("<", "&lt;", StringComparison.Ordinal)
+            .Replace(">", "&gt;", StringComparison.Ordinal)
+            .Replace("`", "&#96;", StringComparison.Ordinal)
+            .Replace("\r\n", "<br/>", StringComparison.Ordinal)
+            .Replace("\r", "<br/>", StringComparison.Ordinal)
+            .Replace("\n", "<br/>", StringComparison.Ordinal);
+
+    private static string EscapeDot(string value) =>
+        value.Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\r\n", "\\n", StringComparison.Ordinal)
+            .Replace("\r", "\\n", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
+
+    private static string GetModuleFullName(IModule module) =>
+        module.GetType().FullName ?? module.GetType().Name;
+
+    private sealed record DependencyGraphDocument(
+        IReadOnlyList<DependencyGraphNode> Nodes,
+        IReadOnlyList<DependencyGraphEdge> Edges);
+
+    private sealed record DependencyGraphNode(
+        string Id,
+        string Name,
+        string FullName,
+        string? Category,
+        bool? Skipped,
+        string? SkipReason,
+        TimeSpan EstimatedDuration);
+
+    private sealed record DependencyGraphEdge(string From, string To);
+
+    private sealed record RunConditionResolution(
+        OrganizedModules OrganizedModules,
+        IReadOnlySet<Type> UnresolvedSkipDecisionTypes);
+
+    private sealed record RunConditionSkipResolution(
+        OrganizedModules OrganizedModules,
+        IReadOnlySet<Type> SkippedModuleTypes);
+
+    private sealed record GraphNodeExecutionState(bool? Skipped, string? SkipReason);
+}

--- a/src/ModularPipelines/Engine/Executors/IIgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IIgnoredModuleResultRegistrar.cs
@@ -1,4 +1,6 @@
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Models;
+using ModularPipelines.Modules;
 
 namespace ModularPipelines.Engine.Executors;
 
@@ -14,4 +16,26 @@ internal interface IIgnoredModuleResultRegistrar
     /// remain skipped after history restoration.
     /// </summary>
     Task<OrganizedModules> RegisterIgnoredModuleResultsAsync(OrganizedModules organizedModules);
+
+    /// <summary>
+    /// Resolves ignored modules and history for planning without mutating runtime results.
+    /// </summary>
+    Task<IgnoredModuleResolution> ResolveIgnoredModuleResultsAsync(
+        OrganizedModules organizedModules,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
+        IReadOnlyDictionary<IModule, IModule> historyModules,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resolves which newly ignored planning modules have historical results.
+    /// </summary>
+    Task<IReadOnlySet<Type>> ResolveHistoryModuleTypesAsync(
+        IEnumerable<IModule> ignoredModules,
+        IReadOnlyDictionary<IModule, IModule> historyModules,
+        CancellationToken cancellationToken);
 }
+
+internal sealed record IgnoredModuleResolution(
+    OrganizedModules OrganizedModules,
+    IReadOnlySet<Type> UsedHistoryModuleTypes);

--- a/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
+++ b/src/ModularPipelines/Engine/Executors/IgnoredModuleResultRegistrar.cs
@@ -21,52 +21,104 @@ namespace ModularPipelines.Engine.Executors;
 /// This ensures tests and other code can retrieve results for these modules.
 /// If a history repository is configured and has a cached result, it will be used.
 /// </summary>
-internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
+internal class IgnoredModuleResultRegistrar(
+    IModuleResultRegistry resultRegistry,
+    IModuleResultHistoryProvider resultHistoryProvider,
+    IPipelineContextProvider pipelineContextProvider,
+    IModuleDependencyRegistry dependencyRegistry,
+    IModuleMetadataRegistry metadataRegistry,
+    IOptions<DistributedOptions> distributedOptions,
+    RoleDetector roleDetector,
+    ILogger<IgnoredModuleResultRegistrar> logger,
+    ModulePlanningSkipEvaluator modulePlanningSkipEvaluator) : IIgnoredModuleResultRegistrar
 {
-    private readonly IModuleResultRegistry _resultRegistry;
-    private readonly IModuleResultHistoryProvider _resultHistoryProvider;
-    private readonly IPipelineContextProvider _pipelineContextProvider;
-    private readonly IModuleDependencyRegistry _dependencyRegistry;
-    private readonly IModuleMetadataRegistry _metadataRegistry;
-    private readonly IOptions<DistributedOptions> _distributedOptions;
-    private readonly RoleDetector _roleDetector;
-    private readonly ILogger<IgnoredModuleResultRegistrar> _logger;
-    private readonly ModulePlanningSkipEvaluator _modulePlanningSkipEvaluator;
-
-    public IgnoredModuleResultRegistrar(
-        IModuleResultRegistry resultRegistry,
-        IModuleResultHistoryProvider resultHistoryProvider,
-        IPipelineContextProvider pipelineContextProvider,
-        IModuleDependencyRegistry dependencyRegistry,
-        IModuleMetadataRegistry metadataRegistry,
-        IOptions<DistributedOptions> distributedOptions,
-        RoleDetector roleDetector,
-        ILogger<IgnoredModuleResultRegistrar> logger,
-        ModulePlanningSkipEvaluator modulePlanningSkipEvaluator)
-    {
-        _resultRegistry = resultRegistry;
-        _resultHistoryProvider = resultHistoryProvider;
-        _pipelineContextProvider = pipelineContextProvider;
-        _dependencyRegistry = dependencyRegistry;
-        _metadataRegistry = metadataRegistry;
-        _distributedOptions = distributedOptions;
-        _roleDetector = roleDetector;
-        _logger = logger;
-        _modulePlanningSkipEvaluator = modulePlanningSkipEvaluator;
-    }
+    private readonly IModuleResultRegistry _resultRegistry = resultRegistry;
+    private readonly IModuleResultHistoryProvider _resultHistoryProvider = resultHistoryProvider;
+    private readonly IPipelineContextProvider _pipelineContextProvider = pipelineContextProvider;
+    private readonly IModuleDependencyRegistry _dependencyRegistry = dependencyRegistry;
+    private readonly IModuleMetadataRegistry _metadataRegistry = metadataRegistry;
+    private readonly IOptions<DistributedOptions> _distributedOptions = distributedOptions;
+    private readonly RoleDetector _roleDetector = roleDetector;
+    private readonly ILogger<IgnoredModuleResultRegistrar> _logger = logger;
+    private readonly ModulePlanningSkipEvaluator _modulePlanningSkipEvaluator = modulePlanningSkipEvaluator;
 
     /// <inheritdoc />
     public async Task<OrganizedModules> RegisterIgnoredModuleResultsAsync(OrganizedModules organizedModules)
     {
+        var resolution = await ResolveIgnoredModuleResultsCoreAsync(
+                organizedModules,
+                _dependencyRegistry,
+                _metadataRegistry,
+                registerResults: true,
+                historyModules: null,
+                CancellationToken.None)
+            .ConfigureAwait(false);
+        return resolution.OrganizedModules;
+    }
+
+    /// <inheritdoc />
+    public Task<IgnoredModuleResolution> ResolveIgnoredModuleResultsAsync(
+        OrganizedModules organizedModules,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
+        IReadOnlyDictionary<IModule, IModule> historyModules,
+        CancellationToken cancellationToken) =>
+        ResolveIgnoredModuleResultsCoreAsync(
+            organizedModules,
+            dependencyRegistry,
+            metadataRegistry,
+            registerResults: false,
+            historyModules,
+            cancellationToken);
+
+    /// <inheritdoc />
+    public async Task<IReadOnlySet<Type>> ResolveHistoryModuleTypesAsync(
+        IEnumerable<IModule> ignoredModules,
+        IReadOnlyDictionary<IModule, IModule> historyModules,
+        CancellationToken cancellationToken)
+    {
+        var usedHistoryModuleTypes = new HashSet<Type>();
         if (IsDistributedWorker())
         {
-            return organizedModules;
+            return usedHistoryModuleTypes;
+        }
+
+        var pipelineContext = _pipelineContextProvider.GetModuleContext();
+        foreach (var module in ignoredModules.Distinct<IModule>(ReferenceEqualityComparer.Instance))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var historicalResult = await _resultHistoryProvider
+                .TryGetAsync(historyModules[module], pipelineContext)
+                .ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (historicalResult is not null)
+            {
+                usedHistoryModuleTypes.Add(module.GetType());
+            }
+        }
+
+        return usedHistoryModuleTypes;
+    }
+
+    private async Task<IgnoredModuleResolution> ResolveIgnoredModuleResultsCoreAsync(
+        OrganizedModules organizedModules,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
+        bool registerResults,
+        IReadOnlyDictionary<IModule, IModule>? historyModules,
+        CancellationToken cancellationToken)
+    {
+        if (IsDistributedWorker())
+        {
+            return new IgnoredModuleResolution(organizedModules, new HashSet<Type>());
         }
 
         var pipelineContext = _pipelineContextProvider.GetModuleContext();
         var runnableModules = organizedModules.RunnableModules.ToList();
         var ignoredModules = organizedModules.IgnoredModules.ToList();
         var allModules = organizedModules.AllModules.ToArray();
+        var usedHistoryModuleTypes = new HashSet<Type>();
+        var skippedModuleTypes = new HashSet<Type>();
         var availableModuleTypes = allModules
             .Select(module => module.GetType())
             .Distinct()
@@ -80,8 +132,11 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
             ReferenceEqualityComparer.Instance);
         foreach (var ignoredModule in ignoredModules)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             historicalResults[ignoredModule.Module] = await _resultHistoryProvider
-                .TryGetAsync(ignoredModule.Module, pipelineContext)
+                .TryGetAsync(
+                    GetHistoryModule(ignoredModule.Module, historyModules),
+                    pipelineContext)
                 .ConfigureAwait(false);
         }
 
@@ -92,27 +147,111 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
             .Where(ignoredModule => historicalResults[ignoredModule.Module] is null)
             .Select(ignoredModule => ignoredModule.Module.GetType())
             .ToHashSet();
-        var consumedArtifactProducerTypes = await ArtifactDemandPlanner.ResolveAsync(async currentDemand =>
+        var consumedArtifactProducerTypes = await ResolveConsumedArtifactProducerTypesAsync(
+                runnableModules,
+                modulesByType,
+                availableModuleTypes,
+                ignoredModuleTypes,
+                ignoredModuleTypesWithoutHistory,
+                historicalResults,
+                planningSkipDecisions,
+                pipelineContext,
+                dependencyRegistry,
+                metadataRegistry,
+                historyModules,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var cascadeResult = await DependencySkipCascade.ApplyAsync(
+            allModules,
+            runnableModules.Select(runnableModule => runnableModule.Module),
+            ignoredModules,
+            dependencyRegistry,
+            metadataRegistry,
+            async pendingIgnoredModules =>
+            {
+                foreach (var ignoredModule in pendingIgnoredModules)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    if (!historicalResults.TryGetValue(ignoredModule.Module, out var historicalResult))
+                    {
+                        historicalResult = await _resultHistoryProvider
+                            .TryGetAsync(
+                                GetHistoryModule(ignoredModule.Module, historyModules),
+                                pipelineContext)
+                            .ConfigureAwait(false);
+                        historicalResults[ignoredModule.Module] = historicalResult;
+                    }
+
+                    var result = CreateIgnoredModuleResult(
+                        ignoredModule,
+                        historicalResult,
+                        allowHistory: !consumedArtifactProducerTypes.Contains(
+                            ignoredModule.Module.GetType()));
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var moduleType = ignoredModule.Module.GetType();
+                    if (result.ModuleStatus == Status.UsedHistory)
+                    {
+                        usedHistoryModuleTypes.Add(moduleType);
+                    }
+                    else
+                    {
+                        skippedModuleTypes.Add(moduleType);
+                    }
+
+                    if (registerResults)
+                    {
+                        _resultRegistry.RegisterResult(moduleType, result);
+                        SetModuleCompletionSource(ignoredModule.Module, ignoredModule.Module.ResultType, result);
+                    }
+                }
+            },
+            skippedModuleTypes.Contains,
+            cancellationToken)
+            .ConfigureAwait(false);
+        var remainingModules = cascadeResult.RunnableModules.ToHashSet<IModule>(
+            ReferenceEqualityComparer.Instance);
+
+        return new IgnoredModuleResolution(
+            new OrganizedModules(
+                [.. runnableModules.Where(runnableModule => remainingModules.Contains(runnableModule.Module))],
+                cascadeResult.IgnoredModules),
+            usedHistoryModuleTypes);
+    }
+
+    private async Task<HashSet<Type>> ResolveConsumedArtifactProducerTypesAsync(
+        IReadOnlyList<RunnableModule> runnableModules,
+        IReadOnlyDictionary<Type, IModule> modulesByType,
+        IReadOnlyCollection<Type> availableModuleTypes,
+        IReadOnlySet<Type> ignoredModuleTypes,
+        IReadOnlySet<Type> ignoredModuleTypesWithoutHistory,
+        IDictionary<IModule, IModuleResult?> historicalResults,
+        IDictionary<IModule, SkipDecision?> planningSkipDecisions,
+        IPipelineContext pipelineContext,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
+        IReadOnlyDictionary<IModule, IModule>? historyModules,
+        CancellationToken cancellationToken)
+    {
+        return await ArtifactDemandPlanner.ResolveAsync(async currentDemand =>
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var nextConsumedArtifactProducerTypes = new HashSet<Type>();
             var unrecoverableIgnoredModuleTypes = ignoredModuleTypesWithoutHistory
                 .Concat(currentDemand)
                 .ToHashSet();
             foreach (var runnableModule in runnableModules)
             {
-                var consumedArtifacts = runnableModule.Module.GetType()
+                var consumedProducerTypes = runnableModule.Module.GetType()
                     .GetCustomAttributes(typeof(ConsumesArtifactAttribute), inherit: true)
                     .Cast<ConsumesArtifactAttribute>()
-                    .Where(attribute => ignoredModuleTypes.Contains(attribute.ProducerModule))
-                    .ToArray();
-                if (consumedArtifacts.Length == 0)
+                    .Select(attribute => attribute.ProducerModule)
+                    .Where(ignoredModuleTypes.Contains)
+                    .ToHashSet();
+                if (consumedProducerTypes.Count == 0)
                 {
                     continue;
                 }
 
-                var consumedProducerTypes = consumedArtifacts
-                    .Select(attribute => attribute.ProducerModule)
-                    .ToHashSet();
                 var dependencyDemand = await GetRequiredDependencyDemandAsync(
                         runnableModule.Module,
                         modulesByType,
@@ -122,7 +261,11 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
                         consumedProducerTypes,
                         historicalResults,
                         planningSkipDecisions,
-                        pipelineContext)
+                        pipelineContext,
+                        dependencyRegistry,
+                        metadataRegistry,
+                        historyModules,
+                        cancellationToken)
                     .ConfigureAwait(false);
                 if (dependencyDemand.IsUnrecoverable)
                 {
@@ -135,9 +278,17 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
                     continue;
                 }
 
-                var skipDecision = await _modulePlanningSkipEvaluator
-                    .EvaluateAsync(runnableModule.Module, CancellationToken.None)
-                    .ConfigureAwait(false);
+                if (!planningSkipDecisions.TryGetValue(runnableModule.Module, out var skipDecision))
+                {
+                    skipDecision = await EvaluatePlanningSkipAsync(
+                            runnableModule.Module,
+                            metadataRegistry,
+                            historyModules,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    planningSkipDecisions[runnableModule.Module] = skipDecision;
+                }
+
                 if (skipDecision?.ShouldSkip != true)
                 {
                     nextConsumedArtifactProducerTypes.UnionWith(consumedProducerTypes);
@@ -146,39 +297,6 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
 
             return nextConsumedArtifactProducerTypes;
         }).ConfigureAwait(false);
-        var cascadeResult = await DependencySkipCascade.ApplyAsync(
-            allModules,
-            runnableModules.Select(runnableModule => runnableModule.Module),
-            ignoredModules,
-            _dependencyRegistry,
-            _metadataRegistry,
-            async pendingIgnoredModules =>
-            {
-                foreach (var ignoredModule in pendingIgnoredModules)
-                {
-                    if (!historicalResults.TryGetValue(ignoredModule.Module, out var historicalResult))
-                    {
-                        historicalResult = await _resultHistoryProvider
-                            .TryGetAsync(ignoredModule.Module, pipelineContext)
-                            .ConfigureAwait(false);
-                        historicalResults[ignoredModule.Module] = historicalResult;
-                    }
-
-                    RegisterIgnoredModuleResult(
-                        ignoredModule,
-                        historicalResult,
-                        allowHistory: !consumedArtifactProducerTypes.Contains(
-                            ignoredModule.Module.GetType()));
-                }
-            },
-            moduleType => _resultRegistry.GetResult(moduleType)?.ModuleStatus == Status.Skipped)
-            .ConfigureAwait(false);
-        var remainingModules = cascadeResult.RunnableModules.ToHashSet<IModule>(
-            ReferenceEqualityComparer.Instance);
-
-        return new OrganizedModules(
-            runnableModules.Where(runnableModule => remainingModules.Contains(runnableModule.Module)).ToList(),
-            cascadeResult.IgnoredModules);
     }
 
     private async Task<RequiredDependencyDemand> GetRequiredDependencyDemandAsync(
@@ -190,7 +308,11 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
         IReadOnlySet<Type> consumedProducerTypes,
         IDictionary<IModule, IModuleResult?> historicalResults,
         IDictionary<IModule, SkipDecision?> planningSkipDecisions,
-        IPipelineContext pipelineContext)
+        IPipelineContext pipelineContext,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
+        IReadOnlyDictionary<IModule, IModule>? historyModules,
+        CancellationToken cancellationToken)
     {
         return await GetRequiredDependencyDemandAsync(
                 module,
@@ -202,6 +324,10 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
                 historicalResults,
                 planningSkipDecisions,
                 pipelineContext,
+                dependencyRegistry,
+                metadataRegistry,
+                historyModules,
+                cancellationToken,
                 new HashSet<Type> { module.GetType() })
             .ConfigureAwait(false);
     }
@@ -216,6 +342,10 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
         IDictionary<IModule, IModuleResult?> historicalResults,
         IDictionary<IModule, SkipDecision?> planningSkipDecisions,
         IPipelineContext pipelineContext,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
+        IReadOnlyDictionary<IModule, IModule>? historyModules,
+        CancellationToken cancellationToken,
         ISet<Type> visitedTypes)
     {
         var hasPendingDependency = false;
@@ -223,8 +353,8 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
             .GetAllDependencies(
                 module,
                 availableModuleTypes,
-                _dependencyRegistry,
-                _metadataRegistry)
+                dependencyRegistry,
+                metadataRegistry)
             .Where(dependency => !dependency.Optional)
             .Select(dependency => dependency.DependencyType);
         foreach (var dependencyType in requiredDependencies)
@@ -239,7 +369,11 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
                     visitedTypes,
                     historicalResults,
                     planningSkipDecisions,
-                    pipelineContext)
+                    pipelineContext,
+                    dependencyRegistry,
+                    metadataRegistry,
+                    historyModules,
+                    cancellationToken)
                 .ConfigureAwait(false);
             if (dependencyDemand.IsUnrecoverable)
             {
@@ -267,7 +401,11 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
         ISet<Type> visitedTypes,
         IDictionary<IModule, IModuleResult?> historicalResults,
         IDictionary<IModule, SkipDecision?> planningSkipDecisions,
-        IPipelineContext pipelineContext)
+        IPipelineContext pipelineContext,
+        IModuleDependencyRegistry dependencyRegistry,
+        IModuleMetadataRegistry metadataRegistry,
+        IReadOnlyDictionary<IModule, IModule>? historyModules,
+        CancellationToken cancellationToken)
     {
         if (ignoredModuleTypes.Contains(dependencyType))
         {
@@ -294,6 +432,10 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
                     historicalResults,
                     planningSkipDecisions,
                     pipelineContext,
+                    dependencyRegistry,
+                    metadataRegistry,
+                    historyModules,
+                    cancellationToken,
                     visitedTypes)
                 .ConfigureAwait(false);
             if (transitiveDemand.IsUnrecoverable)
@@ -310,8 +452,11 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
 
             if (!planningSkipDecisions.TryGetValue(dependencyModule, out var skipDecision))
             {
-                skipDecision = await _modulePlanningSkipEvaluator
-                    .EvaluateAsync(dependencyModule, CancellationToken.None)
+                skipDecision = await EvaluatePlanningSkipAsync(
+                        dependencyModule,
+                        metadataRegistry,
+                        historyModules,
+                        cancellationToken)
                     .ConfigureAwait(false);
                 planningSkipDecisions[dependencyModule] = skipDecision;
             }
@@ -326,7 +471,9 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
             if (!historicalResults.TryGetValue(dependencyModule, out var historicalResult))
             {
                 historicalResult = await _resultHistoryProvider
-                    .TryGetAsync(dependencyModule, pipelineContext)
+                    .TryGetAsync(
+                        GetHistoryModule(dependencyModule, historyModules),
+                        pipelineContext)
                     .ConfigureAwait(false);
                 historicalResults[dependencyModule] = historicalResult;
             }
@@ -345,6 +492,23 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
         bool IsUnrecoverable,
         bool HasPendingDependency);
 
+    private Task<SkipDecision?> EvaluatePlanningSkipAsync(
+        IModule module,
+        IModuleMetadataRegistry metadataRegistry,
+        IReadOnlyDictionary<IModule, IModule>? historyModules,
+        CancellationToken cancellationToken) =>
+        historyModules is null
+            ? _modulePlanningSkipEvaluator.EvaluateAsync(module, cancellationToken)
+            : _modulePlanningSkipEvaluator.EvaluateGraphSafeAsync(
+                module,
+                metadataRegistry,
+                cancellationToken);
+
+    private static IModule GetHistoryModule(
+        IModule module,
+        IReadOnlyDictionary<IModule, IModule>? historyModules) =>
+        historyModules is null ? module : historyModules[module];
+
     private bool IsDistributedWorker()
     {
         var options = _distributedOptions.Value;
@@ -353,7 +517,7 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
                && _roleDetector.DetectRole() == DistributedRole.Worker;
     }
 
-    private void RegisterIgnoredModuleResult(
+    private IModuleResult CreateIgnoredModuleResult(
         IgnoredModule ignoredModule,
         IModuleResult? historicalResult,
         bool allowHistory)
@@ -367,10 +531,7 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
             var usedHistoryResult = ModuleResultFactory.WithStatus(historicalResult, Status.UsedHistory);
             _logger.LogDebug("Using historical result for ignored module {ModuleName}",
                 moduleType.Name);
-            _resultRegistry.RegisterResult(moduleType, usedHistoryResult);
-
-            SetModuleCompletionSource(module, resultType, usedHistoryResult);
-            return;
+            return usedHistoryResult;
         }
 
         _logger.LogDebug("Registering skipped result for ignored module {ModuleName}",
@@ -386,20 +547,15 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
         var hasGeneratedRuntime = GeneratedModuleMetadata.TryGetRuntime(
             moduleType,
             out var runtime);
-        var result = hasGeneratedRuntime
-            ? runtime.CreateSkipped(executionContext)
-            : ModuleResultFactory.CreateSkipped(resultType, executionContext);
-
-        _resultRegistry.RegisterResult(moduleType, result);
-
-        // Set the completion source so awaiting the module returns immediately
-        if (hasGeneratedRuntime)
+        try
         {
-            runtime.SetCompletionSource(module, result);
+            return hasGeneratedRuntime
+                ? runtime.CreateSkipped(executionContext)
+                : ModuleResultFactory.CreateSkipped(resultType, executionContext);
         }
-        else
+        finally
         {
-            SetModuleCompletionSource(module, resultType, result);
+            executionContext.ModuleCancellationTokenSource.Dispose();
         }
     }
 
@@ -409,6 +565,12 @@ internal class IgnoredModuleResultRegistrar : IIgnoredModuleResultRegistrar
     /// </summary>
     private static void SetModuleCompletionSource(IModule module, Type resultType, IModuleResult result)
     {
+        if (GeneratedModuleMetadata.TryGetRuntime(module.GetType(), out var runtime))
+        {
+            runtime.SetCompletionSource(module, result);
+            return;
+        }
+
         var setter = CompletionSourceSetterCache.GetOrCreate(resultType);
         setter(module, result);
     }

--- a/src/ModularPipelines/Engine/IDependencyChainProvider.cs
+++ b/src/ModularPipelines/Engine/IDependencyChainProvider.cs
@@ -5,6 +5,8 @@ namespace ModularPipelines.Engine;
 
 internal interface IDependencyChainProvider
 {
+    bool IsInitialized { get; }
+
     IReadOnlyList<ModuleDependencyModel> ModuleDependencyModels { get; }
 
     void Initialize(IReadOnlyList<IModule> modules);

--- a/src/ModularPipelines/Engine/IDependencyGraphExporter.cs
+++ b/src/ModularPipelines/Engine/IDependencyGraphExporter.cs
@@ -1,0 +1,33 @@
+using ModularPipelines.Enums;
+using ModularPipelines.Models;
+
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Renders and exports the pipeline's resolved module dependency graph.
+/// </summary>
+public interface IDependencyGraphExporter
+{
+    /// <summary>
+    /// Renders the dependency graph in the requested format.
+    /// </summary>
+    Task<string> RenderAsync(
+        DependencyGraphFormat format,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Renders the dependency graph using completed pipeline results for status annotations.
+    /// </summary>
+    Task<string> RenderSummaryAsync(
+        DependencyGraphFormat format,
+        PipelineSummary pipelineSummary,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes the dependency graph to a file.
+    /// </summary>
+    Task ExportAsync(
+        DependencyGraphFormat format,
+        string path,
+        CancellationToken cancellationToken = default);
+}

--- a/src/ModularPipelines/Engine/IModuleActivator.cs
+++ b/src/ModularPipelines/Engine/IModuleActivator.cs
@@ -19,4 +19,12 @@ internal interface IModuleActivator
     /// <param name="serviceProvider">The service provider for resolving dependencies.</param>
     /// <returns>The created module instance.</returns>
     IModule CreateModule(Type moduleType, IServiceProvider serviceProvider);
+
+    /// <summary>
+    /// Creates a module for planning without evaluating its configuration.
+    /// </summary>
+    /// <param name="moduleType">The type of module to create.</param>
+    /// <param name="serviceProvider">The service provider for resolving dependencies.</param>
+    /// <returns>The unconfigured module instance.</returns>
+    IModule CreatePlanningModule(Type moduleType, IServiceProvider serviceProvider);
 }

--- a/src/ModularPipelines/Engine/IModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/IModuleConditionHandler.cs
@@ -1,3 +1,4 @@
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
@@ -9,9 +10,29 @@ internal interface IModuleConditionHandler
         IModule module,
         CancellationToken cancellationToken = default);
 
+    Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnoreByCategory(
+        IModule module,
+        IModuleMetadataRegistry metadataRegistry,
+        CancellationToken cancellationToken = default);
+
     Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnore(IModule module, CancellationToken cancellationToken = default);
 
     Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnoreForPlanning(
         IModule module,
         CancellationToken cancellationToken = default);
+
+    Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnoreForPlanning(
+        IModule module,
+        IModuleMetadataRegistry metadataRegistry,
+        CancellationToken cancellationToken = default);
+
+    Task<PlanningConditionResult> ShouldIgnoreForGraphPlanning(
+        IModule module,
+        IModuleMetadataRegistry metadataRegistry,
+        CancellationToken cancellationToken = default);
 }
+
+internal sealed record PlanningConditionResult(
+    bool ShouldIgnore,
+    SkipDecision? SkipDecision,
+    bool IsResolved);

--- a/src/ModularPipelines/Engine/ModuleActivator.cs
+++ b/src/ModularPipelines/Engine/ModuleActivator.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Logging;
 using ModularPipelines.Modules;
@@ -17,6 +18,9 @@ namespace ModularPipelines.Engine;
 /// </remarks>
 internal sealed class ModuleActivator : IModuleActivator
 {
+    private static readonly ConditionalWeakTable<IModule, ResolvedObjectTrackingServiceProvider>
+        RuntimeServiceOwnership = new();
+
     /// <inheritdoc />
     [UnconditionalSuppressMessage(
         "Trimming",
@@ -24,10 +28,28 @@ internal sealed class ModuleActivator : IModuleActivator
         Justification = "This runtime-Type overload is the reflection fallback; generated registrations use the annotated generic overload.")]
     public IModule CreateModule(Type moduleType, IServiceProvider serviceProvider)
     {
+        var trackingServiceProvider = new ResolvedObjectTrackingServiceProvider(serviceProvider);
+        var module = CreateModuleWithContext(
+            moduleType,
+            trackingServiceProvider,
+            provider => (IModule) ActivatorUtilities.CreateInstance(provider, moduleType),
+            initializeConfiguration: true);
+        RuntimeServiceOwnership.Add(module, trackingServiceProvider);
+        return module;
+    }
+
+    /// <inheritdoc />
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2067",
+        Justification = "This runtime-Type overload is the reflection fallback for dependency-graph planning.")]
+    public IModule CreatePlanningModule(Type moduleType, IServiceProvider serviceProvider)
+    {
         return CreateModuleWithContext(
             moduleType,
             serviceProvider,
-            provider => (IModule) ActivatorUtilities.CreateInstance(provider, moduleType));
+            provider => (IModule) ActivatorUtilities.CreateInstance(provider, moduleType),
+            initializeConfiguration: false);
     }
 
     internal static TModule CreateModule<
@@ -35,16 +57,26 @@ internal sealed class ModuleActivator : IModuleActivator
         IServiceProvider serviceProvider)
         where TModule : class, IModule
     {
-        return CreateModuleWithContext(
+        var trackingServiceProvider = new ResolvedObjectTrackingServiceProvider(serviceProvider);
+        var module = CreateModuleWithContext(
             typeof(TModule),
-            serviceProvider,
-            static provider => ActivatorUtilities.CreateInstance<TModule>(provider));
+            trackingServiceProvider,
+            static provider => ActivatorUtilities.CreateInstance<TModule>(provider),
+            initializeConfiguration: true);
+        RuntimeServiceOwnership.Add(module, trackingServiceProvider);
+        return module;
     }
+
+    internal static bool TryGetRuntimeServiceOwnership(
+        IModule module,
+        [NotNullWhen(true)] out ResolvedObjectTrackingServiceProvider? serviceOwnership) =>
+        RuntimeServiceOwnership.TryGetValue(module, out serviceOwnership);
 
     private static TModule CreateModuleWithContext<TModule>(
         Type moduleType,
         IServiceProvider serviceProvider,
-        Func<IServiceProvider, TModule> activate)
+        Func<IServiceProvider, TModule> activate,
+        bool initializeConfiguration)
         where TModule : IModule
     {
         var previousType = ModuleLogger.CurrentModuleType.Value;
@@ -53,7 +85,11 @@ internal sealed class ModuleActivator : IModuleActivator
         try
         {
             var module = activate(serviceProvider);
-            _ = module.Configuration;
+            if (initializeConfiguration)
+            {
+                _ = module.Configuration;
+            }
+
             return module;
         }
         finally

--- a/src/ModularPipelines/Engine/ModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/ModuleConditionHandler.cs
@@ -261,7 +261,8 @@ internal class ModuleConditionHandler : IModuleConditionHandler
             planningAttributes.Where(attribute => attribute.Logic == ConditionLogic.Any).ToArray(),
             HasDeferredCondition(deferredTypes, ConditionLogic.Skip),
             HasDeferredCondition(deferredTypes, ConditionLogic.All),
-            HasDeferredCondition(deferredTypes, ConditionLogic.Any));
+            HasDeferredCondition(deferredTypes, ConditionLogic.Any),
+            HasDeferredGroupedAnyCondition(deferredTypes));
     }
 
     private static bool HasDeferredCondition(
@@ -269,6 +270,11 @@ internal class ModuleConditionHandler : IModuleConditionHandler
         ConditionLogic logic) =>
         attributeTypes.Any(type => GetConditionLogic(type) is not { } conditionLogic
                                    || conditionLogic == logic);
+
+    private static bool HasDeferredGroupedAnyCondition(IEnumerable<Type> attributeTypes) =>
+        attributeTypes.Any(type =>
+            typeof(IGroupedConditionAttribute).IsAssignableFrom(type)
+            && (GetConditionLogic(type) is not { } logic || logic == ConditionLogic.Any));
 
     private static ConditionLogic? GetConditionLogic(Type attributeType)
     {
@@ -351,6 +357,7 @@ internal class ModuleConditionHandler : IModuleConditionHandler
                 attributes.Any,
                 pipelineContext,
                 attributes.HasDeferredAny,
+                attributes.HasDeferredGroupedAny,
                 cancellationToken)
             .ConfigureAwait(false);
         return anyEvaluation.Result ?? new PlanningConditionResult(
@@ -440,6 +447,7 @@ internal class ModuleConditionHandler : IModuleConditionHandler
         IReadOnlyCollection<IConditionAttribute> attributes,
         IPipelineContext pipelineContext,
         bool hasDeferredConditions,
+        bool hasDeferredGroupedConditions,
         CancellationToken cancellationToken)
     {
         foreach (var attribute in attributes.Where(static attribute =>
@@ -469,6 +477,7 @@ internal class ModuleConditionHandler : IModuleConditionHandler
                     attributes,
                     groupedAttribute.ConditionGroupType,
                     pipelineContext,
+                    hasDeferredGroupedConditions,
                     cancellationToken)
                 .ConfigureAwait(false);
             if (evaluation.Result is not null)
@@ -506,6 +515,7 @@ internal class ModuleConditionHandler : IModuleConditionHandler
         IEnumerable<IConditionAttribute> attributes,
         Type groupType,
         IPipelineContext pipelineContext,
+        bool hasDeferredGroupedConditions,
         CancellationToken cancellationToken)
     {
         var alternatives = attributes
@@ -524,7 +534,7 @@ internal class ModuleConditionHandler : IModuleConditionHandler
             return new PlanningConditionEvaluation(null, IsResolved: true);
         }
 
-        if (planningAlternatives.Length != alternatives.Length)
+        if (hasDeferredGroupedConditions || planningAlternatives.Length != alternatives.Length)
         {
             return new PlanningConditionEvaluation(null, IsResolved: false);
         }
@@ -690,5 +700,6 @@ internal class ModuleConditionHandler : IModuleConditionHandler
         IConditionAttribute[] Any,
         bool HasDeferredSkip = false,
         bool HasDeferredAll = false,
-        bool HasDeferredAny = false);
+        bool HasDeferredAny = false,
+        bool HasDeferredGroupedAny = false);
 }

--- a/src/ModularPipelines/Engine/ModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/ModuleConditionHandler.cs
@@ -456,12 +456,7 @@ internal class ModuleConditionHandler : IModuleConditionHandler
             }
         }
 
-        if (hasDeferredConditions)
-        {
-            return new PlanningConditionEvaluation(null, IsResolved: false);
-        }
-
-        var isResolved = true;
+        var isResolved = !hasDeferredConditions;
         var evaluatedGroups = new HashSet<Type>();
         foreach (var groupedAttribute in attributes.OfType<IGroupedConditionAttribute>())
         {

--- a/src/ModularPipelines/Engine/ModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/ModuleConditionHandler.cs
@@ -77,7 +77,7 @@ internal class ModuleConditionHandler : IModuleConditionHandler
         var result = EvaluateCategoryConditions(module, metadataRegistry);
         if (!result.ShouldIgnore
             && IsDistributedMaster()
-            && OperatingSystemConditions.HasImpossibleCombination(GetConditionAttributes(module.GetType()).All))
+            && OperatingSystemConditions.HasImpossibleCombination(module.GetType()))
         {
             result = (true, SkipDecision.Skip("Module requires mutually exclusive operating systems"));
         }

--- a/src/ModularPipelines/Engine/ModuleConditionHandler.cs
+++ b/src/ModularPipelines/Engine/ModuleConditionHandler.cs
@@ -7,6 +7,7 @@ using ModularPipelines.Conditions;
 using ModularPipelines.Context;
 using ModularPipelines.Distributed;
 using ModularPipelines.Distributed.Configuration;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
@@ -65,9 +66,15 @@ internal class ModuleConditionHandler : IModuleConditionHandler
     public Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnoreByCategory(
         IModule module,
         CancellationToken cancellationToken = default)
+        => ShouldIgnoreByCategory(module, _metadataRegistry, cancellationToken);
+
+    public Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnoreByCategory(
+        IModule module,
+        IModuleMetadataRegistry metadataRegistry,
+        CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var result = EvaluateCategoryConditions(module);
+        var result = EvaluateCategoryConditions(module, metadataRegistry);
         if (!result.ShouldIgnore
             && IsDistributedMaster()
             && OperatingSystemConditions.HasImpossibleCombination(GetConditionAttributes(module.GetType()).All))
@@ -81,33 +88,77 @@ internal class ModuleConditionHandler : IModuleConditionHandler
     public Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnoreForPlanning(
         IModule module,
         CancellationToken cancellationToken = default)
+        => ShouldIgnoreForPlanning(module, _metadataRegistry, cancellationToken);
+
+    public Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> ShouldIgnoreForPlanning(
+        IModule module,
+        IModuleMetadataRegistry metadataRegistry,
+        CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return EvaluateShouldIgnore(module, cancellationToken);
+        return EvaluateShouldIgnore(
+            module,
+            cancellationToken,
+            useFreshAttributes: true,
+            metadataRegistry);
+    }
+
+    public async Task<PlanningConditionResult> ShouldIgnoreForGraphPlanning(
+        IModule module,
+        IModuleMetadataRegistry metadataRegistry,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var categoryResult = EvaluateCategoryConditions(module, metadataRegistry);
+        if (categoryResult.ShouldIgnore)
+        {
+            return new PlanningConditionResult(
+                true,
+                categoryResult.SkipDecision,
+                IsResolved: true);
+        }
+
+        return await EvaluatePlanningConditions(
+                CreatePlanningConditionAttributes(module.GetType()),
+                _pipelineContextProvider.GetModuleContext(),
+                IsDistributedMaster(),
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private async Task<(bool ShouldIgnore, SkipDecision? SkipDecision)> EvaluateShouldIgnore(
         IModule module,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool useFreshAttributes = false,
+        IModuleMetadataRegistry? metadataRegistry = null)
     {
-        var categoryResult = EvaluateCategoryConditions(module);
+        var categoryResult = EvaluateCategoryConditions(module, metadataRegistry ?? _metadataRegistry);
         if (categoryResult.ShouldIgnore)
         {
             return categoryResult;
         }
 
         var moduleType = module.GetType();
-        var conditionResult = await IsRunnableCondition(moduleType, cancellationToken).ConfigureAwait(false);
+        var conditionResult = await IsRunnableCondition(
+                moduleType,
+                cancellationToken,
+                useFreshAttributes)
+            .ConfigureAwait(false);
         return conditionResult.IsRunnable
             ? (false, null)
             : (true, conditionResult.SkipDecision);
     }
 
     private (bool ShouldIgnore, SkipDecision? SkipDecision) EvaluateCategoryConditions(IModule module)
+        => EvaluateCategoryConditions(module, _metadataRegistry);
+
+    private (bool ShouldIgnore, SkipDecision? SkipDecision) EvaluateCategoryConditions(
+        IModule module,
+        IModuleMetadataRegistry metadataRegistry)
     {
         var moduleType = module.GetType();
-        _metadataRegistry.FinalizeMetadata(moduleType, module);
-        var category = _metadataRegistry.GetCategory(moduleType);
+        metadataRegistry.FinalizeMetadata(moduleType, module);
+        var category = metadataRegistry.GetCategory(moduleType);
 
         if (IsIgnoreCategory(category))
         {
@@ -148,10 +199,13 @@ internal class ModuleConditionHandler : IModuleConditionHandler
 
     private async Task<(bool IsRunnable, SkipDecision? SkipDecision)> IsRunnableCondition(
         Type moduleType,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool useFreshAttributes)
     {
         var pipelineContext = _pipelineContextProvider.GetModuleContext();
-        var attributes = GetConditionAttributes(moduleType);
+        var attributes = useFreshAttributes
+            ? CreateConditionAttributes(moduleType)
+            : GetConditionAttributes(moduleType);
         return await EvaluateConditions(
             attributes,
             pipelineContext,
@@ -186,6 +240,312 @@ internal class ModuleConditionHandler : IModuleConditionHandler
             conditionAttributes.Where(attribute => attribute.Logic == ConditionLogic.All).ToArray(),
             conditionAttributes.Where(attribute => attribute.Logic == ConditionLogic.Any).ToArray());
     }
+
+    private static ConditionAttributes CreatePlanningConditionAttributes(Type moduleType)
+    {
+        var conditionData = CustomAttributeMetadata.GetApplicable(
+            moduleType,
+            static type => typeof(IConditionAttribute).IsAssignableFrom(type));
+        var planningAttributes = conditionData
+            .Where(data => IsPlanningConditionAttribute(data.AttributeType))
+            .Select(CustomAttributeMetadata.Create<IConditionAttribute>)
+            .ToArray();
+        var deferredTypes = conditionData
+            .Select(static data => data.AttributeType)
+            .Where(static type => !IsPlanningConditionAttribute(type))
+            .ToArray();
+
+        return new ConditionAttributes(
+            planningAttributes.Where(attribute => attribute.Logic == ConditionLogic.Skip).ToArray(),
+            planningAttributes.Where(attribute => attribute.Logic == ConditionLogic.All).ToArray(),
+            planningAttributes.Where(attribute => attribute.Logic == ConditionLogic.Any).ToArray(),
+            HasDeferredCondition(deferredTypes, ConditionLogic.Skip),
+            HasDeferredCondition(deferredTypes, ConditionLogic.All),
+            HasDeferredCondition(deferredTypes, ConditionLogic.Any));
+    }
+
+    private static bool HasDeferredCondition(
+        IEnumerable<Type> attributeTypes,
+        ConditionLogic logic) =>
+        attributeTypes.Any(type => GetConditionLogic(type) is not { } conditionLogic
+                                   || conditionLogic == logic);
+
+    private static ConditionLogic? GetConditionLogic(Type attributeType)
+    {
+        if (typeof(SkipIfAttribute).IsAssignableFrom(attributeType))
+        {
+            return ConditionLogic.Skip;
+        }
+
+        if (typeof(RunIfAllAttribute).IsAssignableFrom(attributeType))
+        {
+            return ConditionLogic.All;
+        }
+
+        return typeof(RunIfAnyAttribute).IsAssignableFrom(attributeType)
+            ? ConditionLogic.Any
+            : null;
+    }
+
+    private static bool IsPlanningConditionAttribute(IConditionAttribute attribute)
+        => IsPlanningConditionAttribute(attribute.GetType());
+
+    private static bool IsPlanningConditionAttribute(Type attributeType)
+    {
+        if (typeof(IPlanningConditionAttribute).IsAssignableFrom(attributeType))
+        {
+            return true;
+        }
+
+        var conditionTypes = attributeType.GetGenericArguments();
+        return attributeType.IsGenericType
+               && IsBuiltInGenericConditionAttribute(attributeType.GetGenericTypeDefinition())
+               && conditionTypes.All(static type =>
+                   typeof(IPlanningRunCondition).IsAssignableFrom(type));
+    }
+
+    private static bool IsBuiltInGenericConditionAttribute(Type type) =>
+        type == typeof(RunIfAllAttribute<>)
+        || type == typeof(RunIfAllAttribute<,>)
+        || type == typeof(RunIfAllAttribute<,,>)
+        || type == typeof(RunIfAllAttribute<,,,>)
+        || type == typeof(RunIfAnyAttribute<>)
+        || type == typeof(RunIfAnyAttribute<,>)
+        || type == typeof(RunIfAnyAttribute<,,>)
+        || type == typeof(RunIfAnyAttribute<,,,>)
+        || type == typeof(SkipIfAttribute<>)
+        || type == typeof(SkipIfAttribute<,>)
+        || type == typeof(SkipIfAttribute<,,>)
+        || type == typeof(SkipIfAttribute<,,,>);
+
+    private static async Task<PlanningConditionResult> EvaluatePlanningConditions(
+        ConditionAttributes attributes,
+        IPipelineContext pipelineContext,
+        bool isDistributedMaster,
+        CancellationToken cancellationToken)
+    {
+        var skipEvaluation = await EvaluateSkipPlanningConditions(
+                attributes.Skip,
+                pipelineContext,
+                attributes.HasDeferredSkip,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (skipEvaluation.Result is not null)
+        {
+            return skipEvaluation.Result;
+        }
+
+        var allEvaluation = await EvaluateAllPlanningConditions(
+                attributes.All,
+                pipelineContext,
+                isDistributedMaster,
+                attributes.HasDeferredAll,
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (allEvaluation.Result is not null)
+        {
+            return allEvaluation.Result;
+        }
+
+        var anyEvaluation = await EvaluateAnyPlanningConditions(
+                attributes.Any,
+                pipelineContext,
+                attributes.HasDeferredAny,
+                cancellationToken)
+            .ConfigureAwait(false);
+        return anyEvaluation.Result ?? new PlanningConditionResult(
+            false,
+            null,
+            skipEvaluation.IsResolved
+            && allEvaluation.IsResolved
+            && anyEvaluation.IsResolved);
+    }
+
+    private static async Task<PlanningConditionEvaluation> EvaluateSkipPlanningConditions(
+        IEnumerable<IConditionAttribute> attributes,
+        IPipelineContext pipelineContext,
+        bool hasDeferredConditions,
+        CancellationToken cancellationToken)
+    {
+        var isResolved = !hasDeferredConditions;
+        foreach (var attribute in attributes)
+        {
+            if (!IsPlanningConditionAttribute(attribute))
+            {
+                isResolved = false;
+                continue;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            if (await attribute.EvaluateAsync(pipelineContext, cancellationToken).ConfigureAwait(false))
+            {
+                return new PlanningConditionEvaluation(
+                    PlanningSkip($"SkipIf<{attribute.ConditionNames}> returned true"),
+                    IsResolved: true);
+            }
+        }
+
+        return new PlanningConditionEvaluation(null, isResolved);
+    }
+
+    private static async Task<PlanningConditionEvaluation> EvaluateAllPlanningConditions(
+        IEnumerable<IConditionAttribute> attributes,
+        IPipelineContext pipelineContext,
+        bool isDistributedMaster,
+        bool hasDeferredConditions,
+        CancellationToken cancellationToken)
+    {
+        var isResolved = !hasDeferredConditions;
+        var allConditions = attributes
+            .Select(attribute => (
+                Attribute: attribute,
+                OperatingSystemTargets: OperatingSystemConditions.GetTargets(attribute)))
+            .ToArray();
+        var operatingSystemTargets = allConditions
+            .SelectMany(condition => condition.OperatingSystemTargets)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var deferOperatingSystemConditions = isDistributedMaster && operatingSystemTargets.Length == 1;
+        if (deferOperatingSystemConditions)
+        {
+            isResolved = false;
+        }
+
+        foreach (var (attribute, attributeOperatingSystemTargets) in allConditions)
+        {
+            if (deferOperatingSystemConditions && attributeOperatingSystemTargets.Count > 0)
+            {
+                continue;
+            }
+
+            if (!IsPlanningConditionAttribute(attribute))
+            {
+                isResolved = false;
+                continue;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!await attribute.EvaluateAsync(pipelineContext, cancellationToken).ConfigureAwait(false))
+            {
+                return new PlanningConditionEvaluation(
+                    PlanningSkip($"RunIfAll<{attribute.ConditionNames}> not satisfied"),
+                    IsResolved: true);
+            }
+        }
+
+        return new PlanningConditionEvaluation(null, isResolved);
+    }
+
+    private static async Task<PlanningConditionEvaluation> EvaluateAnyPlanningConditions(
+        IReadOnlyCollection<IConditionAttribute> attributes,
+        IPipelineContext pipelineContext,
+        bool hasDeferredConditions,
+        CancellationToken cancellationToken)
+    {
+        foreach (var attribute in attributes.Where(static attribute =>
+                     attribute is not IGroupedConditionAttribute))
+        {
+            var evaluation = await EvaluateSingleAnyPlanningCondition(
+                    attribute,
+                    pipelineContext,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (evaluation.Result is not null)
+            {
+                return evaluation;
+            }
+        }
+
+        if (hasDeferredConditions)
+        {
+            return new PlanningConditionEvaluation(null, IsResolved: false);
+        }
+
+        var isResolved = true;
+        var evaluatedGroups = new HashSet<Type>();
+        foreach (var groupedAttribute in attributes.OfType<IGroupedConditionAttribute>())
+        {
+            if (!evaluatedGroups.Add(groupedAttribute.ConditionGroupType))
+            {
+                continue;
+            }
+
+            var evaluation = await EvaluateGroupedPlanningConditions(
+                    attributes,
+                    groupedAttribute.ConditionGroupType,
+                    pipelineContext,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (evaluation.Result is not null)
+            {
+                return evaluation;
+            }
+
+            isResolved &= evaluation.IsResolved;
+        }
+
+        return new PlanningConditionEvaluation(null, isResolved);
+    }
+
+    private static async Task<PlanningConditionEvaluation> EvaluateSingleAnyPlanningCondition(
+        IConditionAttribute attribute,
+        IPipelineContext pipelineContext,
+        CancellationToken cancellationToken)
+    {
+        if (!IsPlanningConditionAttribute(attribute))
+        {
+            return new PlanningConditionEvaluation(null, IsResolved: false);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var matches = await attribute.EvaluateAsync(pipelineContext, cancellationToken)
+            .ConfigureAwait(false);
+        return matches
+            ? new PlanningConditionEvaluation(null, IsResolved: true)
+            : new PlanningConditionEvaluation(
+                PlanningSkip($"RunIfAny<{attribute.ConditionNames}> not satisfied"),
+                IsResolved: true);
+    }
+
+    private static async Task<PlanningConditionEvaluation> EvaluateGroupedPlanningConditions(
+        IEnumerable<IConditionAttribute> attributes,
+        Type groupType,
+        IPipelineContext pipelineContext,
+        CancellationToken cancellationToken)
+    {
+        var alternatives = attributes
+            .OfType<IGroupedConditionAttribute>()
+            .Where(candidate => candidate.ConditionGroupType == groupType)
+            .ToArray();
+        var planningAlternatives = alternatives
+            .Where(IsPlanningConditionAttribute)
+            .ToArray();
+        if (await AnyConditionMatches(
+                planningAlternatives,
+                pipelineContext,
+                cancellationToken)
+            .ConfigureAwait(false))
+        {
+            return new PlanningConditionEvaluation(null, IsResolved: true);
+        }
+
+        if (planningAlternatives.Length != alternatives.Length)
+        {
+            return new PlanningConditionEvaluation(null, IsResolved: false);
+        }
+
+        return new PlanningConditionEvaluation(
+            PlanningSkip(
+                $"No grouped run conditions were met: {string.Join(", ", alternatives.Select(x => x.ConditionNames))}"),
+            IsResolved: true);
+    }
+
+    private static PlanningConditionResult PlanningSkip(string reason) =>
+        new(true, SkipDecision.Skip(reason), IsResolved: true);
+
+    private readonly record struct PlanningConditionEvaluation(
+        PlanningConditionResult? Result,
+        bool IsResolved);
 
     private static async Task<(bool IsRunnable, SkipDecision? SkipDecision)> EvaluateConditions(
         ConditionAttributes attributes,
@@ -332,5 +692,8 @@ internal class ModuleConditionHandler : IModuleConditionHandler
     private sealed record ConditionAttributes(
         IConditionAttribute[] Skip,
         IConditionAttribute[] All,
-        IConditionAttribute[] Any);
+        IConditionAttribute[] Any,
+        bool HasDeferredSkip = false,
+        bool HasDeferredAll = false,
+        bool HasDeferredAny = false);
 }

--- a/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
+++ b/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
@@ -1,6 +1,8 @@
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
+using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Enums;
 using ModularPipelines.Extensions;
@@ -70,9 +72,12 @@ internal static class ModuleDependencyResolver
     public static IEnumerable<(Type DependencyType, bool Optional)> GetSelectorDependencies(
         Type moduleType,
         IReadOnlyList<Type> availableModuleTypes,
-        IDependencyContext? dependencyContext)
+        IDependencyContext? dependencyContext,
+        bool planningSafeOnly = false)
     {
-        foreach (var attribute in moduleType.GetCustomAttributesIncludingBaseInterfaces<DependsOnAllModulesInheritingFromAttribute>())
+        planningSafeOnly |= dependencyContext is ModuleMetadataRegistry { PlanningSafeOnly: true };
+
+        foreach (var attribute in GetInheritanceSelectorAttributes(moduleType, planningSafeOnly))
         {
             foreach (var candidateType in availableModuleTypes)
             {
@@ -93,7 +98,11 @@ internal static class ModuleDependencyResolver
         // Handle predicate-based dependencies (DependsOnBaseAttribute derivatives)
         if (dependencyContext != null)
         {
-            foreach (var dep in GetPredicateDependencies(moduleType, availableModuleTypes, dependencyContext))
+            foreach (var dep in GetPredicateDependencies(
+                         moduleType,
+                         availableModuleTypes,
+                         dependencyContext,
+                         planningSafeOnly))
             {
                 yield return dep;
             }
@@ -106,15 +115,22 @@ internal static class ModuleDependencyResolver
     /// <param name="moduleType">The module type to get predicate dependencies for.</param>
     /// <param name="availableModuleTypes">All available module types to evaluate against predicates.</param>
     /// <param name="dependencyContext">Context providing access to module metadata.</param>
+    /// <param name="planningSafeOnly">Whether to evaluate only predicates explicitly safe for planning.</param>
     /// <returns>Enumerable of dependency tuples (DependencyType, Optional).</returns>
     public static IEnumerable<(Type DependencyType, bool Optional)> GetPredicateDependencies(
         Type moduleType,
         IReadOnlyList<Type> availableModuleTypes,
-        IDependencyContext dependencyContext)
+        IDependencyContext dependencyContext,
+        bool planningSafeOnly = false)
     {
-        var predicateAttributes = moduleType
-            .GetCustomAttributesIncludingBaseInterfaces<DependsOnBaseAttribute>()
-            .ToList();
+        var predicateAttributes = planningSafeOnly
+            ? moduleType
+                .GetCustomAttributesIncludingBaseInterfaces<PlanningSafeDependsOnBaseAttribute>()
+                .Cast<DependsOnBaseAttribute>()
+                .ToList()
+            : moduleType
+                .GetCustomAttributesIncludingBaseInterfaces<DependsOnBaseAttribute>()
+                .ToList();
 
         if (predicateAttributes.Count == 0)
         {
@@ -189,7 +205,8 @@ internal static class ModuleDependencyResolver
         IModule module,
         IEnumerable<Type> availableModuleTypes,
         IModuleDependencyRegistry? dynamicRegistry = null,
-        IDependencyContext? dependencyContext = null)
+        IDependencyContext? dependencyContext = null,
+        bool planningSafeOnly = false)
     {
         var moduleType = module.GetType();
 
@@ -206,7 +223,11 @@ internal static class ModuleDependencyResolver
         }
 
         var availableModuleTypesList = availableModuleTypes as IReadOnlyList<Type> ?? availableModuleTypes.ToList();
-        foreach (var dep in GetSelectorDependencies(moduleType, availableModuleTypesList, dependencyContext))
+        foreach (var dep in GetSelectorDependencies(
+                     moduleType,
+                     availableModuleTypesList,
+                     dependencyContext,
+                     planningSafeOnly))
         {
             yield return dep;
         }
@@ -233,5 +254,35 @@ internal static class ModuleDependencyResolver
         return moduleType
             .GetCustomAttributesIncludingBaseInterfaces<DependsOnAttribute>()
             .Select(static attribute => (attribute.Type, attribute.Optional));
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2070",
+        Justification = "This is the documented reflection fallback for dynamically supplied module types.")]
+    private static IEnumerable<DependsOnAllModulesInheritingFromAttribute> GetInheritanceSelectorAttributes(
+        Type moduleType,
+        bool planningSafeOnly)
+    {
+        if (!planningSafeOnly)
+        {
+            return moduleType
+                .GetCustomAttributesIncludingBaseInterfaces<DependsOnAllModulesInheritingFromAttribute>();
+        }
+
+        var selectorType = typeof(DependsOnAllModulesInheritingFromAttribute);
+        var attributeData = CustomAttributeMetadata.GetApplicable(
+                moduleType,
+                type => type.IsAssignableTo(selectorType))
+            .Concat(moduleType.GetInterfaces()
+                .SelectMany(static type => type.CustomAttributes)
+                .Where(data => data.AttributeType
+                    .IsAssignableTo(typeof(DependsOnAllModulesInheritingFromAttribute))));
+
+        return attributeData
+            .Where(data => data.AttributeType.Assembly == selectorType.Assembly
+                || data.AttributeType.IsAssignableTo(typeof(IPlanningSafeDependencySelector)))
+            .Select(CustomAttributeMetadata.Create<DependsOnAllModulesInheritingFromAttribute>)
+            .ToArray();
     }
 }

--- a/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
+++ b/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
@@ -147,17 +147,7 @@ internal static class ModuleDependencyResolver
 
             foreach (var attr in predicateAttributes)
             {
-                bool shouldDependOn;
-                try
-                {
-                    shouldDependOn = attr.ShouldDependOn(candidateType, dependencyContext);
-                }
-                catch (PlanningMetadataValueUnavailableException) when (planningSafeOnly)
-                {
-                    continue;
-                }
-
-                if (shouldDependOn)
+                if (attr.ShouldDependOn(candidateType, dependencyContext))
                 {
                     yield return (candidateType, false);
                     break; // Only add once even if multiple attributes match

--- a/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
+++ b/src/ModularPipelines/Engine/ModuleDependencyResolver.cs
@@ -147,7 +147,17 @@ internal static class ModuleDependencyResolver
 
             foreach (var attr in predicateAttributes)
             {
-                if (attr.ShouldDependOn(candidateType, dependencyContext))
+                bool shouldDependOn;
+                try
+                {
+                    shouldDependOn = attr.ShouldDependOn(candidateType, dependencyContext);
+                }
+                catch (PlanningMetadataValueUnavailableException) when (planningSafeOnly)
+                {
+                    continue;
+                }
+
+                if (shouldDependOn)
                 {
                     yield return (candidateType, false);
                     break; // Only add once even if multiple attributes match

--- a/src/ModularPipelines/Engine/ModuleDiscoveryPlanner.cs
+++ b/src/ModularPipelines/Engine/ModuleDiscoveryPlanner.cs
@@ -1,0 +1,1541 @@
+using System.Collections;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using ModularPipelines.Configuration;
+using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Exceptions;
+using ModularPipelines.Helpers;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Engine;
+
+internal sealed class ModuleDiscoveryPlanner(
+    IModuleConditionHandler moduleConditionHandler,
+    IAttributeEventInvoker attributeEventInvoker,
+    IConfiguration configuration,
+    IHostEnvironment environment,
+    IEnumerable<IModule> modules,
+    ISafeModuleEstimatedTimeProvider estimatedTimeProvider,
+    IOptions<PipelineOptions> pipelineOptions,
+    IServiceProvider serviceProvider,
+    IEnumerable<ModulePlanningFactory> planningFactories)
+{
+    private const byte LoadInstanceFieldAddressOpCode = 0x7C;
+    private const byte StoreInstanceFieldOpCode = 0x7D;
+
+    private static readonly OpCode[] OneByteOpCodes = CreateOpCodeLookup(twoByte: false);
+    private static readonly OpCode[] TwoByteOpCodes = CreateOpCodeLookup(twoByte: true);
+
+    private readonly IReadOnlyList<IModule> _modules = modules
+        .Distinct<IModule>(ReferenceEqualityComparer.Instance)
+        .ToArray();
+    private readonly IReadOnlyList<ModulePlanningFactory> _planningFactories =
+        planningFactories.ToArray();
+
+    public async Task<PlannedModuleDiscovery> DiscoverAsync(
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_modules.Count == 0)
+        {
+            throw new PipelineException("No modules have been registered");
+        }
+
+        var planningScope = serviceProvider.CreateAsyncScope();
+        var planningServiceProvider = planningScope.ServiceProvider;
+        var planningModules = new IModule[_modules.Count];
+        var ownedPlanningModules = new List<IModule>();
+        try
+        {
+            var originalModules = new Dictionary<IModule, IModule>(ReferenceEqualityComparer.Instance);
+            for (var index = 0; index < planningModules.Length; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var planningModule = CreatePlanningModule(
+                    _modules[index],
+                    ownedPlanningModules,
+                    planningServiceProvider);
+                planningModules[index] = planningModule.Module;
+                if (planningModule.IsPlannerOwned
+                    && !ReferenceEquals(planningModule.Module, _modules[index]))
+                {
+                    ownedPlanningModules.Add(planningModule.Module);
+                }
+
+                if (planningModule.RequiresIsolation)
+                {
+                    ValidatePlanningModule(
+                        _modules[index],
+                        planningModule.Module,
+                        planningModule.IsServiceProviderOwned);
+                }
+                originalModules.Add(planningModules[index], _modules[index]);
+            }
+
+            var planningDependencyRegistry = new ModuleDependencyRegistry();
+            var attributeEventService = new ModuleAttributeEventService();
+            var planningMetadataRegistry = new ModuleMetadataRegistry(
+                attributeEventService,
+                planningSafeOnly: true);
+            var dependencyChainProvider = new DependencyChainProvider(
+                planningMetadataRegistry,
+                planningDependencyRegistry,
+                planningSafeOnly: true);
+            var registrationEventExecutor = new RegistrationEventExecutor(
+                attributeEventService,
+                attributeEventInvoker,
+                planningDependencyRegistry,
+                planningMetadataRegistry,
+                configuration,
+                environment,
+                planningSafeOnly: true);
+            cancellationToken.ThrowIfCancellationRequested();
+            await registrationEventExecutor.InvokeRegistrationEventsAsync(planningModules)
+                .ConfigureAwait(false);
+
+            var moduleSelection = ModuleSelection.Create(
+                planningModules,
+                dependencyChainProvider,
+                pipelineOptions.Value);
+            var ignoredModules = new List<IgnoredModule>();
+            var runnableModules = new List<IModule>();
+            foreach (var module in planningModules)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (moduleSelection.GetSkipDecision(module) is { } selectionSkipDecision)
+                {
+                    ignoredModules.Add(new IgnoredModule(module, selectionSkipDecision));
+                    continue;
+                }
+
+                var (shouldIgnore, skipDecision) = await moduleConditionHandler
+                    .ShouldIgnoreByCategory(module, planningMetadataRegistry, cancellationToken)
+                    .ConfigureAwait(false);
+                if (shouldIgnore)
+                {
+                    ignoredModules.Add(new IgnoredModule(
+                        module,
+                        skipDecision ?? SkipDecision.Skip("Module was ignored")));
+                }
+                else
+                {
+                    runnableModules.Add(module);
+                }
+            }
+
+            var runnableModulesWithEstimatedDuration = await Task.WhenAll(
+                    runnableModules.Select(async module => new RunnableModule(
+                        module,
+                        await estimatedTimeProvider
+                            .GetModuleEstimatedTimeAsync(module.GetType())
+                            .ConfigureAwait(false))))
+                .ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return new PlannedModuleDiscovery(
+                new OrganizedModules(runnableModulesWithEstimatedDuration, ignoredModules),
+                dependencyChainProvider,
+                planningDependencyRegistry,
+                planningMetadataRegistry,
+                originalModules,
+                ownedPlanningModules,
+                planningScope);
+        }
+        catch (Exception discoveryException)
+        {
+            var cleanupExceptions = await CollectPlanningCleanupExceptionsAsync(
+                    ownedPlanningModules,
+                    planningScope)
+                .ConfigureAwait(false);
+            if (cleanupExceptions.Count > 0)
+            {
+                throw new AggregateException(
+                    "Module discovery and planning cleanup both failed.",
+                    new[] { discoveryException }.Concat(cleanupExceptions));
+            }
+
+            throw;
+        }
+    }
+
+    private PlanningModule CreatePlanningModule(
+        IModule module,
+        ICollection<IModule> ownedPlanningModules,
+        IServiceProvider planningServiceProvider)
+    {
+        if (module is not IPlanningModuleCopyProvider copyProvider)
+        {
+            throw new PipelineException(
+                $"The direct module '{module.GetType().FullName}' cannot be copied for dependency-graph "
+                + "planning without invoking its constructor. Derive from Module<T> and override "
+                + "CreatePlanningCopy to return an isolated copy.");
+        }
+
+        var factory = _planningFactories.LastOrDefault(candidate =>
+            candidate.CreatedRuntimeModule(module));
+        if (factory is null)
+        {
+            return CreatePlanningModuleWithoutFactory(
+                module,
+                copyProvider,
+                ownedPlanningModules,
+                planningServiceProvider);
+        }
+
+        if (HasCustomPlanningCopy(module))
+        {
+            return CreateIsolatedPlanningModule(CreatePlanningCopy(
+                module,
+                copyProvider,
+                ownedPlanningModules,
+                planningServiceProvider));
+        }
+
+        RejectRuntimeBoundPlanningCondition(module, copyProvider);
+        return CreateIsolatedPlanningModule(new PlanningModuleCreation(
+            copyProvider.CreatePlanningCopyFromRegisteredInstance(
+                preserveConfiguration: true),
+            factory.IsRuntimeServiceProviderOwned,
+            IsPlannerOwned: false));
+    }
+
+    private static PlanningModule CreatePlanningModuleWithoutFactory(
+        IModule module,
+        IPlanningModuleCopyProvider copyProvider,
+        ICollection<IModule> ownedPlanningModules,
+        IServiceProvider planningServiceProvider)
+    {
+        if (!HasCustomPlanningCopy(module)
+            && ModuleActivator.TryGetRuntimeServiceOwnership(
+                module,
+                out var runtimeServiceOwnership))
+        {
+            if (TryCreatePlanningCopyFromRegisteredInstance(
+                    module,
+                    copyProvider,
+                    runtimeServiceOwnership,
+                    out var registeredInstanceCopy))
+            {
+                return CreateIsolatedPlanningModule(registeredInstanceCopy);
+            }
+
+            throw new PipelineException(
+                $"The registered module '{module.GetType().FullName}' contains runtime state that "
+                + "cannot be shared with dependency-graph planning. Override CreatePlanningCopy to "
+                + "return an isolated copy.");
+        }
+
+        return CreateIsolatedPlanningModule(CreatePlanningCopy(
+            module,
+            copyProvider,
+            ownedPlanningModules,
+            planningServiceProvider));
+    }
+
+    private static PlanningModule CreateIsolatedPlanningModule(PlanningModuleCreation creation) =>
+        new(
+            creation.Module,
+            creation.IsPlannerOwned,
+            RequiresIsolation: true,
+            creation.IsServiceProviderOwned);
+
+    private static void ValidatePlanningModule(
+        IModule runtimeModule,
+        IModule planningModule,
+        Func<object, bool> isServiceProviderOwned)
+    {
+        if (ReferenceEquals(planningModule, runtimeModule))
+        {
+            throw new PipelineException(
+                $"The module factory for '{runtimeModule.GetType().FullName}' returned the runtime instance " +
+                "during dependency-graph planning. The factory must return a fresh module instance.");
+        }
+
+        if (!IsEquivalentPlanningModule(
+                runtimeModule,
+                planningModule,
+                isServiceProviderOwned))
+        {
+            throw new PipelineException(
+                $"The planning copy for '{runtimeModule.GetType().FullName}' did not preserve the runtime " +
+                "module type and dependency-graph configuration. Override CreatePlanningCopy to " +
+                "return an initialized, isolated copy.");
+        }
+    }
+
+    private static bool IsEquivalentPlanningModule(
+        IModule runtimeModule,
+        IModule planningModule,
+        Func<object, bool> isServiceProviderOwned) =>
+        planningModule.GetType() == runtimeModule.GetType()
+        && HasEquivalentPlanningConfiguration(
+            runtimeModule.Configuration,
+            planningModule.Configuration,
+            isServiceProviderOwned)
+        && HasEquivalentModuleState(
+            runtimeModule,
+            planningModule,
+            isServiceProviderOwned);
+
+    private static bool HasEquivalentPlanningConfiguration(
+        ModuleConfiguration runtimeConfiguration,
+        ModuleConfiguration planningConfiguration,
+        Func<object, bool> isServiceProviderOwned)
+    {
+        if (ReferenceEquals(runtimeConfiguration, planningConfiguration))
+        {
+            return true;
+        }
+
+        var context = new StateComparisonContext(isServiceProviderOwned);
+        return runtimeConfiguration.Dependencies.SequenceEqual(planningConfiguration.Dependencies)
+               && runtimeConfiguration.Tags.SetEquals(planningConfiguration.Tags)
+               && runtimeConfiguration.Category == planningConfiguration.Category
+               && HasEquivalentState(
+                   runtimeConfiguration.SynchronousPlanningSkipCondition,
+                   planningConfiguration.SynchronousPlanningSkipCondition,
+                   context);
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2075",
+        Justification = "The already-loaded runtime module type is inspected only to detect a planning-copy override.")]
+    internal static bool HasCustomPlanningCopy(IModule module)
+    {
+        var method = module.GetType().GetMethod(
+            "CreatePlanningCopy",
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            [typeof(IServiceProvider)],
+            modifiers: null);
+        var declaringType = method?.DeclaringType;
+        return declaringType is not null
+               && (!declaringType.IsGenericType
+                   || declaringType.GetGenericTypeDefinition() != typeof(Module<>));
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Factory-created module state is inspected only to verify planning replay equivalence.")]
+    private static bool HasEquivalentModuleState(
+        IModule runtimeModule,
+        IModule planningModule,
+        Func<object, bool> isServiceProviderOwned)
+    {
+        var context = new StateComparisonContext(isServiceProviderOwned);
+        for (var type = runtimeModule.GetType();
+             type is not null && (!type.IsGenericType
+                                  || type.GetGenericTypeDefinition() != typeof(Module<>));
+             type = type.BaseType)
+        {
+            foreach (var field in type.GetFields(
+                         BindingFlags.Instance
+                         | BindingFlags.Public
+                         | BindingFlags.NonPublic
+                         | BindingFlags.DeclaredOnly))
+            {
+                if (!HasEquivalentState(
+                        field.GetValue(runtimeModule),
+                        field.GetValue(planningModule),
+                        context))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static bool HasEquivalentState(
+        object? first,
+        object? second,
+        StateComparisonContext context)
+    {
+        if (first is null || second is null)
+        {
+            return first is null && second is null;
+        }
+
+        return first.GetType() == second.GetType()
+               && HasEquivalentNonNullState(first, second, context);
+    }
+
+    private static bool HasEquivalentNonNullState(
+        object first,
+        object second,
+        StateComparisonContext context)
+    {
+        var type = first.GetType();
+        if (first is string or Type
+            || type.IsPrimitive
+            || type.IsEnum
+            || type.IsPointer)
+        {
+            return first.Equals(second);
+        }
+
+        if (type.IsValueType)
+        {
+            return HasEquivalentFields(first, second, context);
+        }
+
+        return HasEquivalentReferenceMapping(first, second, context);
+    }
+
+    private static bool HasEquivalentReferenceMapping(
+        object first,
+        object second,
+        StateComparisonContext context)
+    {
+        var mapping = context.Map(first, second);
+        if (mapping == ReferenceMapping.Mismatch)
+        {
+            return false;
+        }
+
+        if (mapping == ReferenceMapping.Existing)
+        {
+            return true;
+        }
+
+        if (ReferenceEquals(first, second))
+        {
+            return HasEquivalentSharedReference(first, context);
+        }
+
+        return HasEquivalentReferenceState(first, second, context);
+    }
+
+    private static bool HasEquivalentSharedReference(
+        object value,
+        StateComparisonContext context) =>
+        context.IsServiceProviderOwned(value)
+        || value is Array { Length: 0 }
+        || (value is not Array && !HasInstanceFields(value))
+        || IsKnownImmutableFrameworkSingleton(value)
+        || (IsFrameworkComparer(value)
+            && HasEquivalentFields(value, value, context))
+        || (value is Delegate sharedDelegate
+            && HasEquivalentDelegates(sharedDelegate, sharedDelegate, context));
+
+    private static bool HasEquivalentReferenceState(
+        object first,
+        object second,
+        StateComparisonContext context)
+    {
+        if (first is Delegate firstDelegate && second is Delegate secondDelegate)
+        {
+            return HasEquivalentDelegates(firstDelegate, secondDelegate, context);
+        }
+
+        return first is Array firstArray && second is Array secondArray
+            ? HasEquivalentArrays(firstArray, secondArray, context)
+            : HasInstanceFields(first)
+              && HasEquivalentFields(first, second, context);
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Factory-created module state is inspected only to verify planning replay equivalence.")]
+    private static bool HasInstanceFields(object value)
+    {
+        for (var current = value.GetType(); current is not null; current = current.BaseType)
+        {
+            if (current.GetFields(
+                    BindingFlags.Instance
+                    | BindingFlags.Public
+                    | BindingFlags.NonPublic
+                    | BindingFlags.DeclaredOnly).Length > 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasEquivalentDelegates(
+        Delegate first,
+        Delegate second,
+        StateComparisonContext context)
+    {
+        var firstInvocationList = first.GetInvocationList();
+        var secondInvocationList = second.GetInvocationList();
+        return firstInvocationList.Length == secondInvocationList.Length
+               && firstInvocationList.Zip(secondInvocationList)
+                   .All(pair => pair.First.Method == pair.Second.Method
+                                && HasEquivalentState(
+                                    pair.First.Target,
+                                    pair.Second.Target,
+                                    context));
+    }
+
+    private static bool HasEquivalentArrays(
+        Array first,
+        Array second,
+        StateComparisonContext context)
+    {
+        return first.Rank == second.Rank
+               && Enumerable.Range(0, first.Rank)
+                   .All(dimension =>
+                       first.GetLength(dimension) == second.GetLength(dimension)
+                       && first.GetLowerBound(dimension) == second.GetLowerBound(dimension))
+               && first.Cast<object?>().Zip(second.Cast<object?>())
+                   .All(pair => HasEquivalentState(pair.First, pair.Second, context));
+    }
+
+    private static bool IsKnownImmutableFrameworkSingleton(object value)
+    {
+        var type = value.GetType();
+        if (type.Assembly != typeof(object).Assembly)
+        {
+            return false;
+        }
+
+        if (value is StringComparer)
+        {
+            return ReferenceEquals(value, StringComparer.Ordinal)
+                   || ReferenceEquals(value, StringComparer.OrdinalIgnoreCase)
+                   || ReferenceEquals(value, StringComparer.InvariantCulture)
+                   || ReferenceEquals(value, StringComparer.InvariantCultureIgnoreCase);
+        }
+
+        return false;
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Framework comparer interfaces are inspected only to validate shared factory state.")]
+    private static bool IsFrameworkComparer(object value)
+    {
+        var type = value.GetType();
+        return type.Assembly == typeof(object).Assembly
+               && (value is System.Collections.IComparer
+                   || value is System.Collections.IEqualityComparer
+                   || type.GetInterfaces().Any(static interfaceType =>
+                   {
+                       if (!interfaceType.IsGenericType)
+                       {
+                           return false;
+                       }
+
+                       var definition = interfaceType.GetGenericTypeDefinition();
+                       return definition == typeof(IComparer<>)
+                              || definition == typeof(IEqualityComparer<>);
+                   }));
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Factory-created module state is inspected only to verify planning replay equivalence.")]
+    private static bool HasEquivalentFields(
+        object first,
+        object second,
+        StateComparisonContext context)
+    {
+        for (var type = first.GetType(); type is not null; type = type.BaseType)
+        {
+            foreach (var field in type.GetFields(
+                         BindingFlags.Instance
+                         | BindingFlags.Public
+                         | BindingFlags.NonPublic
+                         | BindingFlags.DeclaredOnly))
+            {
+                if (!HasEquivalentState(
+                        field.GetValue(first),
+                        field.GetValue(second),
+                        context))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static PlanningModuleCreation CreatePlanningCopy(
+        IModule runtimeModule,
+        IPlanningModuleCopyProvider copyProvider,
+        ICollection<IModule> ownedPlanningModules,
+        IServiceProvider planningServiceProvider)
+    {
+        var trackingServiceProvider = new ResolvedObjectTrackingServiceProvider(planningServiceProvider);
+        var module = copyProvider.CreatePlanningCopy(trackingServiceProvider);
+        var isPlannerOwned = !trackingServiceProvider.IsServiceProviderOwned(module);
+        try
+        {
+            if (module is IPlanningModuleCopyProvider planningCopyProvider)
+            {
+                if (!HasCustomPlanningCopy(runtimeModule)
+                    && (HasServiceProviderOwnedState(
+                            module,
+                            trackingServiceProvider.IsServiceProviderOwned)
+                        || (copyProvider.IsConfigurationInitialized
+                            && ConfigurationTouchesStaticState(runtimeModule))))
+                {
+                    var runtimeConfiguration = runtimeModule.Configuration;
+                    RejectRuntimeBoundPlanningCondition(runtimeModule, copyProvider);
+                    planningCopyProvider.InitializeConfiguration(runtimeConfiguration);
+                }
+                else if (copyProvider.IsConfigurationInitialized)
+                {
+                    planningCopyProvider.InitializeConfiguration();
+                }
+            }
+        }
+        catch
+        {
+            if (isPlannerOwned)
+            {
+                ownedPlanningModules.Add(module);
+            }
+
+            throw;
+        }
+
+        return new PlanningModuleCreation(
+            module,
+            trackingServiceProvider.IsServiceProviderOwned,
+            IsPlannerOwned: isPlannerOwned);
+    }
+
+    private static bool TryCreatePlanningCopyFromRegisteredInstance(
+        IModule runtimeModule,
+        IPlanningModuleCopyProvider copyProvider,
+        ResolvedObjectTrackingServiceProvider runtimeServiceOwnership,
+        [NotNullWhen(true)] out PlanningModuleCreation? creation)
+    {
+        var module = copyProvider.CreatePlanningCopyFromRegisteredInstance(
+            preserveConfiguration: false);
+        if (!HasEquivalentModuleState(
+                runtimeModule,
+                module,
+                runtimeServiceOwnership.IsServiceProviderOwned))
+        {
+            creation = null;
+            return false;
+        }
+
+        if (module is IPlanningModuleCopyProvider planningCopyProvider
+            && copyProvider.IsConfigurationInitialized)
+        {
+            if (HasServiceProviderOwnedState(
+                    module,
+                    runtimeServiceOwnership.IsServiceProviderOwned)
+                || ConfigurationTouchesStaticState(runtimeModule))
+            {
+                RejectRuntimeBoundPlanningCondition(runtimeModule, copyProvider);
+                planningCopyProvider.InitializeConfiguration(runtimeModule.Configuration);
+            }
+            else
+            {
+                planningCopyProvider.InitializeConfiguration();
+            }
+        }
+
+        creation = new PlanningModuleCreation(
+            module,
+            runtimeServiceOwnership.IsServiceProviderOwned,
+            IsPlannerOwned: false);
+        return true;
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Planning module fields are inspected only to detect resolved service references.")]
+    private static bool HasServiceProviderOwnedState(
+        IModule module,
+        Func<object, bool> isServiceProviderOwned)
+    {
+        var visited = new HashSet<object>(ReferenceEqualityComparer.Instance) { module };
+        for (var type = module.GetType();
+             type is not null && (!type.IsGenericType
+                                  || type.GetGenericTypeDefinition() != typeof(Module<>));
+             type = type.BaseType)
+        {
+            if (type.GetFields(
+                    BindingFlags.Instance
+                    | BindingFlags.Public
+                    | BindingFlags.NonPublic
+                    | BindingFlags.DeclaredOnly)
+                .Select(field => field.GetValue(module))
+                .Any(value => ContainsServiceProviderOwnedState(
+                    value,
+                    isServiceProviderOwned,
+                    visited)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsServiceProviderOwnedState(
+        object? value,
+        Func<object, bool> isServiceProviderOwned,
+        ISet<object> visited)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        if (isServiceProviderOwned(value))
+        {
+            return true;
+        }
+
+        var type = value.GetType();
+        if (ShouldSkipPlanningValue(value, type, visited))
+        {
+            return false;
+        }
+
+        if (value is Delegate @delegate)
+        {
+            return @delegate.GetInvocationList().Any(invocation =>
+                ContainsServiceProviderOwnedState(
+                    invocation.Target,
+                    isServiceProviderOwned,
+                    visited));
+        }
+
+        if (value is Array array)
+        {
+            return array.Cast<object?>().Any(item =>
+                ContainsServiceProviderOwnedState(item, isServiceProviderOwned, visited));
+        }
+
+        return GetInstanceFields(type).Any(field =>
+            ContainsServiceProviderOwnedState(
+                field.GetValue(value),
+                isServiceProviderOwned,
+                visited));
+    }
+
+    private static void RejectRuntimeBoundPlanningCondition(
+        IModule module,
+        IPlanningModuleCopyProvider copyProvider)
+    {
+        if (!copyProvider.IsConfigurationInitialized
+            || module.Configuration.SynchronousPlanningSkipCondition is not { } planningCondition)
+        {
+            return;
+        }
+
+        var referencesRuntimeModule = ReferencesObject(
+            planningCondition,
+            module,
+            new HashSet<object>(ReferenceEqualityComparer.Instance));
+        var mutatesCapturedState = MutatesDelegateTargetState(
+            planningCondition,
+            new HashSet<object>(ReferenceEqualityComparer.Instance));
+        if (!referencesRuntimeModule && !mutatesCapturedState)
+        {
+            return;
+        }
+
+        throw new PipelineException(
+            $"The initialized configuration for '{module.GetType().FullName}' contains a planning condition "
+            + "bound to mutable runtime state. Override CreatePlanningCopy to return an isolated copy.");
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Planning delegates are inspected only to reject mutable captured state.")]
+    private static bool MutatesDelegateTargetState(object? value, ISet<object> visited)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        if (value is Delegate @delegate)
+        {
+            return DelegateTargetMutatesState(@delegate, visited);
+        }
+
+        var type = value.GetType();
+        if (ShouldSkipPlanningValue(value, type, visited))
+        {
+            return false;
+        }
+
+        if (value is Array array)
+        {
+            return MutatesPlanningArray(array, visited);
+        }
+
+        return MutatesPlanningObject(value, type, visited);
+    }
+
+    private static bool MutatesPlanningArray(Array array, ISet<object> visited) =>
+        !typeof(Delegate).IsAssignableFrom(array.GetType().GetElementType()!)
+        || array.Cast<object?>().Any(item => MutatesDelegateTargetState(item, visited));
+
+    private static bool MutatesPlanningObject(
+        object value,
+        Type type,
+        ISet<object> visited) =>
+        !type.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false)
+        || GetInstanceFields(type)
+            .Any(field => MutatesDelegateTargetState(field.GetValue(value), visited));
+
+    private static bool ShouldSkipPlanningValue(
+        object value,
+        Type type,
+        ISet<object> visited) =>
+        IsTerminalPlanningValue(value, type)
+        || (!type.IsValueType && !visited.Add(value));
+
+    private static bool DelegateTargetMutatesState(Delegate @delegate, ISet<object> visited) =>
+        @delegate.GetInvocationList().Any(invocation =>
+            (!IsKnownPlanningSafeDelegateWrapper(invocation.Method)
+             && MethodTouchesStaticState(
+                 invocation.Method,
+                 new HashSet<MethodBase>()))
+            || (invocation.Target is { } target
+                && (MutatesDelegateTargetField(invocation.Method, target.GetType())
+                    || MutatesDelegateTargetState(target, visited))));
+
+    private static bool IsKnownPlanningSafeDelegateWrapper(MethodInfo method) =>
+        method.Module.Assembly == typeof(ModuleConfiguration).Assembly
+        && method.DeclaringType?.IsDefined(
+            typeof(CompilerGeneratedAttribute),
+            inherit: false) == true;
+
+    private static bool IsTerminalPlanningValue(object value, Type type) =>
+        value is string or MemberInfo or SkipDecision
+        || type.IsPrimitive
+        || type.IsEnum
+        || type.IsPointer;
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Missing or trimmed method bodies are conservatively treated as mutable.")]
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2070",
+        Justification = "Delegate target fields are inspected only to reject mutable captured state.")]
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Delegate target base fields are inspected only to reject mutable captured state.")]
+    private static bool MutatesDelegateTargetField(MethodInfo method, Type targetType)
+    {
+        var il = method.GetMethodBody()?.GetILAsByteArray();
+        if (il is null)
+        {
+            return true;
+        }
+
+        foreach (var field in GetInstanceFields(targetType))
+        {
+            var token = BitConverter.GetBytes(field.MetadataToken);
+            for (var index = 0; index <= il.Length - token.Length - 1; index++)
+            {
+                if ((il[index] == StoreInstanceFieldOpCode
+                     || il[index] == LoadInstanceFieldAddressOpCode)
+                    && il.AsSpan(index + 1, token.Length).SequenceEqual(token))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2075",
+        Justification = "The already-loaded module Configure method is inspected only to avoid replaying global state.")]
+    private static bool ConfigurationTouchesStaticState(IModule module)
+    {
+        var method = module.GetType().GetMethod(
+            "Configure",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        return method is not null
+               && MethodTouchesStaticStateCore(
+                   method,
+                   new HashSet<MethodBase>(),
+                   module.GetType());
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Missing or trimmed Configure bodies are conservatively treated as stateful.")]
+    private static bool MethodTouchesStaticState(
+        MethodBase method,
+        ISet<MethodBase> visited) =>
+        MethodTouchesStaticStateCore(method, visited, method.DeclaringType);
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Missing or trimmed Configure bodies are conservatively treated as stateful.")]
+    private static bool MethodTouchesStaticStateCore(
+        MethodBase method,
+        ISet<MethodBase> visited,
+        Type? runtimeType)
+    {
+        if (!visited.Add(method))
+        {
+            return false;
+        }
+
+        var il = method.GetMethodBody()?.GetILAsByteArray();
+        if (il is null)
+        {
+            return true;
+        }
+
+        var offset = 0;
+        while (offset < il.Length)
+        {
+            var opCode = ReadOpCode(il, ref offset);
+            if (opCode.Size == 0)
+            {
+                return true;
+            }
+
+            var operandOffset = offset;
+            var operandSize = GetOperandSize(opCode, il, operandOffset);
+            if (operandOffset + operandSize > il.Length)
+            {
+                return true;
+            }
+
+            if (operandSize == sizeof(int)
+                && InstructionTouchesStaticStateCore(
+                    method,
+                    opCode,
+                    il,
+                    operandOffset,
+                    visited,
+                    runtimeType))
+            {
+                return true;
+            }
+
+            offset += operandSize;
+        }
+
+        return false;
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Missing or trimmed Configure metadata is conservatively treated as stateful.")]
+    private static bool InstructionTouchesStaticState(
+        MethodBase method,
+        OpCode opCode,
+        byte[] il,
+        int operandOffset,
+        ISet<MethodBase> visited) =>
+        InstructionTouchesStaticStateCore(
+            method,
+            opCode,
+            il,
+            operandOffset,
+            visited,
+            method.DeclaringType);
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Missing or trimmed Configure metadata is conservatively treated as stateful.")]
+    private static bool InstructionTouchesStaticStateCore(
+        MethodBase method,
+        OpCode opCode,
+        byte[] il,
+        int operandOffset,
+        ISet<MethodBase> visited,
+        Type? runtimeType)
+    {
+        var token = BitConverter.ToInt32(il, operandOffset);
+        var methodGenericArguments = method is MethodInfo methodInfo
+            ? methodInfo.GetGenericArguments()
+            : null;
+        try
+        {
+            if (opCode.OperandType == OperandType.InlineField)
+            {
+                return FieldInstructionTouchesStaticState(
+                    method,
+                    token,
+                    methodGenericArguments);
+            }
+
+            if (opCode.OperandType != OperandType.InlineMethod)
+            {
+                return false;
+            }
+
+            var calledMethod = method.Module.ResolveMethod(
+                    token,
+                    method.DeclaringType?.GetGenericArguments(),
+                    methodGenericArguments);
+            if (calledMethod is null)
+            {
+                return false;
+            }
+
+            return CalledMethodTouchesStaticState(
+                method,
+                calledMethod,
+                opCode,
+                visited,
+                runtimeType);
+        }
+        catch (ArgumentException)
+        {
+            return true;
+        }
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Missing or trimmed Configure metadata is conservatively treated as stateful.")]
+    private static bool FieldInstructionTouchesStaticState(
+        MethodBase method,
+        int token,
+        Type[]? methodGenericArguments)
+    {
+        var field = method.Module.ResolveField(
+            token,
+            method.DeclaringType?.GetGenericArguments(),
+            methodGenericArguments);
+        return field?.IsStatic == true
+               && !IsKnownPlanningSafeConfigurationField(field);
+    }
+
+    private static bool CalledMethodTouchesStaticState(
+        MethodBase sourceMethod,
+        MethodBase calledMethod,
+        OpCode opCode,
+        ISet<MethodBase> visited,
+        Type? runtimeType)
+    {
+        if (calledMethod is ConstructorInfo
+            && calledMethod.DeclaringType?.IsDefined(
+                typeof(CompilerGeneratedAttribute),
+                inherit: false) == true)
+        {
+            return false;
+        }
+
+        if (calledMethod.Module.Assembly == sourceMethod.Module.Assembly)
+        {
+            return AssemblyMethodTouchesStaticState(calledMethod, opCode, visited, runtimeType);
+        }
+
+        return calledMethod is ConstructorInfo
+               || !IsKnownPlanningSafeConfigurationMethod(calledMethod);
+    }
+
+    private static bool AssemblyMethodTouchesStaticState(
+        MethodBase calledMethod,
+        OpCode opCode,
+        ISet<MethodBase> visited,
+        Type? runtimeType)
+    {
+        if (opCode == OpCodes.Callvirt
+            && calledMethod is MethodInfo { IsVirtual: true, IsFinal: false } virtualMethod
+            && (runtimeType is null
+                || virtualMethod.DeclaringType is null
+                || !virtualMethod.DeclaringType.IsAssignableFrom(runtimeType)))
+        {
+            return true;
+        }
+
+        var targetMethod = opCode == OpCodes.Callvirt
+            && calledMethod is MethodInfo calledMethodInfo
+            && runtimeType is not null
+                ? ResolveVirtualTarget(calledMethodInfo, runtimeType)
+                : calledMethod;
+        return MethodTouchesStaticStateCore(targetMethod, visited, runtimeType);
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2070",
+        Justification = "Planning inspects already-loaded runtime module methods only to reject unsafe replay.")]
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Planning inspects already-loaded base methods only to reject unsafe replay.")]
+    private static MethodInfo ResolveVirtualTarget(MethodInfo method, Type runtimeType)
+    {
+        if (!method.IsVirtual
+            || method.IsFinal
+            || method.DeclaringType is null
+            || !method.DeclaringType.IsAssignableFrom(runtimeType))
+        {
+            return method;
+        }
+
+        var baseDefinition = method.GetBaseDefinition();
+        for (var candidateType = runtimeType;
+             candidateType is not null && method.DeclaringType.IsAssignableFrom(candidateType);
+             candidateType = candidateType.BaseType)
+        {
+            var overrideMethod = candidateType
+                .GetMethods(BindingFlags.Instance
+                            | BindingFlags.Public
+                            | BindingFlags.NonPublic
+                            | BindingFlags.DeclaredOnly)
+                .FirstOrDefault(candidate =>
+                    candidate.IsVirtual
+                    && candidate.GetBaseDefinition() == baseDefinition);
+            if (overrideMethod is not null)
+            {
+                return overrideMethod;
+            }
+        }
+
+        return method;
+    }
+
+    private static bool IsKnownPlanningSafeConfigurationMethod(MethodBase method) =>
+        method.DeclaringType == typeof(ModuleConfiguration)
+        || method.DeclaringType == typeof(ModuleConfigurationBuilder)
+        || method.DeclaringType == typeof(AdvancedModuleConfigurationBuilder)
+        || method.DeclaringType == typeof(SkipDecision);
+
+    private static bool IsKnownPlanningSafeConfigurationField(FieldInfo field) =>
+        field.DeclaringType == typeof(SkipDecision) && field.IsInitOnly;
+
+    private static OpCode ReadOpCode(byte[] il, ref int offset)
+    {
+        var firstByte = il[offset++];
+        if (firstByte != 0xFE)
+        {
+            return OneByteOpCodes[firstByte];
+        }
+
+        return offset < il.Length ? TwoByteOpCodes[il[offset++]] : default;
+    }
+
+    private static int GetOperandSize(OpCode opCode, byte[] il, int operandOffset) =>
+        opCode.OperandType switch
+        {
+            OperandType.InlineNone => 0,
+            OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or OperandType.ShortInlineVar => 1,
+            OperandType.InlineVar => 2,
+            OperandType.InlineBrTarget
+                or OperandType.InlineField
+                or OperandType.InlineI
+                or OperandType.InlineMethod
+                or OperandType.InlineSig
+                or OperandType.InlineString
+                or OperandType.InlineTok
+                or OperandType.ShortInlineR => 4,
+            OperandType.InlineI8 or OperandType.InlineR => 8,
+            OperandType.InlineSwitch when operandOffset + sizeof(int) <= il.Length =>
+                sizeof(int) + (BitConverter.ToInt32(il, operandOffset) * sizeof(int)),
+            _ => il.Length - operandOffset,
+        };
+
+    private static OpCode[] CreateOpCodeLookup(bool twoByte)
+    {
+        var lookup = new OpCode[byte.MaxValue + 1];
+        foreach (var field in typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            if (field.GetValue(null) is not OpCode opCode)
+            {
+                continue;
+            }
+
+            var value = unchecked((ushort) opCode.Value);
+            if (twoByte == (value > byte.MaxValue))
+            {
+                lookup[value & byte.MaxValue] = opCode;
+            }
+        }
+
+        return lookup;
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Planning delegates are inspected only to reject references to the runtime module.")]
+    private static bool ReferencesObject(
+        object? value,
+        object target,
+        ISet<object> visited,
+        bool inspectFields = false)
+    {
+        if (ReferenceEquals(value, target))
+        {
+            return true;
+        }
+
+        if (value is null)
+        {
+            return false;
+        }
+
+        var type = value.GetType();
+        if (ShouldSkipPlanningValue(value, type, visited))
+        {
+            return false;
+        }
+
+        if (value is Delegate @delegate)
+        {
+            return @delegate.GetInvocationList().Any(invocation =>
+                ReferencesObject(invocation.Target, target, visited, inspectFields: true));
+        }
+
+        if (value is Array array)
+        {
+            return array.Cast<object?>().Any(item =>
+                ReferencesObject(item, target, visited, inspectFields: true));
+        }
+
+        return ReferencesObjectFields(value, target, visited, inspectFields, type);
+    }
+
+    private static bool ReferencesObjectFields(
+        object value,
+        object target,
+        ISet<object> visited,
+        bool inspectFields,
+        Type type)
+    {
+        var inspectCollectionFields = value is IEnumerable;
+        if (!inspectFields
+            && !inspectCollectionFields
+            && !type.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false))
+        {
+            return false;
+        }
+
+        return GetInstanceFields(type).Any(field => ReferencesObject(
+            field.GetValue(value),
+            target,
+            visited,
+            inspectCollectionFields));
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2070",
+        Justification = "Planning state is inspected only to validate isolated planning copies.")]
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Planning state base fields are inspected only to validate isolated planning copies.")]
+    private static IEnumerable<FieldInfo> GetInstanceFields(Type type)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            foreach (var field in current.GetFields(
+                         BindingFlags.Instance
+                         | BindingFlags.Public
+                         | BindingFlags.NonPublic
+                         | BindingFlags.DeclaredOnly))
+            {
+                yield return field;
+            }
+        }
+    }
+
+    internal static async Task DisposePlanningModulesAsync(IEnumerable<IModule> planningModules)
+    {
+        var exceptions = new List<Exception>();
+        foreach (var module in planningModules
+                     .Distinct<IModule>(ReferenceEqualityComparer.Instance)
+                     .Reverse())
+        {
+            try
+            {
+                await Disposer.DisposeObjectAsync(module).ConfigureAwait(false);
+            }
+            catch (Exception exception) when (exception is not (OutOfMemoryException or StackOverflowException))
+            {
+                exceptions.Add(exception);
+            }
+        }
+
+        if (exceptions.Count > 0)
+        {
+            throw new AggregateException("One or more planning modules failed to dispose", exceptions);
+        }
+    }
+
+    internal static async Task<IReadOnlyList<Exception>> CollectPlanningCleanupExceptionsAsync(
+        IEnumerable<IModule> planningModules,
+        AsyncServiceScope planningScope)
+    {
+        var exceptions = new List<Exception>();
+        try
+        {
+            await DisposePlanningModulesAsync(planningModules).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            exceptions.Add(exception);
+        }
+
+        try
+        {
+            await planningScope.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            exceptions.Add(exception);
+        }
+
+        return exceptions;
+    }
+
+    private sealed class StateComparisonContext(Func<object, bool> isServiceProviderOwned)
+    {
+        private readonly Dictionary<object, object> _firstToSecond =
+            new(ReferenceEqualityComparer.Instance);
+        private readonly Dictionary<object, object> _secondToFirst =
+            new(ReferenceEqualityComparer.Instance);
+
+        public bool IsServiceProviderOwned(object value) => isServiceProviderOwned(value);
+
+        public ReferenceMapping Map(object first, object second)
+        {
+            if (_firstToSecond.TryGetValue(first, out var mappedSecond))
+            {
+                return ReferenceEquals(mappedSecond, second)
+                    ? ReferenceMapping.Existing
+                    : ReferenceMapping.Mismatch;
+            }
+
+            if (_secondToFirst.ContainsKey(second))
+            {
+                return ReferenceMapping.Mismatch;
+            }
+
+            _firstToSecond.Add(first, second);
+            _secondToFirst.Add(second, first);
+            return ReferenceMapping.Added;
+        }
+    }
+
+    private enum ReferenceMapping
+    {
+        Added,
+        Existing,
+        Mismatch,
+    }
+}
+
+internal sealed class ModulePlanningFactory
+{
+    private readonly Func<IServiceProvider, IModule> _create;
+    private IModule? _runtimeModule;
+    private ResolvedObjectTrackingServiceProvider? _runtimeServiceOwnership;
+
+    public ModulePlanningFactory(
+        Func<IServiceProvider, IModule> create,
+        IModule? registeredInstance = null)
+    {
+        _create = create;
+        _runtimeModule = registeredInstance;
+    }
+
+    public IModule CreateRuntimeModule(IServiceProvider serviceProvider)
+    {
+        var runtimeServiceOwnership = new ResolvedObjectTrackingServiceProvider(serviceProvider);
+        var module = _create(runtimeServiceOwnership);
+        if (Interlocked.CompareExchange(ref _runtimeModule, module, null) is null)
+        {
+            Volatile.Write(ref _runtimeServiceOwnership, runtimeServiceOwnership);
+        }
+
+        return module;
+    }
+
+    public bool CreatedRuntimeModule(IModule module) =>
+        ReferenceEquals(Volatile.Read(ref _runtimeModule), module);
+
+    public bool IsRuntimeServiceProviderOwned(object value) =>
+        Volatile.Read(ref _runtimeServiceOwnership)?.IsServiceProviderOwned(value) == true;
+}
+
+internal sealed class ResolvedObjectTrackingServiceProvider(IServiceProvider innerServiceProvider)
+    : IServiceProvider, IKeyedServiceProvider
+{
+    private readonly HashSet<object> _resolvedObjects = new(ReferenceEqualityComparer.Instance);
+
+    public object? GetService(Type serviceType) => Track(innerServiceProvider.GetService(serviceType));
+
+    public object? GetKeyedService(Type serviceType, object? serviceKey) =>
+        Track(((IKeyedServiceProvider) innerServiceProvider).GetKeyedService(serviceType, serviceKey));
+
+    public object GetRequiredKeyedService(Type serviceType, object? serviceKey) =>
+        Track(((IKeyedServiceProvider) innerServiceProvider)
+            .GetRequiredKeyedService(serviceType, serviceKey))!;
+
+    public bool IsServiceProviderOwned(object value)
+    {
+        return _resolvedObjects.Contains(value)
+               || IsTrackedDisposable(value)
+               || IsCachedService(value);
+    }
+
+    private bool IsTrackedDisposable(object value)
+    {
+        if (ContainsTrackedDisposable(innerServiceProvider, value))
+        {
+            return true;
+        }
+
+        var rootScope = GetRootScope();
+        return rootScope is not null
+               && !ReferenceEquals(rootScope, innerServiceProvider)
+               && ContainsTrackedDisposable(rootScope, value);
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Microsoft DI's internal disposal list is inspected only to establish exact instance ownership.")]
+    private static bool ContainsTrackedDisposable(object scope, object value)
+    {
+        var disposablesField = scope.GetType().GetField(
+            "_disposables",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        return disposablesField?.GetValue(scope) is IEnumerable<object> disposables
+               && disposables.Any(disposable => ReferenceEquals(disposable, value));
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Microsoft DI's internal scope caches are inspected only to establish exact instance ownership.")]
+    private bool IsCachedService(object value)
+    {
+        if (ContainsResolvedService(innerServiceProvider, value))
+        {
+            return true;
+        }
+
+        var rootProvider = GetRootProvider();
+        var rootScope = GetRootScope();
+        return (rootScope is not null
+                && !ReferenceEquals(rootScope, innerServiceProvider)
+                && ContainsResolvedService(rootScope, value))
+               || ContainsSingletonCallSiteValue(rootProvider, value);
+    }
+
+    private object GetRootProvider() =>
+        GetPropertyValue(innerServiceProvider, "RootProvider") ?? innerServiceProvider;
+
+    private object? GetRootScope() =>
+        GetPropertyValue(innerServiceProvider, "Root")
+        ?? GetPropertyValue(GetRootProvider(), "Root");
+
+    private static bool ContainsResolvedService(object scope, object value)
+    {
+        var resolvedServices = GetPropertyValue(scope, "ResolvedServices");
+        return GetPropertyValue(resolvedServices, "Values") is System.Collections.IEnumerable values
+               && values.Cast<object?>().Any(resolvedService => ReferenceEquals(resolvedService, value));
+    }
+
+    private static bool ContainsSingletonCallSiteValue(object rootProvider, object value)
+    {
+        var callSiteFactory = GetPropertyValue(rootProvider, "CallSiteFactory");
+        var callSiteCache = GetFieldValue(callSiteFactory, "_callSiteCache");
+        return GetPropertyValue(callSiteCache, "Values") is System.Collections.IEnumerable callSites
+               && callSites.Cast<object>().Any(callSite =>
+                   ReferenceEquals(GetPropertyValue(callSite, "Value"), value)
+                   || ReferenceEquals(GetPropertyValue(callSite, "DefaultValue"), value));
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Microsoft DI's internal scope caches are inspected only to establish exact instance ownership.")]
+    private static object? GetPropertyValue(object? target, string propertyName)
+    {
+        return target?.GetType()
+            .GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?.GetValue(target);
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2075",
+        Justification = "Microsoft DI's internal call-site cache is inspected only to establish exact instance ownership.")]
+    private static object? GetFieldValue(object? target, string fieldName)
+    {
+        return target?.GetType()
+            .GetField(fieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            ?.GetValue(target);
+    }
+
+    private object? Track(object? value)
+    {
+        if (value is not null)
+        {
+            _resolvedObjects.Add(value);
+        }
+
+        return value;
+    }
+}
+
+internal sealed record PlanningModule(
+    IModule Module,
+    bool IsPlannerOwned,
+    bool RequiresIsolation,
+    Func<object, bool> IsServiceProviderOwned);
+
+internal sealed record PlanningModuleCreation(
+    IModule Module,
+    Func<object, bool> IsServiceProviderOwned,
+    bool IsPlannerOwned);
+
+internal sealed record PlannedModuleDiscovery(
+    OrganizedModules OrganizedModules,
+    IDependencyChainProvider DependencyChainProvider,
+    IModuleDependencyRegistry DependencyRegistry,
+    IModuleMetadataRegistry MetadataRegistry,
+    IReadOnlyDictionary<IModule, IModule> OriginalModules,
+    IReadOnlyList<IModule> OwnedPlanningModules,
+    AsyncServiceScope PlanningScope) : IAsyncDisposable
+{
+    public async ValueTask DisposeAsync()
+    {
+        var exceptions = await ModuleDiscoveryPlanner
+            .CollectPlanningCleanupExceptionsAsync(OwnedPlanningModules, PlanningScope)
+            .ConfigureAwait(false);
+        if (exceptions.Count > 0)
+        {
+            throw new AggregateException("Dependency graph planning cleanup failed.", exceptions);
+        }
+    }
+}

--- a/src/ModularPipelines/Engine/ModuleDiscoveryPlanner.cs
+++ b/src/ModularPipelines/Engine/ModuleDiscoveryPlanner.cs
@@ -200,6 +200,7 @@ internal sealed class ModuleDiscoveryPlanner(
                 planningServiceProvider));
         }
 
+        copyProvider.InitializeConfiguration();
         RejectRuntimeBoundPlanningCondition(module, copyProvider);
         return CreateIsolatedPlanningModule(new PlanningModuleCreation(
             copyProvider.CreatePlanningCopyFromRegisteredInstance(
@@ -621,8 +622,10 @@ internal sealed class ModuleDiscoveryPlanner(
         ResolvedObjectTrackingServiceProvider runtimeServiceOwnership,
         [NotNullWhen(true)] out PlanningModuleCreation? creation)
     {
+        copyProvider.InitializeConfiguration();
+        RejectRuntimeBoundPlanningCondition(runtimeModule, copyProvider);
         var module = copyProvider.CreatePlanningCopyFromRegisteredInstance(
-            preserveConfiguration: false);
+            preserveConfiguration: true);
         if (!HasEquivalentModuleState(
                 runtimeModule,
                 module,
@@ -630,23 +633,6 @@ internal sealed class ModuleDiscoveryPlanner(
         {
             creation = null;
             return false;
-        }
-
-        if (module is IPlanningModuleCopyProvider planningCopyProvider
-            && copyProvider.IsConfigurationInitialized)
-        {
-            if (HasServiceProviderOwnedState(
-                    module,
-                    runtimeServiceOwnership.IsServiceProviderOwned)
-                || ConfigurationTouchesStaticState(runtimeModule))
-            {
-                RejectRuntimeBoundPlanningCondition(runtimeModule, copyProvider);
-                planningCopyProvider.InitializeConfiguration(runtimeModule.Configuration);
-            }
-            else
-            {
-                planningCopyProvider.InitializeConfiguration();
-            }
         }
 
         creation = new PlanningModuleCreation(

--- a/src/ModularPipelines/Engine/ModulePlanningSkipEvaluator.cs
+++ b/src/ModularPipelines/Engine/ModulePlanningSkipEvaluator.cs
@@ -1,6 +1,7 @@
 using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Context;
+using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Logging;
@@ -33,6 +34,41 @@ internal sealed class ModulePlanningSkipEvaluator(
             return null;
         }
 
+        return await EvaluateConditionAsync(module, planningSkipCondition, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<SkipDecision?> EvaluateGraphSafeAsync(
+        IModule module,
+        IModuleMetadataRegistry metadataRegistry,
+        CancellationToken cancellationToken)
+    {
+        var conditionResult = await moduleConditionHandler
+            .ShouldIgnoreForGraphPlanning(module, metadataRegistry, cancellationToken)
+            .ConfigureAwait(false);
+        if (conditionResult.ShouldIgnore)
+        {
+            return conditionResult.SkipDecision ?? SkipDecision.Skip("Module was ignored");
+        }
+
+        var planningSkipCondition = module.Configuration.SynchronousPlanningSkipCondition;
+        if (planningSkipCondition is null)
+        {
+            return null;
+        }
+
+        var skipDecision = await EvaluateConditionAsync(module, planningSkipCondition, cancellationToken)
+            .ConfigureAwait(false);
+        return conditionResult.IsResolved || skipDecision?.ShouldSkip == true
+            ? skipDecision
+            : null;
+    }
+
+    private async Task<SkipDecision?> EvaluateConditionAsync(
+        IModule module,
+        Func<IModuleContext, CancellationToken, ValueTask<SkipDecision?>> planningSkipCondition,
+        CancellationToken cancellationToken)
+    {
         await using var scope = serviceProvider.CreateAsyncScope();
         var scopedServices = scope.ServiceProvider;
         var executionContext = ExecutionContextFactory.Create(module, module.GetType());

--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -54,7 +54,12 @@ internal class ModuleRetriever
     [MethodImpl(MethodImplOptions.Synchronized)]
     public Task<OrganizedModules> GetOrganizedModules(CancellationToken cancellationToken = default)
     {
-        return _cached ??= GetInternal(cancellationToken);
+        if (_cached is null || _cached.IsCanceled || _cached.IsFaulted)
+        {
+            _cached = GetInternal(cancellationToken);
+        }
+
+        return _cached;
     }
 
     internal async Task<IReadOnlyList<IModule>> GetRunnableModulesForValidation(

--- a/src/ModularPipelines/Engine/PipelineExecutionState.cs
+++ b/src/ModularPipelines/Engine/PipelineExecutionState.cs
@@ -1,0 +1,50 @@
+using ModularPipelines.Exceptions;
+
+namespace ModularPipelines.Engine;
+
+internal sealed class PipelineExecutionState
+{
+    private int _state;
+
+    public IDisposable EnterGraphExport()
+    {
+        while (true)
+        {
+            var state = Volatile.Read(ref _state);
+            if (state < 0)
+            {
+                throw new PipelineException(
+                    "The dependency graph must be exported before RunAsync starts.");
+            }
+
+            if (Interlocked.CompareExchange(ref _state, state + 1, state) == state)
+            {
+                return new GraphExportLease(this);
+            }
+        }
+    }
+
+    public void MarkExecutionStarted()
+    {
+        var state = Interlocked.CompareExchange(ref _state, -1, 0);
+        if (state > 0)
+        {
+            throw new PipelineException(
+                "RunAsync cannot start while a dependency graph export is in progress.");
+        }
+    }
+
+    private sealed class GraphExportLease(PipelineExecutionState owner) : IDisposable
+    {
+        private PipelineExecutionState? _owner = owner;
+
+        public void Dispose()
+        {
+            var currentOwner = Interlocked.Exchange(ref _owner, null);
+            if (currentOwner is not null)
+            {
+                Interlocked.Decrement(ref currentOwner._state);
+            }
+        }
+    }
+}

--- a/src/ModularPipelines/Enums/DependencyGraphFormat.cs
+++ b/src/ModularPipelines/Enums/DependencyGraphFormat.cs
@@ -1,0 +1,22 @@
+namespace ModularPipelines.Enums;
+
+/// <summary>
+/// Output formats supported by dependency graph export.
+/// </summary>
+public enum DependencyGraphFormat
+{
+    /// <summary>
+    /// Mermaid flowchart markup.
+    /// </summary>
+    Mermaid,
+
+    /// <summary>
+    /// Graphviz DOT markup.
+    /// </summary>
+    Dot,
+
+    /// <summary>
+    /// A machine-readable JSON document.
+    /// </summary>
+    Json,
+}

--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -238,7 +238,7 @@ public static class PipelineBuilderExtensions
         string path,
         CancellationToken cancellationToken = default)
     {
-        await using var pipeline = await builder.BuildAsync().ConfigureAwait(false);
+        await using var pipeline = await builder.BuildForDependencyGraphExportAsync().ConfigureAwait(false);
         await pipeline.ExportDependencyGraphAsync(format, path, cancellationToken)
             .ConfigureAwait(false);
     }

--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Caching;
 using ModularPipelines.Engine;
+using ModularPipelines.Enums;
 using ModularPipelines.Extensions;
 using ModularPipelines.Interfaces;
 using ModularPipelines.Modules;
@@ -222,6 +223,24 @@ public static class PipelineBuilderExtensions
     {
         await using var pipeline = await builder.BuildAsync().ConfigureAwait(false);
         return await pipeline.RunAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Builds the pipeline and exports its resolved dependency graph without executing modules.
+    /// </summary>
+    /// <param name="builder">The pipeline builder.</param>
+    /// <param name="format">The output format.</param>
+    /// <param name="path">The destination file.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    public static async Task ExportDependencyGraphAsync(
+        this PipelineBuilder builder,
+        DependencyGraphFormat format,
+        string path,
+        CancellationToken cancellationToken = default)
+    {
+        await using var pipeline = await builder.BuildAsync().ConfigureAwait(false);
+        await pipeline.ExportDependencyGraphAsync(format, path, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
+++ b/src/ModularPipelines/Extensions/ServiceCollectionExtensions.cs
@@ -83,6 +83,11 @@ internal static class ServiceCollectionExtensions
                 descriptor.ServiceType == typeof(IModule)
                 && ReferenceEquals(descriptor.ImplementationInstance, tModule)))
         {
+            if (tModule is IPlanningModuleCopyProvider)
+            {
+                services.AddSingleton(new ModulePlanningFactory(_ => tModule, tModule));
+            }
+
             services.AddSingleton<IModule>(tModule);
         }
 
@@ -119,22 +124,30 @@ internal static class ServiceCollectionExtensions
         // Track module type for auto-registration and unused module detection
         GetOrCreateModuleTypesHolder(services).Add(typeof(TModule));
 
-        services.AddSingleton<IModule>(sp =>
-        {
-            // Set AsyncLocal context before invoking user's factory
-            var previousType = Logging.ModuleLogger.CurrentModuleType.Value;
-            Logging.ModuleLogger.CurrentModuleType.Value = typeof(TModule);
-
-            try
-            {
-                return tModuleFactory(sp);
-            }
-            finally
-            {
-                Logging.ModuleLogger.CurrentModuleType.Value = previousType;
-            }
-        });
+        var planningFactory = new ModulePlanningFactory(
+            serviceProvider => CreateModuleFromFactory(serviceProvider, tModuleFactory));
+        services.AddSingleton(planningFactory);
+        services.AddSingleton<IModule>(planningFactory.CreateRuntimeModule);
         return services;
+    }
+
+    private static TModule CreateModuleFromFactory<TModule>(
+        IServiceProvider serviceProvider,
+        Func<IServiceProvider, TModule> moduleFactory)
+        where TModule : class, IModule
+    {
+        // Set AsyncLocal context before invoking user's factory
+        var previousType = Logging.ModuleLogger.CurrentModuleType.Value;
+        Logging.ModuleLogger.CurrentModuleType.Value = typeof(TModule);
+
+        try
+        {
+            return moduleFactory(serviceProvider);
+        }
+        finally
+        {
+            Logging.ModuleLogger.CurrentModuleType.Value = previousType;
+        }
     }
 
     /// <summary>

--- a/src/ModularPipelines/IPipeline.cs
+++ b/src/ModularPipelines/IPipeline.cs
@@ -1,3 +1,4 @@
+using ModularPipelines.Enums;
 using ModularPipelines.Models;
 
 namespace ModularPipelines;
@@ -25,4 +26,18 @@ public interface IPipeline : IAsyncDisposable
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>A summary of the pipeline execution results.</returns>
     Task<PipelineSummary> RunAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Exports the resolved module dependency graph without executing modules.
+    /// </summary>
+    /// <param name="format">The output format.</param>
+    /// <param name="path">The destination file.</param>
+    /// <param name="cancellationToken">Optional cancellation token.</param>
+    /// <exception cref="Exceptions.PipelineException">
+    /// Thrown when pipeline execution has already started.
+    /// </exception>
+    Task ExportDependencyGraphAsync(
+        DependencyGraphFormat format,
+        string path,
+        CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Modules/Module.cs
+++ b/src/ModularPipelines/Modules/Module.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
@@ -52,25 +53,23 @@ namespace ModularPipelines.Modules;
 /// }
 /// </code>
 /// </example>
-public abstract class Module<T> : IInternalModule
+public abstract class Module<T> : IInternalModule, IPlanningModuleCopyProvider
 {
-    private readonly Lazy<ModuleConfiguration> _configuration;
+    private Lazy<ModuleConfiguration> _configuration;
 
     // Exposes hook-transformed results to self-awaits without completing the public result early.
-    private readonly AsyncLocal<ModuleResult<T>?> _provisionalResult = new();
+    private AsyncLocal<ModuleResult<T>?> _provisionalResult = new();
 
     /// <summary>
     /// Initialises a new instance of the <see cref="Module{T}"/> class.
     /// </summary>
     protected Module()
     {
-        _configuration = new Lazy<ModuleConfiguration>(
-            CreateConfiguration,
-            LazyThreadSafetyMode.ExecutionAndPublication);
+        _configuration = CreateConfigurationLazy();
     }
 
-    internal TaskCompletionSource<ModuleResult<T>> CompletionSource { get; } =
-        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    internal TaskCompletionSource<ModuleResult<T>> CompletionSource { get; private set; } =
+        CreateCompletionSource();
 
     /// <inheritdoc />
     Task<IModuleResult> IInternalModule.ResultTask
@@ -119,6 +118,44 @@ public abstract class Module<T> : IInternalModule
 
     /// <inheritdoc />
     ModuleConfiguration IModule.Configuration => _configuration.Value;
+
+    IModule IPlanningModuleCopyProvider.CreatePlanningCopy(IServiceProvider serviceProvider) =>
+        CreatePlanningCopy(serviceProvider);
+
+    bool IPlanningModuleCopyProvider.IsConfigurationInitialized => _configuration.IsValueCreated;
+
+    void IPlanningModuleCopyProvider.InitializeConfiguration() => _ = _configuration.Value;
+
+    void IPlanningModuleCopyProvider.InitializeConfiguration(ModuleConfiguration configuration) =>
+        _configuration = CreateInitializedConfigurationLazy(configuration);
+
+    IModule IPlanningModuleCopyProvider.CreatePlanningCopyFromRegisteredInstance(
+        bool preserveConfiguration)
+    {
+        var copy = (Module<T>) MemberwiseClone();
+        copy._configuration = preserveConfiguration && _configuration.IsValueCreated
+            ? CreateInitializedConfigurationLazy(_configuration.Value)
+            : copy.CreateConfigurationLazy();
+        copy._provisionalResult = new AsyncLocal<ModuleResult<T>?>();
+        copy.CompletionSource = CreateCompletionSource();
+        return copy;
+    }
+
+    /// <summary>
+    /// Creates an isolated module instance for dependency-graph planning.
+    /// </summary>
+    /// <remarks>
+    /// Override this when the module is registered with constructor values that cannot be resolved
+    /// from dependency injection. The returned instance must not share mutable module-owned state.
+    /// </remarks>
+    /// <param name="serviceProvider">The pipeline service provider.</param>
+    /// <returns>An isolated module instance used only for planning.</returns>
+    protected virtual Module<T> CreatePlanningCopy(IServiceProvider serviceProvider)
+    {
+        return (Module<T>) serviceProvider
+            .GetRequiredService<IModuleActivator>()
+            .CreatePlanningModule(GetType(), serviceProvider);
+    }
 
     /// <summary>
     /// Executes the module's core logic.
@@ -308,6 +345,29 @@ public abstract class Module<T> : IInternalModule
         ModuleConfigurationAttributeAdapter.Apply(
             GetType(),
             Configure());
+
+    private Lazy<ModuleConfiguration> CreateConfigurationLazy() =>
+        new(CreateConfiguration, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static Lazy<ModuleConfiguration> CreateInitializedConfigurationLazy(
+        ModuleConfiguration configuration) =>
+        new(() => configuration, LazyThreadSafetyMode.ExecutionAndPublication);
+
+    private static TaskCompletionSource<ModuleResult<T>> CreateCompletionSource() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+}
+
+internal interface IPlanningModuleCopyProvider
+{
+    bool IsConfigurationInitialized { get; }
+
+    IModule CreatePlanningCopy(IServiceProvider serviceProvider);
+
+    IModule CreatePlanningCopyFromRegisteredInstance(bool preserveConfiguration);
+
+    void InitializeConfiguration();
+
+    void InitializeConfiguration(ModuleConfiguration configuration);
 }
 
 #pragma warning restore SA1202

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -183,6 +183,11 @@ public sealed class PipelineBuilder : IDisposable
     /// <exception cref="PipelineValidationException">Thrown when validation fails.</exception>
     public async Task<IPipeline> BuildAsync()
     {
+        if (_commandLineOptions.Command == PipelineCommand.ExportGraph)
+        {
+            return await BuildForDependencyGraphExportAsync().ConfigureAwait(false);
+        }
+
         var validatePipeline = _commandLineOptions.Command != PipelineCommand.Help;
         var (pipeline, validationResult, validationException) =
             await BuildAndValidatePipelineAsync(validatePipeline).ConfigureAwait(false);

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -200,6 +200,9 @@ public sealed class PipelineBuilder : IDisposable
         return pipeline!;
     }
 
+    internal Task<IPipeline> BuildForDependencyGraphExportAsync() =>
+        BuildPipelineAsync(initializePipeline: false);
+
     /// <summary>
     /// Validates the pipeline configuration without executing it.
     /// </summary>

--- a/src/ModularPipelines/PipelineImpl.cs
+++ b/src/ModularPipelines/PipelineImpl.cs
@@ -124,21 +124,25 @@ internal sealed class PipelineImpl : IPipeline
             {
                 summary = commandResult;
             }
-            else if (Services.GetRequiredService<IOptions<PipelineOptions>>().Value.DryRun)
-            {
-                var plan = await PlanAsync(cancellationToken).ConfigureAwait(false);
-                Services.GetRequiredService<PipelinePlanPrinter>().Print(plan);
-                var now = DateTimeOffset.UtcNow;
-                summary = new PipelineSummary(plan.Modules, [], TimeSpan.Zero, now, now)
-                {
-                    StatusOverride = Status.Successful,
-                };
-            }
             else
             {
-                summary = await Services.GetRequiredService<IExecutionOrchestrator>()
-                    .ExecuteAsync(cancellationToken)
-                    .ConfigureAwait(false);
+                Services.GetRequiredService<PipelineExecutionState>().MarkExecutionStarted();
+                if (Services.GetRequiredService<IOptions<PipelineOptions>>().Value.DryRun)
+                {
+                    var plan = await PlanAsync(cancellationToken).ConfigureAwait(false);
+                    Services.GetRequiredService<PipelinePlanPrinter>().Print(plan);
+                    var now = DateTimeOffset.UtcNow;
+                    summary = new PipelineSummary(plan.Modules, [], TimeSpan.Zero, now, now)
+                    {
+                        StatusOverride = Status.Successful,
+                    };
+                }
+                else
+                {
+                    summary = await Services.GetRequiredService<IExecutionOrchestrator>()
+                        .ExecuteAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                }
             }
 
             ModuleActivityTracing.RecordPipelineCompletion(
@@ -157,6 +161,14 @@ internal sealed class PipelineImpl : IPipeline
             throw;
         }
     }
+
+    /// <inheritdoc />
+    public Task ExportDependencyGraphAsync(
+        DependencyGraphFormat format,
+        string path,
+        CancellationToken cancellationToken = default) =>
+        Services.GetRequiredService<IDependencyGraphExporter>()
+            .ExportAsync(format, path, cancellationToken);
 
     /// <inheritdoc />
     public ValueTask DisposeAsync()

--- a/test/ModularPipelines.GitHub.UnitTests/GitHubMarkdownSummaryGeneratorTests.cs
+++ b/test/ModularPipelines.GitHub.UnitTests/GitHubMarkdownSummaryGeneratorTests.cs
@@ -1,0 +1,158 @@
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Configuration;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Enums;
+using ModularPipelines.Extensions;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+namespace ModularPipelines.GitHub.UnitTests;
+
+[TUnit.Core.NotInParallel]
+public class GitHubMarkdownSummaryGeneratorTests
+{
+    private static int _skipConditionEvaluations;
+
+    private sealed class DependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("dependency");
+    }
+
+    [ModularPipelines.Attributes.DependsOnAttribute<DependencyModule>]
+    private sealed class TargetModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("target");
+    }
+
+    private sealed class SingleUseSkipConditionModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(_ => Interlocked.Increment(ref _skipConditionEvaluations) == 1
+                ? SkipDecision.DoNotSkip
+                : throw new InvalidOperationException("Skip condition evaluated twice"))
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("executed");
+    }
+
+    private sealed class OversizedDependencyGraphRenderer : IDependencyGraphExporter
+    {
+        public Task<string> RenderAsync(
+            DependencyGraphFormat format,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new string('g', 1024 * 1024));
+
+        public Task<string> RenderSummaryAsync(
+            DependencyGraphFormat format,
+            PipelineSummary pipelineSummary,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(new string('g', 1024 * 1024));
+
+        public Task ExportAsync(
+            DependencyGraphFormat format,
+            string path,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    [Test]
+    public async Task StepSummaryIncludesDependencyGraph()
+    {
+        var directory = Directory.CreateTempSubdirectory("modular-pipelines-github-summary-");
+        var path = Path.Combine(directory.FullName, "summary.md");
+        var previousPath = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
+        try
+        {
+            Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", path);
+            using var builder = Pipeline.CreateBuilder();
+            builder.AddModule<DependencyModule>();
+            builder.AddModule<TargetModule>();
+
+            await builder.ExecutePipelineAsync();
+
+            var summary = await File.ReadAllTextAsync(path);
+            using (Assert.Multiple())
+            {
+                await Assert.That(summary).Contains("### Dependency Graph");
+                await Assert.That(summary).Contains("flowchart TD");
+                await Assert.That(summary).Contains("DependencyModule");
+                await Assert.That(summary).Contains("TargetModule");
+                await Assert.That(summary).Contains(" --> ");
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", previousPath);
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task StepSummaryDoesNotReevaluateSkipConditions()
+    {
+        var directory = Directory.CreateTempSubdirectory("modular-pipelines-github-summary-");
+        var path = Path.Combine(directory.FullName, "summary.md");
+        var previousPath = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
+        try
+        {
+            _skipConditionEvaluations = 0;
+            Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", path);
+            using var builder = Pipeline.CreateBuilder();
+            builder.AddModule<SingleUseSkipConditionModule>();
+
+            await builder.ExecutePipelineAsync();
+
+            var summary = await File.ReadAllTextAsync(path);
+            using (Assert.Multiple())
+            {
+                await Assert.That(_skipConditionEvaluations).IsEqualTo(1);
+                await Assert.That(summary).Contains(nameof(SingleUseSkipConditionModule));
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", previousPath);
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task OversizedDependencyGraphDoesNotSuppressExistingSummary()
+    {
+        var directory = Directory.CreateTempSubdirectory("modular-pipelines-github-summary-");
+        var path = Path.Combine(directory.FullName, "summary.md");
+        var previousPath = Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY");
+        try
+        {
+            Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", path);
+            using var builder = Pipeline.CreateBuilder();
+            builder.Services.AddSingleton<IDependencyGraphExporter, OversizedDependencyGraphRenderer>();
+            builder.AddModule<DependencyModule>();
+
+            await builder.ExecutePipelineAsync();
+
+            var summary = await File.ReadAllTextAsync(path);
+            using (Assert.Multiple())
+            {
+                await Assert.That(summary).Contains("Run Summary");
+                await Assert.That(summary).Contains(nameof(DependencyModule));
+                await Assert.That(summary).DoesNotContain("### Dependency Graph");
+            }
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("GITHUB_STEP_SUMMARY", previousPath);
+            directory.Delete(recursive: true);
+        }
+    }
+}

--- a/test/ModularPipelines.TestHelpers/ExternalConfigurationMutationProbe.cs
+++ b/test/ModularPipelines.TestHelpers/ExternalConfigurationMutationProbe.cs
@@ -1,0 +1,13 @@
+namespace ModularPipelines.TestHelpers;
+
+public sealed class ExternalConfigurationMutationProbe
+{
+    private static int _constructorCalls;
+
+    public ExternalConfigurationMutationProbe() =>
+        Interlocked.Increment(ref _constructorCalls);
+
+    public static int ConstructorCalls => Volatile.Read(ref _constructorCalls);
+
+    public static void Reset() => Volatile.Write(ref _constructorCalls, 0);
+}

--- a/test/ModularPipelines.TestHelpers/ExternalConfigurationState.cs
+++ b/test/ModularPipelines.TestHelpers/ExternalConfigurationState.cs
@@ -1,0 +1,8 @@
+namespace ModularPipelines.TestHelpers;
+
+public static class ExternalConfigurationState
+{
+    public static bool IncludeDependency { get; set; }
+
+    public static bool ShouldIncludeDependency() => IncludeDependency;
+}

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -13,6 +13,7 @@ using ModularPipelines.Interfaces;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
+using ModularPipelines.PipelineCli;
 using Spectre.Console;
 using Spectre.Console.Rendering;
 
@@ -915,6 +916,34 @@ public class PipelineCommandLineTests
     }
 
     [Test]
+    public async Task GraphCommandExportsWithoutExecutingModules()
+    {
+        var directory = Directory.CreateTempSubdirectory("modular-pipelines-cli-graph-");
+        try
+        {
+            var path = Path.Combine(directory.FullName, "pipeline.json");
+            using var builder = CreateExecutionBuilder(["--graph", "json", path]);
+
+            var summary = await builder.ExecutePipelineAsync();
+            var graph = await File.ReadAllTextAsync(path);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(summary.Results).IsEmpty();
+                await Assert.That(graph).Contains(nameof(DependencyModule));
+                await Assert.That(graph).Contains(nameof(TargetModule));
+                await Assert.That(_dependencyExecutions).IsEqualTo(0);
+                await Assert.That(_targetExecutions).IsEqualTo(0);
+                await Assert.That(_unrelatedExecutions).IsEqualTo(0);
+            }
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
     [Arguments("--help")]
     [Arguments("-h")]
     public async Task HelpOptionsPrintUsage(string option)
@@ -1202,6 +1231,86 @@ public class PipelineCommandLineTests
             await Assert.That(plannedModule.IsSkipDecisionKnown).IsTrue();
             await Assert.That(plannedModule.ShouldSkip).IsTrue();
         }
+    }
+
+    [Test]
+    public async Task MermaidGraphCommandDefaultsToRawMermaidExtension()
+    {
+        var options = PipelineCommandLineParser.Parse(["--graph", "mermaid"]);
+
+        await Assert.That(options.GraphPath).IsEqualTo("dependency-graph.mmd");
+    }
+
+    [Test]
+    public async Task GraphCommandDoesNotConsumeHostConfigurationAsPath()
+    {
+        var options = PipelineCommandLineParser.Parse(["--graph", "json", "Feature:Enabled=true"]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(options.GraphPath).IsEqualTo("dependency-graph.json");
+            await Assert.That(options.HostArguments).IsEquivalentTo(["Feature:Enabled=true"]);
+        }
+    }
+
+    [Test]
+    public async Task GraphCommandAcceptsPathContainingEqualsSign()
+    {
+        var options = PipelineCommandLineParser.Parse(
+            ["--graph", "json", "artifacts/branch=main.json"]);
+
+        await Assert.That(options.GraphPath)
+            .IsEqualTo("artifacts/branch=main.json");
+    }
+
+    [Test]
+    public async Task GraphCommandAcceptsExplicitAmbiguousPath()
+    {
+        var options = PipelineCommandLineParser.Parse(
+            ["--graph", "json", "--graph-path", "branch=main.json"]);
+
+        await Assert.That(options.GraphPath).IsEqualTo("branch=main.json");
+    }
+
+    [Test]
+    public async Task GraphPathOptionRequiresGraphCommand()
+    {
+        await Assert.That(() => PipelineCommandLineParser.Parse(
+                ["--graph-path", "branch=main.json"]))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task GraphCommandRejectsDuplicatePaths()
+    {
+        await Assert.That(() => PipelineCommandLineParser.Parse(
+                ["--graph", "json", "graph.json", "--graph-path", "other.json"]))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task GraphCommandRejectsRepeatedFormats()
+    {
+        await Assert.That(() => PipelineCommandLineParser.Parse(
+                ["--graph", "json", "report.json", "--graph", "dot"]))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    [Arguments("0")]
+    [Arguments("1")]
+    [Arguments("2")]
+    public async Task GraphCommandRejectsNumericFormats(string format)
+    {
+        await Assert.That(() => Pipeline.CreateBuilder(["--graph", format]))
+            .Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task GraphCommandRejectsCombinedFormats()
+    {
+        await Assert.That(() => Pipeline.CreateBuilder(["--graph", "mermaid,dot"]))
+            .Throws<ArgumentException>();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -1000,6 +1000,9 @@ public class PipelineCommandLineTests
             .Contains("ModularPipelines command-line options:")
             .And.Contains("--skip-module")
             .And.Contains("--");
+        await Assert.That(PipelineCommandLineHelp.Usage)
+            .Contains("--graph <mermaid|dot|json> [path]")
+            .And.Contains("--graph-path <path>");
     }
 
     [Test]
@@ -1293,6 +1296,17 @@ public class PipelineCommandLineTests
             await Assert.That(options.GraphPath).IsEqualTo("dependency-graph.json");
             await Assert.That(options.HostArguments).IsEquivalentTo(["Feature:Enabled=true"]);
         }
+    }
+
+    [Test]
+    public async Task GraphCommandDoesNotConsumeShortHelpAsPath()
+    {
+        var exception = await Assert.That(() =>
+                PipelineCommandLineParser.Parse(["--graph", "json", "-h"]))
+            .Throws<ArgumentException>();
+
+        await Assert.That(exception!.Message)
+            .Contains("'-h' cannot be combined with another pipeline command");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -237,6 +237,22 @@ public class PipelineCommandLineTests
         }
     }
 
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class RuntimeOnlyDependencyAttribute : DependsOnBaseAttribute
+    {
+        public override bool ShouldDependOn(Type candidateModule, IDependencyContext context) =>
+            throw new InvalidOperationException("Graph export must not evaluate runtime dependency predicates.");
+    }
+
+    [RuntimeOnlyDependency]
+    private sealed class RuntimeOnlyDependencyModule : Module<string>
+    {
+        protected internal override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult("runtime-only-dependency");
+    }
+
     [RunIfAll<TrackingCondition>]
     private sealed class ConditionalModule : Module<string>
     {
@@ -944,6 +960,32 @@ public class PipelineCommandLineTests
     }
 
     [Test]
+    public async Task GraphCommandDoesNotEvaluateRuntimeDependencyPredicatesDuringBuild()
+    {
+        var directory = Directory.CreateTempSubdirectory("modular-pipelines-cli-graph-");
+        try
+        {
+            var path = Path.Combine(directory.FullName, "pipeline.json");
+            using var builder = Pipeline.CreateBuilder(["--graph", "json", path]);
+            builder.AddModule<DependencyModule>();
+            builder.AddModule<RuntimeOnlyDependencyModule>();
+
+            var summary = await builder.ExecutePipelineAsync();
+            var graph = await File.ReadAllTextAsync(path);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(summary.Results).IsEmpty();
+                await Assert.That(graph).Contains(nameof(RuntimeOnlyDependencyModule));
+            }
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
     [Arguments("--help")]
     [Arguments("-h")]
     public async Task HelpOptionsPrintUsage(string option)
@@ -1215,7 +1257,7 @@ public class PipelineCommandLineTests
     }
 
     [Test]
-    public async Task PlanAsyncEvaluatesOptionalRegistrationChecks()
+    public async Task PlanAsyncDefersOptionalRegistrationChecks()
     {
         using var builder = Pipeline.CreateBuilder();
         builder.AddModule<RegistrationOnlyOptionalSkipModule>();
@@ -1228,8 +1270,8 @@ public class PipelineCommandLineTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(plannedModule.IsSkipDecisionKnown).IsTrue();
-            await Assert.That(plannedModule.ShouldSkip).IsTrue();
+            await Assert.That(plannedModule.IsSkipDecisionKnown).IsFalse();
+            await Assert.That(plannedModule.ShouldSkip).IsFalse();
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
@@ -41,6 +41,7 @@ public class DependencyGraphExporterTests
     private static int _globalConfigurationMutations;
     private static int _constructorConfigurationMutations;
     private static int _deferredConditionAttributeConstructions;
+    private static int _deferredGroupedConditionAttributeConstructions;
     private static int _deferredConditionLogicReads;
     private static int _planningCompanionAttributeConstructions;
     private static int _planningPresenceAttributeConstructions;
@@ -1792,6 +1793,22 @@ public class DependencyGraphExporterTests
     }
 
     [AttributeUsage(AttributeTargets.Class)]
+    private sealed class DeferredPlanningAlternativeConditionAttribute
+        : Attribute, IGroupedConditionAttribute
+    {
+        public DeferredPlanningAlternativeConditionAttribute() =>
+            Interlocked.Increment(ref _deferredGroupedConditionAttributeConstructions);
+
+        public ConditionLogic Logic => ConditionLogic.Any;
+
+        public Type ConditionGroupType => typeof(PlanningAlternativeConditionAttribute);
+
+        public string ConditionNames => nameof(DeferredPlanningAlternativeConditionAttribute);
+
+        public Task<bool> EvaluateAsync(IPipelineContext context) => Task.FromResult(true);
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
     private sealed class AsyncPlanningConditionAttribute : RunIfAllAttribute
     {
         public override async Task<bool> EvaluateAsync(IPipelineContext context)
@@ -1880,6 +1897,16 @@ public class DependencyGraphExporterTests
             IModuleContext context,
             CancellationToken cancellationToken) =>
             Task.FromResult<string?>("safe-false-any-group-with-deferred-any");
+    }
+
+    [PlanningAlternativeCondition(false)]
+    [DeferredPlanningAlternativeCondition]
+    private sealed class SafeFalseAnyGroupWithDeferredAlternativeModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("safe-false-any-group-with-deferred-alternative");
     }
 
     private sealed class SingleUseConfigurationFactoryModule : Module<string>
@@ -2991,6 +3018,28 @@ public class DependencyGraphExporterTests
         var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
 
         await Assert.That(node.GetProperty("skipped").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task Safe_False_Any_Group_Defers_When_Alternative_Is_Deferred()
+    {
+        _deferredGroupedConditionAttributeConstructions = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<SafeFalseAnyGroupWithDeferredAlternativeModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var constructionsBeforeRender = _deferredGroupedConditionAttributeConstructions;
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(node.GetProperty("skipped").ValueKind).IsEqualTo(JsonValueKind.Null);
+            await Assert.That(_deferredGroupedConditionAttributeConstructions)
+                .IsEqualTo(constructionsBeforeRender);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
@@ -1,0 +1,4737 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Attributes;
+using ModularPipelines.Attributes.Events;
+using ModularPipelines.Conditions;
+using ModularPipelines.Configuration;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Attributes;
+using ModularPipelines.Engine.Dependencies;
+using ModularPipelines.Enums;
+using ModularPipelines.Exceptions;
+using ModularPipelines.Extensions;
+using ModularPipelines.Interfaces;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+using ModularPipelines.Plugins;
+using ModularPipelines.TestHelpers;
+
+namespace ModularPipelines.UnitTests.Engine;
+
+[TUnit.Core.NotInParallel]
+public class DependencyGraphExporterTests
+{
+    private static int _executions;
+    private static int _asyncSkipConditionEvaluations;
+    private static bool _startupConditionEnabled;
+    private static bool _startupDependencyEnabled;
+    private static bool _startupConfigurationEnabled;
+    private static int _planningActivations;
+    private static int _planningDisposals;
+    private static int _planningRegistrationEvents;
+    private static int _directModuleActivations;
+    private static CancellationTokenSource? _planningCancellation;
+    private static readonly object DependencySentinel = new();
+    private static bool _externalConfigurationIncludesDependency;
+    private static int _customPlanningAttributeEvaluations;
+    private static int _globalConfigurationMutations;
+    private static int _constructorConfigurationMutations;
+    private static int _deferredConditionAttributeConstructions;
+    private static int _deferredConditionLogicReads;
+    private static int _planningCompanionAttributeConstructions;
+    private static int _planningPresenceAttributeConstructions;
+    private static int _staticPlanningSkipEvaluations;
+    private static int _planningCallbackConstructorMutations;
+    private static int _customDependencyAttributeConstructions;
+    private static int _customDependencyPredicateEvaluations;
+    private static int _customDependencySelectorConstructions;
+
+    private sealed class ConstructorMutationState
+    {
+        public int Activations { get; set; }
+    }
+
+    private sealed class ConstructorMutatingModule : Module<int>
+    {
+        private readonly ConstructorMutationState _state;
+
+        public ConstructorMutatingModule(ConstructorMutationState state)
+        {
+            _state = state;
+            _state.Activations++;
+        }
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(_state.Activations);
+    }
+
+    public class SummaryIdentityModuleBase : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>(GetType().Assembly.GetName().Name);
+    }
+
+    private sealed class DependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _executions);
+            return Task.FromResult<string?>("dependency");
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class AddRegistrationDependencyAttribute(Type dependencyType)
+        : Attribute, IPlanningSafeModuleRegistrationEventReceiver
+    {
+        public Task OnRegistrationAsync(IModuleRegistrationContext context)
+        {
+            context.AddDependency(dependencyType);
+            return Task.CompletedTask;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class PlanningCompanionAttribute : Attribute
+    {
+        public PlanningCompanionAttribute()
+        {
+            Interlocked.Increment(ref _planningCompanionAttributeConstructions);
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class AddDependencyWhenCompanionPresentAttribute(Type dependencyType)
+        : Attribute, IPlanningSafeModuleRegistrationEventReceiver
+    {
+        public Task OnRegistrationAsync(IModuleRegistrationContext context)
+        {
+            if (context.ModuleAttributes.Any(static attribute => attribute is PlanningCompanionAttribute))
+            {
+                context.AddDependency(dependencyType);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class PlanningPresenceAttribute : Attribute
+    {
+        public PlanningPresenceAttribute()
+        {
+            Interlocked.Increment(ref _planningPresenceAttributeConstructions);
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class AddStartupDependencyAttribute(Type dependencyType)
+        : Attribute, IModuleRegistrationEventReceiver
+    {
+        public Task OnRegistrationAsync(IModuleRegistrationContext context)
+        {
+            if (_startupDependencyEnabled)
+            {
+                context.AddDependency(dependencyType);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class UnregisteredModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("unregistered");
+    }
+
+    [AddRegistrationDependency(typeof(UnregisteredModule))]
+    private sealed class InvalidDynamicDependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("invalid");
+    }
+
+    [AddRegistrationDependency(typeof(DependencyModule))]
+    private sealed class DynamicDependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("dynamic");
+    }
+
+    [PlanningCompanion]
+    [AddDependencyWhenCompanionPresent(typeof(DependencyModule))]
+    private sealed class CompanionAwareDynamicDependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("companion-aware");
+    }
+
+    [PlanningPresence]
+    private sealed class PresenceDependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("presence-dependency");
+    }
+
+    [DependsOnModulesWithAttribute<PlanningPresenceAttribute>]
+    private sealed class AttributePresenceConsumerModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("attribute-presence-consumer");
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class RuntimeDependencyPredicateAttribute : DependsOnBaseAttribute
+    {
+        public RuntimeDependencyPredicateAttribute() =>
+            Interlocked.Increment(ref _customDependencyAttributeConstructions);
+
+        public override bool ShouldDependOn(Type candidateModule, IDependencyContext context)
+        {
+            Interlocked.Increment(ref _customDependencyPredicateEvaluations);
+            return candidateModule == typeof(DependencyModule);
+        }
+    }
+
+    [RuntimeDependencyPredicate]
+    private sealed class RuntimePredicateConsumerModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("runtime-predicate-consumer");
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class RuntimeDependencySelectorAttribute
+        : DependsOnAllModulesInheritingFromAttribute
+    {
+        public RuntimeDependencySelectorAttribute() : base(typeof(DependencyModule)) =>
+            Interlocked.Increment(ref _customDependencySelectorConstructions);
+    }
+
+    [RuntimeDependencySelector]
+    private sealed class RuntimeSelectorConsumerModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("runtime-selector-consumer");
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class PlanningSafeDependencySelectorAttribute
+        : DependsOnAllModulesInheritingFromAttribute, IPlanningSafeDependencySelector
+    {
+        public PlanningSafeDependencySelectorAttribute() : base(typeof(DependencyModule))
+        {
+        }
+    }
+
+    [PlanningSafeDependencySelector]
+    private sealed class PlanningSafeSelectorConsumerModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("planning-safe-selector-consumer");
+    }
+
+    private sealed class HistoricalDependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("History should satisfy this module.");
+    }
+
+    [ProducesArtifact("graph-output", "graph-output.txt")]
+    private sealed class HistoricalArtifactProducerModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Graph export must not execute modules.");
+    }
+
+    [ModularPipelines.Attributes.DependsOn<HistoricalArtifactProducerModule>]
+    [ConsumesArtifact(typeof(HistoricalArtifactProducerModule), "graph-output")]
+    private sealed class HistoricalArtifactConsumerModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Graph export must not execute modules.");
+    }
+
+    [ModularPipelines.Attributes.DependsOn<HistoricalArtifactProducerModule>]
+    [ConsumesArtifact(typeof(HistoricalArtifactProducerModule), "graph-output")]
+    private sealed class AsyncHistoricalArtifactConsumerModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(async (_, _) =>
+            {
+                Interlocked.Increment(ref _asyncSkipConditionEvaluations);
+                await Task.Yield();
+                return SkipDecision.DoNotSkip;
+            })
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Graph export must not execute modules.");
+    }
+
+    [AsyncPlanningCondition]
+    [ModularPipelines.Attributes.DependsOn<HistoricalArtifactProducerModule>]
+    [ConsumesArtifact(typeof(HistoricalArtifactProducerModule), "graph-output")]
+    private sealed class SynchronouslySkippedArtifactConsumerModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(_ => SkipDecision.Skip("consumer is synchronously skipped"))
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Graph export must not execute modules.");
+    }
+
+    [ModularPipelines.Attributes.DependsOn<HistoricalDependencyModule>]
+    private sealed class HistoricalDependentModule : Module<string>
+    {
+        protected internal override async Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            var dependency = await context.GetModule<HistoricalDependencyModule>();
+            return dependency.ValueOrDefault;
+        }
+    }
+
+    [AddRegistrationDependency(typeof(UnregisteredModule))]
+    private sealed class InvalidSkippedDynamicDependencyModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(_ => SkipDecision.Skip("configured skip"))
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("invalid-skipped");
+    }
+
+    [ModuleCategory("build\r\nrelease")]
+    private sealed class LineBreakCategoryModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("line-break");
+    }
+
+    [ModuleCategory("build\r\n```\r\nrelease")]
+    private sealed class MarkdownFenceCategoryModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("markdown-fence");
+    }
+
+    [ModularPipelines.Attributes.DependsOnAttribute<DependencyModule>]
+    [ModuleCategory(@"build C:\new")]
+    private sealed class TargetModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _executions);
+            return Task.FromResult<string?>("target");
+        }
+    }
+
+    private sealed class SkippedModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _executions);
+            return Task.FromResult<string?>("skipped");
+        }
+    }
+
+    private sealed class NeverRunCondition : IPlanningRunCondition
+    {
+        public Task<bool> EvaluateAsync(IPipelineContext context) => Task.FromResult(false);
+    }
+
+    private sealed class ExecutionMutatingModule : Module<string>
+    {
+        public int Executions { get; private set; }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Executions++;
+            return Task.FromResult<string?>("executed");
+        }
+    }
+
+    private sealed class AlwaysSkipCondition : IPlanningRunCondition
+    {
+        public Task<bool> EvaluateAsync(IPipelineContext context) => Task.FromResult(true);
+    }
+
+    private sealed class StartupStateCondition : IPlanningRunCondition
+    {
+        public Task<bool> EvaluateAsync(IPipelineContext context) =>
+            Task.FromResult(_startupConditionEnabled);
+    }
+
+    private sealed class EnableStartupConditionHook : IPipelineGlobalHooks
+    {
+        public Task OnPipelineStartAsync(IPipelineContext context)
+        {
+            _startupConditionEnabled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class EnableStartupDependencyHook : IPipelineGlobalHooks
+    {
+        public Task OnPipelineStartAsync(IPipelineContext context)
+        {
+            _startupDependencyEnabled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class EnableStartupConfigurationHook : IPipelineGlobalHooks
+    {
+        public Task OnPipelineStartAsync(IPipelineContext context)
+        {
+            _startupConfigurationEnabled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class PlanningCategoryModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithCategory("planning")
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("planning-category");
+    }
+
+    private sealed class MutableConfigurationStateModule : Module<string>
+    {
+        private readonly List<string> _configurationCalls = [];
+
+        public int ConfigurationCallCount => _configurationCalls.Count;
+
+        protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
+            new MutableConfigurationStateModule();
+
+        protected override ModuleConfiguration Configure()
+        {
+            _configurationCalls.Add("configured");
+            if (_configurationCalls.Count > 1)
+            {
+                throw new InvalidOperationException("Mutable configuration state was shared.");
+            }
+
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("mutable-state");
+    }
+
+    private sealed class ConfigurationMutationCounter
+    {
+        public int Activations { get; set; }
+
+        public int Count { get; set; }
+    }
+
+    private sealed class GlobalConfigurationMutationModule : Module<int>
+    {
+        protected override ModuleConfiguration Configure() => CreateConfiguration();
+
+        private static ModuleConfiguration CreateConfiguration()
+        {
+            Interlocked.Increment(ref _globalConfigurationMutations);
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(_globalConfigurationMutations);
+    }
+
+    private sealed class ConstructorConfigurationMutationModule : Module<int>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            _ = new ConfigurationMutationProbe();
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(_constructorConfigurationMutations);
+    }
+
+    private sealed class ExternalConstructorConfigurationMutationModule : Module<int>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            _ = new ExternalConfigurationMutationProbe();
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(ExternalConfigurationMutationProbe.ConstructorCalls);
+    }
+
+    private abstract class VirtualConfigurationMutationBaseModule : Module<int>
+    {
+        protected override ModuleConfiguration Configure() => CreateConfiguration();
+
+        protected virtual ModuleConfiguration CreateConfiguration() =>
+            ModuleConfiguration.Default;
+    }
+
+    private sealed class VirtualConfigurationMutationModule
+        : VirtualConfigurationMutationBaseModule
+    {
+        protected override ModuleConfiguration CreateConfiguration()
+        {
+            Interlocked.Increment(ref _globalConfigurationMutations);
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(_globalConfigurationMutations);
+    }
+
+    private class VirtualConfigurationHelper
+    {
+        public virtual ModuleConfiguration CreateConfiguration() =>
+            ModuleConfiguration.Default;
+    }
+
+    private sealed class StatefulVirtualConfigurationHelper : VirtualConfigurationHelper
+    {
+        public override ModuleConfiguration CreateConfiguration()
+        {
+            Interlocked.Increment(ref _globalConfigurationMutations);
+            return ModuleConfiguration.Default;
+        }
+    }
+
+    private sealed class HelperVirtualConfigurationMutationModule : Module<int>
+    {
+        private readonly VirtualConfigurationHelper _helper =
+            new StatefulVirtualConfigurationHelper();
+
+        protected override ModuleConfiguration Configure() =>
+            _helper.CreateConfiguration();
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(_globalConfigurationMutations);
+    }
+
+    private sealed class ConfigurationMutationProbe
+    {
+        public ConfigurationMutationProbe() =>
+            Interlocked.Increment(ref _constructorConfigurationMutations);
+    }
+
+    private sealed class FrameworkConfigurationMutationModule : Module<string>
+    {
+        public const string EnvironmentVariableName = "MODULAR_PIPELINES_GRAPH_PLANNING_TEST";
+
+        protected override ModuleConfiguration Configure()
+        {
+            var currentValue = Environment.GetEnvironmentVariable(EnvironmentVariableName);
+            Environment.SetEnvironmentVariable(
+                EnvironmentVariableName,
+                currentValue is null ? "configured" : currentValue + "-configured");
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(Environment.GetEnvironmentVariable(EnvironmentVariableName));
+    }
+
+    private sealed class CoreApiConfigurationMutationModule : Module<int>
+    {
+        private readonly PlanningMutationPlugin _plugin = new();
+
+        protected override ModuleConfiguration Configure()
+        {
+            PluginRegistry.Register(_plugin);
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(PluginRegistry.Plugins.Count);
+    }
+
+    private sealed class PlanningMutationPlugin : IModularPipelinesPlugin
+    {
+        public string Name => nameof(PlanningMutationPlugin);
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+        }
+
+        public void ConfigurePipeline(PipelineBuilder pipelineBuilder)
+        {
+        }
+    }
+
+    private abstract class BodylessPlanningProbe
+    {
+        public abstract void Invoke();
+    }
+
+    private sealed class StaticRuntimeBoundPlanningConditionModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(EvaluatePlanningSkip)
+            .Build();
+
+        private static SkipDecision EvaluatePlanningSkip(IModuleContext context) =>
+            Interlocked.Increment(ref _staticPlanningSkipEvaluations) == 1
+                ? SkipDecision.Skip("first evaluation")
+                : SkipDecision.DoNotSkip;
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("static-planning-condition");
+    }
+
+    private sealed class ConstructorBoundPlanningConditionModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(EvaluatePlanningSkip)
+            .Build();
+
+        private static SkipDecision EvaluatePlanningSkip(IModuleContext context)
+        {
+            _ = new PlanningCallbackConstructorMutationProbe();
+            return SkipDecision.DoNotSkip;
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("constructor-bound-planning-condition");
+    }
+
+    private sealed class PlanningCallbackConstructorMutationProbe
+    {
+        public PlanningCallbackConstructorMutationProbe() =>
+            Interlocked.Increment(ref _planningCallbackConstructorMutations);
+    }
+
+    private sealed class InjectedConfigurationMutationModule(ConfigurationMutationCounter counter)
+        : Module<int>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            counter.Count++;
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(counter.Count);
+    }
+
+    private sealed record ConfigurationMutationHolder(ConfigurationMutationCounter Counter);
+
+    private sealed class NestedInjectedConfigurationMutationModule : Module<int>
+    {
+        private readonly ConfigurationMutationHolder _holder;
+
+        public NestedInjectedConfigurationMutationModule(ConfigurationMutationCounter counter)
+        {
+            _holder = new ConfigurationMutationHolder(counter);
+            counter.Activations++;
+        }
+
+        protected override ModuleConfiguration Configure()
+        {
+            _holder.Counter.Count++;
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(_holder.Counter.Count);
+    }
+
+    private sealed class InjectedRuntimeBoundPlanningConditionModule(
+        ConfigurationMutationCounter counter) : Module<string>
+    {
+        private int _planningEvaluations;
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(_ => ++_planningEvaluations == 1
+                ? SkipDecision.DoNotSkip
+                : SkipDecision.Skip("runtime state changed"))
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>(counter.Count.ToString());
+    }
+
+    private sealed class ConfiguredFallbackFactoryModule(string factoryValue) : Module<string>
+    {
+        private int _configurationCallCount;
+
+        public int ConfigurationCallCount => _configurationCallCount;
+
+        protected override ModuleConfiguration Configure()
+        {
+            _configurationCallCount++;
+            var builder = ModuleConfiguration.Create();
+            if (_configurationCallCount == 1)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>(factoryValue);
+    }
+
+    private sealed class FactoryInitializedModule : Module<string>
+    {
+        public bool IncludeDependency { get; init; }
+
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (IncludeDependency)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("factory-initialized");
+    }
+
+    private sealed class FactoryInitializedPlanningCopyModule : Module<string>
+    {
+        public bool IncludeDependency { get; init; }
+
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (IncludeDependency)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
+            new FactoryInitializedPlanningCopyModule { IncludeDependency = IncludeDependency };
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("factory-initialized-planning-copy");
+    }
+
+    private sealed class SharedMutableFactoryStateModule(List<string> state) : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            state.Add("configured");
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("shared-mutable-state");
+    }
+
+    private readonly record struct StructWrappedState(List<string> Values);
+
+    private sealed class StructWrappedFactoryStateModule(StructWrappedState state) : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            state.Values.Add("configured");
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("struct-wrapped-state");
+    }
+
+    private sealed class OverloadedPlanningCopyModule : Module<string>
+    {
+        private Module<string> CreatePlanningCopy() =>
+            throw new InvalidOperationException("The parameterless helper must not be selected.");
+
+        protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
+            new OverloadedPlanningCopyModule();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("overloaded-planning-copy");
+    }
+
+    private sealed class FieldlessStateFactoryModule : Module<string>
+    {
+        private readonly object _gate = new();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            lock (_gate)
+            {
+                return Task.FromResult<string?>("fieldless-state");
+            }
+        }
+    }
+
+    private sealed class DirectInterfaceModule : IModule
+    {
+        public DirectInterfaceModule()
+        {
+            Interlocked.Increment(ref _directModuleActivations);
+        }
+
+        public Type ResultType => typeof(string);
+
+        public ModuleConfiguration Configuration => ModuleConfiguration.Default;
+
+        public Task<IModuleResult> ResultTask =>
+            Task.FromException<IModuleResult>(new InvalidOperationException("Not executed by this test."));
+
+        public bool TrySetDistributedResult(IModuleResult result) => false;
+    }
+
+    private sealed class ReferenceIdentityFactoryModule(object state) : Module<string>
+    {
+        public ReferenceIdentityFactoryModule()
+            : this(new object())
+        {
+        }
+
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (ReferenceEquals(state, DependencySentinel))
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("reference-identity");
+    }
+
+    private sealed class ExternalConfigurationFactoryModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (_externalConfigurationIncludesDependency)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("external-configuration");
+    }
+
+    private sealed class StatefulDirectInterfaceModule : IModule
+    {
+        public StatefulDirectInterfaceModule()
+        {
+            ConfigurationCallCount = InitialConfigurationCallCount;
+        }
+
+        public static int InitialConfigurationCallCount { get; set; }
+
+        public int ConfigurationCallCount { get; private set; }
+
+        public Type ResultType => typeof(string);
+
+        public ModuleConfiguration Configuration
+        {
+            get
+            {
+                ConfigurationCallCount++;
+                return ModuleConfiguration.Default;
+            }
+        }
+
+        public Task<IModuleResult> ResultTask =>
+            Task.FromException<IModuleResult>(new InvalidOperationException("Not executed by this test."));
+
+        public bool TrySetDistributedResult(IModuleResult result) => false;
+    }
+
+    private sealed class ServiceBackedDirectInterfaceModule(DirectModulePlanningState state)
+        : IModule
+    {
+        public Type ResultType => typeof(string);
+
+        public ModuleConfiguration Configuration
+        {
+            get
+            {
+                state.ConfigurationReads++;
+                return ModuleConfiguration.Default;
+            }
+        }
+
+        public Task<IModuleResult> ResultTask =>
+            Task.FromException<IModuleResult>(new InvalidOperationException("Not executed by this test."));
+
+        public bool TrySetDistributedResult(IModuleResult result) => false;
+    }
+
+    private sealed class DirectModulePlanningState
+    {
+        public int ConfigurationReads { get; set; }
+    }
+
+    private sealed class PlanningSingletonDependency
+    {
+        public bool IncludeDependency { get; init; }
+    }
+
+    private sealed class ServiceBackedFactoryModule(PlanningSingletonDependency dependency)
+        : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (dependency.IncludeDependency)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("service-backed");
+    }
+
+    private class FactorySettingsBase
+    {
+        public bool IncludeDependency { get; init; }
+    }
+
+    private sealed class DerivedFactorySettings : FactorySettingsBase
+    {
+        public string Marker { get; init; } = "same";
+    }
+
+    private sealed class InheritedSettingsFactoryModule(DerivedFactorySettings settings)
+        : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (settings.IncludeDependency)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("inherited-settings");
+    }
+
+    private sealed class AliasState
+    {
+        public bool IncludeDependency { get; init; }
+    }
+
+    private sealed class AliasTopologyFactoryModule(AliasState first, AliasState second)
+        : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (ReferenceEquals(first, second) && first.IncludeDependency)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("alias-topology");
+    }
+
+    private sealed class ArrayShapeFactoryModule(Array state) : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (state.Rank == 2
+                && state.GetLength(0) == 1
+                && state.GetLowerBound(0) == 0)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("array-shape");
+    }
+
+    private sealed class ComparerBackedFactoryModule(HashSet<string> values) : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (values.Comparer.Equals("dependency", "DEPENDENCY"))
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("comparer-backed");
+    }
+
+    private sealed class PrecreatedModuleSettings
+    {
+        public bool IncludeDependency { get; init; }
+    }
+
+    private sealed class PrecreatedConfiguredModule(PrecreatedModuleSettings settings) : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (settings.IncludeDependency)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
+            new PrecreatedConfiguredModule(new PrecreatedModuleSettings
+            {
+                IncludeDependency = settings.IncludeDependency,
+            });
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("precreated");
+    }
+
+    private sealed class PrecreatedDisposableState : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose() => IsDisposed = true;
+    }
+
+    private sealed class PrecreatedDisposableModule(PrecreatedDisposableState state)
+        : Module<string>, IDisposable
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            ObjectDisposedException.ThrowIf(state.IsDisposed, state);
+            return Task.FromResult<string?>("precreated-disposable");
+        }
+
+        public void Dispose() => state.Dispose();
+    }
+
+    private sealed class CapturingComparerFactoryModule(IComparer<string> comparer) : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (comparer.Compare("dependency", "other") < 0)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("capturing-comparer");
+    }
+
+    private class FactoryInitializedBaseModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("factory-initialized-base");
+    }
+
+    private sealed class FactoryInitializedDerivedModule : FactoryInitializedBaseModule
+    {
+        public bool IncludeDependency { get; init; }
+
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (IncludeDependency)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("factory-initialized-derived");
+    }
+
+    private sealed class ContainerOwnedPlanningModule : Module<string>, IAsyncDisposable
+    {
+        protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
+            serviceProvider.GetRequiredService<ContainerOwnedPlanningModule>();
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref _planningDisposals);
+            return ValueTask.CompletedTask;
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("container-owned-planning");
+    }
+
+    private sealed class ContainerOwnedPlanningModuleFactory(IServiceProvider serviceProvider)
+    {
+        public ContainerOwnedPlanningModule Create() =>
+            serviceProvider.GetRequiredService<ContainerOwnedPlanningModule>();
+    }
+
+    private readonly struct SelectiveEqualityState(bool includeDependency)
+    {
+        public bool IncludeDependency { get; } = includeDependency;
+
+        public override bool Equals(object? obj) => obj is SelectiveEqualityState;
+
+        public override int GetHashCode() => 0;
+    }
+
+    private sealed class StructEqualityFactoryModule(bool includeDependency = false) : Module<string>
+    {
+        private readonly SelectiveEqualityState _state = new(includeDependency);
+
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (_state.IncludeDependency)
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("struct-equality");
+    }
+
+    private sealed class ContainerOwnedPlanningState;
+
+    private sealed class ContainerOwnedPlanningStateFactory(IServiceProvider serviceProvider)
+    {
+        public ContainerOwnedPlanningState Create() =>
+            serviceProvider.GetRequiredService<ContainerOwnedPlanningState>();
+    }
+
+    private sealed class ModuleWithContainerOwnedPlanningState(
+        ContainerOwnedPlanningState planningState) : Module<string>
+    {
+        private readonly ContainerOwnedPlanningState _planningState = planningState;
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>(_planningState.GetType().Name);
+    }
+
+    private sealed class PlanningFactoryDependency;
+
+    private sealed class ContainerOwnedPlanningCopyModule : Module<string>, IAsyncDisposable
+    {
+        protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
+            serviceProvider.GetRequiredKeyedService<ContainerOwnedPlanningCopyModule>("planning");
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref _planningDisposals);
+            return ValueTask.CompletedTask;
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("container-owned-planning-copy");
+    }
+
+    [CountPlanningRegistration]
+    private sealed class DisposablePlanningModule : Module<string>, IAsyncDisposable
+    {
+        public DisposablePlanningModule()
+        {
+            Interlocked.Increment(ref _planningActivations);
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            Interlocked.Increment(ref _planningDisposals);
+            return ValueTask.CompletedTask;
+        }
+
+        protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
+            new DisposablePlanningModule();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("disposable-planning");
+    }
+
+    private sealed class ThrowingDisposablePlanningModule : Module<string>, IDisposable
+    {
+        protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
+            new ThrowingDisposablePlanningModule();
+
+        public void Dispose() => throw new InvalidOperationException("Planning disposal failed.");
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("throwing-disposable-planning");
+    }
+
+    private sealed class ThrowingPlanningScopeService : IDisposable
+    {
+        public void Dispose() =>
+            throw new InvalidOperationException("Planning scope disposal failed.");
+    }
+
+    private sealed class DualCleanupFailureModule : Module<string>, IDisposable
+    {
+        private static readonly HashSet<DualCleanupFailureModule> PlanningCopies = [];
+
+        protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider)
+        {
+            _ = serviceProvider.GetRequiredService<ThrowingPlanningScopeService>();
+            var copy = new DualCleanupFailureModule();
+            PlanningCopies.Add(copy);
+            return copy;
+        }
+
+        public void Dispose()
+        {
+            if (PlanningCopies.Remove(this))
+            {
+                throw new InvalidOperationException("Planner-owned disposal failed.");
+            }
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("dual-cleanup-failure");
+    }
+
+    private sealed class CountPlanningRegistrationAttribute
+        : Attribute, IModuleRegistrationEventReceiver,
+            IPlanningSafeModuleRegistrationEventReceiver
+    {
+        public Task OnRegistrationAsync(IModuleRegistrationContext context)
+        {
+            Interlocked.Increment(ref _planningRegistrationEvents);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SingletonFactoryModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("singleton-factory");
+    }
+
+    private sealed class StartupConfiguredModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(_ => _startupConfigurationEnabled
+                ? SkipDecision.DoNotSkip
+                : SkipDecision.Skip("startup configuration is not ready"))
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _executions);
+            return Task.FromResult<string?>("startup-configured");
+        }
+    }
+
+    private sealed class FactorySkipModule(bool shouldSkip) : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var capturedDecision = shouldSkip
+                ? SkipDecision.Skip("factory requested a skip")
+                : SkipDecision.DoNotSkip;
+            return ModuleConfiguration.Create()
+                .WithSkipWhen(_ => capturedDecision)
+                .Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("factory-skip");
+    }
+
+    private sealed class MutableClosureFactorySkipModule(string factoryValue) : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var evaluations = 0;
+            return ModuleConfiguration.Create()
+                .WithSkipWhen(_ => ++evaluations == 1
+                    ? SkipDecision.Skip("first evaluation")
+                    : SkipDecision.DoNotSkip)
+                .Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _executions);
+            return Task.FromResult<string?>(factoryValue);
+        }
+    }
+
+    [CountUnsafeRegistration]
+    private sealed class UnsafeRegistrationModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("unsafe-registration");
+    }
+
+    private sealed class CountUnsafeRegistrationAttribute
+        : Attribute, IModuleRegistrationEventReceiver
+    {
+        public Task OnRegistrationAsync(IModuleRegistrationContext context)
+        {
+            Interlocked.Increment(ref _planningRegistrationEvents);
+            return Task.CompletedTask;
+        }
+    }
+
+    [CancelPlanningRegistration]
+    private sealed class CancelPlanningModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("cancel-planning");
+    }
+
+    private sealed class CancelPlanningRegistrationAttribute
+        : Attribute, IModuleRegistrationEventReceiver,
+            IPlanningSafeModuleRegistrationEventReceiver
+    {
+        public Task OnRegistrationAsync(IModuleRegistrationContext context)
+        {
+            _planningCancellation!.Cancel();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class MutableReferenceClosureFactorySkipModule(string factoryValue) : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var decisions = new Queue<SkipDecision>(
+                [SkipDecision.Skip("first evaluation"), SkipDecision.DoNotSkip]);
+            return ModuleConfiguration.Create()
+                .WithSkipWhen(_ => decisions.Dequeue())
+                .Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _executions);
+            return Task.FromResult<string?>(factoryValue);
+        }
+    }
+
+    private struct MutablePlanningCounter
+    {
+        private int _evaluations;
+
+        public SkipDecision NextDecision() => ++_evaluations == 1
+            ? SkipDecision.Skip("first evaluation")
+            : SkipDecision.DoNotSkip;
+    }
+
+    private sealed class MutableStructClosureFactorySkipModule(string factoryValue) : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var counter = new MutablePlanningCounter();
+            return ModuleConfiguration.Create()
+                .WithSkipWhen(_ => counter.NextDecision())
+                .Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _executions);
+            return Task.FromResult<string?>(factoryValue);
+        }
+    }
+
+    private sealed class RuntimeBoundFactorySkipModule(bool shouldSkip) : Module<string>
+    {
+        public int PlanningEvaluations { get; private set; }
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(_ =>
+            {
+                PlanningEvaluations++;
+                return shouldSkip
+                    ? SkipDecision.Skip("factory requested a skip")
+                    : SkipDecision.DoNotSkip;
+            })
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("runtime-bound-factory-skip");
+    }
+
+    private sealed class RuntimeBoundMethodGroupFactorySkipModule(bool shouldSkip) : Module<string>
+    {
+        public int PlanningEvaluations { get; private set; }
+
+        protected override ModuleConfiguration Configure()
+        {
+            var target = new RuntimeBoundSkipTarget(this, shouldSkip);
+            return ModuleConfiguration.Create()
+                .WithSkipWhen(target.ShouldSkip)
+                .Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("runtime-bound-method-group-factory-skip");
+
+        private sealed class RuntimeBoundSkipTarget(
+            RuntimeBoundMethodGroupFactorySkipModule module,
+            bool shouldSkip)
+        {
+            public SkipDecision ShouldSkip(IModuleContext _)
+            {
+                module.PlanningEvaluations++;
+                return shouldSkip
+                    ? SkipDecision.Skip("factory requested a skip")
+                    : SkipDecision.DoNotSkip;
+            }
+        }
+    }
+
+    private sealed class RuntimeBoundCollectionFactorySkipModule(bool shouldSkip) : Module<string>
+    {
+        public int PlanningEvaluations { get; private set; }
+
+        protected override ModuleConfiguration Configure()
+        {
+            var target = new RuntimeBoundCollectionSkipTarget([this], shouldSkip);
+            return ModuleConfiguration.Create()
+                .WithSkipWhen(target.ShouldSkip)
+                .Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("runtime-bound-collection-factory-skip");
+
+        private sealed class RuntimeBoundCollectionSkipTarget(
+            IReadOnlyList<IModule> modules,
+            bool shouldSkip)
+        {
+            public SkipDecision ShouldSkip(IModuleContext _)
+            {
+                ((RuntimeBoundCollectionFactorySkipModule) modules[0]).PlanningEvaluations++;
+                return shouldSkip
+                    ? SkipDecision.Skip("factory requested a skip")
+                    : SkipDecision.DoNotSkip;
+            }
+        }
+    }
+
+    private sealed class RuntimeBoundAsyncFactorySkipModule(bool shouldSkip) : Module<string>
+    {
+        public int PlanningEvaluations { get; private set; }
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(async (_, _) =>
+            {
+                PlanningEvaluations++;
+                await Task.Yield();
+                return shouldSkip
+                    ? SkipDecision.Skip("factory requested a skip")
+                    : SkipDecision.DoNotSkip;
+            })
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("runtime-bound-async-factory-skip");
+    }
+
+    private sealed class ConfigurationThrowingDisposableFactoryModule : Module<string>, IDisposable
+    {
+        public static int Disposals;
+
+        public bool HasFactoryState { get; init; }
+
+        protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
+            new ConfigurationThrowingDisposableFactoryModule();
+
+        public void Dispose() => Interlocked.Increment(ref Disposals);
+
+        protected override ModuleConfiguration Configure() => HasFactoryState
+            ? ModuleConfiguration.Default
+            : throw new InvalidOperationException("Factory state is unavailable.");
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("configuration-throwing-disposable");
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class SingleUseConditionAttribute : RunIfAllAttribute
+    {
+        private bool _evaluated;
+
+        public override Task<bool> EvaluateAsync(IPipelineContext context)
+        {
+            if (_evaluated)
+            {
+                throw new InvalidOperationException("Condition attribute was reused.");
+            }
+
+            _evaluated = true;
+            return Task.FromResult(true);
+        }
+    }
+
+    private sealed class ByRefMutableClosureFactorySkipModule(string factoryValue) : Module<string>
+    {
+        private readonly ModuleConfiguration _configuration = CreateConfiguration();
+
+        protected override ModuleConfiguration Configure() => _configuration;
+
+        private static ModuleConfiguration CreateConfiguration()
+        {
+            var evaluations = 0;
+            return ModuleConfiguration.Create()
+                .WithSkipWhen(_ => NextDecision(ref evaluations))
+                .Build();
+        }
+
+        private static SkipDecision NextDecision(ref int evaluations) =>
+            ++evaluations == 1
+                ? SkipDecision.Skip("first evaluation")
+                : SkipDecision.Skip("later evaluation");
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>(factoryValue);
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class DeferredStatefulConditionAttribute : Attribute, IConditionAttribute
+    {
+        public DeferredStatefulConditionAttribute()
+        {
+            Interlocked.Increment(ref _deferredConditionAttributeConstructions);
+        }
+
+        public ConditionLogic Logic
+        {
+            get
+            {
+                Interlocked.Increment(ref _deferredConditionLogicReads);
+                throw new InvalidOperationException("Deferred condition logic must not run during planning.");
+            }
+        }
+
+        public string ConditionNames => nameof(DeferredStatefulConditionAttribute);
+
+        public Task<bool> EvaluateAsync(IPipelineContext context) =>
+            throw new InvalidOperationException("Deferred condition must not run during planning.");
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class DeferredAnyConditionAttribute : RunIfAnyAttribute
+    {
+        public override Task<bool> EvaluateAsync(IPipelineContext context) =>
+            throw new InvalidOperationException("Deferred condition must not run during planning.");
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class AsyncPlanningConditionAttribute : RunIfAllAttribute
+    {
+        public override async Task<bool> EvaluateAsync(IPipelineContext context)
+        {
+            Interlocked.Increment(ref _asyncSkipConditionEvaluations);
+            await Task.Yield();
+            return false;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class CustomGenericConditionAttribute<T> : RunIfAllAttribute
+        where T : IPlanningRunCondition
+    {
+        public override Task<bool> EvaluateAsync(IPipelineContext context)
+        {
+            Interlocked.Increment(ref _customPlanningAttributeEvaluations);
+            return Task.FromResult(false);
+        }
+
+        public override string ConditionNames => typeof(T).Name;
+    }
+
+    [AsyncPlanningCondition]
+    private sealed class AsyncAttributeConditionModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("async-attribute-condition");
+    }
+
+    [CustomGenericCondition<AlwaysSkipCondition>]
+    private sealed class CustomGenericAttributeConditionModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("custom-generic-attribute-condition");
+    }
+
+    [AsyncPlanningCondition]
+    [SkipIf<AlwaysSkipCondition>]
+    private sealed class SafeSkipWithAsyncAttributeModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("safe-skip-with-async-attribute");
+    }
+
+    [SingleUseCondition]
+    private sealed class SingleUseConditionModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("single-use");
+    }
+
+    [DeferredStatefulCondition]
+    private sealed class DeferredStatefulConditionModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("deferred-stateful-condition");
+    }
+
+    [RunIfAny<NeverRunCondition>]
+    [DeferredAnyCondition]
+    private sealed class SafeFalseAnyWithDeferredAnyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("safe-false-any-with-deferred-any");
+    }
+
+    [AddStartupDependency(typeof(DependencyModule))]
+    private sealed class StartupDynamicDependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("startup-dynamic");
+    }
+
+    [RunIfAll<StartupStateCondition>]
+    private sealed class StartupConditionModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _executions);
+            return Task.FromResult<string?>("startup-condition");
+        }
+    }
+
+    [RunIfAll<NeverRunCondition>]
+    private sealed class ConditionSkippedModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _executions);
+            return Task.FromResult<string?>("condition-skipped");
+        }
+    }
+
+    [ModularPipelines.Attributes.DependsOn<ConditionSkippedModule>]
+    private sealed class DependentOnConditionSkippedModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _executions);
+            return Task.FromResult<string?>("dependent");
+        }
+    }
+
+    [ModularPipelines.Attributes.DependsOn<DependentOnConditionSkippedModule>]
+    private sealed class DownstreamOfConditionSkippedModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("downstream");
+    }
+
+    private sealed class ConfiguredSkippedModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(_ => SkipDecision.Skip("configured skip"))
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("configured-skipped");
+    }
+
+    [ModularPipelines.Attributes.DependsOn<ConfiguredSkippedModule>]
+    private sealed class DependentOnConfiguredSkippedModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("dependent");
+    }
+
+    [ModularPipelines.Attributes.DependsOn<DependencyModule>]
+    private sealed class ResultDependentConfiguredSkipModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(async (context, _) =>
+            {
+                await context.GetModule<DependencyModule>();
+                return SkipDecision.DoNotSkip;
+            })
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("result-dependent");
+    }
+
+    private sealed class AsyncConfiguredSkipModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(async (_, cancellationToken) =>
+            {
+                Interlocked.Increment(ref _asyncSkipConditionEvaluations);
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                return SkipDecision.DoNotSkip;
+            })
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("async-configured");
+    }
+
+    private sealed class SynchronouslySkippedBeforeAsyncModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(_ => SkipDecision.Skip("synchronous short circuit"))
+            .WithSkipWhen(async (_, _) =>
+            {
+                Interlocked.Increment(ref _asyncSkipConditionEvaluations);
+                await Task.Yield();
+                return SkipDecision.DoNotSkip;
+            })
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("mixed-configured");
+    }
+
+    private sealed class SynchronouslySkippedAfterAsyncModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(async (_, _) =>
+            {
+                Interlocked.Increment(ref _asyncSkipConditionEvaluations);
+                await Task.Yield();
+                return SkipDecision.DoNotSkip;
+            })
+            .WithSkipWhen(_ => SkipDecision.Skip("synchronous short circuit"))
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("mixed-configured");
+    }
+
+    [ModularPipelines.Attributes.DependsOn<SynchronouslySkippedBeforeAsyncModule>]
+    private sealed class DependentOnSynchronouslySkippedBeforeAsyncModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("dependent");
+    }
+
+    [ModularPipelines.Attributes.DependsOn<ResultDependentConfiguredSkipModule>]
+    private sealed class DependentOnUnresolvedSkipModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("dependent");
+    }
+
+    private sealed class FixedEstimatedTimeProvider : IModuleEstimatedTimeProvider
+    {
+        public Task<TimeSpan> GetModuleEstimatedTimeAsync(Type moduleType) =>
+            Task.FromResult(TimeSpan.FromSeconds(5));
+
+        public Task SaveModuleTimeAsync(Type moduleType, TimeSpan duration) =>
+            Task.CompletedTask;
+
+        public Task<IEnumerable<SubModuleEstimation>> GetSubModuleEstimatedTimesAsync(Type moduleType) =>
+            Task.FromResult<IEnumerable<SubModuleEstimation>>([]);
+
+        public Task SaveSubModuleTimeAsync(
+            Type moduleType,
+            SubModuleEstimation subModuleEstimation) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class CancelingEstimatedTimeProvider(CancellationTokenSource cancellationTokenSource)
+        : IModuleEstimatedTimeProvider
+    {
+        public Task<TimeSpan> GetModuleEstimatedTimeAsync(Type moduleType)
+        {
+            cancellationTokenSource.Cancel();
+            return Task.FromResult(TimeSpan.FromSeconds(5));
+        }
+
+        public Task SaveModuleTimeAsync(Type moduleType, TimeSpan duration) =>
+            Task.CompletedTask;
+
+        public Task<IEnumerable<SubModuleEstimation>> GetSubModuleEstimatedTimesAsync(Type moduleType) =>
+            Task.FromResult<IEnumerable<SubModuleEstimation>>([]);
+
+        public Task SaveSubModuleTimeAsync(
+            Type moduleType,
+            SubModuleEstimation subModuleEstimation) =>
+            Task.CompletedTask;
+    }
+
+    private sealed class DependencyHistoryRepository : IModuleResultRepository
+    {
+        public bool IsEnabled => true;
+
+        public Task SaveResultAsync<T>(
+            Module<T> module,
+            ModuleResult<T> moduleResult,
+            IPipelineContext pipelineContext) =>
+            Task.CompletedTask;
+
+        public Task<ModuleResult<T>?> GetResultAsync<T>(
+            Module<T> module,
+            IPipelineContext pipelineContext)
+        {
+            var executionContext = new ModuleExecutionContext(module, module.GetType());
+            return Task.FromResult<ModuleResult<T>?>(
+                ModuleResult<T>.CreateSuccess(default!, executionContext));
+        }
+    }
+
+    private sealed class ModuleTypeHistoryRepository(Type moduleType) : IModuleResultRepository
+    {
+        public bool IsEnabled => true;
+
+        public Task SaveResultAsync<T>(
+            Module<T> module,
+            ModuleResult<T> moduleResult,
+            IPipelineContext pipelineContext) =>
+            Task.CompletedTask;
+
+        public Task<ModuleResult<T>?> GetResultAsync<T>(
+            Module<T> module,
+            IPipelineContext pipelineContext)
+        {
+            if (module.GetType() != moduleType)
+            {
+                return Task.FromResult<ModuleResult<T>?>(null);
+            }
+
+            var executionContext = new ModuleExecutionContext(module, module.GetType());
+            return Task.FromResult<ModuleResult<T>?>(
+                ModuleResult<T>.CreateSuccess(default!, executionContext));
+        }
+    }
+
+    private sealed class CancelingModuleTypeHistoryRepository(
+        Type moduleType,
+        CancellationTokenSource cancellationTokenSource) : IModuleResultRepository
+    {
+        private int _readCount;
+
+        public bool IsEnabled => true;
+
+        public int ReadCount => Volatile.Read(ref _readCount);
+
+        public Task SaveResultAsync<T>(
+            Module<T> module,
+            ModuleResult<T> moduleResult,
+            IPipelineContext pipelineContext) =>
+            Task.CompletedTask;
+
+        public Task<ModuleResult<T>?> GetResultAsync<T>(
+            Module<T> module,
+            IPipelineContext pipelineContext)
+        {
+            Interlocked.Increment(ref _readCount);
+            if (module.GetType() != moduleType)
+            {
+                return Task.FromResult<ModuleResult<T>?>(null);
+            }
+
+            cancellationTokenSource.Cancel();
+            var executionContext = new ModuleExecutionContext(module, module.GetType());
+            return Task.FromResult<ModuleResult<T>?>(
+                ModuleResult<T>.CreateSuccess(default!, executionContext));
+        }
+    }
+
+    private sealed class ChangingHistoryRepository : IModuleResultRepository
+    {
+        private int _readCount;
+
+        public bool IsEnabled => true;
+
+        public int ReadCount => Volatile.Read(ref _readCount);
+
+        public Task SaveResultAsync<T>(
+            Module<T> module,
+            ModuleResult<T> moduleResult,
+            IPipelineContext pipelineContext) =>
+            Task.CompletedTask;
+
+        public Task<ModuleResult<T>?> GetResultAsync<T>(
+            Module<T> module,
+            IPipelineContext pipelineContext)
+        {
+            var value = $"history-{Interlocked.Increment(ref _readCount)}";
+            var executionContext = new ModuleExecutionContext(module, module.GetType());
+            return Task.FromResult<ModuleResult<T>?>(
+                ModuleResult<T>.CreateSuccess((T) (object) value, executionContext));
+        }
+    }
+
+    private sealed class InstanceBoundHistoryRepository(IModule expectedModule)
+        : IModuleResultRepository
+    {
+        public bool IsEnabled => true;
+
+        public bool ReceivedExpectedModule { get; private set; }
+
+        public Task SaveResultAsync<T>(
+            Module<T> module,
+            ModuleResult<T> moduleResult,
+            IPipelineContext pipelineContext) =>
+            Task.CompletedTask;
+
+        public Task<ModuleResult<T>?> GetResultAsync<T>(
+            Module<T> module,
+            IPipelineContext pipelineContext)
+        {
+            ReceivedExpectedModule = ReferenceEquals(module, expectedModule);
+            if (!ReceivedExpectedModule)
+            {
+                return Task.FromResult<ModuleResult<T>?>(null);
+            }
+
+            var executionContext = new ModuleExecutionContext(module, module.GetType());
+            return Task.FromResult<ModuleResult<T>?>(
+                ModuleResult<T>.CreateSuccess(default!, executionContext));
+        }
+    }
+
+    [Before(Test)]
+    public void ResetExecutions()
+    {
+        _executions = 0;
+        _asyncSkipConditionEvaluations = 0;
+        _startupConditionEnabled = false;
+        _startupDependencyEnabled = false;
+        _startupConfigurationEnabled = false;
+        _planningActivations = 0;
+        _planningDisposals = 0;
+        _planningRegistrationEvents = 0;
+    }
+
+    [Test]
+    public async Task Renderers_Describe_The_Same_Annotated_Graph()
+    {
+        using var builder = CreateBuilder();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var mermaid = await exporter.RenderAsync(DependencyGraphFormat.Mermaid);
+        var dot = await exporter.RenderAsync(DependencyGraphFormat.Dot);
+        var json = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        using var document = JsonDocument.Parse(json);
+        var nodes = document.RootElement.GetProperty("nodes");
+        var edges = document.RootElement.GetProperty("edges");
+        var targetNode = nodes.EnumerateArray()
+            .Single(node => node.GetProperty("name").GetString() == nameof(TargetModule));
+        using (Assert.Multiple())
+        {
+            await Assert.That(mermaid).Contains("flowchart TD");
+            await Assert.That(mermaid).Contains("Category: build");
+            await Assert.That(mermaid).Contains("Estimated: 00:00:05");
+            await Assert.That(mermaid).Contains("Skipped:");
+            await Assert.That(dot).Contains("digraph ModularPipelines");
+            await Assert.That(dot).Contains(@"Category: build C:\\new");
+            await Assert.That(dot).Contains("n0 -> n2");
+            await Assert.That(nodes.GetArrayLength()).IsEqualTo(3);
+            await Assert.That(edges.GetArrayLength()).IsEqualTo(1);
+            await Assert.That(targetNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(targetNode.GetProperty("skipReason").GetString())
+                .Contains(nameof(DependencyModule));
+            await Assert.That(_executions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Builder_Exports_Graph_Without_Executing_Modules()
+    {
+        var directory = Directory.CreateTempSubdirectory("modular-pipelines-graph-");
+        try
+        {
+            var path = Path.Combine(directory.FullName, "graph.json");
+            using var builder = CreateBuilder();
+
+            await builder.ExportDependencyGraphAsync(
+                DependencyGraphFormat.Json,
+                path);
+
+            using var document = JsonDocument.Parse(await File.ReadAllTextAsync(path));
+            await Assert.That(document.RootElement.GetProperty("nodes").GetArrayLength())
+                .IsEqualTo(3);
+            await Assert.That(_executions).IsEqualTo(0);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Historical_Ignored_Dependency_Does_Not_Skip_Dependent()
+    {
+        using var builder = CreateBuilder();
+        builder.Services.AddSingleton<IModuleResultRepository>(new DependencyHistoryRepository());
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var dependencyNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(DependencyModule));
+        var targetNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(TargetModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(dependencyNode.GetProperty("skipped").GetBoolean()).IsFalse();
+            await Assert.That(dependencyNode.GetProperty("skipReason").ValueKind)
+                .IsEqualTo(JsonValueKind.Null);
+            await Assert.That(targetNode.GetProperty("skipped").GetBoolean()).IsFalse();
+            await Assert.That(_executions).IsEqualTo(0);
+        }
+    }
+
+    private sealed class ExternalHelperConfigurationModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            var builder = ModuleConfiguration.Create();
+            if (ExternalConfigurationState.ShouldIncludeDependency())
+            {
+                builder.DependsOn<DependencyModule>();
+            }
+
+            return builder.Build();
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("external-helper-configuration");
+    }
+
+    [Test]
+    public async Task Historical_Artifact_Producer_Remains_Skipped_When_Artifact_Is_Demanded()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleResultRepository>(
+            new ModuleTypeHistoryRepository(typeof(HistoricalArtifactProducerModule)));
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            SkippedModules = [nameof(HistoricalArtifactProducerModule)],
+        });
+        builder.AddModule<HistoricalArtifactProducerModule>();
+        builder.AddModule<HistoricalArtifactConsumerModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var producerNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(HistoricalArtifactProducerModule));
+        var consumerNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(HistoricalArtifactConsumerModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(producerNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(consumerNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(consumerNode.GetProperty("skipReason").GetString())
+                .Contains(nameof(HistoricalArtifactProducerModule));
+        }
+    }
+
+    [Test]
+    public async Task Artifact_Demand_Does_Not_Run_Async_Configured_Conditions()
+    {
+        _asyncSkipConditionEvaluations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleResultRepository>(
+            new ModuleTypeHistoryRepository(typeof(HistoricalArtifactProducerModule)));
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            SkippedModules = [nameof(HistoricalArtifactProducerModule)],
+        });
+        builder.AddModule<HistoricalArtifactProducerModule>();
+        builder.AddModule<AsyncHistoricalArtifactConsumerModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var producerNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(HistoricalArtifactProducerModule));
+        var consumerNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(AsyncHistoricalArtifactConsumerModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(producerNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(consumerNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(_asyncSkipConditionEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Definitive_Fluent_Skip_Avoids_Artifact_Demand()
+    {
+        _asyncSkipConditionEvaluations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleResultRepository>(
+            new ModuleTypeHistoryRepository(typeof(HistoricalArtifactProducerModule)));
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            SkippedModules = [nameof(HistoricalArtifactProducerModule)],
+        });
+        builder.AddModule<HistoricalArtifactProducerModule>();
+        builder.AddModule<SynchronouslySkippedArtifactConsumerModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var producerNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(HistoricalArtifactProducerModule));
+        var consumerNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(SynchronouslySkippedArtifactConsumerModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(producerNode.GetProperty("skipped").GetBoolean()).IsFalse();
+            await Assert.That(consumerNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(_asyncSkipConditionEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Complete_Runtime_Module_Results()
+    {
+        var repository = new ChangingHistoryRepository();
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleResultRepository>(repository);
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            SkippedModules = [nameof(HistoricalDependencyModule)],
+        });
+        builder.AddModule<HistoricalDependencyModule>();
+        builder.AddModule<HistoricalDependentModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+        var summary = await pipeline.RunAsync();
+        var dependentResult = summary.Results.Single(result =>
+            result.ModuleName == nameof(HistoricalDependentModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(repository.ReadCount).IsEqualTo(2);
+            await Assert.That(dependentResult.ValueOrDefault).IsEqualTo("history-2");
+        }
+    }
+
+    [Test]
+    public async Task Render_Uses_Registered_Module_Instance_For_History()
+    {
+        var dependency = new HistoricalDependencyModule();
+        var repository = new InstanceBoundHistoryRepository(dependency);
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleResultRepository>(repository);
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            SkippedModules = [nameof(HistoricalDependencyModule)],
+        });
+        builder.AddModule(dependency);
+        builder.AddModule<HistoricalDependentModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(repository.ReceivedExpectedModule).IsTrue();
+            await Assert.That(nodes.All(node => !node.GetProperty("skipped").GetBoolean()))
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Configured_Skip_With_History_Does_Not_Skip_Dependent()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleResultRepository>(new DependencyHistoryRepository());
+        builder.AddModule<ConfiguredSkippedModule>();
+        builder.AddModule<DependentOnConfiguredSkippedModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var configuredNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(ConfiguredSkippedModule));
+        var dependentNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(DependentOnConfiguredSkippedModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(configuredNode.GetProperty("skipped").GetBoolean()).IsFalse();
+            await Assert.That(configuredNode.GetProperty("skipReason").ValueKind)
+                .IsEqualTo(JsonValueKind.Null);
+            await Assert.That(dependentNode.GetProperty("skipped").GetBoolean()).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task Run_Condition_With_History_Does_Not_Skip_Dependent()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleResultRepository>(new DependencyHistoryRepository());
+        builder.AddModule<ConditionSkippedModule>();
+        builder.AddModule<DependentOnConditionSkippedModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var conditionNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(ConditionSkippedModule));
+        var dependentNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(DependentOnConditionSkippedModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(conditionNode.GetProperty("skipped").GetBoolean()).IsFalse();
+            await Assert.That(conditionNode.GetProperty("skipReason").ValueKind)
+                .IsEqualTo(JsonValueKind.Null);
+            await Assert.That(dependentNode.GetProperty("skipped").GetBoolean()).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task Cascaded_Dependency_With_History_Does_Not_Skip_Downstream_Module()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleResultRepository>(
+            new ModuleTypeHistoryRepository(typeof(DependentOnConditionSkippedModule)));
+        builder.AddModule<ConditionSkippedModule>();
+        builder.AddModule<DependentOnConditionSkippedModule>();
+        builder.AddModule<DownstreamOfConditionSkippedModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var conditionNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(ConditionSkippedModule));
+        var dependentNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(DependentOnConditionSkippedModule));
+        var downstreamNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(DownstreamOfConditionSkippedModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(conditionNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(dependentNode.GetProperty("skipped").GetBoolean()).IsFalse();
+            await Assert.That(downstreamNode.GetProperty("skipped").GetBoolean()).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task Cascaded_History_Lookup_Observes_Cancellation()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleResultRepository>(
+            new CancelingModuleTypeHistoryRepository(
+                typeof(DependentOnConditionSkippedModule),
+                cancellationTokenSource));
+        builder.AddModule<ConditionSkippedModule>();
+        builder.AddModule<DependentOnConditionSkippedModule>();
+        builder.AddModule<DownstreamOfConditionSkippedModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => exporter.RenderAsync(
+                DependencyGraphFormat.Json,
+                cancellationTokenSource.Token));
+    }
+
+    [Test]
+    public async Task Initial_History_Lookup_Stops_After_Cancellation()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var repository = new CancelingModuleTypeHistoryRepository(
+            typeof(HistoricalDependencyModule),
+            cancellationTokenSource);
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleResultRepository>(repository);
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            SkippedModules =
+            [
+                nameof(HistoricalDependencyModule),
+                nameof(DependencyModule),
+            ],
+        });
+        builder.AddModule<HistoricalDependencyModule>();
+        builder.AddModule<DependencyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => exporter.RenderAsync(
+                DependencyGraphFormat.Json,
+                cancellationTokenSource.Token));
+
+        await Assert.That(repository.ReadCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Run_Conditions_And_Their_Cascade_Are_Annotated_As_Skipped()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<ConditionSkippedModule>();
+        builder.AddModule<DependentOnConditionSkippedModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var conditionNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(ConditionSkippedModule));
+        var dependentNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(DependentOnConditionSkippedModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(conditionNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(conditionNode.GetProperty("skipReason").GetString())
+                .Contains(nameof(NeverRunCondition));
+            await Assert.That(dependentNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(dependentNode.GetProperty("skipReason").GetString())
+                .Contains(nameof(ConditionSkippedModule));
+            await Assert.That(_executions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Configured_Skip_Conditions_And_Their_Cascade_Are_Annotated()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<ConfiguredSkippedModule>();
+        builder.AddModule<DependentOnConfiguredSkippedModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var configuredNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(ConfiguredSkippedModule));
+        var dependentNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(DependentOnConfiguredSkippedModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(configuredNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(configuredNode.GetProperty("skipReason").GetString())
+                .IsEqualTo("configured skip");
+            await Assert.That(dependentNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(dependentNode.GetProperty("skipReason").GetString())
+                .Contains(nameof(ConfiguredSkippedModule));
+        }
+    }
+
+    [Test]
+    public async Task Result_Dependent_Configured_Skips_Are_Annotated_As_Unresolved()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<ResultDependentConfiguredSkipModule>();
+        builder.AddModule<DependentOnUnresolvedSkipModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var configuredNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(ResultDependentConfiguredSkipModule));
+        var dependentNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(DependentOnUnresolvedSkipModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(configuredNode.GetProperty("skipped").ValueKind)
+                .IsEqualTo(JsonValueKind.Null);
+            await Assert.That(dependentNode.GetProperty("skipped").ValueKind)
+                .IsEqualTo(JsonValueKind.Null);
+        }
+    }
+
+    [Test]
+    public async Task Async_Configured_Skip_Is_Unresolved_Without_Starting_Work()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<AsyncConfiguredSkipModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(node.GetProperty("skipped").ValueKind)
+                .IsEqualTo(JsonValueKind.Null);
+            await Assert.That(_asyncSkipConditionEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Pipeline_Rejects_Graph_Export_After_Execution()
+    {
+        var directory = Directory.CreateTempSubdirectory("modular-pipelines-graph-");
+        try
+        {
+            using var builder = Pipeline.CreateBuilder();
+            builder.AddModule<ExecutionMutatingModule>();
+            await using var pipeline = await builder.BuildAsync();
+            _ = await pipeline.RunAsync();
+
+            var exception = await Assert.ThrowsAsync<PipelineException>(() =>
+                pipeline.ExportDependencyGraphAsync(
+                    DependencyGraphFormat.Json,
+                    Path.Combine(directory.FullName, "graph.json")));
+
+            await Assert.That(exception!.Message).Contains("before RunAsync starts");
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Exporter_Rejects_Graph_Render_After_Execution()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<ExecutionMutatingModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        _ = await pipeline.RunAsync();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(() =>
+            exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(exception!.Message).Contains("before RunAsync starts");
+    }
+
+    [Test]
+    public async Task Async_Attribute_Condition_Is_Unresolved_Without_Starting_Work()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<AsyncAttributeConditionModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(node.GetProperty("skipped").ValueKind)
+                .IsEqualTo(JsonValueKind.Null);
+            await Assert.That(_asyncSkipConditionEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Deferred_Condition_Attribute_Is_Not_Constructed_During_Planning()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DeferredStatefulConditionModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        _deferredConditionAttributeConstructions = 0;
+        _deferredConditionLogicReads = 0;
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(node.GetProperty("skipped").ValueKind)
+                .IsEqualTo(JsonValueKind.Null);
+            await Assert.That(_deferredConditionAttributeConstructions).IsEqualTo(0);
+            await Assert.That(_deferredConditionLogicReads).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Custom_Generic_Attribute_Requires_Planning_Opt_In()
+    {
+        _customPlanningAttributeEvaluations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<CustomGenericAttributeConditionModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(node.GetProperty("skipped").ValueKind)
+                .IsEqualTo(JsonValueKind.Null);
+            await Assert.That(_customPlanningAttributeEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Safe_Attribute_Skip_Remains_Definitive_With_Async_Attribute()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<SafeSkipWithAsyncAttributeModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(node.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(_asyncSkipConditionEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Safe_False_Any_Remains_Definitive_With_Deferred_Any()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<SafeFalseAnyWithDeferredAnyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
+
+        await Assert.That(node.GetProperty("skipped").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task Synchronous_Skip_Short_Circuits_Before_Async_Condition()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<SynchronouslySkippedBeforeAsyncModule>();
+        builder.AddModule<DependentOnSynchronouslySkippedBeforeAsyncModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var configuredNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(SynchronouslySkippedBeforeAsyncModule));
+        var dependentNode = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(DependentOnSynchronouslySkippedBeforeAsyncModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(configuredNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(configuredNode.GetProperty("skipReason").GetString())
+                .IsEqualTo("synchronous short circuit");
+            await Assert.That(dependentNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(_asyncSkipConditionEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Synchronous_Skip_Short_Circuits_After_Async_Condition()
+    {
+        _asyncSkipConditionEvaluations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<SynchronouslySkippedAfterAsyncModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(node.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(node.GetProperty("skipReason").GetString())
+                .IsEqualTo("synchronous short circuit");
+            await Assert.That(_asyncSkipConditionEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Invalid_Registration_Dependency()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<InvalidDynamicDependencyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        await Assert.ThrowsAsync<ModuleNotRegisteredException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+    }
+
+    [Test]
+    public async Task Render_Validates_Dependency_Before_Configured_Skip()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<InvalidSkippedDynamicDependencyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        await Assert.ThrowsAsync<ModuleNotRegisteredException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+    }
+
+    [Test]
+    public async Task Render_Includes_Registered_Dynamic_Dependency()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<DynamicDependencyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+        var dependencyId = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(DependencyModule)).GetProperty("id").GetString();
+        var dependentId = nodes.Single(node =>
+            node.GetProperty("name").GetString() == nameof(DynamicDependencyModule)).GetProperty("id").GetString();
+        var edge = document.RootElement.GetProperty("edges").EnumerateArray().Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(edge.GetProperty("from").GetString()).IsEqualTo(dependencyId);
+            await Assert.That(edge.GetProperty("to").GetString()).IsEqualTo(dependentId);
+        }
+    }
+
+    [Test]
+    public async Task Render_Preserves_Companion_Attributes_Without_Constructing_Them()
+    {
+        _planningCompanionAttributeConstructions = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<CompanionAwareDynamicDependencyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var constructionsBeforeRender = _planningCompanionAttributeConstructions;
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+            await Assert.That(_planningCompanionAttributeConstructions).IsEqualTo(constructionsBeforeRender);
+        }
+    }
+
+    [Test]
+    public async Task Render_Checks_Attribute_Presence_Without_Constructing_It()
+    {
+        _planningPresenceAttributeConstructions = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<PresenceDependencyModule>();
+        builder.AddModule<AttributePresenceConsumerModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var constructionsBeforeRender = _planningPresenceAttributeConstructions;
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+            await Assert.That(_planningPresenceAttributeConstructions).IsEqualTo(constructionsBeforeRender);
+        }
+    }
+
+    [Test]
+    public async Task Render_Defers_Custom_Dependency_Predicates()
+    {
+        _customDependencyAttributeConstructions = 0;
+        _customDependencyPredicateEvaluations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<RuntimePredicateConsumerModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var constructionsBeforeRender = _customDependencyAttributeConstructions;
+        var evaluationsBeforeRender = _customDependencyPredicateEvaluations;
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(_customDependencyAttributeConstructions).IsEqualTo(constructionsBeforeRender);
+            await Assert.That(_customDependencyPredicateEvaluations).IsEqualTo(evaluationsBeforeRender);
+        }
+
+        _ = await pipeline.RunAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(_customDependencyAttributeConstructions).IsGreaterThan(constructionsBeforeRender);
+            await Assert.That(_customDependencyPredicateEvaluations).IsGreaterThan(evaluationsBeforeRender);
+        }
+    }
+
+    [Test]
+    public async Task Render_Defers_Custom_Inheritance_Selectors()
+    {
+        _customDependencySelectorConstructions = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<RuntimeSelectorConsumerModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var constructionsBeforeRender = _customDependencySelectorConstructions;
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        await Assert.That(_customDependencySelectorConstructions)
+            .IsEqualTo(constructionsBeforeRender);
+    }
+
+    [Test]
+    public async Task Render_Uses_Explicitly_Planning_Safe_Inheritance_Selectors()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<PlanningSafeSelectorConsumerModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Cascades_Skipped_Dynamic_Dependency()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            SkippedModules = [nameof(DependencyModule)],
+        });
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<DynamicDependencyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var dependentNode = document.RootElement.GetProperty("nodes").EnumerateArray()
+            .Single(node => node.GetProperty("name").GetString() == nameof(DynamicDependencyModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(dependentNode.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(dependentNode.GetProperty("skipReason").GetString())
+                .Contains(nameof(DependencyModule));
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Cache_Conditions_Before_Startup_Hooks()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<StartupConditionModule>();
+        builder.AddPipelineGlobalHooks<EnableStartupConditionHook>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var summary = await pipeline.RunAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(document.RootElement.GetProperty("nodes")[0]
+                    .GetProperty("skipped").GetBoolean())
+                .IsTrue();
+            await Assert.That(summary.Results.Single().ModuleStatus).IsEqualTo(Status.Successful);
+            await Assert.That(_executions).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Rejected_Render_Does_Not_Cache_Registration_Before_Startup_Hooks()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<StartupDynamicDependencyModule>();
+        builder.AddPipelineGlobalHooks<EnableStartupDependencyHook>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var dependencyRegistry = pipeline.Services.GetRequiredService<IModuleDependencyRegistry>();
+
+        await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+        var dependenciesBeforeRun = dependencyRegistry
+            .GetDynamicDependencies(typeof(StartupDynamicDependencyModule))
+            .ToArray();
+        var summary = await pipeline.RunAsync();
+        var dependenciesAfterRun = dependencyRegistry
+            .GetDynamicDependencies(typeof(StartupDynamicDependencyModule))
+            .ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(dependenciesBeforeRun).IsEmpty();
+            await Assert.That(summary.Results).Count().IsEqualTo(2);
+            await Assert.That(dependenciesAfterRun).Contains(typeof(DependencyModule));
+        }
+    }
+
+    [Test]
+    public async Task Rejected_Render_Does_Not_Freeze_Direct_Module_Configuration()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(new StartupConfiguredModule());
+        builder.AddPipelineGlobalHooks<EnableStartupConfigurationHook>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+        var summary = await pipeline.RunAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("mutable runtime state");
+            await Assert.That(summary.Results.Single().ModuleStatus).IsEqualTo(Status.Successful);
+            await Assert.That(_executions).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Rejected_Render_Does_Not_Freeze_Factory_Module_Configuration()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new StartupConfiguredModule());
+        builder.AddPipelineGlobalHooks<EnableStartupConfigurationHook>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+        var summary = await pipeline.RunAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("mutable runtime state");
+            await Assert.That(summary.Results.Single().ModuleStatus).IsEqualTo(Status.Successful);
+            await Assert.That(_executions).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Planning_Conditions_Use_The_Supplied_Metadata_Registry()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var conditionHandler = pipeline.Services.GetRequiredService<IModuleConditionHandler>();
+        var runtimeRegistry = pipeline.Services.GetRequiredService<IModuleMetadataRegistry>();
+        var planningRegistry = new ModuleMetadataRegistry(new ModuleAttributeEventService());
+        var module = new PlanningCategoryModule();
+
+        _ = await conditionHandler.ShouldIgnoreForPlanning(module, planningRegistry);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(planningRegistry.GetCategory(typeof(PlanningCategoryModule)))
+                .IsEqualTo("planning");
+            await Assert.That(runtimeRegistry.GetCategory(typeof(PlanningCategoryModule))).IsNull();
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Share_Mutable_Module_State_With_Runtime()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<MutableConfigurationStateModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+        var summary = await pipeline.RunAsync();
+
+        await Assert.That(summary.Results.Single().ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task Render_Preserves_User_Factory_Initialization()
+    {
+        var factoryCalls = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ =>
+        {
+            Interlocked.Increment(ref factoryCalls);
+            return new FactoryInitializedModule { IncludeDependency = true };
+        });
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+            await Assert.That(factoryCalls).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Rejected_Render_Then_Run_Invokes_Registration_Receivers_Once()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<UnsafeRegistrationModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        _planningRegistrationEvents = 0;
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+        var eventsAfterRender = _planningRegistrationEvents;
+        _ = await pipeline.RunAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message)
+                .Contains(nameof(IPlanningSafeModuleRegistrationEventReceiver));
+            await Assert.That(eventsAfterRender).IsEqualTo(0);
+            await Assert.That(_planningRegistrationEvents).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Configures_Factory_Copy_After_Validation()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new MutableConfigurationStateModule());
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var runtimeModule = pipeline.Services.GetServices<IModule>()
+            .OfType<MutableConfigurationStateModule>()
+            .Single();
+        var planningModule = (MutableConfigurationStateModule) pipeline.Services
+            .GetRequiredService<IModuleActivator>()
+            .CreatePlanningModule(typeof(MutableConfigurationStateModule), pipeline.Services);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(runtimeModule.ConfigurationCallCount).IsEqualTo(1);
+            await Assert.That(planningModule.ConfigurationCallCount).IsEqualTo(0);
+        }
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+        var summary = await pipeline.RunAsync();
+
+        await Assert.That(summary.Results.Single().ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Replay_Configuration_Against_Injected_State()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<ConfigurationMutationCounter>();
+        builder.AddModule<InjectedConfigurationMutationModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var counter = pipeline.Services.GetRequiredService<ConfigurationMutationCounter>();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+        _ = await pipeline.RunAsync();
+        var module = pipeline.Services.GetServices<IModule>()
+            .OfType<InjectedConfigurationMutationModule>()
+            .Single();
+        var result = await module;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(counter.Count).IsEqualTo(1);
+            await Assert.That(result.ValueOrDefault).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Replay_Configuration_Against_Global_State()
+    {
+        _globalConfigurationMutations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<GlobalConfigurationMutationModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var mutationsAfterActivation = _globalConfigurationMutations;
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+        _ = await pipeline.RunAsync();
+        var module = pipeline.Services.GetServices<IModule>()
+            .OfType<GlobalConfigurationMutationModule>()
+            .Single();
+        var result = await module;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(mutationsAfterActivation).IsEqualTo(1);
+            await Assert.That(_globalConfigurationMutations).IsEqualTo(1);
+            await Assert.That(result.ValueOrDefault).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Replay_Configuration_Through_Constructor_State()
+    {
+        _constructorConfigurationMutations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<ConstructorConfigurationMutationModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var mutationsAfterActivation = _constructorConfigurationMutations;
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(mutationsAfterActivation).IsEqualTo(1);
+            await Assert.That(_constructorConfigurationMutations).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Replay_Configuration_Through_Virtual_Override()
+    {
+        _globalConfigurationMutations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<VirtualConfigurationMutationModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var mutationsAfterActivation = _globalConfigurationMutations;
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(mutationsAfterActivation).IsEqualTo(1);
+            await Assert.That(_globalConfigurationMutations).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Replay_Configuration_Through_Helper_Virtual_Override()
+    {
+        _globalConfigurationMutations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<HelperVirtualConfigurationMutationModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var mutationsAfterActivation = _globalConfigurationMutations;
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(mutationsAfterActivation).IsEqualTo(1);
+            await Assert.That(_globalConfigurationMutations).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Replay_Configuration_Through_External_Constructor_State()
+    {
+        ExternalConfigurationMutationProbe.Reset();
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<ExternalConstructorConfigurationMutationModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var mutationsAfterActivation = ExternalConfigurationMutationProbe.ConstructorCalls;
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(mutationsAfterActivation).IsEqualTo(1);
+            await Assert.That(ExternalConfigurationMutationProbe.ConstructorCalls).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Replay_Configuration_Through_Framework_State()
+    {
+        var originalValue = Environment.GetEnvironmentVariable(
+            FrameworkConfigurationMutationModule.EnvironmentVariableName);
+        try
+        {
+            Environment.SetEnvironmentVariable(
+                FrameworkConfigurationMutationModule.EnvironmentVariableName,
+                null);
+            using var builder = Pipeline.CreateBuilder();
+            builder.AddModule<FrameworkConfigurationMutationModule>();
+            await using var pipeline = await builder.BuildAsync();
+            var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+            var valueAfterActivation = Environment.GetEnvironmentVariable(
+                FrameworkConfigurationMutationModule.EnvironmentVariableName);
+
+            _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+            await Assert.That(Environment.GetEnvironmentVariable(
+                    FrameworkConfigurationMutationModule.EnvironmentVariableName))
+                .IsEqualTo(valueAfterActivation);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(
+                FrameworkConfigurationMutationModule.EnvironmentVariableName,
+                originalValue);
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Replay_Configuration_Through_Stateful_Core_Api()
+    {
+        var scanner = typeof(ModuleDiscoveryPlanner).GetMethod(
+            "ConfigurationTouchesStaticState",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var touchesStaticState = (bool) scanner.Invoke(
+            null,
+            [new CoreApiConfigurationMutationModule()])!;
+        await Assert.That(touchesStaticState).IsTrue();
+
+        using var pluginScope = PluginRegistry.BeginIsolatedScope();
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<CoreApiConfigurationMutationModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var registrationsAfterActivation = PluginRegistry.Plugins.Count;
+        PluginRegistry.Clear();
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(registrationsAfterActivation).IsEqualTo(1);
+            await Assert.That(PluginRegistry.Plugins).Count().IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Planning_State_Scanners_Fail_Closed_Without_Metadata()
+    {
+        var bodylessMethod = typeof(BodylessPlanningProbe).GetMethod(
+            nameof(BodylessPlanningProbe.Invoke))!;
+        var mutatesDelegateTarget = typeof(ModuleDiscoveryPlanner).GetMethod(
+            "MutatesDelegateTargetField",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var touchesStaticState = typeof(ModuleDiscoveryPlanner).GetMethod(
+            "MethodTouchesStaticState",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var instructionTouchesStaticState = typeof(ModuleDiscoveryPlanner).GetMethod(
+            "InstructionTouchesStaticState",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That((bool) mutatesDelegateTarget.Invoke(
+                null,
+                [bodylessMethod, typeof(BodylessPlanningProbe)])!).IsTrue();
+            await Assert.That((bool) touchesStaticState.Invoke(
+                null,
+                [bodylessMethod, new HashSet<MethodBase>()])!).IsTrue();
+            await Assert.That((bool) instructionTouchesStaticState.Invoke(
+                null,
+                [
+                    bodylessMethod,
+                    OpCodes.Call,
+                    BitConverter.GetBytes(int.MaxValue),
+                    0,
+                    new HashSet<MethodBase>(),
+                ])!).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Static_Runtime_Bound_Planning_Condition()
+    {
+        _staticPlanningSkipEvaluations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<StaticRuntimeBoundPlanningConditionModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("mutable runtime state");
+            await Assert.That(_staticPlanningSkipEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Planning_Callback_Constructor_Mutation()
+    {
+        _planningCallbackConstructorMutations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<ConstructorBoundPlanningConditionModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("mutable runtime state");
+            await Assert.That(_planningCallbackConstructorMutations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Shared_Module_Owned_Holder_Without_Replaying_Constructor()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<ConfigurationMutationCounter>();
+        builder.AddModule<NestedInjectedConfigurationMutationModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var counter = pipeline.Services.GetRequiredService<ConfigurationMutationCounter>();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+            await Assert.That(counter.Activations).IsEqualTo(1);
+            await Assert.That(counter.Count).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Shared_Runtime_Bound_Planning_Condition()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<ConfigurationMutationCounter>();
+        builder.AddModule<InjectedRuntimeBoundPlanningConditionModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(exception!.Message).Contains("mutable runtime state");
+    }
+
+    [Test]
+    public async Task Render_Preserves_Configured_Fallback_Copy()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ => new ConfiguredFallbackFactoryModule("factory-only"));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var runtimeModule = pipeline.Services.GetServices<IModule>()
+            .OfType<ConfiguredFallbackFactoryModule>()
+            .Single();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+            await Assert.That(runtimeModule.ConfigurationCallCount).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Compares_User_Struct_Fields()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ => new StructEqualityFactoryModule(includeDependency: true));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Matches_User_Factory_To_Derived_Runtime_Type()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<FactoryInitializedBaseModule>(
+            _ => new FactoryInitializedDerivedModule { IncludeDependency = true });
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Replay_Factory_With_Different_Initialization()
+    {
+        var factoryCalls = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ => new FactoryInitializedModule
+        {
+            IncludeDependency = Interlocked.Increment(ref factoryCalls) == 1,
+        });
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+            await Assert.That(factoryCalls).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Factory_Replay_With_Shared_Mutable_State()
+    {
+        var sharedState = new List<string>();
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new SharedMutableFactoryStateModule(sharedState));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var configurationCountBeforeExport = sharedState.Count;
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+        await Assert.That(sharedState).Count().IsEqualTo(configurationCountBeforeExport);
+    }
+
+    [Test]
+    public async Task Render_Rejects_Factory_Replay_With_Struct_Wrapped_Shared_State()
+    {
+        var sharedState = new List<string>();
+        var state = new StructWrappedState(sharedState);
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new StructWrappedFactoryStateModule(state));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var configurationCountBeforeExport = sharedState.Count;
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+        await Assert.That(sharedState).Count().IsEqualTo(configurationCountBeforeExport);
+    }
+
+    [Test]
+    public async Task Render_Selects_Planning_Copy_Override_By_Signature()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new OverloadedPlanningCopyModule());
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var graph = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        await Assert.That(graph).Contains(nameof(OverloadedPlanningCopyModule));
+    }
+
+    [Test]
+    public async Task Render_Accepts_Independent_Fieldless_State()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new FieldlessStateFactoryModule());
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var graph = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        await Assert.That(graph).Contains(nameof(FieldlessStateFactoryModule));
+    }
+
+    [Test]
+    public async Task Render_Preserves_Reference_Identity_Dependent_Configuration()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ => new ReferenceIdentityFactoryModule(DependencySentinel));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Preserves_Initialized_External_Configuration()
+    {
+        _externalConfigurationIncludesDependency = true;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ => new ExternalConfigurationFactoryModule());
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        _externalConfigurationIncludesDependency = false;
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Preserves_Configuration_That_Calls_External_Helper()
+    {
+        ExternalConfigurationState.IncludeDependency = true;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<ExternalHelperConfigurationModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        ExternalConfigurationState.IncludeDependency = false;
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Registration_Rejects_Direct_Interface_Module_Without_Activation()
+    {
+        _directModuleActivations = 0;
+        using var builder = Pipeline.CreateBuilder();
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => builder.AddModule<DirectInterfaceModule>());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("must derive from Module<T> or SyncModule<T>");
+            await Assert.That(_directModuleActivations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Registration_Validates_Direct_Module_Before_Configuration()
+    {
+        var runtimeModule = new StatefulDirectInterfaceModule();
+        using var builder = Pipeline.CreateBuilder();
+        StatefulDirectInterfaceModule.InitialConfigurationCallCount = runtimeModule.ConfigurationCallCount;
+
+        try
+        {
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => builder.AddModule(runtimeModule));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(exception!.Message).Contains("must derive from Module<T> or SyncModule<T>");
+                await Assert.That(runtimeModule.ConfigurationCallCount)
+                    .IsEqualTo(StatefulDirectInterfaceModule.InitialConfigurationCallCount);
+            }
+        }
+        finally
+        {
+            StatefulDirectInterfaceModule.InitialConfigurationCallCount = 0;
+        }
+    }
+
+    [Test]
+    public async Task Registration_Rejects_Service_Backed_Direct_Module_Before_Configuration()
+    {
+        var state = new DirectModulePlanningState();
+        var runtimeModule = new ServiceBackedDirectInterfaceModule(state);
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton(state);
+        var configurationReadsBeforeExport = state.ConfigurationReads;
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => builder.AddModule(runtimeModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("must derive from Module<T> or SyncModule<T>");
+            await Assert.That(state.ConfigurationReads).IsEqualTo(configurationReadsBeforeExport);
+        }
+    }
+
+    [Test]
+    public async Task Registration_Rejects_Direct_Interface_Singleton_Factory_Without_Activation()
+    {
+        _directModuleActivations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<DirectInterfaceModule>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            builder.AddModule(serviceProvider =>
+                serviceProvider.GetRequiredService<DirectInterfaceModule>()));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("must derive from Module<T> or SyncModule<T>");
+            await Assert.That(_directModuleActivations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Accepts_Service_Provider_Owned_Factory_State()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton(new PlanningSingletonDependency
+        {
+            IncludeDependency = true,
+        });
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(serviceProvider => new ServiceBackedFactoryModule(
+            serviceProvider.GetRequiredService<PlanningSingletonDependency>()));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Rejects_Different_Inherited_Factory_State()
+    {
+        var factoryCalls = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ => new InheritedSettingsFactoryModule(new DerivedFactorySettings
+        {
+            IncludeDependency = Interlocked.Increment(ref factoryCalls) == 1,
+        }));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+    }
+
+    [Test]
+    public async Task Render_Rejects_Different_Factory_Alias_Topology()
+    {
+        var factoryCalls = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ =>
+        {
+            var first = new AliasState { IncludeDependency = true };
+            var second = Interlocked.Increment(ref factoryCalls) == 1
+                ? first
+                : new AliasState { IncludeDependency = true };
+            return new AliasTopologyFactoryModule(first, second);
+        });
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+    }
+
+    [Test]
+    public async Task Render_Rejects_Different_Factory_Array_Shape()
+    {
+        var factoryCalls = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ => new ArrayShapeFactoryModule(
+            Interlocked.Increment(ref factoryCalls) == 1
+                ? Array.CreateInstance(typeof(int), [1, 2], [0, 0])
+                : Array.CreateInstance(typeof(int), [2, 1], [1, 0])));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+    }
+
+    [Test]
+    public async Task Render_Requires_Copy_For_Mutable_Factory_Collection()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ => new ComparerBackedFactoryModule(
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+    }
+
+    [Test]
+    public async Task Render_Clones_Precreated_Module_With_NonResolvable_Constructor_State()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(new PrecreatedConfiguredModule(new PrecreatedModuleSettings
+        {
+            IncludeDependency = true,
+        }));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Rejects_Shared_Precreated_State_Without_Disposing_It()
+    {
+        var state = new PrecreatedDisposableState();
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(new PrecreatedDisposableModule(state));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+        await Assert.That(state.IsDisposed).IsFalse();
+
+        var summary = await pipeline.RunAsync();
+        var moduleResult = await summary.Modules
+            .OfType<PrecreatedDisposableModule>()
+            .Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+            await Assert.That(moduleResult.ModuleStatus).IsEqualTo(Status.Successful);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Shared_Comparer_With_Captured_State()
+    {
+        var comparisons = 0;
+        var comparer = Comparer<string>.Create((left, right) =>
+        {
+            comparisons++;
+            return StringComparer.Ordinal.Compare(left, right);
+        });
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ => new CapturingComparerFactoryModule(comparer));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        var comparisonsBeforeRender = comparisons;
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+            await Assert.That(comparisons).IsEqualTo(comparisonsBeforeRender);
+        }
+    }
+
+    [Test]
+    public async Task Render_Uses_Planning_Copy_After_Factory_Replay_Mismatch()
+    {
+        var factoryCalls = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule(_ => new FactoryInitializedPlanningCopyModule
+        {
+            IncludeDependency = Interlocked.Increment(ref factoryCalls) == 1,
+        });
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Uses_Runtime_Factory_Type_Without_Replay()
+    {
+        var factoryCalls = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<FactoryInitializedBaseModule>(_ =>
+            Interlocked.Increment(ref factoryCalls) == 1
+                ? new FactoryInitializedDerivedModule()
+                : new FactoryInitializedBaseModule());
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var graph = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(graph).Contains(nameof(FactoryInitializedDerivedModule));
+            await Assert.That(factoryCalls).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Preserves_Factory_Skip_Decision_Without_Replay()
+    {
+        var factoryCalls = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new FactorySkipModule(
+            Interlocked.Increment(ref factoryCalls) == 1));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(document.RootElement.GetProperty("nodes")[0]
+                    .GetProperty("skipped").GetBoolean())
+                .IsTrue();
+            await Assert.That(factoryCalls).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Mutable_Factory_Closure_Without_Evaluating_It()
+    {
+        _executions = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new MutableClosureFactorySkipModule("factory-only"));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+        var summary = await pipeline.RunAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("mutable runtime state");
+            await Assert.That(summary.Results.Single().ModuleStatus).IsEqualTo(Status.Skipped);
+            await Assert.That(_executions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_ByRef_Mutable_Factory_Closure_Without_Evaluating_It()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new ByRefMutableClosureFactorySkipModule("factory-only"));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(exception!.Message).Contains("mutable runtime state");
+    }
+
+    [Test]
+    public async Task Render_Rejects_Mutable_Reference_Closure_Without_Evaluating_It()
+    {
+        _executions = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new MutableReferenceClosureFactorySkipModule("factory-only"));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+        var summary = await pipeline.RunAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("mutable runtime state");
+            await Assert.That(summary.Results.Single().ModuleStatus).IsEqualTo(Status.Skipped);
+            await Assert.That(_executions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Mutable_Struct_Closure_Without_Evaluating_It()
+    {
+        _executions = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new MutableStructClosureFactorySkipModule("factory-only"));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+        var summary = await pipeline.RunAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("mutable runtime state");
+            await Assert.That(summary.Results.Single().ModuleStatus).IsEqualTo(Status.Skipped);
+            await Assert.That(_executions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Runtime_Bound_Factory_Skip_Condition()
+    {
+        RuntimeBoundFactorySkipModule? runtimeModule = null;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => runtimeModule = new RuntimeBoundFactorySkipModule(shouldSkip: true));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+            await Assert.That(runtimeModule!.PlanningEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Runtime_Bound_Method_Group_Skip_Condition()
+    {
+        RuntimeBoundMethodGroupFactorySkipModule? runtimeModule = null;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ =>
+            runtimeModule = new RuntimeBoundMethodGroupFactorySkipModule(shouldSkip: true));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+            await Assert.That(runtimeModule!.PlanningEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Rejects_Runtime_Bound_Collection_Skip_Condition()
+    {
+        RuntimeBoundCollectionFactorySkipModule? runtimeModule = null;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ =>
+            runtimeModule = new RuntimeBoundCollectionFactorySkipModule(shouldSkip: true));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("Override CreatePlanningCopy");
+            await Assert.That(runtimeModule!.PlanningEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Validate_Unused_Async_Factory_Skip_Condition()
+    {
+        RuntimeBoundAsyncFactorySkipModule? runtimeModule = null;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ =>
+            runtimeModule = new RuntimeBoundAsyncFactorySkipModule(shouldSkip: true));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(node.GetProperty("skipped").ValueKind)
+                .IsEqualTo(JsonValueKind.Null);
+            await Assert.That(runtimeModule!.PlanningEvaluations).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Disposes_Copy_When_Configuration_Initialization_Fails()
+    {
+        ConfigurationThrowingDisposableFactoryModule.Disposals = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule(_ => new ConfigurationThrowingDisposableFactoryModule
+        {
+            HasFactoryState = true,
+        });
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).IsEqualTo("Factory state is unavailable.");
+            await Assert.That(ConfigurationThrowingDisposableFactoryModule.Disposals).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task Render_Disposes_Scoped_Planning_Module_After_Each_Render()
+    {
+        _planningDisposals = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddTransient<ContainerOwnedPlanningModule>();
+        builder.AddModule(serviceProvider =>
+            serviceProvider.GetRequiredService<ContainerOwnedPlanningModule>());
+
+        await using (var pipeline = await builder.BuildAsync())
+        {
+            var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+            _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+            await Assert.That(_planningDisposals).IsEqualTo(1);
+
+            _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+            await Assert.That(_planningDisposals).IsEqualTo(2);
+        }
+
+        await Assert.That(_planningDisposals).IsGreaterThan(2);
+    }
+
+    [Test]
+    public async Task Render_Disposes_Indirectly_Resolved_Scoped_Planning_Module()
+    {
+        _planningDisposals = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddTransient<ContainerOwnedPlanningModule>();
+        builder.Services.AddTransient<ContainerOwnedPlanningModuleFactory>();
+        builder.AddModule(serviceProvider => serviceProvider
+            .GetRequiredService<ContainerOwnedPlanningModuleFactory>()
+            .Create());
+
+        await using (var pipeline = await builder.BuildAsync())
+        {
+            var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+            _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+            await Assert.That(_planningDisposals).IsEqualTo(1);
+        }
+
+        await Assert.That(_planningDisposals).IsGreaterThan(1);
+    }
+
+    [Test]
+    public async Task Render_Disposes_Isolated_Copy_When_Factory_Uses_Root_Service()
+    {
+        _planningDisposals = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddTransient<ContainerOwnedPlanningModule>();
+        builder.Services.AddSingleton<ContainerOwnedPlanningModuleFactory>();
+        builder.AddModule(serviceProvider => serviceProvider
+            .GetRequiredService<ContainerOwnedPlanningModuleFactory>()
+            .Create());
+
+        await using (var pipeline = await builder.BuildAsync())
+        {
+            var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+            _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+            await Assert.That(_planningDisposals).IsEqualTo(1);
+        }
+
+        await Assert.That(_planningDisposals).IsGreaterThan(1);
+    }
+
+    [Test]
+    public async Task Render_Accepts_Indirectly_Resolved_Container_State()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<ContainerOwnedPlanningState>();
+        builder.Services.AddTransient<ContainerOwnedPlanningStateFactory>();
+        builder.AddModule(serviceProvider => new ModuleWithContainerOwnedPlanningState(
+            serviceProvider.GetRequiredService<ContainerOwnedPlanningStateFactory>().Create()));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(document.RootElement.GetProperty("nodes").GetArrayLength())
+            .IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Disposes_Scoped_Planning_Copy()
+    {
+        _planningDisposals = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddKeyedTransient<ContainerOwnedPlanningCopyModule>("planning");
+        builder.AddModule(new ContainerOwnedPlanningCopyModule());
+
+        await using (var pipeline = await builder.BuildAsync())
+        {
+            var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+            _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+            await Assert.That(_planningDisposals).IsEqualTo(1);
+        }
+
+        await Assert.That(_planningDisposals).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Disposes_Manually_Constructed_Registered_Planning_Module()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddTransient<ContainerOwnedPlanningModule>();
+        builder.Services.AddSingleton<PlanningFactoryDependency>();
+        builder.AddModule(serviceProvider =>
+        {
+            _ = serviceProvider.GetRequiredService<PlanningFactoryDependency>();
+            return new ContainerOwnedPlanningModule();
+        });
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        _planningDisposals = 0;
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        await Assert.That(_planningDisposals).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Uses_Isolated_Copy_When_Factory_Returns_Runtime_Singleton()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<SingletonFactoryModule>();
+        builder.AddModule(serviceProvider =>
+            serviceProvider.GetRequiredService<SingletonFactoryModule>());
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+
+        await Assert.That(document.RootElement.GetProperty("nodes").GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Render_Disposes_Isolated_Planning_Modules()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DisposablePlanningModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        _planningDisposals = 0;
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+
+        await Assert.That(_planningDisposals).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Dispose_Planning_Modules_Continues_After_Failure()
+    {
+        _planningDisposals = 0;
+        var disposable = new DisposablePlanningModule();
+        var throwing = new ThrowingDisposablePlanningModule();
+
+        var exception = await Assert.ThrowsAsync<AggregateException>(() =>
+            ModuleDiscoveryPlanner.DisposePlanningModulesAsync([disposable, throwing]));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(_planningDisposals).IsEqualTo(1);
+            await Assert.That(exception!.InnerExceptions).HasSingleItem();
+            await Assert.That(exception.InnerExceptions[0].Message).IsEqualTo("Planning disposal failed.");
+        }
+    }
+
+    [Test]
+    public async Task Render_Aggregates_Planner_And_Scope_Cleanup_Failures()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddScoped<ThrowingPlanningScopeService>();
+        builder.AddModule<DualCleanupFailureModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<AggregateException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+        var failures = exception!.Flatten().InnerExceptions;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(failures.Any(failure =>
+                    failure.Message == "Planner-owned disposal failed."))
+                .IsTrue();
+            await Assert.That(failures.Any(failure =>
+                    failure.Message == "Planning scope disposal failed."))
+                .IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Render_Preserves_Discovery_And_Cleanup_Failures()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<ThrowingDisposablePlanningModule>();
+        builder.AddModule<CancelPlanningModule>();
+        var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        _planningCancellation = cancellationTokenSource;
+
+        var exception = await Assert.ThrowsAsync<AggregateException>(
+            () => exporter.RenderAsync(
+                DependencyGraphFormat.Json,
+                cancellationTokenSource.Token));
+        var failures = exception!.Flatten().InnerExceptions;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(failures.OfType<OperationCanceledException>()).HasSingleItem();
+            await Assert.That(failures.Any(failure =>
+                    failure.Message == "Planning disposal failed."))
+                .IsTrue();
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => pipeline.DisposeAsync().AsTask());
+    }
+
+    [Test]
+    public async Task Render_Preserves_Post_Discovery_And_Cleanup_Failures()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<ThrowingDisposablePlanningModule>();
+        builder.AddModule<InvalidDynamicDependencyModule>();
+        var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var exception = await Assert.ThrowsAsync<AggregateException>(
+            () => exporter.RenderAsync(DependencyGraphFormat.Json));
+        var failures = exception!.Flatten().InnerExceptions;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(failures.OfType<ModuleNotRegisteredException>()).HasSingleItem();
+            await Assert.That(failures.Any(failure =>
+                    failure.Message == "Planning disposal failed."))
+                .IsTrue();
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => pipeline.DisposeAsync().AsTask());
+    }
+
+    [Test]
+    public async Task Canceled_Render_Does_Not_Activate_Or_Register_Planning_Modules()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DisposablePlanningModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        _planningActivations = 0;
+        _planningDisposals = 0;
+        _planningRegistrationEvents = 0;
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => exporter.RenderAsync(
+                DependencyGraphFormat.Json,
+                cancellationTokenSource.Token));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(_planningActivations).IsEqualTo(0);
+            await Assert.That(_planningDisposals).IsEqualTo(0);
+            await Assert.That(_planningRegistrationEvents).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task Render_Observes_Cancellation_After_Loading_Estimates()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleEstimatedTimeProvider>(
+            new CancelingEstimatedTimeProvider(cancellationTokenSource));
+        builder.AddModule<DependencyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => exporter.RenderAsync(
+                DependencyGraphFormat.Json,
+                cancellationTokenSource.Token));
+    }
+
+    [Test]
+    public async Task Completed_Summary_Render_Observes_An_Already_Canceled_Token()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var summary = await pipeline.RunAsync();
+        var renderer = pipeline.Services
+            .GetRequiredService<IDependencyGraphExporter>();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => renderer.RenderSummaryAsync(
+                DependencyGraphFormat.Json,
+                summary,
+                cancellationTokenSource.Token));
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Replay_Default_Module_Constructor()
+    {
+        var state = new ConstructorMutationState();
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton(state);
+        builder.AddModule<ConstructorMutatingModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+        var summary = await pipeline.RunAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(state.Activations).IsEqualTo(1);
+            await Assert.That(summary.Results.Single().ModuleStatus)
+                .IsEqualTo(Status.Successful);
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Replay_Factory_Module_Constructor()
+    {
+        var state = new ConstructorMutationState();
+        using var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton(state);
+        builder.AddModule(serviceProvider => new ConstructorMutatingModule(
+            serviceProvider.GetRequiredService<ConstructorMutationState>()));
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+        var summary = await pipeline.RunAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(state.Activations).IsEqualTo(1);
+            await Assert.That(summary.Results.Single().ModuleStatus)
+                .IsEqualTo(Status.Successful);
+        }
+    }
+
+    [Test]
+    public async Task RenderSummary_Matches_Runtime_Results_By_Assembly_Identity()
+    {
+        const string typeName = "Duplicate.SummaryModule";
+        var firstType = CreateDynamicSummaryModuleType("SummaryAssemblyOne", typeName);
+        var secondType = CreateDynamicSummaryModuleType("SummaryAssemblyTwo", typeName);
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModules(firstType, secondType);
+        await using var pipeline = await builder.BuildAsync();
+        var summary = await pipeline.RunAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderSummaryAsync(DependencyGraphFormat.Json, summary));
+
+        await Assert.That(document.RootElement.GetProperty("nodes").GetArrayLength())
+            .IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task RenderSummary_Does_Not_Match_Ambiguous_Destination_Type_Names()
+    {
+        const string typeName = "Duplicate.DeserializedSummaryModule";
+        var firstType = CreateDynamicSummaryModuleType("DeserializedSummaryAssemblyOne", typeName);
+        var secondType = CreateDynamicSummaryModuleType("DeserializedSummaryAssemblyTwo", typeName);
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModules(firstType, secondType);
+        await using var pipeline = await builder.BuildAsync();
+        _ = await pipeline.RunAsync();
+        var modules = pipeline.Services.GetServices<IModule>().ToArray();
+        var now = DateTimeOffset.UtcNow;
+        var result = new ModuleResult.Skipped(SkipDecision.Skip("ambiguous skip"))
+        {
+            ModuleName = "DeserializedSummaryModule",
+            ModuleTypeName = typeName,
+            ModuleDuration = TimeSpan.Zero,
+            ModuleStart = now,
+            ModuleEnd = now,
+            ModuleStatus = Status.Skipped,
+        };
+        var summary = new PipelineSummary(
+            modules,
+            [result],
+            TimeSpan.Zero,
+            now,
+            now);
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderSummaryAsync(DependencyGraphFormat.Json, summary));
+        var nodes = document.RootElement.GetProperty("nodes").EnumerateArray().ToArray();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(nodes).Count().IsEqualTo(2);
+            await Assert.That(nodes.All(node => !node.GetProperty("skipped").GetBoolean())).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task RenderSummary_Reuses_Initialized_Dependency_Models()
+    {
+        _customDependencyPredicateEvaluations = 0;
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<RuntimePredicateConsumerModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var summary = await pipeline.RunAsync();
+        var evaluationsAfterRun = _customDependencyPredicateEvaluations;
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderSummaryAsync(DependencyGraphFormat.Json, summary));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(_customDependencyPredicateEvaluations).IsEqualTo(evaluationsAfterRun);
+            await Assert.That(document.RootElement.GetProperty("edges").GetArrayLength()).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task RenderSummary_Matches_Deserialized_Result_By_Type_Name()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var module = pipeline.Services.GetServices<IModule>()
+            .OfType<DependencyModule>()
+            .Single();
+        var now = DateTimeOffset.UtcNow;
+        var result = new ModuleResult.Skipped(SkipDecision.Skip("distributed skip"))
+        {
+            ModuleName = nameof(DependencyModule),
+            ModuleTypeName = typeof(DependencyModule).FullName,
+            ModuleDuration = TimeSpan.Zero,
+            ModuleStart = now,
+            ModuleEnd = now,
+            ModuleStatus = Status.Skipped,
+        };
+        var summary = new PipelineSummary(
+            [module],
+            [result],
+            TimeSpan.Zero,
+            now,
+            now);
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderSummaryAsync(DependencyGraphFormat.Json, summary));
+        var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.ModuleType).IsNull();
+            await Assert.That(node.GetProperty("skipped").GetBoolean()).IsTrue();
+            await Assert.That(node.GetProperty("skipReason").GetString()).IsEqualTo("distributed skip");
+        }
+    }
+
+    [Test]
+    public async Task Render_Uses_Fresh_Stateful_Condition_Attributes()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<SingleUseConditionModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        _ = await exporter.RenderAsync(DependencyGraphFormat.Json);
+        var summary = await pipeline.RunAsync();
+
+        await Assert.That(summary.Results.Single().ModuleStatus).IsEqualTo(Status.Successful);
+    }
+
+    [Test]
+    public async Task Render_Can_Retry_After_Canceled_Module_Discovery()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<DependencyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => exporter.RenderAsync(
+                DependencyGraphFormat.Json,
+                cancellationTokenSource.Token));
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        await Assert.That(document.RootElement.GetProperty("nodes").GetArrayLength()).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Dot_Escapes_Line_Breaks_Inside_Label_Values()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<LineBreakCategoryModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var dot = await exporter.RenderAsync(DependencyGraphFormat.Dot);
+
+        await Assert.That(dot).Contains(@"Category: build\nrelease");
+    }
+
+    [Test]
+    public async Task Mermaid_Escapes_Markdown_Fence_Content()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<MarkdownFenceCategoryModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        var mermaid = await exporter.RenderAsync(DependencyGraphFormat.Mermaid);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(mermaid).DoesNotContain("\n```");
+            await Assert.That(mermaid).Contains("&#96;&#96;&#96;");
+            await Assert.That(mermaid).Contains("build<br/>&#96;&#96;&#96;<br/>release");
+        }
+    }
+
+    private static Type CreateDynamicSummaryModuleType(
+        string assemblyName,
+        string typeName)
+    {
+        var assembly = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName(assemblyName),
+            AssemblyBuilderAccess.Run);
+        return assembly
+            .DefineDynamicModule(assemblyName)
+            .DefineType(typeName, TypeAttributes.Public, typeof(SummaryIdentityModuleBase))
+            .CreateType()!;
+    }
+
+    private static PipelineBuilder CreateBuilder()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.Services.AddSingleton<IModuleEstimatedTimeProvider, FixedEstimatedTimeProvider>();
+        builder.AddModule<DependencyModule>();
+        builder.AddModule<TargetModule>();
+        builder.AddModule<SkippedModule>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            SkippedModules = [nameof(DependencyModule)],
+        });
+        return builder;
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
@@ -49,6 +49,7 @@ public class DependencyGraphExporterTests
     private static int _customDependencyAttributeConstructions;
     private static int _customDependencyPredicateEvaluations;
     private static int _customDependencySelectorConstructions;
+    private static int _planningTargetAttributeConstructions;
 
     private sealed class ConstructorMutationState
     {
@@ -201,6 +202,64 @@ public class DependencyGraphExporterTests
             IModuleContext context,
             CancellationToken cancellationToken) =>
             Task.FromResult<string?>("attribute-presence-consumer");
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class StatefulPlanningTargetAttribute : Attribute
+    {
+        public StatefulPlanningTargetAttribute() =>
+            Interlocked.Increment(ref _planningTargetAttributeConstructions);
+    }
+
+    [StatefulPlanningTarget]
+    private sealed class StatefulPlanningTargetModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("stateful-target");
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class PlanningAttributeValueSelectorAttribute : PlanningSafeDependsOnBaseAttribute
+    {
+        public override bool ShouldDependOn(Type candidateModule, IDependencyContext context) =>
+            context.GetAttribute<StatefulPlanningTargetAttribute>(candidateModule) is not null;
+    }
+
+    [PlanningAttributeValueSelector]
+    private sealed class PlanningAttributeValueConsumerModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("attribute-value-consumer");
+    }
+
+    private sealed class OptionalPlanningDependencyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("optional-dependency");
+    }
+
+    private sealed class OptionalLookupPlanningSkipModule : Module<string>
+    {
+        protected override Module<string> CreatePlanningCopy(IServiceProvider serviceProvider) =>
+            new OptionalLookupPlanningSkipModule();
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithSkipWhen(context =>
+                context.GetModuleIfRegistered<OptionalPlanningDependencyModule>() is null
+                    ? SkipDecision.DoNotSkip
+                    : SkipDecision.Skip("Runtime dependency was exposed during planning"))
+            .Build();
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("optional-lookup");
     }
 
     [AttributeUsage(AttributeTargets.Class)]
@@ -2200,6 +2259,66 @@ public class DependencyGraphExporterTests
         {
             directory.Delete(recursive: true);
         }
+    }
+
+    [Test]
+    public async Task Builder_Export_Does_Not_Run_Runtime_Dependency_Validation()
+    {
+        var directory = Directory.CreateTempSubdirectory("modular-pipelines-graph-");
+        try
+        {
+            var path = Path.Combine(directory.FullName, "graph.json");
+            using var builder = Pipeline.CreateBuilder();
+            builder.AddModule<DependencyModule>();
+            builder.AddModule<RuntimePredicateConsumerModule>();
+            _customDependencyAttributeConstructions = 0;
+            _customDependencyPredicateEvaluations = 0;
+
+            await builder.ExportDependencyGraphAsync(DependencyGraphFormat.Json, path);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(_customDependencyAttributeConstructions).IsEqualTo(0);
+                await Assert.That(_customDependencyPredicateEvaluations).IsEqualTo(0);
+            }
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Expose_Runtime_Modules_To_Planning_Skip_Conditions()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<OptionalPlanningDependencyModule>();
+        builder.AddModule<OptionalLookupPlanningSkipModule>();
+        await using var pipeline = await builder.BuildAsync();
+
+        using var document = JsonDocument.Parse(
+            await pipeline.Services.GetRequiredService<IDependencyGraphExporter>()
+                .RenderAsync(DependencyGraphFormat.Json));
+        var lookupNode = document.RootElement.GetProperty("nodes").EnumerateArray()
+            .Single(node => node.GetProperty("name").GetString()
+                == nameof(OptionalLookupPlanningSkipModule));
+
+        await Assert.That(lookupNode.GetProperty("skipped").ValueKind).IsEqualTo(JsonValueKind.Null);
+    }
+
+    [Test]
+    public async Task Render_Does_Not_Construct_Target_Attribute_Values_During_Planning()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<StatefulPlanningTargetModule>();
+        builder.AddModule<PlanningAttributeValueConsumerModule>();
+        await using var pipeline = await builder.BuildAsync();
+        _planningTargetAttributeConstructions = 0;
+
+        _ = await pipeline.Services.GetRequiredService<IDependencyGraphExporter>()
+            .RenderAsync(DependencyGraphFormat.Json);
+
+        await Assert.That(_planningTargetAttributeConstructions).IsEqualTo(0);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
@@ -2419,7 +2419,7 @@ public class DependencyGraphExporterTests
     }
 
     [Test]
-    public async Task Render_Does_Not_Construct_Target_Attribute_Values_During_Planning()
+    public async Task Render_Rejects_Planning_Predicates_That_Require_Target_Attribute_Values()
     {
         using var builder = Pipeline.CreateBuilder();
         builder.AddModule<StatefulPlanningTargetModule>();
@@ -2427,10 +2427,16 @@ public class DependencyGraphExporterTests
         await using var pipeline = await builder.BuildAsync();
         _planningTargetAttributeConstructions = 0;
 
-        _ = await pipeline.Services.GetRequiredService<IDependencyGraphExporter>()
-            .RenderAsync(DependencyGraphFormat.Json);
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await pipeline.Services.GetRequiredService<IDependencyGraphExporter>()
+                .RenderAsync(DependencyGraphFormat.Json));
 
-        await Assert.That(_planningTargetAttributeConstructions).IsEqualTo(0);
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message)
+                .Contains(nameof(StatefulPlanningTargetAttribute));
+            await Assert.That(_planningTargetAttributeConstructions).IsEqualTo(0);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/DependencyGraphExporterTests.cs
@@ -50,6 +50,7 @@ public class DependencyGraphExporterTests
     private static int _customDependencyPredicateEvaluations;
     private static int _customDependencySelectorConstructions;
     private static int _planningTargetAttributeConstructions;
+    private static int _singleUseConfigurationCalls;
 
     private sealed class ConstructorMutationState
     {
@@ -1777,6 +1778,19 @@ public class DependencyGraphExporterTests
             throw new InvalidOperationException("Deferred condition must not run during planning.");
     }
 
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    private sealed class PlanningAlternativeConditionAttribute(bool result)
+        : Attribute, IGroupedConditionAttribute, IPlanningConditionAttribute
+    {
+        public ConditionLogic Logic => ConditionLogic.Any;
+
+        public Type ConditionGroupType => typeof(PlanningAlternativeConditionAttribute);
+
+        public string ConditionNames => nameof(PlanningAlternativeConditionAttribute);
+
+        public Task<bool> EvaluateAsync(IPipelineContext context) => Task.FromResult(result);
+    }
+
     [AttributeUsage(AttributeTargets.Class)]
     private sealed class AsyncPlanningConditionAttribute : RunIfAllAttribute
     {
@@ -1855,6 +1869,35 @@ public class DependencyGraphExporterTests
             IModuleContext context,
             CancellationToken cancellationToken) =>
             Task.FromResult<string?>("safe-false-any-with-deferred-any");
+    }
+
+    [PlanningAlternativeCondition(false)]
+    [PlanningAlternativeCondition(false)]
+    [DeferredAnyCondition]
+    private sealed class SafeFalseAnyGroupWithDeferredAnyModule : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("safe-false-any-group-with-deferred-any");
+    }
+
+    private sealed class SingleUseConfigurationFactoryModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure()
+        {
+            if (Interlocked.Increment(ref _singleUseConfigurationCalls) != 1)
+            {
+                throw new InvalidOperationException("Configuration was replayed.");
+            }
+
+            return ModuleConfiguration.Default;
+        }
+
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<string?>("single-use-configuration");
     }
 
     [AddStartupDependency(typeof(DependencyModule))]
@@ -2281,6 +2324,48 @@ public class DependencyGraphExporterTests
                 await Assert.That(_customDependencyAttributeConstructions).IsEqualTo(0);
                 await Assert.That(_customDependencyPredicateEvaluations).IsEqualTo(0);
             }
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Builder_Export_Configures_Uninitialized_Factory_Once()
+    {
+        var directory = Directory.CreateTempSubdirectory("modular-pipelines-graph-");
+        try
+        {
+            _singleUseConfigurationCalls = 0;
+            var path = Path.Combine(directory.FullName, "graph.json");
+            using var builder = Pipeline.CreateBuilder();
+            builder.AddModule(_ => new SingleUseConfigurationFactoryModule());
+
+            await builder.ExportDependencyGraphAsync(DependencyGraphFormat.Json, path);
+
+            await Assert.That(_singleUseConfigurationCalls).IsEqualTo(1);
+        }
+        finally
+        {
+            directory.Delete(recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task Builder_Export_Configures_Uninitialized_Registered_Instance_Once()
+    {
+        var directory = Directory.CreateTempSubdirectory("modular-pipelines-graph-");
+        try
+        {
+            _singleUseConfigurationCalls = 0;
+            var path = Path.Combine(directory.FullName, "graph.json");
+            using var builder = Pipeline.CreateBuilder();
+            builder.AddModule(new SingleUseConfigurationFactoryModule());
+
+            await builder.ExportDependencyGraphAsync(DependencyGraphFormat.Json, path);
+
+            await Assert.That(_singleUseConfigurationCalls).IsEqualTo(1);
         }
         finally
         {
@@ -2883,6 +2968,21 @@ public class DependencyGraphExporterTests
     {
         using var builder = Pipeline.CreateBuilder();
         builder.AddModule<SafeFalseAnyWithDeferredAnyModule>();
+        await using var pipeline = await builder.BuildAsync();
+        var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
+
+        using var document = JsonDocument.Parse(
+            await exporter.RenderAsync(DependencyGraphFormat.Json));
+        var node = document.RootElement.GetProperty("nodes").EnumerateArray().Single();
+
+        await Assert.That(node.GetProperty("skipped").GetBoolean()).IsTrue();
+    }
+
+    [Test]
+    public async Task Safe_False_Any_Group_Remains_Definitive_With_Deferred_Any()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.AddModule<SafeFalseAnyGroupWithDeferredAnyModule>();
         await using var pipeline = await builder.BuildAsync();
         var exporter = pipeline.Services.GetRequiredService<IDependencyGraphExporter>();
 

--- a/test/ModularPipelines.UnitTests/Engine/ModuleConditionHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleConditionHandlerTests.cs
@@ -124,6 +124,27 @@ public class ModuleConditionHandlerTests
     }
 
     [Test]
+    public async Task Distributed_Master_Graph_Defers_Routable_Os_Condition()
+    {
+        var handler = CreateHandler(new DistributedOptions
+        {
+            Enabled = true,
+            InstanceIndex = 0,
+            TotalInstances = 3,
+        });
+
+        var result = await handler.ShouldIgnoreForGraphPlanning(
+            CreateForeignOsModule(),
+            Mock.Of<IModuleMetadataRegistry>());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.ShouldIgnore).IsFalse();
+            await Assert.That(result.IsResolved).IsFalse();
+        }
+    }
+
+    [Test]
     public async Task Distributed_Master_Does_Not_Filter_Unix_Condition_Group()
     {
         var handler = CreateHandler(new DistributedOptions

--- a/test/ModularPipelines.UnitTests/Engine/ModuleConditionHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleConditionHandlerTests.cs
@@ -18,6 +18,7 @@ namespace ModularPipelines.UnitTests.Engine;
 public class ModuleConditionHandlerTests
 {
     private static int _conditionEvaluationCount;
+    private static int _deferredDiscoveryConditionConstructions;
 
     [Test]
     public async Task Distributed_Master_Does_Not_Filter_Foreign_Os_Module()
@@ -121,6 +122,22 @@ public class ModuleConditionHandlerTests
         var result = await handler.ShouldIgnoreByCategory(CreateForeignOsModule());
 
         await Assert.That(result.ShouldIgnore).IsFalse();
+    }
+
+    [Test]
+    public async Task Distributed_Master_Discovery_Does_Not_Construct_Deferred_Conditions()
+    {
+        var handler = CreateHandler(new DistributedOptions
+        {
+            Enabled = true,
+            InstanceIndex = 0,
+            TotalInstances = 3,
+        });
+        _deferredDiscoveryConditionConstructions = 0;
+
+        _ = await handler.ShouldIgnoreByCategory(new DeferredDiscoveryConditionModule());
+
+        await Assert.That(_deferredDiscoveryConditionConstructions).IsEqualTo(0);
     }
 
     [Test]
@@ -265,6 +282,27 @@ public class ModuleConditionHandlerTests
         {
             return Task.FromResult(string.Empty);
         }
+    }
+
+    [DeferredDiscoveryCondition]
+    private sealed class DeferredDiscoveryConditionModule : Module<string>
+    {
+        protected internal override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(string.Empty);
+    }
+
+    private sealed class DeferredDiscoveryConditionAttribute : Attribute, IConditionAttribute
+    {
+        public DeferredDiscoveryConditionAttribute() =>
+            Interlocked.Increment(ref _deferredDiscoveryConditionConstructions);
+
+        public ConditionLogic Logic => ConditionLogic.All;
+
+        public string ConditionNames => nameof(DeferredDiscoveryConditionAttribute);
+
+        public Task<bool> EvaluateAsync(IPipelineContext context) => Task.FromResult(true);
     }
 
     [RunIfAll<OnUnix>]


### PR DESCRIPTION
Closes #3539

Adds canonical dependency-graph export in Mermaid, DOT, and JSON; `--graph` CLI support; builder/pipeline APIs; annotated nodes; GitHub step-summary flowchart; documentation and regression coverage.

Validation:
- `ModularPipelines.slnx` Release build: 0 warnings/errors
- `src/ModularPipelines.GitHub/ModularPipelines.GitHub.slnx` Release build: 0 errors (3 pre-existing nullable test warnings)
- `DependencyGraphExporterTests`: 124/124
- `PipelineCommandLineTests`: 77/77
- `ModularPipelines.GitHub.UnitTests`: 9/9