### PR TITLE
Detect stateful module auto-properties once per type

### DIFF
--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -124,6 +124,20 @@ public class Module1 : Module<int>
 }}
 ";
 
+    private const string BadModuleWithRequiredMutableAutoProperty = $@"
+{TestSourceConstants.StandardModuleHeader}
+
+public class Module1 : Module<int>
+{{
+    public required int {{|#0:Counter|}} {{ get; set; }}
+
+    protected override Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult(Counter);
+    }}
+}}
+";
+
     private const string PartialModuleWithMutableField = $@"
 {TestSourceConstants.StandardModuleHeader}
 
@@ -151,7 +165,7 @@ public class Module1 : Module<int>
 
     public int InitOnly {{ get; init; }}
 
-    public required int Required {{ get; set; }}
+    public required int Required {{ get; init; }}
 
     public static int Static {{ get; set; }}
 
@@ -751,7 +765,7 @@ public class Module1 : Module<int>
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableField()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0).WithArguments("_state", "Module1");
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.Rule).WithLocation(0).WithArguments("_state", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableField, expected);
     }
@@ -759,7 +773,7 @@ public class Module1 : Module<int>
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableCollection()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0).WithArguments("_items", "Module1");
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.Rule).WithLocation(0).WithArguments("_items", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableCollection, expected);
     }
@@ -767,7 +781,7 @@ public class Module1 : Module<int>
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableDictionary()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0).WithArguments("_cache", "Module1");
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.Rule).WithLocation(0).WithArguments("_cache", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableDictionary, expected);
     }
@@ -775,7 +789,7 @@ public class Module1 : Module<int>
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableCounter()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0).WithArguments("_counter", "Module1");
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.Rule).WithLocation(0).WithArguments("_counter", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableCounter, expected);
     }
@@ -783,7 +797,7 @@ public class Module1 : Module<int>
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableAutoProperty()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId)
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.PropertyRule)
             .WithLocation(0)
             .WithArguments("Counter", "Module1");
 
@@ -791,9 +805,31 @@ public class Module1 : Module<int>
     }
 
     [TestMethod]
+    public async Task AnalyzerIsTriggered_When_RequiredAutoPropertyHasSetter()
+    {
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.PropertyRule)
+            .WithLocation(0)
+            .WithArguments("Counter", "Module1");
+
+        await VerifyCS.VerifyAnalyzerAsync(
+            BadModuleWithRequiredMutableAutoProperty,
+            expected);
+    }
+
+    [TestMethod]
+    public async Task CodeFix_Is_Not_Offered_For_Mutable_Auto_Property()
+    {
+        await VerifyCS.VerifyNoCodeFixAsync(
+            BadModuleWithMutableAutoProperty
+                .Replace("{|#0:", string.Empty)
+                .Replace("|}", string.Empty),
+            StatefulModuleAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
     public async Task AnalyzerReportsMutableFieldOnce_When_ModuleIsPartial()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId)
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.Rule)
             .WithLocation(0)
             .WithArguments("_counter", "Module1");
 
@@ -809,7 +845,7 @@ public class Module1 : Module<int>
     [TestMethod]
     public async Task AnalyzerIsTriggered_When_MutableCustomClass()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0).WithArguments("_cache", "Module1");
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.Rule).WithLocation(0).WithArguments("_cache", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableCustomClass, expected);
     }
@@ -853,7 +889,7 @@ public class Module1 : Module<int>
     [TestMethod]
     public async Task CodeFix_Makes_Eligible_Field_Readonly()
     {
-        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId)
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.Rule)
             .WithLocation(0)
             .WithArguments("_name", "Module1");
 

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers.Test/ModularPipelinesAnalyzersStatefulModuleUnitTests.cs
@@ -110,6 +110,58 @@ public class Module1 : Module<int>
 }}
 ";
 
+    private const string BadModuleWithMutableAutoProperty = $@"
+{TestSourceConstants.StandardModuleHeader}
+
+public class Module1 : Module<int>
+{{
+    public int {{|#0:Counter|}} {{ get; set; }}
+
+    protected override Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult(Counter);
+    }}
+}}
+";
+
+    private const string PartialModuleWithMutableField = $@"
+{TestSourceConstants.StandardModuleHeader}
+
+public partial class Module1 : Module<int>
+{{
+    private int {{|#0:_counter|}};
+
+    protected override Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult(_counter);
+    }}
+}}
+
+public partial class Module1
+{{
+}}
+";
+
+    private const string GoodModuleWithNonWritableProperties = $@"
+{TestSourceConstants.StandardModuleHeader}
+
+public class Module1 : Module<int>
+{{
+    public int GetterOnly {{ get; }}
+
+    public int InitOnly {{ get; init; }}
+
+    public required int Required {{ get; set; }}
+
+    public static int Static {{ get; set; }}
+
+    protected override Task<int> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    {{
+        return Task.FromResult(GetterOnly + InitOnly + Required + Static);
+    }}
+}}
+";
+
     private const string BadModuleWithMutableCustomClass = $@"
 {TestSourceConstants.StandardModuleHeader}
 
@@ -726,6 +778,32 @@ public class Module1 : Module<int>
         var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId).WithLocation(0).WithArguments("_counter", "Module1");
 
         await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableCounter, expected);
+    }
+
+    [TestMethod]
+    public async Task AnalyzerIsTriggered_When_MutableAutoProperty()
+    {
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("Counter", "Module1");
+
+        await VerifyCS.VerifyAnalyzerAsync(BadModuleWithMutableAutoProperty, expected);
+    }
+
+    [TestMethod]
+    public async Task AnalyzerReportsMutableFieldOnce_When_ModuleIsPartial()
+    {
+        var expected = VerifyCS.Diagnostic(StatefulModuleAnalyzer.DiagnosticId)
+            .WithLocation(0)
+            .WithArguments("_counter", "Module1");
+
+        await VerifyCS.VerifyAnalyzerAsync(PartialModuleWithMutableField, expected);
+    }
+
+    [TestMethod]
+    public async Task AnalyzerIsNotTriggered_When_PropertiesCannotLeakMutableState()
+    {
+        await VerifyCS.VerifyAnalyzerAsync(GoodModuleWithNonWritableProperties);
     }
 
     [TestMethod]

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Resources.resx
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/Resources.resx
@@ -186,8 +186,11 @@
   <data name="StatefulModuleAnalyzerMessageFormat" xml:space="preserve">
     <value>Field '{0}' in module '{1}' should be readonly to avoid state leakage between executions</value>
   </data>
+  <data name="StatefulModuleAnalyzerPropertyMessageFormat" xml:space="preserve">
+    <value>Property '{0}' in module '{1}' should be getter-only or init-only to avoid state leakage between executions</value>
+  </data>
   <data name="StatefulModuleAnalyzerDescription" xml:space="preserve">
-    <value>Modules are registered as Singletons in the dependency injection container and can be executed multiple times (retries, sub-modules, parallel pipelines). Instance fields can leak state between executions. Use readonly fields for injected dependencies, or store execution state in IModuleContext.</value>
+    <value>Modules are registered as Singletons in the dependency injection container and can be executed multiple times (retries, sub-modules, parallel pipelines). Instance fields and writable properties can leak state between executions. Use readonly fields or getter-only/init-only properties, or store execution state in IModuleContext.</value>
   </data>
   <data name="InvalidDependsOnTypeAnalyzerTitle" xml:space="preserve">
     <value>Invalid DependsOn type</value>

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
@@ -1,15 +1,13 @@
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using ModularPipelines.Analyzers.Extensions;
 
 namespace ModularPipelines.Analyzers;
 
 /// <summary>
-/// Analyzer that detects mutable instance fields in modules.
+/// Analyzer that detects mutable instance state in modules.
 /// Modules are registered as Singletons, so any instance state can leak between executions.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -17,7 +15,7 @@ namespace ModularPipelines.Analyzers;
 public class StatefulModuleAnalyzer : DiagnosticAnalyzer
 {
     /// <summary>
-    /// Diagnostic ID for mutable instance fields in modules.
+    /// Diagnostic ID for mutable instance state in modules.
     /// </summary>
     public const string DiagnosticId = "StatefulModule";
 
@@ -41,18 +39,12 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
 
-        context.RegisterSyntaxNodeAction(AnalyzeClassDeclaration, SyntaxKind.ClassDeclaration);
+        context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
     }
 
-    private static void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context)
+    private static void AnalyzeNamedType(SymbolAnalysisContext context)
     {
-        if (context.Node is not ClassDeclarationSyntax classDeclaration)
-        {
-            return;
-        }
-
-        var classSymbol = context.SemanticModel.GetDeclaredSymbol(classDeclaration);
-        if (classSymbol is null)
+        if (context.Symbol is not INamedTypeSymbol { TypeKind: TypeKind.Class } classSymbol)
         {
             return;
         }
@@ -63,17 +55,35 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Analyze all instance fields declared directly in this class
-        foreach (var member in classSymbol.GetMembers())
+        var members = classSymbol.GetMembers();
+        var autoProperties = members
+            .OfType<IFieldSymbol>()
+            .Where(static field => field.IsImplicitlyDeclared)
+            .Select(static field => field.AssociatedSymbol)
+            .OfType<IPropertySymbol>()
+            .ToImmutableHashSet<IPropertySymbol>(SymbolEqualityComparer.Default);
+
+        // Analyze all instance state declared directly in this class.
+        foreach (var member in members)
         {
-            if (member is IFieldSymbol fieldSymbol && !fieldSymbol.IsStatic && !fieldSymbol.IsConst)
+            switch (member)
             {
-                AnalyzeField(context, fieldSymbol, classSymbol);
+                case IFieldSymbol { IsStatic: false, IsConst: false } field:
+                    AnalyzeField(context, field, classSymbol);
+                    break;
+                case IPropertySymbol property when IsWritableAutoProperty(
+                    property,
+                    autoProperties):
+                    ReportDiagnostic(context, property, classSymbol);
+                    break;
             }
         }
     }
 
-    private static void AnalyzeField(SyntaxNodeAnalysisContext context, IFieldSymbol fieldSymbol, INamedTypeSymbol classSymbol)
+    private static void AnalyzeField(
+        SymbolAnalysisContext context,
+        IFieldSymbol fieldSymbol,
+        INamedTypeSymbol classSymbol)
     {
         // Skip readonly fields - they're safe if initialized in constructor
         if (fieldSymbol.IsReadOnly)
@@ -87,18 +97,35 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Get field location for reporting
-        var location = fieldSymbol.Locations.FirstOrDefault();
+        ReportDiagnostic(context, fieldSymbol, classSymbol);
+    }
+
+    private static bool IsWritableAutoProperty(
+        IPropertySymbol property,
+        ImmutableHashSet<IPropertySymbol> autoProperties)
+    {
+        return !property.IsStatic
+               && !property.IsIndexer
+               && !property.IsRequired
+               && property.SetMethod is { IsInitOnly: false }
+               && autoProperties.Contains(property);
+    }
+
+    private static void ReportDiagnostic(
+        SymbolAnalysisContext context,
+        ISymbol member,
+        INamedTypeSymbol classSymbol)
+    {
+        var location = member.Locations.FirstOrDefault();
         if (location is null)
         {
             return;
         }
 
-        // Report diagnostic for non-readonly instance fields
         var diagnostic = Diagnostic.Create(
             Rule,
             location,
-            fieldSymbol.Name,
+            member.Name,
             classSymbol.Name);
 
         context.ReportDiagnostic(diagnostic);

--- a/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
+++ b/src/ModularPipelines.Analyzers/ModularPipelines.Analyzers/StatefulModuleAnalyzer.cs
@@ -30,8 +30,19 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
         category: "Design",
         severity: DiagnosticSeverity.Warning);
 
+    /// <summary>
+    /// Gets the diagnostic rule for mutable auto-properties in modules.
+    /// </summary>
+    public static DiagnosticDescriptor PropertyRule { get; } = DiagnosticDescriptorFactory.Create(
+        DiagnosticId,
+        nameof(Resources.StatefulModuleAnalyzerTitle),
+        "StatefulModuleAnalyzerPropertyMessageFormat",
+        nameof(Resources.StatefulModuleAnalyzerDescription),
+        category: "Design",
+        severity: DiagnosticSeverity.Warning);
+
     /// <inheritdoc/>
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule, PropertyRule];
 
     /// <inheritdoc/>
     public override void Initialize(AnalysisContext context)
@@ -74,7 +85,7 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
                 case IPropertySymbol property when IsWritableAutoProperty(
                     property,
                     autoProperties):
-                    ReportDiagnostic(context, property, classSymbol);
+                    ReportDiagnostic(context, PropertyRule, property, classSymbol);
                     break;
             }
         }
@@ -97,7 +108,7 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        ReportDiagnostic(context, fieldSymbol, classSymbol);
+        ReportDiagnostic(context, Rule, fieldSymbol, classSymbol);
     }
 
     private static bool IsWritableAutoProperty(
@@ -106,13 +117,13 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
     {
         return !property.IsStatic
                && !property.IsIndexer
-               && !property.IsRequired
                && property.SetMethod is { IsInitOnly: false }
                && autoProperties.Contains(property);
     }
 
     private static void ReportDiagnostic(
         SymbolAnalysisContext context,
+        DiagnosticDescriptor rule,
         ISymbol member,
         INamedTypeSymbol classSymbol)
     {
@@ -123,7 +134,7 @@ public class StatefulModuleAnalyzer : DiagnosticAnalyzer
         }
 
         var diagnostic = Diagnostic.Create(
-            Rule,
+            rule,
             location,
             member.Name,
             classSymbol.Name);


### PR DESCRIPTION
Closes #3513

## Summary
- run StatefulModuleAnalyzer once per named type instead of once per class declaration
- diagnose writable instance auto-properties backed by compiler fields
- preserve exclusions for readonly fields, getter-only/init/required/static properties
- add partial-type and property regression coverage

## Validation
- focused StatefulModule analyzer tests: 36 passed
- full analyzer suite: 169 passed
- `dotnet format ModularPipelines.Analyzers.sln` passed