### PR TITLE
[Automated] Update podman CLI Options

### DIFF
--- a/src/ModularPipelines.Podman/Options/PodmanContainerExecOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanContainerExecOptions.Generated.cs
@@ -19,7 +19,8 @@ namespace ModularPipelines.Podman.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("container", "exec")]
 public record PodmanContainerExecOptions(
-    [property: CliArgument(0)] string Container
+    [property: CliArgument(0)] string Container,
+    [property: CliArgument(1)] string Command
 ) : PodmanOptions
 {
     /// <summary>
@@ -87,12 +88,6 @@ public record PodmanContainerExecOptions(
     /// </summary>
     [CliOption("--workdir", ShortForm = "-w", Format = OptionFormat.EqualsSeparated)]
     public string? Workdir { get; set; }
-
-    /// <summary>
-    /// The COMMAND operand.
-    /// </summary>
-    [CliArgument(1)]
-    public string? Command { get; set; }
 
     /// <summary>
     /// The ARG operand.

--- a/src/ModularPipelines.Podman/Options/PodmanInspectOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanInspectOptions.Generated.cs
@@ -19,7 +19,7 @@ namespace ModularPipelines.Podman.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("inspect")]
 public record PodmanInspectOptions(
-    [property: CliArgument(0)] string Container
+    [property: CliArgument(0)] IEnumerable<string> Container
 ) : PodmanOptions
 {
     /// <summary>


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **podman** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- podman (podman version 4.9.3): 224 commands, tree 3498384ddb9819ffcda1e4726408cbd804661370adc49a5a9561ed08b75b28cb

## Verification
- [x] Solution builds successfully
- API compatibility gate: **failure**

---
🤖 Generated with ModularPipelines.OptionsGenerator