### PR TITLE
Skip tests when required tools are missing

### DIFF
--- a/test/ModularPipelines.Node.UnitTests/Helpers/NodeTests.cs
+++ b/test/ModularPipelines.Node.UnitTests/Helpers/NodeTests.cs
@@ -18,6 +18,7 @@ public class NodeTests : TestBase
     }
 
     [Test]
+    [RequiresTool("node")]
     public async Task Has_Not_Errored()
     {
         var moduleResult = await await RunModule<NodeVersionModule>();
@@ -26,6 +27,7 @@ public class NodeTests : TestBase
     }
 
     [Test]
+    [RequiresTool("node")]
     public async Task Standard_Output_Is_Version_Number()
     {
         var moduleResult = await await RunModule<NodeVersionModule>();

--- a/test/ModularPipelines.TestHelpers/RequiresToolAttribute.cs
+++ b/test/ModularPipelines.TestHelpers/RequiresToolAttribute.cs
@@ -1,0 +1,87 @@
+using System.Collections.Concurrent;
+
+namespace ModularPipelines.TestHelpers;
+
+public sealed class RequiresToolAttribute : SkipAttribute
+{
+    private static readonly ConcurrentDictionary<string, Lazy<bool>> ToolAvailability =
+        new(OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+
+    private readonly string _tool;
+
+    public RequiresToolAttribute(string tool)
+        : base($"Requires tool '{tool}' on PATH")
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tool);
+        _tool = tool;
+    }
+
+    public override Task<bool> ShouldSkip(TestRegisteredContext context)
+    {
+        var isAvailable = ToolAvailability.GetOrAdd(
+            _tool,
+            static tool => new Lazy<bool>(() => IsAvailableOnPath(tool)));
+
+        return Task.FromResult(!isAvailable.Value);
+    }
+
+    private static bool IsAvailableOnPath(string tool)
+    {
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        var candidateNames = GetCandidateNames(tool);
+        return path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(entry => entry.Trim('"'))
+            .Where(entry => entry.Length > 0)
+            .Any(entry => candidateNames.Any(candidateName => IsExecutable(Path.Combine(entry, candidateName))));
+    }
+
+    private static string[] GetCandidateNames(string tool)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return [tool];
+        }
+
+        var pathExtensions = Environment.GetEnvironmentVariable("PATHEXT") ?? ".COM;.EXE;.BAT;.CMD";
+        return
+        [
+            tool,
+            .. pathExtensions.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(extension => tool + extension),
+        ];
+    }
+
+    private static bool IsExecutable(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return false;
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            return true;
+        }
+
+        try
+        {
+            const UnixFileMode executeBits = UnixFileMode.UserExecute |
+                                             UnixFileMode.GroupExecute |
+                                             UnixFileMode.OtherExecute;
+            return (File.GetUnixFileMode(path) & executeBits) != 0;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Attributes/RequiresToolAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/RequiresToolAttributeTests.cs
@@ -1,0 +1,36 @@
+using ModularPipelines.TestHelpers;
+
+namespace ModularPipelines.UnitTests.Attributes;
+
+public class RequiresToolAttributeTests
+{
+    [Test]
+    public async Task Does_Not_Skip_Tool_On_Path()
+    {
+        var attribute = new RequiresToolAttribute("dotnet");
+
+        var shouldSkip = await attribute.ShouldSkip(null!);
+
+        await Assert.That(shouldSkip).IsFalse();
+    }
+
+    [Test]
+    public async Task Skips_Tool_Not_On_Path()
+    {
+        var attribute = new RequiresToolAttribute($"missing-tool-{Guid.NewGuid():N}");
+
+        var shouldSkip = await attribute.ShouldSkip(null!);
+
+        await Assert.That(shouldSkip).IsTrue();
+    }
+
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments(" ")]
+    public async Task Rejects_Missing_Tool_Name(string? tool)
+    {
+        await Assert.That(() => new RequiresToolAttribute(tool!))
+            .Throws<ArgumentException>();
+    }
+}

--- a/test/ModularPipelines.UnitTests/Helpers/BashTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/BashTests.cs
@@ -33,6 +33,7 @@ public class BashTests : TestBase
     }
 
     [Test]
+    [RequiresTool("bash")]
     public async Task Has_Not_Errored()
     {
         var moduleResult = await await RunModule<BashCommandModule>();
@@ -41,6 +42,7 @@ public class BashTests : TestBase
     }
 
     [Test]
