### PR TITLE
Isolate process environment tests

### DIFF
--- a/test/ModularPipelines.Distributed.Discovery.Redis.UnitTests/RunIdentifierResolverTests.cs
+++ b/test/ModularPipelines.Distributed.Discovery.Redis.UnitTests/RunIdentifierResolverTests.cs
@@ -2,7 +2,7 @@ using ModularPipelines.Distributed.Discovery.Redis;
 
 namespace ModularPipelines.Distributed.Discovery.Redis.UnitTests;
 
-[TUnit.Core.NotInParallel]
+[TUnit.Core.NotInParallel("ProcessEnvironment")]
 public class RunIdentifierResolverTests
 {
     private static readonly string[] CiEnvironmentVariables =

--- a/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
+++ b/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
@@ -1402,7 +1402,7 @@ public class ModuleCacheTests
     }
 
     [Test]
-    [TUnit.Core.NotInParallel(nameof(ModuleCacheTests))]
+    [TUnit.Core.NotInParallel("ProcessEnvironment")]
     public async Task UnsetAndLiteralNullEnvironmentValuesHaveDifferentFingerprints()
     {
         var temporaryDirectory = Path.Combine(

--- a/test/ModularPipelines.UnitTests/Engine/IgnoredModuleResultRegistrarTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/IgnoredModuleResultRegistrarTests.cs
@@ -13,7 +13,7 @@ using Moq;
 
 namespace ModularPipelines.UnitTests.Engine;
 
-[TUnit.Core.NotInParallel("MODULAR_PIPELINES_INSTANCE")]
+[TUnit.Core.NotInParallel("ProcessEnvironment")]
 public class IgnoredModuleResultRegistrarTests
 {
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/ModuleConditionHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleConditionHandlerTests.cs
@@ -14,7 +14,7 @@ using Moq;
 
 namespace ModularPipelines.UnitTests.Engine;
 
-[TUnit.Core.NotInParallel("MODULAR_PIPELINES_INSTANCE")]
+[TUnit.Core.NotInParallel("ProcessEnvironment")]
 public class ModuleConditionHandlerTests
 {
     private static int _conditionEvaluationCount;

--- a/test/ModularPipelines.UnitTests/Helpers/EnvironmentContextTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/EnvironmentContextTests.cs
@@ -3,6 +3,7 @@ using ModularPipelines.TestHelpers;
 
 namespace ModularPipelines.UnitTests.Helpers;
 
+[TUnit.Core.NotInParallel("ProcessEnvironment")]
 public class EnvironmentContextTests : TestBase
 {
     [Test]
@@ -10,12 +11,15 @@ public class EnvironmentContextTests : TestBase
     {
         var guid = Guid.NewGuid().ToString("N");
 
-        Environment.SetEnvironmentVariable(guid, TestConstants.TestString);
+        await RunWithEnvironmentRestored(guid, async () =>
+        {
+            Environment.SetEnvironmentVariable(guid, TestConstants.TestString);
 
-        var context = await GetService<IEnvironmentContext>();
+            var context = await GetService<IEnvironmentContext>();
 
-        var result = context.EnvironmentVariables.GetEnvironmentVariable(guid);
-        await Assert.That(result).IsEqualTo(TestConstants.TestString);
+            var result = context.EnvironmentVariables.GetEnvironmentVariable(guid);
+            await Assert.That(result).IsEqualTo(TestConstants.TestString);
+        });
     }
 
     [Test]
@@ -23,14 +27,17 @@ public class EnvironmentContextTests : TestBase
     {
         var guid = Guid.NewGuid().ToString("N");
 
-        Environment.SetEnvironmentVariable(guid, TestConstants.TestString);
+        await RunWithEnvironmentRestored(guid, async () =>
+        {
+            Environment.SetEnvironmentVariable(guid, TestConstants.TestString);
 
-        var context = await GetService<IEnvironmentContext>();
+            var context = await GetService<IEnvironmentContext>();
 
-        var result = context.EnvironmentVariables.GetEnvironmentVariables();
-        await Assert.That(result).IsNotNull();
-        await Assert.That((object) result).IsAssignableTo<IReadOnlyDictionary<string, string>>();
-        await Assert.That(result[guid]).IsEqualTo(TestConstants.TestString);
+            var result = context.EnvironmentVariables.GetEnvironmentVariables();
+            await Assert.That(result).IsNotNull();
+            await Assert.That((object) result).IsAssignableTo<IReadOnlyDictionary<string, string>>();
+            await Assert.That(result[guid]).IsEqualTo(TestConstants.TestString);
+        });
     }
 
     [Test]
@@ -38,12 +45,15 @@ public class EnvironmentContextTests : TestBase
     {
         var guid = Guid.NewGuid().ToString("N");
 
-        var context = await GetService<IEnvironmentContext>();
+        await RunWithEnvironmentRestored(guid, async () =>
+        {
+            var context = await GetService<IEnvironmentContext>();
 
-        context.EnvironmentVariables.SetEnvironmentVariable(guid, TestConstants.TestString);
+            context.EnvironmentVariables.SetEnvironmentVariable(guid, TestConstants.TestString);
 
-        var result = Environment.GetEnvironmentVariable(guid);
-        await Assert.That(result).IsEqualTo(TestConstants.TestString);
+            var result = Environment.GetEnvironmentVariable(guid);
+            await Assert.That(result).IsEqualTo(TestConstants.TestString);
+        });
     }
 
     [Test]
@@ -53,14 +63,17 @@ public class EnvironmentContextTests : TestBase
 
         var directoryToAdd = Path.Combine(TestContext.WorkingDirectory, Guid.NewGuid().ToString("N"));
 
-        var path = context.EnvironmentVariables.GetPath();
-        await Assert.That(path).IsNotEmpty();
-        await Assert.That(path).DoesNotContain(directoryToAdd);
+        await RunWithEnvironmentRestored("PATH", async () =>
+        {
+            var path = context.EnvironmentVariables.GetPath();
+            await Assert.That(path).IsNotEmpty();
+            await Assert.That(path).DoesNotContain(directoryToAdd);
 
-        context.EnvironmentVariables.AddToPath(directoryToAdd);
+            context.EnvironmentVariables.AddToPath(directoryToAdd);
 
-        path = context.EnvironmentVariables.GetPath();
-        await Assert.That(path).Contains(directoryToAdd);
+            path = context.EnvironmentVariables.GetPath();
+            await Assert.That(path).Contains(directoryToAdd);
+        });
     }
 
     [Test]
@@ -78,6 +91,22 @@ public class EnvironmentContextTests : TestBase
             await Assert.That(context.AppDomainDirectory).IsNotNull();
             await Assert.That(context.GetFolder(Environment.SpecialFolder.LocalApplicationData)).IsNotNull();
             await Assert.That(context.EnvironmentName).IsNotNull();
+        }
+    }
+
+    private static async Task RunWithEnvironmentRestored(
+        string variableName,
+        Func<Task> action)
+    {
+        var previousValue = Environment.GetEnvironmentVariable(variableName);
+
+        try
+        {
+            await action();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(variableName, previousValue);
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Requirements/RequireFactoryTests.cs
+++ b/test/ModularPipelines.UnitTests/Requirements/RequireFactoryTests.cs
@@ -11,6 +11,7 @@ using Status = ModularPipelines.Enums.Status;
 
 namespace ModularPipelines.UnitTests.Requirements;
 
+[TUnit.Core.NotInParallel("ProcessEnvironment")]
 public class RequireFactoryTests
 {
     [Test]
@@ -88,7 +89,7 @@ public class RequireFactoryTests
     [Test]
     public async Task Require_EnvironmentVariable_When_Set_Passes()
     {
-        const string varName = "TEST_REQUIREMENT_VAR";
+        var varName = $"TEST_REQUIREMENT_VAR_{Guid.NewGuid():N}";
         Environment.SetEnvironmentVariable(varName, "some-value");
         try
         {
@@ -112,8 +113,7 @@ public class RequireFactoryTests
     [Test]
     public async Task Require_EnvironmentVariable_When_Not_Set_Fails()
     {
-        const string varName = "UNLIKELY_TO_EXIST_VAR_12345";
-        Environment.SetEnvironmentVariable(varName, null);
+        var varName = $"UNLIKELY_TO_EXIST_VAR_{Guid.NewGuid():N}";
 
         var executePipelineDelegate = async () =>
         {
@@ -131,9 +131,8 @@ public class RequireFactoryTests
     [Test]
     public async Task Require_EnvironmentVariable_With_Custom_Reason()
     {
-        const string varName = "UNLIKELY_TO_EXIST_VAR_67890";
+        var varName = $"UNLIKELY_TO_EXIST_VAR_{Guid.NewGuid():N}";
         const string customReason = "My custom message about the var";
-        Environment.SetEnvironmentVariable(varName, null);
 
         var executePipelineDelegate = async () =>
         {


### PR DESCRIPTION
## Summary
- serialize every process-environment-mutating test with the shared `ProcessEnvironment` constraint
- replace fixed requirement variable names with GUID-scoped names
- restore all environment mutations in `finally`, including the previously leaked `PATH`

## Test plan
- [x] affected core classes (25/25)
- [x] cache environment fingerprint test (1/1)
- [x] Redis run identifier tests (3/3)
- [x] EnvironmentContextTests after cleanup refactor (5/5)
- [x] core Release build (0 warnings, 0 errors)
- [x] Redis solution Release build (0 errors; one unrelated existing SignalR SA1502 warning)
- [x] targeted whitespace formatting

Closes #3533
