### PR TITLE
Disable external Spectre logger scopes

### DIFF
--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -76,6 +76,8 @@ internal static class DependencyInjectionSetup
         config.Template = "[{Level:u4}] {Message}";
         config.ExceptionFormats = ExceptionFormats.Default;
         config.AllowMarkupInMessageTemplate = true;
+        config.IncludeScopes = false;
+        config.IncludeActivity = false;
         config.Theme = new SpectreTheme()
             .WithPlaceholders(placeholders =>
             {

--- a/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SpectreConsoleLoggerTests.cs
@@ -39,6 +39,17 @@ public class SpectreConsoleLoggerTests
     }
 
     [Test]
+    public async Task Configuration_Disables_External_Scope_And_Activity_Rendering()
+    {
+        var options = new SpectreConsoleLoggerOptions();
+
+        DependencyInjectionSetup.ConfigureSpectreConsoleLogger(options, AnsiConsole.Console);
+
+        await Assert.That(options.IncludeScopes).IsFalse();
+        await Assert.That(options.IncludeActivity).IsFalse();
+    }
+
+    [Test]
     public async Task Terminates_Each_Log_Entry_Once()
     {
         var writer = new StringWriter();


### PR DESCRIPTION
## Summary
- disable MEL.Spectre scope capture because ModularPipelines owns log grouping
- disable activity rendering for replayed buffered module logs
- cover both logger options with a regression test

## Test plan
- [x] SpectreConsoleLoggerTests (7/7)
- [x] ModularPipelines.sln Release build (0 warnings, 0 errors)
- [x] targeted whitespace formatting

Closes #3556
