### PR TITLE
Show cache candidates in dry-run plans

### DIFF
--- a/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandHandler.cs
@@ -89,6 +89,9 @@ internal sealed class PipelineCommandHandler(
             [],
             TimeSpan.Zero,
             now,
-            now);
+            now)
+        {
+            StatusOverride = Enums.Status.Successful,
+        };
     }
 }

--- a/src/ModularPipelines/Engine/PipelinePlanner.cs
+++ b/src/ModularPipelines/Engine/PipelinePlanner.cs
@@ -2,6 +2,7 @@ using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
+using ModularPipelines.Caching;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine.Attributes;
@@ -31,6 +32,7 @@ internal sealed class PipelinePlanner
     private readonly IMediator _mediator;
     private readonly IModuleResultHistoryProvider _resultHistoryProvider;
     private readonly IPipelineContextProvider _pipelineContextProvider;
+    private readonly bool _moduleCachingEnabled;
 
     public PipelinePlanner(
         IServiceProvider serviceProvider,
@@ -45,7 +47,8 @@ internal sealed class PipelinePlanner
         IOptions<PipelineOptions> options,
         IMediator mediator,
         IModuleResultHistoryProvider resultHistoryProvider,
-        IPipelineContextProvider pipelineContextProvider)
+        IPipelineContextProvider pipelineContextProvider,
+        IModuleCacheResultRepository? moduleCacheResultRepository = null)
     {
         _serviceProvider = serviceProvider;
         _modules = modules.Distinct<IModule>(ReferenceEqualityComparer.Instance).ToArray();
@@ -60,6 +63,7 @@ internal sealed class PipelinePlanner
         _mediator = mediator;
         _resultHistoryProvider = resultHistoryProvider;
         _pipelineContextProvider = pipelineContextProvider;
+        _moduleCachingEnabled = moduleCacheResultRepository is not null;
     }
 
     public async Task<PipelinePlan> CreateAsync(CancellationToken cancellationToken = default)
@@ -383,7 +387,10 @@ internal sealed class PipelinePlanner
             module,
             _metadataRegistry.GetCategory(module.GetType()),
             skipDecision,
-            estimatedDuration);
+            estimatedDuration,
+            _moduleCachingEnabled
+            && module.Configuration.CacheEnabled
+            && skipDecision?.ShouldSkip is not true);
     }
 
     private TimeSpan CalculateEstimatedDuration(IReadOnlyList<PipelinePlanWave> waves)

--- a/src/ModularPipelines/Models/PipelinePlanModule.cs
+++ b/src/ModularPipelines/Models/PipelinePlanModule.cs
@@ -45,16 +45,26 @@ public sealed record PipelinePlanModule
     /// </summary>
     public TimeSpan EstimatedDuration { get; }
 
+    /// <summary>
+    /// Gets a value indicating whether fingerprint caching may satisfy this module during execution.
+    /// </summary>
+    /// <remarks>
+    /// The planner cannot predict a cache hit because fingerprints may include dependency results.
+    /// </remarks>
+    public bool IsCacheCandidate { get; }
+
     internal PipelinePlanModule(
         IModule module,
         string? category,
         SkipDecision? skipDecision,
-        TimeSpan estimatedDuration)
+        TimeSpan estimatedDuration,
+        bool isCacheCandidate)
     {
         Module = module;
         ModuleName = module.GetType().FullName ?? module.GetType().Name;
         Category = category;
         SkipDecision = skipDecision;
         EstimatedDuration = estimatedDuration;
+        IsCacheCandidate = isCacheCandidate;
     }
 }

--- a/src/ModularPipelines/PipelineCli/PipelinePlanPrinter.cs
+++ b/src/ModularPipelines/PipelineCli/PipelinePlanPrinter.cs
@@ -28,7 +28,9 @@ internal sealed class PipelinePlanPrinter(IConsoleWriter consoleWriter)
                     ? "[yellow]Unknown: requires module results[/]"
                     : module.ShouldSkip
                         ? $"[yellow]Skip: {Markup.Escape(module.SkipDecision.Reason ?? "No reason provided")}[/]"
-                        : "[green]Run[/]";
+                        : module.IsCacheCandidate
+                            ? "[green]Run[/] [dim](cache candidate)[/]"
+                            : "[green]Run[/]";
                 table.AddRow(
                     wave.Number.ToString(System.Globalization.CultureInfo.InvariantCulture),
                     Markup.Escape(wave.EstimatedDuration.ToDisplayString()),
@@ -39,8 +41,11 @@ internal sealed class PipelinePlanPrinter(IConsoleWriter consoleWriter)
             }
         }
 
