### PR TITLE
Cache buffered log rendering

### DIFF
--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -770,8 +770,8 @@ internal sealed class BufferedLogEvent<TState>(
 {
     private readonly Exception? _obfuscatedException =
         ObfuscatedLogException.Create(exception, secretObfuscator);
-    private readonly Lazy<string> _formattedMessage = new(
-        () => secretObfuscator.Obfuscate(formatter(originalState, exception), null) ?? string.Empty,
+    private readonly Lazy<string> _rawFormattedMessage = new(
+        () => formatter(originalState, exception),
         LazyThreadSafetyMode.ExecutionAndPublication);
 
     public LogLevel Level => level;
@@ -808,14 +808,15 @@ internal sealed class BufferedLogEvent<TState>(
             Format);
     }
 
-    public string FormatMessageWithLevel() => $"[{FormatLevel(level)}] {_formattedMessage.Value}";
+    public string FormatMessageWithLevel() => $"[{FormatLevel(level)}] {Format(null, null)}";
 
     public string? FormatException()
         => _obfuscatedException is null
             ? null
             : secretObfuscator.Obfuscate(_obfuscatedException.ToString(), null);
 
-    private string Format(object? state, Exception? logException) => _formattedMessage.Value;
+    private string Format(object? state, Exception? logException)
+        => secretObfuscator.Obfuscate(_rawFormattedMessage.Value, null) ?? string.Empty;
 
     private string FormatTyped(TState state, Exception? logException)
         => Format(state!, logException);

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -810,7 +810,10 @@ internal sealed class BufferedLogEvent<TState>(
 
     public string FormatMessageWithLevel() => $"[{FormatLevel(level)}] {_formattedMessage.Value}";
 
-    public string? FormatException() => _obfuscatedException?.ToString();
+    public string? FormatException()
+        => _obfuscatedException is null
+            ? null
+            : secretObfuscator.Obfuscate(_obfuscatedException.ToString(), null);
 
     private string Format(object? state, Exception? logException) => _formattedMessage.Value;
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -770,6 +770,9 @@ internal sealed class BufferedLogEvent<TState>(
 {
     private readonly Exception? _obfuscatedException =
         ObfuscatedLogException.Create(exception, secretObfuscator);
+    private readonly Lazy<string> _formattedMessage = new(
+        () => secretObfuscator.Obfuscate(formatter(originalState, exception), null) ?? string.Empty,
+        LazyThreadSafetyMode.ExecutionAndPublication);
 
     public LogLevel Level => level;
 
@@ -805,18 +808,11 @@ internal sealed class BufferedLogEvent<TState>(
             Format);
     }
 
-    public string FormatMessageWithLevel() => $"[{FormatLevel(level)}] {Format(obfuscatedState, exception)}";
+    public string FormatMessageWithLevel() => $"[{FormatLevel(level)}] {_formattedMessage.Value}";
 
-    public string? FormatException()
-        => exception is null
-            ? null
-            : secretObfuscator.Obfuscate(exception.ToString(), null);
+    public string? FormatException() => _obfuscatedException?.ToString();
 
-    private string Format(object? state, Exception? logException)
-    {
-        var formatted = formatter(originalState, exception);
-        return secretObfuscator.Obfuscate(formatted, null) ?? string.Empty;
-    }
+    private string Format(object? state, Exception? logException) => _formattedMessage.Value;
 
     private string FormatTyped(TState state, Exception? logException)
         => Format(state!, logException);

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -46,8 +46,8 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
         }
 
         var obfuscatedInput = ShouldShowInput(effectiveOptions)
-            ? _secretObfuscator.Obfuscate(inputToLog, null)
-            : LoggingConstants.CommandMask;
+            ? ObfuscateLogValue(inputToLog)
+            : new PreObfuscatedLogValue(LoggingConstants.CommandMask);
         Logger.LogInformation(
             "{WorkingDirectory}> {Input}",
             commandWorkingDirPath,
@@ -141,7 +141,7 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
 
         logger.LogInformation("{WorkingDirectory}> {Input} [DRY-RUN]",
             workingDirectory,
-            _secretObfuscator.Obfuscate(input, null));
+            ObfuscateLogValue(input));
     }
 
     private void LogOutputLine(
@@ -160,7 +160,7 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
             return;
         }
 
-        var obfuscatedOutput = _secretObfuscator.Obfuscate(line, null);
+        var obfuscatedOutput = ObfuscateLogValue(line);
         Logger.LogInformation(
             isError ? "  ↳ {CommandError}" : "  ↳ {CommandOutput}",
             obfuscatedOutput);
@@ -231,7 +231,7 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
         {
             Logger.LogInformation(
                 "  → {CommandOutput}",
-                _secretObfuscator.Obfuscate(output, null));
+                ObfuscateLogValue(output));
             return;
         }
 
@@ -242,7 +242,7 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
             return;
         }
 
