### PR TITLE
Preserve root failure when AlwaysRun teardown fails

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -125,14 +125,17 @@ internal class ModuleExecutor : IModuleExecutor
         }
     }
 
-    private static IReadOnlyList<Exception> FlattenDistinctExceptions(
+    internal static IReadOnlyList<Exception> FlattenDistinctExceptions(
         params Exception[] exceptions) =>
         exceptions
-            .SelectMany(exception => exception is AggregateException aggregateException
-                ? aggregateException.Flatten().InnerExceptions
-                : [exception])
+            .SelectMany(FlattenException)
             .Distinct<Exception>(ReferenceEqualityComparer.Instance)
             .ToArray();
+
+    private static IEnumerable<Exception> FlattenException(Exception exception) =>
+        exception is AggregateException { InnerExceptions.Count: > 0 } aggregateException
+            ? aggregateException.InnerExceptions.SelectMany(FlattenException)
+            : [exception];
 
     private async Task<IModuleScheduler> InitializeSchedulerAsync(IReadOnlyList<IModule> modules)
     {

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Runtime.ExceptionServices;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Engine.Attributes;
@@ -100,10 +101,18 @@ internal class ModuleExecutor : IModuleExecutor
                 }
                 catch (Exception alwaysRunException)
                 {
-                    throw new AggregateException(
-                        "Pipeline execution and AlwaysRun teardown both failed.",
+                    var pipelineExceptions = FlattenDistinctExceptions(outerEx);
+                    var combinedExceptions = FlattenDistinctExceptions(
                         outerEx,
                         alwaysRunException);
+                    if (combinedExceptions.Count == pipelineExceptions.Count)
+                    {
+                        ExceptionDispatchInfo.Capture(outerEx).Throw();
+                    }
+
+                    throw new AggregateException(
+                        "Pipeline execution and AlwaysRun teardown both failed.",
+                        combinedExceptions);
                 }
             }
 
@@ -115,6 +124,15 @@ internal class ModuleExecutor : IModuleExecutor
             scheduler?.Dispose();
         }
     }
+
+    private static IReadOnlyList<Exception> FlattenDistinctExceptions(
+        params Exception[] exceptions) =>
+        exceptions
+            .SelectMany(exception => exception is AggregateException aggregateException
+                ? aggregateException.Flatten().InnerExceptions
+                : [exception])
+            .Distinct<Exception>(ReferenceEqualityComparer.Instance)
+            .ToArray();
 
     private async Task<IModuleScheduler> InitializeSchedulerAsync(IReadOnlyList<IModule> modules)
     {

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -94,7 +94,17 @@ internal class ModuleExecutor : IModuleExecutor
 
             if (scheduler != null)
             {
-                await _alwaysRunHandler.WaitForAlwaysRunModulesAsync(scheduler, modules).ConfigureAwait(false);
+                try
+                {
+                    await _alwaysRunHandler.WaitForAlwaysRunModulesAsync(scheduler, modules).ConfigureAwait(false);
+                }
+                catch (Exception alwaysRunException)
+                {
+                    throw new AggregateException(
+                        "Pipeline execution and AlwaysRun teardown both failed.",
+                        outerEx,
+                        alwaysRunException);
+                }
             }
 
             _logger.LogDebug("Outer catch block rethrowing exception");

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -107,9 +107,10 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
-    public async Task SchedulerFault_RegistersTerminatedResultsBeforeAlwaysRun()
+    public async Task SchedulerAndAlwaysRunFaults_AreAggregatedAfterRegisteringTerminatedResults()
     {
         var schedulerException = new DependencyCollisionException("Scheduler fault");
+        var alwaysRunException = new InvalidOperationException("AlwaysRun fault");
         var readyModules = Channel.CreateUnbounded<ModuleState>();
         readyModules.Writer.Complete(schedulerException);
         var cancelledModule = new LaterModule();
@@ -134,15 +135,16 @@ public class ModuleExecutorLoggingTests
             .Setup(x => x.WaitForAlwaysRunModulesAsync(
                 scheduler.Object,
                 It.IsAny<IReadOnlyList<IModule>>()))
-            .Callback(() =>
+            .Returns(() =>
             {
                 if (!terminatedResultsRegistered)
                 {
-                    throw new InvalidOperationException(
-                        "Terminated results were not registered before AlwaysRun processing.");
+                    return Task.FromException(new InvalidOperationException(
+                        "Terminated results were not registered before AlwaysRun processing."));
                 }
-            })
-            .Returns(Task.CompletedTask);
+
+                return Task.FromException(alwaysRunException);
+            });
         var registrationEvents = new Mock<IRegistrationEventExecutor>();
         registrationEvents
             .Setup(x => x.InvokeRegistrationEventsAsync(It.IsAny<IReadOnlyList<IModule>>()))
@@ -164,15 +166,20 @@ public class ModuleExecutorLoggingTests
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
             NullLogger<ModuleExecutor>.Instance);
 
-        await Assert.ThrowsAsync<DependencyCollisionException>(
+        var exception = await Assert.ThrowsAsync<AggregateException>(
             async () => await executor.ExecuteAsync([cancelledModule]));
 
-        resultRegistrar.Verify(x => x.RegisterTerminatedResultsForCancelledModules(
-            cancelledModules,
-            schedulerException), Times.Once);
-        alwaysRunHandler.Verify(x => x.WaitForAlwaysRunModulesAsync(
-            scheduler.Object,
-            It.IsAny<IReadOnlyList<IModule>>()), Times.Once);
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.InnerExceptions[0]).IsSameReferenceAs(schedulerException);
+            await Assert.That(exception.InnerExceptions[1]).IsSameReferenceAs(alwaysRunException);
+            resultRegistrar.Verify(x => x.RegisterTerminatedResultsForCancelledModules(
+                cancelledModules,
+                schedulerException), Times.Once);
+            alwaysRunHandler.Verify(x => x.WaitForAlwaysRunModulesAsync(
+                scheduler.Object,
+                It.IsAny<IReadOnlyList<IModule>>()), Times.Once);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -186,6 +186,25 @@ public class ModuleExecutorLoggingTests
     }
 
     [Test]
+    public async Task FlattenDistinctExceptions_PreservesEmptyAggregates()
+    {
+        var pipelineException = new AggregateException();
+        var teardownException = new AggregateException();
+        var nestedTeardownException = new AggregateException(teardownException);
+
+        var exceptions = ModuleExecutor.FlattenDistinctExceptions(
+            pipelineException,
+            nestedTeardownException);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exceptions).Count().IsEqualTo(2);
+            await Assert.That(exceptions[0]).IsSameReferenceAs(pipelineException);
+            await Assert.That(exceptions[1]).IsSameReferenceAs(teardownException);
+        }
+    }
+
+    [Test]
     public async Task StopOnFirstException_SurfacesAllConcurrentWorkerFaults()
     {
         var faultingModule = new FaultingModule();

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -143,7 +143,9 @@ public class ModuleExecutorLoggingTests
                         "Terminated results were not registered before AlwaysRun processing."));
                 }
 
-                return Task.FromException(alwaysRunException);
+                return Task.FromException(new AggregateException(
+                    schedulerException,
+                    alwaysRunException));
             });
         var registrationEvents = new Mock<IRegistrationEventExecutor>();
         registrationEvents
@@ -173,6 +175,7 @@ public class ModuleExecutorLoggingTests
         {
             await Assert.That(exception!.InnerExceptions[0]).IsSameReferenceAs(schedulerException);
             await Assert.That(exception.InnerExceptions[1]).IsSameReferenceAs(alwaysRunException);
+            await Assert.That(exception.InnerExceptions).Count().IsEqualTo(2);
             resultRegistrar.Verify(x => x.RegisterTerminatedResultsForCancelledModules(
                 cancelledModules,
                 schedulerException), Times.Once);


### PR DESCRIPTION
Closes #3785.

## Summary
- aggregate the original pipeline failure with a subsequent AlwaysRun teardown failure
- preserve exception order so the root failure remains first
- cover scheduler and teardown faults with a regression test

## Validation
- focused ModuleExecutor regression: 1/1 passed
- core Release build: 0 warnings, 0 errors