### PR TITLE
Expose fingerprint cache outcomes

### DIFF
--- a/src/ModularPipelines.GitHub/GitHubMarkdownSummaryGenerator.cs
+++ b/src/ModularPipelines.GitHub/GitHubMarkdownSummaryGenerator.cs
@@ -147,11 +147,12 @@ internal class GitHubMarkdownSummaryGenerator : IPipelineGlobalHooks
             : string.Empty;
     }
 
-    private static string GetStatusString(Status status)
+    internal static string GetStatusString(Status status)
     {
         return status switch
         {
-            Status.Successful or Status.UsedHistory => $$$"""${\textsf{\color{lightgreen}{{{status}}}}}$""",
+            Status.Successful or Status.UsedHistory or Status.CachedResult =>
+                $$$"""${\textsf{\color{lightgreen}{{{status}}}}}$""",
             Status.NotYetStarted or Status.IgnoredFailure or Status.Processing or Status.Skipped =>
                 $$$"""${\textsf{\color{orange}{{{status}}}}}$""",
             Status.PipelineTerminated or Status.TimedOut or Status.Failed or Status.Unknown =>

--- a/src/ModularPipelines/Caching/ModuleCacheResultRepository.cs
+++ b/src/ModularPipelines/Caching/ModuleCacheResultRepository.cs
@@ -418,7 +418,7 @@ internal sealed class ModuleCacheResultRepository : IModuleCacheResultRepository
         Append(
             incrementalHash,
             "dependency-status",
-            dependencyResult.ModuleStatus == Status.UsedHistory
+            dependencyResult.ModuleStatus is Status.UsedHistory or Status.CachedResult
                 ? Status.Successful.ToString()
                 : dependencyResult.ModuleStatus.ToString());
 

--- a/src/ModularPipelines/Engine/Execution/DirectHookInvoker.cs
+++ b/src/ModularPipelines/Engine/Execution/DirectHookInvoker.cs
@@ -65,6 +65,26 @@ internal class DirectHookInvoker : IDirectHookInvoker
     }
 
     /// <inheritdoc />
+    public async Task InvokeCachedResultAsync<T>(
+        Module<T> module,
+        IModuleContext context,
+        ModuleResult<T> result,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await module.InvokeOnCachedResultAsync(context, result, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
+        {
+            _logger.LogError(
+                ex,
+                "OnCachedResultAsync hook failed for module {ModuleName}",
+                module.GetType().Name);
+        }
+    }
+
+    /// <inheritdoc />
     public async Task InvokeFailedAsync<T>(
         Module<T> module,
         IModuleContext context,

--- a/src/ModularPipelines/Engine/Execution/IDirectHookInvoker.cs
+++ b/src/ModularPipelines/Engine/Execution/IDirectHookInvoker.cs
@@ -53,6 +53,15 @@ internal interface IDirectHookInvoker
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// Invokes the OnCachedResultAsync hook on the module.
+    /// </summary>
+    Task InvokeCachedResultAsync<T>(
+        Module<T> module,
+        IModuleContext context,
+        ModuleResult<T> result,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Invokes the OnFailedAsync hook on the module.
     /// </summary>
     /// <typeparam name="T">The module result type.</typeparam>

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -493,6 +493,7 @@ internal class ModuleRunner : IModuleRunner
         var telemetryStart = Stopwatch.GetTimestamp();
         var telemetryStatus = "Failed";
         using var activity = ModuleActivityTracing.StartModuleActivity(moduleType);
+        executionContext.ModuleActivity = activity;
 
         // Set up logging and module type context using scope wrapper for proper cleanup
         await using var loggerScope = new ModuleLoggerScope(logger, moduleType);

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -526,6 +526,11 @@ internal class ModuleRunner : IModuleRunner
                 telemetryStatus = "UsedHistory";
                 ModuleActivityTracing.RecordUsedHistory(activity);
             }
+            else if (executionContext.Status == Enums.Status.CachedResult)
+            {
+                telemetryStatus = "CachedResult";
+                ModuleActivityTracing.RecordCachedResult(activity);
+            }
             else if (executionContext.Status == Enums.Status.PipelineTerminated)
             {
                 telemetryStatus = "PipelineTerminated";
@@ -670,7 +675,8 @@ internal class ModuleRunner : IModuleRunner
             return;
         }
 
-        var isSuccessful = executionContext.Status is Enums.Status.Successful or Enums.Status.UsedHistory;
+        var isSuccessful = executionContext.Status is
+            Enums.Status.Successful or Enums.Status.UsedHistory or Enums.Status.CachedResult;
         await _mediator.Publish(
                 new ModuleCompletedNotification(moduleState, isSuccessful),
                 CancellationToken.None)
@@ -684,7 +690,11 @@ internal class ModuleRunner : IModuleRunner
         Exception exception)
     {
         executionContext.Exception = exception;
-        if (executionContext.Status is Enums.Status.Successful or Enums.Status.UsedHistory or Enums.Status.NotYetStarted or Enums.Status.Processing)
+        if (executionContext.Status is Enums.Status.Successful
+            or Enums.Status.UsedHistory
+            or Enums.Status.CachedResult
+            or Enums.Status.NotYetStarted
+            or Enums.Status.Processing)
         {
             executionContext.Status = Enums.Status.Failed;
         }
@@ -740,7 +750,8 @@ internal class ModuleRunner : IModuleRunner
         await _lifecycleEventInvoker.InvokeEndEventAsync(lifecycleContext, executionContext.Status, result).ConfigureAwait(false);
 
         if (!_manageArtifactsLocally
-            || executionContext.Status is not (Enums.Status.Successful or Enums.Status.UsedHistory))
+            || executionContext.Status is not (
+                Enums.Status.Successful or Enums.Status.UsedHistory or Enums.Status.CachedResult))
         {
             return;
         }

--- a/src/ModularPipelines/Engine/MetricsCollector.cs
+++ b/src/ModularPipelines/Engine/MetricsCollector.cs
@@ -44,7 +44,7 @@ internal class MetricsCollector : IMetricsCollector
     {
         var data = _moduleMetrics.GetOrAdd(moduleType, _ => new ModuleMetricsData { ModuleType = moduleType });
         data.EndTime = time;
-        data.WasSuccessful = status is Status.Successful or Status.UsedHistory;
+        data.WasSuccessful = status is Status.Successful or Status.UsedHistory or Status.CachedResult;
         data.WasSkipped = skipped;
         data.Status = status;
     }

--- a/src/ModularPipelines/Engine/ModuleExecutionContext.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionContext.cs
@@ -69,6 +69,11 @@ internal class ModuleExecutionContext : IModuleExecutionContext
     public TimeSpan Duration { get; set; }
 
     /// <summary>
+    /// Gets or sets the activity for this module execution.
+    /// </summary>
+    public Activity? ModuleActivity { get; set; }
+
+    /// <summary>
     /// Gets or sets any exception that occurred during execution.
     /// </summary>
     public Exception? Exception { get; set; }

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -301,7 +301,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
     {
         if (!config.CacheEnabled || _cacheResultRepository is null)
         {
-            ModuleActivityTracing.RecordCacheDisabled();
+            ModuleActivityTracing.RecordCacheDisabled(executionContext.ModuleActivity);
             return null;
         }
 
@@ -314,7 +314,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             .ConfigureAwait(false);
         if (cachedResult is null)
         {
-            ModuleActivityTracing.RecordCacheMiss(module.GetType());
+            ModuleActivityTracing.RecordCacheMiss(executionContext.ModuleActivity, module.GetType());
             return null;
         }
 
@@ -322,7 +322,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             executionContext,
             cachedResult,
             logger);
-        ModuleActivityTracing.RecordCacheHit(module.GetType());
+        ModuleActivityTracing.RecordCacheHit(executionContext.ModuleActivity, module.GetType());
         await _directHookInvoker.InvokeCachedResultAsync(
                 module,
                 moduleContext,

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -301,6 +301,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
     {
         if (!config.CacheEnabled || _cacheResultRepository is null)
         {
+            ModuleActivityTracing.RecordCacheDisabled();
             return null;
         }
 
@@ -313,22 +314,22 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             .ConfigureAwait(false);
         if (cachedResult is null)
         {
+            ModuleActivityTracing.RecordCacheMiss(module.GetType());
             return null;
         }
 
-        var cacheHit = SkipDecision.Skip("Module cache hit");
-        await _directHookInvoker.InvokeSkippedAsync(
-                module,
-                moduleContext,
-                cacheHit,
-                cancellationToken)
-            .ConfigureAwait(false);
-        return UseHistoricalResult(
+        var result = UseCachedResult(
             executionContext,
             cachedResult,
-            cacheHit,
-            logger,
-            "Using cached module result");
+            logger);
+        ModuleActivityTracing.RecordCacheHit(module.GetType());
+        await _directHookInvoker.InvokeCachedResultAsync(
+                module,
+                moduleContext,
+                result,
+                cancellationToken)
+            .ConfigureAwait(false);
+        return result;
     }
 
     private void SetupCancellation(
@@ -449,6 +450,17 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         var usedHistoryResult = historicalResult with { ModuleStatus = Status.UsedHistory };
         logger.LogDebug(message);
         return usedHistoryResult;
+    }
+
+    private static ModuleResult<T> UseCachedResult<T>(
+        ModuleExecutionContext<T> executionContext,
+        ModuleResult<T> cachedResult,
+        IModuleLogger logger)
+    {
+        executionContext.Status = Status.CachedResult;
+        var result = cachedResult with { ModuleStatus = Status.CachedResult };
+        logger.LogDebug("Using cached module result");
+        return result;
     }
 
     private async Task<T> ExecuteWithPolicies<T>(
@@ -834,6 +846,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             Status.IgnoredFailure => LogLevel.Warning,
             Status.PipelineTerminated => LogLevel.Error,
             Status.UsedHistory => LogLevel.Information,
+            Status.CachedResult => LogLevel.Information,
             Status.Retried => LogLevel.Warning,
             _ => LogLevel.Error,
         };

--- a/src/ModularPipelines/Enums/Status.cs
+++ b/src/ModularPipelines/Enums/Status.cs
@@ -29,6 +29,11 @@ public enum Status
     UsedHistory,
 
     /// <summary>
+    /// The module result was restored from the fingerprint cache.
+    /// </summary>
+    CachedResult,
+
+    /// <summary>
     /// The module failed.
     /// </summary>
     Failed,

--- a/src/ModularPipelines/Enums/Status.cs
+++ b/src/ModularPipelines/Enums/Status.cs
@@ -29,11 +29,6 @@ public enum Status
     UsedHistory,
 
     /// <summary>
-    /// The module result was restored from the fingerprint cache.
-    /// </summary>
-    CachedResult,
-
-    /// <summary>
     /// The module failed.
     /// </summary>
     Failed,
@@ -67,4 +62,9 @@ public enum Status
     /// Unknown module status.
     /// </summary>
     Unknown,
+
+    /// <summary>
+    /// The module result was restored from the fingerprint cache.
+    /// </summary>
+    CachedResult,
 }

--- a/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
+++ b/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
@@ -272,6 +272,7 @@ internal class SpectreResultsPrinter : IResultsPrinter
             ModuleStatus.Skipped => $"[dim]{moduleName}[/]",
             ModuleStatus.Successful => $"[green]{moduleName}[/]",
             ModuleStatus.UsedHistory => $"[green3]{moduleName}[/]",
+            ModuleStatus.CachedResult => $"[green3]{moduleName}[/]",
             _ => $"[cyan]{moduleName}[/]",
         };
     }
@@ -286,7 +287,8 @@ internal class SpectreResultsPrinter : IResultsPrinter
             ModuleStatus.PipelineTerminated => "[red]Terminated[/]",
             ModuleStatus.IgnoredFailure => "[yellow]Ignored[/]",
             ModuleStatus.Skipped => "[dim]⏭ skipped[/]",
-            ModuleStatus.UsedHistory => "[green3]Cached[/]",
+            ModuleStatus.UsedHistory => "[green3]History[/]",
+            ModuleStatus.CachedResult => "[green3]Cached[/]",
             ModuleStatus.Retried => "[yellow]Retried[/]",
             ModuleStatus.Processing => "[blue]Running[/]",
             ModuleStatus.NotYetStarted => "[dim]Pending[/]",

--- a/src/ModularPipelines/Helpers/StatusDisplayProvider.cs
+++ b/src/ModularPipelines/Helpers/StatusDisplayProvider.cs
@@ -38,6 +38,7 @@ internal static class StatusDisplayProvider
         [Status.IgnoredFailure] = new("[orange3]⚠[/]", "Module {0} failed but the failure was ignored"),
         [Status.PipelineTerminated] = new(MarkupFormatter.StopIcon, "Module {0} terminated due to pipeline error"),
         [Status.UsedHistory] = new(MarkupFormatter.HistoryIcon, "Module {0} used historical data"),
