### PR TITLE
Correct and page Git commit history

### DIFF
--- a/src/ModularPipelines.Git/GitCommands.cs
+++ b/src/ModularPipelines.Git/GitCommands.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.Git.Models;
@@ -517,20 +516,10 @@ public class GitCommands :
     }
 
     /// <inheritdoc/>
-    public virtual async IAsyncEnumerable<GitCommit> CommitsAsync(string? branch, GitOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        var index = 0;
-        while (!cancellationToken.IsCancellationRequested)
-        {
-            var output = await _gitCommandRunner.RunCommandsOrNull(null, "log", branch, $"--skip={index}", "-1", $"--format={GitConstants.CommitLogFormat}").ConfigureAwait(false);
-
-            if (string.IsNullOrWhiteSpace(output))
-            {
-                yield break;
-            }
-
-            index++;
-            yield return _gitCommitMapper.Map(output);
-        }
-    }
+    public virtual IAsyncEnumerable<GitCommit> CommitsAsync(string? branch, GitOptions? options = null, CancellationToken cancellationToken = default) =>
+        GitCommitPager.EnumerateAsync(
+            _gitCommandRunner,
+            _gitCommitMapper,
+            branch,
+            cancellationToken);
 }

--- a/src/ModularPipelines.Git/GitCommands.cs
+++ b/src/ModularPipelines.Git/GitCommands.cs
@@ -521,5 +521,6 @@ public class GitCommands :
             _gitCommandRunner,
             _gitCommitMapper,
             branch,
+            null,
             cancellationToken);
 }

--- a/src/ModularPipelines.Git/GitCommitPager.cs
+++ b/src/ModularPipelines.Git/GitCommitPager.cs
@@ -16,10 +16,7 @@ internal static class GitCommitPager
         CommandExecutionOptions? commandExecutionOptions,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
-        var completeOutputOptions = (commandExecutionOptions ?? new CommandExecutionOptions()) with
-        {
-            MaxCapturedOutputLength = 0,
-        };
+        var completeOutputOptions = GetCompleteOutputOptions(commandExecutionOptions);
         var skip = 0;
         while (true)
         {
@@ -58,4 +55,11 @@ internal static class GitCommitPager
             skip += records.Length;
         }
     }
+
+    internal static CommandExecutionOptions GetCompleteOutputOptions(
+        CommandExecutionOptions? commandExecutionOptions) =>
+        (commandExecutionOptions ?? new CommandExecutionOptions()) with
+        {
+            MaxCapturedOutputLength = 0,
+        };
 }

--- a/src/ModularPipelines.Git/GitCommitPager.cs
+++ b/src/ModularPipelines.Git/GitCommitPager.cs
@@ -16,12 +16,16 @@ internal static class GitCommitPager
         CommandExecutionOptions? commandExecutionOptions,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        var completeOutputOptions = (commandExecutionOptions ?? new CommandExecutionOptions()) with
+        {
+            MaxCapturedOutputLength = 0,
+        };
         var skip = 0;
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var output = await gitCommandRunner.RunCommandsOrNull(
-                commandExecutionOptions,
+                completeOutputOptions,
                 cancellationToken,
                 "log",
                 branch,

--- a/src/ModularPipelines.Git/GitCommitPager.cs
+++ b/src/ModularPipelines.Git/GitCommitPager.cs
@@ -1,0 +1,57 @@
+using System.Runtime.CompilerServices;
+using ModularPipelines.Git.Models;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Git;
+
+internal static class GitCommitPager
+{
+    private const int PageSize = 50;
+    private const char RecordSeparator = '\0';
+
+    public static async IAsyncEnumerable<GitCommit> EnumerateAsync(
+        IGitCommandRunner gitCommandRunner,
+        IGitCommitMapper gitCommitMapper,
+        string? branch,
+        CommandExecutionOptions? commandExecutionOptions,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var skip = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var output = await gitCommandRunner.RunCommandsOrNull(
+                commandExecutionOptions,
+                cancellationToken,
+                "log",
+                branch,
+                $"--skip={skip}",
+                $"--max-count={PageSize}",
+                $"--format={GitConstants.CommitLogFormat}%x00").ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (string.IsNullOrWhiteSpace(output))
+            {
+                yield break;
+            }
+
+            var records = output
+                .Split(RecordSeparator, StringSplitOptions.RemoveEmptyEntries)
+                .Select(record => record.Trim('\r', '\n'))
+                .Where(record => !string.IsNullOrWhiteSpace(record))
+                .ToArray();
+            foreach (var record in records)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return gitCommitMapper.Map(record);
+            }
+
+            if (records.Length < PageSize)
+            {
+                yield break;
+            }
+
+            skip += records.Length;
+        }
+    }
+}

--- a/src/ModularPipelines.Git/GitInformation.cs
+++ b/src/ModularPipelines.Git/GitInformation.cs
@@ -248,9 +248,9 @@ internal class GitInformation : IGitInformation
             GitCommitPager.GetCompleteOutputOptions(_commandExecutionOptions),
             cancellationToken,
             "log",
-            "--skip=1",
             "-1",
-            $"--format={GitConstants.CommitLogFormat}").ConfigureAwait(false);
+            $"--format={GitConstants.CommitLogFormat}",
+            "HEAD^1").ConfigureAwait(false);
 
         return string.IsNullOrWhiteSpace(output) ? null : _gitCommitMapper.Map(output);
     }

--- a/src/ModularPipelines.Git/GitInformation.cs
+++ b/src/ModularPipelines.Git/GitInformation.cs
@@ -244,7 +244,12 @@ internal class GitInformation : IGitInformation
         IGitCommandRunner gitCommandRunner,
         CancellationToken cancellationToken)
     {
-        var output = await gitCommandRunner.RunCommandsOrNull(_commandExecutionOptions, cancellationToken, "log", "--skip=1", "-1",
+        var output = await gitCommandRunner.RunCommandsOrNull(
+            GitCommitPager.GetCompleteOutputOptions(_commandExecutionOptions),
+            cancellationToken,
+            "log",
+            "--skip=1",
+            "-1",
             $"--format={GitConstants.CommitLogFormat}").ConfigureAwait(false);
 
         return string.IsNullOrWhiteSpace(output) ? null : _gitCommitMapper.Map(output);

--- a/src/ModularPipelines.Git/GitInformation.cs
+++ b/src/ModularPipelines.Git/GitInformation.cs
@@ -75,25 +75,16 @@ internal class GitInformation : IGitInformation
         await using var scope = _serviceScopeFactory.CreateAsyncScope();
         var gitCommandRunner = scope.ServiceProvider.GetRequiredService<IGitCommandRunner>();
 
-        var index = 0;
-        while (!cancellationToken.IsCancellationRequested)
+        await foreach (var commit in GitCommitPager
+                           .EnumerateAsync(
+                               gitCommandRunner,
+                               _gitCommitMapper,
+                               branch,
+                               _commandExecutionOptions,
+                               cancellationToken)
+                           .ConfigureAwait(false))
         {
-            var output = await gitCommandRunner.RunCommandsOrNull(
-                _commandExecutionOptions,
-                cancellationToken,
-                "log",
-                branch,
-                $"--skip={index}",
-                "-1",
-                $"--format={GitConstants.CommitLogFormat}").ConfigureAwait(false);
-
-            if (string.IsNullOrWhiteSpace(output))
-            {
-                yield break;
-            }
-
-            index++;
-            yield return _gitCommitMapper.Map(output);
+            yield return commit;
         }
     }
 
@@ -253,7 +244,7 @@ internal class GitInformation : IGitInformation
         IGitCommandRunner gitCommandRunner,
         CancellationToken cancellationToken)
     {
-        var output = await gitCommandRunner.RunCommandsOrNull(_commandExecutionOptions, cancellationToken, "log", "--skip=0", "-1",
+        var output = await gitCommandRunner.RunCommandsOrNull(_commandExecutionOptions, cancellationToken, "log", "--skip=1", "-1",
             $"--format={GitConstants.CommitLogFormat}").ConfigureAwait(false);
 
         return string.IsNullOrWhiteSpace(output) ? null : _gitCommitMapper.Map(output);

--- a/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
@@ -294,7 +294,7 @@ public class GitInformationTests : TestBase
     }
 
     [Test]
-    public async Task Previous_Commit_Skips_Head()
+    public async Task Previous_Commit_Uses_First_Parent()
     {
         CommandExecutionOptions? observedOptions = null;
         string?[]? observedCommands = null;
@@ -323,8 +323,8 @@ public class GitInformationTests : TestBase
             await Assert.That(repository?.PreviousCommit?.Message?.Subject).IsEqualTo("previous commit");
             await Assert.That(observedOptions).IsNotNull();
             await Assert.That(observedOptions!.MaxCapturedOutputLength).IsLessThanOrEqualTo(0);
-            await Assert.That(observedCommands!).Contains("--skip=1");
-            await Assert.That(observedCommands!).DoesNotContain("--skip=0");
+            await Assert.That(observedCommands!).Contains("HEAD^1");
+            await Assert.That(observedCommands!).DoesNotContain("--skip=1");
         }
 
         await result.Host.DisposeAsync();

--- a/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
@@ -192,14 +192,16 @@ public class GitInformationTests : TestBase
     [Test]
     public async Task Commits_Reads_Multiple_Records_With_One_Git_Process()
     {
+        CommandExecutionOptions? observedOptions = null;
         string?[]? observedCommands = null;
         var runner = new Mock<IGitCommandRunner>();
         runner.Setup(x => x.RunCommandsOrNull(
                 It.IsAny<CommandExecutionOptions?>(),
                 It.IsAny<CancellationToken>(),
                 It.IsAny<string?[]>()))
-            .Returns<CommandExecutionOptions?, CancellationToken, string?[]>((_, _, commands) =>
+            .Returns<CommandExecutionOptions?, CancellationToken, string?[]>((options, _, commands) =>
             {
+                observedOptions = options;
                 observedCommands = commands;
                 return Task.FromResult<string?>(
                     $"{CreateCommitOutput("second commit", '2')}\0{CreateCommitOutput("first commit", '1')}\0");
@@ -218,8 +220,10 @@ public class GitInformationTests : TestBase
             await Assert.That(commits).Count().IsEqualTo(2);
             await Assert.That(commits[0].Message?.Subject).IsEqualTo("second commit");
             await Assert.That(commits[1].Message?.Subject).IsEqualTo("first commit");
+            await Assert.That(observedOptions).IsNotNull();
             await Assert.That(observedCommands!).Contains("--skip=0");
             await Assert.That(observedCommands!).Contains("--max-count=50");
+            await Assert.That(observedOptions!.MaxCapturedOutputLength).IsLessThanOrEqualTo(0);
             await Assert.That(observedCommands!.Single(command =>
                     command?.StartsWith("--format=", StringComparison.Ordinal) == true))
                 .EndsWith("%x00");
@@ -230,6 +234,41 @@ public class GitInformationTests : TestBase
             It.IsAny<CancellationToken>(),
             It.IsAny<string?[]>()), Times.Once());
         await result.Host.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Git_Command_Runner_Preserves_Output_Capture_Limit()
+    {
+        CommandExecutionOptions? observedOptions = null;
+        var command = new Mock<ICommandContext>();
+        command.Setup(context => context.ExecuteCommandLineToolAsync(
+                It.IsAny<CommandLineToolOptions>(),
+                It.IsAny<CommandExecutionOptions?>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<CommandLineToolOptions, CommandExecutionOptions?, CancellationToken>(
+                (_, options, _) =>
+                {
+                    observedOptions = options;
+                    return Task.FromResult(CommandResult.Ok("output"));
+                });
+        var shell = new Mock<IShellContext>();
+        shell.SetupGet(context => context.Command).Returns(command.Object);
+        var pipelineContext = new Mock<IPipelineContext>();
+        pipelineContext.SetupGet(context => context.Shell).Returns(shell.Object);
+        var runner = new GitCommandRunner(
+            pipelineContext.Object,
+            Mock.Of<ILogger<GitCommandRunner>>());
+
+        var output = await runner.RunCommands(
+            new CommandExecutionOptions { MaxCapturedOutputLength = 0 },
+            "status");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).IsEqualTo("output");
+            await Assert.That(observedOptions).IsNotNull();
+            await Assert.That(observedOptions!.MaxCapturedOutputLength).IsLessThanOrEqualTo(0);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
@@ -6,6 +6,7 @@ using ModularPipelines.Context.Domains.Shell;
 using Moq;
 using ModularPipelines.Git;
 using ModularPipelines.Git.Extensions;
+using ModularPipelines.Git.Models;
 using ModularPipelines.Git.Options;
 using ModularPipelines.Models;
 using ModularPipelines.Options;
@@ -188,6 +189,104 @@ public class GitInformationTests : TestBase
         await result.Host.DisposeAsync();
     }
 
+    [Test]
+    public async Task Commits_Reads_Multiple_Records_With_One_Git_Process()
+    {
+        string?[]? observedCommands = null;
+        var runner = new Mock<IGitCommandRunner>();
+        runner.Setup(x => x.RunCommandsOrNull(
+                It.IsAny<CommandExecutionOptions?>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?[]>()))
+            .Returns<CommandExecutionOptions?, CancellationToken, string?[]>((_, _, commands) =>
+            {
+                observedCommands = commands;
+                return Task.FromResult<string?>(
+                    $"{CreateCommitOutput("second commit", '2')}\0{CreateCommitOutput("first commit", '1')}\0");
+            });
+        var result = await GetService<IGitInformation>((_, services) =>
+            services.AddSingleton(runner.Object));
+        var commits = new List<GitCommit>();
+
+        await foreach (var commit in result.T.Commits())
+        {
+            commits.Add(commit);
+        }
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(commits).Count().IsEqualTo(2);
+            await Assert.That(commits[0].Message?.Subject).IsEqualTo("second commit");
+            await Assert.That(commits[1].Message?.Subject).IsEqualTo("first commit");
+            await Assert.That(observedCommands!).Contains("--skip=0");
+            await Assert.That(observedCommands!).Contains("--max-count=50");
+            await Assert.That(observedCommands!.Single(command =>
+                    command?.StartsWith("--format=", StringComparison.Ordinal) == true))
+                .EndsWith("%x00");
+        }
+
+        runner.Verify(x => x.RunCommandsOrNull(
+            It.IsAny<CommandExecutionOptions?>(),
+            It.IsAny<CancellationToken>(),
+            It.IsAny<string?[]>()), Times.Once());
+        await result.Host.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Commits_Throws_When_Cancelled_Between_Records()
+    {
+        var runner = new Mock<IGitCommandRunner>();
+        runner.Setup(x => x.RunCommandsOrNull(
+                It.IsAny<CommandExecutionOptions?>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?[]>()))
+            .ReturnsAsync($"{CreateCommitOutput("second commit", '2')}\0{CreateCommitOutput("first commit", '1')}\0");
+        var result = await GetService<IGitInformation>((_, services) =>
+            services.AddSingleton(runner.Object));
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await using var commits = result.T.Commits(
+            cancellationToken: cancellationTokenSource.Token).GetAsyncEnumerator();
+
+        await Assert.That(await commits.MoveNextAsync()).IsTrue();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await commits.MoveNextAsync());
+        await result.Host.DisposeAsync();
+    }
+
+    [Test]
+    public async Task Previous_Commit_Skips_Head()
+    {
+        string?[]? observedCommands = null;
+        var command = CreateRepositoryCommand((_, _) => CommandResult.Ok());
+        var runner = new Mock<IGitCommandRunner>();
+        runner.Setup(x => x.RunCommandsOrNull(
+                It.IsAny<CommandExecutionOptions?>(),
+                It.IsAny<CancellationToken>(),
+                It.IsAny<string?[]>()))
+            .Returns<CommandExecutionOptions?, CancellationToken, string?[]>((_, _, commands) =>
+            {
+                observedCommands = commands;
+                return Task.FromResult<string?>(CreateCommitOutput("previous commit", '1'));
+            });
+        var result = await GetService<IGitInformation>((_, services) =>
+        {
+            services.AddSingleton<ICommandContext>(command.Object);
+            services.AddSingleton(runner.Object);
+        });
+
+        var repository = await result.T.GetInfoAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(repository?.PreviousCommit?.Message?.Subject).IsEqualTo("previous commit");
+            await Assert.That(observedCommands!).Contains("--skip=1");
+            await Assert.That(observedCommands!).DoesNotContain("--skip=0");
+        }
+
+        await result.Host.DisposeAsync();
+    }
+
     private static Mock<ICommandContext> CreateRepositoryCommand(
         Func<CommandLineToolOptions, CommandExecutionOptions?, CommandResult> responseFactory)
     {
@@ -226,4 +325,18 @@ public class GitInformationTests : TestBase
         capturedOptions = executionOptions;
         return CommandResult.Ok("HEAD branch: trunk\n");
     }
+
+    private static string CreateCommitOutput(string subject, char hashCharacter) =>
+        string.Join(
+            "%\n%",
+            "Author",
+            "author@example.com",
+            "2026-07-31T13:00:45Z",
+            "Committer",
+            "committer@example.com",
+            "2026-07-31T12:15:30Z",
+            new string(hashCharacter, 40),
+            new string(hashCharacter, 7),
+            subject,
+            string.Empty);
 }

--- a/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitInformationTests.cs
@@ -296,6 +296,7 @@ public class GitInformationTests : TestBase
     [Test]
     public async Task Previous_Commit_Skips_Head()
     {
+        CommandExecutionOptions? observedOptions = null;
         string?[]? observedCommands = null;
         var command = CreateRepositoryCommand((_, _) => CommandResult.Ok());
         var runner = new Mock<IGitCommandRunner>();
@@ -303,8 +304,9 @@ public class GitInformationTests : TestBase
                 It.IsAny<CommandExecutionOptions?>(),
                 It.IsAny<CancellationToken>(),
                 It.IsAny<string?[]>()))
