### PR TITLE
Repair the NuGet publishing example

### DIFF
--- a/docs/docs/examples/dotnet-test-build-publish.md
+++ b/docs/docs/examples/dotnet-test-build-publish.md
@@ -88,8 +88,8 @@ public class PackProjectsModule : Module<CommandResult[]>
             ?? throw new InvalidOperationException("Git repository information is unavailable.");
         var projects = repository.Root
             .GetFiles(file => file.Extension == ".csproj"
-                              && !file.Name.Contains(
-                                  "test",
+                              && !file.Name.EndsWith(
+                                  ".UnitTests.csproj",
                                   StringComparison.OrdinalIgnoreCase))
             .ToList();
         var packageDirectory = repository.Root
@@ -133,7 +133,10 @@ public class UploadPackagesToNugetModule : Module<CommandResult[]>
         var packages = repository.Root
             .GetFolder("artifacts")
             .GetFolder("packages")
-            .GetFiles(file => file.Extension == ".nupkg")
+            .GetFiles(file => file.Extension == ".nupkg"
+                              && !file.Name.EndsWith(
+                                  ".symbols.nupkg",
+                                  StringComparison.OrdinalIgnoreCase))
             .ToList();
         var results = new List<CommandResult>();
 

--- a/docs/docs/examples/dotnet-test-build-publish.md
+++ b/docs/docs/examples/dotnet-test-build-publish.md
@@ -66,6 +66,11 @@ public class RunUnitTestsModule : Module<CommandResult[]>
                 new DotNetTestOptions
                 {
                     Project = testProject.Path,
+                    Arguments =
+                    [
+                        "--coverage",
+                        "--coverage-output-format", "cobertura",
+                    ],
                 },
                 cancellationToken: cancellationToken))
             .ProcessInParallel();

--- a/docs/docs/examples/dotnet-test-build-publish.md
+++ b/docs/docs/examples/dotnet-test-build-publish.md
@@ -1,113 +1,155 @@
 ---
-title: .NET Test, Build & Publish
+title: .NET Test, Pack & Publish
 ---
 
-# .NET Test, Build & Publish
+# .NET Test, Pack & Publish
 
-Here's an example of publishing a NuGet package. Complete with generating sematic versioning, and running tests.
+This example tests every unit-test project, packs the remaining projects with a GitVersion-derived
+version, and pushes the resulting NuGet packages. Install the core, .NET, and Git packages first:
 
-## Generate Version Number
+```powershell
+dotnet add package ModularPipelines
+dotnet add package ModularPipelines.DotNet
+dotnet add package ModularPipelines.Git
+```
+
+Set `NUGET_API_KEY` in the pipeline environment, then use this complete pipeline:
 
 ```csharp
+using ModularPipelines;
+using ModularPipelines.Attributes;
+using ModularPipelines.Context;
+using ModularPipelines.DotNet.Options;
+using ModularPipelines.Extensions;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
+
+using var builder = Pipeline.CreateBuilder(args);
+
+builder
+    .AddModule<NugetVersionGeneratorModule>()
+    .AddModule<RunUnitTestsModule>()
+    .AddModule<PackProjectsModule>()
+    .AddModule<UploadPackagesToNugetModule>();
+
+await builder.ExecutePipelineAsync();
+
 public class NugetVersionGeneratorModule : Module<string>
 {
-    protected override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task<string> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
     {
-        var gitVersionInformation = await context.Tools.Git.Versioning.GetGitVersioningInformation();
-        return gitVersionInformation.FullSemVer;
+        var version = await context.Tools.Git.Versioning.GetGitVersioningInformation();
+        return version.FullSemVer
+            ?? throw new InvalidOperationException("GitVersion did not return a semantic version.");
     }
 }
-```
 