+    [RequiresTool("bash")]
     public async Task Standard_Output_Equals_Foo_Bar()
     {
         var moduleResult = await await RunModule<BashCommandModule>();
@@ -50,6 +52,7 @@ public class BashTests : TestBase
 
     [Test]
     [LinuxOnlyTest]
+    [RequiresTool("bash")]
     public async Task Standard_Output_From_Script_Equals_Foo_Bar()
     {
         var moduleResult = await await RunModule<BashScriptModule>();

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -168,10 +168,15 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    public Task Dry_Run_Command_Exposes_Obfuscated_Environment_Variables() =>
+        AssertCommandExposesObfuscatedEnvironmentVariables(dryRun: true);
+
+    [Test]
     [RequiresTool("pwsh")]
-    [Arguments(false)]
-    [Arguments(true)]
-    public async Task Successful_And_Dry_Run_Commands_Expose_Obfuscated_Environment_Variables(bool dryRun)
+    public Task Successful_Command_Exposes_Obfuscated_Environment_Variables() =>
+        AssertCommandExposesObfuscatedEnvironmentVariables(dryRun: false);
+
+    private async Task AssertCommandExposesObfuscatedEnvironmentVariables(bool dryRun)
     {
         const string secret = "command-result-secret-value";
         var (command, pipeline) = await GetService<ICommandContext>(_ => { });
@@ -204,11 +209,15 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    public Task Dry_Run_Command_Preserves_Unix_Environment_Name_Casing() =>
+        AssertCommandPreservesUnixEnvironmentNameCasing(dryRun: true);
+
+    [Test]
     [RequiresTool("pwsh")]
-    [Arguments(false)]
-    [Arguments(true)]
-    public async Task Successful_And_Dry_Run_Commands_Preserve_Unix_Environment_Name_Casing(
-        bool dryRun)
+    public Task Successful_Command_Preserves_Unix_Environment_Name_Casing() =>
+        AssertCommandPreservesUnixEnvironmentNameCasing(dryRun: false);
+
+    private async Task AssertCommandPreservesUnixEnvironmentNameCasing(bool dryRun)
     {
         if (OperatingSystem.IsWindows())
         {

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -39,6 +39,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     public async Task Command_Execution_Caps_Captured_Output_With_Head_And_Tail()
     {
         var command = await GetService<ICommandContext>();
@@ -79,6 +80,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     public async Task Has_Not_Errored()
     {
         var moduleResult = await await RunModule<CommandEchoModule>();
@@ -87,6 +89,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     public async Task Standard_Output_Equals_Foo_Bar()
     {
         var moduleResult = await await RunModule<CommandEchoModule>();
@@ -103,6 +106,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     public async Task Failed_Command_Exposes_Obfuscated_Result()
     {
         const string secret = "command-result-secret-value";
@@ -140,6 +144,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     public async Task Successful_Command_Exposes_Obfuscated_Input()
     {
         const string secret = "successful-command-input-secret";
@@ -163,6 +168,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     [Arguments(false)]
     [Arguments(true)]
     public async Task Successful_And_Dry_Run_Commands_Expose_Obfuscated_Environment_Variables(bool dryRun)
@@ -198,6 +204,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     [Arguments(false)]
     [Arguments(true)]
     public async Task Successful_And_Dry_Run_Commands_Preserve_Unix_Environment_Name_Casing(
@@ -436,6 +443,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     public async Task ExecuteCommandLineToolAsync_ForcefulCancellation_KillsDescendantProcesses()
     {
         var pidFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-child-{Guid.NewGuid():N}.pid");
@@ -486,6 +494,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     public async Task ExecuteCommandLineToolAsync_ForcefulCancellation_KillsDescendantAfterParentExits()
     {
         var fileSuffix = Guid.NewGuid().ToString("N");
@@ -540,6 +549,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     public async Task ExecuteCommandLineToolAsync_GracefulExit_DoesNotWaitForForcefulTimeout()
     {
         var parentExitFile = Path.Combine(
@@ -580,6 +590,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     public async Task ExecuteCommandLineToolAsync_ExecutionTimeout_ThrowsTimeoutException()
     {
         var command = await GetService<ICommandContext>();
@@ -600,6 +611,7 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    [RequiresTool("pwsh")]
     public async Task ExecuteCommandLineToolAsync_ForcefulCancellation_CapturesDescendantSpawnedDuringGrace()
     {
         var fileSuffix = Guid.NewGuid().ToString("N");


### PR DESCRIPTION
Closes #3532

Adds a cached, cross-platform RequiresTool test attribute and applies it to bash, node, and pwsh-dependent tests so lean machines report explicit skips.

Validation:
- ModularPipelines.sln Release build
- ModularPipelines.Node.sln Release build
- RequiresToolAttributeTests (5/5)
- BashTests (2 passed, 1 Linux-only skip)
- CommandTests (22/22)
- NodeTests (3/3)
- scoped format verification