### PR TITLE
Reduce repeated default-timeout log noise

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -405,11 +405,11 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         {
             if (timeout == TimeSpan.Zero)
             {
-                moduleContext.Logger.LogDebug("No module timeout configured. The pipeline default timeout is disabled");
+                moduleContext.Logger.LogTrace("No module timeout configured. The pipeline default timeout is disabled");
             }
             else
             {
-                moduleContext.Logger.LogDebug("No module timeout configured. Using pipeline default timeout {Timeout}", timeout);
+                moduleContext.Logger.LogTrace("No module timeout configured. Using pipeline default timeout {Timeout}", timeout);
             }
         }
 

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -112,6 +112,18 @@ public class ModuleExecutionPipelineTests
         var linkedCancellationTokenSource = executionContext.ModuleCancellationTokenSource;
         Assert.Throws<ObjectDisposedException>(() => _ = originalCancellationTokenSource.Token);
         Assert.Throws<ObjectDisposedException>(() => _ = linkedCancellationTokenSource.Token);
+        logger.Verify(x => x.Log(
+            LogLevel.Trace,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((state, _) => state.ToString()!.StartsWith("No module timeout configured.")),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+        logger.Verify(x => x.Log(
+            LogLevel.Debug,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((state, _) => state.ToString()!.StartsWith("No module timeout configured.")),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Never);
     }
 
     private sealed class CachedSuccessfulModule : SuccessfulModule


### PR DESCRIPTION
Closes #3456.

- demote per-module default-timeout diagnostics from Debug to Trace
- add regression coverage proving the notice no longer appears at Debug

Validation:
- focused module execution logging test: passed
- `ModularPipelines.sln` Release build: 0 warnings, 0 errors