### PR TITLE
Retain run history without report writing

### DIFF
--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -74,7 +74,7 @@ save the updated history under a run-specific key:
 - uses: actions/cache@v4
   with:
     path: .modularpipelines/run-history
-    key: ${{ runner.os }}-modularpipelines-history-${{ github.ref_name }}-${{ github.run_id }}
+    key: ${{ runner.os }}-modularpipelines-history-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}
     restore-keys: |
       ${{ runner.os }}-modularpipelines-history-${{ github.ref_name }}-
 ```

--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -35,10 +35,16 @@ report is also exposed through `PipelineSummary.RunReport`.
 
 ## Local history and deltas
 
-When report writing is enabled, the default `IRunHistoryStore` saves reports under
-`.modularpipelines/run-history`. It retains the latest 20 reports and uses the newest compatible
-report to calculate module and total-duration deltas. When a previous duration exists, the final
-results table includes a `Δ previous` column.
+By default, the `IRunHistoryStore` saves reports under `.modularpipelines/run-history` on local and
+CI runs, even when JSON report writing is disabled. It retains the latest 20 reports and uses the
+newest compatible report to calculate module and total-duration deltas. When a previous duration
+exists, the final results table includes a `Δ previous` column.
+
+Add the default history directory to `.gitignore` if you do not want to commit local run data:
+
+```gitignore
+.modularpipelines/run-history/
+```
 
 Configure or disable retention with `RunReportOptions`:
 
@@ -59,6 +65,19 @@ history store. When `PipelineIdentity` is omitted, Modular Pipelines derives one
 path and registered module types. History is bounded: after each save, the default store deletes
 owned files beyond the configured limit for that pipeline.
 Report and history I/O failures are logged as warnings and do not replace a pipeline failure.
+
+CI agents are often ephemeral, so restore the history directory from a cache before running the
+pipeline. For example, a GitHub Actions workflow can restore the newest cache for its branch and
+save the updated history under a run-specific key:
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: .modularpipelines/run-history
+    key: ${{ runner.os }}-modularpipelines-history-${{ github.ref_name }}-${{ github.run_id }}
+    restore-keys: |
+      ${{ runner.os }}-modularpipelines-history-${{ github.ref_name }}-
+```
 
 ## Custom history stores
 

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -41,7 +41,7 @@ internal sealed class RunReportService(
 
         var reportPath = isDistributedWorker ? null : GetReportPath();
         var pipelineIdentity = GetPipelineIdentity(summary, reportPath);
-        var historyEnabled = reportPath is not null
+        var historyEnabled = !isDistributedWorker
             && pipelineOptions.Value.RunReport.HistoryRetention > 0;
         var previousReport = await LoadPreviousReportAsync(historyEnabled, pipelineIdentity)
             .ConfigureAwait(false);

--- a/src/ModularPipelines/Options/RunReportOptions.cs
+++ b/src/ModularPipelines/Options/RunReportOptions.cs
@@ -29,7 +29,7 @@ public sealed record RunReportOptions
 
     /// <summary>
     /// Gets the maximum number of reports retained by the default history store.
-    /// Set to zero to disable run history.
+    /// History is retained independently of JSON report writing. Set to zero to disable it.
     /// </summary>
     public int HistoryRetention { get; init; } = 20;
 }

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -236,6 +236,29 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task RunHistoryPersistsAndCalculatesDeltasWithoutReportWriting()
+    {
+        var historyPath = CreateTemporaryDirectory();
+
+        try
+        {
+            var firstSummary = await RunPipelineWithoutReportAsync(historyPath);
+            var secondSummary = await RunPipelineWithoutReportAsync(historyPath);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(firstSummary.RunReport!.PreviousTotalDuration).IsNull();
+                await Assert.That(secondSummary.RunReport!.PreviousTotalDuration).IsNotNull();
+                await Assert.That(Directory.GetFiles(historyPath, "*.json")).Count().IsEqualTo(2);
+            }
+        }
+        finally
+        {
+            Directory.Delete(historyPath, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task RunReportSuppressesHistoryForCurrentIdentifierCollisions()
     {
         var firstType = CreateDynamicModuleType("RunReportAssembly", new Version(1, 0));
@@ -2029,6 +2052,24 @@ public class RunReportTests
         builder.AddModule<CommandModule>();
         builder.AddModule<FailingModule>();
         builder.AddModule<SkippedModule>();
+        return await builder.ExecutePipelineAsync();
+    }
+
+    private static async Task<PipelineSummary> RunPipelineWithoutReportAsync(string historyPath)
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            PrintLogo = false,
+            PrintResults = false,
+            RunReport = options.RunReport with
+            {
+                AutoWriteInCi = false,
+                HistoryDirectory = historyPath,
+                HistoryRetention = 2,
+            },
+        });
+        builder.AddModule<SuccessfulModule>();
         return await builder.ExecutePipelineAsync();
     }
 


### PR DESCRIPTION
## Summary
- retain run history whenever `HistoryRetention` is positive, independently of JSON report writing
- preserve distributed-worker suppression while enabling local duration deltas by default
- document `.gitignore` guidance and a branch-aware GitHub Actions cache pattern

## Validation
- `RunReportTests`: 43/43 passed
- `ModularPipelines.slnx` Release build: 0 warnings/errors
- targeted whitespace verification and diff check

Fixes #3743