### PR TITLE
Mask realistic keyed secret names

### DIFF
--- a/src/ModularPipelines/Attributes/SecretValueAttribute.cs
+++ b/src/ModularPipelines/Attributes/SecretValueAttribute.cs
@@ -27,6 +27,7 @@ public class SecretValueAttribute : Attribute
 
     /// <summary>
     /// Gets the keys whose values are sensitive when the annotated property contains key-value pairs.
+    /// Keys also match complete identifier segments separated by dots, underscores, hyphens, or casing changes.
     /// An empty collection means the entire property value is sensitive.
     /// </summary>
     public IReadOnlyList<string> Keys { get; } = [];

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -225,11 +225,90 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
 
         foreach (var keyValue in keyValues)
         {
-            if (secretValueKeys.Contains(keyValue.Key, StringComparer.OrdinalIgnoreCase) &&
+            if (secretValueKeys.Any(secretKey => IsMatchingSecretKey(keyValue.Key, secretKey)) &&
                 !string.IsNullOrWhiteSpace(keyValue.Value))
             {
                 yield return keyValue.Value;
             }
+        }
+    }
+
+    private static bool IsMatchingSecretKey(string key, string secretKey)
+    {
+        if (string.Equals(key, secretKey, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        var keySegments = SplitKeySegments(key);
+        var secretSegments = SplitKeySegments(secretKey);
+        if (secretSegments.Count == 0 || secretSegments.Count > keySegments.Count)
+        {
+            return false;
+        }
+
+        for (var start = 0; start <= keySegments.Count - secretSegments.Count; start++)
+        {
+            var allSegmentsMatch = true;
+            for (var offset = 0; offset < secretSegments.Count; offset++)
+            {
+                if (!string.Equals(
+                        secretSegments[offset],
+                        keySegments[start + offset],
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    allSegmentsMatch = false;
+                    break;
+                }
+            }
+
+            if (allSegmentsMatch)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyList<string> SplitKeySegments(string key)
+    {
+        var segments = new List<string>();
+        var segmentStart = 0;
+        for (var index = 0; index < key.Length; index++)
+        {
+            if (key[index] is '.' or '_' or '-')
+            {
+                AddSegment(key, segmentStart, index, segments);
+                segmentStart = index + 1;
+                continue;
+            }
+
+            if (index > segmentStart
+                && char.IsUpper(key[index])
+                && (char.IsLower(key[index - 1])
+                    || (char.IsUpper(key[index - 1])
+                        && index + 1 < key.Length
+                        && char.IsLower(key[index + 1]))))
+            {
+                AddSegment(key, segmentStart, index, segments);
+                segmentStart = index;
+            }
+        }
+
+        AddSegment(key, segmentStart, key.Length, segments);
+        return segments;
+    }
+
+    private static void AddSegment(
+        string key,
+        int start,
+        int end,
+        ICollection<string> segments)
+    {
+        if (end > start)
+        {
+            segments.Add(key[start..end]);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Attributes/SecretValueNormalizationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/SecretValueNormalizationTests.cs
@@ -47,6 +47,20 @@ internal sealed class ReflectionCharacterSecretOptions : GeneratedCharacterSecre
     private string InaccessibleSecret => " ";
 }
 
+internal sealed class GeneratedKeyedSecretOptions
+{
+    [SecretValue("password", "secret", "token", "apiKey")]
+    public IReadOnlyList<KeyValue> Values { get; init; } =
+    [
+        new("auth.password", "dotted-secret"),
+        new("image.pullSecret", "camel-secret"),
+        new("GITHUB_TOKEN", "snake-secret"),
+        new("nuget-api-key", "kebab-secret"),
+        new("hockey", "not-a-secret"),
+        new("tokenizer", "also-not-a-secret"),
+    ];
+}
+
 public class SecretValueNormalizationTests
 {
     private static readonly string[] CharacterSecrets =
@@ -113,6 +127,22 @@ public class SecretValueNormalizationTests
         }
 
         await Assert.That(registeredSecrets.Where(secret => secret.Length == 1)).IsEmpty();
+    }
+
+    [Test]
+    public async Task KeyedSecrets_MatchCompleteIdentifierSegments()
+    {
+        var provider = CreateProvider(out _);
+
+        var secrets = provider.GetSecretsInObject(new GeneratedKeyedSecretOptions()).ToList();
+
+        await Assert.That(secrets).IsEquivalentTo(
+        [
+            "dotted-secret",
+            "camel-secret",
+            "snake-secret",
+            "kebab-secret",
+        ]);
     }
 
     private static SecretProvider CreateProvider(out Mock<IBuildSystemSecretMasker> nativeMasker)


### PR DESCRIPTION
Closes #3774.

## Summary
- match [SecretValue] key selectors against complete dotted, snake_case, kebab-case, and camelCase identifier segments
- preserve exact case-insensitive matching
- avoid raw substring false positives such as hockey/	okenizer`n- document keyed matching semantics

## Validation
- SecretValueNormalizationTests: 4/4 passed
- ModularPipelines.slnx Release build: 0 warnings, 0 errors

@codex review