### PR TITLE
Apply module timeout per retry attempt

### DIFF
--- a/docs/docs/how-to/retry-policy.md
+++ b/docs/docs/how-to/retry-policy.md
@@ -97,6 +97,12 @@ public class ResilientModule : Module<CommandResult>
 }
 ```
 
+`WithTimeout` applies to each execution attempt, not to the whole retry chain. Backoff delays run
+outside that timeout. A timed-out attempt is passed to the resilience shield as a
+`ModuleTimeoutException`, so exception filters still decide whether it should be retried. If the
+attempt remains active after the cancellation grace period, the engine bypasses retries to avoid
+running the same module instance concurrently with its abandoned attempt.
+
 ## Default Retry Configuration
 
 Retries are off by default. You can set a default retry count on the `PipelineOptions`:

--- a/docs/docs/how-to/retry-policy.md
+++ b/docs/docs/how-to/retry-policy.md
@@ -97,6 +97,12 @@ public class ResilientModule : Module<CommandResult>
 }
 ```
 
+`WithTimeout` applies to each execution attempt, not to the whole retry chain. Backoff delays run
+outside that timeout. A timed-out attempt is passed to the retry policy as a
+`ModuleTimeoutException`, so exception filters still decide whether it should be retried. If the
+attempt remains active after the cancellation grace period, the engine bypasses retries to avoid
+running the same module instance concurrently with its abandoned attempt.
+
 ## Default Retry Policy
 
 Retry policies are off by default. You can set a default retry count on the `PipelineOptions`:

--- a/docs/docs/how-to/timeouts.md
+++ b/docs/docs/how-to/timeouts.md
@@ -75,9 +75,16 @@ public class ResilientModule : Module<CommandResult>
 
 ## Timeout Behavior
 
+Timeouts apply to each execution attempt. With retries enabled, every attempt receives the full
+timeout and retry backoff delays do not consume it. A module configured with a five-minute timeout
+and three retries can therefore spend up to five minutes in each of its four attempts, plus retry
+delays.
+
 When a timeout occurs:
 
 - The `CancellationToken` passed to `ExecuteAsync` will be cancelled
 - The module will fail with a `ModuleTimeoutException`
-- If retry policies are configured, the module may be retried
+- If retry policies are configured and the attempt stops within the cancellation grace period,
+  the module may be retried. An attempt that remains active after the grace period is never retried,
+  preventing concurrent executions of the same module instance.
 - If `WithIgnoreFailures()` is configured, the pipeline will continue despite the timeout

--- a/src/ModularPipelines/Configuration/ModuleConfiguration.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfiguration.cs
@@ -58,10 +58,10 @@ public sealed class ModuleConfiguration
     internal Func<IModuleContext, CancellationToken, ValueTask<SkipDecision?>>? PlanningSkipCondition { get; init; }
 
     /// <summary>
-    /// Gets the timeout duration for module execution.
+    /// Gets the timeout duration for each module execution attempt.
     /// </summary>
     /// <value>
-    /// A <see cref="TimeSpan"/> representing the maximum execution time,
+    /// A <see cref="TimeSpan"/> representing the maximum time for each attempt,
     /// or null if no timeout is configured.
     /// </value>
     public TimeSpan? Timeout { get; init; }

--- a/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
+++ b/src/ModularPipelines/Configuration/ModuleConfigurationBuilder.cs
@@ -325,10 +325,13 @@ public sealed class ModuleConfigurationBuilder
     #region WithTimeout
 
     /// <summary>
-    /// Sets the timeout duration for module execution.
+    /// Sets the timeout duration for each module execution attempt.
     /// </summary>
-    /// <param name="timeout">The maximum duration allowed for module execution.</param>
+    /// <param name="timeout">The maximum duration allowed for each execution attempt.</param>
     /// <returns>This builder instance for method chaining.</returns>
+    /// <remarks>
+    /// When retries are configured, the timeout restarts for every attempt and does not include retry delays.
+    /// </remarks>
     public ModuleConfigurationBuilder WithTimeout(TimeSpan timeout)
     {
         _timeout = timeout;
@@ -349,6 +352,7 @@ public sealed class ModuleConfigurationBuilder
     /// <remarks>
     /// Each delay uses equal jitter between half and all of its exponential-backoff ceiling.
     /// A null <paramref name="shouldRetry"/> retries every exception handled by the retry engine.
+    /// A configured module timeout applies separately to each attempt and does not include these delays.
     /// </remarks>
     public ModuleConfigurationBuilder WithRetry(
         int count,

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -553,19 +553,7 @@ internal sealed class Command : ICommandContext
                         command.WorkingDirPath));
                 var failure = loggingFailures.CombineWith(e);
 
-                if (ShouldPreserveCallerCancellation(e, failure, callerCancellationToken))
-                {
-                    if (e is OperationCanceledException cancellationException
-                        && cancellationException.CancellationToken != callerCancellationToken)
-                    {
-                        throw new OperationCanceledException(
-                            cancellationException.Message,
-                            cancellationException,
-                            callerCancellationToken);
-                    }
-
-                    throw;
-                }
+                ThrowCallerCancellationIfRequired(e, failure, callerCancellationToken);
 
                 throw CreateExecutionFailure(
                     e,
@@ -634,6 +622,38 @@ internal sealed class Command : ICommandContext
         return executionFailure is OperationCanceledException
                && cancellationToken.IsCancellationRequested
                && ReferenceEquals(combinedFailure, executionFailure);
+    }
+
+    private static void ThrowCallerCancellationIfRequired(
+        Exception executionFailure,
+        Exception combinedFailure,
+        CancellationToken callerCancellationToken)
+    {
+        if (!ShouldPreserveCallerCancellation(
+                executionFailure,
+                combinedFailure,
+                callerCancellationToken))
+        {
+            return;
+        }
+
+        if (executionFailure is OperationCanceledException cancellationException
+            && cancellationException.CancellationToken != callerCancellationToken)
+        {
+            throw cancellationException is TaskCanceledException
+                ? new TaskCanceledException(
+                    cancellationException.Message,
+                    cancellationException,
+                    callerCancellationToken)
+                : new OperationCanceledException(
+                    cancellationException.Message,
+                    cancellationException,
+                    callerCancellationToken);
+        }
+
+        System.Runtime.ExceptionServices.ExceptionDispatchInfo
+            .Capture(executionFailure)
+            .Throw();
     }
 
     private Exception CreateExecutionFailure(

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -466,6 +466,15 @@ internal sealed class Command : ICommandContext
 
                 if (ShouldPreserveCallerCancellation(e, failure, callerCancellationToken))
                 {
+                    if (e is OperationCanceledException cancellationException
+                        && cancellationException.CancellationToken != callerCancellationToken)
+                    {
+                        throw new OperationCanceledException(
+                            cancellationException.Message,
+                            cancellationException,
+                            callerCancellationToken);
+                    }
+
                     throw;
                 }
 

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -555,6 +555,15 @@ internal sealed class Command : ICommandContext
 
                 if (ShouldPreserveCallerCancellation(e, failure, callerCancellationToken))
                 {
+                    if (e is OperationCanceledException cancellationException
+                        && cancellationException.CancellationToken != callerCancellationToken)
+                    {
+                        throw new OperationCanceledException(
+                            cancellationException.Message,
+                            cancellationException,
+                            callerCancellationToken);
+                    }
+
                     throw;
                 }
 

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -464,19 +464,7 @@ internal sealed class Command : ICommandContext
                         command.WorkingDirPath));
                 var failure = loggingFailures.CombineWith(e);
 
-                if (ShouldPreserveCallerCancellation(e, failure, callerCancellationToken))
-                {
-                    if (e is OperationCanceledException cancellationException
-                        && cancellationException.CancellationToken != callerCancellationToken)
-                    {
-                        throw new OperationCanceledException(
-                            cancellationException.Message,
-                            cancellationException,
-                            callerCancellationToken);
-                    }
-
-                    throw;
-                }
+                ThrowCallerCancellationIfRequired(e, failure, callerCancellationToken);
 
                 throw CreateExecutionFailure(
                     e,
@@ -543,6 +531,38 @@ internal sealed class Command : ICommandContext
         return executionFailure is OperationCanceledException
                && cancellationToken.IsCancellationRequested
                && ReferenceEquals(combinedFailure, executionFailure);
+    }
+
+    private static void ThrowCallerCancellationIfRequired(
+        Exception executionFailure,
+        Exception combinedFailure,
+        CancellationToken callerCancellationToken)
+    {
+        if (!ShouldPreserveCallerCancellation(
+                executionFailure,
+                combinedFailure,
+                callerCancellationToken))
+        {
+            return;
+        }
+
+        if (executionFailure is OperationCanceledException cancellationException
+            && cancellationException.CancellationToken != callerCancellationToken)
+        {
+            throw cancellationException is TaskCanceledException
+                ? new TaskCanceledException(
+                    cancellationException.Message,
+                    cancellationException,
+                    callerCancellationToken)
+                : new OperationCanceledException(
+                    cancellationException.Message,
+                    cancellationException,
+                    callerCancellationToken);
+        }
+
+        System.Runtime.ExceptionServices.ExceptionDispatchInfo
+            .Capture(executionFailure)
+            .Throw();
     }
 
     private Exception CreateExecutionFailure(

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -475,10 +475,12 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         LogTimeoutConfiguration(config, timeout, moduleContext.Logger);
 
         var cancellationToken = executionContext.ModuleCancellationTokenSource.Token;
-        using var retryCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         // Get resilience shield if applicable
         var resilienceShield = GetResilienceShield(config, moduleContext);
+        using var retryCancellationTokenSource = resilienceShield is null
+            ? null
+            : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var policyExecutionState = new PolicyExecutionState();
 
         // Keep timeout enforcement inside the resilience shield so each attempt gets a fresh budget
@@ -498,13 +500,13 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             result = resilienceShield != null
                 ? await resilienceShield.ExecuteAsync(
                     async shieldToken => await ExecuteModuleAttempt(shieldToken).ConfigureAwait(false),
-                    retryCancellationTokenSource.Token).ConfigureAwait(false)
+                    retryCancellationTokenSource!.Token).ConfigureAwait(false)
                 : await ExecuteModuleAttempt(cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (policyExecutionState.AbandonedAttemptTimeout is not null
                                                  && !cancellationToken.IsCancellationRequested)
         {
-            throw policyExecutionState.AbandonedAttemptTimeout;
+            return ThrowPreservingStack<T>(policyExecutionState.AbandonedAttemptTimeout);
         }
         finally
         {
@@ -515,7 +517,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         if (policyExecutionState.AbandonedAttemptTimeout is { } abandonedAttemptTimeout)
         {
-            throw abandonedAttemptTimeout;
+            return ThrowPreservingStack<T>(abandonedAttemptTimeout);
         }
 
         return result;
@@ -545,10 +547,15 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         ModuleExecutionContext<T> executionContext,
         IModuleContext moduleContext,
         TimeSpan timeout,
-        CancellationTokenSource retryCancellationTokenSource,
+        CancellationTokenSource? retryCancellationTokenSource,
         PolicyExecutionState policyExecutionState,
         CancellationToken cancellationToken)
     {
+        if (policyExecutionState.AbandonedAttemptTimeout is { } abandonedAttemptTimeout)
+        {
+            return ThrowPreservingStack<T>(abandonedAttemptTimeout);
+        }
+
         policyExecutionState.RecordAttempt();
 
         var timeoutResult = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
@@ -573,10 +580,18 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             policyExecutionState.AbandonedAttemptTimeout = timeoutException;
             // Let wrapped policies observe the failure, but cancel their retry delay because
             // re-entering this module while the abandoned attempt is active is unsafe.
-            retryCancellationTokenSource.Cancel();
+            retryCancellationTokenSource?.Cancel();
         }
 
         throw timeoutException;
+    }
+
+    private static T ThrowPreservingStack<T>(Exception exception)
+    {
+        System.Runtime.ExceptionServices.ExceptionDispatchInfo
+            .Capture(exception)
+            .Throw();
+        throw new System.Diagnostics.UnreachableException();
     }
 
     private TimeSpan GetTimeout(ModuleConfiguration config)

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -806,7 +806,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
     private bool IsPipelineCancelled(Exception exception)
     {
-        return exception is TaskCanceledException or OperationCanceledException or ModuleTimeoutException
+        return exception is OperationCanceledException or ModuleTimeoutException
                && _engineCancellationToken.IsCancelled;
     }
 

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -578,8 +578,8 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         if (!timeoutResult.WasCancellationTokenRespected)
         {
             policyExecutionState.AbandonedAttemptTimeout = timeoutException;
-            // Let wrapped policies observe the failure, but cancel their retry delay because
-            // re-entering this module while the abandoned attempt is active is unsafe.
+            // Cancel the shield before its retry delay because re-entering this module while
+            // the abandoned attempt is active is unsafe.
             retryCancellationTokenSource?.Cancel();
         }
 

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -472,80 +472,111 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         IModuleContext moduleContext)
     {
         var timeout = GetTimeout(config);
-        if (config.Timeout is null)
-        {
-            if (timeout == TimeSpan.Zero)
-            {
-                moduleContext.Logger.LogTrace("No module timeout configured. The pipeline default timeout is disabled");
-            }
-            else
-            {
-                moduleContext.Logger.LogTrace("No module timeout configured. Using pipeline default timeout {Timeout}", timeout);
-            }
-        }
+        LogTimeoutConfiguration(config, timeout, moduleContext.Logger);
 
         var cancellationToken = executionContext.ModuleCancellationTokenSource.Token;
+        using var retryCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         // Get resilience shield if applicable
         var resilienceShield = GetResilienceShield(config, moduleContext);
-        var moduleAttemptCount = 0;
-        var moduleAttemptRespondedToCancellation = 0;
+        var policyExecutionState = new PolicyExecutionState();
 
-        async Task<T> ExecuteModuleAttempt(CancellationToken ct)
-        {
-            Interlocked.Increment(ref moduleAttemptCount);
-            try
-            {
-                return await module.ExecuteAsync(moduleContext, ct).ConfigureAwait(false);
-            }
-            finally
-            {
-                if (ct.IsCancellationRequested)
-                {
-                    Volatile.Write(ref moduleAttemptRespondedToCancellation, 1);
-                }
-            }
-        }
+        // Keep timeout enforcement inside the resilience shield so each attempt gets a fresh budget
+        // and shield-owned backoff delays are not mistaken for unresponsive module execution.
+        Task<T> ExecuteModuleAttempt(CancellationToken ct) => ExecuteModuleAttemptAsync(
+            module,
+            executionContext,
+            moduleContext,
+            timeout,
+            retryCancellationTokenSource,
+            policyExecutionState,
+            ct);
 
-        // Create the execution function that optionally includes resilience strategies
-        Func<CancellationToken, Task<T>> executeFunc = resilienceShield != null
-            ? async ct => await resilienceShield.ExecuteAsync(
-                async shieldToken => await ExecuteModuleAttempt(shieldToken).ConfigureAwait(false),
-                ct).ConfigureAwait(false)
-            : ExecuteModuleAttempt;
-
-        // Use TimeoutHelper with detailed results to get information about token cooperation
-        TimeoutExecutionResult<T> timeoutResult;
+        T result;
         try
         {
-            timeoutResult = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
-                executeFunc,
-                timeout == TimeSpan.Zero ? null : timeout,
-                cancellationToken,
-                $"Module {executionContext.ModuleType.Name} timed out after {timeout}").ConfigureAwait(false);
+            result = resilienceShield != null
+                ? await resilienceShield.ExecuteAsync(
+                    async shieldToken => await ExecuteModuleAttempt(shieldToken).ConfigureAwait(false),
+                    retryCancellationTokenSource.Token).ConfigureAwait(false)
+                : await ExecuteModuleAttempt(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (policyExecutionState.AbandonedAttemptTimeout is not null
+                                                 && !cancellationToken.IsCancellationRequested)
+        {
+            throw policyExecutionState.AbandonedAttemptTimeout;
         }
         finally
         {
             ModuleActivityTracing.RecordModuleRetries(
                 executionContext.ModuleType,
-                Math.Max(0, Volatile.Read(ref moduleAttemptCount) - 1));
+                policyExecutionState.RetryCount);
         }
 
-        if (timeoutResult.TimedOut)
+        if (policyExecutionState.AbandonedAttemptTimeout is { } abandonedAttemptTimeout)
         {
-            var wasCancellationTokenRespected = timeoutResult.WasCancellationTokenRespected
-                                                && (resilienceShield is null
-                                                    || Volatile.Read(ref moduleAttemptRespondedToCancellation) == 1);
-
-            // Create a detailed timeout exception with information about token cooperation
-            throw new ModuleTimeoutException(
-                executionContext.ModuleType,
-                timeout,
-                timeoutResult.ElapsedTime,
-                wasCancellationTokenRespected);
+            throw abandonedAttemptTimeout;
         }
 
-        return timeoutResult.Value!;
+        return result;
+    }
+
+    private static void LogTimeoutConfiguration(
+        ModuleConfiguration config,
+        TimeSpan timeout,
+        IModuleLogger logger)
+    {
+        if (config.Timeout is not null)
+        {
+            return;
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            logger.LogTrace("No module timeout configured. The pipeline default timeout is disabled");
+            return;
+        }
+
+        logger.LogTrace("No module timeout configured. Using pipeline default timeout {Timeout}", timeout);
+    }
+
+    private static async Task<T> ExecuteModuleAttemptAsync<T>(
+        Module<T> module,
+        ModuleExecutionContext<T> executionContext,
+        IModuleContext moduleContext,
+        TimeSpan timeout,
+        CancellationTokenSource retryCancellationTokenSource,
+        PolicyExecutionState policyExecutionState,
+        CancellationToken cancellationToken)
+    {
+        policyExecutionState.RecordAttempt();
+
+        var timeoutResult = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            attemptToken => module.ExecuteAsync(moduleContext, attemptToken),
+            timeout == TimeSpan.Zero ? null : timeout,
+            cancellationToken,
+            $"Module {executionContext.ModuleType.Name} timed out after {timeout}").ConfigureAwait(false);
+
+        if (!timeoutResult.TimedOut)
+        {
+            return timeoutResult.Value!;
+        }
+
+        var timeoutException = new ModuleTimeoutException(
+            executionContext.ModuleType,
+            timeout,
+            timeoutResult.ElapsedTime,
+            timeoutResult.WasCancellationTokenRespected);
+
+        if (!timeoutResult.WasCancellationTokenRespected)
+        {
+            policyExecutionState.AbandonedAttemptTimeout = timeoutException;
+            // Let wrapped policies observe the failure, but cancel their retry delay because
+            // re-entering this module while the abandoned attempt is active is unsafe.
+            retryCancellationTokenSource.Cancel();
+        }
+
+        throw timeoutException;
     }
 
     private TimeSpan GetTimeout(ModuleConfiguration config)
@@ -680,7 +711,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         executionContext.Exception = exception;
 
-        executionContext.Status = ClassifyException(config, executionContext, exception);
+        executionContext.Status = ClassifyException(config, exception);
 
         // Use the enhanced exception type for detailed timeout logging.
         if (exception is ModuleTimeoutException timeoutException)
@@ -693,12 +724,10 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
                     timeoutException.ElapsedTime.ToDisplayString());
             }
         }
-
         // Check if we should ignore failures
         if (config.IgnoreFailuresCondition != null
             && (executionContext.Status != Status.PipelineTerminated
-                || exception is ModuleTimeoutException
-                || IsTimeout(config, executionContext, exception)))
+                || exception is ModuleTimeoutException))
         {
             if (await config.IgnoreFailuresCondition(moduleContext, exception).ConfigureAwait(false))
             {
@@ -747,31 +776,23 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
     private Status ClassifyException(
         ModuleConfiguration config,
-        ModuleExecutionContext executionContext,
         Exception exception)
     {
         if (!config.AlwaysRun
-            && _engineCancellationToken.IsCancelled
-            && exception is OperationCanceledException or ModuleTimeoutException)
+            && IsPipelineCancelled(exception))
         {
             return Status.PipelineTerminated;
         }
 
-        return exception is ModuleTimeoutException || IsTimeout(config, executionContext, exception)
+        return exception is ModuleTimeoutException
             ? Status.TimedOut
             : Status.Failed;
     }
 
-    private bool IsTimeout(ModuleConfiguration config, ModuleExecutionContext executionContext, Exception exception)
+    private bool IsPipelineCancelled(Exception exception)
     {
-        var timeout = GetTimeout(config);
-        if (timeout == TimeSpan.Zero)
-        {
-            return false;
-        }
-
-        var isTimeoutExceeded = executionContext.Stopwatch.Elapsed >= timeout;
-        return isTimeoutExceeded && exception is OperationCanceledException;
+        return exception is TaskCanceledException or OperationCanceledException or ModuleTimeoutException
+               && _engineCancellationToken.IsCancelled;
     }
 
     private void CancelPipelineAndThrow(
@@ -839,6 +860,17 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
                 module.CompletionSource.TrySetResult(result);
             }
         }
+    }
+
+    private sealed class PolicyExecutionState
+    {
+        private int _moduleAttemptCount;
+
+        public ModuleTimeoutException? AbandonedAttemptTimeout { get; set; }
+
+        public int RetryCount => Math.Max(0, Volatile.Read(ref _moduleAttemptCount) - 1);
+
+        public void RecordAttempt() => Interlocked.Increment(ref _moduleAttemptCount);
     }
 
     private static void LogModuleStatus(ModuleExecutionContext executionContext, IModuleLogger logger)

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -472,78 +472,111 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         IModuleContext moduleContext)
     {
         var timeout = GetTimeout(config);
-        if (config.Timeout is null)
-        {
-            if (timeout == TimeSpan.Zero)
-            {
-                moduleContext.Logger.LogTrace("No module timeout configured. The pipeline default timeout is disabled");
-            }
-            else
-            {
-                moduleContext.Logger.LogTrace("No module timeout configured. Using pipeline default timeout {Timeout}", timeout);
-            }
-        }
+        LogTimeoutConfiguration(config, timeout, moduleContext.Logger);
 
         var cancellationToken = executionContext.ModuleCancellationTokenSource.Token;
+        using var retryCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         // Get retry policy if applicable
         var retryPolicy = GetRetryPolicy<T>(config, moduleContext);
-        var moduleAttemptCount = 0;
-        var moduleAttemptRespondedToCancellation = 0;
+        var policyExecutionState = new PolicyExecutionState();
 
-        async Task<T> ExecuteModuleAttempt(CancellationToken ct)
-        {
-            Interlocked.Increment(ref moduleAttemptCount);
-            try
-            {
-                return await module.ExecuteAsync(moduleContext, ct).ConfigureAwait(false);
-            }
-            finally
-            {
-                if (ct.IsCancellationRequested)
-                {
-                    Volatile.Write(ref moduleAttemptRespondedToCancellation, 1);
-                }
-            }
-        }
+        // Keep timeout enforcement inside the retry policy so each attempt gets a fresh budget
+        // and policy-owned backoff delays are not mistaken for unresponsive module execution.
+        Task<T> ExecuteModuleAttempt(CancellationToken ct) => ExecuteModuleAttemptAsync(
+            module,
+            executionContext,
+            moduleContext,
+            timeout,
+            retryCancellationTokenSource,
+            policyExecutionState,
+            ct);
 
-        // Create the execution function that optionally includes retry
-        Func<CancellationToken, Task<T>> executeFunc = retryPolicy != null
-            ? ct => retryPolicy.ExecuteAsync(ExecuteModuleAttempt, ct)
-            : ExecuteModuleAttempt;
-
-        // Use TimeoutHelper with detailed results to get information about token cooperation
-        TimeoutExecutionResult<T> timeoutResult;
+        T result;
         try
         {
-            timeoutResult = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
-                executeFunc,
-                timeout == TimeSpan.Zero ? null : timeout,
-                cancellationToken,
-                $"Module {executionContext.ModuleType.Name} timed out after {timeout}").ConfigureAwait(false);
+            result = retryPolicy != null
+                ? await retryPolicy.ExecuteAsync(
+                    ExecuteModuleAttempt,
+                    retryCancellationTokenSource.Token).ConfigureAwait(false)
+                : await ExecuteModuleAttempt(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (policyExecutionState.AbandonedAttemptTimeout is not null
+                                                 && !cancellationToken.IsCancellationRequested)
+        {
+            throw policyExecutionState.AbandonedAttemptTimeout;
         }
         finally
         {
             ModuleActivityTracing.RecordModuleRetries(
                 executionContext.ModuleType,
-                Math.Max(0, Volatile.Read(ref moduleAttemptCount) - 1));
+                policyExecutionState.RetryCount);
         }
 
-        if (timeoutResult.TimedOut)
+        if (policyExecutionState.AbandonedAttemptTimeout is { } abandonedAttemptTimeout)
         {
-            var wasCancellationTokenRespected = timeoutResult.WasCancellationTokenRespected
-                                                && (retryPolicy is null
-                                                    || Volatile.Read(ref moduleAttemptRespondedToCancellation) == 1);
-
-            // Create a detailed timeout exception with information about token cooperation
-            throw new ModuleTimeoutException(
-                executionContext.ModuleType,
-                timeout,
-                timeoutResult.ElapsedTime,
-                wasCancellationTokenRespected);
+            throw abandonedAttemptTimeout;
         }
 
-        return timeoutResult.Value!;
+        return result;
+    }
+
+    private static void LogTimeoutConfiguration(
+        ModuleConfiguration config,
+        TimeSpan timeout,
+        IModuleLogger logger)
+    {
+        if (config.Timeout is not null)
+        {
+            return;
+        }
+
+        if (timeout == TimeSpan.Zero)
+        {
+            logger.LogTrace("No module timeout configured. The pipeline default timeout is disabled");
+            return;
+        }
+
+        logger.LogTrace("No module timeout configured. Using pipeline default timeout {Timeout}", timeout);
+    }
+
+    private static async Task<T> ExecuteModuleAttemptAsync<T>(
+        Module<T> module,
+        ModuleExecutionContext<T> executionContext,
+        IModuleContext moduleContext,
+        TimeSpan timeout,
+        CancellationTokenSource retryCancellationTokenSource,
+        PolicyExecutionState policyExecutionState,
+        CancellationToken cancellationToken)
+    {
+        policyExecutionState.RecordAttempt();
+
+        var timeoutResult = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            attemptToken => module.ExecuteAsync(moduleContext, attemptToken),
+            timeout == TimeSpan.Zero ? null : timeout,
+            cancellationToken,
+            $"Module {executionContext.ModuleType.Name} timed out after {timeout}").ConfigureAwait(false);
+
+        if (!timeoutResult.TimedOut)
+        {
+            return timeoutResult.Value!;
+        }
+
+        var timeoutException = new ModuleTimeoutException(
+            executionContext.ModuleType,
+            timeout,
+            timeoutResult.ElapsedTime,
+            timeoutResult.WasCancellationTokenRespected);
+
+        if (!timeoutResult.WasCancellationTokenRespected)
+        {
+            policyExecutionState.AbandonedAttemptTimeout = timeoutException;
+            // Let wrapped policies observe the failure, but cancel their retry delay because
+            // re-entering this module while the abandoned attempt is active is unsafe.
+            retryCancellationTokenSource.Cancel();
+        }
+
+        throw timeoutException;
     }
 
     private TimeSpan GetTimeout(ModuleConfiguration config)
@@ -678,7 +711,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         executionContext.Exception = exception;
 
-        executionContext.Status = ClassifyException(config, executionContext, exception);
+        executionContext.Status = ClassifyException(config, exception);
 
         // Use the enhanced exception type for detailed timeout logging.
         if (exception is ModuleTimeoutException timeoutException)
@@ -691,12 +724,10 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
                     timeoutException.ElapsedTime.ToDisplayString());
             }
         }
-
         // Check if we should ignore failures
         if (config.IgnoreFailuresCondition != null
             && (executionContext.Status != Status.PipelineTerminated
-                || exception is ModuleTimeoutException
-                || IsTimeout(config, executionContext, exception)))
+                || exception is ModuleTimeoutException))
         {
             if (await config.IgnoreFailuresCondition(moduleContext, exception).ConfigureAwait(false))
             {
@@ -745,31 +776,23 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
     private Status ClassifyException(
         ModuleConfiguration config,
-        ModuleExecutionContext executionContext,
         Exception exception)
     {
         if (!config.AlwaysRun
-            && _engineCancellationToken.IsCancelled
-            && exception is OperationCanceledException or ModuleTimeoutException)
+            && IsPipelineCancelled(exception))
         {
             return Status.PipelineTerminated;
         }
 
-        return exception is ModuleTimeoutException || IsTimeout(config, executionContext, exception)
+        return exception is ModuleTimeoutException
             ? Status.TimedOut
             : Status.Failed;
     }
 
-    private bool IsTimeout(ModuleConfiguration config, ModuleExecutionContext executionContext, Exception exception)
+    private bool IsPipelineCancelled(Exception exception)
     {
-        var timeout = GetTimeout(config);
-        if (timeout == TimeSpan.Zero)
-        {
-            return false;
-        }
-
-        var isTimeoutExceeded = executionContext.Stopwatch.Elapsed >= timeout;
-        return isTimeoutExceeded && exception is OperationCanceledException;
+        return exception is TaskCanceledException or OperationCanceledException or ModuleTimeoutException
+               && _engineCancellationToken.IsCancelled;
     }
 
     private void CancelPipelineAndThrow(
@@ -834,6 +857,17 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
                 module.CompletionSource.TrySetResult(result);
             }
         }
+    }
+
+    private sealed class PolicyExecutionState
+    {
+        private int _moduleAttemptCount;
+
+        public ModuleTimeoutException? AbandonedAttemptTimeout { get; set; }
+
+        public int RetryCount => Math.Max(0, Volatile.Read(ref _moduleAttemptCount) - 1);
+
+        public void RecordAttempt() => Interlocked.Increment(ref _moduleAttemptCount);
     }
 
     private static void LogModuleStatus(ModuleExecutionContext executionContext, IModuleLogger logger)

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -475,10 +475,12 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         LogTimeoutConfiguration(config, timeout, moduleContext.Logger);
 
         var cancellationToken = executionContext.ModuleCancellationTokenSource.Token;
-        using var retryCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
         // Get retry policy if applicable
         var retryPolicy = GetRetryPolicy<T>(config, moduleContext);
+        using var retryCancellationTokenSource = retryPolicy is null
+            ? null
+            : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         var policyExecutionState = new PolicyExecutionState();
 
         // Keep timeout enforcement inside the retry policy so each attempt gets a fresh budget
@@ -498,13 +500,13 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             result = retryPolicy != null
                 ? await retryPolicy.ExecuteAsync(
                     ExecuteModuleAttempt,
-                    retryCancellationTokenSource.Token).ConfigureAwait(false)
+                    retryCancellationTokenSource!.Token).ConfigureAwait(false)
                 : await ExecuteModuleAttempt(cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (policyExecutionState.AbandonedAttemptTimeout is not null
                                                  && !cancellationToken.IsCancellationRequested)
         {
-            throw policyExecutionState.AbandonedAttemptTimeout;
+            return ThrowPreservingStack<T>(policyExecutionState.AbandonedAttemptTimeout);
         }
         finally
         {
@@ -515,7 +517,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         if (policyExecutionState.AbandonedAttemptTimeout is { } abandonedAttemptTimeout)
         {
-            throw abandonedAttemptTimeout;
+            return ThrowPreservingStack<T>(abandonedAttemptTimeout);
         }
 
         return result;
@@ -545,10 +547,15 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         ModuleExecutionContext<T> executionContext,
         IModuleContext moduleContext,
         TimeSpan timeout,
-        CancellationTokenSource retryCancellationTokenSource,
+        CancellationTokenSource? retryCancellationTokenSource,
         PolicyExecutionState policyExecutionState,
         CancellationToken cancellationToken)
     {
+        if (policyExecutionState.AbandonedAttemptTimeout is { } abandonedAttemptTimeout)
+        {
+            return ThrowPreservingStack<T>(abandonedAttemptTimeout);
+        }
+
         policyExecutionState.RecordAttempt();
 
         var timeoutResult = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
@@ -573,10 +580,18 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             policyExecutionState.AbandonedAttemptTimeout = timeoutException;
             // Let wrapped policies observe the failure, but cancel their retry delay because
             // re-entering this module while the abandoned attempt is active is unsafe.
-            retryCancellationTokenSource.Cancel();
+            retryCancellationTokenSource?.Cancel();
         }
 
         throw timeoutException;
+    }
+
+    private static T ThrowPreservingStack<T>(Exception exception)
+    {
+        System.Runtime.ExceptionServices.ExceptionDispatchInfo
+            .Capture(exception)
+            .Throw();
+        throw new System.Diagnostics.UnreachableException();
     }
 
     private TimeSpan GetTimeout(ModuleConfiguration config)

--- a/src/ModularPipelines/Exceptions/ModuleTimeoutException.cs
+++ b/src/ModularPipelines/Exceptions/ModuleTimeoutException.cs
@@ -7,12 +7,13 @@ namespace ModularPipelines.Exceptions;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This exception is thrown when a module's execution time exceeds the configured timeout.
+/// This exception is thrown when a module execution attempt exceeds the configured timeout.
 /// The timeout can be configured per-module using the <c>Timeout</c> property or module options.
+/// When retries are configured, each attempt receives a fresh timeout and retry delays are excluded.
 /// </para>
 /// <para><b>When this is thrown:</b></para>
 /// <list type="bullet">
-/// <item>When a module's <c>ExecuteAsync</c> takes longer than the configured timeout</item>
+/// <item>When a module's <c>ExecuteAsync</c> attempt takes longer than the configured timeout</item>
 /// <item>When the module does not respond to cancellation token within the grace period</item>
 /// </list>
 /// <para><b>Properties available:</b></para>

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -132,15 +132,12 @@ internal static class TimeoutHelper
             var value = await executionTask.ConfigureAwait(false);
             return TimeoutExecutionResult<T>.Success(value, stopwatch.Elapsed);
         }
-        catch (OperationCanceledException exception) when (
-            timeoutElapsedWhenExecutionCompleted
-            && (exception.CancellationToken == timeoutCts.Token
-                || !exception.CancellationToken.CanBeCanceled))
+        catch (OperationCanceledException) when (timeoutElapsedWhenExecutionCompleted)
         {
-            // The task threw OperationCanceledException/TaskCanceledException in response to
-            // our timeout cancellation - this means it DID respect the token.
-            // This can happen when executionTask and cancelledTcs.Task complete at nearly
-            // the same time, and executionTask wins the race.
+            // The deadline elapsed before the completed task was observed. Any cancellation
+            // from that task therefore counts as a response, including cancellation through
+            // a token linked to the supplied timeout token. This can happen when executionTask
+            // and cancelledTcs.Task complete at nearly the same time and executionTask wins.
             return TimeoutExecutionResult<T>.TimeoutWithTokenRespected(stopwatch.Elapsed);
         }
     }

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -94,18 +94,13 @@ internal static class TimeoutHelper
                 .ConfigureAwait(false);
         }
 
-        // Timeout path: create linked token so task can observe both timeout
-        // and external cancellation.
+        // Keep the attempt token separate so signal ordering is recorded before
+        // cancellation is propagated to the executing task.
         using var deadlineCts = new CancellationTokenSource();
-        using var attemptCts = CancellationTokenSource.CreateLinkedTokenSource(
-            cancellationToken,
-            deadlineCts.Token);
+        using var attemptCts = new CancellationTokenSource();
 
-        // Register after linking the attempt token. Cancellation callbacks run in
-        // LIFO order, so these observers record whether execution had already
-        // completed before cancellation propagates to the task.
-        var deadlineState = new CancellationSignalState<T>();
-        var externalCancellationState = new CancellationSignalState<T>();
+        var deadlineState = new CancellationSignalState<T>(attemptCts);
+        var externalCancellationState = new CancellationSignalState<T>(attemptCts);
         using var deadlineRegistration = deadlineCts.Token.Register(
             static state => ((CancellationSignalState<T>) state!).SignalCancellation(),
             deadlineState);
@@ -220,7 +215,7 @@ internal static class TimeoutHelper
         }
     }
 
-    private sealed class CancellationSignalState<T>
+    private sealed class CancellationSignalState<T>(CancellationTokenSource attemptCts)
     {
         public Task<T>? ExecutionTask;
 
@@ -229,7 +224,10 @@ internal static class TimeoutHelper
 
         public void SignalCancellation()
         {
+            // The attempt token is not linked to either source, so this sample is
+            // independent of CancellationTokenSource callback ordering.
             Signal.TrySetResult(Volatile.Read(ref ExecutionTask)?.IsCompleted == true);
+            attemptCts.Cancel();
         }
     }
 }

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -112,8 +112,8 @@ internal static class TimeoutHelper
         deadlineCts.CancelAfter(timeout.Value);
 
         var executionTask = taskFactory(attemptCts.Token);
-        Volatile.Write(ref deadlineState.ExecutionTask, executionTask);
-        Volatile.Write(ref externalCancellationState.ExecutionTask, executionTask);
+        deadlineState.PublishExecutionTask(executionTask);
+        externalCancellationState.PublishExecutionTask(executionTask);
 
         await Task.WhenAny(
                 executionTask,
@@ -215,18 +215,48 @@ internal static class TimeoutHelper
         }
     }
 
-    private sealed class CancellationSignalState<T>(CancellationTokenSource attemptCts)
+    internal sealed class CancellationSignalState<T>(CancellationTokenSource attemptCts)
     {
-        public Task<T>? ExecutionTask;
+        private readonly Lock _lock = new();
+        private Task<T>? _executionTask;
+        private bool _cancellationSignaled;
 
         public TaskCompletionSource<bool> Signal { get; } = new(
             TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public void PublishExecutionTask(Task<T> executionTask)
+        {
+            bool cancellationSignaled;
+            lock (_lock)
+            {
+                _executionTask = executionTask;
+                cancellationSignaled = _cancellationSignaled;
+            }
+
+            if (cancellationSignaled)
+            {
+                // A completed value or fault existed by the time publication caught up
+                // with the signal. A cancelled task still belongs to the signal that
+                // cancelled the attempt token.
+                Signal.TrySetResult(executionTask.IsCompleted && !executionTask.IsCanceled);
+            }
+        }
+
         public void SignalCancellation()
         {
-            // The attempt token is not linked to either source, so this sample is
-            // independent of CancellationTokenSource callback ordering.
-            Signal.TrySetResult(Volatile.Read(ref ExecutionTask)?.IsCompleted == true);
+            Task<T>? executionTask;
+            lock (_lock)
+            {
+                _cancellationSignaled = true;
+                executionTask = _executionTask;
+            }
+
+            if (executionTask is not null)
+            {
+                // Record ordering before propagating cancellation to the attempt.
+                Signal.TrySetResult(executionTask.IsCompleted);
+            }
+
             attemptCts.Cancel();
         }
     }

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -123,16 +123,19 @@ internal static class TimeoutHelper
                 .ConfigureAwait(false);
         }
 
-        // Task completed before timeout
+        var timeoutElapsedWhenExecutionCompleted = timeoutCts.IsCancellationRequested
+                                                   && !cancellationToken.IsCancellationRequested;
+
+        // The execution task won the completion race.
         try
         {
             var value = await executionTask.ConfigureAwait(false);
             return TimeoutExecutionResult<T>.Success(value, stopwatch.Elapsed);
         }
         catch (OperationCanceledException exception) when (
-            exception.CancellationToken == timeoutCts.Token
-            && timeoutCts.IsCancellationRequested
-            && !cancellationToken.IsCancellationRequested)
+            timeoutElapsedWhenExecutionCompleted
+            && (exception.CancellationToken == timeoutCts.Token
+                || !exception.CancellationToken.CanBeCanceled))
         {
             // The task threw OperationCanceledException/TaskCanceledException in response to
             // our timeout cancellation - this means it DID respect the token.

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -96,51 +96,48 @@ internal static class TimeoutHelper
 
         // Timeout path: create linked token so task can observe both timeout
         // and external cancellation.
-        using var timeoutCts = CancellationTokenSource
-            .CreateLinkedTokenSource(cancellationToken);
+        using var deadlineCts = new CancellationTokenSource();
+        using var attemptCts = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            deadlineCts.Token);
 
-        // Set up cancellation detection BEFORE scheduling timeout to avoid race
-        // condition where timeout fires before registration completes
-        // (with very small timeouts)
-        var cancelledTcs = new TaskCompletionSource<T>(
-            TaskCreationOptions.RunContinuationsAsynchronously);
-        using var registration = timeoutCts.Token.Register(
-            static state => ((TaskCompletionSource<T>) state!)
-                .TrySetCanceled(),
-            cancelledTcs);
+        // Register after linking the attempt token. Cancellation callbacks run in
+        // LIFO order, so these observers record whether execution had already
+        // completed before cancellation propagates to the task.
+        var deadlineState = new CancellationSignalState<T>();
+        var externalCancellationState = new CancellationSignalState<T>();
+        using var deadlineRegistration = deadlineCts.Token.Register(
+            static state => ((CancellationSignalState<T>) state!).SignalCancellation(),
+            deadlineState);
+        using var externalCancellationRegistration = cancellationToken.Register(
+            static state => ((CancellationSignalState<T>) state!).SignalCancellation(),
+            externalCancellationState);
 
         // Now schedule the timeout - registration is guaranteed to catch it
-        timeoutCts.CancelAfter(timeout.Value);
+        deadlineCts.CancelAfter(timeout.Value);
 
-        var executionTask = taskFactory(timeoutCts.Token);
-        var executionTimedOutTask = executionTask.ContinueWith(
-            static (_, state) =>
-            {
-                var (timeoutToken, externalToken) =
-                    ((CancellationToken TimeoutToken, CancellationToken ExternalToken)) state!;
-                return timeoutToken.IsCancellationRequested
-                       && !externalToken.IsCancellationRequested;
-            },
-            (timeoutCts.Token, cancellationToken),
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
+        var executionTask = taskFactory(attemptCts.Token);
+        Volatile.Write(ref deadlineState.ExecutionTask, executionTask);
+        Volatile.Write(ref externalCancellationState.ExecutionTask, executionTask);
 
-        var winner = await Task.WhenAny(executionTimedOutTask, cancelledTcs.Task)
+        await Task.WhenAny(
+                executionTask,
+                deadlineState.Signal.Task,
+                externalCancellationState.Signal.Task)
             .ConfigureAwait(false);
 
-        if (winner == cancelledTcs.Task)
+        if (externalCancellationState.Signal.Task.IsCompletedSuccessfully
+            && !await externalCancellationState.Signal.Task.ConfigureAwait(false))
+        {
+            TaskObservation.ObserveFault(executionTask);
+            throw new OperationCanceledException(cancellationToken);
+        }
+
+        if (deadlineState.Signal.Task.IsCompletedSuccessfully
+            && !await deadlineState.Signal.Task.ConfigureAwait(false))
         {
             return await CreateTimeoutResultAsync(executionTask, cancellationToken, stopwatch)
                 .ConfigureAwait(false);
-        }
-
-        if (await executionTimedOutTask.ConfigureAwait(false))
-        {
-            // Any completion after the deadline counts as a response, including a fault
-            // raised while handling cancellation. The synchronous continuation records the
-            // ordering at task completion instead of when the winner is later observed.
-            return TimeoutExecutionResult<T>.TimeoutWithTokenRespected(stopwatch.Elapsed);
         }
 
         var value = await executionTask.ConfigureAwait(false);
@@ -220,6 +217,19 @@ internal static class TimeoutHelper
         catch (Exception)
         {
             return true;
+        }
+    }
+
+    private sealed class CancellationSignalState<T>
+    {
+        public Task<T>? ExecutionTask;
+
+        public TaskCompletionSource<bool> Signal { get; } = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void SignalCancellation()
+        {
+            Signal.TrySetResult(Volatile.Read(ref ExecutionTask)?.IsCompleted == true);
         }
     }
 }

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -113,8 +113,20 @@ internal static class TimeoutHelper
         timeoutCts.CancelAfter(timeout.Value);
 
         var executionTask = taskFactory(timeoutCts.Token);
+        var executionTimedOutTask = executionTask.ContinueWith(
+            static (_, state) =>
+            {
+                var (timeoutToken, externalToken) =
+                    ((CancellationToken TimeoutToken, CancellationToken ExternalToken)) state!;
+                return timeoutToken.IsCancellationRequested
+                       && !externalToken.IsCancellationRequested;
+            },
+            (timeoutCts.Token, cancellationToken),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
 
-        var winner = await Task.WhenAny(executionTask, cancelledTcs.Task)
+        var winner = await Task.WhenAny(executionTimedOutTask, cancelledTcs.Task)
             .ConfigureAwait(false);
 
         if (winner == cancelledTcs.Task)
@@ -123,23 +135,16 @@ internal static class TimeoutHelper
                 .ConfigureAwait(false);
         }
 
-        var timeoutElapsedWhenExecutionCompleted = timeoutCts.IsCancellationRequested
-                                                   && !cancellationToken.IsCancellationRequested;
-
-        // The execution task won the completion race.
-        try
+        if (await executionTimedOutTask.ConfigureAwait(false))
         {
-            var value = await executionTask.ConfigureAwait(false);
-            return TimeoutExecutionResult<T>.Success(value, stopwatch.Elapsed);
-        }
-        catch (OperationCanceledException) when (timeoutElapsedWhenExecutionCompleted)
-        {
-            // The deadline elapsed before the completed task was observed. Any cancellation
-            // from that task therefore counts as a response, including cancellation through
-            // a token linked to the supplied timeout token. This can happen when executionTask
-            // and cancelledTcs.Task complete at nearly the same time and executionTask wins.
+            // Any completion after the deadline counts as a response, including a fault
+            // raised while handling cancellation. The synchronous continuation records the
+            // ordering at task completion instead of when the winner is later observed.
             return TimeoutExecutionResult<T>.TimeoutWithTokenRespected(stopwatch.Elapsed);
         }
+
+        var value = await executionTask.ConfigureAwait(false);
+        return TimeoutExecutionResult<T>.Success(value, stopwatch.Elapsed);
     }
 
     private static async Task<TimeoutExecutionResult<T>> ExecuteWithoutTimeoutAsync<T>(

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -129,7 +129,10 @@ internal static class TimeoutHelper
             var value = await executionTask.ConfigureAwait(false);
             return TimeoutExecutionResult<T>.Success(value, stopwatch.Elapsed);
         }
-        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException exception) when (
+            exception.CancellationToken == timeoutCts.Token
+            && timeoutCts.IsCancellationRequested
+            && !cancellationToken.IsCancellationRequested)
         {
             // The task threw OperationCanceledException/TaskCanceledException in response to
             // our timeout cancellation - this means it DID respect the token.

--- a/src/ModularPipelines/Helpers/TimeoutHelper.cs
+++ b/src/ModularPipelines/Helpers/TimeoutHelper.cs
@@ -90,31 +90,8 @@ internal static class TimeoutHelper
         // Fast path: no timeout specified
         if (!timeout.HasValue || timeout.Value == TimeSpan.Zero)
         {
-            var task = taskFactory(cancellationToken);
-
-            // If the token can't be cancelled, just await directly (avoid allocations)
-            if (!cancellationToken.CanBeCanceled)
-            {
-                var result = await task.ConfigureAwait(false);
-                return TimeoutExecutionResult<T>.Success(result, stopwatch.Elapsed);
-            }
-
-            // Race against cancellation - TrySetCanceled makes the TCS throw
-            // OperationCanceledException when awaited
-            var tcs = new TaskCompletionSource<T>(
-                TaskCreationOptions.RunContinuationsAsynchronously);
-            using var reg = cancellationToken.Register(
-                static state => ((TaskCompletionSource<T>) state!).TrySetCanceled(),
-                tcs);
-
-            var fastPathWinner = await Task.WhenAny(task, tcs.Task).ConfigureAwait(false);
-            if (fastPathWinner != task)
-            {
-                TaskObservation.ObserveFault(task);
-            }
-
-            var winningResult = await fastPathWinner.ConfigureAwait(false);
-            return TimeoutExecutionResult<T>.Success(winningResult, stopwatch.Elapsed);
+            return await ExecuteWithoutTimeoutAsync(taskFactory, cancellationToken, stopwatch)
+                .ConfigureAwait(false);
         }
 
         // Timeout path: create linked token so task can observe both timeout
@@ -142,50 +119,8 @@ internal static class TimeoutHelper
 
         if (winner == cancelledTcs.Task)
         {
-            // Determine if it was external cancellation or timeout
-            if (cancellationToken.IsCancellationRequested)
-            {
-                TaskObservation.ObserveFault(executionTask);
-                throw new OperationCanceledException(cancellationToken);
-            }
-
-            // Timeout occurred - the task did NOT respond to the cancellation token
-            // in time (otherwise executionTask would have completed first with a
-            // TaskCanceledException). Give it a brief grace period to clean up.
-            var taskRespondedDuringGrace = false;
-            try
-            {
-                await executionTask.WaitAsync(GracePeriod, CancellationToken.None).ConfigureAwait(false);
-
-                // Task completed during grace period - it did eventually respond
-                taskRespondedDuringGrace = true;
-            }
-            catch (TimeoutException)
-            {
-                // Task still didn't complete - definitely not respecting the token
-                taskRespondedDuringGrace = false;
-                TaskObservation.ObserveFault(executionTask);
-            }
-            catch (OperationCanceledException)
-            {
-                // Task threw OperationCanceledException/TaskCanceledException from
-                // finally observing the cancellation token - consider it responsive
-                taskRespondedDuringGrace = true;
-            }
-            catch (Exception)
-            {
-                // Task threw some other exception during grace period - it did respond
-                // (with an error), so consider it responsive to the cancellation
-                taskRespondedDuringGrace = true;
-            }
-
-            var elapsedTime = stopwatch.Elapsed;
-
-            // If the task completed exactly when timeout fired (race condition),
-            // we still consider it a timeout since the deadline was reached
-            return taskRespondedDuringGrace
-                ? TimeoutExecutionResult<T>.TimeoutWithTokenRespected(elapsedTime)
-                : TimeoutExecutionResult<T>.TimeoutWithTokenIgnored(elapsedTime);
+            return await CreateTimeoutResultAsync(executionTask, cancellationToken, stopwatch)
+                .ConfigureAwait(false);
         }
 
         // Task completed before timeout
@@ -201,6 +136,82 @@ internal static class TimeoutHelper
             // This can happen when executionTask and cancelledTcs.Task complete at nearly
             // the same time, and executionTask wins the race.
             return TimeoutExecutionResult<T>.TimeoutWithTokenRespected(stopwatch.Elapsed);
+        }
+    }
+
+    private static async Task<TimeoutExecutionResult<T>> ExecuteWithoutTimeoutAsync<T>(
+        Func<CancellationToken, Task<T>> taskFactory,
+        CancellationToken cancellationToken,
+        Stopwatch stopwatch)
+    {
+        var task = taskFactory(cancellationToken);
+
+        if (!cancellationToken.CanBeCanceled)
+        {
+            var result = await task.ConfigureAwait(false);
+            return TimeoutExecutionResult<T>.Success(result, stopwatch.Elapsed);
+        }
+
+        var cancellationTaskSource = new TaskCompletionSource<T>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        using var registration = cancellationToken.Register(
+            static state => ((TaskCompletionSource<T>) state!).TrySetCanceled(),
+            cancellationTaskSource);
+
+        var winner = await Task.WhenAny(task, cancellationTaskSource.Task).ConfigureAwait(false);
+        if (winner != task)
+        {
+            TaskObservation.ObserveFault(task);
+        }
+
+        var resultValue = await winner.ConfigureAwait(false);
+        return TimeoutExecutionResult<T>.Success(resultValue, stopwatch.Elapsed);
+    }
+
+    private static async Task<TimeoutExecutionResult<T>> CreateTimeoutResultAsync<T>(
+        Task<T> executionTask,
+        CancellationToken cancellationToken,
+        Stopwatch stopwatch)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            TaskObservation.ObserveFault(executionTask);
+            throw new OperationCanceledException(cancellationToken);
+        }
+
+        var taskRespondedDuringGrace = await DidTaskRespondDuringGracePeriodAsync(executionTask)
+            .ConfigureAwait(false);
+        var elapsedTime = stopwatch.Elapsed;
+
+        return taskRespondedDuringGrace
+            ? TimeoutExecutionResult<T>.TimeoutWithTokenRespected(elapsedTime)
+            : TimeoutExecutionResult<T>.TimeoutWithTokenIgnored(elapsedTime);
+    }
+
+    private static async Task<bool> DidTaskRespondDuringGracePeriodAsync(Task executionTask)
+    {
+        try
+        {
+            await executionTask.WaitAsync(GracePeriod, CancellationToken.None).ConfigureAwait(false);
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            var taskRespondedDuringGrace = executionTask.IsCompleted;
+            if (!taskRespondedDuringGrace)
+            {
+                TaskObservation.ObserveFault(executionTask);
+            }
+
+            return taskRespondedDuringGrace;
+        }
+        catch (OperationCanceledException)
+        {
+            return true;
+        }
+        catch (Exception)
+        {
+            return true;
         }
     }
 }

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -88,8 +88,9 @@ public record PipelineOptions
     public ExecutionMode ExecutionMode { get; init; } = ExecutionMode.StopOnFirstException;
 
     /// <summary>
-    /// Gets the default timeout for modules that do not configure their own timeout.
+    /// Gets the default per-attempt timeout for modules that do not configure their own timeout.
     /// Set to <see cref="TimeSpan.Zero"/> to disable the default module timeout.
+    /// Retry delays do not count toward this timeout.
     /// </summary>
     public TimeSpan DefaultModuleTimeout { get; init; } = TimeSpan.FromMinutes(30);
 

--- a/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Commands/CommandLoggerTests.cs
@@ -549,6 +549,56 @@ public class CommandLoggerTests : TestBase
     }
 
     [Test]
+    public async Task CallerCancellationPreservesCallerTokenIdentity()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var commandContext = await GetService<ICommandContext>();
+        var readyFile = Path.Combine(
+            TestContext.WorkingDirectory,
+            $"command-cancellation-{Guid.NewGuid():N}.ready");
+        var commandTask = commandContext.ExecuteCommandLineToolAsync(
+            new PowershellScriptOptions(
+                "[IO.File]::WriteAllText($env:MP_COMMAND_CANCELLATION_READY_FILE, 'ready'); "
+                + "Start-Sleep -Seconds 30"),
+            new CommandExecutionOptions
+            {
+                EnvironmentVariables = new Dictionary<string, string?>
+                {
+                    ["MP_COMMAND_CANCELLATION_READY_FILE"] = readyFile,
+                },
+                GracefulShutdownTimeout = TimeSpan.FromMilliseconds(50),
+            },
+            cancellationToken: cancellationTokenSource.Token);
+
+        try
+        {
+            await Assert.That(await WaitUntilAsync(
+                    () => File.Exists(readyFile),
+                    TimeSpan.FromSeconds(30)))
+                .IsTrue();
+            await cancellationTokenSource.CancelAsync();
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => commandTask);
+
+            await Assert.That(
+                    exception!.CancellationToken == cancellationTokenSource.Token)
+                .IsTrue();
+        }
+        finally
+        {
+            await cancellationTokenSource.CancelAsync();
+            try
+            {
+                await commandTask;
+            }
+            catch (OperationCanceledException) when (cancellationTokenSource.IsCancellationRequested)
+            {
+            }
+
+            File.Delete(readyFile);
+        }
+    }
+
+    [Test]
     public async Task Deferred_Logging_Failure_After_NonZero_Exit_Preserves_Command_Failure()
     {
         var marker = $"throwing-failure-output-{Guid.NewGuid():N}";

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -209,7 +209,7 @@ public class ModuleExecutionPipelineTests
     }
 
     [Test]
-    public async Task ExecuteAsync_ClassifiesAlwaysRunElapsedCancellationAsTimeout()
+    public async Task ExecuteAsync_DoesNotClassifyAlwaysRunElapsedCancellationAsTimeout()
     {
         var module = new AlwaysRunElapsedCancellationModule();
         var executionContext = new ModuleExecutionContext<int>(module, module.GetType());
@@ -220,7 +220,7 @@ public class ModuleExecutionPipelineTests
         await Assert.That(async () => await ExecuteAfterPipelineCancellation(module, executionContext))
             .Throws<ModuleFailedException>();
 
-        await Assert.That(executionContext.Status).IsEqualTo(Status.TimedOut);
+        await Assert.That(executionContext.Status).IsEqualTo(Status.Failed);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -299,6 +299,34 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
+    public async Task Completed_Execution_Published_After_Deadline_Signal_Wins()
+    {
+        using var attemptCancellation = new CancellationTokenSource();
+        var signalState = new TimeoutHelper.CancellationSignalState<bool>(attemptCancellation);
+
+        signalState.SignalCancellation();
+        signalState.PublishExecutionTask(Task.FromResult(true));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(await signalState.Signal.Task).IsTrue();
+            await Assert.That(attemptCancellation.IsCancellationRequested).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Cancelled_Execution_Published_After_Deadline_Signal_Belongs_To_Deadline()
+    {
+        using var attemptCancellation = new CancellationTokenSource();
+        var signalState = new TimeoutHelper.CancellationSignalState<bool>(attemptCancellation);
+
+        signalState.SignalCancellation();
+        signalState.PublishExecutionTask(Task.FromCanceled<bool>(attemptCancellation.Token));
+
+        await Assert.That(await signalState.Signal.Task).IsFalse();
+    }
+
+    [Test]
     public async Task Timeout_Claims_Tokenless_Cooperative_Cancellation()
     {
         var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -252,4 +252,26 @@ public class ModuleTimeoutTests : TestBase
 
         await Assert.That(exception!.CancellationToken).IsEqualTo(unrelatedCancellation.Token);
     }
+
+    [Test]
+    public async Task Timeout_Claims_Tokenless_Cooperative_Cancellation()
+    {
+        var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            timeoutToken =>
+            {
+                timeoutToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
+                var completion = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                completion.TrySetCanceled();
+                return completion.Task;
+            },
+            TimeSpan.FromMilliseconds(10),
+            CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.TimedOut).IsTrue();
+            await Assert.That(result.WasCancellationTokenRespected).IsTrue();
+        }
+    }
 }

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -274,6 +274,18 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
+    public async Task Fault_Completed_Before_Deadline_Is_Not_Claimed_By_Timeout()
+    {
+        var exception = await Assert.ThrowsAsync<TimeoutException>(async () =>
+            await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+                _ => Task.FromException<bool>(new TimeoutException("Inner operation timed out.")),
+                TimeSpan.FromMilliseconds(10),
+                CancellationToken.None));
+
+        await Assert.That(exception!.Message).IsEqualTo("Inner operation timed out.");
+    }
+
+    [Test]
     public async Task Timeout_Claims_Tokenless_Cooperative_Cancellation()
     {
         var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -233,4 +233,23 @@ public class ModuleTimeoutTests : TestBase
             await Assert.That(result.WasCancellationTokenRespected).IsTrue();
         }
     }
+
+    [Test]
+    public async Task Timeout_Does_Not_Claim_Unrelated_Cancellation_When_Deadline_Elapses()
+    {
+        using var unrelatedCancellation = new CancellationTokenSource();
+        unrelatedCancellation.Cancel();
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+                timeoutToken =>
+                {
+                    timeoutToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
+                    return Task.FromCanceled<bool>(unrelatedCancellation.Token);
+                },
+                TimeSpan.FromMilliseconds(10),
+                CancellationToken.None));
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(unrelatedCancellation.Token);
+    }
 }

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -265,6 +265,18 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
+    public async Task Fault_Completed_Before_Deadline_Is_Not_Claimed_By_Timeout()
+    {
+        var exception = await Assert.ThrowsAsync<TimeoutException>(async () =>
+            await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+                _ => Task.FromException<bool>(new TimeoutException("Inner operation timed out.")),
+                TimeSpan.FromMilliseconds(10),
+                CancellationToken.None));
+
+        await Assert.That(exception!.Message).IsEqualTo("Inner operation timed out.");
+    }
+
+    [Test]
     public async Task Timeout_Claims_Tokenless_Cooperative_Cancellation()
     {
         var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -1,6 +1,7 @@
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Exceptions;
+using ModularPipelines.Helpers;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
@@ -204,5 +205,32 @@ public class ModuleTimeoutTests : TestBase
         var timeoutException = exception!.InnerException as ModuleTimeoutException;
         await Assert.That(timeoutException).IsNotNull();
         await Assert.That(timeoutException!.Message).Contains("did not complete within the cancellation grace period");
+    }
+
+    [Test]
+    public async Task Timeout_Fault_During_Grace_Period_Counts_As_Response()
+    {
+        var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            async cancellationToken =>
+            {
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw new TimeoutException("Inner operation timed out.");
+                }
+
+                return true;
+            },
+            TimeSpan.FromMilliseconds(10),
+            CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.TimedOut).IsTrue();
+            await Assert.That(result.WasCancellationTokenRespected).IsTrue();
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -226,22 +226,42 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
-    public async Task Timeout_Does_Not_Claim_Unrelated_Cancellation_When_Deadline_Elapses()
+    public async Task Timeout_Does_Not_Claim_Unrelated_Cancellation_Before_Deadline()
     {
         using var unrelatedCancellation = new CancellationTokenSource();
         unrelatedCancellation.Cancel();
 
         var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
-                timeoutToken =>
-                {
-                    timeoutToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
-                    return Task.FromCanceled<bool>(unrelatedCancellation.Token);
-                },
-                TimeSpan.FromMilliseconds(10),
+                _ => Task.FromCanceled<bool>(unrelatedCancellation.Token),
+                TimeSpan.FromSeconds(1),
                 CancellationToken.None));
 
         await Assert.That(exception!.CancellationToken).IsEqualTo(unrelatedCancellation.Token);
+    }
+
+    [Test]
+    public async Task Timeout_Claims_Cancellation_Through_Linked_Attempt_Token()
+    {
+        using var unrelatedCancellation = new CancellationTokenSource();
+
+        var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            timeoutToken =>
+            {
+                using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                    timeoutToken,
+                    unrelatedCancellation.Token);
+                timeoutToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
+                return Task.FromCanceled<bool>(linkedCancellation.Token);
+            },
+            TimeSpan.FromMilliseconds(10),
+            CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.TimedOut).IsTrue();
+            await Assert.That(result.WasCancellationTokenRespected).IsTrue();
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -243,4 +243,26 @@ public class ModuleTimeoutTests : TestBase
 
         await Assert.That(exception!.CancellationToken).IsEqualTo(unrelatedCancellation.Token);
     }
