### PR TITLE
Print resolved Git information in build output

### DIFF
--- a/src/ModularPipelines.Build/Modules/PrintGitInformationModule.cs
+++ b/src/ModularPipelines.Build/Modules/PrintGitInformationModule.cs
@@ -9,10 +9,11 @@ namespace ModularPipelines.Build.Modules;
 
 public class PrintGitInformationModule : Module<IDictionary<string, object>>
 {
-    protected override Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task<IDictionary<string, object>?> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        context.Logger.LogInformation("Git Info: {GitInfo}", JsonSerializer.Serialize(context.Git().Information, DiagnosticSerializerOptions.Instance));
+        var gitInformation = await context.Git().Information.GetInfoAsync(cancellationToken);
+        context.Logger.LogInformation("Git Info: {GitInfo}", JsonSerializer.Serialize(gitInformation, DiagnosticSerializerOptions.Instance));
 
-        return Task.FromResult<IDictionary<string, object>?>(null);
+        return null;
     }
 }


### PR DESCRIPTION
## Summary

- await `IGitInformation.GetInfoAsync` before serializing build-pipeline Git diagnostics
- forward module cancellation to Git information loading
- log the resolved repository model instead of the service object (`{}`)

## Validation

- `ModularPipelines.Build.csproj` Release build succeeded
- 0 errors; 2 pre-existing unrelated StyleCop warnings in `MasterServerHost.cs` and `PackProjectsModule.cs`
- full build pipeline was not executed per repository guidance

Closes #3553