### PR TITLE
fix: normalize GitHub repository names from remote URLs

### DIFF
--- a/src/ModularPipelines.GitHub/GitHubRepositoryInfo.cs
+++ b/src/ModularPipelines.GitHub/GitHubRepositoryInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 using Initialization.Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -72,18 +71,11 @@ internal record GitHubRepositoryInfo : IGitHubRepositoryInfo, IInitializer
                 return;
             }
 
-            // Parse owner and repository name from the remote URL
             var endpoint = "github";
-            var sshPattern = $@"git@{endpoint}\.com:(?<owner>.+)/(?<name>.+)\.git";
-            var httpsPattern = $@"https://(.*@)?{endpoint}\.com/(?<owner>.+)/(?<name>.+)(\.git)?";
-
-            var match = Regex.Match(remoteUrl, sshPattern);
-            if (!match.Success)
-            {
-                match = Regex.Match(remoteUrl, httpsPattern);
-            }
-
-            if (!match.Success)
+            if (!GitHubRepositoryUrlParser.TryParse(
+                    remoteUrl,
+                    out var owner,
+                    out var repositoryName))
             {
                 // Will not initialize as git repo is not setup
                 return;
@@ -91,8 +83,8 @@ internal record GitHubRepositoryInfo : IGitHubRepositoryInfo, IInitializer
 
             Url = remoteUrl;
             Endpoint = endpoint;
-            Owner = match.Groups["owner"].Value;
-            RepositoryName = match.Groups["name"].Value;
+            Owner = owner;
+            RepositoryName = repositoryName;
 
             IsInitialized = true;
         }

--- a/src/ModularPipelines.GitHub/GitHubRepositoryUrlParser.cs
+++ b/src/ModularPipelines.GitHub/GitHubRepositoryUrlParser.cs
@@ -1,0 +1,59 @@
+namespace ModularPipelines.GitHub;
+
+internal static class GitHubRepositoryUrlParser
+{
+    private const string GitHubHost = "github.com";
+    private const string SshPrefix = "git@github.com:";
+
+    public static bool TryParse(
+        string remoteUrl,
+        out string owner,
+        out string repositoryName)
+    {
+        owner = string.Empty;
+        repositoryName = string.Empty;
+
+        var normalizedUrl = remoteUrl.Trim();
+        string repositoryPath;
+
+        if (normalizedUrl.StartsWith(SshPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            repositoryPath = normalizedUrl[SshPrefix.Length..];
+        }
+        else if (Uri.TryCreate(normalizedUrl, UriKind.Absolute, out var uri)
+                 && uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                 && uri.Host.Equals(GitHubHost, StringComparison.OrdinalIgnoreCase))
+        {
+            repositoryPath = uri.AbsolutePath;
+        }
+        else
+        {
+            return false;
+        }
+
+        var pathSegments = repositoryPath
+            .Trim('/')
+            .Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (pathSegments.Length != 2)
+        {
+            return false;
+        }
+
+        owner = Uri.UnescapeDataString(pathSegments[0]);
+        repositoryName = Uri.UnescapeDataString(pathSegments[1]);
+        if (repositoryName.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+        {
+            repositoryName = repositoryName[..^4];
+        }
+
+        if (!string.IsNullOrWhiteSpace(owner)
+            && !string.IsNullOrWhiteSpace(repositoryName))
+        {
+            return true;
+        }
+
+        owner = string.Empty;
+        repositoryName = string.Empty;
+        return false;
+    }
+}

--- a/src/ModularPipelines.GitHub/ModularPipelines.GitHub.csproj
+++ b/src/ModularPipelines.GitHub/ModularPipelines.GitHub.csproj
@@ -9,4 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Octokit" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>ModularPipelines.GitHub.UnitTests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/test/ModularPipelines.GitHub.UnitTests/Helpers/GitHubRepositoryUrlParserTests.cs
+++ b/test/ModularPipelines.GitHub.UnitTests/Helpers/GitHubRepositoryUrlParserTests.cs
@@ -1,0 +1,48 @@
+using ModularPipelines.GitHub;
+
+namespace ModularPipelines.GitHub.UnitTests.Helpers;
+
+public class GitHubRepositoryUrlParserTests
+{
+    [Test]
+    [Arguments("https://github.com/owner/repository.git")]
+    [Arguments("https://github.com/owner/repository")]
+    [Arguments("https://github.com/owner/repository.git/")]
+    [Arguments("https://username:token@github.com/owner/repository.git")]
+    [Arguments("git@github.com:owner/repository.git")]
+    [Arguments("git@github.com:owner/repository")]
+    public async Task Supported_Remote_Urls_Are_Parsed(string remoteUrl)
+    {
+        var parsed = GitHubRepositoryUrlParser.TryParse(
+            remoteUrl,
+            out var owner,
+            out var repositoryName);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(parsed).IsTrue();
+            await Assert.That(owner).IsEqualTo("owner");
+            await Assert.That(repositoryName).IsEqualTo("repository");
+        }
+    }
+
+    [Test]
+    [Arguments("")]
+    [Arguments("https://gitlab.com/owner/repository.git")]
+    [Arguments("https://github.com/owner")]
+    [Arguments("https://github.com/owner/repository/extra")]
+    public async Task Unsupported_Remote_Urls_Are_Rejected(string remoteUrl)
+    {
+        var parsed = GitHubRepositoryUrlParser.TryParse(
+            remoteUrl,
+            out var owner,
+            out var repositoryName);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(parsed).IsFalse();
+            await Assert.That(owner).IsEmpty();
+            await Assert.That(repositoryName).IsEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replace greedy remote URL regex parsing with a dedicated parser.
- Normalize HTTPS and SSH repository names by removing the optional `.git` suffix.
- Cover authenticated HTTPS, SSH, trailing slash, and invalid remote URL cases.

## Problem

The existing HTTPS regex greedily included the optional `.git` suffix in `RepositoryName`. For example, `https://github.com/owner/repository.git` produced `owner/repository.git`, while the equivalent SSH remote produced `owner/repository`.

This made `IGitHubRepositoryInfo.Identifier` depend on the configured remote URL format.

## Validation

- `dotnet build src/ModularPipelines.GitHub/ModularPipelines.GitHub.sln -c Release`
- `ModularPipelines.GitHub.UnitTests`: 21 passed, 0 failed
- Scoped `dotnet format --verify-no-changes --severity info` for all changed C# files
- `git diff --check`

The build reports one pre-existing nullability warning in `ModuleExecutionPipeline.cs`, outside this change.