### PR TITLE
Add safe pipeline CLI help

### DIFF
--- a/docs/docs/how-to/command-line.md
+++ b/docs/docs/how-to/command-line.md
@@ -23,6 +23,7 @@ await builder.ExecutePipelineAsync();
 
 | Option | Behavior |
 | --- | --- |
+| `--help`, `-h` | Prints built-in pipeline command-line usage without executing modules. |
 | `--dry-run` | Validates the pipeline and prints dependency-ordered execution waves, skip reasons, categories, and duration estimates without executing modules. |
 | `--list-modules` | Lists registered modules, categories, and direct dependencies without executing modules. |
 | `--module <name>` | Runs a module and its transitive dependency closure. Repeat the option or separate names with commas. |
@@ -51,7 +52,14 @@ If a required dependency is skipped, the existing dependency skip behavior also
 skips modules that require it.
 
 Arguments that ModularPipelines does not recognize continue to the .NET host and
-configuration providers.
+configuration providers. Likely misspellings of pipeline options fail with a suggestion
+and usage text so that a typo cannot accidentally run the full pipeline. Put `--` before
+an intentional host argument that resembles a pipeline option; the separator itself is
+not forwarded.
+
+```shell
+dotnet run -- -- --dryrun=true
+```
 
 ## Programmatic Selection
 

--- a/src/ModularPipelines/CommandLine/PipelineCommand.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommand.cs
@@ -3,6 +3,7 @@ namespace ModularPipelines.PipelineCli;
 internal enum PipelineCommand
 {
     Run,
+    Help,
     DryRun,
     ListModules,
     Validate,

--- a/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
@@ -27,6 +27,8 @@ internal sealed class PipelineCommandHandler(
             case PipelineCommand.Run:
             case PipelineCommand.DryRun:
                 return null;
+            case PipelineCommand.Help:
+                return ShowHelp();
             case PipelineCommand.ListModules:
                 await FinalizeModulesAsync(cancellationToken).ConfigureAwait(false);
                 return ListModules();
@@ -36,6 +38,12 @@ internal sealed class PipelineCommandHandler(
             default:
                 throw new ArgumentOutOfRangeException(nameof(commandLineOptions));
         }
+    }
+
+    private PipelineSummary ShowHelp()
+    {
+        consoleWriter.LogToConsole(Markup.Escape(PipelineCommandLineHelp.Usage));
+        return CreateSummary();
     }
 
     private PipelineSummary ListModules()

--- a/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
@@ -27,8 +27,6 @@ internal sealed class PipelineCommandHandler(
             case PipelineCommand.Run:
             case PipelineCommand.DryRun:
                 return null;
-            case PipelineCommand.Help:
-                return PipelineCommandLineHelp.Show(consoleWriter);
             case PipelineCommand.ListModules:
                 await FinalizeModulesAsync(cancellationToken).ConfigureAwait(false);
                 return ListModules();

--- a/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
@@ -28,7 +28,7 @@ internal sealed class PipelineCommandHandler(
             case PipelineCommand.DryRun:
                 return null;
             case PipelineCommand.Help:
-                return ShowHelp();
+                return PipelineCommandLineHelp.Show(consoleWriter);
             case PipelineCommand.ListModules:
                 await FinalizeModulesAsync(cancellationToken).ConfigureAwait(false);
                 return ListModules();
@@ -38,12 +38,6 @@ internal sealed class PipelineCommandHandler(
             default:
                 throw new ArgumentOutOfRangeException(nameof(commandLineOptions));
         }
-    }
-
-    private PipelineSummary ShowHelp()
-    {
-        consoleWriter.LogToConsole(Markup.Escape(PipelineCommandLineHelp.Usage));
-        return CreateSummary();
     }
 
     private PipelineSummary ListModules()

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineHelp.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineHelp.cs
@@ -1,3 +1,6 @@
+using ModularPipelines.Interfaces;
+using ModularPipelines.Models;
+
 namespace ModularPipelines.PipelineCli;
 
 internal static class PipelineCommandLineHelp
@@ -17,4 +20,11 @@ internal static class PipelineCommandLineHelp
         Options accepting values may be repeated or written as --option=value.
         Unrecognized arguments are forwarded to host configuration.
         """;
+
+    public static PipelineSummary Show(IConsoleWriter consoleWriter)
+    {
+        consoleWriter.LogToConsole(Spectre.Console.Markup.Escape(Usage));
+        var now = DateTimeOffset.UtcNow;
+        return new PipelineSummary([], [], TimeSpan.Zero, now, now);
+    }
 }

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineHelp.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineHelp.cs
@@ -1,0 +1,20 @@
+namespace ModularPipelines.PipelineCli;
+
+internal static class PipelineCommandLineHelp
+{
+    public const string Usage = """
+        ModularPipelines command-line options:
+          --help, -h                     Show this help.
+          --dry-run                      Print the execution plan without running modules.
+          --list-modules                 List registered modules and dependencies.
+          --validate                     Validate the pipeline without running modules.
+          --module <name>[,<name>...]    Run selected modules and their dependencies.
+          --skip-module <name>[,<name>...] Exclude selected modules.
+          --categories <name>[,<name>...]  Run selected categories.
+          --ignore-categories <name>[,<name>...] Exclude selected categories.
+          --                             Forward all remaining arguments to host configuration.
+
+        Options accepting values may be repeated or written as --option=value.
+        Unrecognized arguments are forwarded to host configuration.
+        """;
+}

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
@@ -2,6 +2,8 @@ namespace ModularPipelines.PipelineCli;
 
 internal static class PipelineCommandLineParser
 {
+    private const string HelpOption = "--help";
+    private const string ShortHelpOption = "-h";
     private const string ListModulesOption = "--list-modules";
     private const string ValidateOption = "--validate";
     private const string DryRunOption = "--dry-run";
@@ -9,6 +11,18 @@ internal static class PipelineCommandLineParser
     private const string SkipModuleOption = "--skip-module";
     private const string CategoriesOption = "--categories";
     private const string IgnoreCategoriesOption = "--ignore-categories";
+
+    private static readonly string[] KnownLongOptions =
+    [
+        HelpOption,
+        ListModulesOption,
+        ValidateOption,
+        DryRunOption,
+        ModuleOption,
+        SkipModuleOption,
+        CategoriesOption,
+        IgnoreCategoriesOption,
+    ];
 
     public static PipelineCommandLineOptions Parse(IReadOnlyList<string>? arguments)
     {
@@ -27,6 +41,19 @@ internal static class PipelineCommandLineParser
         for (var index = 0; index < arguments.Count; index++)
         {
             var argument = arguments[index];
+            if (argument == "--")
+            {
+                hostArguments.AddRange(arguments.Skip(index + 1));
+                break;
+            }
+
+            if (argument.Equals(HelpOption, StringComparison.OrdinalIgnoreCase)
+                || argument.Equals(ShortHelpOption, StringComparison.OrdinalIgnoreCase))
+            {
+                command = SetCommand(command, PipelineCommand.Help, argument);
+                continue;
+            }
+
             if (argument.Equals(ListModulesOption, StringComparison.OrdinalIgnoreCase))
             {
                 command = SetCommand(command, PipelineCommand.ListModules, argument);
@@ -53,6 +80,8 @@ internal static class PipelineCommandLineParser
                 continue;
             }
 
+            ThrowForLikelyPipelineOptionTypo(argument);
+
             hostArguments.Add(argument);
         }
 
@@ -77,7 +106,7 @@ internal static class PipelineCommandLineParser
         {
             if (++index >= arguments.Count || arguments[index].StartsWith("--", StringComparison.Ordinal))
             {
-                throw new ArgumentException($"Command-line option '{option}' requires a value.", nameof(arguments));
+                throw CreateParseException($"Command-line option '{option}' requires a value.");
             }
 
             value = arguments[index];
@@ -96,7 +125,7 @@ internal static class PipelineCommandLineParser
             : value.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
         if (values.Length == 0)
         {
-            throw new ArgumentException($"Command-line option '{option}' requires a non-empty value.", nameof(arguments));
+            throw CreateParseException($"Command-line option '{option}' requires a non-empty value.");
         }
 
         destination.AddRange(values);
@@ -127,7 +156,7 @@ internal static class PipelineCommandLineParser
     {
         if (current != PipelineCommand.Run && current != requested)
         {
-            throw new ArgumentException(
+            throw CreateParseException(
                 $"Command-line option '{option}' cannot be combined with another pipeline command.");
         }
 
@@ -136,4 +165,66 @@ internal static class PipelineCommandLineParser
 
     private static IReadOnlyList<string> Distinct(IEnumerable<string> values) =>
         values.Distinct(StringComparer.OrdinalIgnoreCase).ToArray();
+
+    private static void ThrowForLikelyPipelineOptionTypo(string argument)
+    {
+        if (!argument.StartsWith("--", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var option = argument.Split('=', 2)[0];
+        var maximumDistance = option.Length switch
+        {
+            <= 7 => 1,
+            <= 12 => 2,
+            _ => 3,
+        };
+        var suggestion = KnownLongOptions
+            .Select(knownOption => new
+            {
+                Option = knownOption,
+                Distance = GetEditDistance(option, knownOption),
+            })
+            .Where(candidate => candidate.Distance <= maximumDistance)
+            .OrderBy(candidate => candidate.Distance)
+            .ThenBy(candidate => candidate.Option, StringComparer.Ordinal)
+            .FirstOrDefault();
+
+        if (suggestion is not null)
+        {
+            throw CreateParseException(
+                $"Unknown pipeline option '{option}'. Did you mean '{suggestion.Option}'? "
+                + "Use '--' before the option to forward it to host configuration.");
+        }
+    }
+
+    private static int GetEditDistance(string left, string right)
+    {
+        var previous = Enumerable.Range(0, right.Length + 1).ToArray();
+
+        for (var leftIndex = 1; leftIndex <= left.Length; leftIndex++)
+        {
+            var current = new int[right.Length + 1];
+            current[0] = leftIndex;
+
+            for (var rightIndex = 1; rightIndex <= right.Length; rightIndex++)
+            {
+                var substitutionCost = char.ToUpperInvariant(left[leftIndex - 1])
+                    == char.ToUpperInvariant(right[rightIndex - 1])
+                    ? 0
+                    : 1;
+                current[rightIndex] = Math.Min(
+                    Math.Min(current[rightIndex - 1] + 1, previous[rightIndex] + 1),
+                    previous[rightIndex - 1] + substitutionCost);
+            }
+
+            previous = current;
+        }
+
+        return previous[right.Length];
+    }
+
+    private static ArgumentException CreateParseException(string message) =>
+        new($"{message}{Environment.NewLine}{Environment.NewLine}{PipelineCommandLineHelp.Usage}");
 }

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
@@ -24,6 +24,14 @@ internal static class PipelineCommandLineParser
         IgnoreCategoriesOption,
     ];
 
+    private static readonly string[] FlagOptions =
+    [
+        HelpOption,
+        ListModulesOption,
+        ValidateOption,
+        DryRunOption,
+    ];
+
     public static PipelineCommandLineOptions Parse(IReadOnlyList<string>? arguments)
     {
         if (arguments is null || arguments.Count == 0)
@@ -173,7 +181,16 @@ internal static class PipelineCommandLineParser
             return;
         }
 
-        var option = argument.Split('=', 2)[0];
+        var equalsIndex = argument.IndexOf('=', StringComparison.Ordinal);
+        var option = equalsIndex < 0 ? argument : argument[..equalsIndex];
+        var flagOption = FlagOptions.FirstOrDefault(
+            knownOption => option.Equals(knownOption, StringComparison.OrdinalIgnoreCase));
+        if (equalsIndex >= 0 && flagOption is not null)
+        {
+            throw CreateParseException(
+                $"Command-line option '{flagOption}' does not accept a value.");
+        }
+
         var maximumDistance = option.Length switch
         {
             <= 7 => 1,

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -181,8 +181,9 @@ public sealed class PipelineBuilder : IDisposable
     /// <exception cref="PipelineValidationException">Thrown when validation fails.</exception>
     public async Task<IPipeline> BuildAsync()
     {
+        var validatePipeline = _commandLineOptions.Command != PipelineCommand.Help;
         var (pipeline, validationResult, validationException) =
-            await BuildAndValidatePipelineAsync().ConfigureAwait(false);
+            await BuildAndValidatePipelineAsync(validatePipeline).ConfigureAwait(false);
 
         if (validationResult.HasErrors)
         {
@@ -204,7 +205,7 @@ public sealed class PipelineBuilder : IDisposable
     public async Task<ValidationResult> ValidateAsync()
     {
         var (pipeline, validationResult, _) =
-            await BuildAndValidatePipelineAsync().ConfigureAwait(false);
+            await BuildAndValidatePipelineAsync(validatePipeline: true).ConfigureAwait(false);
 
         try
         {
@@ -220,14 +221,16 @@ public sealed class PipelineBuilder : IDisposable
     }
 
     private async Task<(IPipeline? Pipeline, ValidationResult ValidationResult, Exception? ValidationException)>
-        BuildAndValidatePipelineAsync()
+        BuildAndValidatePipelineAsync(bool validatePipeline)
     {
         IPipeline? pipeline = null;
 
         try
         {
-            pipeline = await BuildPipelineAsync().ConfigureAwait(false);
-            var validationResult = await ValidatePipelineAsync(pipeline.Services).ConfigureAwait(false);
+            pipeline = await BuildPipelineAsync(initializePipeline: validatePipeline).ConfigureAwait(false);
+            var validationResult = validatePipeline
+                ? await ValidatePipelineAsync(pipeline.Services).ConfigureAwait(false)
+                : ValidationResult.Success();
             return (pipeline, validationResult, null);
         }
         catch (PipelineException ex) when (ex.Message.Contains("No modules"))
@@ -313,7 +316,7 @@ public sealed class PipelineBuilder : IDisposable
     private static IReadOnlyList<string>? NullIfEmpty(IReadOnlyList<string> values) =>
         values.Count == 0 ? null : values;
 
-    private async Task<IPipeline> BuildPipelineAsync()
+    private async Task<IPipeline> BuildPipelineAsync(bool initializePipeline)
     {
         LoadModularPipelineAssembliesIfNotLoadedYet();
 
@@ -359,7 +362,7 @@ public sealed class PipelineBuilder : IDisposable
             }
         });
 
-        return await PipelineImpl.CreateAsync(_hostBuilder).ConfigureAwait(false);
+        return await PipelineImpl.CreateAsync(_hostBuilder, initializePipeline).ConfigureAwait(false);
     }
 
     private void LoadModularPipelineAssembliesIfNotLoadedYet()

--- a/src/ModularPipelines/PipelineImpl.cs
+++ b/src/ModularPipelines/PipelineImpl.cs
@@ -108,6 +108,7 @@ internal sealed class PipelineImpl : IPipeline
         try
         {
             PipelineSummary summary;
+            // Help must bypass PipelineCommandHandler because constructing it enumerates and activates modules.
             if (Services.GetRequiredService<PipelineCommandLineOptions>().Command == PipelineCommand.Help)
             {
                 summary = PipelineCommandLineHelp.Show(Services.GetRequiredService<IConsoleWriter>());

--- a/src/ModularPipelines/PipelineImpl.cs
+++ b/src/ModularPipelines/PipelineImpl.cs
@@ -10,6 +10,7 @@ using ModularPipelines.Engine.Executors;
 using ModularPipelines.Enums;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers;
+using ModularPipelines.Interfaces;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
@@ -107,7 +108,11 @@ internal sealed class PipelineImpl : IPipeline
         try
         {
             PipelineSummary summary;
-            if (await Services.GetRequiredService<PipelineCommandHandler>()
+            if (Services.GetRequiredService<PipelineCommandLineOptions>().Command == PipelineCommand.Help)
+            {
+                summary = PipelineCommandLineHelp.Show(Services.GetRequiredService<IConsoleWriter>());
+            }
+            else if (await Services.GetRequiredService<PipelineCommandHandler>()
                     .TryExecuteAsync(cancellationToken)
                     .ConfigureAwait(false) is { } commandResult)
             {

--- a/src/ModularPipelines/PipelineImpl.cs
+++ b/src/ModularPipelines/PipelineImpl.cs
@@ -41,13 +41,18 @@ internal sealed class PipelineImpl : IPipeline
         _shutdownRegistration = Disposer.RegisterOnShutdownWithUnregistration(this);
     }
 
-    internal static async Task<PipelineImpl> CreateAsync(IHostBuilder hostBuilder)
+    internal static async Task<PipelineImpl> CreateAsync(IHostBuilder hostBuilder, bool initializePipeline)
     {
         var pipeline = new PipelineImpl(hostBuilder.Build());
         var services = pipeline._host.Services;
 
         try
         {
+            if (!initializePipeline)
+            {
+                return pipeline;
+            }
+
             try
             {
                 ValidateModuleDependencies(services, services.GetServices<IModule>());

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -30,8 +30,11 @@ public class PipelineCommandLineTests
     {
         public IRenderable? Renderable { get; private set; }
 
+        public List<string> Messages { get; } = [];
+
         public void LogToConsole(string value)
         {
+            Messages.Add(value);
         }
 
         public void Write(IRenderable renderable)
@@ -701,6 +704,53 @@ public class PipelineCommandLineTests
     }
 
     [Test]
+    public async Task ShortHostOptionIsNotMistakenForPipelineTypo()
+    {
+        using var builder = Pipeline.CreateBuilder(["--mode", "safe"]);
+
+        await Assert.That(builder.Configuration["mode"]).IsEqualTo("safe");
+    }
+
+    [Test]
+    public async Task SeparatorForwardsLikelyTypoToHostConfiguration()
+    {
+        using var builder = Pipeline.CreateBuilder(["--", "--skip-modules", "Deploy"]);
+
+        await Assert.That(builder.Options.SkippedModules).IsNull();
+        await Assert.That(builder.Configuration["skip-modules"]).IsEqualTo("Deploy");
+    }
+
+    [Test]
+    [Arguments("--skip-modules", "--skip-module")]
+    [Arguments("--dryrun", "--dry-run")]
+    [Arguments("--ignore-category", "--ignore-categories")]
+    public async Task LikelyPipelineOptionTypoFailsWithSuggestion(string typo, string suggestion)
+    {
+        var exception = await Assert.That(() => Pipeline.CreateBuilder([typo]))
+            .Throws<ArgumentException>();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains($"Did you mean '{suggestion}'?");
+            await Assert.That(exception.Message).Contains("ModularPipelines command-line options:");
+            await Assert.That(exception.Message).Contains("Use '--'");
+        }
+    }
+
+    [Test]
+    public async Task MissingOptionValueIncludesUsage()
+    {
+        var exception = await Assert.That(() => Pipeline.CreateBuilder(["--module"]))
+            .Throws<ArgumentException>();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("requires a value");
+            await Assert.That(exception.Message).Contains("ModularPipelines command-line options:");
+        }
+    }
+
+    [Test]
     public async Task RepeatedCommaSeparatedAndEqualsValuesAreParsed()
     {
         using var builder = Pipeline.CreateBuilder(
@@ -782,6 +832,8 @@ public class PipelineCommandLineTests
     }
 
     [Test]
+    [Arguments("--help")]
+    [Arguments("-h")]
     [Arguments("--list-modules")]
     [Arguments("--validate")]
     public async Task InformationalCommandsDoNotExecuteModules(string command)
@@ -797,6 +849,23 @@ public class PipelineCommandLineTests
             await Assert.That(_targetExecutions).IsEqualTo(0);
             await Assert.That(_unrelatedExecutions).IsEqualTo(0);
         }
+    }
+
+    [Test]
+    [Arguments("--help")]
+    [Arguments("-h")]
+    public async Task HelpOptionsPrintUsage(string option)
+    {
+        var consoleWriter = new CapturingConsoleWriter();
+        using var builder = CreateExecutionBuilder([option]);
+        builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
+
+        await builder.ExecutePipelineAsync();
+
+        await Assert.That(consoleWriter.Messages.Single())
+            .Contains("ModularPipelines command-line options:")
+            .And.Contains("--skip-module")
+            .And.Contains("--");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -751,6 +751,25 @@ public class PipelineCommandLineTests
     }
 
     [Test]
+    [Arguments("--help=value", "--help")]
+    [Arguments("--list-modules=value", "--list-modules")]
+    [Arguments("--validate=value", "--validate")]
+    [Arguments("--dry-run=value", "--dry-run")]
+    public async Task FlagOptionValueFailsWithClearError(string argument, string option)
+    {
+        var exception = await Assert.That(() => Pipeline.CreateBuilder([argument]))
+            .Throws<ArgumentException>();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message)
+                .Contains($"Command-line option '{option}' does not accept a value.");
+            await Assert.That(exception.Message).DoesNotContain("Did you mean");
+            await Assert.That(exception.Message).Contains("ModularPipelines command-line options:");
+        }
+    }
+
+    [Test]
     public async Task RepeatedCommaSeparatedAndEqualsValuesAreParsed()
     {
         using var builder = Pipeline.CreateBuilder(
@@ -866,6 +885,23 @@ public class PipelineCommandLineTests
             .Contains("ModularPipelines command-line options:")
             .And.Contains("--skip-module")
             .And.Contains("--");
+    }
+
+    [Test]
+    public async Task HelpDoesNotRequireAValidPipeline()
+    {
+        var consoleWriter = new CapturingConsoleWriter();
+        using var builder = Pipeline.CreateBuilder(["--help"]);
+        builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
+
+        var summary = await builder.ExecutePipelineAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(summary.Results).IsEmpty();
+            await Assert.That(consoleWriter.Messages.Single())
+                .Contains("ModularPipelines command-line options:");
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -108,6 +108,28 @@ public class PipelineCommandLineTests
             Task.FromResult<string>("unregistered");
     }
 
+    private sealed class ThrowingConstructorModule : Module<string>
+    {
+        public ThrowingConstructorModule() =>
+            throw new InvalidOperationException("Help must not activate modules.");
+
+        protected internal override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Help must not execute modules.");
+    }
+
+    private sealed class ThrowingConfigurationModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() =>
+            throw new InvalidOperationException("Help must not read module configuration.");
+
+        protected internal override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Help must not execute modules.");
+    }
+
     [AddRegistrationDependency(typeof(UnregisteredModule))]
     [ModuleCategory("excluded")]
     private sealed class InvalidDynamicDependencyModule : Module<string>
@@ -893,6 +915,42 @@ public class PipelineCommandLineTests
         var consoleWriter = new CapturingConsoleWriter();
         using var builder = Pipeline.CreateBuilder(["--help"]);
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
+
+        var summary = await builder.ExecutePipelineAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(summary.Results).IsEmpty();
+            await Assert.That(consoleWriter.Messages.Single())
+                .Contains("ModularPipelines command-line options:");
+        }
+    }
+
+    [Test]
+    public async Task HelpDoesNotActivateModules()
+    {
+        var consoleWriter = new CapturingConsoleWriter();
+        using var builder = Pipeline.CreateBuilder(["--help"]);
+        builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
+        builder.AddModule<ThrowingConstructorModule>();
+
+        var summary = await builder.ExecutePipelineAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(summary.Results).IsEmpty();
+            await Assert.That(consoleWriter.Messages.Single())
+                .Contains("ModularPipelines command-line options:");
+        }
+    }
+
+    [Test]
+    public async Task HelpDoesNotReadModuleConfiguration()
+    {
+        var consoleWriter = new CapturingConsoleWriter();
+        using var builder = Pipeline.CreateBuilder(["--help"]);
+        builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
+        builder.AddModule<ThrowingConfigurationModule>();
 
         var summary = await builder.ExecutePipelineAsync();
 


### PR DESCRIPTION
Closes #3800.

## Summary
- add `--help` and `-h` usage output without executing modules
- include usage in parse errors and reject close pipeline-option misspellings with a suggested correction
- support `--` as an explicit host-configuration passthrough separator
- document the behavior and cover help, typo, passthrough, and regression cases

## Validation
- `PipelineCommandLineTests`: 52 passed
- `dotnet build ModularPipelines.slnx -c Release --no-restore`: 0 warnings, 0 errors