### PR TITLE
Honor cancellation during run-report completion

### DIFF
--- a/src/ModularPipelines/Engine/EngineCancellationToken.cs
+++ b/src/ModularPipelines/Engine/EngineCancellationToken.cs
@@ -11,15 +11,17 @@ namespace ModularPipelines.Engine;
 [ExcludeFromCodeCoverage]
 internal class EngineCancellationToken : IDisposable
 {
-    private readonly CancellationTokenSource _cts = new();
+    private readonly CancellationTokenSource _cts;
+    private readonly CancellationTokenSource _nonFailureCancellationTokenSource = new();
     private readonly CancellationToken _token;
+    private readonly CancellationToken _nonFailureCancellationToken;
     private readonly IPrimaryExceptionContainer _primaryExceptionContainer;
     private readonly object _lifetimeLock = new();
 
     private int _activeCancellationOperations;
     private int _cancelKeyPressReceived;
-    private bool _disposeCancellationTokenSource;
-    private bool _ctsDisposed;
+    private bool _disposeCancellationTokenSources;
+    private bool _cancellationTokenSourcesDisposed;
 
     public string? Reason { get; private set; }
 
@@ -27,6 +29,12 @@ internal class EngineCancellationToken : IDisposable
     /// Gets the cancellation token from the underlying CancellationTokenSource.
     /// </summary>
     public CancellationToken Token => _token;
+
+    /// <summary>
+    /// Gets a token that is cancelled for user, console, and process-exit cancellation,
+    /// but not for pipeline failure cancellation.
+    /// </summary>
+    public CancellationToken NonFailureCancellationToken => _nonFailureCancellationToken;
 
     /// <summary>
     /// Gets a value indicating whether cancellation has been requested on the underlying token source.
@@ -56,6 +64,8 @@ internal class EngineCancellationToken : IDisposable
     public EngineCancellationToken(IPrimaryExceptionContainer primaryExceptionContainer)
     {
         _primaryExceptionContainer = primaryExceptionContainer;
+        _nonFailureCancellationToken = _nonFailureCancellationTokenSource.Token;
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(_nonFailureCancellationToken);
         _token = _cts.Token;
 
         System.Console.CancelKeyPress += OnCancelKeyPress;
@@ -66,7 +76,7 @@ internal class EngineCancellationToken : IDisposable
     {
         Reason = reason;
         _isCancelled = true;
-        Cancel();
+        Cancel(_nonFailureCancellationTokenSource);
     }
 
     public void CancelWithException(Exception exception, string? reason = null)
@@ -75,7 +85,7 @@ internal class EngineCancellationToken : IDisposable
 
         Reason = reason ?? exception.Message;
         _isCancelled = true;
-        Cancel();
+        Cancel(_cts);
     }
 
     public void RecordException(Exception exception)
@@ -86,7 +96,9 @@ internal class EngineCancellationToken : IDisposable
     /// <summary>
     /// Communicates a request for cancellation.
     /// </summary>
-    public void Cancel()
+    public void Cancel() => Cancel(_nonFailureCancellationTokenSource);
+
+    private void Cancel(CancellationTokenSource cancellationTokenSource)
     {
         if (!TryBeginCancellation())
         {
@@ -95,7 +107,7 @@ internal class EngineCancellationToken : IDisposable
 
         try
         {
-            _cts.Cancel();
+            cancellationTokenSource.Cancel();
         }
         finally
         {
@@ -111,7 +123,7 @@ internal class EngineCancellationToken : IDisposable
 
     protected virtual void Dispose(bool disposing)
     {
-        CancellationTokenSource? cancellationTokenSourceToDispose = null;
+        var disposeCancellationTokenSources = false;
 
         lock (_lifetimeLock)
         {
@@ -121,12 +133,12 @@ internal class EngineCancellationToken : IDisposable
             }
 
             _disposed = true;
-            _disposeCancellationTokenSource = disposing;
+            _disposeCancellationTokenSources = disposing;
 
             if (disposing && _activeCancellationOperations == 0)
             {
-                _ctsDisposed = true;
-                cancellationTokenSourceToDispose = _cts;
+                _cancellationTokenSourcesDisposed = true;
+                disposeCancellationTokenSources = true;
             }
         }
 
@@ -134,7 +146,10 @@ internal class EngineCancellationToken : IDisposable
         {
             System.Console.CancelKeyPress -= OnCancelKeyPress;
             AppDomain.CurrentDomain.ProcessExit -= OnProcessExit;
-            cancellationTokenSourceToDispose?.Dispose();
+            if (disposeCancellationTokenSources)
+            {
+                DisposeCancellationTokenSources();
+            }
         }
     }
 
@@ -165,7 +180,7 @@ internal class EngineCancellationToken : IDisposable
         try
         {
             _isCancelled = true;
-            _cts.Cancel();
+            _nonFailureCancellationTokenSource.Cancel();
             return true;
         }
         finally
@@ -190,22 +205,31 @@ internal class EngineCancellationToken : IDisposable
 
     private void EndCancellation()
     {
-        CancellationTokenSource? cancellationTokenSourceToDispose = null;
+        var disposeCancellationTokenSources = false;
 
         lock (_lifetimeLock)
         {
             _activeCancellationOperations--;
 
             if (_disposed
-                && _disposeCancellationTokenSource
-                && !_ctsDisposed
+                && _disposeCancellationTokenSources
+                && !_cancellationTokenSourcesDisposed
                 && _activeCancellationOperations == 0)
             {
-                _ctsDisposed = true;
-                cancellationTokenSourceToDispose = _cts;
+                _cancellationTokenSourcesDisposed = true;
+                disposeCancellationTokenSources = true;
             }
         }
 
-        cancellationTokenSourceToDispose?.Dispose();
+        if (disposeCancellationTokenSources)
+        {
+            DisposeCancellationTokenSources();
+        }
+    }
+
+    private void DisposeCancellationTokenSources()
+    {
+        _cts.Dispose();
+        _nonFailureCancellationTokenSource.Dispose();
     }
 }

--- a/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
+++ b/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
@@ -146,7 +146,14 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
         }
 
         // Step 2: Always print summary (exactly once)
-        summary = await PrintSummary(allModules, stopWatch, start, summary, caughtException).ConfigureAwait(false);
+        summary = await PrintSummary(
+                allModules,
+                stopWatch,
+                start,
+                summary,
+                caughtException,
+                GetRunReportCancellationToken())
+            .ConfigureAwait(false);
 
         // Step 3: Handle exceptions - rethrow original if present, otherwise check for pipeline failure
         if (caughtException != null)
@@ -175,7 +182,8 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
         Stopwatch stopWatch,
         DateTimeOffset start,
         PipelineSummary? existingSummary,
-        Exception? pipelineException)
+        Exception? pipelineException,
+        CancellationToken cancellationToken)
     {
         var end = DateTimeOffset.UtcNow;
         var totalDuration = stopWatch.Elapsed;
@@ -197,7 +205,8 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
         {
             RunReport = await _runReportService.CompleteAsync(
                     summary,
-                    GetPipelineReportException(summary, pipelineException))
+                    GetPipelineReportException(summary, pipelineException),
+                    cancellationToken)
                 .ConfigureAwait(false),
             StatusOverride = pipelineException is null ? summary.StatusOverride : Status.Failed,
         };
