### PR TITLE
Initialize and flush OpenTelemetry providers

### DIFF
--- a/docs/docs/how-to/opentelemetry.md
+++ b/docs/docs/how-to/opentelemetry.md
@@ -27,6 +27,9 @@ builder.AddOpenTelemetry(openTelemetry => openTelemetry.AddOtlpExporter());
 The exporter uses the standard `OTEL_EXPORTER_OTLP_*` environment variables. For
 example, set `OTEL_EXPORTER_OTLP_ENDPOINT` to the collector endpoint.
 
+The trace and metric providers start when the pipeline is built. When the pipeline
+is disposed, both providers are flushed before their exporters are shut down.
+
 ## Traces
 
 Each run creates a `Pipeline.Run` root span. Module spans are its children, and

--- a/src/ModularPipelines.OpenTelemetry/ModularPipelines.OpenTelemetry.csproj
+++ b/src/ModularPipelines.OpenTelemetry/ModularPipelines.OpenTelemetry.csproj
@@ -5,6 +5,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Initialization.Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
   </ItemGroup>

--- a/src/ModularPipelines.OpenTelemetry/OpenTelemetryInitializer.cs
+++ b/src/ModularPipelines.OpenTelemetry/OpenTelemetryInitializer.cs
@@ -1,0 +1,29 @@
+using Initialization.Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace ModularPipelines.OpenTelemetry;
+
+internal sealed class OpenTelemetryInitializer : IInitializer, IDisposable
+{
+    private readonly TracerProvider _tracerProvider;
+    private readonly MeterProvider _meterProvider;
+
+    public OpenTelemetryInitializer(
+        TracerProvider tracerProvider,
+        MeterProvider meterProvider)
+    {
+        _tracerProvider = tracerProvider;
+        _meterProvider = meterProvider;
+    }
+
+    public int Order => 0;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public void Dispose()
+    {
+        _tracerProvider.ForceFlush();
+        _meterProvider.ForceFlush();
+    }
+}

--- a/src/ModularPipelines.OpenTelemetry/OpenTelemetryInitializer.cs
+++ b/src/ModularPipelines.OpenTelemetry/OpenTelemetryInitializer.cs
@@ -4,8 +4,13 @@ using OpenTelemetry.Trace;
 
 namespace ModularPipelines.OpenTelemetry;
 
+// IInitializer forces the providers to be constructed during pipeline startup. Because this
+// singleton is constructed after its provider dependencies, DI disposes it first so both
+// providers can be flushed before their exporters are shut down.
 internal sealed class OpenTelemetryInitializer : IInitializer, IDisposable
 {
+    private const int FlushTimeoutMilliseconds = 5_000;
+
     private readonly TracerProvider _tracerProvider;
     private readonly MeterProvider _meterProvider;
 
@@ -23,7 +28,13 @@ internal sealed class OpenTelemetryInitializer : IInitializer, IDisposable
 
     public void Dispose()
     {
-        _tracerProvider.ForceFlush();
-        _meterProvider.ForceFlush();
+        try
+        {
+            _tracerProvider.ForceFlush(FlushTimeoutMilliseconds);
+        }
+        finally
+        {
+            _meterProvider.ForceFlush(FlushTimeoutMilliseconds);
+        }
     }
 }

--- a/src/ModularPipelines.OpenTelemetry/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines.OpenTelemetry/PipelineBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.OpenTelemetry;
 using ModularPipelines.Tracing;
 using OpenTelemetry.Metrics;
@@ -53,6 +54,8 @@ public static class OpenTelemetryPipelineBuilderExtensions
                 ModuleActivityTracing.ModuleSourceName,
                 ModuleActivityTracing.CommandSourceName))
             .WithMetrics(metrics => metrics.AddMeter(ModuleActivityTracing.MeterName));
+
+        builder.Services.TryAddSingleton<OpenTelemetryInitializer>();
 
         configure?.Invoke(new ModularPipelinesOpenTelemetryBuilder(openTelemetryBuilder));
         return builder;

--- a/test/ModularPipelines.OpenTelemetry.UnitTests/OpenTelemetryRegistrationTests.cs
+++ b/test/ModularPipelines.OpenTelemetry.UnitTests/OpenTelemetryRegistrationTests.cs
@@ -57,7 +57,9 @@ public class OpenTelemetryRegistrationTests
         await pipeline.DisposeAsync();
 
         await Assert.That(activityProcessor.ForceFlushCalled).IsTrue();
+        await Assert.That(activityProcessor.FlushTimeoutMilliseconds).IsGreaterThan(0);
         await Assert.That(metricReader.CollectCalled).IsTrue();
+        await Assert.That(metricReader.CollectTimeoutMilliseconds).IsGreaterThan(0);
     }
 
     [Test]