-## Pack Projects
-```csharp
+public class RunUnitTestsModule : Module<CommandResult[]>
+{
+    protected override async Task<CommandResult[]> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
+    {
+        var repository = await context.Tools.Git.Information.GetInfoAsync(cancellationToken)
+            ?? throw new InvalidOperationException("Git repository information is unavailable.");
+        var testProjects = repository.Root
+            .GetFiles(file => file.Name.EndsWith(
+                ".UnitTests.csproj",
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var results = new List<CommandResult>();
+
+        foreach (var testProject in testProjects)
+        {
+            results.Add(await context.Tools.DotNet.TestAsync(
+                new DotNetTestOptions
+                {
+                    Project = testProject.Path,
+                },
+                cancellationToken: cancellationToken));
+        }
+
+        return results.ToArray();
+    }
+}
+
 [DependsOn<NugetVersionGeneratorModule>]
+[DependsOn<RunUnitTestsModule>]
 public class PackProjectsModule : Module<CommandResult[]>
 {
-    protected override async Task<CommandResult[]> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+    protected override async Task<CommandResult[]> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
     {
         var packageVersion = await context.GetModule<NugetVersionGeneratorModule>();
-
-        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync()
+        var repository = await context.Tools.Git.Information.GetInfoAsync(cancellationToken)
             ?? throw new InvalidOperationException("Git repository information is unavailable.");
-        var projects = repositoryInfo.Root
-            .GetFiles(x =>
-                x.Extension == ".csproj" && !x.Name.Contains("test", StringComparison.InvariantCultureIgnoreCase))
+        var projects = repository.Root
+            .GetFiles(file => file.Extension == ".csproj"
+                              && !file.Name.Contains(
+                                  "test",
+                                  StringComparison.OrdinalIgnoreCase))
             .ToList();
+        var packageDirectory = repository.Root
+            .GetFolder("artifacts")
+            .GetFolder("packages");
+        var results = new List<CommandResult>();
 
-        return await projects
-            .ToAsyncProcessorBuilder()
-            .SelectAsync(async projectFile => await context.Tools.DotNet.PackAsync(new DotNetPackOptions
-            {
-                TargetPath = projectFile.Path,
-                IncludeSource = true,
-                Properties = new List<string>
+        foreach (var project in projects)
+        {
+            results.Add(await context.Tools.DotNet.PackAsync(
+                new DotNetPackOptions
                 {
-                    $"PackageVersion={packageVersion.Value}",
-                    $"Version={packageVersion.Value}",
+                    ProjectSolution = project.Path,
+                    Output = packageDirectory.Path,
+                    IncludeSource = true,
+                    Properties =
+                    [
+                        new KeyValue("PackageVersion", packageVersion.Value),
+                        new KeyValue("Version", packageVersion.Value),
+                    ],
                 },
-            }, cancellationToken))
-            .ProcessOneAtATime();
+                cancellationToken: cancellationToken));
+        }
+
+        return results.ToArray();
     }
 }
 
-```
-
-## Run Unit Tests
-
-```csharp
-[DependsOn<PackProjectsModule>]
-public class RunUnitTestsModule : Module<DotNetTestResult[]>
-{
-    protected override async Task<DotNetTestResult[]> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-    {
-        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync()
-            ?? throw new InvalidOperationException("Git repository information is unavailable.");
-        return await repositoryInfo.Root
-            .GetFiles(file => file.Path.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)
-                              && file.Path.Contains("UnitTests", StringComparison.OrdinalIgnoreCase))
-            .ToAsyncProcessorBuilder()
-            .SelectAsync(async unitTestProjectFile => await context.Tools.DotNet.TestAsync(new DotNetTestOptions
-            {
-                TargetPath = unitTestProjectFile.Path,
-                Collect = "XPlat Code Coverage",
-            }, cancellationToken))
-            .ProcessInParallel();
-    }
-}
-
-```
-
-## Upload Packages
-
-```csharp
-[DependsOn<RunUnitTestsModule>]
 [DependsOn<PackProjectsModule>]
 public class UploadPackagesToNugetModule : Module<CommandResult[]>
 {
-    private readonly IOptions<NuGetSettings> _nugetSettings;
-
-    public UploadPackagesToNugetModule(IOptions<NuGetSettings> nugetSettings, IOptions<PublishSettings> publishSettings)
+    protected override async Task<CommandResult[]> ExecuteAsync(
+        IModuleContext context,
+        CancellationToken cancellationToken)
     {
-        _nugetSettings = nugetSettings;
-    }
+        var apiKey = context.Environment.Variables.GetEnvironmentVariable("NUGET_API_KEY");
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
 
-    protected override async Task<CommandResult[]> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(_nugetSettings.Value.ApiKey);
-
-        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync()
+        var repository = await context.Tools.Git.Information.GetInfoAsync(cancellationToken)
             ?? throw new InvalidOperationException("Git repository information is unavailable.");
-        var packages = repositoryInfo.Root
-            .GetFiles(x =>
-                x.Extension == ".nupkg")
+        var packages = repository.Root
+            .GetFolder("artifacts")
+            .GetFolder("packages")
+            .GetFiles(file => file.Extension == ".nupkg")
             .ToList();
+        var results = new List<CommandResult>();
 
-        return await context.NuGet()
-            .UploadPackages(new NuGetUploadOptions(packages.AsPaths(), new Uri("https://api.nuget.org/v3/index.json"))
-            {
-                ApiKey = _nugetSettings.Value.ApiKey!,
-            });
+        foreach (var package in packages)
+        {
+            results.Add(await context.Tools.DotNet.NuGet.PushAsync(
+                new DotNetNuGetPushOptions
+                {
+                    Path = package.Path,
+                    Source = "https://api.nuget.org/v3/index.json",
+                    ApiKey = apiKey,
+                },
+                cancellationToken: cancellationToken));
+        }
+
+        return results.ToArray();
     }
 }
 ```

--- a/docs/docs/examples/dotnet-test-build-publish.md
+++ b/docs/docs/examples/dotnet-test-build-publish.md
@@ -16,6 +16,7 @@ dotnet add package ModularPipelines.Git
 Set `NUGET_API_KEY` in the pipeline environment, then use this complete pipeline:
 
 ```csharp
+using EnumerableAsyncProcessor.Extensions;
 using ModularPipelines;
 using ModularPipelines.Attributes;
 using ModularPipelines.Context;
@@ -59,19 +60,15 @@ public class RunUnitTestsModule : Module<CommandResult[]>
                 ".UnitTests.csproj",
                 StringComparison.OrdinalIgnoreCase))
             .ToList();
-        var results = new List<CommandResult>();
-
-        foreach (var testProject in testProjects)
-        {
-            results.Add(await context.Tools.DotNet.TestAsync(
+        return await testProjects
+            .ToAsyncProcessorBuilder()
+            .SelectAsync(testProject => context.Tools.DotNet.TestAsync(
                 new DotNetTestOptions
                 {
                     Project = testProject.Path,
                 },
-                cancellationToken: cancellationToken));
-        }
-
-        return results.ToArray();
+                cancellationToken: cancellationToken))
+            .ProcessInParallel();
     }
 }
 
@@ -95,11 +92,9 @@ public class PackProjectsModule : Module<CommandResult[]>
         var packageDirectory = repository.Root
             .GetFolder("artifacts")
             .GetFolder("packages");
-        var results = new List<CommandResult>();
-
-        foreach (var project in projects)
-        {
-            results.Add(await context.Tools.DotNet.PackAsync(
+        return await projects
+            .ToAsyncProcessorBuilder()
+            .SelectAsync(project => context.Tools.DotNet.PackAsync(
                 new DotNetPackOptions
                 {
                     ProjectSolution = project.Path,
@@ -111,10 +106,8 @@ public class PackProjectsModule : Module<CommandResult[]>
                         new KeyValue("Version", packageVersion.Value),
                     ],
                 },
-                cancellationToken: cancellationToken));
-        }
-
-        return results.ToArray();
+                cancellationToken: cancellationToken))
+            .ProcessInParallel();
     }
 }
 
@@ -138,21 +131,17 @@ public class UploadPackagesToNugetModule : Module<CommandResult[]>
                                   ".symbols.nupkg",
                                   StringComparison.OrdinalIgnoreCase))
             .ToList();
-        var results = new List<CommandResult>();
-
-        foreach (var package in packages)
-        {
-            results.Add(await context.Tools.DotNet.NuGet.PushAsync(
+        return await packages
+            .ToAsyncProcessorBuilder()
+            .SelectAsync(package => context.Tools.DotNet.NuGet.PushAsync(
                 new DotNetNuGetPushOptions
                 {
                     Path = package.Path,
                     Source = "https://api.nuget.org/v3/index.json",
                     ApiKey = apiKey,
                 },
-                cancellationToken: cancellationToken));
-        }
-
-        return results.ToArray();
+                cancellationToken: cancellationToken))
+            .ProcessOneAtATime();
     }
 }
 ```

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -70,6 +70,18 @@ public static class CurrentApiSnippets
         }
     }
 
+    public static async Task ConfigureTestPackPublishPipeline(string[] args)
+    {
+        using var builder = Pipeline.CreateBuilder(args);
+        builder
+            .AddModule<NugetVersionGeneratorModule>()
+            .AddModule<RunUnitTestsModule>()
+            .AddModule<PackProjectsModule>()
+            .AddModule<UploadPackagesToNugetModule>();
+
+        await builder.ExecutePipelineAsync();
+    }
+
     public sealed record BuildInfo(string Version, string OutputPath);
 
     public sealed class BuildModule : Module<BuildInfo>