@@ -223,6 +232,11 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
 
         return summary;
     }
+
+    private CancellationToken GetRunReportCancellationToken() =>
+        _engineCancellationToken.OriginalException is null
+            ? _engineCancellationToken.Token
+            : CancellationToken.None;
 
     private static Exception? GetPipelineReportException(
         PipelineSummary summary,

--- a/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
+++ b/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
@@ -152,7 +152,7 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
                 start,
                 summary,
                 caughtException,
-                GetRunReportCancellationToken())
+                _engineCancellationToken.NonFailureCancellationToken)
             .ConfigureAwait(false);
 
         // Step 3: Handle exceptions - rethrow original if present, otherwise check for pipeline failure
@@ -232,11 +232,6 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
 
         return summary;
     }
-
-    private CancellationToken GetRunReportCancellationToken() =>
-        _engineCancellationToken.OriginalException is null
-            ? _engineCancellationToken.Token
-            : CancellationToken.None;
 
     private static Exception? GetPipelineReportException(
         PipelineSummary summary,

--- a/src/ModularPipelines/Engine/IRunReportService.cs
+++ b/src/ModularPipelines/Engine/IRunReportService.cs
@@ -6,5 +6,6 @@ internal interface IRunReportService
 {
     Task<PipelineRunReport> CompleteAsync(
         PipelineSummary summary,
-        Exception? pipelineException = null);
+        Exception? pipelineException = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -33,42 +33,56 @@ internal sealed class RunReportService(
 
     public async Task<PipelineRunReport> CompleteAsync(
         PipelineSummary summary,
-        Exception? pipelineException = null)
+        Exception? pipelineException = null,
+        CancellationToken cancellationToken = default)
     {
         var isDistributedWorker = IsDistributedWorker();
-        await SynchronizeDistributedMetricsAsync(isDistributedWorker, summary)
+        await SynchronizeDistributedMetricsAsync(isDistributedWorker, summary, cancellationToken)
             .ConfigureAwait(false);
 
         var reportPath = isDistributedWorker ? null : GetReportPath();
         var pipelineIdentity = GetPipelineIdentity(summary, reportPath);
         var historyEnabled = !isDistributedWorker
             && pipelineOptions.Value.RunReport.HistoryRetention > 0;
-        var previousReport = await LoadPreviousReportAsync(historyEnabled, pipelineIdentity)
+        var previousReport = await LoadPreviousReportAsync(
+                historyEnabled,
+                pipelineIdentity,
+                cancellationToken)
             .ConfigureAwait(false);
         var report = CreateReport(summary, previousReport, pipelineIdentity, pipelineException);
 
-        await WriteReportAsync(reportPath, report).ConfigureAwait(false);
-        await SaveHistoryAsync(historyEnabled, report).ConfigureAwait(false);
+        if (!cancellationToken.IsCancellationRequested)
+        {
+            await WriteReportAsync(reportPath, report, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!cancellationToken.IsCancellationRequested)
+        {
+            await SaveHistoryAsync(historyEnabled, report, cancellationToken).ConfigureAwait(false);
+        }
+
         return report;
     }
 
     private async Task SynchronizeDistributedMetricsAsync(
         bool isDistributedWorker,
-        PipelineSummary summary)
+        PipelineSummary summary,
+        CancellationToken cancellationToken)
     {
         if (isDistributedWorker)
         {
-            await PublishWorkerMetricsAsync().ConfigureAwait(false);
+            await PublishWorkerMetricsAsync(cancellationToken).ConfigureAwait(false);
         }
         else if (IsDistributedMaster())
         {
-            await AggregateWorkerMetricsAsync(summary).ConfigureAwait(false);
+            await AggregateWorkerMetricsAsync(summary, cancellationToken).ConfigureAwait(false);
         }
     }
 
     private async Task<PipelineRunReport?> LoadPreviousReportAsync(
         bool historyEnabled,
-        string pipelineIdentity)
+        string pipelineIdentity,
+        CancellationToken cancellationToken)
     {
         if (!historyEnabled)
         {
@@ -77,10 +91,16 @@ internal sealed class RunReportService(
 
         try
         {
-            using var timeout = new CancellationTokenSource(_historyStoreTimeout);
+            using var timeout = CreatePhaseCancellationTokenSource(
+                _historyStoreTimeout,
+                cancellationToken);
             return await historyStore.GetLatestAsync(pipelineIdentity, timeout.Token)
                 .WaitAsync(timeout.Token)
                 .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return null;
         }
         catch (Exception exception)
         {
@@ -140,7 +160,10 @@ internal sealed class RunReportService(
             };
     }
 
-    private async Task WriteReportAsync(string? reportPath, PipelineRunReport report)
+    private async Task WriteReportAsync(
+        string? reportPath,
+        PipelineRunReport report,
+        CancellationToken cancellationToken)
     {
         if (reportPath is null)
         {
@@ -151,12 +174,18 @@ internal sealed class RunReportService(
         {
             var fullPath = Path.GetFullPath(reportPath);
             Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
-            using var timeout = new CancellationTokenSource(ReportWriteTimeout);
+            using var timeout = CreatePhaseCancellationTokenSource(
+                ReportWriteTimeout,
+                cancellationToken);
             await File.WriteAllTextAsync(
                     fullPath,
                     RunReportJsonSerializer.Serialize(report),
                     timeout.Token)
                 .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // User cancellation intentionally skips persistence.
         }
         catch (Exception exception)
         {
@@ -164,7 +193,10 @@ internal sealed class RunReportService(
         }
     }
 
-    private async Task SaveHistoryAsync(bool historyEnabled, PipelineRunReport report)
+    private async Task SaveHistoryAsync(
+        bool historyEnabled,
+        PipelineRunReport report,
+        CancellationToken cancellationToken)
     {
         if (!historyEnabled)
         {
@@ -173,10 +205,16 @@ internal sealed class RunReportService(
 
         try
         {
-            using var timeout = new CancellationTokenSource(_historyStoreTimeout);
+            using var timeout = CreatePhaseCancellationTokenSource(
+                _historyStoreTimeout,
+                cancellationToken);
             await historyStore.SaveAsync(report, timeout.Token)
                 .WaitAsync(timeout.Token)
                 .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // User cancellation intentionally skips persistence.
         }
         catch (Exception exception)
         {
@@ -213,7 +251,7 @@ internal sealed class RunReportService(
                && roleDetector.DetectRole() == DistributedRole.Master;
     }
 
-    private async Task PublishWorkerMetricsAsync()
+    private async Task PublishWorkerMetricsAsync(CancellationToken cancellationToken)
     {
         var options = distributedOptions.Value;
         var capabilities = new HashSet<string>(options.Capabilities, StringComparer.OrdinalIgnoreCase);
@@ -224,7 +262,9 @@ internal sealed class RunReportService(
 
         try
         {
-            using var timeout = new CancellationTokenSource(_workerMetricsTimeout);
+            using var timeout = CreatePhaseCancellationTokenSource(
+                _workerMetricsTimeout,
+                cancellationToken);
             await distributedCoordinator.RegisterWorkerAsync(
                     new WorkerRegistration(
                         options.InstanceIndex,
@@ -246,15 +286,23 @@ internal sealed class RunReportService(
                 .WaitAsync(timeout.Token)
                 .ConfigureAwait(false);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // User cancellation intentionally skips final worker publication.
+        }
         catch (Exception exception)
         {
             logger.LogWarning(exception, "Could not publish distributed worker command metrics");
         }
     }
 
-    private async Task AggregateWorkerMetricsAsync(PipelineSummary summary)
+    private async Task AggregateWorkerMetricsAsync(
+        PipelineSummary summary,
+        CancellationToken cancellationToken)
     {
-        using var timeout = new CancellationTokenSource(_workerMetricsTimeout);
+        using var timeout = CreatePhaseCancellationTokenSource(
+            _workerMetricsTimeout,
+            cancellationToken);
         try
         {
             var options = distributedOptions.Value;
@@ -263,6 +311,11 @@ internal sealed class RunReportService(
                     options.ExecutionIdentifier,
                     timeout.Token)
                 .ConfigureAwait(false);
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
             if (!waitResult.Completed)
             {
                 logger.LogWarning("Timed out waiting for distributed worker command metrics");
@@ -468,6 +521,15 @@ internal sealed class RunReportService(
             worker.ExecutionIdentifier,
             executionIdentifier,
             StringComparison.Ordinal);
+
+    private static CancellationTokenSource CreatePhaseCancellationTokenSource(
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cancellationTokenSource.CancelAfter(timeout);
+        return cancellationTokenSource;
+    }
 
     private string GetPipelineIdentity(PipelineSummary summary, string? reportPath)
     {

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -89,24 +89,12 @@ internal sealed class RunReportService(
             return null;
         }
 
-        try
-        {
-            using var timeout = CreatePhaseCancellationTokenSource(
+        return await RunTimedPhaseWithResultAsync(
+                token => historyStore.GetLatestAsync(pipelineIdentity, token),
                 _historyStoreTimeout,
-                cancellationToken);
-            return await historyStore.GetLatestAsync(pipelineIdentity, timeout.Token)
-                .WaitAsync(timeout.Token)
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            return null;
-        }
-        catch (Exception exception)
-        {
-            logger.LogWarning(exception, "Could not load previous pipeline run report");
-            return null;
-        }
+                cancellationToken,
+                exception => logger.LogWarning(exception, "Could not load previous pipeline run report"))
+            .ConfigureAwait(false);
     }
 
     private PipelineRunReport CreateReport(
@@ -170,27 +158,24 @@ internal sealed class RunReportService(
             return;
         }
 
-        try
-        {
-            var fullPath = Path.GetFullPath(reportPath);
-            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
-            using var timeout = CreatePhaseCancellationTokenSource(
+        await RunTimedPhaseAsync(
+                async token =>
+                {
+                    var fullPath = Path.GetFullPath(reportPath);
+                    Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+                    await AtomicFileWriter.WriteAllTextAsync(
+                            fullPath,
+                            RunReportJsonSerializer.Serialize(report),
+                            token)
+                        .ConfigureAwait(false);
+                },
                 ReportWriteTimeout,
-                cancellationToken);
-            await AtomicFileWriter.WriteAllTextAsync(
-                    fullPath,
-                    RunReportJsonSerializer.Serialize(report),
-                    timeout.Token)
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            // User cancellation intentionally skips persistence.
-        }
-        catch (Exception exception)
-        {
-            logger.LogWarning(exception, "Could not write pipeline run report to {RunReportPath}", reportPath);
-        }
+                cancellationToken,
+                exception => logger.LogWarning(
+                    exception,
+                    "Could not write pipeline run report to {RunReportPath}",
+                    reportPath))
+            .ConfigureAwait(false);
     }
 
     private async Task SaveHistoryAsync(
@@ -203,23 +188,12 @@ internal sealed class RunReportService(
             return;
         }
 
-        try
-        {
-            using var timeout = CreatePhaseCancellationTokenSource(
+        await RunTimedPhaseAsync(
+                token => historyStore.SaveAsync(report, token),
                 _historyStoreTimeout,
-                cancellationToken);
-            await historyStore.SaveAsync(report, timeout.Token)
-                .WaitAsync(timeout.Token)
-                .ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            // User cancellation intentionally skips persistence.
-        }
-        catch (Exception exception)
-        {
-            logger.LogWarning(exception, "Could not save pipeline run history");
-        }
+                cancellationToken,
+                exception => logger.LogWarning(exception, "Could not save pipeline run history"))
+            .ConfigureAwait(false);
     }
 
     internal string? GetReportPath()
@@ -260,39 +234,73 @@ internal sealed class RunReportService(
             capabilities.UnionWith(OsCapabilityDetector.Detect());
         }
 
+        await RunTimedPhaseAsync(
+                async token =>
+                {
+                    await distributedCoordinator.RegisterWorkerAsync(
+                            new WorkerRegistration(
+                                options.InstanceIndex,
+                                capabilities,
+                                DateTimeOffset.UtcNow)
+                            {
+                                ExecutionIdentifier = options.ExecutionIdentifier,
+                                UnattributedCommandCount = commandExecutionCounter.UnattributedCount,
+                                ModuleCommandCounts = commandExecutionCounter.GetModuleCounts()
+                                    .GroupBy(
+                                        static count => ModuleTypeIdentifier.Get(count.Key),
+                                        StringComparer.Ordinal)
+                                    .ToDictionary(
+                                        static group => group.Key,
+                                        static group => group.Sum(count => count.Value),
+                                        StringComparer.Ordinal),
+                            },
+                            token)
+                        .ConfigureAwait(false);
+                },
+                _workerMetricsTimeout,
+                cancellationToken,
+                exception => logger.LogWarning(
+                    exception,
+                    "Could not publish distributed worker command metrics"))
+            .ConfigureAwait(false);
+    }
+
+    private Task RunTimedPhaseAsync(
+        Func<CancellationToken, Task> phase,
+        TimeSpan timeout,
+        CancellationToken cancellationToken,
+        Action<Exception> logWarning) =>
+        RunTimedPhaseWithResultAsync<object?>(
+            async token =>
+            {
+                await phase(token).ConfigureAwait(false);
+                return null;
+            },
+            timeout,
+            cancellationToken,
+            logWarning);
+
+    private async Task<T?> RunTimedPhaseWithResultAsync<T>(
+        Func<CancellationToken, Task<T>> phase,
+        TimeSpan timeout,
+        CancellationToken cancellationToken,
+        Action<Exception> logWarning)
+    {
         try
         {
-            using var timeout = CreatePhaseCancellationTokenSource(
-                _workerMetricsTimeout,
-                cancellationToken);
-            await distributedCoordinator.RegisterWorkerAsync(
-                    new WorkerRegistration(
-                        options.InstanceIndex,
-                        capabilities,
-                        DateTimeOffset.UtcNow)
-                    {
-                        ExecutionIdentifier = options.ExecutionIdentifier,
-                        UnattributedCommandCount = commandExecutionCounter.UnattributedCount,
-                        ModuleCommandCounts = commandExecutionCounter.GetModuleCounts()
-                            .GroupBy(
-                                static count => ModuleTypeIdentifier.Get(count.Key),
-                                StringComparer.Ordinal)
-                            .ToDictionary(
-                                static group => group.Key,
-                                static group => group.Sum(count => count.Value),
-                                StringComparer.Ordinal),
-                    },
-                    timeout.Token)
-                .WaitAsync(timeout.Token)
+            using var timeoutSource = CreatePhaseCancellationTokenSource(timeout, cancellationToken);
+            return await phase(timeoutSource.Token)
+                .WaitAsync(timeoutSource.Token)
                 .ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            // User cancellation intentionally skips final worker publication.
+            return default;
         }
         catch (Exception exception)
         {
-            logger.LogWarning(exception, "Could not publish distributed worker command metrics");
+            logWarning(exception);
+            return default;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
@@ -54,6 +54,16 @@ public class ExecutionOrchestratorTests
             .Setup(x => x.DisposeAsync())
             .Returns(ValueTask.CompletedTask);
 
+        var runReportCancellationToken = CancellationToken.None;
+        var runReportService = new Mock<IRunReportService>();
+        runReportService.Setup(x => x.CompleteAsync(
+                It.IsAny<PipelineSummary>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<PipelineSummary, Exception?, CancellationToken>((_, _, token) =>
+                runReportCancellationToken = token)
+            .ReturnsAsync(new PipelineRunReport());
+
         using var engineCancellationToken =
             new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
         var orchestrator = new ExecutionOrchestrator(
@@ -69,13 +79,18 @@ public class ExecutionOrchestratorTests
             Mock.Of<IExceptionRethrowService>(),
             OptionsFactory.Create(new PipelineOptions()),
             Mock.Of<ILogger<ExecutionOrchestrator>>(),
-            CreateRunReportService());
+            runReportService.Object);
         using var callerCancellationTokenSource = new CancellationTokenSource();
 
         await orchestrator.ExecuteAsync(callerCancellationTokenSource.Token);
         callerCancellationTokenSource.Cancel();
 
-        await Assert.That(engineCancellationToken.IsCancellationRequested).IsFalse();
+        using (Assert.Multiple())
+        {
+            await Assert.That(engineCancellationToken.IsCancellationRequested).IsFalse();
+            await Assert.That(runReportCancellationToken.CanBeCanceled).IsTrue();
+            await Assert.That(runReportCancellationToken.IsCancellationRequested).IsFalse();
+        }
     }
 
     [Test]
@@ -217,7 +232,10 @@ public class ExecutionOrchestratorTests
             .Returns(summary);
         var runReportService = new Mock<IRunReportService>();
         runReportService
-            .Setup(x => x.CompleteAsync(summary, initializationException))
+            .Setup(x => x.CompleteAsync(
+                summary,
+                initializationException,
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PipelineRunReport { Status = Status.Failed });
         var outputCoordinator = new Mock<IPipelineOutputCoordinator>();
         using var engineCancellationToken =
@@ -242,7 +260,10 @@ public class ExecutionOrchestratorTests
 
         await Assert.That(exception).IsSameReferenceAs(initializationException);
         runReportService.Verify(
-            x => x.CompleteAsync(summary, initializationException),
+            x => x.CompleteAsync(
+                summary,
+                initializationException,
+                It.IsAny<CancellationToken>()),
             Times.Once);
         pipelineSummaryFactory.Verify(x => x.Create(
             It.Is<IReadOnlyList<IModule>>(modules => modules.Count == 1 && ReferenceEquals(modules[0], module)),
@@ -258,7 +279,8 @@ public class ExecutionOrchestratorTests
         var service = new Mock<IRunReportService>();
         service.Setup(x => x.CompleteAsync(
                 It.IsAny<PipelineSummary>(),
-                It.IsAny<Exception?>()))
+                It.IsAny<Exception?>(),
+                It.IsAny<CancellationToken>()))
             .ReturnsAsync(new PipelineRunReport());
         return service.Object;
     }

--- a/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
@@ -14,7 +14,10 @@ namespace ModularPipelines.UnitTests.Engine;
 public class ExecutionOrchestratorTests
 {
     [Test]
-    public async Task CallerCancellationRegistration_IsDisposedAfterExecution()
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task CallerCancellationToken_IsPassedToRunReport_AndRegistrationIsDisposed(
+        bool hasRecordedFailure)
     {
         var organizedModules = new OrganizedModules([], []);
         var summary = new PipelineSummary(
@@ -66,6 +69,11 @@ public class ExecutionOrchestratorTests
 
         using var engineCancellationToken =
             new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+        if (hasRecordedFailure)
+        {
+            engineCancellationToken.RecordException(new InvalidOperationException("module failed"));
+        }
+
         var orchestrator = new ExecutionOrchestrator(
             pipelineInitializer.Object,
             moduleDisposeExecutor.Object,

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1284,6 +1284,71 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task CancellationInterruptsHistoryLoadAndSkipsPersistence()
+    {
+        var directory = CreateTemporaryDirectory();
+        var reportPath = Path.Combine(directory, "run-report.json");
+        var readStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var readCompletion = new TaskCompletionSource<PipelineRunReport?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var historyStore = new Mock<IRunHistoryStore>();
+        historyStore.Setup(store => store.GetLatestAsync(
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((_, _) => readStarted.TrySetResult())
+            .Returns(readCompletion.Task);
+        var distributedOptions = OptionsFactory.Create(new DistributedOptions());
+        var commandExecutionCounter = new CommandExecutionCounter();
+        var service = new RunReportService(
+            historyStore.Object,
+            new PipelineRunReportFactory(
+                commandExecutionCounter,
+                new PassthroughSecretObfuscator()),
+            Mock.Of<IBuildSystemDetector>(),
+            OptionsFactory.Create(new PipelineOptions
+            {
+                RunReport = new RunReportOptions
+                {
+                    ReportPath = reportPath,
+                    HistoryRetention = 1,
+                },
+            }),
+            distributedOptions,
+            new RoleDetector(distributedOptions),
+            Mock.Of<IDistributedCoordinator>(),
+            commandExecutionCounter,
+            NullLogger<RunReportService>.Instance,
+            historyStoreTimeout: TimeSpan.FromMinutes(1));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        try
+        {
+            var completion = service.CompleteAsync(
+                CreateEmptySummary(),
+                cancellationToken: cancellationTokenSource.Token);
+            await readStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+            cancellationTokenSource.Cancel();
+            var report = await completion.WaitAsync(TimeSpan.FromSeconds(2));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(report).IsNotNull();
+                await Assert.That(File.Exists(reportPath)).IsFalse();
+                historyStore.Verify(store => store.SaveAsync(
+                    It.IsAny<PipelineRunReport>(),
+                    It.IsAny<CancellationToken>()), Times.Never);
+            }
+        }
+        finally
+        {
+            readCompletion.TrySetResult(null);
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task DistributedWorkerMetricsTimeoutWhenCoordinatorIgnoresCancellation()
     {
         var coordinator = new Mock<IDistributedCoordinator>();

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -272,6 +272,33 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
+    public async Task FailureCancellation_DoesNotCancelNonFailureToken()
+    {
+        using var engineCancellationToken =
+            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+
+        engineCancellationToken.CancelWithException(new InvalidOperationException("module failed"));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(engineCancellationToken.Token.IsCancellationRequested).IsTrue();
+            await Assert.That(engineCancellationToken.NonFailureCancellationToken.IsCancellationRequested).IsFalse();
+        }
+    }
+
+    [Test]
+    public async Task UserCancellationAfterFailure_CancelsNonFailureToken()
+    {
+        using var engineCancellationToken =
+            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+        engineCancellationToken.CancelWithException(new InvalidOperationException("module failed"));
+
+        engineCancellationToken.CancelWithReason("user cancelled");
+
+        await Assert.That(engineCancellationToken.NonFailureCancellationToken.IsCancellationRequested).IsTrue();
+    }
+
+    [Test]
     public async Task Cancel_And_Dispose_Can_Run_Concurrently()
     {
         for (var iteration = 0; iteration < 1_000; iteration++)


### PR DESCRIPTION
Closes #3742

## Summary
- thread engine shutdown cancellation through run-report completion
- link caller cancellation with each existing phase timeout
- return the in-memory report while skipping report/history persistence after cancellation
- keep failure-triggered engine cancellation from suppressing failed-run history

## Validation
- `RunReportTests`: 48 passed
- `ExecutionOrchestratorTests`: 4 passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors