### PR TITLE
Support stable module cache assembly keys

### DIFF
--- a/docs/docs/how-to/module-caching.md
+++ b/docs/docs/how-to/module-caching.md
@@ -37,7 +37,7 @@ Patterns are relative to `ModuleCacheOptions.WorkingDirectory`. They support `*`
 
 The fingerprint contains:
 
-- the module type and assembly version;
+- the module type and its assembly module version ID (MVID), unless explicitly overridden;
 - the content and relative path of every declared input;
 - explicit key parts and declared environment variable values;
 - normalized results from all direct, selector-based, and dynamic dependencies.
@@ -58,6 +58,29 @@ protected override ModuleConfiguration Configure() =>
 ```
 
 Changing any key part or declared environment value invalidates the entry.
+
+## Stabilize the module version key
+
+By default, the fingerprint includes the module assembly's MVID so rebuilding changed module
+code invalidates cached results. Some versioning tools generate different assembly metadata for
+every commit, which can also change the MVID when the module implementation is unchanged. This
+can eliminate cross-commit cache hits, and changing any code in the assembly can invalidate every
+cached module declared by that assembly.
+
+Use an explicit version key only when your build changes the MVID independently of module behavior:
+
+```csharp
+protected override ModuleConfiguration Configure() =>
+    ModuleConfiguration.Create()
+        .WithCacheKeyPart("configuration=v1")
+        .WithCacheAssemblyVersionKey("build-module-v3")
+        .Build();
+```
+
+You must update this key whenever the module implementation changes. Reusing it after a behavior
+change can restore stale results or artifacts. Cache misses log bounded fingerprint-component
+diagnostics at `Debug`; user-controlled key parts, environment values, exception messages, and
+skip reasons appear only as SHA-256 hashes.
 
 ## Configure limits and locations
 

--- a/src/ModularPipelines/Caching/ModuleCacheResultRepository.cs
+++ b/src/ModularPipelines/Caching/ModuleCacheResultRepository.cs
@@ -186,17 +186,19 @@ internal sealed class ModuleCacheResultRepository : IModuleCacheResultRepository
             return null;
         }
 
-        var fingerprint = await ComputeFingerprintAsync(module, pipelineContext, cancellationToken)
+        var computedFingerprint = await ComputeFingerprintAsync(module, pipelineContext, cancellationToken)
             .ConfigureAwait(false);
+        var fingerprint = computedFingerprint.Value;
         _fingerprints[module] = fingerprint;
         await using var cachedStream = await _store.OpenReadAsync(fingerprint, cancellationToken)
             .ConfigureAwait(false);
         if (cachedStream is null)
         {
             _logger.LogDebug(
-                "Module cache miss {Fingerprint} for {Module}",
+                "Module cache miss {Fingerprint} for {Module}. Fingerprint components: {FingerprintComponents}",
                 fingerprint,
-                module.GetType().Name);
+                module.GetType().Name,
+                computedFingerprint.Diagnostics);
             return null;
         }
 
@@ -293,7 +295,7 @@ internal sealed class ModuleCacheResultRepository : IModuleCacheResultRepository
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Dependency result fingerprints require runtime result type metadata.")]
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Dependency result fingerprints require runtime result type metadata.")]
-    private async Task<string> ComputeFingerprintAsync<T>(
+    private async Task<ComputedFingerprint> ComputeFingerprintAsync<T>(
         Module<T> module,
         IPipelineContext pipelineContext,
         CancellationToken cancellationToken)
@@ -311,61 +313,77 @@ internal sealed class ModuleCacheResultRepository : IModuleCacheResultRepository
                 cancellationToken)
             .ConfigureAwait(false);
 
-        using var incrementalHash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        using var fingerprint = new FingerprintBuilder(_logger.IsEnabled(LogLevel.Debug));
         AppendModuleFingerprintData(
-            incrementalHash,
+            fingerprint,
             module,
             configuration,
             inputFiles,
             hashes);
         var dependencyTypes = GetDependencyTypes(module);
         await AppendDependencyFingerprintsAsync(
-                incrementalHash,
+                fingerprint,
                 dependencyTypes,
                 pipelineContext,
                 cancellationToken)
             .ConfigureAwait(false);
 
-        return Convert.ToHexString(incrementalHash.GetHashAndReset());
+        return fingerprint.Complete();
     }
 
     private void AppendModuleFingerprintData<T>(
-        IncrementalHash incrementalHash,
+        FingerprintBuilder fingerprint,
         Module<T> module,
         ModuleConfiguration configuration,
         IReadOnlyList<string> inputFiles,
         IReadOnlyDictionary<string, string> hashes)
     {
-        Append(incrementalHash, "format", "2");
-        Append(incrementalHash, "module", module.GetType().AssemblyQualifiedName ?? module.GetType().FullName!);
-        Append(incrementalHash, "module-version", module.GetType().Assembly.ManifestModule.ModuleVersionId.ToString("N"));
+        fingerprint.Append("format", "2");
+        fingerprint.Append("module", module.GetType().AssemblyQualifiedName ?? module.GetType().FullName!);
+        if (configuration.CacheAssemblyVersionKey is { } assemblyVersionKey)
+        {
+            fingerprint.Append(
+                "module-version",
+                assemblyVersionKey,
+                protectDiagnosticValue: true,
+                diagnosticName: "module-version-override");
+        }
+        else
+        {
+            fingerprint.Append(
+                "module-version",
+                module.GetType().Assembly.ManifestModule.ModuleVersionId.ToString("N"),
+                diagnosticName: "module-version-mvid");
+        }
 
         foreach (var pattern in configuration.CacheInputPatterns)
         {
-            Append(incrementalHash, "input-pattern", pattern);
+            fingerprint.Append("input-pattern", pattern);
         }
 
         foreach (var path in inputFiles)
         {
-            Append(incrementalHash, "input-path", ModuleCacheFileResolver.GetRelativePath(_options.WorkingDirectory, path));
-            Append(incrementalHash, "input-hash", hashes[path]);
+            fingerprint.Append("input-path", ModuleCacheFileResolver.GetRelativePath(_options.WorkingDirectory, path));
+            fingerprint.Append("input-hash", hashes[path]);
         }
 
         foreach (var keyPart in configuration.CacheKeyParts)
         {
-            Append(incrementalHash, "key-part", keyPart);
+            fingerprint.Append("key-part", keyPart, protectDiagnosticValue: true);
         }
 
         foreach (var variableName in configuration.CacheEnvironmentVariables.Order(StringComparer.Ordinal))
         {
             var value = Environment.GetEnvironmentVariable(variableName);
-            Append(
-                incrementalHash,
+            fingerprint.Append(
                 $"environment:{variableName}:presence",
                 value is null ? "unset" : "set");
             if (value is not null)
             {
-                Append(incrementalHash, $"environment:{variableName}:value", value);
+                fingerprint.Append(
+                    $"environment:{variableName}:value",
+                    value,
+                    protectDiagnosticValue: true);
             }
         }
     }
@@ -385,7 +403,7 @@ internal sealed class ModuleCacheResultRepository : IModuleCacheResultRepository
     }
 
     private static async Task AppendDependencyFingerprintsAsync(
-        IncrementalHash incrementalHash,
+        FingerprintBuilder fingerprint,
         IEnumerable<Type> dependencyTypes,
         IPipelineContext pipelineContext,
         CancellationToken cancellationToken)
@@ -396,27 +414,26 @@ internal sealed class ModuleCacheResultRepository : IModuleCacheResultRepository
             var dependencyModule = internalContext.GetModule(dependencyType);
             if (dependencyModule is null)
             {
-                Append(incrementalHash, "dependency-missing", dependencyType.AssemblyQualifiedName!);
+                fingerprint.Append("dependency-missing", dependencyType.AssemblyQualifiedName!);
                 continue;
             }
 
             var dependencyResult = await dependencyModule.ResultTask
                 .WaitAsync(cancellationToken)
                 .ConfigureAwait(false);
-            AppendDependencyFingerprint(incrementalHash, dependencyType, dependencyResult);
+            AppendDependencyFingerprint(fingerprint, dependencyType, dependencyResult);
         }
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Dependency result fingerprints require runtime result type metadata.")]
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Dependency result fingerprints require runtime result type metadata.")]
     private static void AppendDependencyFingerprint(
-        IncrementalHash incrementalHash,
+        FingerprintBuilder fingerprint,
         Type dependencyType,
         IModuleResult dependencyResult)
     {
-        Append(incrementalHash, "dependency", dependencyType.AssemblyQualifiedName!);
-        Append(
-            incrementalHash,
+        fingerprint.Append("dependency", dependencyType.AssemblyQualifiedName!);
+        fingerprint.Append(
             "dependency-status",
             dependencyResult.ModuleStatus == Status.UsedHistory
                 ? Status.Successful.ToString()
@@ -424,28 +441,33 @@ internal sealed class ModuleCacheResultRepository : IModuleCacheResultRepository
 
         if (dependencyResult.ValueOrDefault is { } value)
         {
-            Append(
-                incrementalHash,
+            fingerprint.Append(
                 "dependency-value-type",
                 value.GetType().AssemblyQualifiedName ?? value.GetType().FullName!);
             var valueBytes = JsonSerializer.SerializeToUtf8Bytes(value, value.GetType());
-            Append(incrementalHash, "dependency-value", Convert.ToHexString(SHA256.HashData(valueBytes)));
+            fingerprint.Append("dependency-value", Convert.ToHexString(SHA256.HashData(valueBytes)));
         }
         else
         {
-            Append(incrementalHash, "dependency-value-type", "<null>");
-            Append(incrementalHash, "dependency-value", "<null>");
+            fingerprint.Append("dependency-value-type", "<null>");
+            fingerprint.Append("dependency-value", "<null>");
         }
 
         if (dependencyResult.ExceptionOrDefault is { } exception)
         {
-            Append(incrementalHash, "dependency-exception-type", exception.GetType().FullName!);
-            Append(incrementalHash, "dependency-exception-message", exception.Message);
+            fingerprint.Append("dependency-exception-type", exception.GetType().FullName!);
+            fingerprint.Append(
+                "dependency-exception-message",
+                exception.Message,
+                protectDiagnosticValue: true);
         }
 
         if (dependencyResult.SkipDecisionOrDefault is { } skipDecision)
         {
-            Append(incrementalHash, "dependency-skip", skipDecision.Reason ?? string.Empty);
+            fingerprint.Append(
+                "dependency-skip",
+                skipDecision.Reason ?? string.Empty,
+                protectDiagnosticValue: true);
         }
     }
 
@@ -1206,18 +1228,69 @@ internal sealed class ModuleCacheResultRepository : IModuleCacheResultRepository
         return (unixAttributes & UnixFileTypeMask) == UnixFileTypeSymbolicLink;
     }
 
-    private static void Append(IncrementalHash hash, string name, string value)
-    {
-        AppendLengthPrefixed(hash, Encoding.UTF8.GetBytes(name));
-        AppendLengthPrefixed(hash, Encoding.UTF8.GetBytes(value));
-    }
-
     private static void AppendLengthPrefixed(IncrementalHash hash, byte[] value)
     {
         Span<byte> length = stackalloc byte[sizeof(int)];
         BinaryPrimitives.WriteInt32LittleEndian(length, value.Length);
         hash.AppendData(length);
         hash.AppendData(value);
+    }
+
+    private sealed record ComputedFingerprint(string Value, string Diagnostics);
+
+    private sealed class FingerprintBuilder(bool captureDiagnostics) : IDisposable
+    {
+        private const int MaximumLoggedComponents = 128;
+        private readonly IncrementalHash _hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        private readonly List<string>? _components = captureDiagnostics ? [] : null;
+
+        public void Append(
+            string name,
+            string value,
+            bool protectDiagnosticValue = false,
+            string? diagnosticName = null)
+        {
+            AppendLengthPrefixed(_hash, Encoding.UTF8.GetBytes(name));
+            AppendLengthPrefixed(_hash, Encoding.UTF8.GetBytes(value));
+
+            if (_components is null)
+            {
+                return;
+            }
+
+            var diagnosticValue = protectDiagnosticValue
+                ? $"sha256:{Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(value)))}"
+                : value;
+            _components.Add($"{diagnosticName ?? name}=\"{JsonEncodedText.Encode(diagnosticValue)}\"");
+        }
+
+        public ComputedFingerprint Complete()
+        {
+            var value = Convert.ToHexString(_hash.GetHashAndReset());
+            return new ComputedFingerprint(value, BuildDiagnostics());
+        }
+
+        public void Dispose() => _hash.Dispose();
+
+        private string BuildDiagnostics()
+        {
+            if (_components is null)
+            {
+                return string.Empty;
+            }
+
+            if (_components.Count <= MaximumLoggedComponents)
+            {
+                return string.Join(", ", _components);
+            }
+
+            var omittedComponents = string.Join(", ", _components.Skip(MaximumLoggedComponents));
+            var omittedDigest = Convert.ToHexString(
+                SHA256.HashData(Encoding.UTF8.GetBytes(omittedComponents)));
+            return string.Join(", ", _components.Take(MaximumLoggedComponents))
+                   + $", ... {_components.Count - MaximumLoggedComponents} component(s) omitted"
+                   + $" (sha256:{omittedDigest})";
+        }
     }
 
     private sealed class ArtifactByteBudget

--- a/src/ModularPipelines/Configuration/ModuleConfiguration.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfiguration.cs
@@ -127,6 +127,14 @@ public sealed class ModuleConfiguration
     public IReadOnlyList<string> CacheEnvironmentVariables { get; init; } = [];
 
     /// <summary>
+    /// Gets an explicit stable replacement for the module assembly MVID in the cache fingerprint.
+    /// </summary>
+    /// <remarks>
+    /// This value must change whenever the module implementation changes. A null value uses the assembly MVID.
+    /// </remarks>
+    public string? CacheAssemblyVersionKey { get; init; }
+
+    /// <summary>
     /// Gets a value indicating whether fingerprint-based caching is enabled for this module.
     /// </summary>
     /// <remarks>
@@ -136,7 +144,8 @@ public sealed class ModuleConfiguration
     public bool CacheEnabled =>
         CacheInputPatterns.Count > 0
         || CacheKeyParts.Count > 0
-        || CacheEnvironmentVariables.Count > 0;
+        || CacheEnvironmentVariables.Count > 0
+        || CacheAssemblyVersionKey is not null;
 
     /// <summary>
     /// Gets dependencies declared through fluent configuration or attributes.

--- a/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationAttributeAdapter.cs
@@ -51,6 +51,7 @@ internal static class ModuleConfigurationAttributeAdapter
             CacheInputPatterns = cacheInputPatterns,
             CacheKeyParts = configured.CacheKeyParts,
             CacheEnvironmentVariables = configured.CacheEnvironmentVariables,
+            CacheAssemblyVersionKey = configured.CacheAssemblyVersionKey,
             Dependencies = dependencies,
         };
     }

--- a/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
@@ -42,6 +42,7 @@ public sealed class ModuleConfigurationBuilder
     private readonly List<Func<IModuleContext, CancellationToken, ValueTask<SkipDecision?>>> _planningSkipConditions = [];
     private readonly List<string> _cacheKeyParts = [];
     private readonly HashSet<string> _cacheEnvironmentVariables = [with(StringComparer.Ordinal)];
+    private string? _cacheAssemblyVersionKey;
     private TimeSpan? _timeout;
     private ModuleRetryConfiguration? _retryConfiguration;
     private Func<IModuleContext, IAsyncPolicy>? _advancedRetryPolicyFactory;
@@ -159,6 +160,22 @@ public sealed class ModuleConfigurationBuilder
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(variableName);
         _cacheEnvironmentVariables.Add(variableName);
+        return this;
+    }
+
+    /// <summary>
+    /// Replaces the module assembly MVID in this module's cache fingerprint with an explicit stable key.
+    /// </summary>
+    /// <param name="value">A stable version key that changes whenever the module implementation changes.</param>
+    /// <returns>This builder instance for method chaining.</returns>
+    /// <remarks>
+    /// Use this when build tooling changes the assembly MVID without changing module behavior.
+    /// Reusing a key after changing the module implementation can restore stale cached results.
+    /// </remarks>
+    public ModuleConfigurationBuilder WithCacheAssemblyVersionKey(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        _cacheAssemblyVersionKey = value;
         return this;
     }
 
@@ -425,6 +442,7 @@ public sealed class ModuleConfigurationBuilder
             Category = _category,
             CacheKeyParts = [.. _cacheKeyParts],
             CacheEnvironmentVariables = [.. _cacheEnvironmentVariables],
+            CacheAssemblyVersionKey = _cacheAssemblyVersionKey,
             Dependencies = [.. _dependencies],
         };
     }

--- a/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
+++ b/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
@@ -2,6 +2,7 @@ using System.IO.Compression;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Caching;
 using ModularPipelines.Context;
@@ -18,6 +19,24 @@ namespace ModularPipelines.UnitTests.Caching;
 
 public class ModuleCacheTests
 {
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Messages.Add(formatter(state, exception));
+    }
+
     private sealed class TrackingProgressDisplay : IProgressDisplay
     {
         public bool? LastCompletionWasSuccessful { get; private set; }
@@ -95,6 +114,23 @@ public class ModuleCacheTests
         protected internal override Task<string> ExecuteAsync(
             IModuleContext context,
             CancellationToken cancellationToken) => Task.FromResult<string>(Value);
+    }
+
+    [CacheInputs("unused.txt")]
+    private sealed class StableAssemblyVersionKeyModule : Module<string>
+    {
+        public const string AssemblyVersionKey = "stable-build-module-v3";
+        public const string KeyPart = "configuration-value";
+
+        protected override ModularPipelines.Configuration.ModuleConfiguration Configure() =>
+            ModularPipelines.Configuration.ModuleConfiguration.Create()
+                .WithCacheKeyPart(KeyPart)
+                .WithCacheAssemblyVersionKey(AssemblyVersionKey)
+                .Build();
+
+        protected internal override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult("stable");
     }
 
     private sealed class RuntimeTypedDependencyModule : Module<object>
@@ -1061,6 +1097,7 @@ public class ModuleCacheTests
         var configuration = ModularPipelines.Configuration.ModuleConfiguration.Create()
             .WithCacheKeyPart("configuration=v1")
             .WithCacheEnvironmentVariable("CI")
+            .WithCacheAssemblyVersionKey("build-module-v3")
             .Build();
 
         using (Assert.Multiple())
@@ -1068,6 +1105,55 @@ public class ModuleCacheTests
             await Assert.That(configuration.CacheEnabled).IsTrue();
             await Assert.That(configuration.CacheKeyParts).IsEquivalentTo(new[] { "configuration=v1" });
             await Assert.That(configuration.CacheEnvironmentVariables).IsEquivalentTo(new[] { "CI" });
+            await Assert.That(configuration.CacheAssemblyVersionKey).IsEqualTo("build-module-v3");
+        }
+    }
+
+    [Test]
+    public async Task CacheAssemblyVersionKeyRejectsWhitespace()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            ModularPipelines.Configuration.ModuleConfiguration.Create()
+                .WithCacheAssemblyVersionKey(" "));
+
+        await Assert.That(exception.ParamName).IsEqualTo("value");
+    }
+
+    [Test]
+    public async Task CacheMissLogsProtectedFingerprintComponents()
+    {
+        var temporaryDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"ModularPipelines-cache-diagnostics-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(temporaryDirectory);
+        var logger = new RecordingLogger<ModuleCacheResultRepository>();
+
+        try
+        {
+            using var builder = Pipeline.CreateBuilder();
+            builder.AddModuleCache<FileSystemModuleCache>(options =>
+            {
+                options.WorkingDirectory = temporaryDirectory;
+                options.CacheDirectory = Path.Combine(temporaryDirectory, "cache");
+            });
+            builder.Services.AddSingleton<ILogger<ModuleCacheResultRepository>>(logger);
+            builder.AddModule<StableAssemblyVersionKeyModule>();
+
+            await builder.ExecutePipelineAsync();
+
+            var miss = logger.Messages.Single(message => message.Contains("Module cache miss"));
+            using (Assert.Multiple())
+            {
+                await Assert.That(miss).Contains("module-version-override=");
+                await Assert.That(miss).Contains("key-part=");
+                await Assert.That(miss).Contains("sha256:");
+                await Assert.That(miss).DoesNotContain(StableAssemblyVersionKeyModule.AssemblyVersionKey);
+                await Assert.That(miss).DoesNotContain(StableAssemblyVersionKeyModule.KeyPart);
+            }
+        }
+        finally
+        {
+            Directory.Delete(temporaryDirectory, recursive: true);
         }
     }
 


### PR DESCRIPTION
Closes #3803

## Summary
- add `WithCacheAssemblyVersionKey` as an opt-in stable replacement for assembly MVID fingerprinting
- emit bounded Debug diagnostics for cache-miss fingerprint components while hashing user-controlled values
- document MVID invalidation behavior and the stale-cache responsibility of explicit keys

## Validation
- focused assembly-key validation/configuration/diagnostic tests passed
- existing cache-hit and artifact-restore regression passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors