### PR TITLE
Mask generated OTP option values

### DIFF
--- a/src/ModularPipelines.Node/Options/PnpmPublishOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmPublishOptions.Generated.cs
@@ -65,6 +65,7 @@ public record PnpmPublishOptions : PnpmOptions
     /// <summary>
     /// When publishing packages that require two-factor authentication, this option can specify a one-time password
     /// </summary>
+    [SecretValue]
     [CliOption("--otp")]
     public string? Otp { get; set; }
 

--- a/src/ModularPipelines.Node/Options/PnpmStageOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmStageOptions.Generated.cs
@@ -41,6 +41,7 @@ public record PnpmStageOptions : PnpmOptions
     /// <summary>
     /// One-time password for approve and reject.
     /// </summary>
+    [SecretValue]
     [CliOption("--otp")]
     public string? Otp { get; set; }
 

--- a/test/ModularPipelines.Node.UnitTests/Api/PnpmSecretOptionsTests.cs
+++ b/test/ModularPipelines.Node.UnitTests/Api/PnpmSecretOptionsTests.cs
@@ -1,0 +1,18 @@
+using ModularPipelines.Attributes;
+using ModularPipelines.Node.Options;
+
+namespace ModularPipelines.Node.UnitTests.Api;
+
+public class PnpmSecretOptionsTests
+{
+    [Test]
+    [Arguments(typeof(PnpmPublishOptions))]
+    [Arguments(typeof(PnpmStageOptions))]
+    public async Task Otp_Is_Marked_As_Secret(Type optionsType)
+    {
+        var otpProperty = optionsType.GetProperty(nameof(PnpmPublishOptions.Otp));
+
+        await Assert.That(otpProperty).IsNotNull();
+        await Assert.That(otpProperty!.IsDefined(typeof(SecretValueAttribute), inherit: true)).IsTrue();
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
@@ -691,6 +691,17 @@ public class GeneratorUtilsTests
     }
 
     [Test]
+    [Arguments("Otp")]
+    [Arguments("OTP")]
+    [Arguments("RegistryOtp")]
+    public async Task IsSecretOption_Returns_True_For_Otp_Variants(string propertyName)
+    {
+        var result = GeneratorUtils.IsSecretOption(propertyName, isFlag: false);
+
+        await Assert.That(result).IsTrue();
+    }
+
+    [Test]
     [Arguments("ApiKey")]
     [Arguments("MyApiKey")]
     [Arguments("ApiKeyValue")]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
@@ -694,6 +694,8 @@ public class GeneratorUtilsTests
     [Arguments("Otp")]
     [Arguments("OTP")]
     [Arguments("RegistryOtp")]
+    [Arguments("OtpCode")]
+    [Arguments("RegistryOtpCode")]
     public async Task IsSecretOption_Returns_True_For_Otp_Variants(string propertyName)
     {
         var result = GeneratorUtils.IsSecretOption(propertyName, isFlag: false);
@@ -749,6 +751,10 @@ public class GeneratorUtilsTests
     [Arguments("ConfigFile")]
     [Arguments("Namespace")]
     [Arguments("Repository")]
+    [Arguments("ExecutorRootPath")]
+    [Arguments("GrpcWebRootPath")]
+    [Arguments("RdbSnapshotPeriod")]
+    [Arguments("AutopilotPrivilegedAdmission")]
     public async Task IsSecretOption_Returns_False_For_Non_Secret_Names(string propertyName)
     {
         var result = GeneratorUtils.IsSecretOption(propertyName, isFlag: false);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -747,6 +747,7 @@ public static partial class GeneratorUtils
         "Passphrase",
         "Token",
         "Credential",
+        "Otp",
         "ApiKey",
         "PrivateKey",
         "AccessKey",
@@ -755,8 +756,9 @@ public static partial class GeneratorUtils
 
     /// <summary>
     /// Determines if an option should be marked as a secret based on its property name.
-    /// Options containing keywords like "Secret", "Password", "Token", "Key", or "Credential"
-    /// in their name are considered secrets and should be obfuscated in logs.
+    /// Options containing secret-related keywords such as "Secret", "Password", "Passphrase",
+    /// "Token", "Credential", "Otp", or known compound key names are considered secrets and
+    /// should be obfuscated in logs.
     /// </summary>
     /// <param name="propertyName">The C# property name of the option.</param>
     /// <param name="isFlag">Whether this is a boolean flag (flags are not considered secrets).</param>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -788,10 +788,10 @@ public static partial class GeneratorUtils
              index = propertyName.IndexOf(segment, index + 1, StringComparison.OrdinalIgnoreCase))
         {
             var startsAtBoundary = index == 0
-                                   || char.IsUpper(propertyName[index])
-                                   && (char.IsLower(propertyName[index - 1])
-                                       || char.IsDigit(propertyName[index - 1])
-                                       || propertyName[index - 1] == '_');
+                                   || (char.IsUpper(propertyName[index])
+                                       && (char.IsLower(propertyName[index - 1])
+                                           || char.IsDigit(propertyName[index - 1])
+                                           || propertyName[index - 1] == '_'));
             var endIndex = index + segment.Length;
             var endsAtBoundary = endIndex == propertyName.Length
                                  || char.IsUpper(propertyName[endIndex])

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -747,7 +747,6 @@ public static partial class GeneratorUtils
         "Passphrase",
         "Token",
         "Credential",
-        "Otp",
         "ApiKey",
         "PrivateKey",
         "AccessKey",
@@ -778,7 +777,33 @@ public static partial class GeneratorUtils
 
         // Check if the property name contains any secret-related keywords
         return SecretKeywords.Any(keyword =>
-            propertyName.Contains(keyword, StringComparison.OrdinalIgnoreCase));
+                   propertyName.Contains(keyword, StringComparison.OrdinalIgnoreCase))
+               || ContainsIdentifierSegment(propertyName, "Otp");
+    }
+
+    private static bool ContainsIdentifierSegment(string propertyName, string segment)
+    {
+        for (var index = propertyName.IndexOf(segment, StringComparison.OrdinalIgnoreCase);
+             index >= 0;
+             index = propertyName.IndexOf(segment, index + 1, StringComparison.OrdinalIgnoreCase))
+        {
+            var startsAtBoundary = index == 0
+                                   || char.IsUpper(propertyName[index])
+                                   && (char.IsLower(propertyName[index - 1])
+                                       || char.IsDigit(propertyName[index - 1])
+                                       || propertyName[index - 1] == '_');
+            var endIndex = index + segment.Length;
+            var endsAtBoundary = endIndex == propertyName.Length
+                                 || char.IsUpper(propertyName[endIndex])
+                                 || char.IsDigit(propertyName[endIndex])
+                                 || propertyName[endIndex] == '_';
+            if (startsAtBoundary && endsAtBoundary)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- classify `Otp` property names as secret options
- regenerate pnpm publish/stage options with `[SecretValue]`
- cover detector casing and both generated pnpm properties

## Validation
- OptionsGenerator `GeneratorUtilsTests`: 110 passed
- Node `PnpmSecretOptionsTests`: 2 passed
- OptionsGenerator Release build: 0 warnings/errors
- Node Release build: 0 warnings/errors
- changed-file formatting verification passed

Closes #3516