-            .Returns<CommandExecutionOptions?, CancellationToken, string?[]>((_, _, commands) =>
+            .Returns<CommandExecutionOptions?, CancellationToken, string?[]>((options, _, commands) =>
             {
+                observedOptions = options;
                 observedCommands = commands;
                 return Task.FromResult<string?>(CreateCommitOutput("previous commit", '1'));
             });
@@ -319,6 +321,8 @@ public class GitInformationTests : TestBase
         using (Assert.Multiple())
         {
             await Assert.That(repository?.PreviousCommit?.Message?.Subject).IsEqualTo("previous commit");
+            await Assert.That(observedOptions).IsNotNull();
+            await Assert.That(observedOptions!.MaxCapturedOutputLength).IsLessThanOrEqualTo(0);
             await Assert.That(observedCommands!).Contains("--skip=1");
             await Assert.That(observedCommands!).DoesNotContain("--skip=0");
         }


### PR DESCRIPTION
Closes #3478.

## Summary
- make `GitRepositoryInfo.PreviousCommit` skip HEAD
- page commit history in batches of 50 instead of spawning one Git process per commit
- share paging and cancellation behavior across both commit enumeration APIs

## Validation
- GitInformationTests: 10 passed
- GitCommandsTests: 1 passed
- ModularPipelines.Git.sln Release build: clean
- targeted `dotnet format`: clean