### PR TITLE
Require identity-aware run history lookup

### DIFF
--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -69,7 +69,5 @@ register it on the builder:
 builder.AddRunHistoryStore<MyRunHistoryStore>();
 ```
 
-The store returns the latest report for comparison and saves the completed current report. Custom
-stores own their retention behavior. Override the identity-aware `GetLatestAsync` overload when the
-backend can search past a newer report belonging to another pipeline; its default implementation
-only validates the store's latest report.
+The store returns the latest report for the requested pipeline identity and saves the completed
+current report. Custom stores own their retention behavior.

--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -71,3 +71,7 @@ builder.AddRunHistoryStore<MyRunHistoryStore>();
 
 The store returns the latest report for the requested pipeline identity and saves the completed
 current report. Custom stores own their retention behavior.
+
+In v4, `IRunHistoryStore` removes the parameterless `GetLatestAsync` member. Existing custom stores
+must move any identity filtering into `GetLatestAsync(string pipelineIdentity, CancellationToken)`,
+which is now the only read member to implement.

--- a/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
@@ -13,20 +13,13 @@ internal sealed class FileSystemRunHistoryStore(
 {
     private const string OwnedFilePrefix = "modularpipelines-run-";
 
-    public Task<PipelineRunReport?> GetLatestAsync(CancellationToken cancellationToken = default) =>
-        GetLatestAsyncCore($"{OwnedFilePrefix}*.json", pipelineIdentity: null, cancellationToken);
-
     public Task<PipelineRunReport?> GetLatestAsync(
         string pipelineIdentity,
         CancellationToken cancellationToken = default) =>
-        GetLatestAsyncCore(
-            $"{GetPipelineFilePrefix(pipelineIdentity)}*.json",
-            pipelineIdentity,
-            cancellationToken);
+        GetLatestAsyncCore(pipelineIdentity, cancellationToken);
 
     private async Task<PipelineRunReport?> GetLatestAsyncCore(
-        string searchPattern,
-        string? pipelineIdentity,
+        string pipelineIdentity,
         CancellationToken cancellationToken)
     {
         var directory = GetHistoryDirectory();
@@ -38,7 +31,7 @@ internal sealed class FileSystemRunHistoryStore(
         PipelineRunReport? latestReport = null;
         foreach (var file in Directory.EnumerateFiles(
                      directory,
-                     searchPattern,
+                     $"{GetPipelineFilePrefix(pipelineIdentity)}*.json",
                      SearchOption.TopDirectoryOnly))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -47,11 +40,10 @@ internal sealed class FileSystemRunHistoryStore(
                 var json = await File.ReadAllTextAsync(file, cancellationToken).ConfigureAwait(false);
                 if (RunReportJsonSerializer.Deserialize(json) is
                     { SchemaVersion: PipelineRunReport.CurrentSchemaVersion } report
-                    && (pipelineIdentity is null
-                        || string.Equals(
-                            report.PipelineIdentity,
-                            pipelineIdentity,
-                            StringComparison.Ordinal)))
+                    && string.Equals(
+                        report.PipelineIdentity,
+                        pipelineIdentity,
+                        StringComparison.Ordinal))
                 {
                     if (latestReport is null || report.End > latestReport.End)
                     {

--- a/src/ModularPipelines/Engine/IRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/IRunHistoryStore.cs
@@ -8,27 +8,14 @@ namespace ModularPipelines.Engine;
 public interface IRunHistoryStore
 {
     /// <summary>
-    /// Gets the latest retained run report, or <see langword="null"/> when none exists.
-    /// </summary>
-    /// <param name="cancellationToken">A token that cancels the operation.</param>
-    /// <returns>The latest report, or <see langword="null"/>.</returns>
-    Task<PipelineRunReport?> GetLatestAsync(CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Gets the latest retained report for a pipeline identity.
     /// </summary>
     /// <param name="pipelineIdentity">The stable pipeline identity.</param>
     /// <param name="cancellationToken">A token that cancels the operation.</param>
     /// <returns>The latest matching report, or <see langword="null"/>.</returns>
-    async Task<PipelineRunReport?> GetLatestAsync(
+    Task<PipelineRunReport?> GetLatestAsync(
         string pipelineIdentity,
-        CancellationToken cancellationToken = default)
-    {
-        var report = await GetLatestAsync(cancellationToken).ConfigureAwait(false);
-        return string.Equals(report?.PipelineIdentity, pipelineIdentity, StringComparison.Ordinal)
-            ? report
-            : null;
-    }
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Saves a run report and applies the store's configured retention policy.

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -815,13 +815,11 @@ public class RunReportTests
 
             var pipelineA = await store.GetLatestAsync("pipeline-a");
             var pipelineB = await store.GetLatestAsync("pipeline-b");
-            var latest = await store.GetLatestAsync();
 
             using (Assert.Multiple())
             {
                 await Assert.That(pipelineA?.PipelineIdentity).IsEqualTo("pipeline-a");
                 await Assert.That(pipelineB?.PipelineIdentity).IsEqualTo("pipeline-b");
-                await Assert.That(latest?.PipelineIdentity).IsEqualTo("pipeline-b");
                 await Assert.That(Directory.GetFiles(directory, "modularpipelines-run-*.json"))
                     .Count().IsEqualTo(2);
             }


### PR DESCRIPTION
## Summary
- make identity-aware `GetLatestAsync` the sole abstract history read API
- remove the ambiguous parameterless latest-report lookup from the built-in store
- simplify filesystem filtering and update custom-store documentation

## Validation
- `RunReportTests`: 42/42 passed
- focused filesystem history-store tests: 3/3 passed
- `ModularPipelines.slnx` Release build: 0 warnings/errors
- targeted whitespace verification and diff check

Fixes #3745