@@ -133,6 +145,129 @@ public static class CurrentApiSnippets
                     Output = "publish/",
                 },
                 cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    public sealed class NugetVersionGeneratorModule : Module<string>
+    {
+        protected override async Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            var version = await context.Tools.Git.Versioning.GetGitVersioningInformation();
+            return version.FullSemVer
+                   ?? throw new InvalidOperationException(
+                       "GitVersion did not return a semantic version.");
+        }
+    }
+
+    public sealed class RunUnitTestsModule : Module<CommandResult[]>
+    {
+        protected override async Task<CommandResult[]> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            var repository = await context.Tools.Git.Information.GetInfoAsync(cancellationToken)
+                             ?? throw new InvalidOperationException(
+                                 "Git repository information is unavailable.");
+            var testProjects = repository.Root
+                .GetFiles(file => file.Name.EndsWith(
+                    ".UnitTests.csproj",
+                    StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var results = new List<CommandResult>();
+
+            foreach (var testProject in testProjects)
+            {
+                results.Add(await context.Tools.DotNet.TestAsync(
+                    new DotNetTestOptions
+                    {
+                        Project = testProject.Path,
+                    },
+                    cancellationToken: cancellationToken));
+            }
+
+            return results.ToArray();
+        }
+    }
+
+    [DependsOn<NugetVersionGeneratorModule>]
+    [DependsOn<RunUnitTestsModule>]
+    public sealed class PackProjectsModule : Module<CommandResult[]>
+    {
+        protected override async Task<CommandResult[]> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            var packageVersion = await context.GetModule<NugetVersionGeneratorModule>();
+            var repository = await context.Tools.Git.Information.GetInfoAsync(cancellationToken)
+                             ?? throw new InvalidOperationException(
+                                 "Git repository information is unavailable.");
+            var projects = repository.Root
+                .GetFiles(file => file.Extension == ".csproj"
+                                  && !file.Name.Contains(
+                                      "test",
+                                      StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var packageDirectory = repository.Root
+                .GetFolder("artifacts")
+                .GetFolder("packages");
+            var results = new List<CommandResult>();
+
+            foreach (var project in projects)
+            {
+                results.Add(await context.Tools.DotNet.PackAsync(
+                    new DotNetPackOptions
+                    {
+                        ProjectSolution = project.Path,
+                        Output = packageDirectory.Path,
+                        IncludeSource = true,
+                        Properties =
+                        [
+                            new KeyValue("PackageVersion", packageVersion.Value),
+                            new KeyValue("Version", packageVersion.Value),
+                        ],
+                    },
+                    cancellationToken: cancellationToken));
+            }
+
+            return results.ToArray();
+        }
+    }
+
+    [DependsOn<PackProjectsModule>]
+    public sealed class UploadPackagesToNugetModule : Module<CommandResult[]>
+    {
+        protected override async Task<CommandResult[]> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            var apiKey = context.Environment.Variables.GetEnvironmentVariable("NUGET_API_KEY");
+            ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+
+            var repository = await context.Tools.Git.Information.GetInfoAsync(cancellationToken)
+                             ?? throw new InvalidOperationException(
+                                 "Git repository information is unavailable.");
+            var packages = repository.Root
+                .GetFolder("artifacts")
+                .GetFolder("packages")
+                .GetFiles(file => file.Extension == ".nupkg")
+                .ToList();
+            var results = new List<CommandResult>();
+
+            foreach (var package in packages)
+            {
+                results.Add(await context.Tools.DotNet.NuGet.PushAsync(
+                    new DotNetNuGetPushOptions
+                    {
+                        Path = package.Path,
+                        Source = "https://api.nuget.org/v3/index.json",
+                        ApiKey = apiKey,
+                    },
+                    cancellationToken: cancellationToken));
+            }
+
+            return results.ToArray();
         }
     }
 

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -182,6 +182,11 @@ public static class CurrentApiSnippets
                     new DotNetTestOptions
                     {
                         Project = testProject.Path,
+                        Arguments =
+                        [
+                            "--coverage",
+                            "--coverage-output-format", "cobertura",
+                        ],
                     },
                     cancellationToken: cancellationToken))
                 .ProcessInParallel();

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -205,8 +205,8 @@ public static class CurrentApiSnippets
                                  "Git repository information is unavailable.");
             var projects = repository.Root
                 .GetFiles(file => file.Extension == ".csproj"
-                                  && !file.Name.Contains(
-                                      "test",
+                                  && !file.Name.EndsWith(
+                                      ".UnitTests.csproj",
                                       StringComparison.OrdinalIgnoreCase))
                 .ToList();
             var packageDirectory = repository.Root
@@ -251,7 +251,10 @@ public static class CurrentApiSnippets
             var packages = repository.Root
                 .GetFolder("artifacts")
                 .GetFolder("packages")
-                .GetFiles(file => file.Extension == ".nupkg")
+                .GetFiles(file => file.Extension == ".nupkg"
+                                  && !file.Name.EndsWith(
+                                      ".symbols.nupkg",
+                                      StringComparison.OrdinalIgnoreCase))
                 .ToList();
             var results = new List<CommandResult>();
 

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -1,3 +1,4 @@
+using EnumerableAsyncProcessor.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Attributes;
 using ModularPipelines.Conditions;
@@ -175,19 +176,15 @@ public static class CurrentApiSnippets
                     ".UnitTests.csproj",
                     StringComparison.OrdinalIgnoreCase))
                 .ToList();
-            var results = new List<CommandResult>();
-
-            foreach (var testProject in testProjects)
-            {
-                results.Add(await context.Tools.DotNet.TestAsync(
+            return await testProjects
+                .ToAsyncProcessorBuilder()
+                .SelectAsync(testProject => context.Tools.DotNet.TestAsync(
                     new DotNetTestOptions
                     {
                         Project = testProject.Path,
                     },
-                    cancellationToken: cancellationToken));
-            }
-
-            return results.ToArray();
+                    cancellationToken: cancellationToken))
+                .ProcessInParallel();
         }
     }
 
@@ -212,11 +209,9 @@ public static class CurrentApiSnippets
             var packageDirectory = repository.Root
                 .GetFolder("artifacts")
                 .GetFolder("packages");
-            var results = new List<CommandResult>();
-
-            foreach (var project in projects)
-            {
-                results.Add(await context.Tools.DotNet.PackAsync(
+            return await projects
+                .ToAsyncProcessorBuilder()
+                .SelectAsync(project => context.Tools.DotNet.PackAsync(
                     new DotNetPackOptions
                     {
                         ProjectSolution = project.Path,
@@ -228,10 +223,8 @@ public static class CurrentApiSnippets
                             new KeyValue("Version", packageVersion.Value),
                         ],
                     },
-                    cancellationToken: cancellationToken));
-            }
-
-            return results.ToArray();
+                    cancellationToken: cancellationToken))
+                .ProcessInParallel();
         }
     }
 
@@ -256,21 +249,17 @@ public static class CurrentApiSnippets
                                       ".symbols.nupkg",
                                       StringComparison.OrdinalIgnoreCase))
                 .ToList();
-            var results = new List<CommandResult>();
-
-            foreach (var package in packages)
-            {
-                results.Add(await context.Tools.DotNet.NuGet.PushAsync(
+            return await packages
+                .ToAsyncProcessorBuilder()
+                .SelectAsync(package => context.Tools.DotNet.NuGet.PushAsync(
                     new DotNetNuGetPushOptions
                     {
                         Path = package.Path,
                         Source = "https://api.nuget.org/v3/index.json",
                         ApiKey = apiKey,
                     },
-                    cancellationToken: cancellationToken));
-            }
-
-            return results.ToArray();
+                    cancellationToken: cancellationToken))
+                .ProcessOneAtATime();
         }
     }
 

--- a/test/ModularPipelines.DocumentationSnippets/ModularPipelines.DocumentationSnippets.csproj
+++ b/test/ModularPipelines.DocumentationSnippets/ModularPipelines.DocumentationSnippets.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ModularPipelines.DotNet\ModularPipelines.DotNet.csproj" />
+    <ProjectReference Include="..\..\src\ModularPipelines.Git\ModularPipelines.Git.csproj" />
     <ProjectReference Include="..\..\src\ModularPipelines\ModularPipelines.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #3763

## Summary
- replace the stale NuGet publishing guide with one complete v4 pipeline
- use current Git, test, pack, and `dotnet nuget push` APIs
- compile the entire documented workflow against public package surfaces

## Validation
- `ModularPipelines.DotNet.slnx` Release build
- `ModularPipelines.Git.slnx` Release build
- `ModularPipelines.DocumentationSnippets.csproj` Release build (0 warnings, 0 errors)
- scoped whitespace formatting
- `git diff --check`