### PR TITLE
Read compatible run-report schemas

### DIFF
--- a/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Models;
@@ -76,6 +77,26 @@ internal sealed class FileSystemRunHistoryStore(
         ref bool incompatibleSchemaLogged,
         out PipelineRunReport report)
     {
+        using var document = JsonDocument.Parse(json);
+        var schemaVersion = document.RootElement.TryGetProperty("schemaVersion", out var schemaVersionElement)
+            ? schemaVersionElement.GetInt32()
+            : PipelineRunReport.CurrentSchemaVersion;
+        if (!IsSchemaVersionCompatible(schemaVersion))
+        {
+            if (!incompatibleSchemaLogged)
+            {
+                logger.LogWarning(
+                    "Skipped pipeline run history with schema version {SchemaVersion}; supported versions are {MinimumSchemaVersion} through {CurrentSchemaVersion}",
+                    schemaVersion,
+                    MinimumCompatibleSchemaVersion,
+                    PipelineRunReport.CurrentSchemaVersion);
+                incompatibleSchemaLogged = true;
+            }
+
+            report = null!;
+            return false;
+        }
+
         var deserializedReport = RunReportJsonSerializer.Deserialize(json);
         if (deserializedReport is null)
         {
@@ -84,22 +105,7 @@ internal sealed class FileSystemRunHistoryStore(
         }
 
         report = deserializedReport;
-        if (IsSchemaVersionCompatible(report.SchemaVersion))
-        {
-            return true;
-        }
-
-        if (!incompatibleSchemaLogged)
-        {
-            logger.LogWarning(
-                "Skipped pipeline run history with schema version {SchemaVersion}; supported versions are {MinimumSchemaVersion} through {CurrentSchemaVersion}",
-                report.SchemaVersion,
-                MinimumCompatibleSchemaVersion,
-                PipelineRunReport.CurrentSchemaVersion);
-            incompatibleSchemaLogged = true;
-        }
-
-        return false;
+        return true;
     }
 
     internal static bool IsSchemaVersionCompatible(

--- a/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
@@ -78,9 +78,7 @@ internal sealed class FileSystemRunHistoryStore(
         out PipelineRunReport report)
     {
         using var document = JsonDocument.Parse(json);
-        var schemaVersion = document.RootElement.TryGetProperty("schemaVersion", out var schemaVersionElement)
-            ? schemaVersionElement.GetInt32()
-            : PipelineRunReport.CurrentSchemaVersion;
+        var schemaVersion = ReadSchemaVersion(document.RootElement);
         if (!IsSchemaVersionCompatible(schemaVersion))
         {
             if (!incompatibleSchemaLogged)
@@ -106,6 +104,27 @@ internal sealed class FileSystemRunHistoryStore(
 
         report = deserializedReport;
         return true;
+    }
+
+    private static int ReadSchemaVersion(JsonElement root)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            throw new JsonException("Pipeline run history must contain a JSON object.");
+        }
+
+        if (!root.TryGetProperty("schemaVersion", out var schemaVersionElement))
+        {
+            return PipelineRunReport.CurrentSchemaVersion;
+        }
+
+        if (schemaVersionElement.ValueKind != JsonValueKind.Number
+            || !schemaVersionElement.TryGetInt32(out var schemaVersion))
+        {
+            throw new JsonException("Pipeline run history schemaVersion must be a 32-bit integer.");
+        }
+
+        return schemaVersion;
     }
 
     internal static bool IsSchemaVersionCompatible(

--- a/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
@@ -12,6 +12,7 @@ internal sealed class FileSystemRunHistoryStore(
     ILogger<FileSystemRunHistoryStore> logger) : IRunHistoryStore
 {
     private const string OwnedFilePrefix = "modularpipelines-run-";
+    private const int MinimumCompatibleSchemaVersion = 1;
 
     public Task<PipelineRunReport?> GetLatestAsync(CancellationToken cancellationToken = default) =>
         GetLatestAsyncCore($"{OwnedFilePrefix}*.json", pipelineIdentity: null, cancellationToken);
@@ -36,6 +37,7 @@ internal sealed class FileSystemRunHistoryStore(
         }
 
         PipelineRunReport? latestReport = null;
+        var incompatibleSchemaLogged = false;
         foreach (var file in Directory.EnumerateFiles(
                      directory,
                      searchPattern,
@@ -45,18 +47,19 @@ internal sealed class FileSystemRunHistoryStore(
             try
             {
                 var json = await File.ReadAllTextAsync(file, cancellationToken).ConfigureAwait(false);
-                if (RunReportJsonSerializer.Deserialize(json) is
-                    { SchemaVersion: PipelineRunReport.CurrentSchemaVersion } report
-                    && (pipelineIdentity is null
-                        || string.Equals(
-                            report.PipelineIdentity,
-                            pipelineIdentity,
-                            StringComparison.Ordinal)))
+                if (!TryDeserializeCompatibleReport(json, ref incompatibleSchemaLogged, out var report))
                 {
-                    if (latestReport is null || report.End > latestReport.End)
-                    {
-                        latestReport = report;
-                    }
+                    continue;
+                }
+
+                if ((pipelineIdentity is null
+                     || string.Equals(
+                         report.PipelineIdentity,
+                         pipelineIdentity,
+                         StringComparison.Ordinal))
+                    && (latestReport is null || report.End > latestReport.End))
+                {
+                    latestReport = report;
                 }
             }
             catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or System.Text.Json.JsonException)
@@ -67,6 +70,42 @@ internal sealed class FileSystemRunHistoryStore(
 
         return latestReport;
     }
+
+    private bool TryDeserializeCompatibleReport(
+        string json,
+        ref bool incompatibleSchemaLogged,
+        out PipelineRunReport report)
+    {
+        var deserializedReport = RunReportJsonSerializer.Deserialize(json);
+        if (deserializedReport is null)
+        {
+            report = null!;
+            return false;
+        }
+
+        report = deserializedReport;
+        if (IsSchemaVersionCompatible(report.SchemaVersion))
+        {
+            return true;
+        }
+
+        if (!incompatibleSchemaLogged)
+        {
+            logger.LogWarning(
+                "Skipped pipeline run history with schema version {SchemaVersion}; supported versions are {MinimumSchemaVersion} through {CurrentSchemaVersion}",
+                report.SchemaVersion,
+                MinimumCompatibleSchemaVersion,
+                PipelineRunReport.CurrentSchemaVersion);
+            incompatibleSchemaLogged = true;
+        }
+
+        return false;
+    }
+
+    internal static bool IsSchemaVersionCompatible(
+        int schemaVersion,
+        int currentSchemaVersion = PipelineRunReport.CurrentSchemaVersion) =>
+        schemaVersion >= MinimumCompatibleSchemaVersion && schemaVersion <= currentSchemaVersion;
 
     public async Task SaveAsync(
         PipelineRunReport report,

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.Loader;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -20,6 +21,7 @@ using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.Requirements;
 using ModularPipelines.UnitTests.Attributes;
+using ModularPipelines.UnitTests.Logging;
 using ModularPipelines.Validation;
 using Moq;
 using OptionsFactory = Microsoft.Extensions.Options.Options;
@@ -824,6 +826,62 @@ public class RunReportTests
                 await Assert.That(latest?.PipelineIdentity).IsEqualTo("pipeline-b");
                 await Assert.That(Directory.GetFiles(directory, "modularpipelines-run-*.json"))
                     .Count().IsEqualTo(2);
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task FileSystemHistoryStoreAcceptsAdditiveOlderSchemas()
+    {
+        using (Assert.Multiple())
+        {
+            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(1, 2)).IsTrue();
+            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(2, 2)).IsTrue();
+            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(0, 2)).IsFalse();
+            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(3, 2)).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task FileSystemHistoryStoreLogsUnsupportedSchemaOncePerRead()
+    {
+        var directory = CreateTemporaryDirectory();
+        var log = new StringBuilder();
+        var store = new FileSystemRunHistoryStore(
+            OptionsFactory.Create(new PipelineOptions
+            {
+                RunReport = new RunReportOptions
+                {
+                    HistoryDirectory = directory,
+                    HistoryRetention = 2,
+                },
+            }),
+            new StringLogger<FileSystemRunHistoryStore>(log));
+
+        try
+        {
+            for (var second = 1; second <= 2; second++)
+            {
+                await store.SaveAsync(new PipelineRunReport
+                {
+                    SchemaVersion = PipelineRunReport.CurrentSchemaVersion + 1,
+                    PipelineIdentity = "pipeline-a",
+                    End = new DateTimeOffset(2026, 8, 2, 12, 0, second, TimeSpan.Zero),
+                });
+            }
+
+            var latest = await store.GetLatestAsync("pipeline-a");
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(latest).IsNull();
+                await Assert.That(log.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
+                    .Count().IsEqualTo(1);
+                await Assert.That(log.ToString()).Contains("supported versions are 1 through");
             }
         }
         finally

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -903,6 +903,58 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task FileSystemHistoryStoreSkipsInvalidSchemaMetadata()
+    {
+        var directory = CreateTemporaryDirectory();
+        var log = new StringBuilder();
+        var store = new FileSystemRunHistoryStore(
+            OptionsFactory.Create(new PipelineOptions
+            {
+                RunReport = new RunReportOptions
+                {
+                    HistoryDirectory = directory,
+                    HistoryRetention = 4,
+                },
+            }),
+            new StringLogger<FileSystemRunHistoryStore>(log));
+
+        try
+        {
+            var invalidReports = new[]
+            {
+                "[]",
+                "{ \"schemaVersion\": \"future\" }",
+                "{ \"schemaVersion\": 2147483648 }",
+            };
+            for (var index = 0; index < invalidReports.Length; index++)
+            {
+                await File.WriteAllTextAsync(
+                    Path.Combine(directory, $"modularpipelines-run-invalid-{index}.json"),
+                    invalidReports[index]);
+            }
+
+            await store.SaveAsync(new PipelineRunReport
+            {
+                PipelineIdentity = "pipeline-a",
+                End = new DateTimeOffset(2026, 8, 2, 12, 0, 1, TimeSpan.Zero),
+            });
+
+            var latest = await store.GetLatestAsync();
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(latest?.PipelineIdentity).IsEqualTo("pipeline-a");
+                await Assert.That(log.ToString().Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries))
+                    .Count().IsEqualTo(invalidReports.Length);
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
     [WindowsOnlyTest]
     public async Task FileSystemHistoryStoreContinuesPruningAfterDeleteFailure()
     {

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -874,6 +874,18 @@ public class RunReportTests
                 });
             }
 
+            foreach (var file in Directory.GetFiles(directory, "modularpipelines-run-*.json"))
+            {
+                await File.WriteAllTextAsync(
+                    file,
+                    $$"""
+                      {
+                        "schemaVersion": {{PipelineRunReport.CurrentSchemaVersion + 1}},
+                        "pipelineIdentity": { "future": "pipeline-a" }
+                      }
+                      """);
+            }
+
             var latest = await store.GetLatestAsync("pipeline-a");
 
             using (Assert.Multiple())


### PR DESCRIPTION
Closes #3740

## Summary
- accept additive older run-report schema versions instead of requiring exact equality
- reject invalid/future schemas and log the incompatibility once per history read
- cover compatibility bounds and repeated unsupported files

## Validation
- FileSystemHistoryStore tests: 5 passed
- ModularPipelines.slnx Release build: 0 warnings, 0 errors
- scoped formatting and git diff checks