### PR TITLE
Add distributed coordinator contract tests

### DIFF
--- a/src/ModularPipelines.Distributed.Redis/Coordination/RedisDistributedCoordinator.cs
+++ b/src/ModularPipelines.Distributed.Redis/Coordination/RedisDistributedCoordinator.cs
@@ -17,17 +17,21 @@ internal sealed class RedisDistributedCoordinator : IDistributedCoordinator
     private readonly RedisKeyBuilder _keys;
     private readonly TimeSpan _keyExpiration;
     private readonly JsonSerializerOptions _jsonOptions;
+    // Lets real-backend contract tests synchronize after the race-closing reads complete.
+    private readonly Action? _onWaitReady;
 
     public RedisDistributedCoordinator(
         IDatabase database,
         ISubscriber subscriber,
         RedisKeyBuilder keys,
-        RedisDistributedOptions options)
+        RedisDistributedOptions options,
+        Action? onWaitReady = null)
     {
         _database = database;
         _subscriber = subscriber;
         _keys = keys;
         _keyExpiration = TimeSpan.FromSeconds(options.KeyExpirationSeconds);
+        _onWaitReady = onWaitReady;
         _jsonOptions = new JsonSerializerOptions
         {
             Converters = { new ReadOnlySetJsonConverter() },
@@ -81,6 +85,8 @@ internal sealed class RedisDistributedCoordinator : IDistributedCoordinator
             {
                 return null;
             }
+
+            _onWaitReady?.Invoke();
 
             // Wait for notifications — only LRANGE when a publish says work is available
             while (!cancellationToken.IsCancellationRequested)
@@ -156,6 +162,11 @@ internal sealed class RedisDistributedCoordinator : IDistributedCoordinator
             if (!existing.IsNullOrEmpty)
             {
                 tcs.TrySetResult(JsonSerializer.Deserialize<SerializedModuleResult>(existing.ToString(), _jsonOptions)!);
+            }
+
+            if (!tcs.Task.IsCompleted)
+            {
+                _onWaitReady?.Invoke();
             }
 
             using var reg = cancellationToken.Register(() => tcs.TrySetCanceled(cancellationToken));

--- a/test/ModularPipelines.Distributed.Redis.UnitTests/Coordination/RedisDistributedCoordinatorContractTests.cs
+++ b/test/ModularPipelines.Distributed.Redis.UnitTests/Coordination/RedisDistributedCoordinatorContractTests.cs
@@ -28,7 +28,7 @@ public class RedisDistributedCoordinatorContractTests
         return RunContractAsync(DistributedCoordinatorContract.CompletionUnblocksPendingDequeueAsync);
     }
 
-    private static async Task RunContractAsync(Func<IDistributedCoordinator, Task> contract)
+    private static async Task RunContractAsync(Func<IDistributedCoordinator, Task, Task> contract)
     {
         var connectionString = Environment.GetEnvironmentVariable(ConnectionStringVariable);
         if (string.IsNullOrWhiteSpace(connectionString))
@@ -44,9 +44,15 @@ public class RedisDistributedCoordinatorContractTests
             KeyPrefix = "modpipe-contract",
             RunIdentifier = Guid.NewGuid().ToString("N"),
         };
-        var factory = new RedisDistributedCoordinatorFactory(options, connection);
-        var coordinator = await factory.CreateAsync(CancellationToken.None);
+        var keys = new RedisKeyBuilder(options.KeyPrefix, options.RunIdentifier!);
+        var ready = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var coordinator = new RedisDistributedCoordinator(
+            connection.GetDatabase(),
+            connection.GetSubscriber(),
+            keys,
+            options,
+            () => ready.TrySetResult());
 
-        await contract(coordinator);
+        await contract(coordinator, ready.Task);
     }
 }

--- a/test/ModularPipelines.Distributed.Redis.UnitTests/Coordination/RedisDistributedCoordinatorContractTests.cs
+++ b/test/ModularPipelines.Distributed.Redis.UnitTests/Coordination/RedisDistributedCoordinatorContractTests.cs
@@ -1,0 +1,52 @@
+using ModularPipelines.Distributed.Redis.Configuration;
+using ModularPipelines.Distributed.Redis.Coordination;
+using ModularPipelines.TestHelpers.Distributed;
+using StackExchange.Redis;
+using TUnit.Core.Exceptions;
+
+namespace ModularPipelines.Distributed.Redis.UnitTests.Coordination;
+
+public class RedisDistributedCoordinatorContractTests
+{
+    private const string ConnectionStringVariable = "MODULAR_PIPELINES_REDIS_TEST_CONNECTION_STRING";
+
+    [Test]
+    public Task Enqueue_And_Dequeue_RoundTrips()
+    {
+        return RunContractAsync(DistributedCoordinatorContract.EnqueueAndDequeueRoundTripsAsync);
+    }
+
+    [Test]
+    public Task Publish_Unblocks_Wait_And_RoundTrips_Result()
+    {
+        return RunContractAsync(DistributedCoordinatorContract.ResultRoundTripsAfterWaitStartsAsync);
+    }
+
+    [Test]
+    public Task Completion_Signal_Unblocks_Pending_Dequeue()
+    {
+        return RunContractAsync(DistributedCoordinatorContract.CompletionUnblocksPendingDequeueAsync);
+    }
+
+    private static async Task RunContractAsync(Func<IDistributedCoordinator, Task> contract)
+    {
+        var connectionString = Environment.GetEnvironmentVariable(ConnectionStringVariable);
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new SkipTestException($"Set {ConnectionStringVariable} to run real Redis contract tests.");
+        }
+
+        using var connection = await ConnectionMultiplexer.ConnectAsync(connectionString);
+        var options = new RedisDistributedOptions
+        {
+            ConnectionString = connectionString,
+            KeyExpirationSeconds = 60,
+            KeyPrefix = "modpipe-contract",
+            RunIdentifier = Guid.NewGuid().ToString("N"),
+        };
+        var factory = new RedisDistributedCoordinatorFactory(options, connection);
+        var coordinator = await factory.CreateAsync(CancellationToken.None);
+
+        await contract(coordinator);
+    }
+}

--- a/test/ModularPipelines.Distributed.Redis.UnitTests/ModularPipelines.Distributed.Redis.UnitTests.csproj
+++ b/test/ModularPipelines.Distributed.Redis.UnitTests/ModularPipelines.Distributed.Redis.UnitTests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\ModularPipelines\ModularPipelines.csproj" />
     <ProjectReference Include="..\..\src\ModularPipelines.Distributed.Redis\ModularPipelines.Distributed.Redis.csproj" />
+    <ProjectReference Include="..\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/ModularPipelines.Distributed.UnitTests/Coordination/InMemoryDistributedCoordinatorTests.cs
+++ b/test/ModularPipelines.Distributed.UnitTests/Coordination/InMemoryDistributedCoordinatorTests.cs
@@ -1,4 +1,5 @@
 using ModularPipelines.Distributed.Coordination;
+using ModularPipelines.TestHelpers.Distributed;
 
 namespace ModularPipelines.Distributed.UnitTests.Coordination;
 
@@ -8,47 +9,14 @@ public class InMemoryDistributedCoordinatorTests
     public async Task Enqueue_And_Dequeue_Returns_Assignment()
     {
         var coordinator = new InMemoryDistributedCoordinator();
-
-        var assignment = new ModuleAssignment(
-            ModuleTypeName: "Test.Module",
-            ResultTypeName: "System.String",
-            RequiredCapabilities: new HashSet<string>(),
-            MatrixTarget: null,
-            AssignedAt: DateTimeOffset.UtcNow,
-            Configuration: new ModuleAssignmentConfig(null, 0, false));
-
-        await coordinator.EnqueueModuleAsync(assignment, CancellationToken.None);
-
-        var result = await coordinator.DequeueModuleAsync(
-            new HashSet<string>(), CancellationToken.None);
-
-        await Assert.That(result).IsNotNull();
-        await Assert.That(result!.ModuleTypeName).IsEqualTo("Test.Module");
+        await DistributedCoordinatorContract.EnqueueAndDequeueRoundTripsAsync(coordinator);
     }
 
     [Test]
     public async Task Publish_And_Wait_For_Result()
     {
         var coordinator = new InMemoryDistributedCoordinator();
-
-        var serializedResult = new SerializedModuleResult(
-            ModuleTypeName: "Test.Module",
-            ResultTypeName: "System.String",
-            WorkerIndex: 1,
-            SerializedJson: "{}",
-            CompletedAt: DateTimeOffset.UtcNow);
-
-        // Start waiting before publishing
-        var waitTask = coordinator.WaitForResultAsync("Test.Module", CancellationToken.None);
-
-        // Publish after a small delay
-        await Task.Delay(50);
-        await coordinator.PublishResultAsync(serializedResult, CancellationToken.None);
-
-        var result = await waitTask;
-
-        await Assert.That(result.ModuleTypeName).IsEqualTo("Test.Module");
-        await Assert.That(result.WorkerIndex).IsEqualTo(1);
+        await DistributedCoordinatorContract.ResultRoundTripsAfterWaitStartsAsync(coordinator);
     }
 
     [Test]
@@ -73,18 +41,7 @@ public class InMemoryDistributedCoordinatorTests
     public async Task SignalCompletion_CausesDequeueToReturnNull()
     {
         var coordinator = new InMemoryDistributedCoordinator();
-
-        // Start dequeue in background (will block waiting for work)
-        var dequeueTask = coordinator.DequeueModuleAsync(
-            new HashSet<string>(), CancellationToken.None);
-
-        // Signal completion after a small delay
-        await Task.Delay(50);
-        await coordinator.SignalCompletionAsync(CancellationToken.None);
-
-        var result = await dequeueTask;
-
-        await Assert.That(result).IsNull();
+        await DistributedCoordinatorContract.CompletionUnblocksPendingDequeueAsync(coordinator);
     }
 
     [Test]

--- a/test/ModularPipelines.Distributed.UnitTests/ModularPipelines.Distributed.UnitTests.csproj
+++ b/test/ModularPipelines.Distributed.UnitTests/ModularPipelines.Distributed.UnitTests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\ModularPipelines\ModularPipelines.csproj" />
+    <ProjectReference Include="..\ModularPipelines.TestHelpers\ModularPipelines.TestHelpers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/ModularPipelines.TestHelpers/Distributed/DistributedCoordinatorContract.cs
+++ b/test/ModularPipelines.TestHelpers/Distributed/DistributedCoordinatorContract.cs
@@ -4,11 +4,14 @@ namespace ModularPipelines.TestHelpers.Distributed;
 
 public static class DistributedCoordinatorContract
 {
-    public static async Task EnqueueAndDequeueRoundTripsAsync(IDistributedCoordinator coordinator)
+    public static async Task EnqueueAndDequeueRoundTripsAsync(
+        IDistributedCoordinator coordinator,
+        Task? waitUntilReady = null)
     {
         var assignment = CreateAssignment("Contract.EnqueueDequeue");
         var dequeueTask = coordinator.DequeueModuleAsync(new HashSet<string>(), CancellationToken.None);
 
+        await WaitUntilReadyAsync(waitUntilReady);
         await coordinator.EnqueueModuleAsync(assignment, CancellationToken.None);
         var result = await dequeueTask.WaitAsync(TimeSpan.FromSeconds(5));
 
@@ -18,25 +21,39 @@ public static class DistributedCoordinatorContract
         await Assert.That(result.Configuration).IsEqualTo(assignment.Configuration);
     }
 
-    public static async Task ResultRoundTripsAfterWaitStartsAsync(IDistributedCoordinator coordinator)
+    public static async Task ResultRoundTripsAfterWaitStartsAsync(
+        IDistributedCoordinator coordinator,
+        Task? waitUntilReady = null)
     {
         var result = CreateResult("Contract.ResultRoundTrip");
         var waitTask = coordinator.WaitForResultAsync(result.ModuleTypeName, CancellationToken.None);
 
+        await WaitUntilReadyAsync(waitUntilReady);
         await coordinator.PublishResultAsync(result, CancellationToken.None);
         var received = await waitTask.WaitAsync(TimeSpan.FromSeconds(5));
 
         await Assert.That(received).IsEqualTo(result);
     }
 
-    public static async Task CompletionUnblocksPendingDequeueAsync(IDistributedCoordinator coordinator)
+    public static async Task CompletionUnblocksPendingDequeueAsync(
+        IDistributedCoordinator coordinator,
+        Task? waitUntilReady = null)
     {
         var dequeueTask = coordinator.DequeueModuleAsync(new HashSet<string>(), CancellationToken.None);
 
+        await WaitUntilReadyAsync(waitUntilReady);
         await coordinator.SignalCompletionAsync(CancellationToken.None);
         var result = await dequeueTask.WaitAsync(TimeSpan.FromSeconds(5));
 
         await Assert.That(result).IsNull();
+    }
+
+    private static async Task WaitUntilReadyAsync(Task? waitUntilReady)
+    {
+        if (waitUntilReady is not null)
+        {
+            await waitUntilReady.WaitAsync(TimeSpan.FromSeconds(5));
+        }
     }
 
     private static ModuleAssignment CreateAssignment(string moduleTypeName)

--- a/test/ModularPipelines.TestHelpers/Distributed/DistributedCoordinatorContract.cs
+++ b/test/ModularPipelines.TestHelpers/Distributed/DistributedCoordinatorContract.cs
@@ -1,0 +1,62 @@
+using ModularPipelines.Distributed;
+
+namespace ModularPipelines.TestHelpers.Distributed;
+
+public static class DistributedCoordinatorContract
+{
+    public static async Task EnqueueAndDequeueRoundTripsAsync(IDistributedCoordinator coordinator)
+    {
+        var assignment = CreateAssignment("Contract.EnqueueDequeue");
+        var dequeueTask = coordinator.DequeueModuleAsync(new HashSet<string>(), CancellationToken.None);
+
+        await coordinator.EnqueueModuleAsync(assignment, CancellationToken.None);
+        var result = await dequeueTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.ModuleTypeName).IsEqualTo(assignment.ModuleTypeName);
+        await Assert.That(result.ResultTypeName).IsEqualTo(assignment.ResultTypeName);
+        await Assert.That(result.Configuration).IsEqualTo(assignment.Configuration);
+    }
+
+    public static async Task ResultRoundTripsAfterWaitStartsAsync(IDistributedCoordinator coordinator)
+    {
+        var result = CreateResult("Contract.ResultRoundTrip");
+        var waitTask = coordinator.WaitForResultAsync(result.ModuleTypeName, CancellationToken.None);
+
+        await coordinator.PublishResultAsync(result, CancellationToken.None);
+        var received = await waitTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(received).IsEqualTo(result);
+    }
+
+    public static async Task CompletionUnblocksPendingDequeueAsync(IDistributedCoordinator coordinator)
+    {
+        var dequeueTask = coordinator.DequeueModuleAsync(new HashSet<string>(), CancellationToken.None);
+
+        await coordinator.SignalCompletionAsync(CancellationToken.None);
+        var result = await dequeueTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result).IsNull();
+    }
+
+    private static ModuleAssignment CreateAssignment(string moduleTypeName)
+    {
+        return new ModuleAssignment(
+            ModuleTypeName: moduleTypeName,
+            ResultTypeName: "System.String",
+            RequiredCapabilities: new HashSet<string>(),
+            MatrixTarget: null,
+            AssignedAt: DateTimeOffset.UtcNow,
+            Configuration: new ModuleAssignmentConfig(null, 0, false));
+    }
+
+    private static SerializedModuleResult CreateResult(string moduleTypeName)
+    {
+        return new SerializedModuleResult(
+            ModuleTypeName: moduleTypeName,
+            ResultTypeName: "System.String",
+            WorkerIndex: 1,
+            SerializedJson: "{\"value\":\"contract\"}",
+            CompletedAt: DateTimeOffset.UtcNow);
+    }
+}


### PR DESCRIPTION
Closes #3535

Adds one shared coordinator contract for queue wake-up/round-trip, result wake-up/round-trip, and completion signaling. The existing in-memory tests use the same contract, while Redis runs it against a real instance when MODULAR_PIPELINES_REDIS_TEST_CONNECTION_STRING is set; otherwise those integration cases skip.

Validation:
- In-memory coordinator tests: 5 passed
- Redis unit suite without integration environment: 40 passed, 3 skipped
- Redis contract tests against ephemeral Redis 7: 3 passed
- Redis solution Release build: succeeded
- Distributed unit-test project Release build: succeeded