### PR TITLE
Exclude failed runs from duration deltas

### DIFF
--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -38,7 +38,9 @@ report is also exposed through `PipelineSummary.RunReport`.
 By default, the `IRunHistoryStore` saves reports under `.modularpipelines/run-history` on local and
 CI runs, even when JSON report writing is disabled. It retains the latest 20 reports and uses the
 newest compatible report to calculate module and total-duration deltas. When a previous duration
-exists, the final results table includes a `Δ previous` column.
+exists, the final results table includes a `Δ previous` column. Deltas compare only successful
+runs and successful module executions, so failed or timed-out durations do not create false
+regressions on a later run.
 
 Add the default history directory to `.gitignore` if you do not want to commit local run data:
 

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -68,18 +68,23 @@ internal sealed class PipelineRunReportFactory(
                 uniqueModuleTypeNames,
                 previousByType))
             .ToArray();
+        var status = pipelineException is null ? summary.Status : Status.Failed;
+        TimeSpan? previousTotalDuration = status == Status.Successful
+                                          && previousReport?.Status == Status.Successful
+            ? previousReport.TotalDuration
+            : null;
 
         return new PipelineRunReport
         {
             PipelineIdentity = pipelineIdentity,
-            Status = pipelineException is null ? summary.Status : Status.Failed,
+            Status = status,
             Start = summary.Start,
             End = summary.End,
             TotalDuration = summary.TotalDuration,
-            PreviousTotalDuration = previousReport?.TotalDuration,
-            TotalDurationDelta = previousReport is null
+            PreviousTotalDuration = previousTotalDuration,
+            TotalDurationDelta = previousTotalDuration is null
                 ? null
-                : summary.TotalDuration - previousReport.TotalDuration,
+                : summary.TotalDuration - previousTotalDuration.Value,
             Metrics = summary.Metrics,
             Exception = CreateExceptionDetails(pipelineException),
             Modules = modules,
@@ -114,7 +119,7 @@ internal sealed class PipelineRunReportFactory(
             ? previousByType.GetValueOrDefault(typeName)
             : null;
         var current = CreateCurrentReportValues(result, timeline);
-        var previousDuration = GetPreviousDuration(current.DurationMeasured, previous);
+        var previousDuration = GetPreviousDuration(current.Status, current.DurationMeasured, previous);
         return new ModuleRunReport
         {
             ModuleName = moduleType.Name,
@@ -172,9 +177,12 @@ internal sealed class PipelineRunReportFactory(
     }
 
     private static TimeSpan? GetPreviousDuration(
+        Status status,
         bool durationMeasured,
         ModuleRunReport? previous) =>
-        durationMeasured && previous is { DurationMeasured: true }
+        status == Status.Successful
+        && durationMeasured
+        && previous is { Status: Status.Successful, DurationMeasured: true }
             ? previous.Duration
             : null;
 

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -225,9 +225,16 @@ public class RunReportTests
 
             using (Assert.Multiple())
             {
-                await Assert.That(secondSummary.RunReport!.PreviousTotalDuration).IsNotNull();
-                await Assert.That(secondReport!.TotalDurationDelta).IsNotNull();
-                await Assert.That(secondReport.Modules.All(module => module.PreviousDuration.HasValue)).IsTrue();
+                await Assert.That(secondSummary.RunReport!.PreviousTotalDuration).IsNull();
+                await Assert.That(secondReport!.TotalDurationDelta).IsNull();
+                await Assert.That(secondReport.Modules
+                        .Single(module => module.Status == Status.Successful)
+                        .PreviousDuration)
+                    .IsNotNull();
+                await Assert.That(secondReport.Modules
+                        .Where(module => module.Status != Status.Successful)
+                        .All(module => module.PreviousDuration is null))
+                    .IsTrue();
                 await Assert.That(Directory.GetFiles(historyPath, "*.json")).Count().IsEqualTo(2);
             }
         }
@@ -586,6 +593,42 @@ public class RunReportTests
             await Assert.That(nonExecutedReport.Modules.Single().DurationDelta).IsNull();
             await Assert.That(successfulReport.Modules.Single().PreviousDuration).IsNull();
             await Assert.That(successfulReport.Modules.Single().DurationDelta).IsNull();
+        }
+    }
+
+    [Test]
+    [Arguments(Status.Failed)]
+    [Arguments(Status.TimedOut)]
+    public async Task RunReportDoesNotCompareMeasuredUnsuccessfulCurrentDurations(Status status)
+    {
+        var previousReport = CreateMeasuredRunReport(Status.Successful, TimeSpan.FromSeconds(10));
+        var report = CreateMeasuredRunReport(status, TimeSpan.FromSeconds(1), previousReport);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(report.PreviousTotalDuration).IsNull();
+            await Assert.That(report.TotalDurationDelta).IsNull();
+            await Assert.That(report.Modules.Single().DurationMeasured).IsTrue();
+            await Assert.That(report.Modules.Single().PreviousDuration).IsNull();
+            await Assert.That(report.Modules.Single().DurationDelta).IsNull();
+        }
+    }
+
+    [Test]
+    [Arguments(Status.Failed)]
+    [Arguments(Status.TimedOut)]
+    public async Task RunReportDoesNotCompareAgainstMeasuredUnsuccessfulPreviousDurations(Status status)
+    {
+        var previousReport = CreateMeasuredRunReport(status, TimeSpan.FromSeconds(1));
+        var report = CreateMeasuredRunReport(Status.Successful, TimeSpan.FromSeconds(10), previousReport);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(report.Status).IsEqualTo(Status.Successful);
+            await Assert.That(report.PreviousTotalDuration).IsNull();
+            await Assert.That(report.TotalDurationDelta).IsNull();
+            await Assert.That(report.Modules.Single().PreviousDuration).IsNull();
+            await Assert.That(report.Modules.Single().DurationDelta).IsNull();
         }
     }
 
