### PR TITLE
Move builder APIs into the root namespace

### DIFF
--- a/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
+++ b/src/ModularPipelines/Extensions/PipelineBuilderExtensions.cs
@@ -4,12 +4,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Caching;
 using ModularPipelines.Engine;
+using ModularPipelines.Extensions;
 using ModularPipelines.Interfaces;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.Requirements;
 
-namespace ModularPipelines.Extensions;
+namespace ModularPipelines;
 
 /// <summary>
 /// Convenience extension methods for PipelineBuilder that delegate to Services.

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -104,7 +104,7 @@ public sealed class PipelineBuilder : IDisposable
     /// Gets the current immutable pipeline options snapshot.
     /// </summary>
     /// <remarks>
-    /// Use <see cref="Extensions.PipelineBuilderExtensions.ConfigurePipelineOptions(PipelineBuilder, Func{PipelineOptions, PipelineOptions})"/>
+    /// Use <see cref="PipelineBuilderExtensions.ConfigurePipelineOptions(PipelineBuilder, Func{PipelineOptions, PipelineOptions})"/>
     /// to replace this snapshot.
     /// </remarks>
     public PipelineOptions Options => _options;

--- a/test/ModularPipelines.UnitTests/Api/PipelineBuilderApiAnnotationTests.cs
+++ b/test/ModularPipelines.UnitTests/Api/PipelineBuilderApiAnnotationTests.cs
@@ -1,11 +1,16 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using ModularPipelines.Extensions;
-
 namespace ModularPipelines.UnitTests.Api;
 
 public class PipelineBuilderApiAnnotationTests
 {
+    [Test]
+    public async Task Builder_Extensions_Are_In_Root_Namespace()
+    {
+        await Assert.That(typeof(PipelineBuilderExtensions).Namespace)
+            .IsEqualTo("ModularPipelines");
+    }
+
     [Test]
     public async Task Runtime_Type_Registration_Warns_Trim_And_Aot_Callers()
     {

--- a/test/ModularPipelines.UnitTests/Api/RootNamespaceGoldenPathCompileFixture.cs
+++ b/test/ModularPipelines.UnitTests/Api/RootNamespaceGoldenPathCompileFixture.cs
@@ -1,0 +1,23 @@
+using ModularPipelines;
+using ModularPipelines.Context;
+using ModularPipelines.Modules;
+
+namespace RootNamespaceConsumer;
+
+internal static class RootNamespaceGoldenPathCompileFixture
+{
+    public static async Task ConfigureAndExecuteAsync(PipelineBuilder builder)
+    {
+        builder.AddModule<GoldenPathModule>();
+        builder.ConfigurePipelineOptions(options => options);
+        await builder.ExecutePipelineAsync();
+    }
+
+    private sealed class GoldenPathModule : Module<string>
+    {
+        protected internal override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+            => Task.FromResult(string.Empty);
+    }
+}


### PR DESCRIPTION
Closes #3761

Moves `PipelineBuilderExtensions` into the `ModularPipelines` namespace so the core builder golden path needs one using directive.

Adds an API namespace assertion and a consumer compile fixture covering `AddModule`, `ConfigurePipelineOptions`, and `ExecutePipelineAsync` with only `using ModularPipelines;`.

Validation:
- focused `PipelineBuilderApiAnnotationTests`: 3 passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors