### PR TITLE
Cache artifact demand planning safely

### DIFF
--- a/src/ModularPipelines/Engine/ArtifactDemandPlanCache.cs
+++ b/src/ModularPipelines/Engine/ArtifactDemandPlanCache.cs
@@ -1,0 +1,47 @@
+namespace ModularPipelines.Engine;
+
+internal sealed class ArtifactDemandPlanCache
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private HashSet<Type>? _completedModuleTypes;
+    private ArtifactDemandPlan? _plan;
+
+    public async Task<ArtifactDemandPlan> GetAsync(
+        Func<HashSet<Type>> getCompletedModuleTypes,
+        Func<Task<ArtifactDemandPlan>> resolve,
+        CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            while (true)
+            {
+                var completedBeforeResolution = getCompletedModuleTypes();
+                if (_plan is not null
+                    && _completedModuleTypes!.SetEquals(completedBeforeResolution))
+                {
+                    return _plan;
+                }
+
+                var plan = await resolve().ConfigureAwait(false);
+                var completedAfterResolution = getCompletedModuleTypes();
+                if (!completedBeforeResolution.SetEquals(completedAfterResolution))
+                {
+                    continue;
+                }
+
+                _completedModuleTypes = completedAfterResolution;
+                _plan = plan;
+                return plan;
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+}
+
+internal sealed record ArtifactDemandPlan(
+    IReadOnlySet<Type> RequiredProducerTypes,
+    IReadOnlyDictionary<Type, IReadOnlySet<string>> RequiredArtifactsByProducer);

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -49,6 +49,8 @@ internal class ModuleRunner : IModuleRunner
     private readonly bool _manageArtifactsLocally;
     private readonly IReadOnlyDictionary<Type, IReadOnlyDictionary<string, IReadOnlySet<Type>>>
         _localArtifactConsumers;
+    private readonly IReadOnlyList<Type> _registeredModuleTypes;
+    private readonly ArtifactDemandPlanCache _artifactDemandPlanCache = new();
     private readonly ConcurrentDictionary<Type, Lazy<Task<SkipDecision?>>>
         _planningSkipEvaluations = new();
     private readonly ConcurrentDictionary<Type, Lazy<Task<bool>>> _historicalResultAvailability = new();
@@ -98,6 +100,7 @@ internal class ModuleRunner : IModuleRunner
         _manageArtifactsLocally = !distributedOptions.Value.Enabled
                                   || distributedOptions.Value.TotalInstances <= 1;
         var registeredModules = modules.ToArray();
+        _registeredModuleTypes = registeredModules.Select(static module => module.GetType()).ToArray();
         _localArtifactConsumers = GetLocalArtifactConsumers(registeredModules);
     }
 
@@ -192,39 +195,17 @@ internal class ModuleRunner : IModuleRunner
         CancellationToken cancellationToken)
     {
         if (!_manageArtifactsLocally
-            || !_localArtifactConsumers.TryGetValue(moduleType, out var consumersByArtifact))
+            || !_localArtifactConsumers.ContainsKey(moduleType))
         {
             return;
         }
 
-        var requiredProducerTypes = await GetArtifactProducerTypesRequiringExecutionAsync(
+        var demandPlan = await GetArtifactDemandPlanAsync(
                 scheduler,
                 cancellationToken)
             .ConfigureAwait(false);
-        if (!requiredProducerTypes.Contains(moduleType))
-        {
-            return;
-        }
-
-        var artifactNames = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var (artifactName, consumerTypes) in consumersByArtifact)
-        {
-            foreach (var consumerType in consumerTypes)
-            {
-                if (await IsRunnableArtifactConsumerAsync(
-                        consumerType,
-                        scheduler,
-                        cancellationToken,
-                        requiredProducerTypes)
-                    .ConfigureAwait(false))
-                {
-                    artifactNames.Add(artifactName);
-                    break;
-                }
-            }
-        }
-
-        if (artifactNames.Count == 0)
+        if (!demandPlan.RequiredArtifactsByProducer.TryGetValue(moduleType, out var artifactNames)
+            || artifactNames.Count == 0)
         {
             return;
         }