-        Logger.LogInformation("  ↳ {CommandOutput}", _secretObfuscator.Obfuscate(output, null));
+        Logger.LogInformation("  ↳ {CommandOutput}", ObfuscateLogValue(output));
     }
 
     private void LogCapturedError(
@@ -258,7 +258,7 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
             return;
         }
 
-        Logger.LogWarning("  ✗ {CommandError}", _secretObfuscator.Obfuscate(error, null));
+        Logger.LogWarning("  ✗ {CommandError}", ObfuscateLogValue(error));
     }
 
     private void LogCommandStatus(
@@ -278,14 +278,17 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
         if (!string.IsNullOrEmpty(commandStatus))
         {
             var obfuscatedInput = ShouldShowInput(options)
-                ? _secretObfuscator.Obfuscate(inputToLog, null)
-                : LoggingConstants.CommandMask;
+                ? ObfuscateLogValue(inputToLog)
+                : new PreObfuscatedLogValue(LoggingConstants.CommandMask);
             Logger.LogInformation(
                 "{CommandStatus} {Input}",
                 commandStatus.TrimStart(),
                 obfuscatedInput);
         }
     }
+
+    private PreObfuscatedLogValue ObfuscateLogValue(string? value) =>
+        new(_secretObfuscator.Obfuscate(value, null));
 
     private static bool ShouldShowInput(CommandLoggingOptions options)
     {

--- a/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
+++ b/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
@@ -61,6 +61,11 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
 
     private object ObfuscateValue(object value)
     {
+        if (value is PreObfuscatedLogValue preObfuscatedValue)
+        {
+            return preObfuscatedValue.Value;
+        }
+
         string originalValue;
         try
         {
@@ -76,6 +81,14 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
             ? value
             : obfuscatedValue;
     }
+}
+
+/// <summary>
+/// Marks a structured log value that has already passed through secret obfuscation.
+/// </summary>
+internal sealed record PreObfuscatedLogValue(string Value)
+{
+    public override string ToString() => Value;
 }
 
 /// <summary>

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -199,7 +199,7 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
-    public async Task BufferedLogEvent_FormatsAndObfuscatesMessageOnce()
+    public async Task BufferedLogEvent_FormatsOnceAndObfuscatesEveryTime()
     {
         var formatterCalls = 0;
         var secretObfuscator = new Mock<ISecretObfuscator>();
@@ -227,7 +227,39 @@ public class ModuleOutputBufferTests
         await Assert.That(formatterCalls).IsEqualTo(1);
         secretObfuscator.Verify(
             x => x.Obfuscate("value:secret", null),
-            Times.Once);
+            Times.Exactly(4));
+    }
+
+    [Test]
+    public async Task BufferedLogEvent_ReobfuscatesMessageWithCurrentSecrets()
+    {
+        const string secret = "late-registered-secret";
+        var redactSecret = false;
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) => redactSecret
+                ? value?.Replace(secret, "***", StringComparison.Ordinal) ?? string.Empty
+                : value ?? string.Empty);
+        var logEvent = new BufferedLogEvent<string>(
+            LogLevel.Information,
+            default,
+            secret,
+            secret,
+            null,
+            static (state, _) => state,
+            secretObfuscator.Object);
+
+        var beforeRegistration = logEvent.FormatMessageWithLevel();
+        redactSecret = true;
+        var afterRegistration = logEvent.FormatMessageWithLevel();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(beforeRegistration).Contains(secret);
+            await Assert.That(afterRegistration).Contains("***");
+            await Assert.That(afterRegistration).DoesNotContain(secret);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.BuildSystemFormatters;
+using Moq;
 
 namespace ModularPipelines.UnitTests.Console;
 
@@ -195,6 +196,38 @@ public class ModuleOutputBufferTests
         logEvent.WriteTo(logger);
 
         await Assert.That(logger.StateTypes).HasSingleItem().And.IsEquivalentTo([typeof(string)]);
+    }
+
+    [Test]
+    public async Task BufferedLogEvent_FormatsAndObfuscatesMessageOnce()
+    {
+        var formatterCalls = 0;
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) => value?.Replace("secret", "***") ?? string.Empty);
+        var logEvent = new BufferedLogEvent<string>(
+            LogLevel.Information,
+            default,
+            "secret",
+            "***",
+            null,
+            (state, _) =>
+            {
+                formatterCalls++;
+                return $"value:{state}";
+            },
+            secretObfuscator.Object);
+
+        logEvent.WriteTo(new RecordingLogger());
+        logEvent.WriteTo(new RecordingLogger());
+        _ = logEvent.FormatMessageWithLevel();
+        _ = logEvent.FormatMessageWithLevel();
+
+        await Assert.That(formatterCalls).IsEqualTo(1);
+        secretObfuscator.Verify(
+            x => x.Obfuscate("value:secret", null),
+            Times.Once);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -231,6 +231,34 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task BufferedLogEvent_ReobfuscatesExceptionWithCurrentSecrets()
+    {
+        const string secret = "late-registered-secret";
+        var redactSecret = false;
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) => redactSecret
+                ? value?.Replace(secret, "***", StringComparison.Ordinal) ?? string.Empty
+                : value ?? string.Empty);
+        var logEvent = new BufferedLogEvent<string>(
+            LogLevel.Error,
+            default,
+            "failure",
+            "failure",
+            new InvalidOperationException(secret),
+            static (state, _) => state,
+            secretObfuscator.Object);
+
+        redactSecret = true;
+
+        var formattedException = logEvent.FormatException();
+
+        await Assert.That(formattedException).Contains("***");
+        await Assert.That(formattedException).DoesNotContain(secret);
+    }
+
+    [Test]
     public async Task ConsoleOutputAddedAfterCompletion_IsRetained()
     {
         var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));

--- a/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
@@ -124,6 +124,27 @@ public class FormattedLogValuesObfuscatorTests
             Times.Never);
     }
 
+    [Test]
+    public async Task TryObfuscateValues_DoesNotRescanPreObfuscatedValues()
+    {
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        var state = new[]
+        {
+            new KeyValuePair<string, object?>(
+                "CommandOutput",
+                new PreObfuscatedLogValue("already-masked")),
+        };
+
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object)
+            .TryObfuscateValues(state);
+        var value = ((IReadOnlyList<KeyValuePair<string, object?>>) obfuscatedState)[0].Value;
+
+        await Assert.That(value).IsEqualTo("already-masked");
+        secretObfuscator.Verify(
+            x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()),
+            Times.Never);
+    }
+
     private sealed class ThrowingToStringState
     {
         public override string ToString() => throw new InvalidOperationException("Cannot format state.");


### PR DESCRIPTION
## Summary
- cache each buffered event's formatted and obfuscated message for reuse across sinks
- mark eagerly obfuscated command values so structured logging does not scan them again
- reuse the cached obfuscated exception text on direct output

## Validation
- focused `FormattedLogValuesObfuscatorTests`: 7 passed
- focused buffered event tests: 2 passed
- focused `ModuleLogger` raw-state test: 1 passed
- focused command secret masking tests: 2 passed
- guarded Release build of `ModularPipelines.slnx`: succeeded, 0 warnings

Closes #3752