### PR TITLE
Reuse registered secret masking patterns

### DIFF
--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -96,15 +96,22 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         var minimumLength = Math.Max(1, options.MinimumSecretLength);
         var extraSecrets = _secretProvider.GetSecretsInObject(optionsObject)
             .Where(secret => secret.Length >= minimumLength)
-            .SelectMany(SecretMaskingPatternGenerator.Generate)
+            .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        return extraSecrets.Length == 0
-            ? registeredSecrets
-            : CreateSecretCache(
-                registeredSecrets.Secrets.Concat(extraSecrets),
-                registeredSecrets.Version,
-                caseInsensitive);
+        if (extraSecrets.Length == 0
+            || extraSecrets.All(registeredSecrets.ExactSecrets.Contains))
+        {
+            return registeredSecrets;
+        }
+
+        var extraPatterns = extraSecrets
+            .Where(secret => !registeredSecrets.ExactSecrets.Contains(secret))
+            .SelectMany(SecretMaskingPatternGenerator.Generate);
+        return CreateSecretCache(
+            registeredSecrets.Secrets.Concat(extraPatterns),
+            registeredSecrets.Version,
+            caseInsensitive);
     }
 
     private SecretCache GetRegisteredSecretCache(bool caseInsensitive)
@@ -143,8 +150,10 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         bool caseInsensitive)
     {
         var comparer = caseInsensitive ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
-        var orderedSecrets = secrets
+        var nonBlankSecrets = secrets
             .Where(secret => !string.IsNullOrWhiteSpace(secret))
+            .ToArray();
+        var orderedSecrets = nonBlankSecrets
             .Distinct(comparer)
             .OrderByDescending(secret => secret.Length)
             .ToArray();
@@ -153,7 +162,12 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
             ? null
             : SearchValues.Create(orderedSecrets, comparison);
 
-        return new SecretCache(version, caseInsensitive, orderedSecrets, searchValues);
+        return new SecretCache(
+            version,
+            caseInsensitive,
+            orderedSecrets,
+            nonBlankSecrets.ToHashSet(StringComparer.Ordinal),
+            searchValues);
     }
 
     /// <summary>
@@ -224,5 +238,6 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         long Version,
         bool CaseInsensitive,
         string[] Secrets,
+        IReadOnlySet<string> ExactSecrets,
         SearchValues<string>? SearchValues);
 }

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -99,17 +99,22 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        if (extraSecrets.Length == 0
-            || extraSecrets.All(registeredSecrets.ExactSecrets.Contains))
+        if (extraSecrets.Length == 0)
         {
             return registeredSecrets;
         }
 
-        var extraPatterns = extraSecrets
-            .Where(secret => !registeredSecrets.ExactSecrets.Contains(secret))
-            .SelectMany(SecretMaskingPatternGenerator.Generate);
+        var missingPatterns = extraSecrets
+            .SelectMany(SecretMaskingPatternGenerator.Generate)
+            .Where(pattern => !registeredSecrets.ExactSecrets.Contains(pattern))
+            .ToArray();
+        if (missingPatterns.Length == 0)
+        {
+            return registeredSecrets;
+        }
+
         return CreateSecretCache(
-            registeredSecrets.Secrets.Concat(extraPatterns),
+            registeredSecrets.Secrets.Concat(missingPatterns),
             registeredSecrets.Version,
             caseInsensitive);
     }

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Initialization.Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -31,6 +32,7 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
     private readonly ISecretProvider _secretProvider;
     private readonly IOptions<SecretMaskingOptions> _maskingOptions;
     private readonly object _secretCacheLock = new();
+    private readonly ConditionalWeakTable<object, OptionsSecretCache> _optionsSecretCaches = [];
 
     private SecretCache? _secretCache;
 
@@ -82,7 +84,7 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         return ObfuscateCaseSensitive(input, secretCache.Secrets, maskValue);
     }
 
-    private SecretCache GetSecretCache(
+    internal SecretCache GetSecretCache(
         object? optionsObject,
         SecretMaskingOptions options,
         bool caseInsensitive)
@@ -94,6 +96,37 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         }
 
         var minimumLength = Math.Max(1, options.MinimumSecretLength);
+        var optionsSecretCache = _optionsSecretCaches.GetValue(
+            optionsObject,
+            static _ => new OptionsSecretCache());
+
+        lock (optionsSecretCache.SyncRoot)
+        {
+            if (optionsSecretCache.Cache is { } currentCache
+                && currentCache.Version == registeredSecrets.Version
+                && currentCache.CaseInsensitive == caseInsensitive
+                && optionsSecretCache.MinimumSecretLength == minimumLength)
+            {
+                return currentCache;
+            }
+
+            var cache = CreateOptionsSecretCache(
+                optionsObject,
+                registeredSecrets,
+                minimumLength,
+                caseInsensitive);
+            optionsSecretCache.MinimumSecretLength = minimumLength;
+            optionsSecretCache.Cache = cache;
+            return cache;
+        }
+    }
+
+    private SecretCache CreateOptionsSecretCache(
+        object optionsObject,
+        SecretCache registeredSecrets,
+        int minimumLength,
+        bool caseInsensitive)
+    {
         var extraSecrets = _secretProvider.GetSecretsInObject(optionsObject)
             .Where(secret => secret.Length >= minimumLength)
             .Distinct(StringComparer.Ordinal)
@@ -171,7 +204,7 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
             version,
             caseInsensitive,
             orderedSecrets,
-            nonBlankSecrets.ToHashSet(StringComparer.Ordinal),
+            nonBlankSecrets.ToHashSet(comparer),
             searchValues);
     }
 
@@ -239,7 +272,16 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         return result.ToString();
     }
 
-    private sealed record SecretCache(
+    private sealed class OptionsSecretCache
+    {
+        public object SyncRoot { get; } = new();
+
+        public int MinimumSecretLength { get; set; }
+
+        public SecretCache? Cache { get; set; }
+    }
+
+    internal sealed record SecretCache(
         long Version,
         bool CaseInsensitive,
         string[] Secrets,

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -96,60 +96,50 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         }
 
         var minimumLength = Math.Max(1, options.MinimumSecretLength);
+        var extraSecrets = _secretProvider.GetSecretsInObject(optionsObject)
+            .Where(secret => secret.Length >= minimumLength)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
         var optionsSecretCache = _optionsSecretCaches.GetValue(
             optionsObject,
             static _ => new OptionsSecretCache());
 
         lock (optionsSecretCache.SyncRoot)
         {
-            if (optionsSecretCache.Cache is { } currentCache
+            var secretsChanged = optionsSecretCache.MinimumSecretLength != minimumLength
+                                 || !optionsSecretCache.ExtraSecrets.SequenceEqual(
+                                     extraSecrets,
+                                     StringComparer.Ordinal);
+            if (!secretsChanged
+                && optionsSecretCache.Cache is { } currentCache
                 && currentCache.Version == registeredSecrets.Version
-                && currentCache.CaseInsensitive == caseInsensitive
-                && optionsSecretCache.MinimumSecretLength == minimumLength)
+                && currentCache.CaseInsensitive == caseInsensitive)
             {
                 return currentCache;
             }
 
-            var cache = CreateOptionsSecretCache(
-                optionsObject,
-                registeredSecrets,
-                minimumLength,
-                caseInsensitive);
-            optionsSecretCache.MinimumSecretLength = minimumLength;
+            if (secretsChanged)
+            {
+                optionsSecretCache.MinimumSecretLength = minimumLength;
+                optionsSecretCache.ExtraSecrets = extraSecrets;
+                optionsSecretCache.Patterns = extraSecrets
+                    .SelectMany(SecretMaskingPatternGenerator.Generate)
+                    .ToArray();
+            }
+
+            var missingPatterns = optionsSecretCache.Patterns
+                .Where(pattern => !registeredSecrets.ExactSecrets.Contains(pattern))
+                .ToArray();
+            var cache = missingPatterns.Length == 0
+                ? registeredSecrets
+                : CreateSecretCache(
+                    registeredSecrets.Secrets.Concat(missingPatterns),
+                    registeredSecrets.Version,
+                    caseInsensitive);
             optionsSecretCache.Cache = cache;
             return cache;
         }
-    }
-
-    private SecretCache CreateOptionsSecretCache(
-        object optionsObject,
-        SecretCache registeredSecrets,
-        int minimumLength,
-        bool caseInsensitive)
-    {
-        var extraSecrets = _secretProvider.GetSecretsInObject(optionsObject)
-            .Where(secret => secret.Length >= minimumLength)
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-
-        if (extraSecrets.Length == 0)
-        {
-            return registeredSecrets;
-        }
-
-        var missingPatterns = extraSecrets
-            .SelectMany(SecretMaskingPatternGenerator.Generate)
-            .Where(pattern => !registeredSecrets.ExactSecrets.Contains(pattern))
-            .ToArray();
-        if (missingPatterns.Length == 0)
-        {
-            return registeredSecrets;
-        }
-
-        return CreateSecretCache(
-            registeredSecrets.Secrets.Concat(missingPatterns),
-            registeredSecrets.Version,
-            caseInsensitive);
     }
 
     private SecretCache GetRegisteredSecretCache(bool caseInsensitive)
@@ -277,6 +267,10 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         public object SyncRoot { get; } = new();
 
         public int MinimumSecretLength { get; set; }
+
+        public string[] ExtraSecrets { get; set; } = [];
+
+        public string[] Patterns { get; set; } = [];
 
         public SecretCache? Cache { get; set; }
     }

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
@@ -116,7 +116,7 @@ public class SecretObfuscatorCachingTests
             await Assert.That(repeatedOptionsCache).IsSameReferenceAs(registeredCache);
         }
 
-        secretProvider.Verify(x => x.GetSecretsInObject(optionsObject), Times.Once);
+        secretProvider.Verify(x => x.GetSecretsInObject(optionsObject), Times.Exactly(2));
     }
 
     [Test]
@@ -191,7 +191,30 @@ public class SecretObfuscatorCachingTests
             await Assert.That(refreshed).IsNotSameReferenceAs(first);
         }
 
-        secretProvider.Verify(x => x.GetSecretsInObject(optionsObject), Times.Exactly(2));
+        secretProvider.Verify(x => x.GetSecretsInObject(optionsObject), Times.Exactly(3));
+    }
+
+    [Test]
+    public async Task InvalidatesOptionsCacheWhenOptionsObjectChanges()
+    {
+        var optionSecret = "first-option-secret";
+        var optionsObject = new object();
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, []));
+        secretProvider.Setup(x => x.GetSecretsInObject(optionsObject))
+            .Returns(() => [optionSecret]);
+        var obfuscator = CreateObfuscator(secretProvider.Object);
+        var maskingOptions = new SecretMaskingOptions();
+
+        var first = obfuscator.GetSecretCache(optionsObject, maskingOptions, false);
+        optionSecret = "second-option-secret";
+        var refreshed = obfuscator.GetSecretCache(optionsObject, maskingOptions, false);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(refreshed).IsNotSameReferenceAs(first);
+            await Assert.That(obfuscator.Obfuscate(optionSecret, optionsObject)).IsEqualTo("**********");
+        }
     }
 
     private static SecretObfuscator CreateObfuscator(

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 using ModularPipelines.Options;
@@ -93,10 +95,67 @@ public class SecretObfuscatorCachingTests
         secretProvider.Verify(x => x.GetSnapshot(), Times.Exactly(2));
     }
 
-    private static SecretObfuscator CreateObfuscator(ISecretProvider secretProvider)
+    [Test]
+    public async Task ReusesRegisteredCacheWhenOptionSecretsAreAlreadyRegistered()
+    {
+        const string secret = "registered-secret";
+        var optionsObject = new object();
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.Setup(x => x.GetSnapshot())
+            .Returns(new SecretSnapshot(0, SecretMaskingPatternGenerator.Generate(secret)));
+        secretProvider.Setup(x => x.GetSecretsInObject(optionsObject)).Returns([secret]);
+        var obfuscator = CreateObfuscator(secretProvider.Object);
+        var maskingOptions = new SecretMaskingOptions();
+
+        var registeredCache = GetSecretCache(obfuscator, null, maskingOptions, false);
+        var optionsCache = GetSecretCache(obfuscator, optionsObject, maskingOptions, false);
+
+        await Assert.That(optionsCache).IsSameReferenceAs(registeredCache);
+    }
+
+    [Test]
+    public async Task BuildsExtraPatternsForCaseVariantOptionSecrets()
+    {
+        const string registeredSecret = "CaseSensitiveSecret";
+        const string optionSecret = "casesensitivesecret";
+        var optionsObject = new object();
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.Setup(x => x.GetSnapshot())
+            .Returns(new SecretSnapshot(
+                0,
+                SecretMaskingPatternGenerator.Generate(registeredSecret)));
+        secretProvider.Setup(x => x.GetSecretsInObject(optionsObject)).Returns([optionSecret]);
+        var obfuscator = CreateObfuscator(secretProvider.Object, caseInsensitive: true);
+        var encodedOptionSecret = Convert.ToBase64String(Encoding.UTF8.GetBytes(optionSecret));
+
+        var result = obfuscator.Obfuscate(encodedOptionSecret, optionsObject);
+
+        await Assert.That(result).IsEqualTo("**********");
+    }
+
+    private static object GetSecretCache(
+        SecretObfuscator obfuscator,
+        object? optionsObject,
+        SecretMaskingOptions maskingOptions,
+        bool caseInsensitive)
+    {
+        var method = typeof(SecretObfuscator).GetMethod(
+            "GetSecretCache",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return method.Invoke(
+            obfuscator,
+            [optionsObject, maskingOptions, caseInsensitive])!;
+    }
+
+    private static SecretObfuscator CreateObfuscator(
+        ISecretProvider secretProvider,
+        bool caseInsensitive = false)
     {
         return new SecretObfuscator(
             secretProvider,
-            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
+            {
+                CaseInsensitive = caseInsensitive,
+            }));
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
@@ -133,6 +133,26 @@ public class SecretObfuscatorCachingTests
         await Assert.That(result).IsEqualTo("**********");
     }
 
+    [Test]
+    public async Task BuildsExtraPatternsWhenOptionSecretMatchesRegisteredDerivedPattern()
+    {
+        const string registeredSecret = "foo";
+        var optionSecret = Convert.ToBase64String(Encoding.UTF8.GetBytes(registeredSecret));
+        var optionsObject = new object();
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.Setup(x => x.GetSnapshot())
+            .Returns(new SecretSnapshot(
+                0,
+                SecretMaskingPatternGenerator.Generate(registeredSecret)));
+        secretProvider.Setup(x => x.GetSecretsInObject(optionsObject)).Returns([optionSecret]);
+        var obfuscator = CreateObfuscator(secretProvider.Object);
+        var encodedOptionSecret = Convert.ToBase64String(Encoding.UTF8.GetBytes(optionSecret));
+
+        var result = obfuscator.Obfuscate(encodedOptionSecret, optionsObject);
+
+        await Assert.That(result).IsEqualTo("**********");
+    }
+
     private static object GetSecretCache(
         SecretObfuscator obfuscator,
         object? optionsObject,

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
@@ -107,10 +106,17 @@ public class SecretObfuscatorCachingTests
         var obfuscator = CreateObfuscator(secretProvider.Object);
         var maskingOptions = new SecretMaskingOptions();
 
-        var registeredCache = GetSecretCache(obfuscator, null, maskingOptions, false);
-        var optionsCache = GetSecretCache(obfuscator, optionsObject, maskingOptions, false);
+        var registeredCache = obfuscator.GetSecretCache(null, maskingOptions, false);
+        var optionsCache = obfuscator.GetSecretCache(optionsObject, maskingOptions, false);
+        var repeatedOptionsCache = obfuscator.GetSecretCache(optionsObject, maskingOptions, false);
 
-        await Assert.That(optionsCache).IsSameReferenceAs(registeredCache);
+        using (Assert.Multiple())
+        {
+            await Assert.That(optionsCache).IsSameReferenceAs(registeredCache);
+            await Assert.That(repeatedOptionsCache).IsSameReferenceAs(registeredCache);
+        }
+
+        secretProvider.Verify(x => x.GetSecretsInObject(optionsObject), Times.Once);
     }
 
     [Test]
@@ -129,8 +135,16 @@ public class SecretObfuscatorCachingTests
         var encodedOptionSecret = Convert.ToBase64String(Encoding.UTF8.GetBytes(optionSecret));
 
         var result = obfuscator.Obfuscate(encodedOptionSecret, optionsObject);
+        var registeredCache = obfuscator.GetSecretCache(
+            null,
+            new SecretMaskingOptions(),
+            caseInsensitive: true);
 
-        await Assert.That(result).IsEqualTo("**********");
+        using (Assert.Multiple())
+        {
+            await Assert.That(result).IsEqualTo("**********");
+            await Assert.That(registeredCache.ExactSecrets.Contains(optionSecret)).IsTrue();
+        }
     }
 
     [Test]
@@ -153,18 +167,31 @@ public class SecretObfuscatorCachingTests
         await Assert.That(result).IsEqualTo("**********");
     }
 
-    private static object GetSecretCache(
-        SecretObfuscator obfuscator,
-        object? optionsObject,
-        SecretMaskingOptions maskingOptions,
-        bool caseInsensitive)
+    [Test]
+    public async Task InvalidatesOptionsCacheWhenRegisteredSecretsChange()
     {
-        var method = typeof(SecretObfuscator).GetMethod(
-            "GetSecretCache",
-            BindingFlags.Instance | BindingFlags.NonPublic)!;
-        return method.Invoke(
-            obfuscator,
-            [optionsObject, maskingOptions, caseInsensitive])!;
+        var version = 0L;
+        var optionsObject = new object();
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(() => version);
+        secretProvider.Setup(x => x.GetSnapshot())
+            .Returns(() => new SecretSnapshot(version, []));
+        secretProvider.Setup(x => x.GetSecretsInObject(optionsObject)).Returns(["option-secret"]);
+        var obfuscator = CreateObfuscator(secretProvider.Object);
+        var maskingOptions = new SecretMaskingOptions();
+
+        var first = obfuscator.GetSecretCache(optionsObject, maskingOptions, false);
+        var repeated = obfuscator.GetSecretCache(optionsObject, maskingOptions, false);
+        version += 2;
+        var refreshed = obfuscator.GetSecretCache(optionsObject, maskingOptions, false);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(repeated).IsSameReferenceAs(first);
+            await Assert.That(refreshed).IsNotSameReferenceAs(first);
+        }
+
+        secretProvider.Verify(x => x.GetSecretsInObject(optionsObject), Times.Exactly(2));
     }
 
     private static SecretObfuscator CreateObfuscator(


### PR DESCRIPTION
Closes #3751

## Summary
- reuse the registered SecretObfuscator cache when option secrets are already registered
- generate encoded patterns only for exact raw secrets missing from the registered snapshot
- preserve case-variant encoded masking and mutable-options correctness

## Validation
- `SecretObfuscatorCachingTests` (7/7)
- registered, options-object, and short-secret pattern regressions
- core Release build (0 warnings, 0 errors)
- unit-test project Release build (0 errors; existing nullability warnings only)
- scoped whitespace formatting and `git diff --check`