### PR TITLE
Fix extension imports in quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Then configure and execute the pipeline from `Program.cs`:
 
 ```csharp
 using ModularPipelines;
+using ModularPipelines.Extensions;
 
 using var builder = Pipeline.CreateBuilder(args);
 await builder.ExecutePipelineAsync();

--- a/README_Template.md
+++ b/README_Template.md
@@ -136,6 +136,7 @@ Then configure and execute the pipeline from `Program.cs`:
 
 ```csharp
 using ModularPipelines;
+using ModularPipelines.Extensions;
 
 using var builder = Pipeline.CreateBuilder(args);
 await builder.ExecutePipelineAsync();

--- a/docs/docs/distributed/getting-started.md
+++ b/docs/docs/distributed/getting-started.md
@@ -120,6 +120,7 @@ using ModularPipelines.Attributes;
 using ModularPipelines.Context;
 using ModularPipelines.Distributed.Extensions;
 using ModularPipelines.Distributed.Redis.Extensions;
+using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/docs/docs/distributed/github-actions.md
+++ b/docs/docs/distributed/github-actions.md
@@ -137,6 +137,7 @@ using ModularPipelines.Attributes;
 using ModularPipelines.Context;
 using ModularPipelines.Distributed.Extensions;
 using ModularPipelines.Distributed.Redis.Extensions;
+using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
 using Microsoft.Extensions.DependencyInjection;
 


### PR DESCRIPTION
## Summary
- import `ModularPipelines.Extensions` in the README existing-project quickstart
- fix the same missing import in current distributed getting-started and GitHub Actions programs
- leave versioned 3.x snippets on their older API surface

## Validation
- audited all current Markdown C# program snippets containing `using ModularPipelines;`
- zero snippets call `AddModule` or `ExecutePipelineAsync` without `using ModularPipelines.Extensions;`
- `git diff --check` passes

Closes #3760