### PR TITLE
[Automated] Update podman CLI Options

### DIFF
--- a/src/ModularPipelines.Podman/Options/PodmanBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanBuildOptions.Generated.cs
@@ -407,7 +407,7 @@ public record PodmanBuildOptions : PodmanOptions
     /// <summary>
     /// Pull image policy ("always/true"|"missing"|"never/false"|"newer") (default "missing")
     /// </summary>
-    [CliOption("--pull", Format = OptionFormat.EqualsSeparated)]
+    [CliOption("--pull", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
     public string? Pull { get; set; }
 
     /// <summary>

--- a/src/ModularPipelines.Podman/Options/PodmanExecOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanExecOptions.Generated.cs
@@ -19,7 +19,8 @@ namespace ModularPipelines.Podman.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("exec")]
 public record PodmanExecOptions(
-    [property: CliArgument(0)] string Container
+    [property: CliArgument(0)] string Container,
+    [property: CliArgument(1)] string Command
 ) : PodmanOptions
 {
     /// <summary>
@@ -87,12 +88,6 @@ public record PodmanExecOptions(
     /// </summary>
     [CliOption("--workdir", ShortForm = "-w", Format = OptionFormat.EqualsSeparated)]
     public string? Workdir { get; set; }
-
-    /// <summary>
-    /// The COMMAND operand.
-    /// </summary>
-    [CliArgument(1)]
-    public string? Command { get; set; }
 
     /// <summary>
     /// The ARG operand.

--- a/src/ModularPipelines.Podman/Options/PodmanFarmBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanFarmBuildOptions.Generated.cs
@@ -371,7 +371,7 @@ public record PodmanFarmBuildOptions : PodmanOptions
     /// <summary>
     /// Pull image policy ("always/true"|"missing"|"never/false"|"newer") (default "missing")
     /// </summary>
-    [CliOption("--pull", Format = OptionFormat.EqualsSeparated)]
+    [CliOption("--pull", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
     public string? Pull { get; set; }
 
     /// <summary>

--- a/src/ModularPipelines.Podman/Options/PodmanImageBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanImageBuildOptions.Generated.cs
@@ -407,7 +407,7 @@ public record PodmanImageBuildOptions : PodmanOptions
     /// <summary>
     /// Pull image policy ("always/true"|"missing"|"never/false"|"newer") (default "missing")
     /// </summary>
-    [CliOption("--pull", Format = OptionFormat.EqualsSeparated)]
+    [CliOption("--pull", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
     public string? Pull { get; set; }
 
     /// <summary>


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **podman** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- podman (podman version 4.9.3): 224 commands, tree 3498384ddb9819ffcda1e4726408cbd804661370adc49a5a9561ed08b75b28cb

## Verification
- [x] Solution builds successfully
- API compatibility gate: **failure (explicitly approved)**

---
🤖 Generated with ModularPipelines.OptionsGenerator