### PR TITLE
Replace fixed test windows with ordering signals

### DIFF
--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -368,14 +368,10 @@ public class OutputCoordinatorTests
         await Assert.ThrowsAsync<OperationCanceledException>(async () => await flush);
 
         var waitForPendingFlushes = coordinator.WaitForPendingFlushesAsync();
-        var completedBeforeRelease = ReferenceEquals(
-            await Task.WhenAny(waitForPendingFlushes, Task.Delay(TimeSpan.FromMilliseconds(50))),
-            waitForPendingFlushes);
+        await Assert.That(waitForPendingFlushes.IsCompleted).IsFalse();
 
         buffer.ReleaseFlush.TrySetResult();
         await waitForPendingFlushes;
-
-        await Assert.That(completedBeforeRelease).IsFalse();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -368,10 +368,14 @@ public class OutputCoordinatorTests
         await Assert.ThrowsAsync<OperationCanceledException>(async () => await flush);
 
         var waitForPendingFlushes = coordinator.WaitForPendingFlushesAsync();
-        await Assert.That(waitForPendingFlushes.IsCompleted).IsFalse();
+        var completedBeforeRelease = ReferenceEquals(
+            await Task.WhenAny(waitForPendingFlushes, Task.Delay(TimeSpan.FromMilliseconds(50))),
+            waitForPendingFlushes);
 
         buffer.ReleaseFlush.TrySetResult();
         await waitForPendingFlushes;
+
+        await Assert.That(completedBeforeRelease).IsFalse();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -289,6 +289,7 @@ public class AlwaysRunHandlerTests
         var prerequisiteStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releasePrerequisite = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var dependentStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ModuleExecutionState? prerequisiteStateWhenDependentStarted = null;
 
         moduleRunner
             .Setup(x => x.ExecuteWithoutDependencyWaitAsync(
@@ -309,6 +310,7 @@ public class AlwaysRunHandlerTests
                 CancellationToken.None))
             .Returns(() =>
             {
+                prerequisiteStateWhenDependentStarted = prerequisiteState.State;
                 dependentStarted.TrySetResult();
                 dependentState.State = ModuleExecutionState.Completed;
                 dependentState.CompletionSource.TrySetResult(dependent);
@@ -321,19 +323,12 @@ public class AlwaysRunHandlerTests
             [prerequisite, dependent]);
 
         await prerequisiteStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        moduleRunner.Verify(x => x.ExecuteWithoutDependencyWaitAsync(
-            dependentState,
-            scheduler.Object,
-            CancellationToken.None), Times.Never);
-
         releasePrerequisite.TrySetResult();
         await dependentStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await handlerTask;
 
-        moduleRunner.Verify(x => x.ExecuteWithoutDependencyWaitAsync(
-            dependentState,
-            scheduler.Object,
-            CancellationToken.None), Times.Once);
+        await Assert.That(prerequisiteStateWhenDependentStarted)
+            .IsEqualTo(ModuleExecutionState.Completed);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -279,7 +279,6 @@ public class AlwaysRunHandlerTests
     [Test]
     public async Task WaitForAlwaysRunModulesAsync_PreservesAlwaysRunDependencyOrder()
     {
-        var timeProvider = TestPipelineHostBuilder.CreateFakeTimeProvider();
         var prerequisite = new FirstAlwaysRunModule();
         var dependent = new SecondAlwaysRunModule();
         var prerequisiteState = new ModuleState(prerequisite, prerequisite.GetType());
@@ -316,21 +315,25 @@ public class AlwaysRunHandlerTests
                 return Task.CompletedTask;
             });
 
-        var handler = CreateHandler(moduleRunner.Object, timeProvider: timeProvider);
+        var handler = CreateHandler(moduleRunner.Object);
         var handlerTask = handler.WaitForAlwaysRunModulesAsync(
             scheduler.Object,
             [prerequisite, dependent]);
 
         await prerequisiteStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        var dependencyObservation = Task.WhenAny(
-            dependentStarted.Task,
-            Task.Delay(TimeSpan.FromMilliseconds(200), timeProvider));
-        timeProvider.Advance(TimeSpan.FromMilliseconds(200));
-        var dependentStartedBeforePrerequisiteCompleted = await dependencyObservation == dependentStarted.Task;
+        moduleRunner.Verify(x => x.ExecuteWithoutDependencyWaitAsync(
+            dependentState,
+            scheduler.Object,
+            CancellationToken.None), Times.Never);
+
         releasePrerequisite.TrySetResult();
+        await dependentStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await handlerTask;
 
-        await Assert.That(dependentStartedBeforePrerequisiteCompleted).IsFalse();
+        moduleRunner.Verify(x => x.ExecuteWithoutDependencyWaitAsync(
+            dependentState,
+            scheduler.Object,
+            CancellationToken.None), Times.Once);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -95,12 +95,20 @@ public class ModuleSchedulerDynamicCycleTests
 
         using var scheduler = CreateScheduler(
             constraintEvaluator.Object,
-            statusReporter.Object);
+            statusReporter.Object,
+            new SchedulerOptions
+            {
+                NotificationTimeout = TimeSpan.FromMilliseconds(20),
+            });
         scheduler.InitializeModules([new CompletedDependencyModule()]);
 
         var schedulerTask = scheduler.RunSchedulerAsync(CancellationToken.None);
         var module = await scheduler.ReadyModules.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(scheduler.MarkModuleStarted(module.ModuleType)).IsTrue();
+
+        // This observation window must exceed NotificationTimeout so a regression to
+        // timeout-based polling has time to execute another scheduling cycle.
+        await Task.Delay(150);
 
         statusReporter.Verify(
             x => x.LogStatusIfIntervalElapsed(

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -95,31 +95,24 @@ public class ModuleSchedulerDynamicCycleTests
 
         using var scheduler = CreateScheduler(
             constraintEvaluator.Object,
-            statusReporter.Object,
-            new SchedulerOptions
-            {
-                NotificationTimeout = TimeSpan.FromMilliseconds(20),
-            });
+            statusReporter.Object);
         scheduler.InitializeModules([new CompletedDependencyModule()]);
 
         var schedulerTask = scheduler.RunSchedulerAsync(CancellationToken.None);
         var module = await scheduler.ReadyModules.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(scheduler.MarkModuleStarted(module.ModuleType)).IsTrue();
 
-        await Task.Delay(150);
-
         statusReporter.Verify(
             x => x.LogStatusIfIntervalElapsed(
                 It.IsAny<ModuleStateQueries>(),
                 It.IsAny<ReaderWriterLockSlim>()),
             Times.Never);
-
-        scheduler.MarkModuleCompleted(module.ModuleType, success: true);
-        await schedulerTask.WaitAsync(TimeSpan.FromSeconds(5));
-
         constraintEvaluator.Verify(
             x => x.CanQueue(It.IsAny<ModuleState>(), It.IsAny<IEnumerable<ModuleState>>()),
             Times.Never);
+
+        scheduler.MarkModuleCompleted(module.ModuleType, success: true);
+        await schedulerTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- replace three fixed negative timing windows with explicit ordering/state signals
- verify AlwaysRun dependency execution before and after prerequisite release
- verify scheduler/output inactivity between start/cancel and completion/release events

## Test plan
- [x] `AlwaysRunHandlerTests` (8/8)
- [x] `ModuleSchedulerDynamicCycleTests` (5/5)
- [x] `OutputCoordinatorTests` (19/19)
- [x] Release build of `ModularPipelines.UnitTests.csproj`
- [x] changed-file whitespace verification

Closes #3534
