### PR TITLE
Fix and bound default branch detection

### DIFF
--- a/src/ModularPipelines.Git/GitInformation.cs
+++ b/src/ModularPipelines.Git/GitInformation.cs
@@ -165,45 +165,49 @@ internal class GitInformation : IGitInformation
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        try
-        {
-            var output = await GetOutput(
-                command,
-                logger,
-                new GitRemoteShowOptions { Remote = "origin" },
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-            if (output == null)
+        var localOutput = await GetOutput(
+            command,
+            logger,
+            new GenericCommandLineToolOptions("git")
             {
-                return null;
-            }
-
-            return output.Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-                .FirstOrDefault(x => x.StartsWith("HEAD branch:"))
-                ?.Split("HEAD branch: ")[1];
-        }
-        catch (Exception ex) when (ex is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
-        {
-            // Fallback: If 'git remote show origin' fails (e.g., no remote configured, network issues,
-            // or shallow clone), try parsing origin/HEAD reference instead. This provides a best-effort
-            // approach to determine the default branch in various git repository states.
-            logger.LogDebug(ex, "Failed to get default branch from 'git remote show origin', falling back to origin/HEAD");
-            var output = await GetOutput(command, logger, new GitRevParseOptions
-            {
-                Committish = "origin/HEAD",
-                AbbrevRef = true,
-            }, new CommandExecutionOptions
+                Arguments = ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+            },
+            new CommandExecutionOptions
             {
                 ThrowOnNonZeroExitCode = false,
-            }, cancellationToken).ConfigureAwait(false);
-
-            return output?.Replace("origin/", string.Empty);
+            },
+            cancellationToken).ConfigureAwait(false);
+        if (localOutput?.StartsWith("origin/", StringComparison.Ordinal) == true)
+        {
+            return localOutput["origin/".Length..];
         }
+
+        var remoteOutput = await GetOutput(
+            command,
+            logger,
+            new GitRemoteShowOptions { Remote = "origin" },
+            new CommandExecutionOptions
+            {
+                ThrowOnNonZeroExitCode = false,
+                ExecutionTimeout = TimeSpan.FromSeconds(10),
+            },
+            cancellationToken).ConfigureAwait(false);
+        if (remoteOutput == null)
+        {
+            return null;
+        }
+
+        const string headBranchPrefix = "HEAD branch:";
+        var headBranch = remoteOutput
+            .Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(line => line.StartsWith(headBranchPrefix, StringComparison.Ordinal));
+        return headBranch?[headBranchPrefix.Length..].Trim();
     }
 
     private static async Task<string?> GetOutput(
         ICommandContext command,
         ILogger logger,
-        GitOptions gitOptions,
+        CommandLineToolOptions gitOptions,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {

--- a/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
@@ -4,6 +4,7 @@ using ModularPipelines.Context.Domains.Shell;
 using Moq;
 using ModularPipelines.Git;
 using ModularPipelines.Git.Extensions;
+using ModularPipelines.Git.Options;
 using ModularPipelines.Models;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
@@ -51,6 +52,46 @@ public class GitInformationTests : TestBase
             services.AddSingleton<ICommandContext>(command.Object));
 
         await Assert.That(await result.T.GetInfoAsync()).IsNull();
+        await result.Host.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Default_Branch_Uses_Local_Origin_Head_Without_Remote_Query()
+    {
+        var command = CreateRepositoryCommand((options, _) => options switch
+        {
+            GenericCommandLineToolOptions { Tool: "git" } => CommandResult.Ok("origin/main\n"),
+            _ => CommandResult.Ok(),
+        });
+        var result = await GetGitInformation(command);
+
+        var repository = await result.T.GetInfoAsync();
+
+        await Assert.That(repository?.DefaultBranchName).IsEqualTo("main");
+        command.Verify(context => context.ExecuteCommandLineToolAsync(
+            It.IsAny<GitRemoteShowOptions>(),
+            It.IsAny<CommandExecutionOptions?>(),
+            It.IsAny<CancellationToken>()), Times.Never());
+        await result.Host.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Default_Branch_Bounds_Remote_Fallback_When_Local_Head_Is_Unavailable()
+    {
+        CommandExecutionOptions? remoteExecutionOptions = null;
+        var command = CreateRepositoryCommand((options, executionOptions) => options switch
+        {
+            GenericCommandLineToolOptions { Tool: "git" } => CommandResult.Ok(),
+            GitRemoteShowOptions => CaptureRemoteOptions(executionOptions, out remoteExecutionOptions),
+            _ => CommandResult.Ok(),
+        });
+        var result = await GetGitInformation(command);
+
+        var repository = await result.T.GetInfoAsync();
+
+        await Assert.That(repository?.DefaultBranchName).IsEqualTo("trunk");
+        await Assert.That(remoteExecutionOptions?.ThrowOnNonZeroExitCode).IsFalse();
+        await Assert.That(remoteExecutionOptions?.ExecutionTimeout).IsEqualTo(TimeSpan.FromSeconds(10));
         await result.Host.DisposeAsync();
     }
 
@@ -112,5 +153,44 @@ public class GitInformationTests : TestBase
 
         await Assert.That(observedToken).IsEqualTo(cancellationTokenSource.Token);
         await result.Host.DisposeAsync();
+    }
+
+    private static Mock<ICommandContext> CreateRepositoryCommand(
+        Func<CommandLineToolOptions, CommandExecutionOptions?, CommandResult> responseFactory)
+    {
+        var command = new Mock<ICommandContext>();
+        command.Setup(context => context.ExecuteCommandLineToolAsync(
+                It.IsAny<CommandLineToolOptions>(),
+                It.IsAny<CommandExecutionOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CommandLineToolOptions options, CommandExecutionOptions? executionOptions, CancellationToken _) =>
+                options is GitRevParseOptions { ShowToplevel: true }
+                    ? CommandResult.Ok(Environment.CurrentDirectory)
+                    : responseFactory(options, executionOptions));
+        return command;
+    }
+
+    private async Task<(IGitInformation T, IPipeline Host)> GetGitInformation(
+        Mock<ICommandContext> command)
+    {
+        var runner = new Mock<IGitCommandRunner>();
+        runner.Setup(x => x.RunCommandsOrNull(
+                It.IsAny<CommandExecutionOptions?>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?[]>()))
+            .ReturnsAsync((string?) null);
+        return await GetService<IGitInformation>((_, services) =>
+        {
+            services.AddSingleton<ICommandContext>(command.Object);
+            services.AddSingleton(runner.Object);
+        });
+    }
+
+    private static CommandResult CaptureRemoteOptions(
+        CommandExecutionOptions? executionOptions,
+        out CommandExecutionOptions? capturedOptions)
+    {
+        capturedOptions = executionOptions;
+        return CommandResult.Ok("HEAD branch: trunk\n");
     }
 }


### PR DESCRIPTION
Closes #3477.

- resolve `origin/HEAD` locally with `git symbolic-ref` before any remote query
- make the remote fallback non-throwing and bound it to 10 seconds
- add coverage for local short-circuiting and fallback execution settings

Validation:
- 2 focused fallback tests: passed
- live `DefaultBranchName` integration test: passed
- `ModularPipelines.Git.sln` Release build: 0 warnings, 0 errors