### PR TITLE
Add multi-run history queries and duration trends

### DIFF
--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -112,6 +112,36 @@ a complete report with partial JSON. After each successful history save, the bui
 removes atomic-write temporary files older than 24 hours while leaving recent files for concurrent
 writers.
 
+Query retained reports newest-first through `IRunHistoryStore`:
+
+```csharp
+await foreach (var failedRun in historyStore.GetRunsAsync(new RunHistoryQuery
+{
+    PipelineIdentity = "release-pipeline",
+    MaxRuns = 10,
+    Since = DateTimeOffset.UtcNow.AddDays(-30),
+    Status = Status.Failed,
+}, cancellationToken))
+{
+    // Inspect failedRun.
+}
+```
+
+`GetLatestAsync(pipelineIdentity, cancellationToken)` remains available as an extension method over
+`GetRunsAsync`. The registered `IRunHistoryReader` provides measured, attributable module-duration
+samples from the latest runs:
+
+```csharp
+var samples = await historyReader.GetModuleDurationTrendAsync(
+    moduleTypeName,
+    lastN: 10,
+    cancellationToken);
+```
+
+Configure `RunReportOptions.PipelineIdentity` before using `IRunHistoryReader`; the reader uses that
+identity to select the current pipeline's retained history. Schema-v1 reports remain queryable, but
+they have no run ID and are therefore omitted from duration trends.
+
 CI agents are often ephemeral, so restore the history directory from a cache before running the
 pipeline. For example, a GitHub Actions workflow can restore the newest cache for its branch and
 save the updated history under a run-specific key:
@@ -134,9 +164,9 @@ register it on the builder:
 builder.AddRunHistoryStore<MyRunHistoryStore>();
 ```
 
-The store returns the latest report for the requested pipeline identity and saves the completed
-current report. Custom stores own their retention behavior.
+The store returns matching reports newest-first and saves the completed current report. Custom
+stores own their retention behavior.
 
-In v4, `IRunHistoryStore` removes the parameterless `GetLatestAsync` member. Existing custom stores
-must move any identity filtering into `GetLatestAsync(string pipelineIdentity, CancellationToken)`,
-which is now the only read member to implement.
+In v4, custom stores implement `GetRunsAsync(RunHistoryQuery, CancellationToken)`. The former
+`GetLatestAsync` interface member is now an extension method, so stores need only implement the
+query operation and `SaveAsync`.

--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -127,6 +127,9 @@ await foreach (var failedRun in historyStore.GetRunsAsync(new RunHistoryQuery
 }
 ```
 
+`Since` is an inclusive cutoff on each run's start time. A run that started before the cutoff is
+excluded even if it completed after the cutoff.
+
 `GetLatestAsync(pipelineIdentity, cancellationToken)` remains available as an extension method over
 `GetRunsAsync`. The registered `IRunHistoryReader` provides measured, attributable module-duration
 samples from the latest runs:

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -299,6 +299,7 @@ internal static class DependencyInjectionSetup
 
         services.TryAddSingleton<RunReportPathResolver>();
         services.TryAddSingleton<IRunHistoryStore, FileSystemRunHistoryStore>();
+        services.TryAddSingleton<IRunHistoryReader, RunHistoryReader>();
     }
 
     /// <summary>