@@ -244,39 +225,83 @@ internal class ModuleRunner : IModuleRunner
             return false;
         }
 
-        var requiredProducerTypes = await GetArtifactProducerTypesRequiringExecutionAsync(
+        var demandPlan = await GetArtifactDemandPlanAsync(
                 scheduler,
                 cancellationToken)
             .ConfigureAwait(false);
-        return requiredProducerTypes.Contains(producerType);
+        return demandPlan.RequiredProducerTypes.Contains(producerType);
     }
 
-    private async Task<HashSet<Type>> GetArtifactProducerTypesRequiringExecutionAsync(
+    private Task<ArtifactDemandPlan> GetArtifactDemandPlanAsync(
         IModuleScheduler scheduler,
         CancellationToken cancellationToken)
     {
-        return await ArtifactDemandPlanner.ResolveAsync(async currentDemand =>
-        {
-            var nextRequiredProducerTypes = new HashSet<Type>();
-            foreach (var (producerType, consumersByArtifact) in _localArtifactConsumers)
+        return _artifactDemandPlanCache.GetAsync(
+            () => _registeredModuleTypes
+                .Where(moduleType => scheduler.GetModuleCompletionTask(moduleType)?.IsCompleted == true)
+                .ToHashSet(),
+            async () =>
             {
-                foreach (var consumerType in consumersByArtifact.Values.SelectMany(consumers => consumers))
+                var requiredProducerTypes = await ArtifactDemandPlanner.ResolveAsync(async currentDemand =>
                 {
-                    if (await IsRunnableArtifactConsumerAsync(
-                            consumerType,
-                            scheduler,
-                            cancellationToken,
-                            currentDemand)
-                        .ConfigureAwait(false))
+                    var nextRequiredProducerTypes = new HashSet<Type>();
+                    foreach (var (producerType, consumersByArtifact) in _localArtifactConsumers)
                     {
-                        nextRequiredProducerTypes.Add(producerType);
-                        break;
+                        foreach (var consumerType in consumersByArtifact.Values.SelectMany(consumers => consumers))
+                        {
+                            if (await IsRunnableArtifactConsumerAsync(
+                                    consumerType,
+                                    scheduler,
+                                    cancellationToken,
+                                    currentDemand)
+                                .ConfigureAwait(false))
+                            {
+                                nextRequiredProducerTypes.Add(producerType);
+                                break;
+                            }
+                        }
+                    }
+
+                    return nextRequiredProducerTypes;
+                }).ConfigureAwait(false);
+
+                var requiredArtifactsByProducer = new Dictionary<Type, IReadOnlySet<string>>();
+                foreach (var producerType in requiredProducerTypes)
+                {
+                    if (!_localArtifactConsumers.TryGetValue(producerType, out var consumersByArtifact))
+                    {
+                        continue;
+                    }
+
+                    var requiredArtifactNames = new HashSet<string>(StringComparer.Ordinal);
+                    foreach (var (artifactName, consumerTypes) in consumersByArtifact)
+                    {
+                        foreach (var consumerType in consumerTypes)
+                        {
+                            if (!await IsRunnableArtifactConsumerAsync(
+                                    consumerType,
+                                    scheduler,
+                                    cancellationToken,
+                                    requiredProducerTypes)
+                                .ConfigureAwait(false))
+                            {
+                                continue;
+                            }
+
+                            requiredArtifactNames.Add(artifactName);
+                            break;
+                        }
+                    }
+
+                    if (requiredArtifactNames.Count > 0)
+                    {
+                        requiredArtifactsByProducer.Add(producerType, requiredArtifactNames);
                     }
                 }
-            }
 
-            return nextRequiredProducerTypes;
-        }).ConfigureAwait(false);
+                return new ArtifactDemandPlan(requiredProducerTypes, requiredArtifactsByProducer);
+            },
+            cancellationToken);
     }
 
     private async Task<bool> IsRunnableArtifactConsumerAsync(
@@ -314,7 +339,7 @@ internal class ModuleRunner : IModuleRunner
             return true;
         }
 
-        moduleState.SkipResult = skipDecision;
+        moduleState.TrySetSkipResult(skipDecision);
         return false;
     }
 
@@ -396,7 +421,7 @@ internal class ModuleRunner : IModuleRunner
                     .ConfigureAwait(false);
                 if (skipDecision?.ShouldSkip == true)
                 {
-                    dependencyState.SkipResult = skipDecision;
+                    dependencyState.TrySetSkipResult(skipDecision);
                     if (await IsSkippedDependencyUnrecoverableAsync(
                             dependency.Key,
                             dependencyState,
@@ -620,7 +645,7 @@ internal class ModuleRunner : IModuleRunner
         finally
         {
             // Store execution context results in module state
-            moduleState.SkipResult = executionContext.SkipResult;
+            moduleState.TrySetSkipResult(executionContext.SkipResult);
 
             if (!_pipelineOptions.Value.ShowProgressInConsole)
             {

--- a/src/ModularPipelines/Engine/ModuleState.cs
+++ b/src/ModularPipelines/Engine/ModuleState.cs
@@ -47,6 +47,7 @@ internal enum ModuleExecutionState
 internal class ModuleState
 {
     private ImmutableDictionary<Type, bool> _dependencies = ImmutableDictionary<Type, bool>.Empty;
+    private SkipDecision _skipResult = SkipDecision.DoNotSkip;
 
     public ModuleState(IModule module, Type moduleType)
     {
@@ -158,7 +159,23 @@ internal class ModuleState
     public IModuleResult? Result { get; set; }
 
     /// <summary>
-    /// Gets or sets the skip decision if the module was skipped.
+    /// Gets the first skip decision recorded for the module.
     /// </summary>
-    public SkipDecision SkipResult { get; set; } = SkipDecision.DoNotSkip;
+    public SkipDecision SkipResult => Volatile.Read(ref _skipResult);
+
+    /// <summary>
+    /// Records a skip decision unless another caller already recorded one.
+    /// </summary>
+    public bool TrySetSkipResult(SkipDecision value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        if (!value.ShouldSkip)
+        {
+            return false;
+        }
+
+        return ReferenceEquals(
+            Interlocked.CompareExchange(ref _skipResult, value, SkipDecision.DoNotSkip),
+            SkipDecision.DoNotSkip);
+    }
 }

--- a/test/ModularPipelines.UnitTests/Engine/ArtifactDemandPlannerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ArtifactDemandPlannerTests.cs
@@ -1,4 +1,7 @@
+using ModularPipelines.Context;
 using ModularPipelines.Engine;
+using ModularPipelines.Models;
+using ModularPipelines.Modules;
 
 namespace ModularPipelines.UnitTests.Engine;
 
@@ -30,5 +33,141 @@ public class ArtifactDemandPlannerTests
         });
 
         await Assert.That(result).IsEquivalentTo([typeof(BEffectiveProducer)]);
+    }
+
+    [Test]
+    public async Task DemandPlanCache_Coalesces_Concurrent_Resolution()
+    {
+        var cache = new ArtifactDemandPlanCache();
+        var resolutionStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseResolution = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var resolutionCount = 0;
+
+        async Task<ArtifactDemandPlan> Resolve()
+        {
+            Interlocked.Increment(ref resolutionCount);
+            resolutionStarted.TrySetResult();
+            await releaseResolution.Task;
+            return CreatePlan(typeof(BEffectiveProducer));
+        }
+
+        var first = cache.GetAsync(() => [], Resolve, CancellationToken.None);
+        await resolutionStarted.Task;
+        var second = cache.GetAsync(() => [], Resolve, CancellationToken.None);
+        releaseResolution.SetResult();
+
+        var plans = await Task.WhenAll(first, second);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolutionCount).IsEqualTo(1);
+            await Assert.That(plans[0].RequiredProducerTypes)
+                .IsEquivalentTo([typeof(BEffectiveProducer)]);
+            await Assert.That(plans[1].RequiredProducerTypes)
+                .IsEquivalentTo([typeof(BEffectiveProducer)]);
+        }
+    }
+
+    [Test]
+    public async Task DemandPlanCache_Recomputes_After_Completion_Changes()
+    {
+        var cache = new ArtifactDemandPlanCache();
+        var completed = false;
+        var resolutionCount = 0;
+
+        ArtifactDemandPlan Resolve()
+        {
+            resolutionCount++;
+            return CreatePlan(completed ? typeof(CEffectiveProducer) : typeof(BEffectiveProducer));
+        }
+
+        var first = await cache.GetAsync(
+            () => completed ? [typeof(AUnnecessaryProducer)] : [],
+            () => Task.FromResult(Resolve()),
+            CancellationToken.None);
+        var cached = await cache.GetAsync(
+            () => completed ? [typeof(AUnnecessaryProducer)] : [],
+            () => Task.FromResult(Resolve()),
+            CancellationToken.None);
+        completed = true;
+        var refreshed = await cache.GetAsync(
+            () => completed ? [typeof(AUnnecessaryProducer)] : [],
+            () => Task.FromResult(Resolve()),
+            CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolutionCount).IsEqualTo(2);
+            await Assert.That(first.RequiredProducerTypes)
+                .IsEquivalentTo([typeof(BEffectiveProducer)]);
+            await Assert.That(cached.RequiredProducerTypes)
+                .IsEquivalentTo([typeof(BEffectiveProducer)]);
+            await Assert.That(refreshed.RequiredProducerTypes)
+                .IsEquivalentTo([typeof(CEffectiveProducer)]);
+        }
+    }
+
+    [Test]
+    public async Task DemandPlanCache_Does_Not_Publish_A_Plan_From_A_Changing_Snapshot()
+    {
+        var cache = new ArtifactDemandPlanCache();
+        var completed = false;
+        var resolutionCount = 0;
+
+        Task<ArtifactDemandPlan> Resolve()
+        {
+            resolutionCount++;
+            if (resolutionCount == 1)
+            {
+                completed = true;
+            }
+
+            return Task.FromResult(CreatePlan(
+                completed ? typeof(CEffectiveProducer) : typeof(BEffectiveProducer)));
+        }
+
+        var result = await cache.GetAsync(
+            () => completed ? [typeof(AUnnecessaryProducer)] : [],
+            Resolve,
+            CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolutionCount).IsEqualTo(2);
+            await Assert.That(result.RequiredProducerTypes)
+                .IsEquivalentTo([typeof(CEffectiveProducer)]);
+        }
+    }
+
+    [Test]
+    public async Task ModuleState_Records_Exactly_One_Concurrent_Skip_Decision()
+    {
+        var module = new TestModule();
+        var state = new ModuleState(module, module.GetType());
+        var decisions = Enumerable.Range(0, 32)
+            .Select(index => SkipDecision.Skip(index.ToString()))
+            .ToArray();
+        var attempts = await Task.WhenAll(decisions.Select(decision => Task.Run(() =>
+            (Decision: decision, Recorded: state.TrySetSkipResult(decision)))));
+        var winner = attempts.Single(attempt => attempt.Recorded);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(attempts.Count(attempt => attempt.Recorded)).IsEqualTo(1);
+            await Assert.That(state.SkipResult).IsSameReferenceAs(winner.Decision);
+        }
+    }
+
+    private static ArtifactDemandPlan CreatePlan(Type producerType) =>
+        new(
+            new HashSet<Type> { producerType },
+            new Dictionary<Type, IReadOnlySet<string>>());
+
+    private sealed class TestModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(true);
     }
 }


### PR DESCRIPTION
Closes #3802

## Summary
- serialize and cache artifact-demand plans by the completed-module snapshot
- include demanded artifact names in the cached plan, avoiding a second consumer scan during upload
- make module skip decisions volatile and first-writer-wins
- retry resolution if module completion changes while a plan is being computed

## Validation
- ArtifactDemandPlannerTests: 5/5
- ArtifactContractTests: 55/55
- core Release build: 0 warnings, 0 errors