@@ -74,9 +76,12 @@ public class OpenTelemetryRegistrationTests
     {
         public bool ForceFlushCalled { get; private set; }
 
+        public int FlushTimeoutMilliseconds { get; private set; }
+
         protected override bool OnForceFlush(int timeoutMilliseconds)
         {
             ForceFlushCalled = true;
+            FlushTimeoutMilliseconds = timeoutMilliseconds;
             return true;
         }
     }
@@ -85,9 +90,12 @@ public class OpenTelemetryRegistrationTests
     {
         public bool CollectCalled { get; private set; }
 
+        public int CollectTimeoutMilliseconds { get; private set; }
+
         protected override bool OnCollect(int timeoutMilliseconds)
         {
             CollectCalled = true;
+            CollectTimeoutMilliseconds = timeoutMilliseconds;
             return true;
         }
     }

--- a/test/ModularPipelines.OpenTelemetry.UnitTests/OpenTelemetryRegistrationTests.cs
+++ b/test/ModularPipelines.OpenTelemetry.UnitTests/OpenTelemetryRegistrationTests.cs
@@ -1,7 +1,11 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
+using ModularPipelines.Tracing;
+using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
 
@@ -15,16 +19,45 @@ public class OpenTelemetryRegistrationTests
     }
 
     [Test]
-    public async Task AddOpenTelemetry_Registers_Trace_And_Meter_Providers()
+    public async Task AddOpenTelemetry_Initializes_Trace_And_Meter_Providers()
     {
+        var metricReader = new RecordingMetricReader();
         var builder = TestPipelineBuilder.Create();
 
         builder.AddOpenTelemetry();
+        builder.Services.AddOpenTelemetry().WithMetrics(metrics => metrics.AddReader(metricReader));
         builder.AddModule<TestModule>();
 
         await using var pipeline = await builder.BuildAsync();
+
+        using var activity = ModuleActivityTracing.PipelineSource.StartActivity("test");
+        using var meter = new Meter(ModuleActivityTracing.MeterName);
+        var counter = meter.CreateCounter<long>("test");
+
+        await Assert.That(activity).IsNotNull();
+        await Assert.That(counter.Enabled).IsTrue();
         await Assert.That(pipeline.Services.GetService<TracerProvider>()).IsNotNull();
         await Assert.That(pipeline.Services.GetService<MeterProvider>()).IsNotNull();
+    }
+
+    [Test]
+    public async Task AddOpenTelemetry_ForceFlushes_Providers_Before_Disposal()
+    {
+        var activityProcessor = new RecordingActivityProcessor();
+        var metricReader = new RecordingMetricReader();
+        var builder = TestPipelineBuilder.Create();
+
+        builder.AddOpenTelemetry();
+        builder.Services.AddOpenTelemetry().WithTracing(tracing =>
+            tracing.AddProcessor(activityProcessor));
+        builder.Services.AddOpenTelemetry().WithMetrics(metrics => metrics.AddReader(metricReader));
+        builder.AddModule<TestModule>();
+
+        var pipeline = await builder.BuildAsync();
+        await pipeline.DisposeAsync();
+
+        await Assert.That(activityProcessor.ForceFlushCalled).IsTrue();
+        await Assert.That(metricReader.CollectCalled).IsTrue();
     }
 
     [Test]
@@ -35,5 +68,27 @@ public class OpenTelemetryRegistrationTests
         var result = builder.AddOpenTelemetry();
 
         await Assert.That(result).IsSameReferenceAs(builder);
+    }
+
+    private sealed class RecordingActivityProcessor : BaseProcessor<Activity>
+    {
+        public bool ForceFlushCalled { get; private set; }
+
+        protected override bool OnForceFlush(int timeoutMilliseconds)
+        {
+            ForceFlushCalled = true;
+            return true;
+        }
+    }
+
+    private sealed class RecordingMetricReader : MetricReader
+    {
+        public bool CollectCalled { get; private set; }
+
+        protected override bool OnCollect(int timeoutMilliseconds)
+        {
+            CollectCalled = true;
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- initialize OpenTelemetry trace and metric providers when the pipeline is built
- force-flush both providers before dependency-injection disposal shuts exporters down
- document lifecycle behavior and cover provider activation plus shutdown flushing

## Validation
- `pwsh scripts/Invoke-AgentDotNet.ps1 -DotNetArguments @('run','--project','test/ModularPipelines.OpenTelemetry.UnitTests/ModularPipelines.OpenTelemetry.UnitTests.csproj','--framework','net10.0','--','--coverage','--coverage-output-format','cobertura')`
- `pwsh scripts/Invoke-AgentDotNet.ps1 -DotNetArguments @('build','src/ModularPipelines.OpenTelemetry/ModularPipelines.OpenTelemetry.slnx','-c','Release')`
- targeted `dotnet format ... whitespace --verify-no-changes`

Fixes #3796