--- a/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -20,69 +21,92 @@ internal sealed class FileSystemRunHistoryStore(
     private readonly RunReportPathResolver _pathResolver = pathResolver ?? new RunReportPathResolver();
     private static readonly TimeSpan StaleTemporaryFileAge = TimeSpan.FromDays(1);
 
-    public Task<PipelineRunReport?> GetLatestAsync(
-        string pipelineIdentity,
-        CancellationToken cancellationToken = default) =>
-        GetLatestAsyncCore(pipelineIdentity, cancellationToken);
-
-    private async Task<PipelineRunReport?> GetLatestAsyncCore(
-        string pipelineIdentity,
-        CancellationToken cancellationToken)
+    public async IAsyncEnumerable<PipelineRunReport> GetRunsAsync(
+        RunHistoryQuery query,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentException.ThrowIfNullOrWhiteSpace(query.PipelineIdentity);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(query.MaxRuns);
+
         var directory = GetHistoryDirectory();
         if (!Directory.Exists(directory))
         {
-            return null;
+            yield break;
         }
 
         var incompatibleSchemaLogged = false;
         var files = GetHistoryFilesNewestFirst(
             directory,
-            $"{GetPipelineFilePrefix(pipelineIdentity)}*.json");
+            $"{GetPipelineFilePrefix(query.PipelineIdentity)}*.json");
+        var matchedRuns = 0;
         foreach (var file in files)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            try
-            {
-                await using var stream = new FileStream(
+            var readResult = await ReadHistoryFileAsync(
                     file,
-                    new FileStreamOptions
-                    {
-                        Access = FileAccess.Read,
-                        Mode = FileMode.Open,
-                        Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
-                        Share = FileShare.Read | FileShare.Delete,
-                    });
-                var (report, incompatibleSchemaVersion) = await ReadReportAsync(stream, cancellationToken)
-                    .ConfigureAwait(false);
-                if (incompatibleSchemaVersion is { } schemaVersion)
-                {
-                    if (!incompatibleSchemaLogged)
-                    {
-                        logger.LogWarning(
-                            "Skipped pipeline run history with schema version {SchemaVersion}; supported versions are {MinimumSchemaVersion} through {CurrentSchemaVersion}",
-                            schemaVersion,
-                            MinimumCompatibleSchemaVersion,
-                            PipelineRunReport.CurrentSchemaVersion);
-                        incompatibleSchemaLogged = true;
-                    }
-
-                    continue;
-                }
-
-                if (report is not null
-                    && string.Equals(report.PipelineIdentity, pipelineIdentity, StringComparison.Ordinal))
-                {
-                    return report;
-                }
-            }
-            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or System.Text.Json.JsonException)
+                    incompatibleSchemaLogged,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            incompatibleSchemaLogged = readResult.IncompatibleSchemaLogged;
+            if (readResult.Report is null || !MatchesQuery(readResult.Report, query))
             {
-                logger.LogWarning(exception, "Could not read pipeline run history file {HistoryFile}", file);
+                continue;
+            }
+
+            yield return readResult.Report;
+            matchedRuns++;
+            if (matchedRuns >= query.MaxRuns)
+            {
+                yield break;
             }
         }
+    }
 
-        return null;
+    private static bool MatchesQuery(PipelineRunReport report, RunHistoryQuery query) =>
+        string.Equals(report.PipelineIdentity, query.PipelineIdentity, StringComparison.Ordinal)
+        && (!query.Since.HasValue || report.End >= query.Since.Value)
+        && (!query.Status.HasValue || report.Status == query.Status.Value);
+
+    private async Task<HistoryReadResult> ReadHistoryFileAsync(
+        string file,
+        bool incompatibleSchemaLogged,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await using var stream = new FileStream(
+                file,
+                new FileStreamOptions
+                {
+                    Access = FileAccess.Read,
+                    Mode = FileMode.Open,
+                    Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+                    Share = FileShare.Read | FileShare.Delete,
+                });
+            var (report, incompatibleSchemaVersion) = await ReadReportAsync(stream, cancellationToken)
+                .ConfigureAwait(false);
+            if (incompatibleSchemaVersion is not { } schemaVersion)
+            {
+                return new HistoryReadResult(report, incompatibleSchemaLogged);
+            }
+
+            if (!incompatibleSchemaLogged)
+            {
+                logger.LogWarning(
+                    "Skipped pipeline run history with schema version {SchemaVersion}; supported versions are {MinimumSchemaVersion} through {CurrentSchemaVersion}",
+                    schemaVersion,
+                    MinimumCompatibleSchemaVersion,
+                    PipelineRunReport.CurrentSchemaVersion);
+            }
+
+            return new HistoryReadResult(null, IncompatibleSchemaLogged: true);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
+        {
+            logger.LogWarning(exception, "Could not read pipeline run history file {HistoryFile}", file);
+            return new HistoryReadResult(null, incompatibleSchemaLogged);
+        }
     }
 
     private static async Task<(PipelineRunReport? Report, int? IncompatibleSchemaVersion)> ReadReportAsync(
@@ -253,4 +277,8 @@ internal sealed class FileSystemRunHistoryStore(
         var identityHash = Convert.ToHexString(SHA256.HashData(identityBytes)).ToLowerInvariant();
         return $"{OwnedFilePrefix}{identityHash}-";
     }
+
+    private sealed record HistoryReadResult(
+        PipelineRunReport? Report,
+        bool IncompatibleSchemaLogged);
 }

--- a/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
@@ -65,7 +65,7 @@ internal sealed class FileSystemRunHistoryStore(
 
     private static bool MatchesQuery(PipelineRunReport report, RunHistoryQuery query) =>
         string.Equals(report.PipelineIdentity, query.PipelineIdentity, StringComparison.Ordinal)
-        && (!query.Since.HasValue || report.End >= query.Since.Value)
+        && (!query.Since.HasValue || report.Start >= query.Since.Value)
         && (!query.Status.HasValue || report.Status == query.Status.Value);
 
     private async Task<HistoryReadResult> ReadHistoryFileAsync(

--- a/src/ModularPipelines/Engine/IRunHistoryReader.cs
+++ b/src/ModularPipelines/Engine/IRunHistoryReader.cs
@@ -1,0 +1,21 @@
+using ModularPipelines.Models;
+
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Provides convenient cross-run history queries for the current pipeline.
+/// </summary>
+public interface IRunHistoryReader
+{
+    /// <summary>
+    /// Gets measured duration samples for a module over the latest pipeline runs.
+    /// </summary>
+    /// <param name="moduleTypeName">The stable module type identifier.</param>
+    /// <param name="lastN">The number of latest pipeline runs to inspect.</param>
+    /// <param name="cancellationToken">A token that cancels the operation.</param>
+    /// <returns>Newest-first attributable module duration samples.</returns>
+    Task<IReadOnlyList<ModuleDurationSample>> GetModuleDurationTrendAsync(
+        string moduleTypeName,
+        int lastN,
+        CancellationToken cancellationToken = default);
+}

--- a/src/ModularPipelines/Engine/IRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/IRunHistoryStore.cs
@@ -8,13 +8,13 @@ namespace ModularPipelines.Engine;
 public interface IRunHistoryStore
 {
     /// <summary>
-    /// Gets the latest retained report for a pipeline identity.
+    /// Gets retained reports matching a query, ordered newest first.
     /// </summary>
-    /// <param name="pipelineIdentity">The stable pipeline identity.</param>
+    /// <param name="query">The history query.</param>
     /// <param name="cancellationToken">A token that cancels the operation.</param>
-    /// <returns>The latest matching report, or <see langword="null"/>.</returns>
-    Task<PipelineRunReport?> GetLatestAsync(
-        string pipelineIdentity,
+    /// <returns>The matching retained reports.</returns>
+    IAsyncEnumerable<PipelineRunReport> GetRunsAsync(
+        RunHistoryQuery query,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/ModularPipelines/Engine/RunHistoryQuery.cs
+++ b/src/ModularPipelines/Engine/RunHistoryQuery.cs
@@ -1,0 +1,29 @@
+using ModularPipelines.Enums;
+
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Describes a bounded query over retained pipeline run reports.
+/// </summary>
+public sealed record RunHistoryQuery
+{
+    /// <summary>
+    /// Gets the stable pipeline identity whose history should be queried.
+    /// </summary>
+    public required string PipelineIdentity { get; init; }
+
+    /// <summary>
+    /// Gets the maximum number of reports to return.
+    /// </summary>
+    public int MaxRuns { get; init; } = 20;
+
+    /// <summary>
+    /// Gets the inclusive lower bound for a report's end time.
+    /// </summary>
+    public DateTimeOffset? Since { get; init; }
+
+    /// <summary>
+    /// Gets the pipeline status to match, or <see langword="null"/> for every status.
+    /// </summary>
+    public Status? Status { get; init; }
+}

--- a/src/ModularPipelines/Engine/RunHistoryQuery.cs
+++ b/src/ModularPipelines/Engine/RunHistoryQuery.cs
@@ -18,7 +18,7 @@ public sealed record RunHistoryQuery
     public int MaxRuns { get; init; } = 20;
 
     /// <summary>
-    /// Gets the inclusive lower bound for a report's end time.
+    /// Gets the inclusive lower bound for a report's start time.
     /// </summary>
     public DateTimeOffset? Since { get; init; }
 

--- a/src/ModularPipelines/Engine/RunHistoryReader.cs
+++ b/src/ModularPipelines/Engine/RunHistoryReader.cs
@@ -1,0 +1,52 @@
+using Microsoft.Extensions.Options;
+using ModularPipelines.Models;
+using ModularPipelines.Options;
+
+namespace ModularPipelines.Engine;
+
+internal sealed class RunHistoryReader(
+    IRunHistoryStore historyStore,
+    IOptions<PipelineOptions> pipelineOptions) : IRunHistoryReader
+{
+    public async Task<IReadOnlyList<ModuleDurationSample>> GetModuleDurationTrendAsync(
+        string moduleTypeName,
+        int lastN,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(moduleTypeName);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(lastN);
+
+        var pipelineIdentity = pipelineOptions.Value.RunReport.PipelineIdentity;
+        if (string.IsNullOrWhiteSpace(pipelineIdentity))
+        {
+            throw new InvalidOperationException(
+                $"{nameof(RunReportOptions.PipelineIdentity)} must be configured to query run history.");
+        }
+
+        var samples = new List<ModuleDurationSample>();
+        await foreach (var report in historyStore.GetRunsAsync(
+                               new RunHistoryQuery
+                               {
+                                   PipelineIdentity = pipelineIdentity,
+                                   MaxRuns = lastN,
+                               },
+                               cancellationToken)
+                           .ConfigureAwait(false))
+        {
+            var module = report.Modules.FirstOrDefault(candidate =>
+                string.Equals(candidate.ModuleTypeName, moduleTypeName, StringComparison.Ordinal));
+            if (module is not { DurationMeasured: true } || string.IsNullOrWhiteSpace(report.RunId))
+            {
+                continue;
+            }
+
+            samples.Add(new ModuleDurationSample(
+                report.RunId,
+                report.End,
+                module.Status,
+                module.Duration));
+        }
+
+        return samples;
+    }
+}

--- a/src/ModularPipelines/Engine/RunHistoryReader.cs
+++ b/src/ModularPipelines/Engine/RunHistoryReader.cs
@@ -33,9 +33,14 @@ internal sealed class RunHistoryReader(
                                cancellationToken)
                            .ConfigureAwait(false))
         {
-            var module = report.Modules.FirstOrDefault(candidate =>
-                string.Equals(candidate.ModuleTypeName, moduleTypeName, StringComparison.Ordinal));
-            if (module is not { DurationMeasured: true } || string.IsNullOrWhiteSpace(report.RunId))
+            var matchingModules = report.Modules
+                .Where(candidate =>
+                    string.Equals(candidate.ModuleTypeName, moduleTypeName, StringComparison.Ordinal))
+                .Take(2)
+                .ToArray();
+            if (matchingModules.Length != 1
+                || matchingModules[0] is not { DurationMeasured: true } module
+                || string.IsNullOrWhiteSpace(report.RunId))
             {
                 continue;
             }

--- a/src/ModularPipelines/Engine/RunHistoryStoreExtensions.cs
+++ b/src/ModularPipelines/Engine/RunHistoryStoreExtensions.cs
@@ -1,0 +1,38 @@
+using ModularPipelines.Models;
+
+namespace ModularPipelines.Engine;
+
+/// <summary>
+/// Convenience operations over <see cref="IRunHistoryStore"/>.
+/// </summary>
+public static class RunHistoryStoreExtensions
+{
+    /// <summary>
+    /// Gets the latest retained report for a pipeline identity.
+    /// </summary>
+    /// <param name="historyStore">The history store.</param>
+    /// <param name="pipelineIdentity">The stable pipeline identity.</param>
+    /// <param name="cancellationToken">A token that cancels the operation.</param>
+    /// <returns>The latest matching report, or <see langword="null"/>.</returns>
+    public static async Task<PipelineRunReport?> GetLatestAsync(
+        this IRunHistoryStore historyStore,
+        string pipelineIdentity,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(historyStore);
+
+        await foreach (var report in historyStore.GetRunsAsync(
+                               new RunHistoryQuery
+                               {
+                                   PipelineIdentity = pipelineIdentity,
+                                   MaxRuns = 1,
+                               },
+                               cancellationToken)
+                           .ConfigureAwait(false))
+        {
+            return report;
+        }
+
+        return null;
+    }
+}

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -64,7 +64,10 @@ internal sealed class RunReportService(
             pipelineIdentity,
             runId,
             pipelineException);
-        report = await EnrichReportAsync(report, pipelineIdentity, reportPath is not null)
+        report = await EnrichReportAsync(
+                report,
+                pipelineIdentity,
+                reportPath is not null || historyEnabled)
             .ConfigureAwait(false);
         report = report with
         {

--- a/src/ModularPipelines/Models/ModuleDurationSample.cs
+++ b/src/ModularPipelines/Models/ModuleDurationSample.cs
@@ -1,0 +1,16 @@
+using ModularPipelines.Enums;
+
+namespace ModularPipelines.Models;
+
+/// <summary>
+/// Represents one attributable module-duration observation from retained run history.
+/// </summary>
+/// <param name="RunId">The unique pipeline run identifier.</param>
+/// <param name="End">When the pipeline run ended.</param>
+/// <param name="Status">The module's final status.</param>
+/// <param name="Duration">The module's measured duration.</param>
+public sealed record ModuleDurationSample(
+    string RunId,
+    DateTimeOffset End,
+    Status Status,
+    TimeSpan Duration);

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1050,6 +1050,7 @@ public class RunReportTests
                     RunId = $"run-{index}",
                     PipelineIdentity = "pipeline-a",
                     Status = index % 2 == 0 ? Status.Failed : Status.Successful,
+                    Start = index == 2 ? start.AddMinutes(1) : start.AddMinutes(index),
                     End = start.AddMinutes(index),
                 });
             }
@@ -1073,9 +1074,8 @@ public class RunReportTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(reports).Count().IsEqualTo(2);
+                await Assert.That(reports).Count().IsEqualTo(1);
                 await Assert.That(reports[0].RunId).IsEqualTo("run-4");
-                await Assert.That(reports[1].RunId).IsEqualTo("run-2");
             }
         }
         finally
@@ -1215,6 +1215,7 @@ public class RunReportTests
                 It.IsAny<RunHistoryQuery>(),
                 It.IsAny<CancellationToken>()))
             .Returns(Reports(
+                CreateAmbiguousTrendReport("ambiguous", end.AddMinutes(3), moduleTypeName),
                 CreateTrendReport("run-2", end.AddMinutes(2), moduleTypeName, measured: true),
                 CreateTrendReport("", end.AddMinutes(1), moduleTypeName, measured: true),
                 CreateTrendReport("run-0", end, moduleTypeName, measured: false)));
@@ -1225,7 +1226,7 @@ public class RunReportTests
                 RunReport = new RunReportOptions { PipelineIdentity = "pipeline-a" },
             }));
 
-        var samples = await reader.GetModuleDurationTrendAsync(moduleTypeName, 3);
+        var samples = await reader.GetModuleDurationTrendAsync(moduleTypeName, 4);
 
         using (Assert.Multiple())
         {
@@ -1237,7 +1238,7 @@ public class RunReportTests
                 TimeSpan.FromSeconds(2)));
             historyStore.Verify(store => store.GetRunsAsync(
                 It.Is<RunHistoryQuery>(query =>
-                    query.PipelineIdentity == "pipeline-a" && query.MaxRuns == 3),
+                    query.PipelineIdentity == "pipeline-a" && query.MaxRuns == 4),
                 It.IsAny<CancellationToken>()), Times.Once);
         }
     }
@@ -3471,4 +3472,20 @@ public class RunReportTests
                 },
             ],
         };
+
+    private static PipelineRunReport CreateAmbiguousTrendReport(
+        string runId,
+        DateTimeOffset end,
+        string moduleTypeName)
+    {
+        var report = CreateTrendReport(runId, end, moduleTypeName, measured: true);
+        return report with
+        {
+            Modules =
+            [
+                report.Modules[0],
+                report.Modules[0] with { Duration = TimeSpan.FromSeconds(3) },
+            ],
+        };
+    }
 }

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
+using ModularPipelines.DependencyInjection;
 using ModularPipelines.Distributed;
 using ModularPipelines.Distributed.Configuration;
 using ModularPipelines.Enums;
@@ -1034,6 +1035,56 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task FileSystemHistoryStoreQueriesNewestRunsWithFilters()
+    {
+        var directory = CreateTemporaryDirectory();
+        var store = CreateHistoryStore(directory, historyRetention: 8);
+        var start = new DateTimeOffset(2026, 8, 2, 12, 0, 0, TimeSpan.Zero);
+
+        try
+        {
+            for (var index = 1; index <= 4; index++)
+            {
+                await store.SaveAsync(new PipelineRunReport
+                {
+                    RunId = $"run-{index}",
+                    PipelineIdentity = "pipeline-a",
+                    Status = index % 2 == 0 ? Status.Failed : Status.Successful,
+                    End = start.AddMinutes(index),
+                });
+            }
+
+            await store.SaveAsync(new PipelineRunReport
+            {
+                RunId = "other-pipeline",
+                PipelineIdentity = "pipeline-b",
+                Status = Status.Failed,
+                End = start.AddMinutes(5),
+            });
+
+            var reports = await System.Linq.AsyncEnumerable.ToListAsync(
+                store.GetRunsAsync(new RunHistoryQuery
+                {
+                    PipelineIdentity = "pipeline-a",
+                    MaxRuns = 2,
+                    Since = start.AddMinutes(2),
+                    Status = Status.Failed,
+                }));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(reports).Count().IsEqualTo(2);
+                await Assert.That(reports[0].RunId).IsEqualTo("run-4");
+                await Assert.That(reports[1].RunId).IsEqualTo("run-2");
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task FileSystemHistoryStorePrunesAbandonedPipelineIdentitiesToGlobalRetention()
     {
         var directory = CreateTemporaryDirectory();
@@ -1155,6 +1206,43 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task RunHistoryReaderReturnsMeasuredAttributableModuleTrends()
+    {
+        var moduleTypeName = ModuleTypeIdentifier.Get(typeof(SuccessfulModule));
+        var end = new DateTimeOffset(2026, 8, 2, 12, 0, 0, TimeSpan.Zero);
+        var historyStore = new Mock<IRunHistoryStore>();
+        historyStore.Setup(store => store.GetRunsAsync(
+                It.IsAny<RunHistoryQuery>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Reports(
+                CreateTrendReport("run-2", end.AddMinutes(2), moduleTypeName, measured: true),
+                CreateTrendReport("", end.AddMinutes(1), moduleTypeName, measured: true),
+                CreateTrendReport("run-0", end, moduleTypeName, measured: false)));
+        var reader = new RunHistoryReader(
+            historyStore.Object,
+            OptionsFactory.Create(new PipelineOptions
+            {
+                RunReport = new RunReportOptions { PipelineIdentity = "pipeline-a" },
+            }));
+
+        var samples = await reader.GetModuleDurationTrendAsync(moduleTypeName, 3);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(samples).Count().IsEqualTo(1);
+            await Assert.That(samples[0]).IsEqualTo(new ModuleDurationSample(
+                "run-2",
+                end.AddMinutes(2),
+                Status.Successful,
+                TimeSpan.FromSeconds(2)));
+            historyStore.Verify(store => store.GetRunsAsync(
+                It.Is<RunHistoryQuery>(query =>
+                    query.PipelineIdentity == "pipeline-a" && query.MaxRuns == 3),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+
+    [Test]
     public async Task AtomicFileWriterReplacesExistingFileAfterCompletedWrite()
     {
         var directory = CreateTemporaryDirectory();
@@ -1177,6 +1265,30 @@ public class RunReportTests
         {
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    [Test]
+    public async Task RunHistoryReaderRequiresConfiguredPipelineIdentity()
+    {
+        var reader = new RunHistoryReader(
+            Mock.Of<IRunHistoryStore>(),
+            OptionsFactory.Create(new PipelineOptions()));
+
+        await Assert.That(async () => await reader.GetModuleDurationTrendAsync("module", 1))
+            .Throws<InvalidOperationException>()
+            .WithMessage("PipelineIdentity must be configured to query run history.");
+    }
+
+    [Test]
+    public async Task PipelineRegistersRunHistoryReader()
+    {
+        var services = new ServiceCollection();
+        DependencyInjectionSetup.Initialize(services);
+
+        await Assert.That(services.Any(descriptor =>
+                descriptor.ServiceType == typeof(IRunHistoryReader)
+                && descriptor.ImplementationType == typeof(RunHistoryReader)))
+            .IsTrue();
     }
 
     [Test]
@@ -1495,6 +1607,52 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task HistoryPersistenceInvokesRunReportEnrichersWithoutReportFile()
+    {
+        PipelineRunReport? savedReport = null;
+        var historyStore = new Mock<IRunHistoryStore>();
+        historyStore.Setup(store => store.GetRunsAsync(
+                It.IsAny<RunHistoryQuery>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(EmptyReports());
+        historyStore.Setup(store => store.SaveAsync(
+                It.IsAny<PipelineRunReport>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<PipelineRunReport, CancellationToken>((report, _) => savedReport = report)
+            .Returns(Task.CompletedTask);
+        var distributedOptions = OptionsFactory.Create(new DistributedOptions());
+        var commandExecutionCounter = new CommandExecutionCounter();
+        var service = new RunReportService(
+            historyStore.Object,
+            new PipelineRunReportFactory(
+                commandExecutionCounter,
+                new PassthroughSecretObfuscator()),
+            Mock.Of<IBuildSystemDetector>(),
+            OptionsFactory.Create(new PipelineOptions
+            {
+                RunReport = new RunReportOptions
+                {
+                    AutoWriteInCi = false,
+                    HistoryRetention = 1,
+                },
+            }),
+            distributedOptions,
+            new RoleDetector(distributedOptions),
+            Mock.Of<IDistributedCoordinator>(),
+            commandExecutionCounter,
+            NullLogger<RunReportService>.Instance,
+            runReportEnrichers: [new StaticRunReportEnricher()]);
+
+        var report = await service.CompleteAsync(CreateEmptySummary());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(report.Correlation!.GitSha).IsEqualTo("secret-sha");
+            await Assert.That(savedReport).IsSameReferenceAs(report);
+        }
+    }
+
+    [Test]
     public async Task RepeatedCompletionsReceiveDistinctRunIds()
     {
         var distributedOptions = OptionsFactory.Create(new DistributedOptions());
@@ -1601,7 +1759,14 @@ public class RunReportTests
                 commandExecutionCounter,
                 new PassthroughSecretObfuscator()),
             Mock.Of<IBuildSystemDetector>(),
-            OptionsFactory.Create(new PipelineOptions()),
+            OptionsFactory.Create(new PipelineOptions
+            {
+                RunReport = new RunReportOptions
+                {
+                    AutoWriteInCi = false,
+                    HistoryRetention = 0,
+                },
+            }),
             distributedOptions,
             new RoleDetector(distributedOptions),
             Mock.Of<IDistributedCoordinator>(),
@@ -1920,7 +2085,7 @@ public class RunReportTests
                 await Assert.That(report).IsNotNull();
                 await Assert.That(File.Exists(reportPath)).IsFalse();
                 historyStore.Verify(
-                    store => store.GetLatestAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                    store => store.GetRunsAsync(It.IsAny<RunHistoryQuery>(), It.IsAny<CancellationToken>()),
                     Times.Never);
                 historyStore.Verify(
                     store => store.SaveAsync(It.IsAny<PipelineRunReport>(), It.IsAny<CancellationToken>()),
@@ -2034,11 +2199,11 @@ public class RunReportTests
         var historyStore = new Mock<IRunHistoryStore>();
         var readToken = CancellationToken.None;
         var saveToken = CancellationToken.None;
-        historyStore.Setup(store => store.GetLatestAsync(
-                It.IsAny<string>(),
+        historyStore.Setup(store => store.GetRunsAsync(
+                It.IsAny<RunHistoryQuery>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, CancellationToken>((_, token) => readToken = token)
-            .ReturnsAsync((PipelineRunReport?) null);
+            .Callback<RunHistoryQuery, CancellationToken>((_, token) => readToken = token)
+            .Returns(EmptyReports());
         historyStore.Setup(store => store.SaveAsync(
                 It.IsAny<PipelineRunReport>(),
                 It.IsAny<CancellationToken>()))
@@ -2089,14 +2254,13 @@ public class RunReportTests
         var reportPath = Path.Combine(directory, "run-report.json");
         var readStarted = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        var readCompletion = new TaskCompletionSource<PipelineRunReport?>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
         var historyStore = new Mock<IRunHistoryStore>();
-        historyStore.Setup(store => store.GetLatestAsync(
-                It.IsAny<string>(),
+        historyStore.Setup(store => store.GetRunsAsync(
+                It.IsAny<RunHistoryQuery>(),
                 It.IsAny<CancellationToken>()))
-            .Callback<string, CancellationToken>((_, _) => readStarted.TrySetResult())
-            .Returns(readCompletion.Task);
+            .Callback<RunHistoryQuery, CancellationToken>((_, _) => readStarted.TrySetResult())
+            .Returns((RunHistoryQuery _, CancellationToken token) =>
+                ReportsAfterAsync(Task.Delay(Timeout.InfiniteTimeSpan, token)));
         var distributedOptions = OptionsFactory.Create(new DistributedOptions());
         var commandExecutionCounter = new CommandExecutionCounter();
         var service = new RunReportService(
@@ -2142,7 +2306,6 @@ public class RunReportTests
         }
         finally
         {
-            readCompletion.TrySetResult(null);
             Directory.Delete(directory, recursive: true);
         }
     }
@@ -2202,15 +2365,15 @@ public class RunReportTests
     {
         var directory = CreateTemporaryDirectory();
         var reportPath = Path.Combine(directory, "run-report.json");
-        var readCompletion = new TaskCompletionSource<PipelineRunReport?>(
+        var readCompletion = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var saveCompletion = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
         var historyStore = new Mock<IRunHistoryStore>();
-        historyStore.Setup(store => store.GetLatestAsync(
-                It.IsAny<string>(),
+        historyStore.Setup(store => store.GetRunsAsync(
+                It.IsAny<RunHistoryQuery>(),
                 It.IsAny<CancellationToken>()))
-            .Returns(readCompletion.Task);
+            .Returns(ReportsAfterAsync(readCompletion.Task));
         historyStore.Setup(store => store.SaveAsync(
                 It.IsAny<PipelineRunReport>(),
                 It.IsAny<CancellationToken>()))
@@ -2244,8 +2407,8 @@ public class RunReportTests
                 .WaitAsync(TimeSpan.FromSeconds(2));
 
             await Assert.That(report).IsNotNull();
-            historyStore.Verify(store => store.GetLatestAsync(
-                It.IsAny<string>(),
+            historyStore.Verify(store => store.GetRunsAsync(
+                It.IsAny<RunHistoryQuery>(),
                 It.IsAny<CancellationToken>()), Times.Once);
             historyStore.Verify(store => store.SaveAsync(
                 It.IsAny<PipelineRunReport>(),
@@ -2253,6 +2416,8 @@ public class RunReportTests
         }
         finally
         {
+            readCompletion.TrySetResult();
+            saveCompletion.TrySetResult();
             Directory.Delete(directory, recursive: true);
         }
     }
@@ -3261,5 +3426,49 @@ public class RunReportTests
             EndTime = start + duration,
             ExecutionDuration = duration,
             Status = Status.Successful,
+        };
+
+    private static async IAsyncEnumerable<PipelineRunReport> EmptyReports()
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<PipelineRunReport> ReportsAfterAsync(Task completion)
+    {
+        await completion;
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<PipelineRunReport> Reports(
+        params PipelineRunReport[] reports)
+    {
+        await Task.CompletedTask;
+        foreach (var report in reports)
+        {
+            yield return report;
+        }
+    }
+
+    private static PipelineRunReport CreateTrendReport(
+        string runId,
+        DateTimeOffset end,
+        string moduleTypeName,
+        bool measured) => new()
+        {
+            RunId = runId,
+            PipelineIdentity = "pipeline-a",
+            End = end,
+            Modules =
+            [
+                new ModuleRunReport
+                {
+                    ModuleName = nameof(SuccessfulModule),
+                    ModuleTypeName = moduleTypeName,
+                    Status = Status.Successful,
+                    Duration = TimeSpan.FromSeconds(2),
+                    DurationMeasured = measured,
+                },
+            ],
         };
 }


### PR DESCRIPTION
Closes #3746.

Depends on #3827 for run IDs and correlation metadata. The shared commits are intentionally present until that prerequisite merges.

## Summary
- replace the store read contract with bounded, newest-first `RunHistoryQuery` enumeration
- keep `GetLatestAsync` as a convenience extension
- register `IRunHistoryReader` and expose measured, attributable module duration trends
- document querying and custom-store migration

## Validation
- `RunReportTests`: 58 passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors
- format verification passed for changed C# files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added flexible querying of retained pipeline run history by identity, count, date, and status.
  - Added module-duration trend retrieval with run metadata, status, and duration details.
  - Added automatic registration of run-history services.
  - Preserved latest-run lookup through a simplified convenience method.

- **Bug Fixes**
  - Reports are now enriched before persistence when history retention is enabled, even without a report file.

- **Documentation**
  - Expanded guidance for querying run history and interpreting duration trends, including schema limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->