### PR TITLE
Add module cache kill switch

### DIFF
--- a/docs/docs/how-to/command-line.md
+++ b/docs/docs/how-to/command-line.md
@@ -24,6 +24,7 @@ await builder.ExecutePipelineAsync();
 | Option | Behavior |
 | --- | --- |
 | `--dry-run` | Validates the pipeline and prints dependency-ordered execution waves, skip reasons, categories, and duration estimates without executing modules. |
+| `--no-cache` | Disables module cache reads and writes for this run. |
 | `--list-modules` | Lists registered modules, categories, and direct dependencies without executing modules. |
 | `--module <name>` | Runs a module and its transitive dependency closure. Repeat the option or separate names with commas. |
 | `--skip-module <name>` | Excludes a module. Repeat the option or separate names with commas. |
@@ -42,6 +43,7 @@ dotnet run -- --module TestModule
 dotnet run -- --module BuildModule,TestModule --skip-module SlowTestModule
 dotnet run -- --categories Test --ignore-categories Integration
 dotnet run -- --dry-run
+dotnet run -- --no-cache
 dotnet run -- --list-modules
 dotnet run -- --validate
 ```

--- a/docs/docs/how-to/module-caching.md
+++ b/docs/docs/how-to/module-caching.md
@@ -44,6 +44,8 @@ The fingerprint contains:
 
 A hit has `Status.UsedHistory`. Cache lookup or storage failures are logged and the module executes normally.
 
+Use `--no-cache` to bypass all module cache reads and writes for one command-line run. For programmatic control, set `PipelineOptions.DisableModuleCache` to `true`.
+
 ## Include configuration
 
 File contents do not represent every input. Add configuration or tool versions explicitly:

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineOptions.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineOptions.cs
@@ -2,6 +2,7 @@ namespace ModularPipelines.PipelineCli;
 
 internal sealed record PipelineCommandLineOptions(
     PipelineCommand Command,
+    bool DisableModuleCache,
     IReadOnlyList<string> HostArguments,
     IReadOnlyList<string> TargetModules,
     IReadOnlyList<string> SkippedModules,
@@ -10,6 +11,7 @@ internal sealed record PipelineCommandLineOptions(
 {
     public static PipelineCommandLineOptions Empty { get; } = new(
         PipelineCommand.Run,
+        false,
         [],
         [],
         [],

--- a/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
+++ b/src/ModularPipelines/CommandLine/PipelineCommandLineParser.cs
@@ -5,6 +5,7 @@ internal static class PipelineCommandLineParser
     private const string ListModulesOption = "--list-modules";
     private const string ValidateOption = "--validate";
     private const string DryRunOption = "--dry-run";
+    private const string NoCacheOption = "--no-cache";
     private const string ModuleOption = "--module";
     private const string SkipModuleOption = "--skip-module";
     private const string CategoriesOption = "--categories";
@@ -18,6 +19,7 @@ internal static class PipelineCommandLineParser
         }
 
         var command = PipelineCommand.Run;
+        var disableModuleCache = false;
         var hostArguments = new List<string>();
         var targetModules = new List<string>();
         var skippedModules = new List<string>();
@@ -45,6 +47,12 @@ internal static class PipelineCommandLineParser
                 continue;
             }
 
+            if (argument.Equals(NoCacheOption, StringComparison.OrdinalIgnoreCase))
+            {
+                disableModuleCache = true;
+                continue;
+            }
+
             if (TryReadValues(arguments, ref index, ModuleOption, targetModules)
                 || TryReadValues(arguments, ref index, SkipModuleOption, skippedModules)
                 || TryReadValues(arguments, ref index, CategoriesOption, runOnlyCategories)
@@ -58,6 +66,7 @@ internal static class PipelineCommandLineParser
 
         return new PipelineCommandLineOptions(
             command,
+            disableModuleCache,
             hostArguments,
             Distinct(targetModules),
             Distinct(skippedModules),

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -299,7 +299,9 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         IModuleContext moduleContext,
         IModuleLogger logger)
     {
-        if (!config.CacheEnabled || _cacheResultRepository is null)
+        if (_pipelineOptions.Value.DisableModuleCache
+            || !config.CacheEnabled
+            || _cacheResultRepository is null)
         {
             return null;
         }
@@ -600,7 +602,9 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         IModuleContext moduleContext,
         CancellationToken cancellationToken)
     {
-        if (!((IModule) module).Configuration.CacheEnabled || _cacheResultRepository is null)
+        if (_pipelineOptions.Value.DisableModuleCache
+            || !((IModule) module).Configuration.CacheEnabled
+            || _cacheResultRepository is null)
         {
             return;
         }

--- a/src/ModularPipelines/Engine/PipelinePlanner.cs
+++ b/src/ModularPipelines/Engine/PipelinePlanner.cs
@@ -389,6 +389,7 @@ internal sealed class PipelinePlanner
             skipDecision,
             estimatedDuration,
             _moduleCachingEnabled
+            && !_options.Value.DisableModuleCache
             && module.Configuration.CacheEnabled
             && skipDecision?.ShouldSkip is not true);
     }

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -66,6 +66,11 @@ public record PipelineOptions
     public bool DryRun { get; init; }
 
     /// <summary>
+    /// Gets a value indicating whether module cache reads and writes are disabled for this run.
+    /// </summary>
+    public bool DisableModuleCache { get; init; }
+
+    /// <summary>
     /// Gets the execution mode that determines how the pipeline handles failures.
     /// </summary>
     public ExecutionMode ExecutionMode { get; init; } = ExecutionMode.StopOnFirstException;

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -61,6 +61,7 @@ public sealed class PipelineBuilder : IDisposable
         _options = new PipelineOptions
         {
             DryRun = _commandLineOptions.Command == PipelineCommand.DryRun,
+            DisableModuleCache = _commandLineOptions.DisableModuleCache,
             TargetModules = NullIfEmpty(_commandLineOptions.TargetModules),
             SkippedModules = NullIfEmpty(_commandLineOptions.SkippedModules),
             RunOnlyCategories = NullIfEmpty(_commandLineOptions.RunOnlyCategories),

--- a/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
+++ b/test/ModularPipelines.UnitTests/Caching/ModuleCacheTests.cs
@@ -736,6 +736,47 @@ public class ModuleCacheTests
 
     [Test]
     [TUnit.Core.NotInParallel(nameof(ModuleCacheTests))]
+    public async Task DisabledModuleCacheNeitherReadsNorWritesEntries()
+    {
+        var temporaryDirectory = Path.Combine(Path.GetTempPath(), $"ModularPipelines-cache-disabled-{Guid.NewGuid():N}");
+        var cacheDirectory = Path.Combine(temporaryDirectory, "cache");
+        Directory.CreateDirectory(temporaryDirectory);
+        CachedModule.WorkingDirectory = temporaryDirectory;
+        CachedModule.ExecutionCount = 0;
+
+        try
+        {
+            await System.IO.File.WriteAllTextAsync(Path.Combine(temporaryDirectory, "input.txt"), "value");
+
+            var firstStatus = await RunPipelineAsync(temporaryDirectory, cacheDirectory);
+            var disabledStatus = await RunPipelineAsync(
+                temporaryDirectory,
+                cacheDirectory,
+                disableModuleCache: true);
+
+            Directory.Delete(cacheDirectory, recursive: true);
+            var disabledWithoutEntryStatus = await RunPipelineAsync(
+                temporaryDirectory,
+                cacheDirectory,
+                disableModuleCache: true);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(firstStatus).IsEqualTo(Status.Successful);
+                await Assert.That(disabledStatus).IsEqualTo(Status.Successful);
+                await Assert.That(disabledWithoutEntryStatus).IsEqualTo(Status.Successful);
+                await Assert.That(CachedModule.ExecutionCount).IsEqualTo(3);
+                await Assert.That(Directory.Exists(cacheDirectory)).IsFalse();
+            }
+        }
+        finally
+        {
+            Directory.Delete(temporaryDirectory, recursive: true);
+        }
+    }
+
+    [Test]
+    [TUnit.Core.NotInParallel(nameof(ModuleCacheTests))]
     public async Task FluentSkipConditionTakesPrecedenceOverCacheHit()
     {
         var temporaryDirectory = Path.Combine(
@@ -3171,16 +3212,24 @@ public class ModuleCacheTests
         }
     }
 
-    private static async Task<Status> RunPipelineAsync(string workingDirectory, string cacheDirectory)
+    private static async Task<Status> RunPipelineAsync(
+        string workingDirectory,
+        string cacheDirectory,
+        bool disableModuleCache = false)
     {
-        await using var host = await TestPipelineBuilder.Create()
+        var builder = TestPipelineBuilder.Create()
             .AddModuleCache<FileSystemModuleCache>(options =>
             {
                 options.WorkingDirectory = workingDirectory;
                 options.CacheDirectory = cacheDirectory;
             })
-            .AddModule<CachedModule>()
-            .BuildAsync();
+            .AddModule<CachedModule>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            DisableModuleCache = disableModuleCache,
+        });
+
+        await using var host = await builder.BuildAsync();
 
         await host.RunAsync();
         return host.Services

--- a/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
+++ b/test/ModularPipelines.UnitTests/CommandLine/PipelineCommandLineTests.cs
@@ -701,6 +701,15 @@ public class PipelineCommandLineTests
     }
 
     [Test]
+    public async Task NoCacheOptionBindsPipelineOption()
+    {
+        using var builder = Pipeline.CreateBuilder(["--no-cache"]);
+
+        await Assert.That(builder.Options.DisableModuleCache).IsTrue();
+        await Assert.That(builder.Configuration["no-cache"]).IsNull();
+    }
+
+    [Test]
     public async Task UnknownArgumentsStillFlowToHostConfiguration()
     {
         using var builder = Pipeline.CreateBuilder(
@@ -1355,6 +1364,20 @@ public class PipelineCommandLineTests
             await Assert.That(output).Contains("Run (cache candidate)");
             await Assert.That(output).Contains("cache hits may reduce actual duration");
         }
+    }
+
+    [Test]
+    public async Task DryRunDoesNotMarkCacheCandidatesWhenCacheIsDisabled()
+    {
+        using var builder = Pipeline.CreateBuilder(["--dry-run", "--no-cache"]);
+        builder.AddModuleCache<FileSystemModuleCache>();
+        builder.AddModule<CacheCandidateModule>();
+
+        await using var pipeline = await builder.BuildAsync();
+        var plan = await pipeline.PlanAsync();
+
+        await Assert.That(plan.Waves.SelectMany(wave => wave.Modules).Single().IsCacheCandidate)
+            .IsFalse();
     }
 
     [Test]


### PR DESCRIPTION
Closes #3801

## Summary
- add `--no-cache` and `PipelineOptions.DisableModuleCache`
- bypass module-cache reads and writes when disabled
- remove cache-candidate annotations from dry-run plans
- document CLI and programmatic usage

## Validation
- focused command-line tests (2 passed)
- focused module-cache test (1 passed)
- `ModularPipelines.slnx` Release build (0 warnings, 0 errors)