+        [Status.CachedResult] = new(MarkupFormatter.HistoryIcon, "Module {0} used a cached result"),
         [Status.Retried] = new(MarkupFormatter.RetryIcon, "Module {0} retried"),
     };
 

--- a/src/ModularPipelines/Helpers/StatusFormatter.cs
+++ b/src/ModularPipelines/Helpers/StatusFormatter.cs
@@ -21,6 +21,7 @@ internal static class StatusFormatter
             Status.Unknown => "[yellow]Unknown[/]",
             Status.Retried => "[yellow]Retried[/]",
             Status.UsedHistory => "[green3]Used History[/]",
+            Status.CachedResult => "[green3]Cached Result[/]",
             _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
         };
     }

--- a/src/ModularPipelines/Modules/Module.cs
+++ b/src/ModularPipelines/Modules/Module.cs
@@ -194,6 +194,19 @@ public abstract class Module<T> : IModule
         => Task.CompletedTask;
 
     /// <summary>
+    /// Called when the module's result is restored from the fingerprint cache.
+    /// </summary>
+    /// <param name="context">The module context.</param>
+    /// <param name="result">The cached module result.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>A task representing the operation.</returns>
+    protected virtual Task OnCachedResultAsync(
+        IModuleContext context,
+        ModuleResult<T> result,
+        CancellationToken cancellationToken)
+        => Task.CompletedTask;
+
+    /// <summary>
     /// Called when the module fails with an exception. Override to add error handling.
     /// Called before OnAfterExecuteAsync.
     /// </summary>
@@ -242,6 +255,15 @@ public abstract class Module<T> : IModule
         SkipDecision skipDecision,
         CancellationToken cancellationToken)
         => OnSkippedAsync(context, skipDecision, cancellationToken);
+
+    /// <summary>
+    /// Internal accessor to invoke OnCachedResultAsync from the engine.
+    /// </summary>
+    internal Task InvokeOnCachedResultAsync(
+        IModuleContext context,
+        ModuleResult<T> result,
+        CancellationToken cancellationToken)
+        => OnCachedResultAsync(context, result, cancellationToken);
 
     /// <summary>
     /// Internal accessor to invoke OnFailedAsync from the engine.

--- a/src/ModularPipelines/Tracing/ModuleActivityTracing.cs
+++ b/src/ModularPipelines/Tracing/ModuleActivityTracing.cs
@@ -42,6 +42,11 @@ public static class ModuleActivityTracing
     public const string ModuleStatusTag = "modular_pipelines.module.status";
 
     /// <summary>
+    /// Tag key for the module fingerprint-cache outcome.
+    /// </summary>
+    public const string ModuleCacheTag = "modular_pipelines.module.cache";
+
+    /// <summary>
     /// Tag key for exception type when a module fails.
     /// </summary>
     public const string ExceptionTypeTag = "exception.type";
@@ -59,6 +64,8 @@ public static class ModuleActivityTracing
     public const string ModuleDurationMetric = "modular_pipelines.module.duration";
     public const string ModulesFailedMetric = "modular_pipelines.modules.failed";
     public const string ModuleRetriesMetric = "modular_pipelines.module.retries";
+    public const string ModuleCacheHitsMetric = "modular_pipelines.module.cache_hits";
+    public const string ModuleCacheMissesMetric = "modular_pipelines.module.cache_misses";
 
     public static readonly Meter TelemetryMeter = new(MeterName, "1.0.0");
 
@@ -76,6 +83,16 @@ public static class ModuleActivityTracing
         ModuleRetriesMetric,
         unit: "{retry}",
         description: "Number of module retry attempts.");
+
+    private static readonly Counter<long> ModuleCacheHits = TelemetryMeter.CreateCounter<long>(
+        ModuleCacheHitsMetric,
+        unit: "{hit}",
+        description: "Number of module fingerprint-cache hits.");
+
+    private static readonly Counter<long> ModuleCacheMisses = TelemetryMeter.CreateCounter<long>(
+        ModuleCacheMissesMetric,
+        unit: "{miss}",
+        description: "Number of module fingerprint-cache misses.");
 
     public static readonly ActivitySource PipelineSource = new(PipelineSourceName, "1.0.0");
 
@@ -190,6 +207,23 @@ public static class ModuleActivityTracing
             });
     }
 
+    internal static void RecordCacheDisabled()
+    {
+        Activity.Current?.SetTag(ModuleCacheTag, "disabled");
+    }
+
+    internal static void RecordCacheHit(Type moduleType)
+    {
+        Activity.Current?.SetTag(ModuleCacheTag, "hit");
+        ModuleCacheHits.Add(1, CreateModuleIdentityTags(moduleType));
+    }
+
+    internal static void RecordCacheMiss(Type moduleType)
+    {
+        Activity.Current?.SetTag(ModuleCacheTag, "miss");
+        ModuleCacheMisses.Add(1, CreateModuleIdentityTags(moduleType));
+    }
+
     /// <summary>
     /// Starts a new Activity for module execution.
     /// </summary>
@@ -224,6 +258,13 @@ public static class ModuleActivityTracing
     {
         activity?.SetTag(ModuleStatusTag, "UsedHistory");
         activity?.SetStatus(ActivityStatusCode.Ok, "Module result restored from history");
+    }
+
+    internal static void RecordCachedResult(Activity? activity)
+    {
+        activity?.SetTag(ModuleStatusTag, "CachedResult");
+        activity?.SetTag(ModuleCacheTag, "hit");
+        activity?.SetStatus(ActivityStatusCode.Ok, "Module result restored from fingerprint cache");
     }
 
     internal static void RecordPipelineTerminated(Activity? activity)
@@ -308,5 +349,14 @@ public static class ModuleActivityTracing
         activity?.SetTag(ExceptionTypeTag, exception.GetType().FullName);
         activity?.SetTag(ExceptionMessageTag, obfuscatedMessage);
         activity?.SetStatus(ActivityStatusCode.Error, obfuscatedMessage);
+    }
+
+    private static TagList CreateModuleIdentityTags(Type moduleType)
+    {
+        return new TagList
+        {
+            { ModuleTypeTag, moduleType.Name },
+            { ModuleTypeFullNameTag, moduleType.FullName },
+        };
     }
 }

--- a/src/ModularPipelines/Tracing/ModuleActivityTracing.cs
+++ b/src/ModularPipelines/Tracing/ModuleActivityTracing.cs
@@ -207,20 +207,20 @@ public static class ModuleActivityTracing
             });
     }
 
-    internal static void RecordCacheDisabled()
+    internal static void RecordCacheDisabled(Activity? activity)
     {
-        Activity.Current?.SetTag(ModuleCacheTag, "disabled");
+        activity?.SetTag(ModuleCacheTag, "disabled");
     }
 
-    internal static void RecordCacheHit(Type moduleType)
+    internal static void RecordCacheHit(Activity? activity, Type moduleType)
     {
-        Activity.Current?.SetTag(ModuleCacheTag, "hit");
+        activity?.SetTag(ModuleCacheTag, "hit");
         ModuleCacheHits.Add(1, CreateModuleIdentityTags(moduleType));
     }
 
-    internal static void RecordCacheMiss(Type moduleType)
+    internal static void RecordCacheMiss(Activity? activity, Type moduleType)
     {
-        Activity.Current?.SetTag(ModuleCacheTag, "miss");
+        activity?.SetTag(ModuleCacheTag, "miss");
         ModuleCacheMisses.Add(1, CreateModuleIdentityTags(moduleType));
     }
 

--- a/test/ModularPipelines.GitHub.UnitTests/Engine/GitHubMarkdownSummaryGeneratorTests.cs
+++ b/test/ModularPipelines.GitHub.UnitTests/Engine/GitHubMarkdownSummaryGeneratorTests.cs
@@ -1,0 +1,18 @@
+using ModularPipelines.Enums;
+
+namespace ModularPipelines.GitHub.UnitTests.Engine;
+
+public class GitHubMarkdownSummaryGeneratorTests
+{
+    [Test]
+    public async Task CachedResultUsesSuccessfulColor()
+    {
+        var status = GitHubMarkdownSummaryGenerator.GetStatusString(Status.CachedResult);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(status).Contains("lightgreen");
+            await Assert.That(status).Contains(nameof(Status.CachedResult));
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
+++ b/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
@@ -77,6 +77,12 @@ public class ModuleCacheTests
 
         public static int ExecutionCount;
 
+        public static int SkippedHookCount;
+
+        public static int CachedResultHookCount;
+
+        public static Status? CachedResultHookStatus;
+
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
             CancellationToken cancellationToken)
@@ -85,6 +91,25 @@ public class ModuleCacheTests
             var value = System.IO.File.ReadAllText(Path.Combine(WorkingDirectory, "input.txt"));
             System.IO.File.WriteAllText(Path.Combine(WorkingDirectory, "output.txt"), $"output:{value}");
             return Task.FromResult<string>($"result:{value}");
+        }
+
+        protected override Task OnSkippedAsync(
+            IModuleContext context,
+            SkipDecision skipDecision,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref SkippedHookCount);
+            return Task.CompletedTask;
+        }
+
+        protected override Task OnCachedResultAsync(
+            IModuleContext context,
+            ModuleResult<string> result,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref CachedResultHookCount);
+            CachedResultHookStatus = result.ModuleStatus;
+            return Task.CompletedTask;
         }
     }
 
@@ -699,6 +724,9 @@ public class ModuleCacheTests
         Directory.CreateDirectory(temporaryDirectory);
         CachedModule.WorkingDirectory = temporaryDirectory;
         CachedModule.ExecutionCount = 0;
+        CachedModule.SkippedHookCount = 0;
+        CachedModule.CachedResultHookCount = 0;
+        CachedModule.CachedResultHookStatus = null;
 
         try
         {
@@ -713,8 +741,11 @@ public class ModuleCacheTests
             using (Assert.Multiple())
             {
                 await Assert.That(firstStatus).IsEqualTo(Status.Successful);
-                await Assert.That(secondStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(secondStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(CachedModule.ExecutionCount).IsEqualTo(1);
+                await Assert.That(CachedModule.SkippedHookCount).IsEqualTo(0);
+                await Assert.That(CachedModule.CachedResultHookCount).IsEqualTo(1);
+                await Assert.That(CachedModule.CachedResultHookStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(await System.IO.File.ReadAllTextAsync(outputPath)).IsEqualTo("output:first");
             }
 
@@ -1101,7 +1132,7 @@ public class ModuleCacheTests
             using (Assert.Multiple())
             {
                 await Assert.That(firstStatus).IsEqualTo(Status.Successful);
-                await Assert.That(secondStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(secondStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(thirdStatus).IsEqualTo(Status.Successful);
                 await Assert.That(CachedDependentModule.ExecutionCount).IsEqualTo(2);
             }
@@ -1133,7 +1164,7 @@ public class ModuleCacheTests
             {
                 await Assert.That(firstStatus).IsEqualTo(Status.Successful);
                 await Assert.That(secondStatus).IsEqualTo(Status.Successful);
-                await Assert.That(thirdStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(thirdStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(InputMutatingModule.ExecutionCount).IsEqualTo(2);
             }
         }
@@ -1167,7 +1198,7 @@ public class ModuleCacheTests
             using (Assert.Multiple())
             {
                 await Assert.That(firstStatus).IsEqualTo(Status.Successful);
-                await Assert.That(secondStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(secondStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(AfterHookArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(await System.IO.File.ReadAllTextAsync(outputPath))
                     .IsEqualTo("after-hook");
@@ -1197,7 +1228,7 @@ public class ModuleCacheTests
             using (Assert.Multiple())
             {
                 await Assert.That(first.ModuleResult.ModuleStatus).IsEqualTo(Status.Successful);
-                await Assert.That(second.ModuleResult.ModuleStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(second.ModuleResult.ModuleStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(first.ModuleResult.ValueOrDefault).IsEqualTo("transformed");
                 await Assert.That(second.ModuleResult.ValueOrDefault).IsEqualTo("transformed");
                 await Assert.That(first.DependentValue).IsEqualTo("transformed");
@@ -1238,7 +1269,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(VaryingArtifactSetModule.ExecutionCount).IsEqualTo(2);
                 await Assert.That(System.IO.File.Exists(Path.Combine(artifactDirectory, "a.txt")))
                     .IsTrue();
@@ -1281,7 +1312,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(VaryingArtifactSetModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(new DirectoryInfo(artifactDirectory).LinkTarget).IsNull();
                 await Assert.That(await System.IO.File.ReadAllTextAsync(
@@ -1325,7 +1356,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(CachedModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(new FileInfo(outputPath).LinkTarget).IsNull();
                 await Assert.That(await System.IO.File.ReadAllTextAsync(outputPath))
@@ -1360,7 +1391,7 @@ public class ModuleCacheTests
             using (Assert.Multiple())
             {
                 await Assert.That(firstStatus).IsEqualTo(Status.Successful);
-                await Assert.That(secondStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(secondStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(thirdStatus).IsEqualTo(Status.Successful);
                 await Assert.That(RuntimeTypedCachedDependentModule.ExecutionCount).IsEqualTo(2);
             }
@@ -1389,7 +1420,7 @@ public class ModuleCacheTests
             using (Assert.Multiple())
             {
                 await Assert.That(first.Status).IsEqualTo(Status.Successful);
-                await Assert.That(second.Status).IsEqualTo(Status.UsedHistory);
+                await Assert.That(second.Status).IsEqualTo(Status.CachedResult);
                 await Assert.That(second.Value).IsTypeOf<int>();
                 await Assert.That(second.Value).IsEqualTo(1);
                 await Assert.That(RuntimeTypedCachedResultModule.ExecutionCount).IsEqualTo(1);
@@ -1428,7 +1459,7 @@ public class ModuleCacheTests
             using (Assert.Multiple())
             {
                 await Assert.That(firstStatus).IsEqualTo(Status.Successful);
-                await Assert.That(secondStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(secondStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(thirdStatus).IsEqualTo(Status.Successful);
                 await Assert.That(EnvironmentCachedModule.ExecutionCount).IsEqualTo(2);
             }
@@ -1538,7 +1569,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(CachedModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(await System.IO.File.ReadAllTextAsync(outputPath))
                     .IsEqualTo("output:input");
@@ -1768,7 +1799,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(OptionalArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(Directory.Exists(artifactPath)).IsFalse();
                 await Assert.That(await System.IO.File.ReadAllTextAsync(
@@ -1817,7 +1848,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(NestedOptionalArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(System.IO.File.Exists(artifactPath)).IsFalse();
                 await Assert.That(System.IO.File.GetUnixFileMode(artifactParent))
@@ -1864,7 +1895,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(DanglingSymbolicLinkArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(new FileInfo(artifactPath).LinkTarget)
                     .IsEqualTo("missing-target");
@@ -1898,7 +1929,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(WorkingDirectoryArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(await System.IO.File.ReadAllTextAsync(
                         Path.Combine(temporaryDirectory, "root-artifact.txt")))
@@ -1963,7 +1994,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(DanglingDirectorySymbolicLinkArtifactModule.ExecutionCount)
                     .IsEqualTo(1);
                 await Assert.That(new DirectoryInfo(artifactPath).LinkTarget)
@@ -2006,7 +2037,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(GlobOptionalArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(Directory.Exists(staleLink)).IsFalse();
                 await Assert.That(await System.IO.File.ReadAllTextAsync(externalSentinel))
@@ -2059,7 +2090,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(GlobOptionalArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(System.IO.File.Exists(staleFile)).IsFalse();
                 await Assert.That(System.IO.File.GetUnixFileMode(artifactDirectory))
@@ -2243,7 +2274,7 @@ public class ModuleCacheTests
             using (Assert.Multiple())
             {
                 await Assert.That(firstStatus).IsEqualTo(Status.Successful);
-                await Assert.That(secondStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(secondStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(MultipleArtifactFilesModule.ExecutionCount).IsEqualTo(1);
             }
         }
@@ -2418,7 +2449,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(ShallowGlobArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(System.IO.File.GetUnixFileMode(staleDirectory))
                     .IsEqualTo(expectedMode);
@@ -2832,7 +2863,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(ExecutableArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(System.IO.File.GetUnixFileMode(artifactPath))
                     .IsEqualTo(expectedMode);
@@ -2869,7 +2900,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(SymbolicLinkArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(link.LinkTarget).IsEqualTo("tool-v2");
                 await Assert.That(await System.IO.File.ReadAllTextAsync(link.FullName))
@@ -2920,7 +2951,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(DirectorySymbolicLinkArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(directoryLink.LinkTarget).IsEqualTo("version-2");
                 await Assert.That(await System.IO.File.ReadAllTextAsync(
@@ -2982,7 +3013,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(DirectorySymbolicLinkArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(directoryLink.LinkTarget).IsEqualTo("version-2");
                 await Assert.That(await System.IO.File.ReadAllTextAsync(
@@ -3042,7 +3073,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(DirectorySymbolicLinkArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(System.IO.File.GetUnixFileMode(artifactDirectory))
                     .IsEqualTo(
@@ -3096,7 +3127,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(ReadOnlyFileParentArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(await System.IO.File.ReadAllTextAsync(
                         Path.Combine(artifactParent, "tool")))
@@ -3144,7 +3175,7 @@ public class ModuleCacheTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(restoredStatus).IsEqualTo(Status.UsedHistory);
+                await Assert.That(restoredStatus).IsEqualTo(Status.CachedResult);
                 await Assert.That(EmptyDirectoryArtifactModule.ExecutionCount).IsEqualTo(1);
                 await Assert.That(Directory.Exists(artifactDirectory)).IsTrue();
                 await Assert.That(Directory.Exists(Path.Combine(artifactDirectory, "nested-empty")))

--- a/test/ModularPipelines.UnitTests/Compatibility/StatusCompatibilityTests.cs
+++ b/test/ModularPipelines.UnitTests/Compatibility/StatusCompatibilityTests.cs
@@ -1,0 +1,24 @@
+using ModularPipelines.Enums;
+
+namespace ModularPipelines.UnitTests.Compatibility;
+
+public class StatusCompatibilityTests
+{
+    [Test]
+    [Arguments(Status.NotYetStarted, 0)]
+    [Arguments(Status.Processing, 1)]
+    [Arguments(Status.Successful, 2)]
+    [Arguments(Status.UsedHistory, 3)]
+    [Arguments(Status.Failed, 4)]
+    [Arguments(Status.IgnoredFailure, 5)]
+    [Arguments(Status.PipelineTerminated, 6)]
+    [Arguments(Status.TimedOut, 7)]
+    [Arguments(Status.Skipped, 8)]
+    [Arguments(Status.Retried, 9)]
+    [Arguments(Status.Unknown, 10)]
+    [Arguments(Status.CachedResult, 11)]
+    public async Task NumericValuesRemainStable(Status status, int expectedValue)
+    {
+        await Assert.That((int)status).IsEqualTo(expectedValue);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -498,6 +498,7 @@ public class RunReportTests
     [Test]
     [Arguments(Status.Skipped)]
     [Arguments(Status.UsedHistory)]
+    [Arguments(Status.CachedResult)]
     public async Task RunReportDoesNotCompareNonExecutedModuleDurations(Status status)
     {
         var module = new SkippedModule();
@@ -524,9 +525,13 @@ public class RunReportTests
         var nonExecutedReport = factory.Create(
             new PipelineSummary(
                 [module],
-                [status == Status.Skipped
-                    ? CreateSkippedResult(module)
-                    : CreateHistoricalResult(module, start)],
+                [status switch
+                {
+                    Status.Skipped => CreateSkippedResult(module),
+                    Status.UsedHistory => CreateHistoricalResult(module, start),
+                    Status.CachedResult => CreateCachedResult(module, start),
+                    _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),
+                }],
                 TimeSpan.Zero,
                 start,
                 start),
@@ -2138,6 +2143,12 @@ public class RunReportTests
         (ModuleResult)CreateResult(module, start, TimeSpan.Zero) with
         {
             ModuleStatus = Status.UsedHistory,
+        };
+
+    private static IModuleResult CreateCachedResult(IModule module, DateTimeOffset start) =>
+        (ModuleResult)CreateResult(module, start, TimeSpan.Zero) with
+        {
+            ModuleStatus = Status.CachedResult,
         };
 
     private static ModuleRunReport CreatePreviousModuleReport(

--- a/test/ModularPipelines.UnitTests/Modules/ExecutionApiSurfaceTests.cs
+++ b/test/ModularPipelines.UnitTests/Modules/ExecutionApiSurfaceTests.cs
@@ -27,6 +27,7 @@ public class ExecutionApiSurfaceTests
             .Where(static method => method.Name is
                 "OnBeforeExecute" or
                 "OnAfterExecute" or
+                "OnCachedResult" or
                 "OnSkipped" or
                 "OnFailed")
             .ToArray();

--- a/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
@@ -338,19 +338,19 @@ public class TelemetryIntegrationTests
 
         using (var activity = ModuleActivityTracing.StartModuleActivity(typeof(CommandModule)))
         {
-            ModuleActivityTracing.RecordCacheHit(typeof(CommandModule));
+            ModuleActivityTracing.RecordCacheHit(activity, typeof(CommandModule));
             ModuleActivityTracing.RecordCachedResult(activity);
         }
 
         using (var activity = ModuleActivityTracing.StartModuleActivity(typeof(RetriedModule)))
         {
-            ModuleActivityTracing.RecordCacheMiss(typeof(RetriedModule));
+            ModuleActivityTracing.RecordCacheMiss(activity, typeof(RetriedModule));
             ModuleActivityTracing.RecordSuccess(activity);
         }
 
         using (var activity = ModuleActivityTracing.StartModuleActivity(typeof(TimedOutModule)))
         {
-            ModuleActivityTracing.RecordCacheDisabled();
+            ModuleActivityTracing.RecordCacheDisabled(activity);
             ModuleActivityTracing.RecordSuccess(activity);
         }
 
@@ -377,6 +377,28 @@ public class TelemetryIntegrationTests
                 .IsEqualTo("miss");
             await Assert.That(disabledActivity.GetTagItem(ModuleActivityTracing.ModuleCacheTag))
                 .IsEqualTo("disabled");
+        }
+    }
+
+    [Test]
+    public async Task Cache_Outcomes_Do_Not_Tag_Pipeline_When_Module_Is_Not_Sampled()
+    {
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == ModuleActivityTracing.PipelineSourceName,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        using var pipelineActivity = ModuleActivityTracing.StartPipelineActivity("TestPipeline");
+        ModuleActivityTracing.RecordCacheHit(activity: null, typeof(CommandModule));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(Activity.Current).IsSameReferenceAs(pipelineActivity);
+            await Assert.That(pipelineActivity!.GetTagItem(ModuleActivityTracing.ModuleCacheTag))
+                .IsNull();
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
@@ -329,6 +329,58 @@ public class TelemetryIntegrationTests
     }
 
     [Test]
+    public async Task Cache_Outcomes_Record_Metrics_And_Activity_Tags()
+    {
+        var measurements = new ConcurrentBag<(string Name, double Value)>();
+        var stoppedActivities = new ConcurrentBag<Activity>();
+        using var meterListener = CreateMeterListener(measurements);
+        using var activityListener = CreateActivityListener(stoppedActivities);
+
+        using (var activity = ModuleActivityTracing.StartModuleActivity(typeof(CommandModule)))
+        {
+            ModuleActivityTracing.RecordCacheHit(typeof(CommandModule));
+            ModuleActivityTracing.RecordCachedResult(activity);
+        }
+
+        using (var activity = ModuleActivityTracing.StartModuleActivity(typeof(RetriedModule)))
+        {
+            ModuleActivityTracing.RecordCacheMiss(typeof(RetriedModule));
+            ModuleActivityTracing.RecordSuccess(activity);
+        }
+
+        using (var activity = ModuleActivityTracing.StartModuleActivity(typeof(TimedOutModule)))
+        {
+            ModuleActivityTracing.RecordCacheDisabled();
+            ModuleActivityTracing.RecordSuccess(activity);
+        }
+
+        var hitActivity = stoppedActivities.Single(activity =>
+            activity.OperationName == $"Module.{nameof(CommandModule)}");
+        var missActivity = stoppedActivities.Single(activity =>
+            activity.OperationName == $"Module.{nameof(RetriedModule)}");
+        var disabledActivity = stoppedActivities.Single(activity =>
+            activity.OperationName == $"Module.{nameof(TimedOutModule)}");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(measurements.Single(measurement =>
+                    measurement.Name == ModuleActivityTracing.ModuleCacheHitsMetric).Value)
+                .IsEqualTo(1);
+            await Assert.That(measurements.Single(measurement =>
+                    measurement.Name == ModuleActivityTracing.ModuleCacheMissesMetric).Value)
+                .IsEqualTo(1);
+            await Assert.That(hitActivity.GetTagItem(ModuleActivityTracing.ModuleStatusTag))
+                .IsEqualTo("CachedResult");
+            await Assert.That(hitActivity.GetTagItem(ModuleActivityTracing.ModuleCacheTag))
+                .IsEqualTo("hit");
+            await Assert.That(missActivity.GetTagItem(ModuleActivityTracing.ModuleCacheTag))
+                .IsEqualTo("miss");
+            await Assert.That(disabledActivity.GetTagItem(ModuleActivityTracing.ModuleCacheTag))
+                .IsEqualTo("disabled");
+        }
+    }
+
+    [Test]
     public async Task Failure_Activities_Obfuscate_Registered_Secrets()
     {
         var stoppedActivities = new ConcurrentBag<Activity>();


### PR DESCRIPTION
Closes #3799

## Summary
- report fingerprint restores as Status.CachedResult instead of UsedHistory
- add OnCachedResultAsync without firing OnSkippedAsync on cache hits
- expose hit/miss counters and hit/miss/disabled activity tags
- preserve cached results as successful across metrics, notifications, artifacts, and dependency fingerprints

## Validation
- ModuleCacheTests: 61/61 passed
- RunReport non-executed status tests: 3/3 passed
- telemetry and execution API focused tests passed
- Release core build: 0 warnings, 0 errors