+        var cacheNote = plan.Waves.SelectMany(wave => wave.Modules).Any(module => module.IsCacheCandidate)
+            ? " [dim](cache hits may reduce actual duration)[/]"
+            : string.Empty;
         table.Caption = new TableTitle(
-            $"[bold]Estimated pipeline duration: {Markup.Escape(plan.EstimatedDuration.ToDisplayString())}[/]");
+            $"[bold]Estimated pipeline duration: {Markup.Escape(plan.EstimatedDuration.ToDisplayString())}[/]{cacheNote}");
         consoleWriter.Write(table);
     }
 }

--- a/src/ModularPipelines/PipelineImpl.cs
+++ b/src/ModularPipelines/PipelineImpl.cs
@@ -113,7 +113,10 @@ internal sealed class PipelineImpl : IPipeline
                 var plan = await PlanAsync(cancellationToken).ConfigureAwait(false);
                 Services.GetRequiredService<PipelinePlanPrinter>().Print(plan);
                 var now = DateTimeOffset.UtcNow;
-                summary = new PipelineSummary(plan.Modules, [], TimeSpan.Zero, now, now);
+                summary = new PipelineSummary(plan.Modules, [], TimeSpan.Zero, now, now)
+                {
+                    StatusOverride = Status.Successful,
+                };
             }
             else
             {

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Attributes;
 using ModularPipelines.Attributes.Events;
+using ModularPipelines.Caching;
 using ModularPipelines.Conditions;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
@@ -95,6 +96,18 @@ public class PipelineCommandLineTests
             IModuleContext context,
             CancellationToken cancellationToken) =>
             Task.FromResult("configured-category");
+    }
+
+    private sealed class CacheCandidateModule : Module<string>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithCacheKeyPart("plan-v1")
+            .Build();
+
+        protected internal override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("Dry-run must not execute modules.");
     }
 
     private sealed class UnregisteredModule : Module<string>
@@ -1309,6 +1322,7 @@ public class PipelineCommandLineTests
         {
             await Assert.That(builder.Options.DryRun).IsTrue();
             await Assert.That(summary.Results).IsEmpty();
+            await Assert.That(summary.Status).IsEqualTo(ModularPipelines.Enums.Status.Successful);
             await Assert.That(consoleWriter.Renderable).IsNotNull();
             await Assert.That(output).Contains("Pipeline dry-run plan");
             await Assert.That(output).Contains("Wave ETA");
@@ -1316,6 +1330,30 @@ public class PipelineCommandLineTests
             await Assert.That(_dependencyExecutions).IsEqualTo(0);
             await Assert.That(_targetExecutions).IsEqualTo(0);
             await Assert.That(_unrelatedExecutions).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task DryRunMarksCacheCandidatesAndQualifiesEstimate()
+    {
+        var consoleWriter = new CapturingConsoleWriter();
+        using var builder = Pipeline.CreateBuilder(["--dry-run"]);
+        builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
+        builder.AddModuleCache<FileSystemModuleCache>();
+        builder.AddModule<CacheCandidateModule>();
+
+        await using var pipeline = await builder.BuildAsync();
+        var plan = await pipeline.PlanAsync();
+        var summary = await pipeline.RunAsync();
+        var output = Render(consoleWriter.Renderable!);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(plan.Waves.SelectMany(wave => wave.Modules).Single().IsCacheCandidate)
+                .IsTrue();
+            await Assert.That(summary.Status).IsEqualTo(ModularPipelines.Enums.Status.Successful);
+            await Assert.That(output).Contains("Run (cache candidate)");
+            await Assert.That(output).Contains("cache hits may reduce actual duration");
         }
     }
 
@@ -1354,11 +1392,25 @@ public class PipelineCommandLineTests
         builder.Services.AddSingleton<IConsoleWriter>(consoleWriter);
         builder.AddModule<ConfiguredCategoryModule>();
 
-        await builder.ExecutePipelineAsync();
+        var summary = await builder.ExecutePipelineAsync();
 
         var output = Render(consoleWriter.Renderable!);
 
-        await Assert.That(output).Contains("configured-category");
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).Contains("configured-category");
+            await Assert.That(summary.Status).IsEqualTo(ModularPipelines.Enums.Status.Successful);
+        }
+    }
+
+    [Test]
+    public async Task ValidateCommandReturnsSuccessfulSummary()
+    {
+        using var builder = CreateExecutionBuilder(["--validate"]);
+
+        var summary = await builder.ExecutePipelineAsync();
+
+        await Assert.That(summary.Status).IsEqualTo(ModularPipelines.Enums.Status.Successful);
     }
 
     private static string Render(IRenderable renderable)


### PR DESCRIPTION
Closes #3804

## Summary
- expose cache candidates in pipeline plans when a cache backend is active
- label dry-run cache candidates and qualify duration estimates
- report successful status for dry-run, validate, and list-modules command summaries

## Validation
- `PipelineCommandLineTests`: 44/44 passed
- focused cache-candidate test: 1/1 passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors