### PR TITLE
Mask entire configuration sections as secrets

### DIFF
--- a/docs/docs/how-to/secrets.md
+++ b/docs/docs/how-to/secrets.md
@@ -27,3 +27,27 @@ public record MySettings
     public string? ApiKey { get; set; }
 }
 ```
+
+## Mask a configuration section
+
+When a configuration provider supplies a group of secrets, you can register every leaf value in
+that section without adding `[SecretValue]` to an options class:
+
+```csharp
+using var builder = Pipeline.CreateBuilder();
+
+builder.MaskConfigurationSection("Secrets");
+```
+
+Nested values such as `Secrets:Database:Password` are included. Missing sections and empty values
+are ignored. The values are registered during pipeline startup and use the same log and CI-native
+masking as `[SecretValue]` and `ISecretRegistry`.
+
+You can also configure multiple sections through options:
+
+```csharp
+builder.Services.Configure<SecretMaskingOptions>(options =>
+{
+    options.MaskedConfigurationSections = ["Secrets", "ConnectionStrings"];
+});
+```

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -305,14 +305,9 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
 
     private static IEnumerable<string?> GetLeafValues(IConfigurationSection section)
     {
-        var children = section.GetChildren().ToArray();
-        if (children.Length == 0)
-        {
-            yield return section.Value;
-            yield break;
-        }
+        yield return section.Value;
 
-        foreach (var child in children)
+        foreach (var child in section.GetChildren())
         {
             foreach (var value in GetLeafValues(child))
             {

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using Initialization.Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
@@ -24,6 +25,7 @@ namespace ModularPipelines.Engine;
 /// </para>
 /// <list type="bullet">
 /// <item>Properties marked with <see cref="SecretValueAttribute"/> on IOptions classes (discovered at initialization)</item>
+/// <item>Leaf values beneath configured <see cref="SecretMaskingOptions.MaskedConfigurationSections"/> paths</item>
 /// <item>Secrets registered programmatically via <see cref="ISecretRegistry"/> (can be added at any time)</item>
 /// </list>
 /// </remarks>
@@ -36,6 +38,7 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
     private readonly IBuildSystemSecretMasker _buildSystemSecretMasker;
     private readonly IOptions<SecretMaskingOptions> _maskingOptions;
     private readonly ILogger<SecretProvider> _logger;
+    private readonly IConfiguration? _configuration;
     private readonly HashSet<string> _secrets = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, byte> _nativeMaskPatterns = new();
     private readonly ConcurrentDictionary<string, byte> _shortSecretWarnings = new();
@@ -62,12 +65,14 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
         IOptionsProvider optionsProvider,
         IBuildSystemSecretMasker buildSystemSecretMasker,
         IOptions<SecretMaskingOptions> maskingOptions,
-        ILogger<SecretProvider> logger)
+        ILogger<SecretProvider> logger,
+        IConfiguration? configuration = null)
     {
         _optionsProvider = optionsProvider;
         _buildSystemSecretMasker = buildSystemSecretMasker;
         _maskingOptions = maskingOptions;
         _logger = logger;
+        _configuration = configuration;
     }
 
     /// <inheritdoc />
@@ -185,6 +190,7 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             }
 
             AddSecrets(GetSecrets(_optionsProvider.GetOptions()));
+            AddSecrets(GetConfiguredSectionSecrets());
 
             _initialized = true;
         }
@@ -275,6 +281,42 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             foreach (var secret in GetSecretsInObject(option))
             {
                 yield return secret;
+            }
+        }
+    }
+
+    private IEnumerable<string?> GetConfiguredSectionSecrets()
+    {
+        if (_configuration is null)
+        {
+            yield break;
+        }
+
+        foreach (var sectionPath in _maskingOptions.Value.MaskedConfigurationSections
+                     .Where(static path => !string.IsNullOrWhiteSpace(path))
+                     .Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            foreach (var value in GetLeafValues(_configuration.GetSection(sectionPath)))
+            {
+                yield return value;
+            }
+        }
+    }
+
+    private static IEnumerable<string?> GetLeafValues(IConfigurationSection section)
+    {
+        var children = section.GetChildren().ToArray();
+        if (children.Length == 0)
+        {
+            yield return section.Value;
+            yield break;
+        }
+
+        foreach (var child in children)
+        {
+            foreach (var value in GetLeafValues(child))
+            {
+                yield return value;
             }
         }
     }

--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -195,6 +195,28 @@ public static class PipelineBuilderExtensions
     }
 
     /// <summary>
+    /// Registers every leaf value beneath a configuration section as a secret during pipeline startup.
+    /// </summary>
+    /// <param name="builder">The pipeline builder.</param>
+    /// <param name="sectionPath">The configuration section path, such as <c>Secrets</c>.</param>
+    /// <returns>The same builder instance for chaining.</returns>
+    public static PipelineBuilder MaskConfigurationSection(this PipelineBuilder builder, string sectionPath)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sectionPath);
+
+        builder.Services.Configure<SecretMaskingOptions>(options =>
+        {
+            options.MaskedConfigurationSections = options.MaskedConfigurationSections
+                .Append(sectionPath)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        });
+
+        return builder;
+    }
+
+    /// <summary>
     /// Builds the pipeline and executes it.
     /// </summary>
     /// <param name="builder">The pipeline builder.</param>

--- a/src/ModularPipelines/Options/SecretMaskingOptions.cs
+++ b/src/ModularPipelines/Options/SecretMaskingOptions.cs
@@ -79,6 +79,16 @@ public record SecretMaskingOptions
     public string MaskValue { get; set; } = "**********";
 
     /// <summary>
+    /// Gets or sets the configuration section paths whose leaf values are registered as secrets.
+    /// </summary>
+    /// <remarks>
+    /// Paths use the standard configuration delimiter, for example <c>Secrets</c> or
+    /// <c>Tenants:Production:Credentials</c>. Values are collected once during pipeline startup.
+    /// Missing sections and empty values are ignored.
+    /// </remarks>
+    public IReadOnlyList<string> MaskedConfigurationSections { get; set; } = [];
+
+    /// <summary>
     /// Gets default secret masking options with case-sensitive matching and minimum length of 3.
     /// </summary>
     public static SecretMaskingOptions Default { get; } = new();

--- a/test/ModularPipelines.UnitTests/Logging/ConfigurationSectionSecretMaskingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ConfigurationSectionSecretMaskingTests.cs
@@ -1,0 +1,90 @@
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Context;
+using ModularPipelines.Extensions;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+using ModularPipelines.TestHelpers;
+
+namespace ModularPipelines.UnitTests.Logging;
+
+public class ConfigurationSectionSecretMaskingTests
+{
+    private sealed class ConfigurationLoggingModule(IConfiguration configuration) : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            context.Logger.LogInformation("First secret: {Secret}", configuration["Secrets:ApiKey"]);
+            context.Logger.LogInformation("Nested secret: {Secret}", configuration["Secrets:Database:Password"]);
+            context.Logger.LogInformation("Connection: {Secret}", configuration["ConnectionStrings:Database"]);
+            context.Logger.LogInformation("Public value: {Value}", configuration["Public:Value"]);
+            return Task.FromResult(true);
+        }
+    }
+
+    [Test]
+    public async Task FluentConfigurationMasksNestedLeavesOnly()
+    {
+        var output = new StringBuilder();
+        using var builder = CreateBuilder(output);
+        builder.MaskConfigurationSection("Secrets");
+
+        await builder.ExecutePipelineAsync();
+
+        var log = output.ToString();
+        await Assert.That(log).DoesNotContain("api-secret-123");
+        await Assert.That(log).DoesNotContain("database-secret-456");
+        await Assert.That(log).Contains("connection-visible");
+        await Assert.That(log).Contains("public-visible");
+        await Assert.That(log).Contains("**********");
+    }
+
+    [Test]
+    public async Task OptionsCanMaskMultipleSections()
+    {
+        var output = new StringBuilder();
+        using var builder = CreateBuilder(output);
+        builder.Services.Configure<SecretMaskingOptions>(options =>
+            options.MaskedConfigurationSections = ["Secrets", "ConnectionStrings", "Missing"]);
+
+        await builder.ExecutePipelineAsync();
+
+        var log = output.ToString();
+        await Assert.That(log).DoesNotContain("api-secret-123");
+        await Assert.That(log).DoesNotContain("database-secret-456");
+        await Assert.That(log).DoesNotContain("connection-visible");
+        await Assert.That(log).Contains("public-visible");
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task FluentConfigurationRejectsInvalidPaths(string? sectionPath)
+    {
+        using var builder = TestPipelineHostBuilder.Create();
+
+        await Assert.That(() => builder.MaskConfigurationSection(sectionPath!))
+            .Throws<ArgumentException>();
+    }
+
+    private static PipelineBuilder CreateBuilder(StringBuilder output)
+    {
+        var builder = TestPipelineHostBuilder.Create();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["Secrets:ApiKey"] = "api-secret-123",
+            ["Secrets:Database:Password"] = "database-secret-456",
+            ["ConnectionStrings:Database"] = "connection-visible",
+            ["Public:Value"] = "public-visible",
+        });
+        builder.Services.AddSingleton<ILogger<ConfigurationLoggingModule>>(
+            new StringLogger<ConfigurationLoggingModule>(output));
+        builder.AddModule<ConfigurationLoggingModule>();
+        return builder;
+    }
+}

--- a/test/ModularPipelines.UnitTests/Logging/ConfigurationSectionSecretMaskingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ConfigurationSectionSecretMaskingTests.cs
@@ -20,6 +20,7 @@ public class ConfigurationSectionSecretMaskingTests
         {
             context.Logger.LogInformation("First secret: {Secret}", configuration["Secrets:ApiKey"]);
             context.Logger.LogInformation("Nested secret: {Secret}", configuration["Secrets:Database:Password"]);
+            context.Logger.LogInformation("Section secret: {Secret}", configuration["Secrets"]);
             context.Logger.LogInformation("Connection: {Secret}", configuration["ConnectionStrings:Database"]);
             context.Logger.LogInformation("Public value: {Value}", configuration["Public:Value"]);
             return Task.FromResult(true);
@@ -27,7 +28,7 @@ public class ConfigurationSectionSecretMaskingTests
     }
 
     [Test]
-    public async Task FluentConfigurationMasksNestedLeavesOnly()
+    public async Task FluentConfigurationMasksSectionValuesAndNestedLeaves()
     {
         var output = new StringBuilder();
         using var builder = CreateBuilder(output);
@@ -38,6 +39,7 @@ public class ConfigurationSectionSecretMaskingTests
         var log = output.ToString();
         await Assert.That(log).DoesNotContain("api-secret-123");
         await Assert.That(log).DoesNotContain("database-secret-456");
+        await Assert.That(log).DoesNotContain("section-secret-789");
         await Assert.That(log).Contains("connection-visible");
         await Assert.That(log).Contains("public-visible");
         await Assert.That(log).Contains("**********");
@@ -56,6 +58,7 @@ public class ConfigurationSectionSecretMaskingTests
         var log = output.ToString();
         await Assert.That(log).DoesNotContain("api-secret-123");
         await Assert.That(log).DoesNotContain("database-secret-456");
+        await Assert.That(log).DoesNotContain("section-secret-789");
         await Assert.That(log).DoesNotContain("connection-visible");
         await Assert.That(log).Contains("public-visible");
     }
@@ -77,6 +80,7 @@ public class ConfigurationSectionSecretMaskingTests
         var builder = TestPipelineHostBuilder.Create();
         builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
         {
+            ["Secrets"] = "section-secret-789",
             ["Secrets:ApiKey"] = "api-secret-123",
             ["Secrets:Database:Password"] = "database-secret-456",
             ["ConnectionStrings:Database"] = "connection-visible",


### PR DESCRIPTION
## Summary
- add SecretMaskingOptions.MaskedConfigurationSections and MaskConfigurationSection(...) builder sugar
- register nested configuration leaf values through the existing secret registry at startup, including CI-native masking
- document both configuration forms and cover nested, multiple, missing, and invalid sections

## Validation
- core Release build: 0 warnings/errors
- ConfigurationSectionSecretMaskingTests: 5/5
- SecretMaskingTests: 13/13
- PublicCollectionApiTests: 2/2

Closes #3544