@@ -1532,7 +1575,7 @@ public class RunReportTests
                 await Assert.That(failedReport.Modules).HasSingleItem();
                 await Assert.That(failedReport.Modules[0].ModuleName).IsEqualTo(nameof(SuccessfulModule));
                 await Assert.That(successfulReport.PipelineIdentity).IsEqualTo(failedReport.PipelineIdentity);
-                await Assert.That(successfulReport.PreviousTotalDuration).IsNotNull();
+                await Assert.That(successfulReport.PreviousTotalDuration).IsNull();
             }
         }
         finally
@@ -2330,6 +2373,40 @@ public class RunReportTests
             Start = start,
             End = start + duration,
         };
+
+    private static PipelineRunReport CreateMeasuredRunReport(
+        Status status,
+        TimeSpan duration,
+        PipelineRunReport? previousReport = null)
+    {
+        var module = new SuccessfulModule();
+        var start = new DateTimeOffset(2026, 8, 3, 12, 0, 0, TimeSpan.Zero);
+        var result = (ModuleResult)CreateResult(module, start, duration) with
+        {
+            ModuleStatus = status,
+        };
+        var summary = new PipelineSummary(
+            [module],
+            [result],
+            duration,
+            start,
+            start + duration,
+            moduleTimelines:
+            [
+                CreateTimeline(typeof(SuccessfulModule), start, duration) with
+                {
+                    Status = status,
+                },
+            ]) with
+        {
+            StatusOverride = status,
+        };
+
+        return new PipelineRunReportFactory(
+                Mock.Of<ICommandExecutionCounter>(),
+                new PassthroughSecretObfuscator())
+            .Create(summary, previousReport, "measured-run");
+    }
 
     private static ModuleTimeline CreateTimeline(
         Type moduleType,


### PR DESCRIPTION
## Summary
- calculate total-duration deltas only between successful pipeline reports
- calculate module deltas only between measured successful module executions
- retain successful-module comparisons even when the surrounding pipeline failed
- document successful-only comparison semantics

## Validation
- `RunReportTests`: 51/51 passed
- Failed/TimedOut current and previous regressions: passed
- post-main-sync core Release build: 0 warnings, 0 errors
- scoped format completed (expected F# unsupported notice only)

Closes #3741