### PR TITLE
Fix Claude review for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,6 +41,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Claude Code Review
+        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.user.login != 'dependabot[bot]'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary

- skip the credentialed Claude review action for Dependabot-authored pull requests
- keep the workflow job successful so dependency-update checks can complete
- preserve manual workflow dispatch behavior

## Evidence

PRs #3734, #3735, and #3736 all fail because Dependabot workflows cannot read CLAUDE_CODE_OAUTH_TOKEN; the action exits during credential validation.

## Validation

- YAML parsed successfully
- git diff --check passes