### PR TITLE
Remove dead Retried module status

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -847,7 +847,6 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             Status.PipelineTerminated => LogLevel.Error,
             Status.UsedHistory => LogLevel.Information,
             Status.CachedResult => LogLevel.Information,
-            Status.Retried => LogLevel.Warning,
             _ => LogLevel.Error,
         };
 

--- a/src/ModularPipelines/Enums/Status.cs
+++ b/src/ModularPipelines/Enums/Status.cs
@@ -54,17 +54,12 @@ public enum Status
     Skipped,
 
     /// <summary>
-    /// The module was retried.
-    /// </summary>
-    Retried,
-
-    /// <summary>
     /// Unknown module status.
     /// </summary>
-    Unknown,
+    Unknown = 10,
 
     /// <summary>
     /// The module result was restored from the fingerprint cache.
     /// </summary>
-    CachedResult,
+    CachedResult = 11,
 }

--- a/src/ModularPipelines/Helpers/MarkupFormatter.cs
+++ b/src/ModularPipelines/Helpers/MarkupFormatter.cs
@@ -36,7 +36,6 @@ internal static class MarkupFormatter
     public const string SkipIcon = "[yellow]⊘[/]";
     public const string TimeoutIcon = "[red]⏱[/]";
     public const string StopIcon = "[red]⏹[/]";
-    public const string RetryIcon = "[yellow]↻[/]";
     public const string HistoryIcon = "[green3]↻[/]";
     public const string QuestionIcon = "[red]?[/]";
     public const string PlayIcon = "[bold cyan]▶[/]";

--- a/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
+++ b/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
@@ -289,7 +289,6 @@ internal class SpectreResultsPrinter : IResultsPrinter
             ModuleStatus.Skipped => "[dim]⏭ skipped[/]",
             ModuleStatus.UsedHistory => "[green3]History[/]",
             ModuleStatus.CachedResult => "[green3]Cached[/]",
-            ModuleStatus.Retried => "[yellow]Retried[/]",
             ModuleStatus.Processing => "[blue]Running[/]",
             ModuleStatus.NotYetStarted => "[dim]Pending[/]",
             ModuleStatus.Unknown => "[dim]Unknown[/]",

--- a/src/ModularPipelines/Helpers/StatusDisplayProvider.cs
+++ b/src/ModularPipelines/Helpers/StatusDisplayProvider.cs
@@ -39,7 +39,6 @@ internal static class StatusDisplayProvider
         [Status.PipelineTerminated] = new(MarkupFormatter.StopIcon, "Module {0} terminated due to pipeline error"),
         [Status.UsedHistory] = new(MarkupFormatter.HistoryIcon, "Module {0} used historical data"),
         [Status.CachedResult] = new(MarkupFormatter.HistoryIcon, "Module {0} used a cached result"),
-        [Status.Retried] = new(MarkupFormatter.RetryIcon, "Module {0} retried"),
     };
 
     /// <summary>

--- a/src/ModularPipelines/Helpers/StatusFormatter.cs
+++ b/src/ModularPipelines/Helpers/StatusFormatter.cs
@@ -19,7 +19,6 @@ internal static class StatusFormatter
             Status.TimedOut => "[red]Timed Out[/]",
             Status.Skipped => "[yellow]Skipped[/]",
             Status.Unknown => "[yellow]Unknown[/]",
-            Status.Retried => "[yellow]Retried[/]",
             Status.UsedHistory => "[green3]Used History[/]",
             Status.CachedResult => "[green3]Cached Result[/]",
             _ => throw new ArgumentOutOfRangeException(nameof(status), status, null),

--- a/test/ModularPipelines.UnitTests/Compatibility/StatusCompatibilityTests.cs
+++ b/test/ModularPipelines.UnitTests/Compatibility/StatusCompatibilityTests.cs
@@ -14,11 +14,16 @@ public class StatusCompatibilityTests
     [Arguments(Status.PipelineTerminated, 6)]
     [Arguments(Status.TimedOut, 7)]
     [Arguments(Status.Skipped, 8)]
-    [Arguments(Status.Retried, 9)]
     [Arguments(Status.Unknown, 10)]
     [Arguments(Status.CachedResult, 11)]
     public async Task NumericValuesRemainStable(Status status, int expectedValue)
     {
         await Assert.That((int)status).IsEqualTo(expectedValue);
+    }
+
+    [Test]
+    public async Task RemovedRetriedValueRemainsUnassigned()
+    {
+        await Assert.That(Enum.IsDefined(typeof(Status), 9)).IsFalse();
     }
 }


### PR DESCRIPTION
## Summary
- remove the unreachable public `Status.Retried` enum member and its display branches
- retain the numeric values of later enum members for serialized-data compatibility
- cover the deliberately unassigned legacy numeric value

## Validation
- `StatusCompatibilityTests`: 12 passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors

Closes #3788