+
+    [Test]
+    public async Task Timeout_Claims_Tokenless_Cooperative_Cancellation()
+    {
+        var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            timeoutToken =>
+            {
+                timeoutToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
+                var completion = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+                completion.TrySetCanceled();
+                return completion.Task;
+            },
+            TimeSpan.FromMilliseconds(10),
+            CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.TimedOut).IsTrue();
+            await Assert.That(result.WasCancellationTokenRespected).IsTrue();
+        }
+    }
 }

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -224,4 +224,23 @@ public class ModuleTimeoutTests : TestBase
             await Assert.That(result.WasCancellationTokenRespected).IsTrue();
         }
     }
+
+    [Test]
+    public async Task Timeout_Does_Not_Claim_Unrelated_Cancellation_When_Deadline_Elapses()
+    {
+        using var unrelatedCancellation = new CancellationTokenSource();
+        unrelatedCancellation.Cancel();
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+                timeoutToken =>
+                {
+                    timeoutToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
+                    return Task.FromCanceled<bool>(unrelatedCancellation.Token);
+                },
+                TimeSpan.FromMilliseconds(10),
+                CancellationToken.None));
+
+        await Assert.That(exception!.CancellationToken).IsEqualTo(unrelatedCancellation.Token);
+    }
 }

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -277,6 +277,28 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
+    public async Task Completion_With_Asynchronous_Continuations_Before_Deadline_Is_Not_Claimed_By_Timeout()
+    {
+        var completion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var execution = TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            _ => completion.Task,
+            TimeSpan.FromSeconds(1),
+            CancellationToken.None);
+
+        completion.SetResult(true);
+
+        var result = await execution;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.TimedOut).IsFalse();
+            await Assert.That(result.Value).IsTrue();
+        }
+    }
+
+    [Test]
     public async Task Timeout_Claims_Tokenless_Cooperative_Cancellation()
     {
         var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -308,6 +308,34 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
+    public async Task Completed_Execution_Published_After_Deadline_Signal_Wins()
+    {
+        using var attemptCancellation = new CancellationTokenSource();
+        var signalState = new TimeoutHelper.CancellationSignalState<bool>(attemptCancellation);
+
+        signalState.SignalCancellation();
+        signalState.PublishExecutionTask(Task.FromResult(true));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(await signalState.Signal.Task).IsTrue();
+            await Assert.That(attemptCancellation.IsCancellationRequested).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Cancelled_Execution_Published_After_Deadline_Signal_Belongs_To_Deadline()
+    {
+        using var attemptCancellation = new CancellationTokenSource();
+        var signalState = new TimeoutHelper.CancellationSignalState<bool>(attemptCancellation);
+
+        signalState.SignalCancellation();
+        signalState.PublishExecutionTask(Task.FromCanceled<bool>(attemptCancellation.Token));
+
+        await Assert.That(await signalState.Signal.Task).IsFalse();
+    }
+
+    [Test]
     public async Task Timeout_Claims_Tokenless_Cooperative_Cancellation()
     {
         var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -235,22 +235,42 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
-    public async Task Timeout_Does_Not_Claim_Unrelated_Cancellation_When_Deadline_Elapses()
+    public async Task Timeout_Does_Not_Claim_Unrelated_Cancellation_Before_Deadline()
     {
         using var unrelatedCancellation = new CancellationTokenSource();
         unrelatedCancellation.Cancel();
 
         var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
-                timeoutToken =>
-                {
-                    timeoutToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
-                    return Task.FromCanceled<bool>(unrelatedCancellation.Token);
-                },
-                TimeSpan.FromMilliseconds(10),
+                _ => Task.FromCanceled<bool>(unrelatedCancellation.Token),
+                TimeSpan.FromSeconds(1),
                 CancellationToken.None));
 
         await Assert.That(exception!.CancellationToken).IsEqualTo(unrelatedCancellation.Token);
+    }
+
+    [Test]
+    public async Task Timeout_Claims_Cancellation_Through_Linked_Attempt_Token()
+    {
+        using var unrelatedCancellation = new CancellationTokenSource();
+
+        var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            timeoutToken =>
+            {
+                using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                    timeoutToken,
+                    unrelatedCancellation.Token);
+                timeoutToken.WaitHandle.WaitOne(TimeSpan.FromSeconds(1));
+                return Task.FromCanceled<bool>(linkedCancellation.Token);
+            },
+            TimeSpan.FromMilliseconds(10),
+            CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.TimedOut).IsTrue();
+            await Assert.That(result.WasCancellationTokenRespected).IsTrue();
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -1,6 +1,7 @@
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Exceptions;
+using ModularPipelines.Helpers;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
@@ -195,5 +196,32 @@ public class ModuleTimeoutTests : TestBase
         var timeoutException = exception!.InnerException as ModuleTimeoutException;
         await Assert.That(timeoutException).IsNotNull();
         await Assert.That(timeoutException!.Message).Contains("did not complete within the cancellation grace period");
+    }
+
+    [Test]
+    public async Task Timeout_Fault_During_Grace_Period_Counts_As_Response()
+    {
+        var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            async cancellationToken =>
+            {
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw new TimeoutException("Inner operation timed out.");
+                }
+
+                return true;
+            },
+            TimeSpan.FromMilliseconds(10),
+            CancellationToken.None);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.TimedOut).IsTrue();
+            await Assert.That(result.WasCancellationTokenRespected).IsTrue();
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -286,6 +286,28 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
+    public async Task Completion_With_Asynchronous_Continuations_Before_Deadline_Is_Not_Claimed_By_Timeout()
+    {
+        var completion = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var execution = TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(
+            _ => completion.Task,
+            TimeSpan.FromSeconds(1),
+            CancellationToken.None);
+
+        completion.SetResult(true);
+
+        var result = await execution;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.TimedOut).IsFalse();
+            await Assert.That(result.Value).IsTrue();
+        }
+    }
+
+    [Test]
     public async Task Timeout_Claims_Tokenless_Cooperative_Cancellation()
     {
         var result = await TimeoutHelper.ExecuteWithTimeoutAndDetailsAsync(

--- a/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
+using ModularPipelines.Enums;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
 using ModularPipelines.Models;
@@ -158,12 +159,16 @@ public class RetryTests : TestBase
 
     private class CancellableModuleWithTimeout : Module<bool>
     {
+        internal int ExecutionCount;
+
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
             .WithTimeout(TimeSpan.FromMilliseconds(ModuleTimeoutMs))
+            .WithRetry(DefaultRetryCount, TimeSpan.Zero)
             .Build();
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
+            ExecutionCount++;
             await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
             return true;
         }
@@ -294,14 +299,67 @@ public class RetryTests : TestBase
         }
     }
 
+    private class NonCancellableModuleWithTimeout : Module<bool>
+    {
+        private readonly TaskCompletionSource<bool> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal int ExecutionCount;
+
+        internal int RetryCallbackCount;
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithTimeout(TimeSpan.FromMilliseconds(50))
+            .Advanced
+            .WithRetryPolicy(Policy
+                .Handle<Exception>()
+                .WaitAndRetryAsync(
+                    DefaultRetryCount,
+                    _ => TimeSpan.FromMinutes(1),
+                    (_, _, _, _) => RetryCallbackCount++))
+            .Build();
+
+        protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            ExecutionCount++;
+            return await _completion.Task;
+        }
+
+        internal void Complete() => _completion.TrySetResult(true);
+    }
+
+    private class CancelledDuringRetryModule : Module<bool>
+    {
+        private readonly TaskCompletionSource _secondAttemptStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal Task SecondAttemptStarted => _secondAttemptStarted.Task;
+
+        internal int ExecutionCount;
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithTimeout(TimeSpan.FromSeconds(2))
+            .WithRetry(1, TimeSpan.FromMilliseconds(250))
+            .Build();
+
+        protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            ExecutionCount++;
+            if (ExecutionCount == 1)
+            {
+                throw new RetryableTestException();
+            }
+
+            _secondAttemptStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return true;
+        }
+    }
+
     [Test]
-    public async Task When_Retry_With_Timeout_Then_Honour_Overall_Timeout()
+    public async Task When_Retry_Backoff_Exceeds_Timeout_Then_All_Attempts_Run()
     {
         var host = await TestPipelineBuilder.Create()
-            .ConfigurePipelineOptions((_, options) => options with
-            {
-                DefaultRetryCount = DefaultRetryCount,
-            })
             .AddModule<FailedModuleWithTimeout>()
             .BuildAsync();
 
@@ -309,27 +367,82 @@ public class RetryTests : TestBase
 
         var module = host.Services.GetServices<IModule>().OfType<FailedModuleWithTimeout>().Single();
         var timeoutException = moduleFailedException?.InnerException as ModuleTimeoutException;
-        await Assert.That(timeoutException).IsNotNull();
         using (Assert.Multiple())
         {
-            await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedSingleExecutionCount);
-            await Assert.That(timeoutException!.WasCancellationTokenRespected).IsFalse();
+            await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedExecutionCountAfterRetries);
+            await Assert.That(timeoutException).IsNull();
         }
     }
 
     [Test]
     public async Task When_Retry_Timeouts_During_Module_Then_Report_Token_Respected()
     {
-        var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(async () => await TestPipelineBuilder.Create()
-            .ConfigurePipelineOptions((_, options) => options with
-            {
-                DefaultRetryCount = DefaultRetryCount,
-            })
+        var host = await TestPipelineBuilder.Create()
             .AddModule<CancellableModuleWithTimeout>()
-            .ExecutePipelineAsync());
+            .BuildAsync();
 
+        var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(() => host.RunAsync());
+
+        var module = host.Services.GetServices<IModule>().OfType<CancellableModuleWithTimeout>().Single();
         var timeoutException = moduleFailedException?.InnerException as ModuleTimeoutException;
-        await Assert.That(timeoutException).IsNotNull();
-        await Assert.That(timeoutException!.WasCancellationTokenRespected).IsTrue();
+        using (Assert.Multiple())
+        {
+            await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedExecutionCountAfterRetries);
+            await Assert.That(timeoutException).IsNotNull();
+            await Assert.That(timeoutException!.WasCancellationTokenRespected).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task When_Timed_Out_Attempt_Remains_Active_Then_Do_Not_Retry()
+    {
+        var host = await TestPipelineBuilder.Create()
+            .AddModule<NonCancellableModuleWithTimeout>()
+            .BuildAsync();
+        var module = host.Services.GetServices<IModule>().OfType<NonCancellableModuleWithTimeout>().Single();
+
+        try
+        {
+            var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(
+                () => host.RunAsync().WaitAsync(TimeSpan.FromSeconds(10)));
+            var timeoutException = moduleFailedException?.InnerException as ModuleTimeoutException;
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedSingleExecutionCount);
+                await Assert.That(module.RetryCallbackCount).IsEqualTo(1);
+                await Assert.That(timeoutException).IsNotNull();
+                await Assert.That(timeoutException!.WasCancellationTokenRespected).IsFalse();
+            }
+        }
+        finally
+        {
+            module.Complete();
+        }
+    }
+
+    [Test]
+    public async Task When_Cancelled_During_Later_Attempt_Then_Report_PipelineTerminated()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var host = await TestPipelineBuilder.Create()
+            .AddModule<CancelledDuringRetryModule>()
+            .BuildAsync();
+        var module = host.Services.GetServices<IModule>().OfType<CancelledDuringRetryModule>().Single();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+        var pipelineTask = host.RunAsync(cancellationTokenSource.Token);
+
+        await module.SecondAttemptStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellationTokenSource.Cancel();
+
+        await pipelineTask;
+
+        var result = resultRegistry.GetResult(typeof(CancelledDuringRetryModule));
+        using (Assert.Multiple())
+        {
+            await Assert.That(module.ExecutionCount).IsEqualTo(2);
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
@@ -319,6 +319,37 @@ public class RetryTests : TestBase
         internal void Complete() => _completion.TrySetResult(true);
     }
 
+    private class NonCancellableModuleWithAdvancedShield : Module<bool>
+    {
+        private readonly TaskCompletionSource<bool> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal int ExecutionCount;
+        internal int ObservedTimeoutCount;
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithTimeout(TimeSpan.FromMilliseconds(50))
+            .Advanced
+            .WithShield(Shield
+                .When<ModuleTimeoutException>(_ =>
+                {
+                    ObservedTimeoutCount++;
+                    return true;
+                })
+                .Retry(DefaultRetryCount, Backoff.None))
+            .Build();
+
+        protected internal override async Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            ExecutionCount++;
+            return await _completion.Task;
+        }
+
+        internal void Complete() => _completion.TrySetResult(true);
+    }
+
     private class CancelledDuringRetryModule : Module<bool>
     {
         private readonly TaskCompletionSource _secondAttemptStarted =
@@ -401,6 +432,36 @@ public class RetryTests : TestBase
             using (Assert.Multiple())
             {
                 await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedSingleExecutionCount);
+                await Assert.That(timeoutException).IsNotNull();
+                await Assert.That(timeoutException!.WasCancellationTokenRespected).IsFalse();
+            }
+        }
+        finally
+        {
+            module.Complete();
+        }
+    }
+
+    [Test]
+    public async Task When_Advanced_Shield_Sees_Abandoned_Attempt_Then_Do_Not_Reenter_Module()
+    {
+        var host = await TestPipelineBuilder.Create()
+            .AddModule<NonCancellableModuleWithAdvancedShield>()
+            .BuildAsync();
+        var module = host.Services.GetServices<IModule>()
+            .OfType<NonCancellableModuleWithAdvancedShield>()
+            .Single();
+
+        try
+        {
+            var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(
+                () => host.RunAsync().WaitAsync(TimeSpan.FromSeconds(10)));
+            var timeoutException = moduleFailedException?.InnerException as ModuleTimeoutException;
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedSingleExecutionCount);
+                await Assert.That(module.ObservedTimeoutCount).IsEqualTo(ExpectedSingleExecutionCount);
                 await Assert.That(timeoutException).IsNotNull();
                 await Assert.That(timeoutException!.WasCancellationTokenRespected).IsFalse();
             }

--- a/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
@@ -305,17 +305,9 @@ public class RetryTests : TestBase
 
         internal int ExecutionCount;
 
-        internal int RetryCallbackCount;
-
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
             .WithTimeout(TimeSpan.FromMilliseconds(50))
-            .Advanced
-            .WithRetryPolicy(Policy
-                .Handle<Exception>()
-                .WaitAndRetryAsync(
-                    DefaultRetryCount,
-                    _ => TimeSpan.FromMinutes(1),
-                    (_, _, _, _) => RetryCallbackCount++))
+            .WithRetry(DefaultRetryCount, TimeSpan.FromMinutes(1))
             .Build();
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -409,7 +401,6 @@ public class RetryTests : TestBase
             using (Assert.Multiple())
             {
                 await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedSingleExecutionCount);
-                await Assert.That(module.RetryCallbackCount).IsEqualTo(1);
                 await Assert.That(timeoutException).IsNotNull();
                 await Assert.That(timeoutException!.WasCancellationTokenRespected).IsFalse();
             }

--- a/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/RetryTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
+using ModularPipelines.Enums;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
 using ModularPipelines.Models;
@@ -157,12 +158,16 @@ public class RetryTests : TestBase
 
     private class CancellableModuleWithTimeout : Module<bool>
     {
+        internal int ExecutionCount;
+
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
             .WithTimeout(TimeSpan.FromMilliseconds(ModuleTimeoutMs))
+            .WithRetry(DefaultRetryCount, TimeSpan.Zero)
             .Build();
 
         protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
+            ExecutionCount++;
             await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
             return true;
         }
@@ -293,14 +298,67 @@ public class RetryTests : TestBase
         }
     }
 
+    private class NonCancellableModuleWithTimeout : Module<bool>
+    {
+        private readonly TaskCompletionSource<bool> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal int ExecutionCount;
+
+        internal int RetryCallbackCount;
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithTimeout(TimeSpan.FromMilliseconds(50))
+            .Advanced
+            .WithRetryPolicy(Policy
+                .Handle<Exception>()
+                .WaitAndRetryAsync(
+                    DefaultRetryCount,
+                    _ => TimeSpan.FromMinutes(1),
+                    (_, _, _, _) => RetryCallbackCount++))
+            .Build();
+
+        protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            ExecutionCount++;
+            return await _completion.Task;
+        }
+
+        internal void Complete() => _completion.TrySetResult(true);
+    }
+
+    private class CancelledDuringRetryModule : Module<bool>
+    {
+        private readonly TaskCompletionSource _secondAttemptStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal Task SecondAttemptStarted => _secondAttemptStarted.Task;
+
+        internal int ExecutionCount;
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithTimeout(TimeSpan.FromSeconds(2))
+            .WithRetry(1, TimeSpan.FromMilliseconds(250))
+            .Build();
+
+        protected internal override async Task<bool> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
+            ExecutionCount++;
+            if (ExecutionCount == 1)
+            {
+                throw new RetryableTestException();
+            }
+
+            _secondAttemptStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return true;
+        }
+    }
+
     [Test]
-    public async Task When_Retry_With_Timeout_Then_Honour_Overall_Timeout()
+    public async Task When_Retry_Backoff_Exceeds_Timeout_Then_All_Attempts_Run()
     {
         var host = await TestPipelineBuilder.Create()
-            .ConfigurePipelineOptions((_, options) => options with
-            {
-                DefaultRetryCount = DefaultRetryCount,
-            })
             .AddModule<FailedModuleWithTimeout>()
             .BuildAsync();
 
@@ -308,27 +366,82 @@ public class RetryTests : TestBase
 
         var module = host.Services.GetServices<IModule>().OfType<FailedModuleWithTimeout>().Single();
         var timeoutException = moduleFailedException?.InnerException as ModuleTimeoutException;
-        await Assert.That(timeoutException).IsNotNull();
         using (Assert.Multiple())
         {
-            await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedSingleExecutionCount);
-            await Assert.That(timeoutException!.WasCancellationTokenRespected).IsFalse();
+            await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedExecutionCountAfterRetries);
+            await Assert.That(timeoutException).IsNull();
         }
     }
 
     [Test]
     public async Task When_Retry_Timeouts_During_Module_Then_Report_Token_Respected()
     {
-        var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(async () => await TestPipelineBuilder.Create()
-            .ConfigurePipelineOptions((_, options) => options with
-            {
-                DefaultRetryCount = DefaultRetryCount,
-            })
+        var host = await TestPipelineBuilder.Create()
             .AddModule<CancellableModuleWithTimeout>()
-            .ExecutePipelineAsync());
+            .BuildAsync();
 
+        var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(() => host.RunAsync());
+
+        var module = host.Services.GetServices<IModule>().OfType<CancellableModuleWithTimeout>().Single();
         var timeoutException = moduleFailedException?.InnerException as ModuleTimeoutException;
-        await Assert.That(timeoutException).IsNotNull();
-        await Assert.That(timeoutException!.WasCancellationTokenRespected).IsTrue();
+        using (Assert.Multiple())
+        {
+            await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedExecutionCountAfterRetries);
+            await Assert.That(timeoutException).IsNotNull();
+            await Assert.That(timeoutException!.WasCancellationTokenRespected).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task When_Timed_Out_Attempt_Remains_Active_Then_Do_Not_Retry()
+    {
+        var host = await TestPipelineBuilder.Create()
+            .AddModule<NonCancellableModuleWithTimeout>()
+            .BuildAsync();
+        var module = host.Services.GetServices<IModule>().OfType<NonCancellableModuleWithTimeout>().Single();
+
+        try
+        {
+            var moduleFailedException = await Assert.ThrowsAsync<ModuleFailedException>(
+                () => host.RunAsync().WaitAsync(TimeSpan.FromSeconds(10)));
+            var timeoutException = moduleFailedException?.InnerException as ModuleTimeoutException;
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(module.ExecutionCount).IsEqualTo(ExpectedSingleExecutionCount);
+                await Assert.That(module.RetryCallbackCount).IsEqualTo(1);
+                await Assert.That(timeoutException).IsNotNull();
+                await Assert.That(timeoutException!.WasCancellationTokenRespected).IsFalse();
+            }
+        }
+        finally
+        {
+            module.Complete();
+        }
+    }
+
+    [Test]
+    public async Task When_Cancelled_During_Later_Attempt_Then_Report_PipelineTerminated()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var host = await TestPipelineBuilder.Create()
+            .AddModule<CancelledDuringRetryModule>()
+            .BuildAsync();
+        var module = host.Services.GetServices<IModule>().OfType<CancelledDuringRetryModule>().Single();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+        var pipelineTask = host.RunAsync(cancellationTokenSource.Token);
+
+        await module.SecondAttemptStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellationTokenSource.Cancel();
+
+        await pipelineTask;
+
+        var result = resultRegistry.GetResult(typeof(CancelledDuringRetryModule));
+        using (Assert.Multiple())
+        {
+            await Assert.That(module.ExecutionCount).IsEqualTo(2);
+            await Assert.That(result).IsNotNull();
+            await Assert.That(result!.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- enforce module timeout independently for every retry attempt
- exclude retry backoff from timeout and cancellation-cooperation accounting
- document timeout/retry composition across API docs and guides

## Validation
- RetryTests: 8 passed
- ModuleTimeoutTests: 12 passed
- TelemetryIntegrationTests: 18 passed
- ModularPipelines.slnx Release build: 0 warnings, 0 errors

Closes #3790