### PR TITLE
Add size-capped module output to run reports

### DIFF
--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -190,7 +190,9 @@ builder.AddRunHistoryStore<MyRunHistoryStore>();
 ```
 
 The store returns matching reports newest-first and saves the completed current report. Custom
-stores own their retention behavior.
+stores own their retention behavior. Module output excerpts are omitted from reports passed to a
+custom store because user persistence code can register secrets while saving; the built-in file
+store retains the already-masked excerpts.
 
 In v4, custom stores implement `GetRunsAsync(RunHistoryQuery, CancellationToken)`. The former
 `GetLatestAsync` interface member is now an extension method, so stores need only implement the

--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -38,13 +38,14 @@ The current schema version is available as `PipelineRunReport.CurrentSchemaVersi
 report is also exposed through `PipelineSummary.RunReport`.
 After a successful write, an information log records the report's resolved path.
 
-Each schema-v3 report has a unique `RunId`, `RunCorrelation` metadata for the machine and detected
+Each report has a unique `RunId`, `RunCorrelation` metadata for the machine and detected
 build system, and the previous run's finish time when it supplies a duration-delta baseline.
 Registering the Git or GitHub integration also adds the available commit, branch, and CI run URL.
 Correlation strings pass through secret obfuscation before persistence.
 
 ## Include module output excerpts
 
+Schema v4 adds the optional per-module `Output` excerpt.
 Module output is excluded by default. Opt in when reports need enough output to diagnose recent
 failures without opening the full CI log:
 

--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -43,6 +43,27 @@ build system, and the previous run's finish time when it supplies a duration-del
 Registering the Git or GitHub integration also adds the available commit, branch, and CI run URL.
 Correlation strings pass through secret obfuscation before persistence.
 
+## Include module output excerpts
+
+Module output is excluded by default. Opt in when reports need enough output to diagnose recent
+failures without opening the full CI log:
+
+```csharp
+builder.ConfigurePipelineOptions(options => options with
+{
+    RunReport = options.RunReport with
+    {
+        IncludeModuleOutput = true,
+        MaxOutputBytesPerModule = 8 * 1024,
+    },
+});
+```
+
+Each module gets one shared UTF-8 byte budget across its `stdoutTail` and `stderrTail`; the newest
+output wins when the limit is reached. Console error and command-error output is retained in
+`stderrTail`, while console output and other module logs are retained in `stdoutTail`. Excerpts are
+taken only from secret-masked module buffers and are masked again when the report is created.
+
 When report writing is enabled, add application-specific metadata through a bounded
 `IRunReportEnricher`:
 

--- a/src/ModularPipelines.Testing/ModuleTester.cs
+++ b/src/ModularPipelines.Testing/ModuleTester.cs
@@ -187,6 +187,7 @@ public class ModuleTestBuilder<TModule>
         builder.Services.AddSingleton(recorder);
         builder.Services.AddSingleton<ICommandInterceptor>(recorder);
         builder.Services.AddSingleton<IConsoleCoordinator>(NoOpConsoleServices.Instance);
+        builder.Services.AddSingleton<IModuleOutputExcerptProvider>(NoOpConsoleServices.Instance);
         builder.Services.AddSingleton<IOutputCoordinator>(NoOpConsoleServices.Instance);
         builder.Services.AddSingleton<IProgressDisplay>(NoOpConsoleServices.Instance);
         builder.AddModule<TModule>();

--- a/src/ModularPipelines.Testing/NoOpConsoleServices.cs
+++ b/src/ModularPipelines.Testing/NoOpConsoleServices.cs
@@ -29,6 +29,8 @@ internal sealed class NoOpConsoleServices :
 
     public IModuleOutputBuffer GetModuleBuffer(Type moduleType) => Buffer;
 
+    public ModuleOutputExcerpt? GetModuleOutputExcerpt(Type moduleType) => null;
+
     public IModuleOutputBuffer GetUnattributedBuffer() => Buffer;
 
     public Task<IReadOnlyList<IModuleOutputBuffer>> FlushPendingWritesAsync() =>

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -41,6 +41,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
     private readonly ISecretProvider _secretProvider;
     private readonly IOptions<PipelineOptions> _options;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger? _outputExcerptLogger;
     private readonly IBuildSystemDetector _buildSystemDetector;
     private readonly IServiceProvider _serviceProvider;
     private readonly object _phaseLock = new();
@@ -81,6 +82,9 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         _secretProvider = secretProvider;
         _options = options;
         _loggerFactory = loggerFactory;
+        _outputExcerptLogger = _options.Value.RunReport.IncludeModuleOutput
+            ? _loggerFactory.CreateLogger<ModuleOutputExcerptBuffer>()
+            : null;
         _buildSystemDetector = buildSystemDetector;
         _serviceProvider = serviceProvider;
         _outputCoordinator = outputCoordinator;
@@ -312,7 +316,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                     : 0,
                 outputExcerptSecretObfuscator: _secretObfuscator,
                 outputExcerptSecretProvider: _secretProvider,
-                outputExcerptLogger: _loggerFactory.CreateLogger<ModuleOutputExcerptBuffer>()));
+                outputExcerptLogger: _outputExcerptLogger));
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -155,7 +155,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                     _originalConsoleError,
                     () => _isProgressActive,
                     _secretObfuscator,
-                    _secretProvider);
+                    _secretProvider,
+                    isError: true);
 
                 System.Console.SetOut(_coordinatedOut);
                 System.Console.SetError(_coordinatedError);
@@ -304,8 +305,17 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                 isSpectreEnabled: logLevel => _loggerControl.WouldRender(
                     OutputLoggerCategories.ForModule(t),
                     logLevel),
-                showFailureHeaderWithoutOutput: !_options.Value.Console.PrintResults));
+                showFailureHeaderWithoutOutput: !_options.Value.Console.PrintResults,
+                outputExcerptMaximumBytes: _options.Value.RunReport.IncludeModuleOutput
+                    ? _options.Value.RunReport.MaxOutputBytesPerModule
+                    : 0));
     }
+
+    /// <inheritdoc />
+    public ModuleOutputExcerpt? GetModuleOutputExcerpt(Type moduleType) =>
+        _moduleBuffers.TryGetValue(moduleType, out var buffer)
+            ? buffer.GetOutputExcerpt()
+            : null;
 
     /// <inheritdoc />
     public IModuleOutputBuffer GetUnattributedBuffer() => _unattributedBuffer;

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -308,7 +308,9 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                 showFailureHeaderWithoutOutput: !_options.Value.Console.PrintResults,
                 outputExcerptMaximumBytes: _options.Value.RunReport.IncludeModuleOutput
                     ? _options.Value.RunReport.MaxOutputBytesPerModule
-                    : 0));
+                    : 0,
+                outputExcerptSecretObfuscator: _secretObfuscator,
+                outputExcerptSecretProvider: _secretProvider));
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -299,6 +299,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         return _moduleBuffers.GetOrAdd(
             moduleType,
             t => new ModuleOutputBuffer(
+                t.Name,
                 t,
                 _options.Value.Console.ModuleOutputFlushThreshold,
                 RequestThresholdFlush,
@@ -310,7 +311,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                     ? _options.Value.RunReport.MaxOutputBytesPerModule
                     : 0,
                 outputExcerptSecretObfuscator: _secretObfuscator,
-                outputExcerptSecretProvider: _secretProvider));
+                outputExcerptSecretProvider: _secretProvider,
+                outputExcerptLogger: _loggerFactory.CreateLogger<ModuleOutputExcerptBuffer>()));
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -222,18 +222,29 @@ internal class CoordinatedTextWriter : TextWriter
     /// <summary>
     /// Routes a message to the appropriate buffer based on current module context.
     /// </summary>
-    private void RouteToBuffer(string message, Type? moduleType)
+    private void RouteToBuffer(string message, Type? moduleType, bool appendNewLine)
     {
         var buffer = moduleType is not null
             ? _coordinator.GetModuleBuffer(moduleType)
             : _coordinator.GetUnattributedBuffer();
         if (_isError)
         {
-            buffer.WriteErrorLine(message);
+            if (appendNewLine)
+            {
+                buffer.WriteErrorLine(message);
+            }
+            else
+            {
+                buffer.WriteError(message);
+            }
+        }
+        else if (appendNewLine)
+        {
+            buffer.WriteLine(message);
         }
         else
         {
-            buffer.WriteLine(message);
+            buffer.Write(message);
         }
     }
 
@@ -764,7 +775,8 @@ internal class CoordinatedTextWriter : TextWriter
         {
             RouteToBuffer(
                 ObfuscateCustomOutput(line, secretPatterns),
-                moduleType);
+                moduleType,
+                appendNewLine: true);
         }
         else
         {
@@ -800,7 +812,8 @@ internal class CoordinatedTextWriter : TextWriter
         {
             RouteToBuffer(
                 ObfuscateCustomOutput(pending, secretPatterns),
-                state.ModuleType);
+                state.ModuleType,
+                appendNewLine: false);
         }
         else
         {

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -134,18 +134,29 @@ internal class CoordinatedTextWriter : TextWriter
     /// <summary>
     /// Routes a message to the appropriate buffer based on current module context.
     /// </summary>
-    private void RouteToBuffer(string message, Type? moduleType)
+    private void RouteToBuffer(string message, Type? moduleType, bool appendNewLine)
     {
         var buffer = moduleType is not null
             ? _coordinator.GetModuleBuffer(moduleType)
             : _coordinator.GetUnattributedBuffer();
         if (_isError)
         {
-            buffer.WriteErrorLine(message);
+            if (appendNewLine)
+            {
+                buffer.WriteErrorLine(message);
+            }
+            else
+            {
+                buffer.WriteError(message);
+            }
+        }
+        else if (appendNewLine)
+        {
+            buffer.WriteLine(message);
         }
         else
         {
-            buffer.WriteLine(message);
+            buffer.Write(message);
         }
     }
 
@@ -407,7 +418,7 @@ internal class CoordinatedTextWriter : TextWriter
 
         if (shouldBuffer)
         {
-            RouteToBuffer(obfuscated, moduleType);
+            RouteToBuffer(obfuscated, moduleType, appendNewLine: true);
         }
         else
         {
@@ -433,7 +444,7 @@ internal class CoordinatedTextWriter : TextWriter
 
         if (shouldBuffer)
         {
-            RouteToBuffer(obfuscated, state.ModuleType);
+            RouteToBuffer(obfuscated, state.ModuleType, appendNewLine: false);
         }
         else
         {

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -35,6 +35,7 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly Func<bool> _shouldBuffer;
     private readonly ISecretObfuscator _secretObfuscator;
     private readonly ISecretProvider _secretProvider;
+    private readonly bool _isError;
     private readonly Dictionary<LineBufferKey, LineBufferState> _lineBuffers = [];
     private readonly object _lineBufferLock = new();
     private string[] _secretPatterns = [];
@@ -49,18 +50,21 @@ internal class CoordinatedTextWriter : TextWriter
     /// <param name="shouldBuffer">Function that returns whether output should be buffered.</param>
     /// <param name="secretObfuscator">Obfuscator for secrets in output.</param>
     /// <param name="secretProvider">Provider for registered secret patterns.</param>
+    /// <param name="isError">Whether this writer represents standard error.</param>
     public CoordinatedTextWriter(
         IConsoleCoordinator coordinator,
         TextWriter realConsole,
         Func<bool> shouldBuffer,
         ISecretObfuscator secretObfuscator,
-        ISecretProvider secretProvider)
+        ISecretProvider secretProvider,
+        bool isError = false)
     {
         _coordinator = coordinator;
         _realConsole = realConsole;
         _shouldBuffer = shouldBuffer;
         _secretObfuscator = secretObfuscator;
         _secretProvider = secretProvider;
+        _isError = isError;
     }
 
     /// <inheritdoc />
@@ -132,16 +136,16 @@ internal class CoordinatedTextWriter : TextWriter
     /// </summary>
     private void RouteToBuffer(string message, Type? moduleType)
     {
-        if (moduleType != null)
+        var buffer = moduleType is not null
+            ? _coordinator.GetModuleBuffer(moduleType)
+            : _coordinator.GetUnattributedBuffer();
+        if (_isError)
         {
-            // Inside a module - route to that module's buffer
-            var buffer = _coordinator.GetModuleBuffer(moduleType);
-            buffer.WriteLine(message);
+            buffer.WriteErrorLine(message);
         }
         else
         {
-            // Outside any module - route to unattributed buffer
-            _coordinator.GetUnattributedBuffer().WriteLine(message);
+            buffer.WriteLine(message);
         }
     }
 

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -43,6 +43,7 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly Func<bool> _shouldBuffer;
     private readonly ISecretObfuscator _secretObfuscator;
     private readonly ISecretProvider _secretProvider;
+    private readonly bool _isError;
     private readonly Dictionary<LineBufferKey, LineBufferState> _lineBuffers = [];
     private readonly ConditionalWeakTable<object, Dictionary<LineBufferKey, LineBufferState>>
         _scopedLineBuffers = [];
@@ -70,18 +71,21 @@ internal class CoordinatedTextWriter : TextWriter
     /// <param name="shouldBuffer">Function that returns whether output should be buffered.</param>
     /// <param name="secretObfuscator">Obfuscator for secrets in output.</param>
     /// <param name="secretProvider">Provider for registered secret patterns.</param>
+    /// <param name="isError">Whether this writer represents standard error.</param>
     public CoordinatedTextWriter(
         IConsoleCoordinator coordinator,
         TextWriter realConsole,
         Func<bool> shouldBuffer,
         ISecretObfuscator secretObfuscator,
-        ISecretProvider secretProvider)
+        ISecretProvider secretProvider,
+        bool isError = false)
     {
         _coordinator = coordinator;
         _realConsole = realConsole;
         _shouldBuffer = shouldBuffer;
         _secretObfuscator = secretObfuscator;
         _secretProvider = secretProvider;
+        _isError = isError;
     }
 
     /// <inheritdoc />
@@ -220,16 +224,16 @@ internal class CoordinatedTextWriter : TextWriter
     /// </summary>
     private void RouteToBuffer(string message, Type? moduleType)
     {
-        if (moduleType != null)
+        var buffer = moduleType is not null
+            ? _coordinator.GetModuleBuffer(moduleType)
+            : _coordinator.GetUnattributedBuffer();
+        if (_isError)
         {
-            // Inside a module - route to that module's buffer
-            var buffer = _coordinator.GetModuleBuffer(moduleType);
-            buffer.WriteLine(message);
+            buffer.WriteErrorLine(message);
         }
         else
         {
-            // Outside any module - route to unattributed buffer
-            _coordinator.GetUnattributedBuffer().WriteLine(message);
+            buffer.WriteLine(message);
         }
     }
 

--- a/src/ModularPipelines/Console/IConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/IConsoleCoordinator.cs
@@ -27,7 +27,7 @@ namespace ModularPipelines.Console;
 /// concurrently from multiple threads.
 /// </para>
 /// </remarks>
-internal interface IConsoleCoordinator : IAsyncDisposable
+internal interface IConsoleCoordinator : IModuleOutputExcerptProvider, IAsyncDisposable
 {
     /// <summary>
     /// Installs the coordinator, intercepting Console.Out/Error.

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -36,10 +36,20 @@ internal interface IModuleOutputBuffer
     void WriteLine(string message);
 
     /// <summary>
+    /// Adds plain string output without a trailing line terminator.
+    /// </summary>
+    void Write(string message) => WriteLine(message);
+
+    /// <summary>
     /// Adds a standard-error line to the buffer.
     /// </summary>
     /// <param name="message">The message to buffer.</param>
     void WriteErrorLine(string message) => WriteLine(message);
+
+    /// <summary>
+    /// Adds standard-error output without a trailing line terminator.
+    /// </summary>
+    void WriteError(string message) => WriteErrorLine(message);
 
     /// <summary>
     /// Gets the retained report excerpt, when excerpt capture is enabled and output exists.

--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -1,6 +1,7 @@
 using MEL.Spectre;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Console;
 
@@ -33,6 +34,17 @@ internal interface IModuleOutputBuffer
     /// </summary>
     /// <param name="message">The message to buffer.</param>
     void WriteLine(string message);
+
+    /// <summary>
+    /// Adds a standard-error line to the buffer.
+    /// </summary>
+    /// <param name="message">The message to buffer.</param>
+    void WriteErrorLine(string message) => WriteLine(message);
+
+    /// <summary>
+    /// Gets the retained report excerpt, when excerpt capture is enabled and output exists.
+    /// </summary>
+    ModuleOutputExcerpt? GetOutputExcerpt() => null;
 
     /// <summary>
     /// Buffers a build-system group command while preserving its position relative to section output.

--- a/src/ModularPipelines/Console/IModuleOutputExcerptProvider.cs
+++ b/src/ModularPipelines/Console/IModuleOutputExcerptProvider.cs
@@ -1,0 +1,8 @@
+using ModularPipelines.Models;
+
+namespace ModularPipelines.Console;
+
+internal interface IModuleOutputExcerptProvider
+{
+    ModuleOutputExcerpt? GetModuleOutputExcerpt(Type moduleType);
+}

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
+using ModularPipelines.Models;
 using Spectre.Console;
 
 namespace ModularPipelines.Console;
@@ -38,6 +39,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly Action<IModuleOutputBuffer>? _requestIncrementalFlush;
     private readonly bool _showFailureHeaderWithoutOutput;
     private readonly bool _showSuccessMarker;
+    private readonly ModuleOutputExcerptBuffer? _outputExcerptBuffer;
     private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = [];
     private Exception? _exception;
     private bool _isComplete;
@@ -59,13 +61,15 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="renderGateTimeout">Maximum time to wait for the Spectre logger render gate.</param>
     /// <param name="isSpectreEnabled">Determines whether Spectre would render a structured event level.</param>
     /// <param name="showFailureHeaderWithoutOutput">Whether a failed empty buffer renders a failure header.</param>
+    /// <param name="outputExcerptMaximumBytes">Maximum retained UTF-8 bytes for report output, or zero to disable capture.</param>
     public ModuleOutputBuffer(
         Type moduleType,
         int outputFlushThreshold = 0,
         Action<IModuleOutputBuffer>? requestIncrementalFlush = null,
         TimeSpan? renderGateTimeout = null,
         Func<LogLevel, bool>? isSpectreEnabled = null,
-        bool showFailureHeaderWithoutOutput = false)
+        bool showFailureHeaderWithoutOutput = false,
+        int outputExcerptMaximumBytes = 0)
         : this(
             moduleType.Name,
             moduleType,
@@ -73,7 +77,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             requestIncrementalFlush,
             renderGateTimeout,
             isSpectreEnabled,
-            showFailureHeaderWithoutOutput)
+            showFailureHeaderWithoutOutput,
+            outputExcerptMaximumBytes: outputExcerptMaximumBytes)
     {
     }
 
@@ -89,6 +94,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="isSpectreEnabled">Determines whether Spectre would render a structured event level.</param>
     /// <param name="showFailureHeaderWithoutOutput">Whether a failed empty buffer renders a failure header.</param>
     /// <param name="showSuccessMarker">Whether successful output groups include a success marker.</param>
+    /// <param name="outputExcerptMaximumBytes">Maximum retained UTF-8 bytes for report output, or zero to disable capture.</param>
     internal ModuleOutputBuffer(
         string name,
         Type moduleType,
@@ -97,7 +103,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         TimeSpan? renderGateTimeout = null,
         Func<LogLevel, bool>? isSpectreEnabled = null,
         bool showFailureHeaderWithoutOutput = false,
-        bool showSuccessMarker = true)
+        bool showSuccessMarker = true,
+        int outputExcerptMaximumBytes = 0)
     {
         ModuleType = moduleType;
         _moduleName = name;
@@ -108,12 +115,25 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         _isSpectreEnabled = isSpectreEnabled ?? (static _ => true);
         _showFailureHeaderWithoutOutput = showFailureHeaderWithoutOutput;
         _showSuccessMarker = showSuccessMarker;
+        _outputExcerptBuffer = outputExcerptMaximumBytes > 0
+            ? new ModuleOutputExcerptBuffer(outputExcerptMaximumBytes)
+            : null;
     }
 
     /// <inheritdoc />
     public void WriteLine(string message)
     {
-        AddOutput(BufferedOutput.FromString(message), allowAfterCompletion: true);
+        AddOutput(
+            BufferedOutput.FromString(message, ModuleOutputStream.StandardOutput),
+            allowAfterCompletion: true);
+    }
+
+    /// <inheritdoc />
+    public void WriteErrorLine(string message)
+    {
+        AddOutput(
+            BufferedOutput.FromString(message, ModuleOutputStream.StandardError),
+            allowAfterCompletion: true);
     }
 
     /// <inheritdoc />
@@ -202,6 +222,15 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         lock (_lock)
         {
             _isComplete = true;
+        }
+    }
+
+    /// <inheritdoc />
+    public ModuleOutputExcerpt? GetOutputExcerpt()
+    {
+        lock (_lock)
+        {
+            return _outputExcerptBuffer?.CreateExcerpt();
         }
     }
 
@@ -296,6 +325,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             }
 
             _outputs.Add(output);
+            CaptureOutputExcerpt(output);
             if (_requestIncrementalFlush is not null
                 && _outputFlushThreshold > 0
                 && _outputs.Count >= _outputFlushThreshold
@@ -307,6 +337,38 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
 
         requestIncrementalFlush?.Invoke(this);
+    }
+
+    private void CaptureOutputExcerpt(BufferedOutput output)
+    {
+        if (_outputExcerptBuffer is null || output.IsRawBuildSystemCommand)
+        {
+            return;
+        }
+
+        try
+        {
+            if (output.IsString)
+            {
+                _outputExcerptBuffer.Append(output.StringValue!, output.Stream);
+                return;
+            }
+
+            if (output.LogEvent is not { } logEvent)
+            {
+                return;
+            }
+
+            _outputExcerptBuffer.Append(logEvent.FormatMessageWithLevel(), logEvent.Stream);
+            if (logEvent.FormatException() is { } exception)
+            {
+                _outputExcerptBuffer.Append(exception, logEvent.Stream);
+            }
+        }
+        catch (Exception)
+        {
+            // Report capture must never disrupt module logging or execution.
+        }
     }
 
     private bool TryTakeOutputs(
@@ -740,9 +802,17 @@ internal readonly struct BufferedOutput
     public bool IsRawBuildSystemCommand { get; private init; }
 
     /// <summary>
+    /// Gets the output stream represented by this item.
+    /// </summary>
+    public ModuleOutputStream Stream { get; private init; }
+
+    /// <summary>
     /// Creates a buffered output from a string.
     /// </summary>
-    public static BufferedOutput FromString(string value) => new() { StringValue = value };
+    public static BufferedOutput FromString(
+        string value,
+        ModuleOutputStream stream = ModuleOutputStream.StandardOutput) =>
+        new() { StringValue = value, Stream = stream };
 
     /// <summary>
     /// Creates a buffered output from a raw build-system command.
@@ -758,7 +828,7 @@ internal readonly struct BufferedOutput
     /// Creates a buffered output from a log event.
     /// </summary>
     public static BufferedOutput FromLogEvent(IBufferedLogEvent logEvent)
-        => new() { LogEvent = logEvent };
+        => new() { LogEvent = logEvent, Stream = logEvent.Stream };
 }
 
 /// <summary>
@@ -767,6 +837,8 @@ internal readonly struct BufferedOutput
 internal interface IBufferedLogEvent
 {
     LogLevel Level { get; }
+
+    ModuleOutputStream Stream => ModuleOutputStream.StandardOutput;
 
     void WriteTo(ILogger logger);
 
@@ -794,6 +866,8 @@ internal sealed class BufferedLogEvent<TState>(
         LazyThreadSafetyMode.ExecutionAndPublication);
 
     public LogLevel Level => level;
+
+    public ModuleOutputStream Stream { get; } = GetStream(obfuscatedState);
 
     public void WriteTo(ILogger logger)
     {
@@ -854,4 +928,15 @@ internal sealed class BufferedLogEvent<TState>(
             LogLevel.Critical => "CRIT",
             _ => "NONE",
         };
+
+    private static ModuleOutputStream GetStream(object? state)
+    {
+        if (state is IEnumerable<KeyValuePair<string, object?>> properties
+            && properties.Any(static property => property.Key == "CommandError"))
+        {
+            return ModuleOutputStream.StandardError;
+        }
+
+        return ModuleOutputStream.StandardOutput;
+    }
 }

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -103,6 +103,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="outputExcerptMaximumBytes">Maximum retained UTF-8 bytes for report output, or zero to disable capture.</param>
     /// <param name="outputExcerptSecretObfuscator">Obfuscator used before the final excerpt tail is selected.</param>
     /// <param name="outputExcerptSecretProvider">Provider used to validate late-registered secret boundaries.</param>
+    /// <param name="outputExcerptLogger">Logger for fail-closed excerpt diagnostics.</param>
     internal ModuleOutputBuffer(
         string name,
         Type moduleType,
@@ -114,7 +115,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         bool showSuccessMarker = true,
         int outputExcerptMaximumBytes = 0,
         ISecretObfuscator? outputExcerptSecretObfuscator = null,
-        ISecretProvider? outputExcerptSecretProvider = null)
+        ISecretProvider? outputExcerptSecretProvider = null,
+        ILogger? outputExcerptLogger = null)
     {
         ModuleType = moduleType;
         _moduleName = name;
@@ -129,7 +131,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             ? new ModuleOutputExcerptBuffer(
                 outputExcerptMaximumBytes,
                 outputExcerptSecretObfuscator,
-                outputExcerptSecretProvider)
+                outputExcerptSecretProvider,
+                outputExcerptLogger)
             : null;
     }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -62,6 +62,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="isSpectreEnabled">Determines whether Spectre would render a structured event level.</param>
     /// <param name="showFailureHeaderWithoutOutput">Whether a failed empty buffer renders a failure header.</param>
     /// <param name="outputExcerptMaximumBytes">Maximum retained UTF-8 bytes for report output, or zero to disable capture.</param>
+    /// <param name="outputExcerptSecretObfuscator">Obfuscator used before the final excerpt tail is selected.</param>
+    /// <param name="outputExcerptSecretProvider">Provider used to validate late-registered secret boundaries.</param>
     public ModuleOutputBuffer(
         Type moduleType,
         int outputFlushThreshold = 0,
@@ -69,7 +71,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         TimeSpan? renderGateTimeout = null,
         Func<LogLevel, bool>? isSpectreEnabled = null,
         bool showFailureHeaderWithoutOutput = false,
-        int outputExcerptMaximumBytes = 0)
+        int outputExcerptMaximumBytes = 0,
+        ISecretObfuscator? outputExcerptSecretObfuscator = null,
+        ISecretProvider? outputExcerptSecretProvider = null)
         : this(
             moduleType.Name,
             moduleType,
@@ -78,7 +82,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             renderGateTimeout,
             isSpectreEnabled,
             showFailureHeaderWithoutOutput,
-            outputExcerptMaximumBytes: outputExcerptMaximumBytes)
+            outputExcerptMaximumBytes: outputExcerptMaximumBytes,
+            outputExcerptSecretObfuscator: outputExcerptSecretObfuscator,
+            outputExcerptSecretProvider: outputExcerptSecretProvider)
     {
     }
 
@@ -95,6 +101,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="showFailureHeaderWithoutOutput">Whether a failed empty buffer renders a failure header.</param>
     /// <param name="showSuccessMarker">Whether successful output groups include a success marker.</param>
     /// <param name="outputExcerptMaximumBytes">Maximum retained UTF-8 bytes for report output, or zero to disable capture.</param>
+    /// <param name="outputExcerptSecretObfuscator">Obfuscator used before the final excerpt tail is selected.</param>
+    /// <param name="outputExcerptSecretProvider">Provider used to validate late-registered secret boundaries.</param>
     internal ModuleOutputBuffer(
         string name,
         Type moduleType,
@@ -104,7 +112,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         Func<LogLevel, bool>? isSpectreEnabled = null,
         bool showFailureHeaderWithoutOutput = false,
         bool showSuccessMarker = true,
-        int outputExcerptMaximumBytes = 0)
+        int outputExcerptMaximumBytes = 0,
+        ISecretObfuscator? outputExcerptSecretObfuscator = null,
+        ISecretProvider? outputExcerptSecretProvider = null)
     {
         ModuleType = moduleType;
         _moduleName = name;
@@ -116,7 +126,10 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         _showFailureHeaderWithoutOutput = showFailureHeaderWithoutOutput;
         _showSuccessMarker = showSuccessMarker;
         _outputExcerptBuffer = outputExcerptMaximumBytes > 0
-            ? new ModuleOutputExcerptBuffer(outputExcerptMaximumBytes)
+            ? new ModuleOutputExcerptBuffer(
+                outputExcerptMaximumBytes,
+                outputExcerptSecretObfuscator,
+                outputExcerptSecretProvider)
             : null;
     }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -143,10 +143,32 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     /// <inheritdoc />
+    public void Write(string message)
+    {
+        AddOutput(
+            BufferedOutput.FromString(
+                message,
+                ModuleOutputStream.StandardOutput,
+                appendNewLine: false),
+            allowAfterCompletion: true);
+    }
+
+    /// <inheritdoc />
     public void WriteErrorLine(string message)
     {
         AddOutput(
             BufferedOutput.FromString(message, ModuleOutputStream.StandardError),
+            allowAfterCompletion: true);
+    }
+
+    /// <inheritdoc />
+    public void WriteError(string message)
+    {
+        AddOutput(
+            BufferedOutput.FromString(
+                message,
+                ModuleOutputStream.StandardError,
+                appendNewLine: false),
             allowAfterCompletion: true);
     }
 
@@ -393,7 +415,10 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             if (output.IsString)
             {
-                _outputExcerptBuffer.Append(output.StringValue!, output.Stream);
+                _outputExcerptBuffer.Append(
+                    output.StringValue!,
+                    output.Stream,
+                    output.AppendNewLine);
                 return;
             }
 
@@ -607,7 +632,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             }
             else if (output.IsString)
             {
-                WriteDirect(directConsole, console, output.StringValue);
+                WriteDirect(
+                    directConsole,
+                    console,
+                    output.StringValue,
+                    output.AppendNewLine);
             }
             else if (output.LogEvent is { } logEvent)
             {
@@ -789,7 +818,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private static void WriteDirect(
         IAnsiConsole directConsole,
         TextWriter console,
-        string? value)
+        string? value,
+        bool appendNewLine = true)
     {
         if (string.IsNullOrEmpty(value))
         {
@@ -798,12 +828,26 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         try
         {
-            directConsole.MarkupLine(value);
+            if (appendNewLine)
+            {
+                directConsole.MarkupLine(value);
+            }
+            else
+            {
+                directConsole.Markup(value);
+            }
         }
         catch (Exception)
         {
             // CI workflow commands and arbitrary output can contain brackets that are not Spectre markup.
-            console.WriteLine(value);
+            if (appendNewLine)
+            {
+                console.WriteLine(value);
+            }
+            else
+            {
+                console.Write(value);
+            }
         }
     }
 
@@ -851,12 +895,18 @@ internal readonly struct BufferedOutput
     public ModuleOutputStream Stream { get; private init; }
 
     /// <summary>
+    /// Gets a value indicating whether a line terminator follows the string output.
+    /// </summary>
+    public bool AppendNewLine { get; private init; }
+
+    /// <summary>
     /// Creates a buffered output from a string.
     /// </summary>
     public static BufferedOutput FromString(
         string value,
-        ModuleOutputStream stream = ModuleOutputStream.StandardOutput) =>
-        new() { StringValue = value, Stream = stream };
+        ModuleOutputStream stream = ModuleOutputStream.StandardOutput,
+        bool appendNewLine = true) =>
+        new() { StringValue = value, Stream = stream, AppendNewLine = appendNewLine };
 
     /// <summary>
     /// Creates a buffered output from a raw build-system command.

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -944,10 +944,25 @@ internal sealed class BufferedLogEvent<TState>(
 
     private static ModuleOutputStream GetStream(object? state)
     {
-        if (state is IEnumerable<KeyValuePair<string, object?>> properties
-            && properties.Any(static property => property.Key == "CommandError"))
+        if (state is not IReadOnlyList<KeyValuePair<string, object?>> properties)
         {
-            return ModuleOutputStream.StandardError;
+            return ModuleOutputStream.StandardOutput;
+        }
+
+        try
+        {
+            for (var index = 0; index < properties.Count; index++)
+            {
+                if (properties[index].Key == "CommandError")
+                {
+                    return ModuleOutputStream.StandardError;
+                }
+            }
+        }
+        catch (Exception exception) when (exception is not (OutOfMemoryException or StackOverflowException))
+        {
+            // Structured state is user-controlled. Classification is best-effort and
+            // must not make an otherwise valid logging call fail.
         }
 
         return ModuleOutputStream.StandardOutput;

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
+using ModularPipelines.Models;
 using Spectre.Console;
 
 namespace ModularPipelines.Console;
@@ -38,6 +39,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly Action<IModuleOutputBuffer>? _requestIncrementalFlush;
     private readonly bool _showFailureHeaderWithoutOutput;
     private readonly bool _showSuccessMarker;
+    private readonly ModuleOutputExcerptBuffer? _outputExcerptBuffer;
     private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = [];
     private Exception? _exception;
     private Action<Exception>? _deferredFlushFailureHandler;
@@ -60,13 +62,15 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="renderGateTimeout">Maximum time to wait for the Spectre logger render gate.</param>
     /// <param name="isSpectreEnabled">Determines whether Spectre would render a structured event level.</param>
     /// <param name="showFailureHeaderWithoutOutput">Whether a failed empty buffer renders a failure header.</param>
+    /// <param name="outputExcerptMaximumBytes">Maximum retained UTF-8 bytes for report output, or zero to disable capture.</param>
     public ModuleOutputBuffer(
         Type moduleType,
         int outputFlushThreshold = 0,
         Action<IModuleOutputBuffer>? requestIncrementalFlush = null,
         TimeSpan? renderGateTimeout = null,
         Func<LogLevel, bool>? isSpectreEnabled = null,
-        bool showFailureHeaderWithoutOutput = false)
+        bool showFailureHeaderWithoutOutput = false,
+        int outputExcerptMaximumBytes = 0)
         : this(
             moduleType.Name,
             moduleType,
@@ -74,7 +78,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             requestIncrementalFlush,
             renderGateTimeout,
             isSpectreEnabled,
-            showFailureHeaderWithoutOutput)
+            showFailureHeaderWithoutOutput,
+            outputExcerptMaximumBytes: outputExcerptMaximumBytes)
     {
     }
 
@@ -90,6 +95,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="isSpectreEnabled">Determines whether Spectre would render a structured event level.</param>
     /// <param name="showFailureHeaderWithoutOutput">Whether a failed empty buffer renders a failure header.</param>
     /// <param name="showSuccessMarker">Whether successful output groups include a success marker.</param>
+    /// <param name="outputExcerptMaximumBytes">Maximum retained UTF-8 bytes for report output, or zero to disable capture.</param>
     internal ModuleOutputBuffer(
         string name,
         Type moduleType,
@@ -98,7 +104,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         TimeSpan? renderGateTimeout = null,
         Func<LogLevel, bool>? isSpectreEnabled = null,
         bool showFailureHeaderWithoutOutput = false,
-        bool showSuccessMarker = true)
+        bool showSuccessMarker = true,
+        int outputExcerptMaximumBytes = 0)
     {
         ModuleType = moduleType;
         _moduleName = name;
@@ -109,12 +116,25 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         _isSpectreEnabled = isSpectreEnabled ?? (static _ => true);
         _showFailureHeaderWithoutOutput = showFailureHeaderWithoutOutput;
         _showSuccessMarker = showSuccessMarker;
+        _outputExcerptBuffer = outputExcerptMaximumBytes > 0
+            ? new ModuleOutputExcerptBuffer(outputExcerptMaximumBytes)
+            : null;
     }
 
     /// <inheritdoc />
     public void WriteLine(string message)
     {
-        AddOutput(BufferedOutput.FromString(message), allowAfterCompletion: true);
+        AddOutput(
+            BufferedOutput.FromString(message, ModuleOutputStream.StandardOutput),
+            allowAfterCompletion: true);
+    }
+
+    /// <inheritdoc />
+    public void WriteErrorLine(string message)
+    {
+        AddOutput(
+            BufferedOutput.FromString(message, ModuleOutputStream.StandardError),
+            allowAfterCompletion: true);
     }
 
     /// <inheritdoc />
@@ -236,6 +256,15 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     /// <inheritdoc />
+    public ModuleOutputExcerpt? GetOutputExcerpt()
+    {
+        lock (_lock)
+        {
+            return _outputExcerptBuffer?.CreateExcerpt();
+        }
+    }
+
+    /// <inheritdoc />
     public async Task FlushToAsync(
         TextWriter console,
         IBuildSystemFormatter formatter,
@@ -326,6 +355,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             }
 
             _outputs.Add(output);
+            CaptureOutputExcerpt(output);
             if (_requestIncrementalFlush is not null
                 && _outputFlushThreshold > 0
                 && _outputs.Count >= _outputFlushThreshold
@@ -337,6 +367,38 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         }
 
         requestIncrementalFlush?.Invoke(this);
+    }
+
+    private void CaptureOutputExcerpt(BufferedOutput output)
+    {
+        if (_outputExcerptBuffer is null || output.IsRawBuildSystemCommand)
+        {
+            return;
+        }
+
+        try
+        {
+            if (output.IsString)
+            {
+                _outputExcerptBuffer.Append(output.StringValue!, output.Stream);
+                return;
+            }
+
+            if (output.LogEvent is not { } logEvent)
+            {
+                return;
+            }
+
+            _outputExcerptBuffer.Append(logEvent.FormatMessageWithLevel(), logEvent.Stream);
+            if (logEvent.FormatException() is { } exception)
+            {
+                _outputExcerptBuffer.Append(exception, logEvent.Stream);
+            }
+        }
+        catch (Exception)
+        {
+            // Report capture must never disrupt module logging or execution.
+        }
     }
 
     private bool TryTakeOutputs(
@@ -771,9 +833,17 @@ internal readonly struct BufferedOutput
     public bool IsRawBuildSystemCommand { get; private init; }
 
     /// <summary>
+    /// Gets the output stream represented by this item.
+    /// </summary>
+    public ModuleOutputStream Stream { get; private init; }
+
+    /// <summary>
     /// Creates a buffered output from a string.
     /// </summary>
-    public static BufferedOutput FromString(string value) => new() { StringValue = value };
+    public static BufferedOutput FromString(
+        string value,
+        ModuleOutputStream stream = ModuleOutputStream.StandardOutput) =>
+        new() { StringValue = value, Stream = stream };
 
     /// <summary>
     /// Creates a buffered output from a raw build-system command.
@@ -789,7 +859,7 @@ internal readonly struct BufferedOutput
     /// Creates a buffered output from a log event.
     /// </summary>
     public static BufferedOutput FromLogEvent(IBufferedLogEvent logEvent)
-        => new() { LogEvent = logEvent };
+        => new() { LogEvent = logEvent, Stream = logEvent.Stream };
 }
 
 /// <summary>
@@ -798,6 +868,8 @@ internal readonly struct BufferedOutput
 internal interface IBufferedLogEvent
 {
     LogLevel Level { get; }
+
+    ModuleOutputStream Stream => ModuleOutputStream.StandardOutput;
 
     void WriteTo(ILogger logger);
 
@@ -825,6 +897,8 @@ internal sealed class BufferedLogEvent<TState>(
         LazyThreadSafetyMode.ExecutionAndPublication);
 
     public LogLevel Level => level;
+
+    public ModuleOutputStream Stream { get; } = GetStream(obfuscatedState);
 
     public void WriteTo(ILogger logger)
     {
@@ -885,4 +959,15 @@ internal sealed class BufferedLogEvent<TState>(
             LogLevel.Critical => "CRIT",
             _ => "NONE",
         };
+
+    private static ModuleOutputStream GetStream(object? state)
+    {
+        if (state is IEnumerable<KeyValuePair<string, object?>> properties
+            && properties.Any(static property => property.Key == "CommandError"))
+        {
+            return ModuleOutputStream.StandardError;
+        }
+
+        return ModuleOutputStream.StandardOutput;
+    }
 }

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -63,6 +63,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="isSpectreEnabled">Determines whether Spectre would render a structured event level.</param>
     /// <param name="showFailureHeaderWithoutOutput">Whether a failed empty buffer renders a failure header.</param>
     /// <param name="outputExcerptMaximumBytes">Maximum retained UTF-8 bytes for report output, or zero to disable capture.</param>
+    /// <param name="outputExcerptSecretObfuscator">Obfuscator used before the final excerpt tail is selected.</param>
+    /// <param name="outputExcerptSecretProvider">Provider used to validate late-registered secret boundaries.</param>
     public ModuleOutputBuffer(
         Type moduleType,
         int outputFlushThreshold = 0,
@@ -70,7 +72,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         TimeSpan? renderGateTimeout = null,
         Func<LogLevel, bool>? isSpectreEnabled = null,
         bool showFailureHeaderWithoutOutput = false,
-        int outputExcerptMaximumBytes = 0)
+        int outputExcerptMaximumBytes = 0,
+        ISecretObfuscator? outputExcerptSecretObfuscator = null,
+        ISecretProvider? outputExcerptSecretProvider = null)
         : this(
             moduleType.Name,
             moduleType,
@@ -79,7 +83,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             renderGateTimeout,
             isSpectreEnabled,
             showFailureHeaderWithoutOutput,
-            outputExcerptMaximumBytes: outputExcerptMaximumBytes)
+            outputExcerptMaximumBytes: outputExcerptMaximumBytes,
+            outputExcerptSecretObfuscator: outputExcerptSecretObfuscator,
+            outputExcerptSecretProvider: outputExcerptSecretProvider)
     {
     }
 
@@ -96,6 +102,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="showFailureHeaderWithoutOutput">Whether a failed empty buffer renders a failure header.</param>
     /// <param name="showSuccessMarker">Whether successful output groups include a success marker.</param>
     /// <param name="outputExcerptMaximumBytes">Maximum retained UTF-8 bytes for report output, or zero to disable capture.</param>
+    /// <param name="outputExcerptSecretObfuscator">Obfuscator used before the final excerpt tail is selected.</param>
+    /// <param name="outputExcerptSecretProvider">Provider used to validate late-registered secret boundaries.</param>
     internal ModuleOutputBuffer(
         string name,
         Type moduleType,
@@ -105,7 +113,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         Func<LogLevel, bool>? isSpectreEnabled = null,
         bool showFailureHeaderWithoutOutput = false,
         bool showSuccessMarker = true,
-        int outputExcerptMaximumBytes = 0)
+        int outputExcerptMaximumBytes = 0,
+        ISecretObfuscator? outputExcerptSecretObfuscator = null,
+        ISecretProvider? outputExcerptSecretProvider = null)
     {
         ModuleType = moduleType;
         _moduleName = name;
@@ -117,7 +127,10 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         _showFailureHeaderWithoutOutput = showFailureHeaderWithoutOutput;
         _showSuccessMarker = showSuccessMarker;
         _outputExcerptBuffer = outputExcerptMaximumBytes > 0
-            ? new ModuleOutputExcerptBuffer(outputExcerptMaximumBytes)
+            ? new ModuleOutputExcerptBuffer(
+                outputExcerptMaximumBytes,
+                outputExcerptSecretObfuscator,
+                outputExcerptSecretProvider)
             : null;
     }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -975,10 +975,25 @@ internal sealed class BufferedLogEvent<TState>(
 
     private static ModuleOutputStream GetStream(object? state)
     {
-        if (state is IEnumerable<KeyValuePair<string, object?>> properties
-            && properties.Any(static property => property.Key == "CommandError"))
+        if (state is not IReadOnlyList<KeyValuePair<string, object?>> properties)
         {
-            return ModuleOutputStream.StandardError;
+            return ModuleOutputStream.StandardOutput;
+        }
+
+        try
+        {
+            for (var index = 0; index < properties.Count; index++)
+            {
+                if (properties[index].Key == "CommandError")
+                {
+                    return ModuleOutputStream.StandardError;
+                }
+            }
+        }
+        catch (Exception exception) when (exception is not (OutOfMemoryException or StackOverflowException))
+        {
+            // Structured state is user-controlled. Classification is best-effort and
+            // must not make an otherwise valid logging call fail.
         }
 
         return ModuleOutputStream.StandardOutput;

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -104,6 +104,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="outputExcerptMaximumBytes">Maximum retained UTF-8 bytes for report output, or zero to disable capture.</param>
     /// <param name="outputExcerptSecretObfuscator">Obfuscator used before the final excerpt tail is selected.</param>
     /// <param name="outputExcerptSecretProvider">Provider used to validate late-registered secret boundaries.</param>
+    /// <param name="outputExcerptLogger">Logger for fail-closed excerpt diagnostics.</param>
     internal ModuleOutputBuffer(
         string name,
         Type moduleType,
@@ -115,7 +116,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         bool showSuccessMarker = true,
         int outputExcerptMaximumBytes = 0,
         ISecretObfuscator? outputExcerptSecretObfuscator = null,
-        ISecretProvider? outputExcerptSecretProvider = null)
+        ISecretProvider? outputExcerptSecretProvider = null,
+        ILogger? outputExcerptLogger = null)
     {
         ModuleType = moduleType;
         _moduleName = name;
@@ -130,7 +132,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             ? new ModuleOutputExcerptBuffer(
                 outputExcerptMaximumBytes,
                 outputExcerptSecretObfuscator,
-                outputExcerptSecretProvider)
+                outputExcerptSecretProvider,
+                outputExcerptLogger)
             : null;
     }
 

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -142,10 +142,32 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     }
 
     /// <inheritdoc />
+    public void Write(string message)
+    {
+        AddOutput(
+            BufferedOutput.FromString(
+                message,
+                ModuleOutputStream.StandardOutput,
+                appendNewLine: false),
+            allowAfterCompletion: true);
+    }
+
+    /// <inheritdoc />
     public void WriteErrorLine(string message)
     {
         AddOutput(
             BufferedOutput.FromString(message, ModuleOutputStream.StandardError),
+            allowAfterCompletion: true);
+    }
+
+    /// <inheritdoc />
+    public void WriteError(string message)
+    {
+        AddOutput(
+            BufferedOutput.FromString(
+                message,
+                ModuleOutputStream.StandardError,
+                appendNewLine: false),
             allowAfterCompletion: true);
     }
 
@@ -363,7 +385,10 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             if (output.IsString)
             {
-                _outputExcerptBuffer.Append(output.StringValue!, output.Stream);
+                _outputExcerptBuffer.Append(
+                    output.StringValue!,
+                    output.Stream,
+                    output.AppendNewLine);
                 return;
             }
 
@@ -577,7 +602,11 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             }
             else if (output.IsString)
             {
-                WriteDirect(directConsole, console, output.StringValue);
+                WriteDirect(
+                    directConsole,
+                    console,
+                    output.StringValue,
+                    output.AppendNewLine);
             }
             else if (output.LogEvent is { } logEvent)
             {
@@ -758,7 +787,8 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private static void WriteDirect(
         IAnsiConsole directConsole,
         TextWriter console,
-        string? value)
+        string? value,
+        bool appendNewLine = true)
     {
         if (string.IsNullOrEmpty(value))
         {
@@ -767,12 +797,26 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
         try
         {
-            directConsole.MarkupLine(value);
+            if (appendNewLine)
+            {
+                directConsole.MarkupLine(value);
+            }
+            else
+            {
+                directConsole.Markup(value);
+            }
         }
         catch (Exception)
         {
             // CI workflow commands and arbitrary output can contain brackets that are not Spectre markup.
-            console.WriteLine(value);
+            if (appendNewLine)
+            {
+                console.WriteLine(value);
+            }
+            else
+            {
+                console.Write(value);
+            }
         }
     }
 
@@ -820,12 +864,18 @@ internal readonly struct BufferedOutput
     public ModuleOutputStream Stream { get; private init; }
 
     /// <summary>
+    /// Gets a value indicating whether a line terminator follows the string output.
+    /// </summary>
+    public bool AppendNewLine { get; private init; }
+
+    /// <summary>
     /// Creates a buffered output from a string.
     /// </summary>
     public static BufferedOutput FromString(
         string value,
-        ModuleOutputStream stream = ModuleOutputStream.StandardOutput) =>
-        new() { StringValue = value, Stream = stream };
+        ModuleOutputStream stream = ModuleOutputStream.StandardOutput,
+        bool appendNewLine = true) =>
+        new() { StringValue = value, Stream = stream, AppendNewLine = appendNewLine };
 
     /// <summary>
     /// Creates a buffered output from a raw build-system command.

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -70,10 +70,17 @@ internal sealed class ModuleOutputExcerptBuffer(
                 .Append(Utf8.GetString(chunk.Bytes));
         }
 
+        var stdoutValue = stdout.ToString();
+        var stderrValue = stderr.ToString();
         var (stdoutBytes, stderrBytes) = GetFinalStreamByteLimits();
+        var truncatedBytes = GetTruncatedByteCount(
+            stdoutValue,
+            stderrValue,
+            stdoutBytes,
+            stderrBytes);
         if (!TryCreateTails(
-                stdout.ToString(),
-                stderr.ToString(),
+                stdoutValue,
+                stderrValue,
                 stdoutBytes,
                 stderrBytes,
                 out var stdoutTail,
@@ -86,13 +93,20 @@ internal sealed class ModuleOutputExcerptBuffer(
         {
             StdoutTail = stdoutTail,
             StderrTail = stderrTail,
-            TruncatedBytes = Math.Max(
-                0,
-                _totalBytes
-                - Utf8.GetByteCount(stdoutTail ?? string.Empty)
-                - Utf8.GetByteCount(stderrTail ?? string.Empty)),
+            TruncatedBytes = truncatedBytes,
         };
     }
+
+    private long GetTruncatedByteCount(
+        string stdout,
+        string stderr,
+        int stdoutBytes,
+        int stderrBytes) =>
+        Math.Max(
+            0,
+            _totalBytes
+            - Utf8.GetByteCount(GetUtf8Tail(stdout, stdoutBytes) ?? string.Empty)
+            - Utf8.GetByteCount(GetUtf8Tail(stderr, stderrBytes) ?? string.Empty));
 
     private bool TryCreateTails(
         string stdout,
@@ -109,12 +123,30 @@ internal sealed class ModuleOutputExcerptBuffer(
             return true;
         }
 
+        return TryCreateMaskedTails(
+            stdout,
+            stderr,
+            stdoutBytes,
+            stderrBytes,
+            out stdoutTail,
+            out stderrTail);
+    }
+
+    private bool TryCreateMaskedTails(
+        string stdout,
+        string stderr,
+        int stdoutBytes,
+        int stderrBytes,
+        out string? stdoutTail,
+        out string? stderrTail)
+    {
+        stdoutTail = null;
+        stderrTail = null;
+
         // Custom or incomplete masking dependencies do not expose enough information
         // to prove that a bounded context is safe.
         if (secretObfuscator is not SecretObfuscator concreteObfuscator || secretProvider is null)
         {
-            stdoutTail = null;
-            stderrTail = null;
             return false;
         }
 
@@ -127,26 +159,31 @@ internal sealed class ModuleOutputExcerptBuffer(
             .Max();
         if (maximumMatchBytes > maximumBytes)
         {
-            stdoutTail = null;
-            stderrTail = null;
             return false;
         }
 
+        var maskedStdout = secretObfuscator.Obfuscate(stdout, null);
+        var maskedStderr = secretObfuscator.Obfuscate(stderr, null);
+        (stdoutBytes, stderrBytes) = RebalanceMaskedStreamByteLimits(
+            stdoutBytes,
+            stderrBytes,
+            Utf8.GetByteCount(maskedStdout),
+            Utf8.GetByteCount(maskedStderr));
+
         if (!TryGetSafeMaskedTail(
-                secretObfuscator.Obfuscate(stdout, null),
+                maskedStdout,
                 stdoutBytes,
                 _totalStdoutBytes > Utf8.GetByteCount(stdout),
                 maximumMatchBytes,
                 out stdoutTail)
             || !TryGetSafeMaskedTail(
-                secretObfuscator.Obfuscate(stderr, null),
+                maskedStderr,
                 stderrBytes,
                 _totalStderrBytes > Utf8.GetByteCount(stderr),
                 maximumMatchBytes,
                 out stderrTail))
         {
-            stdoutTail = null;
-            stderrTail = null;
+            stdoutTail = stderrTail = null;
             return false;
         }
 
@@ -154,6 +191,39 @@ internal sealed class ModuleOutputExcerptBuffer(
         // boundary. Omit the excerpt rather than risk returning a partial secret.
         return secretProvider.Version == snapshot.Version
                && concreteObfuscator.CaseInsensitive == caseInsensitive;
+    }
+
+    private (int StdoutBytes, int StderrBytes) RebalanceMaskedStreamByteLimits(
+        int stdoutBytes,
+        int stderrBytes,
+        int maskedStdoutBytes,
+        int maskedStderrBytes)
+    {
+        stdoutBytes = Math.Min(stdoutBytes, maskedStdoutBytes);
+        stderrBytes = Math.Min(stderrBytes, maskedStderrBytes);
+        var remaining = maximumBytes - stdoutBytes - stderrBytes;
+        var stdoutNeeded = maskedStdoutBytes - stdoutBytes;
+        var stderrNeeded = maskedStderrBytes - stderrBytes;
+
+        for (var chunk = _chunks.Last; chunk is not null && remaining > 0; chunk = chunk.Previous)
+        {
+            if (chunk.Value.Stream is ModuleOutputStream.StandardError && stderrNeeded > 0)
+            {
+                var added = Math.Min(stderrNeeded, remaining);
+                stderrBytes += added;
+                stderrNeeded -= added;
+                remaining -= added;
+            }
+            else if (chunk.Value.Stream is ModuleOutputStream.StandardOutput && stdoutNeeded > 0)
+            {
+                var added = Math.Min(stdoutNeeded, remaining);
+                stdoutBytes += added;
+                stdoutNeeded -= added;
+                remaining -= added;
+            }
+        }
+
+        return (stdoutBytes, stderrBytes);
     }
 
     private static bool TryGetSafeMaskedTail(

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -160,6 +160,11 @@ internal sealed class ModuleOutputExcerptBuffer(
 
         var caseInsensitive = concreteObfuscator.CaseInsensitive;
         var snapshot = secretProvider.GetSnapshot();
+        if (!concreteObfuscator.CanSafelyPreserveMasks(snapshot.Secrets))
+        {
+            return false;
+        }
+
         var maximumMatchBytes = snapshot.Secrets
             .Where(static secret => !string.IsNullOrEmpty(secret))
             .Select(secret => GetMaximumMatchByteCount(secret, caseInsensitive))

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -62,6 +62,8 @@ internal sealed class ModuleOutputExcerptBuffer(
             return null;
         }
 
+        var secretPatternsVersion = secretProvider?.Version;
+
         var stdout = new StringBuilder();
         var stderr = new StringBuilder();
         foreach (var chunk in _chunks)
@@ -89,11 +91,17 @@ internal sealed class ModuleOutputExcerptBuffer(
             return null;
         }
 
+        if (secretPatternsVersion is { } version && secretProvider?.Version != version)
+        {
+            return null;
+        }
+
         return new ModuleOutputExcerpt
         {
             StdoutTail = stdoutTail,
             StderrTail = stderrTail,
             TruncatedBytes = truncatedBytes,
+            SecretPatternsVersion = secretPatternsVersion,
         };
     }
 

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -18,11 +18,22 @@ internal sealed class ModuleOutputExcerptBuffer(
         ? int.MaxValue
         : maximumBytes * 2;
     private long _totalBytes;
+    private long _totalStdoutBytes;
+    private long _totalStderrBytes;
     private int _retainedBytes;
 
     public void Append(string value, ModuleOutputStream stream)
     {
-        _totalBytes += (long) Utf8.GetByteCount(value) + NewLineBytes.Length;
+        var appendedBytes = (long) Utf8.GetByteCount(value) + NewLineBytes.Length;
+        _totalBytes += appendedBytes;
+        if (stream is ModuleOutputStream.StandardError)
+        {
+            _totalStderrBytes += appendedBytes;
+        }
+        else
+        {
+            _totalStdoutBytes += appendedBytes;
+        }
 
         // One UTF-16 code unit always produces at least one UTF-8 byte. Keep one extra output
         // window so late-registered secrets can be masked before the final tail is selected.
@@ -109,22 +120,60 @@ internal sealed class ModuleOutputExcerptBuffer(
 
         var caseInsensitive = concreteObfuscator.CaseInsensitive;
         var snapshot = secretProvider.GetSnapshot();
-        if (snapshot.Secrets
+        var maximumMatchBytes = snapshot.Secrets
             .Where(static secret => !string.IsNullOrEmpty(secret))
-            .Any(secret => GetMaximumMatchByteCount(secret, caseInsensitive) > maximumBytes))
+            .Select(secret => GetMaximumMatchByteCount(secret, caseInsensitive))
+            .DefaultIfEmpty()
+            .Max();
+        if (maximumMatchBytes > maximumBytes)
         {
             stdoutTail = null;
             stderrTail = null;
             return false;
         }
 
-        stdoutTail = GetUtf8Tail(secretObfuscator.Obfuscate(stdout, null), stdoutBytes);
-        stderrTail = GetUtf8Tail(secretObfuscator.Obfuscate(stderr, null), stderrBytes);
+        if (!TryGetSafeMaskedTail(
+                secretObfuscator.Obfuscate(stdout, null),
+                stdoutBytes,
+                _totalStdoutBytes > Utf8.GetByteCount(stdout),
+                maximumMatchBytes,
+                out stdoutTail)
+            || !TryGetSafeMaskedTail(
+                secretObfuscator.Obfuscate(stderr, null),
+                stderrBytes,
+                _totalStderrBytes > Utf8.GetByteCount(stderr),
+                maximumMatchBytes,
+                out stderrTail))
+        {
+            stdoutTail = null;
+            stderrTail = null;
+            return false;
+        }
 
         // If registration changed during masking, a new secret may cross the retained
         // boundary. Omit the excerpt rather than risk returning a partial secret.
         return secretProvider.Version == snapshot.Version
                && concreteObfuscator.CaseInsensitive == caseInsensitive;
+    }
+
+    private static bool TryGetSafeMaskedTail(
+        string maskedOutput,
+        int maximumTailBytes,
+        bool rawPrefixWasTrimmed,
+        int maximumMatchBytes,
+        out string? tail)
+    {
+        tail = GetUtf8Tail(maskedOutput, maximumTailBytes);
+        if (!rawPrefixWasTrimmed || maximumTailBytes == 0)
+        {
+            return true;
+        }
+
+        // Mask contraction must not pull the selected tail within one possible
+        // cross-boundary match of the discarded raw prefix.
+        var discardedMaskedBytes = Utf8.GetByteCount(maskedOutput)
+                                   - Utf8.GetByteCount(tail ?? string.Empty);
+        return discardedMaskedBytes >= maximumMatchBytes;
     }
 
     private (int StdoutBytes, int StderrBytes) GetFinalStreamByteLimits()

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -212,31 +212,49 @@ internal sealed class ModuleOutputExcerptBuffer(
     {
         var stdoutBytes = 0;
         var stderrBytes = 0;
-        var remaining = maximumBytes;
         var stdoutNeeded = maskedStdoutBytes;
         var stderrNeeded = maskedStderrBytes;
+        var stdoutSuffix = new StringBuilder();
+        var stderrSuffix = new StringBuilder();
 
-        for (var chunk = _chunks.Last; chunk is not null && remaining > 0; chunk = chunk.Previous)
+        for (var chunk = _chunks.Last; chunk is not null; chunk = chunk.Previous)
         {
-            var maskedChunkBytes = Utf8.GetByteCount(
-                obfuscator.ObfuscatePreservingMasks(Utf8.GetString(chunk.Value.Bytes)));
-            if (chunk.Value.Stream is ModuleOutputStream.StandardError && stderrNeeded > 0)
+            var chunkText = Utf8.GetString(chunk.Value.Bytes);
+            if (chunk.Value.Stream is ModuleOutputStream.StandardError)
             {
-                var added = Math.Min(Math.Min(stderrNeeded, maskedChunkBytes), remaining);
-                stderrBytes += added;
-                stderrNeeded -= added;
-                remaining -= added;
+                stderrSuffix.Insert(0, chunkText);
+                var available = Math.Min(
+                    stderrNeeded,
+                    Utf8.GetByteCount(obfuscator.ObfuscatePreservingMasks(stderrSuffix.ToString())));
+                stderrBytes = RebalanceStreamBytes(
+                    available,
+                    stderrBytes,
+                    stdoutBytes);
             }
-            else if (chunk.Value.Stream is ModuleOutputStream.StandardOutput && stdoutNeeded > 0)
+            else
             {
-                var added = Math.Min(Math.Min(stdoutNeeded, maskedChunkBytes), remaining);
-                stdoutBytes += added;
-                stdoutNeeded -= added;
-                remaining -= added;
+                stdoutSuffix.Insert(0, chunkText);
+                var available = Math.Min(
+                    stdoutNeeded,
+                    Utf8.GetByteCount(obfuscator.ObfuscatePreservingMasks(stdoutSuffix.ToString())));
+                stdoutBytes = RebalanceStreamBytes(
+                    available,
+                    stdoutBytes,
+                    stderrBytes);
             }
         }
 
         return (stdoutBytes, stderrBytes);
+    }
+
+    private int RebalanceStreamBytes(
+        int availableBytes,
+        int allocatedBytes,
+        int otherStreamBytes)
+    {
+        allocatedBytes = Math.Min(allocatedBytes, availableBytes);
+        var remaining = Math.Max(0, maximumBytes - allocatedBytes - otherStreamBytes);
+        return allocatedBytes + Math.Min(availableBytes - allocatedBytes, remaining);
     }
 
     private static bool TryGetSafeMaskedTail(

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -22,9 +22,13 @@ internal sealed class ModuleOutputExcerptBuffer(
     private long _totalStderrBytes;
     private int _retainedBytes;
 
-    public void Append(string value, ModuleOutputStream stream)
+    public void Append(
+        string value,
+        ModuleOutputStream stream,
+        bool appendNewLine = true)
     {
-        var appendedBytes = (long) Utf8.GetByteCount(value) + NewLineBytes.Length;
+        var lineTerminatorByteCount = appendNewLine ? NewLineBytes.Length : 0;
+        var appendedBytes = (long) Utf8.GetByteCount(value) + lineTerminatorByteCount;
         _totalBytes += appendedBytes;
         if (stream is ModuleOutputStream.StandardError)
         {
@@ -47,9 +51,12 @@ internal sealed class ModuleOutputExcerptBuffer(
 
         var retainedValue = value.AsSpan(start);
         var valueByteCount = Utf8.GetByteCount(retainedValue);
-        var bytes = new byte[valueByteCount + NewLineBytes.Length];
+        var bytes = new byte[valueByteCount + lineTerminatorByteCount];
         Utf8.GetBytes(retainedValue, bytes);
-        NewLineBytes.CopyTo(bytes, valueByteCount);
+        if (appendNewLine)
+        {
+            NewLineBytes.CopyTo(bytes, valueByteCount);
+        }
         _chunks.AddLast(new OutputChunk(stream, bytes));
         _retainedBytes += bytes.Length;
         TrimToLimit(_retentionBytes);

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 using ModularPipelines.Models;
 
@@ -7,7 +8,8 @@ namespace ModularPipelines.Console;
 internal sealed class ModuleOutputExcerptBuffer(
     int maximumBytes,
     ISecretObfuscator? secretObfuscator = null,
-    ISecretProvider? secretProvider = null)
+    ISecretProvider? secretProvider = null,
+    ILogger? logger = null)
 {
     private static readonly Encoding Utf8 = new UTF8Encoding(
         encoderShouldEmitUTF8Identifier: false,
@@ -57,7 +59,7 @@ internal sealed class ModuleOutputExcerptBuffer(
         {
             NewLineBytes.CopyTo(bytes, valueByteCount);
         }
-        _chunks.AddLast(new OutputChunk(stream, bytes));
+        _chunks.AddLast(new OutputChunk(stream, bytes, Utf8.GetString(bytes)));
         _retainedBytes += bytes.Length;
         TrimToLimit(_retentionBytes);
     }
@@ -76,24 +78,20 @@ internal sealed class ModuleOutputExcerptBuffer(
         foreach (var chunk in _chunks)
         {
             (chunk.Stream is ModuleOutputStream.StandardError ? stderr : stdout)
-                .Append(Utf8.GetString(chunk.Bytes));
+                .Append(chunk.Text);
         }
 
         var stdoutValue = stdout.ToString();
         var stderrValue = stderr.ToString();
         var (stdoutBytes, stderrBytes) = GetFinalStreamByteLimits(stdoutValue, stderrValue);
-        var truncatedBytes = GetTruncatedByteCount(
-            stdoutValue,
-            stderrValue,
-            stdoutBytes,
-            stderrBytes);
         if (!TryCreateTails(
                 stdoutValue,
                 stderrValue,
                 stdoutBytes,
                 stderrBytes,
                 out var stdoutTail,
-                out var stderrTail))
+                out var stderrTail,
+                out var retainedSourceBytes))
         {
             return null;
         }
@@ -107,21 +105,10 @@ internal sealed class ModuleOutputExcerptBuffer(
         {
             StdoutTail = stdoutTail,
             StderrTail = stderrTail,
-            TruncatedBytes = truncatedBytes,
+            TruncatedBytes = Math.Max(0, _totalBytes - retainedSourceBytes),
             SecretPatternsVersion = secretPatternsVersion,
         };
     }
-
-    private long GetTruncatedByteCount(
-        string stdout,
-        string stderr,
-        int stdoutBytes,
-        int stderrBytes) =>
-        Math.Max(
-            0,
-            _totalBytes
-            - Utf8.GetByteCount(GetUtf8Tail(stdout, stdoutBytes) ?? string.Empty)
-            - Utf8.GetByteCount(GetUtf8Tail(stderr, stderrBytes) ?? string.Empty));
 
     private bool TryCreateTails(
         string stdout,
@@ -129,39 +116,43 @@ internal sealed class ModuleOutputExcerptBuffer(
         int stdoutBytes,
         int stderrBytes,
         out string? stdoutTail,
-        out string? stderrTail)
+        out string? stderrTail,
+        out long retainedSourceBytes)
     {
         if (secretObfuscator is null && secretProvider is null)
         {
             stdoutTail = GetUtf8Tail(stdout, stdoutBytes);
             stderrTail = GetUtf8Tail(stderr, stderrBytes);
+            retainedSourceBytes = Utf8.GetByteCount(stdoutTail ?? string.Empty)
+                                  + Utf8.GetByteCount(stderrTail ?? string.Empty);
             return true;
         }
 
         return TryCreateMaskedTails(
             stdout,
             stderr,
-            stdoutBytes,
-            stderrBytes,
             out stdoutTail,
-            out stderrTail);
+            out stderrTail,
+            out retainedSourceBytes);
     }
 
     private bool TryCreateMaskedTails(
         string stdout,
         string stderr,
-        int stdoutBytes,
-        int stderrBytes,
         out string? stdoutTail,
-        out string? stderrTail)
+        out string? stderrTail,
+        out long retainedSourceBytes)
     {
         stdoutTail = null;
         stderrTail = null;
+        retainedSourceBytes = 0;
 
         // Custom or incomplete masking dependencies do not expose enough information
         // to prove that a bounded context is safe.
         if (secretObfuscator is not SecretObfuscator concreteObfuscator || secretProvider is null)
         {
+            logger?.LogDebug(
+                "Omitting module output excerpt because its masking dependencies cannot provide a safe source map.");
             return false;
         }
 
@@ -169,6 +160,8 @@ internal sealed class ModuleOutputExcerptBuffer(
         var snapshot = secretProvider.GetSnapshot();
         if (!concreteObfuscator.CanSafelyPreserveMasks(snapshot.Secrets))
         {
+            logger?.LogDebug(
+                "Omitting module output excerpt because the configured mask contains a registered secret.");
             return false;
         }
 
@@ -179,12 +172,16 @@ internal sealed class ModuleOutputExcerptBuffer(
             .Max();
         if (maximumMatchBytes > maximumBytes)
         {
+            logger?.LogDebug(
+                "Omitting module output excerpt because a possible secret match of {MaximumMatchBytes} UTF-8 bytes exceeds the {MaximumExcerptBytes}-byte excerpt cap.",
+                maximumMatchBytes,
+                maximumBytes);
             return false;
         }
 
         var maskedStdout = concreteObfuscator.ObfuscatePreservingMasksWithSourceMap(stdout);
         var maskedStderr = concreteObfuscator.ObfuscatePreservingMasksWithSourceMap(stderr);
-        (stdoutBytes, stderrBytes) = RebalanceMaskedStreamByteLimits(
+        var (stdoutBytes, stderrBytes) = RebalanceMaskedStreamByteLimits(
             maskedStdout,
             maskedStderr);
 
@@ -202,13 +199,36 @@ internal sealed class ModuleOutputExcerptBuffer(
                 out stderrTail))
         {
             stdoutTail = stderrTail = null;
+            logger?.LogDebug(
+                "Omitting module output excerpt because the retained context cannot prove both masked stream boundaries safe.");
             return false;
         }
 
+        retainedSourceBytes = GetRetainedSourceByteCount(maskedStdout, stdout, stdoutTail)
+                              + GetRetainedSourceByteCount(maskedStderr, stderr, stderrTail);
+
         // If registration changed during masking, a new secret may cross the retained
         // boundary. Omit the excerpt rather than risk returning a partial secret.
-        return secretProvider.Version == snapshot.Version
-               && concreteObfuscator.CaseInsensitive == caseInsensitive;
+        if (secretProvider.Version != snapshot.Version
+            || concreteObfuscator.CaseInsensitive != caseInsensitive)
+        {
+            retainedSourceBytes = 0;
+            logger?.LogDebug(
+                "Omitting module output excerpt because secret masking configuration changed while the excerpt was created.");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static int GetRetainedSourceByteCount(
+        SecretObfuscator.MappedObfuscatedOutput maskedOutput,
+        string source,
+        string? tail)
+    {
+        var tailBytes = Utf8.GetByteCount(tail ?? string.Empty);
+        var sourceOffset = maskedOutput.GetSourceOffsetForOutputSuffix(tailBytes);
+        return Utf8.GetByteCount(source.AsSpan(sourceOffset));
     }
 
     private (int StdoutBytes, int StderrBytes) RebalanceMaskedStreamByteLimits(
@@ -224,7 +244,7 @@ internal sealed class ModuleOutputExcerptBuffer(
         var chunks = new List<MappedOutputChunk>(_chunks.Count);
         foreach (var chunk in _chunks)
         {
-            var textLength = Utf8.GetString(chunk.Bytes).Length;
+            var textLength = chunk.Text.Length;
             if (chunk.Stream is ModuleOutputStream.StandardError)
             {
                 chunks.Add(new MappedOutputChunk(chunk.Stream, stderrOffset));
@@ -332,11 +352,7 @@ internal sealed class ModuleOutputExcerptBuffer(
             return bytes.Length;
         }
 
-        var start = bytes.Length - maximumTailBytes;
-        while (start < bytes.Length && IsUtf8ContinuationByte(bytes[start]))
-        {
-            start++;
-        }
+        var start = GetUtf8Boundary(bytes, bytes.Length - maximumTailBytes);
 
         return bytes.Length - start;
     }
@@ -354,11 +370,7 @@ internal sealed class ModuleOutputExcerptBuffer(
             return value;
         }
 
-        var start = bytes.Length - maximumTailBytes;
-        while (start < bytes.Length && IsUtf8ContinuationByte(bytes[start]))
-        {
-            start++;
-        }
+        var start = GetUtf8Boundary(bytes, bytes.Length - maximumTailBytes);
 
         return start == bytes.Length ? null : Utf8.GetString(bytes.AsSpan(start));
     }
@@ -376,16 +388,22 @@ internal sealed class ModuleOutputExcerptBuffer(
                 continue;
             }
 
-            var start = overflow;
-            while (start < oldest.Bytes.Length && IsUtf8ContinuationByte(oldest.Bytes[start]))
-            {
-                start++;
-            }
+            var start = GetUtf8Boundary(oldest.Bytes, overflow);
 
             var tail = oldest.Bytes[start..];
-            _chunks.AddFirst(new OutputChunk(oldest.Stream, tail));
+            _chunks.AddFirst(new OutputChunk(oldest.Stream, tail, Utf8.GetString(tail)));
             _retainedBytes -= start;
         }
+    }
+
+    private static int GetUtf8Boundary(byte[] bytes, int start)
+    {
+        while (start < bytes.Length && IsUtf8ContinuationByte(bytes[start]))
+        {
+            start++;
+        }
+
+        return start;
     }
 
     private static bool IsUtf8ContinuationByte(byte value) => (value & 0xC0) == 0x80;
@@ -416,7 +434,10 @@ internal sealed class ModuleOutputExcerptBuffer(
         return maximumBytes > int.MaxValue ? int.MaxValue : (int) maximumBytes;
     }
 
-    private readonly record struct OutputChunk(ModuleOutputStream Stream, byte[] Bytes);
+    private readonly record struct OutputChunk(
+        ModuleOutputStream Stream,
+        byte[] Bytes,
+        string Text);
 
     private readonly record struct MappedOutputChunk(ModuleOutputStream Stream, int SourceOffset);
 }

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using ModularPipelines.Models;
+
+namespace ModularPipelines.Console;
+
+internal sealed class ModuleOutputExcerptBuffer(int maximumBytes)
+{
+    private static readonly Encoding Utf8 = new UTF8Encoding(
+        encoderShouldEmitUTF8Identifier: false,
+        throwOnInvalidBytes: false);
+    private static readonly byte[] NewLineBytes = Utf8.GetBytes(Environment.NewLine);
+    private readonly LinkedList<OutputChunk> _chunks = [];
+    private long _totalBytes;
+    private int _retainedBytes;
+
+    public void Append(string value, ModuleOutputStream stream)
+    {
+        _totalBytes += (long) Utf8.GetByteCount(value) + NewLineBytes.Length;
+
+        // One UTF-16 code unit always produces at least one UTF-8 byte. Starting no more than
+        // maximumBytes code units from the end bounds the temporary allocation as well as storage.
+        var start = Math.Max(0, value.Length - maximumBytes);
+        if (start > 0
+            && char.IsLowSurrogate(value[start])
+            && char.IsHighSurrogate(value[start - 1]))
+        {
+            start--;
+        }
+
+        var retainedValue = value.AsSpan(start);
+        var valueByteCount = Utf8.GetByteCount(retainedValue);
+        var bytes = new byte[valueByteCount + NewLineBytes.Length];
+        Utf8.GetBytes(retainedValue, bytes);
+        NewLineBytes.CopyTo(bytes, valueByteCount);
+        _chunks.AddLast(new OutputChunk(stream, bytes));
+        _retainedBytes += bytes.Length;
+        TrimToLimit();
+    }
+
+    public ModuleOutputExcerpt? CreateExcerpt()
+    {
+        if (_chunks.Count == 0)
+        {
+            return null;
+        }
+
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        foreach (var chunk in _chunks)
+        {
+            (chunk.Stream is ModuleOutputStream.StandardError ? stderr : stdout)
+                .Append(Utf8.GetString(chunk.Bytes));
+        }
+
+        return new ModuleOutputExcerpt
+        {
+            StdoutTail = stdout.Length == 0 ? null : stdout.ToString(),
+            StderrTail = stderr.Length == 0 ? null : stderr.ToString(),
+            TruncatedBytes = _totalBytes - _retainedBytes,
+        };
+    }
+
+    private void TrimToLimit()
+    {
+        while (_retainedBytes > maximumBytes)
+        {
+            var overflow = _retainedBytes - maximumBytes;
+            var oldest = _chunks.First!.Value;
+            _chunks.RemoveFirst();
+            if (oldest.Bytes.Length <= overflow)
+            {
+                _retainedBytes -= oldest.Bytes.Length;
+                continue;
+            }
+
+            var start = overflow;
+            while (start < oldest.Bytes.Length && IsUtf8ContinuationByte(oldest.Bytes[start]))
+            {
+                start++;
+            }
+
+            var tail = oldest.Bytes[start..];
+            _chunks.AddFirst(new OutputChunk(oldest.Stream, tail));
+            _retainedBytes -= start;
+        }
+    }
+
+    private static bool IsUtf8ContinuationByte(byte value) => (value & 0xC0) == 0x80;
+
+    private readonly record struct OutputChunk(ModuleOutputStream Stream, byte[] Bytes);
+}
+
+internal enum ModuleOutputStream
+{
+    StandardOutput,
+    StandardError,
+}

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -175,21 +175,20 @@ internal sealed class ModuleOutputExcerptBuffer(
             return false;
         }
 
-        var maskedStdout = concreteObfuscator.ObfuscatePreservingMasks(stdout);
-        var maskedStderr = concreteObfuscator.ObfuscatePreservingMasks(stderr);
+        var maskedStdout = concreteObfuscator.ObfuscatePreservingMasksWithSourceMap(stdout);
+        var maskedStderr = concreteObfuscator.ObfuscatePreservingMasksWithSourceMap(stderr);
         (stdoutBytes, stderrBytes) = RebalanceMaskedStreamByteLimits(
             maskedStdout,
-            maskedStderr,
-            concreteObfuscator);
+            maskedStderr);
 
         if (!TryGetSafeMaskedTail(
-                maskedStdout,
+                maskedStdout.Value,
                 stdoutBytes,
                 _totalStdoutBytes > Utf8.GetByteCount(stdout),
                 maximumMatchBytes,
                 out stdoutTail)
             || !TryGetSafeMaskedTail(
-                maskedStderr,
+                maskedStderr.Value,
                 stderrBytes,
                 _totalStderrBytes > Utf8.GetByteCount(stderr),
                 maximumMatchBytes,
@@ -206,77 +205,49 @@ internal sealed class ModuleOutputExcerptBuffer(
     }
 
     private (int StdoutBytes, int StderrBytes) RebalanceMaskedStreamByteLimits(
-        string maskedStdout,
-        string maskedStderr,
-        SecretObfuscator obfuscator)
+        SecretObfuscator.MappedObfuscatedOutput maskedStdout,
+        SecretObfuscator.MappedObfuscatedOutput maskedStderr)
     {
-        var maskedStdoutBytes = Utf8.GetByteCount(maskedStdout);
-        var maskedStderrBytes = Utf8.GetByteCount(maskedStderr);
+        var maskedStdoutBytes = Utf8.GetBytes(maskedStdout.Value);
+        var maskedStderrBytes = Utf8.GetBytes(maskedStderr.Value);
         var stdoutBytes = 0;
         var stderrBytes = 0;
-        var stdoutNeeded = maskedStdoutBytes;
-        var stderrNeeded = maskedStderrBytes;
-        var stdoutSuffix = new StringBuilder();
-        var stderrSuffix = new StringBuilder();
-        var maskedAvailability = new List<(ModuleOutputStream Stream, int Bytes)>();
-        var chunks = GetCoalescedChunks();
+        var stdoutOffset = 0;
+        var stderrOffset = 0;
+        var chunks = new List<MappedOutputChunk>(_chunks.Count);
+        foreach (var chunk in _chunks)
+        {
+            var textLength = Utf8.GetString(chunk.Bytes).Length;
+            if (chunk.Stream is ModuleOutputStream.StandardError)
+            {
+                chunks.Add(new MappedOutputChunk(chunk.Stream, stderrOffset));
+                stderrOffset += textLength;
+            }
+            else
+            {
+                chunks.Add(new MappedOutputChunk(chunk.Stream, stdoutOffset));
+                stdoutOffset += textLength;
+            }
+        }
 
         for (var index = chunks.Count - 1; index >= 0; index--)
         {
             var chunk = chunks[index];
-            var chunkText = chunk.Text.ToString();
             if (chunk.Stream is ModuleOutputStream.StandardError)
             {
-                stderrSuffix.Insert(0, chunkText);
-                var available = Math.Min(
-                    stderrNeeded,
-                    Utf8.GetByteCount(obfuscator.ObfuscatePreservingMasks(stderrSuffix.ToString())));
-                maskedAvailability.Add((ModuleOutputStream.StandardError, available));
-            }
-            else
-            {
-                stdoutSuffix.Insert(0, chunkText);
-                var available = Math.Min(
-                    stdoutNeeded,
-                    Utf8.GetByteCount(obfuscator.ObfuscatePreservingMasks(stdoutSuffix.ToString())));
-                maskedAvailability.Add((ModuleOutputStream.StandardOutput, available));
-            }
-        }
-
-        var stableStdoutAvailability = stdoutNeeded;
-        var stableStderrAvailability = stderrNeeded;
-        for (var index = maskedAvailability.Count - 1; index >= 0; index--)
-        {
-            var availability = maskedAvailability[index];
-            if (availability.Stream is ModuleOutputStream.StandardError)
-            {
-                stableStderrAvailability = Math.Min(stableStderrAvailability, availability.Bytes);
-                maskedAvailability[index] = (availability.Stream, stableStderrAvailability);
-            }
-            else
-            {
-                stableStdoutAvailability = Math.Min(stableStdoutAvailability, availability.Bytes);
-                maskedAvailability[index] = (availability.Stream, stableStdoutAvailability);
-            }
-        }
-
-        foreach (var availability in maskedAvailability)
-        {
-            if (availability.Stream is ModuleOutputStream.StandardError)
-            {
                 stderrBytes = RebalanceStreamBytes(
-                    availability.Bytes,
+                    maskedStderr.GetSuffixByteCount(chunk.SourceOffset),
                     stderrBytes,
                     stdoutBytes);
-                stderrBytes = GetUtf8TailByteCount(maskedStderr, stderrBytes);
+                stderrBytes = GetUtf8TailByteCount(maskedStderrBytes, stderrBytes);
             }
             else
             {
                 stdoutBytes = RebalanceStreamBytes(
-                    availability.Bytes,
+                    maskedStdout.GetSuffixByteCount(chunk.SourceOffset),
                     stdoutBytes,
                     stderrBytes);
-                stdoutBytes = GetUtf8TailByteCount(maskedStdout, stdoutBytes);
+                stdoutBytes = GetUtf8TailByteCount(maskedStdoutBytes, stdoutBytes);
             }
         }
 
@@ -317,6 +288,8 @@ internal sealed class ModuleOutputExcerptBuffer(
         string stdout,
         string stderr)
     {
+        var stdoutUtf8 = Utf8.GetBytes(stdout);
+        var stderrUtf8 = Utf8.GetBytes(stderr);
         var stdoutBytes = 0;
         var stderrBytes = 0;
         for (var chunk = _chunks.Last;
@@ -328,40 +301,38 @@ internal sealed class ModuleOutputExcerptBuffer(
             if (chunk.Value.Stream is ModuleOutputStream.StandardError)
             {
                 stderrBytes += retained;
-                stderrBytes = GetUtf8TailByteCount(stderr, stderrBytes);
+                stderrBytes = GetUtf8TailByteCount(stderrUtf8, stderrBytes);
             }
             else
             {
                 stdoutBytes += retained;
-                stdoutBytes = GetUtf8TailByteCount(stdout, stdoutBytes);
+                stdoutBytes = GetUtf8TailByteCount(stdoutUtf8, stdoutBytes);
             }
         }
 
         return (stdoutBytes, stderrBytes);
     }
 
-    private IReadOnlyList<CoalescedOutputChunk> GetCoalescedChunks()
+    private static int GetUtf8TailByteCount(byte[] bytes, int maximumTailBytes)
     {
-        var coalescedChunks = new List<CoalescedOutputChunk>();
-        foreach (var chunk in _chunks)
+        if (maximumTailBytes == 0 || bytes.Length == 0)
         {
-            var previous = coalescedChunks.Count == 0 ? null : coalescedChunks[^1];
-            if (previous?.Stream == chunk.Stream)
-            {
-                previous.Text.Append(Utf8.GetString(chunk.Bytes));
-                continue;
-            }
-
-            coalescedChunks.Add(new CoalescedOutputChunk(
-                chunk.Stream,
-                new StringBuilder(Utf8.GetString(chunk.Bytes))));
+            return 0;
         }
 
-        return coalescedChunks;
-    }
+        if (bytes.Length <= maximumTailBytes)
+        {
+            return bytes.Length;
+        }
 
-    private static int GetUtf8TailByteCount(string value, int maximumTailBytes) =>
-        Utf8.GetByteCount(GetUtf8Tail(value, maximumTailBytes) ?? string.Empty);
+        var start = bytes.Length - maximumTailBytes;
+        while (start < bytes.Length && IsUtf8ContinuationByte(bytes[start]))
+        {
+            start++;
+        }
+
+        return bytes.Length - start;
+    }
 
     internal static string? GetUtf8Tail(string value, int maximumTailBytes)
     {
@@ -440,14 +411,7 @@ internal sealed class ModuleOutputExcerptBuffer(
 
     private readonly record struct OutputChunk(ModuleOutputStream Stream, byte[] Bytes);
 
-    private sealed class CoalescedOutputChunk(
-        ModuleOutputStream stream,
-        StringBuilder text)
-    {
-        public ModuleOutputStream Stream { get; } = stream;
-
-        public StringBuilder Text { get; } = text;
-    }
+    private readonly record struct MappedOutputChunk(ModuleOutputStream Stream, int SourceOffset);
 }
 
 internal enum ModuleOutputStream

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -170,15 +170,6 @@ internal sealed class ModuleOutputExcerptBuffer(
             .Select(secret => GetMaximumMatchByteCount(secret, caseInsensitive))
             .DefaultIfEmpty()
             .Max();
-        if (maximumMatchBytes > maximumBytes)
-        {
-            logger?.LogDebug(
-                "Omitting module output excerpt because a possible secret match of {MaximumMatchBytes} UTF-8 bytes exceeds the {MaximumExcerptBytes}-byte excerpt cap.",
-                maximumMatchBytes,
-                maximumBytes);
-            return false;
-        }
-
         var maskedStdout = concreteObfuscator.ObfuscatePreservingMasksWithSourceMap(stdout);
         var maskedStderr = concreteObfuscator.ObfuscatePreservingMasksWithSourceMap(stderr);
         var (stdoutBytes, stderrBytes) = RebalanceMaskedStreamByteLimits(

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -173,8 +173,6 @@ internal sealed class ModuleOutputExcerptBuffer(
         var maskedStdout = secretObfuscator.Obfuscate(stdout, null);
         var maskedStderr = secretObfuscator.Obfuscate(stderr, null);
         (stdoutBytes, stderrBytes) = RebalanceMaskedStreamByteLimits(
-            stdoutBytes,
-            stderrBytes,
             Utf8.GetByteCount(maskedStdout),
             Utf8.GetByteCount(maskedStderr),
             concreteObfuscator);
@@ -203,17 +201,15 @@ internal sealed class ModuleOutputExcerptBuffer(
     }
 
     private (int StdoutBytes, int StderrBytes) RebalanceMaskedStreamByteLimits(
-        int stdoutBytes,
-        int stderrBytes,
         int maskedStdoutBytes,
         int maskedStderrBytes,
         ISecretObfuscator obfuscator)
     {
-        stdoutBytes = Math.Min(stdoutBytes, maskedStdoutBytes);
-        stderrBytes = Math.Min(stderrBytes, maskedStderrBytes);
-        var remaining = maximumBytes - stdoutBytes - stderrBytes;
-        var stdoutNeeded = maskedStdoutBytes - stdoutBytes;
-        var stderrNeeded = maskedStderrBytes - stderrBytes;
+        var stdoutBytes = 0;
+        var stderrBytes = 0;
+        var remaining = maximumBytes;
+        var stdoutNeeded = maskedStdoutBytes;
+        var stderrNeeded = maskedStderrBytes;
 
         for (var chunk = _chunks.Last; chunk is not null && remaining > 0; chunk = chunk.Previous)
         {

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -216,6 +216,7 @@ internal sealed class ModuleOutputExcerptBuffer(
         var stderrNeeded = maskedStderrBytes;
         var stdoutSuffix = new StringBuilder();
         var stderrSuffix = new StringBuilder();
+        var maskedAvailability = new List<(ModuleOutputStream Stream, int Bytes)>();
 
         for (var chunk = _chunks.Last; chunk is not null; chunk = chunk.Previous)
         {
@@ -226,10 +227,7 @@ internal sealed class ModuleOutputExcerptBuffer(
                 var available = Math.Min(
                     stderrNeeded,
                     Utf8.GetByteCount(obfuscator.ObfuscatePreservingMasks(stderrSuffix.ToString())));
-                stderrBytes = RebalanceStreamBytes(
-                    available,
-                    stderrBytes,
-                    stdoutBytes);
+                maskedAvailability.Add((ModuleOutputStream.StandardError, available));
             }
             else
             {
@@ -237,8 +235,40 @@ internal sealed class ModuleOutputExcerptBuffer(
                 var available = Math.Min(
                     stdoutNeeded,
                     Utf8.GetByteCount(obfuscator.ObfuscatePreservingMasks(stdoutSuffix.ToString())));
+                maskedAvailability.Add((ModuleOutputStream.StandardOutput, available));
+            }
+        }
+
+        var stableStdoutAvailability = stdoutNeeded;
+        var stableStderrAvailability = stderrNeeded;
+        for (var index = maskedAvailability.Count - 1; index >= 0; index--)
+        {
+            var availability = maskedAvailability[index];
+            if (availability.Stream is ModuleOutputStream.StandardError)
+            {
+                stableStderrAvailability = Math.Min(stableStderrAvailability, availability.Bytes);
+                maskedAvailability[index] = (availability.Stream, stableStderrAvailability);
+            }
+            else
+            {
+                stableStdoutAvailability = Math.Min(stableStdoutAvailability, availability.Bytes);
+                maskedAvailability[index] = (availability.Stream, stableStdoutAvailability);
+            }
+        }
+
+        foreach (var availability in maskedAvailability)
+        {
+            if (availability.Stream is ModuleOutputStream.StandardError)
+            {
+                stderrBytes = RebalanceStreamBytes(
+                    availability.Bytes,
+                    stderrBytes,
+                    stdoutBytes);
+            }
+            else
+            {
                 stdoutBytes = RebalanceStreamBytes(
-                    available,
+                    availability.Bytes,
                     stdoutBytes,
                     stderrBytes);
             }

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -219,11 +219,13 @@ internal sealed class ModuleOutputExcerptBuffer(
         var stdoutSuffix = new StringBuilder();
         var stderrSuffix = new StringBuilder();
         var maskedAvailability = new List<(ModuleOutputStream Stream, int Bytes)>();
+        var chunks = GetCoalescedChunks();
 
-        for (var chunk = _chunks.Last; chunk is not null; chunk = chunk.Previous)
+        for (var index = chunks.Count - 1; index >= 0; index--)
         {
-            var chunkText = Utf8.GetString(chunk.Value.Bytes);
-            if (chunk.Value.Stream is ModuleOutputStream.StandardError)
+            var chunk = chunks[index];
+            var chunkText = chunk.Text.ToString();
+            if (chunk.Stream is ModuleOutputStream.StandardError)
             {
                 stderrSuffix.Insert(0, chunkText);
                 var available = Math.Min(
@@ -338,6 +340,26 @@ internal sealed class ModuleOutputExcerptBuffer(
         return (stdoutBytes, stderrBytes);
     }
 
+    private IReadOnlyList<CoalescedOutputChunk> GetCoalescedChunks()
+    {
+        var coalescedChunks = new List<CoalescedOutputChunk>();
+        foreach (var chunk in _chunks)
+        {
+            var previous = coalescedChunks.Count == 0 ? null : coalescedChunks[^1];
+            if (previous?.Stream == chunk.Stream)
+            {
+                previous.Text.Append(Utf8.GetString(chunk.Bytes));
+                continue;
+            }
+
+            coalescedChunks.Add(new CoalescedOutputChunk(
+                chunk.Stream,
+                new StringBuilder(Utf8.GetString(chunk.Bytes))));
+        }
+
+        return coalescedChunks;
+    }
+
     private static int GetUtf8TailByteCount(string value, int maximumTailBytes) =>
         Utf8.GetByteCount(GetUtf8Tail(value, maximumTailBytes) ?? string.Empty);
 
@@ -417,6 +439,15 @@ internal sealed class ModuleOutputExcerptBuffer(
     }
 
     private readonly record struct OutputChunk(ModuleOutputStream Stream, byte[] Bytes);
+
+    private sealed class CoalescedOutputChunk(
+        ModuleOutputStream stream,
+        StringBuilder text)
+    {
+        public ModuleOutputStream Stream { get; } = stream;
+
+        public StringBuilder Text { get; } = text;
+    }
 }
 
 internal enum ModuleOutputStream

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -170,8 +170,8 @@ internal sealed class ModuleOutputExcerptBuffer(
             return false;
         }
 
-        var maskedStdout = secretObfuscator.Obfuscate(stdout, null);
-        var maskedStderr = secretObfuscator.Obfuscate(stderr, null);
+        var maskedStdout = concreteObfuscator.ObfuscatePreservingMasks(stdout);
+        var maskedStderr = concreteObfuscator.ObfuscatePreservingMasks(stderr);
         (stdoutBytes, stderrBytes) = RebalanceMaskedStreamByteLimits(
             Utf8.GetByteCount(maskedStdout),
             Utf8.GetByteCount(maskedStderr),
@@ -203,7 +203,7 @@ internal sealed class ModuleOutputExcerptBuffer(
     private (int StdoutBytes, int StderrBytes) RebalanceMaskedStreamByteLimits(
         int maskedStdoutBytes,
         int maskedStderrBytes,
-        ISecretObfuscator obfuscator)
+        SecretObfuscator obfuscator)
     {
         var stdoutBytes = 0;
         var stderrBytes = 0;
@@ -214,7 +214,7 @@ internal sealed class ModuleOutputExcerptBuffer(
         for (var chunk = _chunks.Last; chunk is not null && remaining > 0; chunk = chunk.Previous)
         {
             var maskedChunkBytes = Utf8.GetByteCount(
-                obfuscator.Obfuscate(Utf8.GetString(chunk.Value.Bytes), null));
+                obfuscator.ObfuscatePreservingMasks(Utf8.GetString(chunk.Value.Bytes)));
             if (chunk.Value.Stream is ModuleOutputStream.StandardError && stderrNeeded > 0)
             {
                 var added = Math.Min(Math.Min(stderrNeeded, maskedChunkBytes), remaining);

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -74,7 +74,7 @@ internal sealed class ModuleOutputExcerptBuffer(
 
         var stdoutValue = stdout.ToString();
         var stderrValue = stderr.ToString();
-        var (stdoutBytes, stderrBytes) = GetFinalStreamByteLimits();
+        var (stdoutBytes, stderrBytes) = GetFinalStreamByteLimits(stdoutValue, stderrValue);
         var truncatedBytes = GetTruncatedByteCount(
             stdoutValue,
             stderrValue,
@@ -178,8 +178,8 @@ internal sealed class ModuleOutputExcerptBuffer(
         var maskedStdout = concreteObfuscator.ObfuscatePreservingMasks(stdout);
         var maskedStderr = concreteObfuscator.ObfuscatePreservingMasks(stderr);
         (stdoutBytes, stderrBytes) = RebalanceMaskedStreamByteLimits(
-            Utf8.GetByteCount(maskedStdout),
-            Utf8.GetByteCount(maskedStderr),
+            maskedStdout,
+            maskedStderr,
             concreteObfuscator);
 
         if (!TryGetSafeMaskedTail(
@@ -206,10 +206,12 @@ internal sealed class ModuleOutputExcerptBuffer(
     }
 
     private (int StdoutBytes, int StderrBytes) RebalanceMaskedStreamByteLimits(
-        int maskedStdoutBytes,
-        int maskedStderrBytes,
+        string maskedStdout,
+        string maskedStderr,
         SecretObfuscator obfuscator)
     {
+        var maskedStdoutBytes = Utf8.GetByteCount(maskedStdout);
+        var maskedStderrBytes = Utf8.GetByteCount(maskedStderr);
         var stdoutBytes = 0;
         var stderrBytes = 0;
         var stdoutNeeded = maskedStdoutBytes;
@@ -264,6 +266,7 @@ internal sealed class ModuleOutputExcerptBuffer(
                     availability.Bytes,
                     stderrBytes,
                     stdoutBytes);
+                stderrBytes = GetUtf8TailByteCount(maskedStderr, stderrBytes);
             }
             else
             {
@@ -271,6 +274,7 @@ internal sealed class ModuleOutputExcerptBuffer(
                     availability.Bytes,
                     stdoutBytes,
                     stderrBytes);
+                stdoutBytes = GetUtf8TailByteCount(maskedStdout, stdoutBytes);
             }
         }
 
@@ -307,28 +311,35 @@ internal sealed class ModuleOutputExcerptBuffer(
         return discardedMaskedBytes >= maximumMatchBytes;
     }
 
-    private (int StdoutBytes, int StderrBytes) GetFinalStreamByteLimits()
+    private (int StdoutBytes, int StderrBytes) GetFinalStreamByteLimits(
+        string stdout,
+        string stderr)
     {
         var stdoutBytes = 0;
         var stderrBytes = 0;
-        var remaining = maximumBytes;
-        for (var chunk = _chunks.Last; chunk is not null && remaining > 0; chunk = chunk.Previous)
+        for (var chunk = _chunks.Last;
+             chunk is not null && stdoutBytes + stderrBytes < maximumBytes;
+             chunk = chunk.Previous)
         {
+            var remaining = maximumBytes - stdoutBytes - stderrBytes;
             var retained = Math.Min(chunk.Value.Bytes.Length, remaining);
             if (chunk.Value.Stream is ModuleOutputStream.StandardError)
             {
                 stderrBytes += retained;
+                stderrBytes = GetUtf8TailByteCount(stderr, stderrBytes);
             }
             else
             {
                 stdoutBytes += retained;
+                stdoutBytes = GetUtf8TailByteCount(stdout, stdoutBytes);
             }
-
-            remaining -= retained;
         }
 
         return (stdoutBytes, stderrBytes);
     }
+
+    private static int GetUtf8TailByteCount(string value, int maximumTailBytes) =>
+        Utf8.GetByteCount(GetUtf8Tail(value, maximumTailBytes) ?? string.Empty);
 
     internal static string? GetUtf8Tail(string value, int maximumTailBytes)
     {

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -176,7 +176,8 @@ internal sealed class ModuleOutputExcerptBuffer(
             stdoutBytes,
             stderrBytes,
             Utf8.GetByteCount(maskedStdout),
-            Utf8.GetByteCount(maskedStderr));
+            Utf8.GetByteCount(maskedStderr),
+            concreteObfuscator);
 
         if (!TryGetSafeMaskedTail(
                 maskedStdout,
@@ -205,7 +206,8 @@ internal sealed class ModuleOutputExcerptBuffer(
         int stdoutBytes,
         int stderrBytes,
         int maskedStdoutBytes,
-        int maskedStderrBytes)
+        int maskedStderrBytes,
+        ISecretObfuscator obfuscator)
     {
         stdoutBytes = Math.Min(stdoutBytes, maskedStdoutBytes);
         stderrBytes = Math.Min(stderrBytes, maskedStderrBytes);
@@ -215,16 +217,18 @@ internal sealed class ModuleOutputExcerptBuffer(
 
         for (var chunk = _chunks.Last; chunk is not null && remaining > 0; chunk = chunk.Previous)
         {
+            var maskedChunkBytes = Utf8.GetByteCount(
+                obfuscator.Obfuscate(Utf8.GetString(chunk.Value.Bytes), null));
             if (chunk.Value.Stream is ModuleOutputStream.StandardError && stderrNeeded > 0)
             {
-                var added = Math.Min(stderrNeeded, remaining);
+                var added = Math.Min(Math.Min(stderrNeeded, maskedChunkBytes), remaining);
                 stderrBytes += added;
                 stderrNeeded -= added;
                 remaining -= added;
             }
             else if (chunk.Value.Stream is ModuleOutputStream.StandardOutput && stdoutNeeded > 0)
             {
-                var added = Math.Min(stdoutNeeded, remaining);
+                var added = Math.Min(Math.Min(stdoutNeeded, maskedChunkBytes), remaining);
                 stdoutBytes += added;
                 stdoutNeeded -= added;
                 remaining -= added;

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -1,15 +1,22 @@
 using System.Text;
+using ModularPipelines.Engine;
 using ModularPipelines.Models;
 
 namespace ModularPipelines.Console;
 
-internal sealed class ModuleOutputExcerptBuffer(int maximumBytes)
+internal sealed class ModuleOutputExcerptBuffer(
+    int maximumBytes,
+    ISecretObfuscator? secretObfuscator = null,
+    ISecretProvider? secretProvider = null)
 {
     private static readonly Encoding Utf8 = new UTF8Encoding(
         encoderShouldEmitUTF8Identifier: false,
         throwOnInvalidBytes: false);
     private static readonly byte[] NewLineBytes = Utf8.GetBytes(Environment.NewLine);
     private readonly LinkedList<OutputChunk> _chunks = [];
+    private readonly int _retentionBytes = maximumBytes > int.MaxValue / 2
+        ? int.MaxValue
+        : maximumBytes * 2;
     private long _totalBytes;
     private int _retainedBytes;
 
@@ -17,9 +24,9 @@ internal sealed class ModuleOutputExcerptBuffer(int maximumBytes)
     {
         _totalBytes += (long) Utf8.GetByteCount(value) + NewLineBytes.Length;
 
-        // One UTF-16 code unit always produces at least one UTF-8 byte. Starting no more than
-        // maximumBytes code units from the end bounds the temporary allocation as well as storage.
-        var start = Math.Max(0, value.Length - maximumBytes);
+        // One UTF-16 code unit always produces at least one UTF-8 byte. Keep one extra output
+        // window so late-registered secrets can be masked before the final tail is selected.
+        var start = Math.Max(0, value.Length - _retentionBytes);
         if (start > 0
             && char.IsLowSurrogate(value[start])
             && char.IsHighSurrogate(value[start - 1]))
@@ -34,7 +41,7 @@ internal sealed class ModuleOutputExcerptBuffer(int maximumBytes)
         NewLineBytes.CopyTo(bytes, valueByteCount);
         _chunks.AddLast(new OutputChunk(stream, bytes));
         _retainedBytes += bytes.Length;
-        TrimToLimit();
+        TrimToLimit(_retentionBytes);
     }
 
     public ModuleOutputExcerpt? CreateExcerpt()
@@ -52,19 +59,118 @@ internal sealed class ModuleOutputExcerptBuffer(int maximumBytes)
                 .Append(Utf8.GetString(chunk.Bytes));
         }
 
+        var (stdoutBytes, stderrBytes) = GetFinalStreamByteLimits();
+        if (!TryCreateTails(
+                stdout.ToString(),
+                stderr.ToString(),
+                stdoutBytes,
+                stderrBytes,
+                out var stdoutTail,
+                out var stderrTail))
+        {
+            return null;
+        }
+
         return new ModuleOutputExcerpt
         {
-            StdoutTail = stdout.Length == 0 ? null : stdout.ToString(),
-            StderrTail = stderr.Length == 0 ? null : stderr.ToString(),
-            TruncatedBytes = _totalBytes - _retainedBytes,
+            StdoutTail = stdoutTail,
+            StderrTail = stderrTail,
+            TruncatedBytes = Math.Max(0, _totalBytes - maximumBytes),
         };
     }
 
-    private void TrimToLimit()
+    private bool TryCreateTails(
+        string stdout,
+        string stderr,
+        int stdoutBytes,
+        int stderrBytes,
+        out string? stdoutTail,
+        out string? stderrTail)
     {
-        while (_retainedBytes > maximumBytes)
+        if (secretObfuscator is null && secretProvider is null)
         {
-            var overflow = _retainedBytes - maximumBytes;
+            stdoutTail = GetUtf8Tail(stdout, stdoutBytes);
+            stderrTail = GetUtf8Tail(stderr, stderrBytes);
+            return true;
+        }
+
+        // Custom or incomplete masking dependencies do not expose enough information
+        // to prove that a bounded context is safe.
+        if (secretObfuscator is not SecretObfuscator || secretProvider is null)
+        {
+            stdoutTail = null;
+            stderrTail = null;
+            return false;
+        }
+
+        var snapshot = secretProvider.GetSnapshot();
+        if (snapshot.Secrets
+            .Where(static secret => !string.IsNullOrEmpty(secret))
+            .Any(secret => Utf8.GetByteCount(secret) > maximumBytes))
+        {
+            stdoutTail = null;
+            stderrTail = null;
+            return false;
+        }
+
+        stdoutTail = GetUtf8Tail(secretObfuscator.Obfuscate(stdout, null), stdoutBytes);
+        stderrTail = GetUtf8Tail(secretObfuscator.Obfuscate(stderr, null), stderrBytes);
+
+        // If registration changed during masking, a new secret may cross the retained
+        // boundary. Omit the excerpt rather than risk returning a partial secret.
+        return secretProvider.Version == snapshot.Version;
+    }
+
+    private (int StdoutBytes, int StderrBytes) GetFinalStreamByteLimits()
+    {
+        var stdoutBytes = 0;
+        var stderrBytes = 0;
+        var remaining = maximumBytes;
+        for (var chunk = _chunks.Last; chunk is not null && remaining > 0; chunk = chunk.Previous)
+        {
+            var retained = Math.Min(chunk.Value.Bytes.Length, remaining);
+            if (chunk.Value.Stream is ModuleOutputStream.StandardError)
+            {
+                stderrBytes += retained;
+            }
+            else
+            {
+                stdoutBytes += retained;
+            }
+
+            remaining -= retained;
+        }
+
+        return (stdoutBytes, stderrBytes);
+    }
+
+    private static string? GetUtf8Tail(string value, int maximumTailBytes)
+    {
+        if (maximumTailBytes == 0 || value.Length == 0)
+        {
+            return null;
+        }
+
+        var bytes = Utf8.GetBytes(value);
+        if (bytes.Length <= maximumTailBytes)
+        {
+            return value;
+        }
+
+        var start = bytes.Length - maximumTailBytes;
+        while (start < bytes.Length && IsUtf8ContinuationByte(bytes[start]))
+        {
+            start++;
+        }
+
+        return start == bytes.Length ? null : Utf8.GetString(bytes.AsSpan(start));
+    }
+
+    private void TrimToLimit(int limit)
+    {
+        while (_retainedBytes > limit)
+        {
+            var overflow = _retainedBytes - limit;
             var oldest = _chunks.First!.Value;
             _chunks.RemoveFirst();
             if (oldest.Bytes.Length <= overflow)

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -75,7 +75,11 @@ internal sealed class ModuleOutputExcerptBuffer(
         {
             StdoutTail = stdoutTail,
             StderrTail = stderrTail,
-            TruncatedBytes = Math.Max(0, _totalBytes - maximumBytes),
+            TruncatedBytes = Math.Max(
+                0,
+                _totalBytes
+                - Utf8.GetByteCount(stdoutTail ?? string.Empty)
+                - Utf8.GetByteCount(stderrTail ?? string.Empty)),
         };
     }
 
@@ -146,7 +150,7 @@ internal sealed class ModuleOutputExcerptBuffer(
         return (stdoutBytes, stderrBytes);
     }
 
-    private static string? GetUtf8Tail(string value, int maximumTailBytes)
+    internal static string? GetUtf8Tail(string value, int maximumTailBytes)
     {
         if (maximumTailBytes == 0 || value.Length == 0)
         {

--- a/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputExcerptBuffer.cs
@@ -96,17 +96,18 @@ internal sealed class ModuleOutputExcerptBuffer(
 
         // Custom or incomplete masking dependencies do not expose enough information
         // to prove that a bounded context is safe.
-        if (secretObfuscator is not SecretObfuscator || secretProvider is null)
+        if (secretObfuscator is not SecretObfuscator concreteObfuscator || secretProvider is null)
         {
             stdoutTail = null;
             stderrTail = null;
             return false;
         }
 
+        var caseInsensitive = concreteObfuscator.CaseInsensitive;
         var snapshot = secretProvider.GetSnapshot();
         if (snapshot.Secrets
             .Where(static secret => !string.IsNullOrEmpty(secret))
-            .Any(secret => Utf8.GetByteCount(secret) > maximumBytes))
+            .Any(secret => GetMaximumMatchByteCount(secret, caseInsensitive) > maximumBytes))
         {
             stdoutTail = null;
             stderrTail = null;
@@ -118,7 +119,8 @@ internal sealed class ModuleOutputExcerptBuffer(
 
         // If registration changed during masking, a new secret may cross the retained
         // boundary. Omit the excerpt rather than risk returning a partial secret.
-        return secretProvider.Version == snapshot.Version;
+        return secretProvider.Version == snapshot.Version
+               && concreteObfuscator.CaseInsensitive == caseInsensitive;
     }
 
     private (int StdoutBytes, int StderrBytes) GetFinalStreamByteLimits()
@@ -192,6 +194,32 @@ internal sealed class ModuleOutputExcerptBuffer(
     }
 
     private static bool IsUtf8ContinuationByte(byte value) => (value & 0xC0) == 0x80;
+
+    private static int GetMaximumMatchByteCount(string secret, bool caseInsensitive)
+    {
+        if (!caseInsensitive)
+        {
+            return Utf8.GetByteCount(secret);
+        }
+
+        var maximumBytes = 0L;
+        for (var index = 0; index < secret.Length; index++)
+        {
+            if (char.IsHighSurrogate(secret[index])
+                && index + 1 < secret.Length
+                && char.IsLowSurrogate(secret[index + 1]))
+            {
+                maximumBytes += 4;
+                index++;
+            }
+            else
+            {
+                maximumBytes += 3;
+            }
+        }
+
+        return maximumBytes > int.MaxValue ? int.MaxValue : (int) maximumBytes;
+    }
 
     private readonly record struct OutputChunk(ModuleOutputStream Stream, byte[] Bytes);
 }

--- a/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
+++ b/src/ModularPipelines/DependencyInjection/DependencyInjectionSetup.cs
@@ -204,6 +204,7 @@ internal static class DependencyInjectionSetup
             // Console coordinator - single point of control for all console output
             .AddSingleton<Console.ConsoleCoordinator>()
             .AddSingleton<Console.IConsoleCoordinator>(sp => sp.GetRequiredService<Console.ConsoleCoordinator>())
+            .AddSingleton<Console.IModuleOutputExcerptProvider>(sp => sp.GetRequiredService<Console.ConsoleCoordinator>())
             .AddSingleton<IProgressDisplay>(sp => sp.GetRequiredService<Console.ConsoleCoordinator>())
 
             // Output coordinator - manages immediate output during live display

--- a/src/ModularPipelines/Engine/AtomicFileWriter.cs
+++ b/src/ModularPipelines/Engine/AtomicFileWriter.cs
@@ -27,6 +27,7 @@ internal static class AtomicFileWriter
             contents,
             writeAsync,
             replacementContentsFactory: null,
+            tryPublish: null,
             cancellationToken);
 
     internal static async Task WriteAllTextAsync(
@@ -34,6 +35,7 @@ internal static class AtomicFileWriter
         string contents,
         Func<string, string, CancellationToken, Task> writeAsync,
         Func<string?>? replacementContentsFactory,
+        Func<Action, bool>? tryPublish = null,
         CancellationToken cancellationToken = default)
     {
         var directory = Path.GetDirectoryName(path)
@@ -45,14 +47,28 @@ internal static class AtomicFileWriter
         try
         {
             await writeAsync(temporaryPath, contents, cancellationToken).ConfigureAwait(false);
-            if (replacementContentsFactory?.Invoke() is { } replacementContents)
+            var replacementContents = replacementContentsFactory?.Invoke();
+            if (replacementContents is not null)
             {
                 await writeAsync(temporaryPath, replacementContents, cancellationToken)
                     .ConfigureAwait(false);
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            File.Move(temporaryPath, path, overwrite: true);
+            if (replacementContents is not null || tryPublish is null)
+            {
+                File.Move(temporaryPath, path, overwrite: true);
+            }
+            else if (!tryPublish(() => File.Move(temporaryPath, path, overwrite: true)))
+            {
+                replacementContents = replacementContentsFactory?.Invoke()
+                    ?? throw new InvalidOperationException(
+                        "Atomic publication validation failed without safe replacement contents.");
+                await writeAsync(temporaryPath, replacementContents, cancellationToken)
+                    .ConfigureAwait(false);
+                cancellationToken.ThrowIfCancellationRequested();
+                File.Move(temporaryPath, path, overwrite: true);
+            }
         }
         finally
         {

--- a/src/ModularPipelines/Engine/AtomicFileWriter.cs
+++ b/src/ModularPipelines/Engine/AtomicFileWriter.cs
@@ -17,10 +17,23 @@ internal static class AtomicFileWriter
                 File.WriteAllTextAsync(temporaryPath, text, token),
             cancellationToken);
 
+    internal static Task WriteAllTextAsync(
+        string path,
+        string contents,
+        Func<string, string, CancellationToken, Task> writeAsync,
+        CancellationToken cancellationToken = default) =>
+        WriteAllTextAsync(
+            path,
+            contents,
+            writeAsync,
+            replacementContentsFactory: null,
+            cancellationToken);
+
     internal static async Task WriteAllTextAsync(
         string path,
         string contents,
         Func<string, string, CancellationToken, Task> writeAsync,
+        Func<string?>? replacementContentsFactory,
         CancellationToken cancellationToken = default)
     {
         var directory = Path.GetDirectoryName(path)
@@ -32,6 +45,12 @@ internal static class AtomicFileWriter
         try
         {
             await writeAsync(temporaryPath, contents, cancellationToken).ConfigureAwait(false);
+            if (replacementContentsFactory?.Invoke() is { } replacementContents)
+            {
+                await writeAsync(temporaryPath, replacementContents, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
             File.Move(temporaryPath, path, overwrite: true);
         }

--- a/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
+++ b/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
@@ -201,7 +201,7 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
                 StatusOverride = existingSummary.StatusOverride,
             };
 
-        await _outputCoordinator.FlushConsoleAsync().ConfigureAwait(false);
+        await FlushConsoleBestEffortAsync().ConfigureAwait(false);
 
         summary = summary with
         {
@@ -215,7 +215,7 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
 
         _outputCoordinator.PrintResults(summary);
 
-        await _outputCoordinator.FlushConsoleAsync().ConfigureAwait(false);
+        await FlushConsoleBestEffortAsync().ConfigureAwait(false);
 
         // Flush any buffered exceptions after the results table has been printed
         _outputCoordinator.FlushExceptions();
@@ -233,6 +233,18 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
         }
 
         return summary;
+    }
+
+    private async Task FlushConsoleBestEffortAsync()
+    {
+        try
+        {
+            await _outputCoordinator.FlushConsoleAsync().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogWarning(exception, "Could not flush pipeline console output");
+        }
     }
 
     private static Exception? GetPipelineReportException(

--- a/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
+++ b/src/ModularPipelines/Engine/Executors/ExecutionOrchestrator.cs
@@ -201,6 +201,8 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
                 StatusOverride = existingSummary.StatusOverride,
             };
 
+        await _outputCoordinator.FlushConsoleAsync().ConfigureAwait(false);
+
         summary = summary with
         {
             RunReport = await _runReportService.CompleteAsync(
@@ -213,7 +215,7 @@ internal class ExecutionOrchestrator : IExecutionOrchestrator
 
         _outputCoordinator.PrintResults(summary);
 
-        await System.Console.Out.FlushAsync().ConfigureAwait(false);
+        await _outputCoordinator.FlushConsoleAsync().ConfigureAwait(false);
 
         // Flush any buffered exceptions after the results table has been printed
         _outputCoordinator.FlushExceptions();

--- a/src/ModularPipelines/Engine/Executors/IPipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/IPipelineOutputCoordinator.cs
@@ -15,6 +15,11 @@ internal interface IPipelineOutputCoordinator
     Task<IPipelineOutputScope> InitializeAsync();
 
     /// <summary>
+    /// Flushes intercepted console fragments into their module buffers.
+    /// </summary>
+    Task FlushConsoleAsync();
+
+    /// <summary>
     /// Prints the final pipeline results.
     /// </summary>
     void PrintResults(PipelineSummary pipelineSummary);

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -82,12 +82,30 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
     /// <inheritdoc />
     public async Task FlushConsoleAsync()
     {
-        var output = System.Console.Out;
-        var error = System.Console.Error;
-        await output.FlushAsync().ConfigureAwait(false);
+        await FlushWritersAsync(System.Console.Out, System.Console.Error).ConfigureAwait(false);
+    }
+
+    internal static async Task FlushWritersAsync(TextWriter output, TextWriter error)
+    {
+        var exceptions = new List<Exception>();
+        await CaptureExceptionAsync(
+            () => output.FlushAsync(),
+            exceptions).ConfigureAwait(false);
         if (!ReferenceEquals(error, output))
         {
-            await error.FlushAsync().ConfigureAwait(false);
+            await CaptureExceptionAsync(
+                () => error.FlushAsync(),
+                exceptions).ConfigureAwait(false);
+        }
+
+        if (exceptions.Count == 1)
+        {
+            ExceptionDispatchInfo.Capture(exceptions[0]).Throw();
+        }
+
+        if (exceptions.Count > 1)
+        {
+            throw new AggregateException("Console flush failed.", exceptions);
         }
     }
 
@@ -123,6 +141,20 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
                 liveFlushInterval,
                 $"The interval must be between {TimeSpan.Zero} and " +
                 $"{PipelineConsoleOptions.MaximumModuleOutputFlushInterval}.");
+        }
+    }
+
+    private static async Task CaptureExceptionAsync(
+        Func<Task> operation,
+        ICollection<Exception> exceptions)
+    {
+        try
+        {
+            await operation().ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            exceptions.Add(exception);
         }
     }
 
@@ -222,20 +254,6 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
             if (exceptions.Count > 1)
             {
                 throw new AggregateException("Pipeline output teardown failed.", exceptions);
-            }
-        }
-
-        private static async Task CaptureExceptionAsync(
-            Func<Task> operation,
-            ICollection<Exception> exceptions)
-        {
-            try
-            {
-                await operation().ConfigureAwait(false);
-            }
-            catch (Exception exception)
-            {
-                exceptions.Add(exception);
             }
         }
 

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -80,6 +80,18 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
     }
 
     /// <inheritdoc />
+    public async Task FlushConsoleAsync()
+    {
+        var output = System.Console.Out;
+        var error = System.Console.Error;
+        await output.FlushAsync().ConfigureAwait(false);
+        if (!ReferenceEquals(error, output))
+        {
+            await error.FlushAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
     public void PrintResults(PipelineSummary pipelineSummary)
     {
         _consolePrinter.PrintResults(pipelineSummary);

--- a/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
@@ -173,9 +173,9 @@ internal sealed class FileSystemRunHistoryStore(
             : Guid.NewGuid().ToString("N");
         var fileName = $"{filePrefix}{report.End.UtcDateTime:yyyyMMddHHmmssfffffff}-{runId}.json";
         var path = Path.Combine(directory, fileName);
-        await AtomicFileWriter.WriteAllTextAsync(
+        await reportFactory.WriteWithValidatedOutputExcerptsAsync(
                 path,
-                reportFactory.SerializeWithValidatedOutputExcerpts(report),
+                report,
                 cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
@@ -13,6 +13,7 @@ namespace ModularPipelines.Engine;
 internal sealed class FileSystemRunHistoryStore(
     IOptions<PipelineOptions> pipelineOptions,
     ILogger<FileSystemRunHistoryStore> logger,
+    PipelineRunReportFactory reportFactory,
     RunReportPathResolver? pathResolver = null) : IRunHistoryStore
 {
     private const string OwnedFilePrefix = "modularpipelines-run-";
@@ -174,7 +175,7 @@ internal sealed class FileSystemRunHistoryStore(
         var path = Path.Combine(directory, fileName);
         await AtomicFileWriter.WriteAllTextAsync(
                 path,
-                RunReportJsonSerializer.Serialize(report),
+                reportFactory.SerializeWithValidatedOutputExcerpts(report),
                 cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/ModularPipelines/Engine/ISecretProvider.cs
+++ b/src/ModularPipelines/Engine/ISecretProvider.cs
@@ -18,6 +18,12 @@ internal interface ISecretProvider
     SecretSnapshot GetSnapshot();
 
     /// <summary>
+    /// Executes an action while preventing secret registration, provided the
+    /// registered-secret version is still current.
+    /// </summary>
+    bool TryExecuteIfVersionCurrent(long expectedVersion, Action action);
+
+    /// <summary>
     /// Returns any values in the object marked with the [SecretValue] attribute.
     /// </summary>
     /// <param name="value">Object to check for secret values within its properties.</param>

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -1,3 +1,4 @@
+using ModularPipelines.Console;
 using ModularPipelines.Enums;
 using ModularPipelines.Extensions;
 using ModularPipelines.Models;
@@ -6,7 +7,8 @@ namespace ModularPipelines.Engine;
 
 internal sealed class PipelineRunReportFactory(
     ICommandExecutionCounter commandExecutionCounter,
-    ISecretObfuscator secretObfuscator)
+    ISecretObfuscator secretObfuscator,
+    IModuleOutputExcerptProvider? outputExcerptProvider = null)
 {
     public PipelineRunReport Create(
         PipelineSummary summary,
@@ -156,6 +158,7 @@ internal sealed class PipelineRunReportFactory(
             End = current.End,
             SkipReason = GetSkipReason(result),
             Exception = CreateExceptionDetails(result?.ExceptionOrDefault),
+            Output = CreateOutputExcerpt(moduleType),
             CommandCount = commandExecutionCounter.GetCount(moduleType),
             PreviousDuration = previousDuration,
             DurationDelta = previousDuration.HasValue
@@ -215,6 +218,21 @@ internal sealed class PipelineRunReportFactory(
         result?.SkipDecisionOrDefault?.Reason is { } skipReason
             ? secretObfuscator.Obfuscate(skipReason, null)
             : null;
+
+    private ModuleOutputExcerpt? CreateOutputExcerpt(Type moduleType)
+    {
+        var excerpt = outputExcerptProvider?.GetModuleOutputExcerpt(moduleType);
+        return excerpt is null
+            ? null
+            : excerpt with
+            {
+                StdoutTail = ObfuscateOptional(excerpt.StdoutTail),
+                StderrTail = ObfuscateOptional(excerpt.StderrTail),
+            };
+    }
+
+    private string? ObfuscateOptional(string? value) =>
+        value is null ? null : secretObfuscator.Obfuscate(value, null);
 
     private static string? GetResultTypeName(IModuleResult result) =>
         result is ModuleResult { ModuleType: { } moduleType }

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -304,6 +304,23 @@ internal sealed class PipelineRunReportFactory(
                 .ToArray(),
         };
 
+    internal string SerializeWithValidatedOutputExcerpts(PipelineRunReport report)
+    {
+        var validatedReport = RemoveStaleOutputExcerpts(report);
+        var serializedReport = RunReportJsonSerializer.Serialize(validatedReport);
+        var outputExcerptCount = validatedReport.Modules.Count(static module => module.Output is not null);
+        if (outputExcerptCount == 0)
+        {
+            return serializedReport;
+        }
+
+        var revalidatedReport = RemoveStaleOutputExcerpts(validatedReport);
+        return revalidatedReport.Modules.Count(static module => module.Output is not null)
+               == outputExcerptCount
+            ? serializedReport
+            : RunReportJsonSerializer.Serialize(revalidatedReport);
+    }
+
     private static int GetByteCount(string? value) => Utf8.GetByteCount(value ?? string.Empty);
 
     private static string? GetUtf8Tail(string? value, int maximumBytes) =>

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -333,6 +333,9 @@ internal sealed class PipelineRunReportFactory(
                   && secretProvider?.Version != version
                 ? RunReportJsonSerializer.Serialize(RemoveOutputExcerpts(report))
                 : null,
+            serialization.SecretPatternsVersion is { } version
+                ? action => secretProvider?.TryExecuteIfVersionCurrent(version, action) == true
+                : null,
             cancellationToken);
     }
 

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -12,7 +12,8 @@ internal sealed class PipelineRunReportFactory(
     ICommandExecutionCounter commandExecutionCounter,
     ISecretObfuscator secretObfuscator,
     IModuleOutputExcerptProvider? outputExcerptProvider = null,
-    IOptions<PipelineOptions>? pipelineOptions = null)
+    IOptions<PipelineOptions>? pipelineOptions = null,
+    ISecretProvider? secretProvider = null)
 {
     private static readonly Encoding Utf8 = new UTF8Encoding(
         encoderShouldEmitUTF8Identifier: false,
@@ -235,6 +236,11 @@ internal sealed class PipelineRunReportFactory(
             return null;
         }
 
+        if (!HasCurrentSecretPatterns(excerpt))
+        {
+            return null;
+        }
+
         var maskedStdout = ObfuscateOptional(excerpt.StdoutTail);
         var maskedStderr = ObfuscateOptional(excerpt.StderrTail);
         var maximumBytes = pipelineOptions?.Value.RunReport.MaxOutputBytesPerModule ?? int.MaxValue;
@@ -249,13 +255,19 @@ internal sealed class PipelineRunReportFactory(
             - GetByteCount(stdoutTail)
             - GetByteCount(stderrTail));
 
-        return excerpt with
+        var finalExcerpt = excerpt with
         {
             StdoutTail = stdoutTail,
             StderrTail = stderrTail,
             TruncatedBytes = excerpt.TruncatedBytes + additionallyTruncatedBytes,
         };
+
+        return HasCurrentSecretPatterns(excerpt) ? finalExcerpt : null;
     }
+
+    private bool HasCurrentSecretPatterns(ModuleOutputExcerpt excerpt) =>
+        excerpt.SecretPatternsVersion is not { } version
+        || secretProvider?.Version == version;
 
     private static int GetByteCount(string? value) => Utf8.GetByteCount(value ?? string.Empty);
 

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -246,6 +246,7 @@ internal sealed class PipelineRunReportFactory(
                 : null;
         }
 
+        var secretPatternsVersion = secretProvider?.Version;
         var maskedStdout = ObfuscateOptional(excerpt.StdoutTail);
         var maskedStderr = ObfuscateOptional(excerpt.StderrTail);
         var maximumBytes = pipelineOptions?.Value.RunReport.MaxOutputBytesPerModule ?? int.MaxValue;
@@ -265,9 +266,34 @@ internal sealed class PipelineRunReportFactory(
             StdoutTail = stdoutTail,
             StderrTail = stderrTail,
             TruncatedBytes = excerpt.TruncatedBytes + additionallyTruncatedBytes,
+            SecretPatternsVersion = secretPatternsVersion,
         };
 
-        return finalExcerpt;
+        return secretProvider?.Version == secretPatternsVersion ? finalExcerpt : null;
+    }
+
+    internal PipelineRunReport RemoveStaleOutputExcerpts(PipelineRunReport report)
+    {
+        if (secretProvider is null || report.Modules.All(static module => module.Output is null))
+        {
+            return report;
+        }
+
+        var currentVersion = secretProvider.Version;
+        var modules = report.Modules
+            .Select(module => module.Output?.SecretPatternsVersion == currentVersion
+                ? module
+                : module with { Output = null })
+            .ToArray();
+
+        if (secretProvider.Version != currentVersion)
+        {
+            modules = modules
+                .Select(static module => module with { Output = null })
+                .ToArray();
+        }
+
+        return report with { Modules = modules };
     }
 
     private static int GetByteCount(string? value) => Utf8.GetByteCount(value ?? string.Empty);

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -296,6 +296,14 @@ internal sealed class PipelineRunReportFactory(
         return report with { Modules = modules };
     }
 
+    internal PipelineRunReport RemoveOutputExcerpts(PipelineRunReport report) =>
+        report with
+        {
+            Modules = report.Modules
+                .Select(static module => module with { Output = null })
+                .ToArray(),
+        };
+
     private static int GetByteCount(string? value) => Utf8.GetByteCount(value ?? string.Empty);
 
     private static string? GetUtf8Tail(string? value, int maximumBytes) =>

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -1,15 +1,23 @@
+using System.Text;
+using Microsoft.Extensions.Options;
 using ModularPipelines.Console;
 using ModularPipelines.Enums;
 using ModularPipelines.Extensions;
 using ModularPipelines.Models;
+using ModularPipelines.Options;
 
 namespace ModularPipelines.Engine;
 
 internal sealed class PipelineRunReportFactory(
     ICommandExecutionCounter commandExecutionCounter,
     ISecretObfuscator secretObfuscator,
-    IModuleOutputExcerptProvider? outputExcerptProvider = null)
+    IModuleOutputExcerptProvider? outputExcerptProvider = null,
+    IOptions<PipelineOptions>? pipelineOptions = null)
 {
+    private static readonly Encoding Utf8 = new UTF8Encoding(
+        encoderShouldEmitUTF8Identifier: false,
+        throwOnInvalidBytes: false);
+
     public PipelineRunReport Create(
         PipelineSummary summary,
         PipelineRunReport? previousReport,
@@ -222,14 +230,37 @@ internal sealed class PipelineRunReportFactory(
     private ModuleOutputExcerpt? CreateOutputExcerpt(Type moduleType)
     {
         var excerpt = outputExcerptProvider?.GetModuleOutputExcerpt(moduleType);
-        return excerpt is null
-            ? null
-            : excerpt with
-            {
-                StdoutTail = ObfuscateOptional(excerpt.StdoutTail),
-                StderrTail = ObfuscateOptional(excerpt.StderrTail),
-            };
+        if (excerpt is null)
+        {
+            return null;
+        }
+
+        var maskedStdout = ObfuscateOptional(excerpt.StdoutTail);
+        var maskedStderr = ObfuscateOptional(excerpt.StderrTail);
+        var maximumBytes = pipelineOptions?.Value.RunReport.MaxOutputBytesPerModule ?? int.MaxValue;
+        var stdoutBudget = Math.Min(GetByteCount(excerpt.StdoutTail), maximumBytes);
+        var stderrBudget = Math.Min(GetByteCount(excerpt.StderrTail), maximumBytes - stdoutBudget);
+        var stdoutTail = GetUtf8Tail(maskedStdout, stdoutBudget);
+        var stderrTail = GetUtf8Tail(maskedStderr, stderrBudget);
+        var additionallyTruncatedBytes = Math.Max(
+            0,
+            GetByteCount(maskedStdout)
+            + GetByteCount(maskedStderr)
+            - GetByteCount(stdoutTail)
+            - GetByteCount(stderrTail));
+
+        return excerpt with
+        {
+            StdoutTail = stdoutTail,
+            StderrTail = stderrTail,
+            TruncatedBytes = excerpt.TruncatedBytes + additionallyTruncatedBytes,
+        };
     }
+
+    private static int GetByteCount(string? value) => Utf8.GetByteCount(value ?? string.Empty);
+
+    private static string? GetUtf8Tail(string? value, int maximumBytes) =>
+        value is null ? null : ModuleOutputExcerptBuffer.GetUtf8Tail(value, maximumBytes);
 
     private string? ObfuscateOptional(string? value) =>
         value is null ? null : secretObfuscator.Obfuscate(value, null);

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -304,22 +304,61 @@ internal sealed class PipelineRunReportFactory(
                 .ToArray(),
         };
 
-    internal string SerializeWithValidatedOutputExcerpts(PipelineRunReport report)
+    internal string SerializeWithValidatedOutputExcerpts(PipelineRunReport report) =>
+        CreateValidatedSerialization(report).Contents;
+
+    internal Task WriteWithValidatedOutputExcerptsAsync(
+        string path,
+        PipelineRunReport report,
+        CancellationToken cancellationToken = default) =>
+        WriteWithValidatedOutputExcerptsAsync(
+            path,
+            report,
+            static (temporaryPath, contents, token) =>
+                File.WriteAllTextAsync(temporaryPath, contents, token),
+            cancellationToken);
+
+    internal Task WriteWithValidatedOutputExcerptsAsync(
+        string path,
+        PipelineRunReport report,
+        Func<string, string, CancellationToken, Task> writeAsync,
+        CancellationToken cancellationToken = default)
+    {
+        var serialization = CreateValidatedSerialization(report);
+        return AtomicFileWriter.WriteAllTextAsync(
+            path,
+            serialization.Contents,
+            writeAsync,
+            () => serialization.SecretPatternsVersion is { } version
+                  && secretProvider?.Version != version
+                ? RunReportJsonSerializer.Serialize(RemoveOutputExcerpts(report))
+                : null,
+            cancellationToken);
+    }
+
+    private ValidatedSerialization CreateValidatedSerialization(PipelineRunReport report)
     {
         var validatedReport = RemoveStaleOutputExcerpts(report);
         var serializedReport = RunReportJsonSerializer.Serialize(validatedReport);
         var outputExcerptCount = validatedReport.Modules.Count(static module => module.Output is not null);
         if (outputExcerptCount == 0)
         {
-            return serializedReport;
+            return new ValidatedSerialization(serializedReport, null);
         }
 
         var revalidatedReport = RemoveStaleOutputExcerpts(validatedReport);
-        return revalidatedReport.Modules.Count(static module => module.Output is not null)
-               == outputExcerptCount
-            ? serializedReport
-            : RunReportJsonSerializer.Serialize(revalidatedReport);
+        var excerptsRemainCurrent = revalidatedReport.Modules.Count(static module => module.Output is not null)
+                                    == outputExcerptCount;
+        return new ValidatedSerialization(
+            excerptsRemainCurrent
+                ? serializedReport
+                : RunReportJsonSerializer.Serialize(revalidatedReport),
+            revalidatedReport.Modules
+                .Select(static module => module.Output?.SecretPatternsVersion)
+                .FirstOrDefault(static version => version is not null));
     }
+
+    private sealed record ValidatedSerialization(string Contents, long? SecretPatternsVersion);
 
     private static int GetByteCount(string? value) => Utf8.GetByteCount(value ?? string.Empty);
 

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -236,9 +236,14 @@ internal sealed class PipelineRunReportFactory(
             return null;
         }
 
-        if (!HasCurrentSecretPatterns(excerpt))
+        if (excerpt.SecretPatternsVersion is { } version)
         {
-            return null;
+            var currentVersion = secretProvider?.Version;
+            // Detect a pattern change while the already-masked excerpt is handed off.
+            return currentVersion == version
+                   && secretProvider?.Version == currentVersion
+                ? excerpt
+                : null;
         }
 
         var maskedStdout = ObfuscateOptional(excerpt.StdoutTail);
@@ -262,12 +267,8 @@ internal sealed class PipelineRunReportFactory(
             TruncatedBytes = excerpt.TruncatedBytes + additionallyTruncatedBytes,
         };
 
-        return HasCurrentSecretPatterns(excerpt) ? finalExcerpt : null;
+        return finalExcerpt;
     }
-
-    private bool HasCurrentSecretPatterns(ModuleOutputExcerpt excerpt) =>
-        excerpt.SecretPatternsVersion is not { } version
-        || secretProvider?.Version == version;
 
     private static int GetByteCount(string? value) => Utf8.GetByteCount(value ?? string.Empty);
 

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -92,6 +92,24 @@ internal sealed class RunReportService(
         return report;
     }
 
+    private PipelineRunReport PrepareHistoryReport(PipelineRunReport report)
+    {
+        if (historyStore is FileSystemRunHistoryStore
+            || report.Modules.All(static module => module.Output is null))
+        {
+            return report;
+        }
+
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            logger.LogDebug(
+                "Omitting module output excerpts from custom run history store {HistoryStoreType}",
+                historyStore.GetType().FullName);
+        }
+
+        return reportFactory.RemoveOutputExcerpts(report);
+    }
+
     private async Task SynchronizeDistributedMetricsAsync(
         bool isDistributedWorker,
         PipelineSummary summary,
@@ -297,6 +315,7 @@ internal sealed class RunReportService(
             return;
         }
 
+        report = PrepareHistoryReport(report);
         await RunTimedPhaseAsync(
                 token => historyStore.SaveAsync(report, token),
                 _historyStoreTimeout,

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -64,17 +64,20 @@ internal sealed class RunReportService(
             pipelineIdentity,
             runId,
             pipelineException);
-        report = await EnrichReportAsync(
+        var enrichment = await EnrichReportAsync(
                 report,
                 pipelineIdentity,
                 reportPath is not null || historyEnabled)
             .ConfigureAwait(false);
+        report = enrichment.Report;
         report = report with
         {
             CommandCount = commandExecutionCounter.TotalCount,
             UnattributedCommandCount = commandExecutionCounter.UnattributedCount,
         };
-        report = reportFactory.RemoveStaleOutputExcerpts(report);
+        report = enrichment.HasIncompleteEnricher
+            ? reportFactory.RemoveOutputExcerpts(report)
+            : reportFactory.RemoveStaleOutputExcerpts(report);
 
         if (!cancellationToken.IsCancellationRequested)
         {
@@ -155,7 +158,7 @@ internal sealed class RunReportService(
         }
     }
 
-    private async Task<PipelineRunReport> EnrichReportAsync(
+    private async Task<EnrichedRunReport> EnrichReportAsync(
         PipelineRunReport report,
         string pipelineIdentity,
         bool invokeEnrichers)
@@ -165,25 +168,31 @@ internal sealed class RunReportService(
             pipelineIdentity,
             Environment.MachineName,
             buildSystemDetector.Current);
+        var hasIncompleteEnricher = false;
         if (invokeEnrichers)
         {
-            context = await InvokeEnrichersAsync(context).ConfigureAwait(false);
+            var enrichment = await InvokeEnrichersAsync(context).ConfigureAwait(false);
+            context = enrichment.Context;
+            hasIncompleteEnricher = enrichment.HasIncompleteEnricher;
         }
 
         try
         {
-            return reportFactory.WithCorrelation(report, context);
+            return new EnrichedRunReport(
+                reportFactory.WithCorrelation(report, context),
+                hasIncompleteEnricher);
         }
         catch (Exception exception)
         {
             logger.LogWarning(exception, "Could not obfuscate pipeline run correlation metadata");
-            return report;
+            return new EnrichedRunReport(report, hasIncompleteEnricher);
         }
     }
 
-    private async Task<RunReportEnrichmentContext> InvokeEnrichersAsync(
+    private async Task<RunReportEnrichment> InvokeEnrichersAsync(
         RunReportEnrichmentContext context)
     {
+        var hasIncompleteEnricher = false;
         foreach (var enricher in _runReportEnrichers)
         {
             using var timeout = new CancellationTokenSource(_enricherTimeout);
@@ -198,6 +207,7 @@ internal sealed class RunReportService(
             }
             catch (OperationCanceledException) when (timeout.IsCancellationRequested)
             {
+                hasIncompleteEnricher = true;
                 logger.LogWarning(
                     "Timed out enriching pipeline run report using {EnricherType} after {Timeout}",
                     enricher.GetType().FullName,
@@ -212,8 +222,16 @@ internal sealed class RunReportService(
             }
         }
 
-        return context;
+        return new RunReportEnrichment(context, hasIncompleteEnricher);
     }
+
+    private sealed record RunReportEnrichment(
+        RunReportEnrichmentContext Context,
+        bool HasIncompleteEnricher);
+
+    private sealed record EnrichedRunReport(
+        PipelineRunReport Report,
+        bool HasIncompleteEnricher);
 
     private static RunReportExceptionDetails? CreateFallbackExceptionDetails(Exception? exception)
     {

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -74,6 +74,7 @@ internal sealed class RunReportService(
             CommandCount = commandExecutionCounter.TotalCount,
             UnattributedCommandCount = commandExecutionCounter.UnattributedCount,
         };
+        report = reportFactory.RemoveStaleOutputExcerpts(report);
 
         if (!cancellationToken.IsCancellationRequested)
         {

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -78,6 +78,9 @@ internal sealed class RunReportService(
         report = enrichment.HasIncompleteEnricher
             ? reportFactory.RemoveOutputExcerpts(report)
             : reportFactory.RemoveStaleOutputExcerpts(report);
+        report = historyEnabled
+            ? PrepareHistoryReport(report)
+            : report;
 
         if (!cancellationToken.IsCancellationRequested)
         {
@@ -315,7 +318,6 @@ internal sealed class RunReportService(
             return;
         }
 
-        report = PrepareHistoryReport(report);
         await RunTimedPhaseAsync(
                 token => historyStore.SaveAsync(report, token),
                 _historyStoreTimeout,

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -290,10 +290,9 @@ internal sealed class RunReportService(
                 {
                     var fullPath = Path.GetFullPath(reportPath);
                     Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
-                    var persistenceReport = reportFactory.RemoveStaleOutputExcerpts(report);
                     await AtomicFileWriter.WriteAllTextAsync(
                             fullPath,
-                            RunReportJsonSerializer.Serialize(persistenceReport),
+                            reportFactory.SerializeWithValidatedOutputExcerpts(report),
                             token)
                         .ConfigureAwait(false);
                     logger.LogInformation(

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -290,9 +290,9 @@ internal sealed class RunReportService(
                 {
                     var fullPath = Path.GetFullPath(reportPath);
                     Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
-                    await AtomicFileWriter.WriteAllTextAsync(
+                    await reportFactory.WriteWithValidatedOutputExcerptsAsync(
                             fullPath,
-                            reportFactory.SerializeWithValidatedOutputExcerpts(report),
+                            report,
                             token)
                         .ConfigureAwait(false);
                     logger.LogInformation(

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -92,7 +92,7 @@ internal sealed class RunReportService(
             await SaveHistoryAsync(historyEnabled, report, cancellationToken).ConfigureAwait(false);
         }
 
-        return report;
+        return reportFactory.RemoveStaleOutputExcerpts(report);
     }
 
     private PipelineRunReport PrepareHistoryReport(PipelineRunReport report)
@@ -290,9 +290,10 @@ internal sealed class RunReportService(
                 {
                     var fullPath = Path.GetFullPath(reportPath);
                     Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+                    var persistenceReport = reportFactory.RemoveStaleOutputExcerpts(report);
                     await AtomicFileWriter.WriteAllTextAsync(
                             fullPath,
-                            RunReportJsonSerializer.Serialize(report),
+                            RunReportJsonSerializer.Serialize(persistenceReport),
                             token)
                         .ConfigureAwait(false);
                     logger.LogInformation(
@@ -319,7 +320,9 @@ internal sealed class RunReportService(
         }
 
         await RunTimedPhaseAsync(
-                token => historyStore.SaveAsync(report, token),
+                token => historyStore.SaveAsync(
+                    PrepareHistoryReport(reportFactory.RemoveStaleOutputExcerpts(report)),
+                    token),
                 _historyStoreTimeout,
                 cancellationToken,
                 exception => logger.LogWarning(exception, "Could not save pipeline run history"))

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -299,31 +299,19 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         var inputOffset = 0;
         while (inputOffset < input.Length)
         {
-            var remainingInput = input.AsSpan(inputOffset);
-            var relativeMatchIndex = remainingInput.IndexOfAny(searchValues);
-            if (relativeMatchIndex < 0)
+            if (!TryFindNextMatch(
+                    input,
+                    inputOffset,
+                    secrets,
+                    searchValues,
+                    comparison,
+                    out var matchIndex,
+                    out var matchedSecret))
             {
                 break;
             }
 
-            var matchIndex = inputOffset + relativeMatchIndex;
             result.Append(input, inputOffset, matchIndex - inputOffset);
-
-            var matchingInput = input.AsSpan(matchIndex);
-            string? matchedSecret = null;
-            foreach (var secret in secrets)
-            {
-                if (matchingInput.StartsWith(secret, comparison))
-                {
-                    matchedSecret = secret;
-                    break;
-                }
-            }
-
-            if (matchedSecret is null)
-            {
-                throw new InvalidOperationException("SearchValues returned a position without a matching secret.");
-            }
 
             if (IsContainedInExistingMask(
                     existingMaskRanges,
@@ -360,14 +348,18 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         var outputByteCount = 0;
         while (inputOffset < input.Length)
         {
-            var remainingInput = input.AsSpan(inputOffset);
-            var relativeMatchIndex = remainingInput.IndexOfAny(searchValues);
-            if (relativeMatchIndex < 0)
+            if (!TryFindNextMatch(
+                    input,
+                    inputOffset,
+                    secrets,
+                    searchValues,
+                    comparison,
+                    out var matchIndex,
+                    out var matchedSecret))
             {
                 break;
             }
 
-            var matchIndex = inputOffset + relativeMatchIndex;
             AppendUnchangedWithSourceMap(
                 result,
                 input,
@@ -375,22 +367,6 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
                 matchIndex,
                 sourceToOutputByteOffsets,
                 ref outputByteCount);
-
-            var matchingInput = input.AsSpan(matchIndex);
-            string? matchedSecret = null;
-            foreach (var secret in secrets)
-            {
-                if (matchingInput.StartsWith(secret, comparison))
-                {
-                    matchedSecret = secret;
-                    break;
-                }
-            }
-
-            if (matchedSecret is null)
-            {
-                throw new InvalidOperationException("SearchValues returned a position without a matching secret.");
-            }
 
             var matchEnd = matchIndex + matchedSecret.Length;
             if (IsContainedInExistingMask(
@@ -430,6 +406,38 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             sourceToOutputByteOffsets,
             ref outputByteCount);
         return new MappedObfuscatedOutput(result.ToString(), sourceToOutputByteOffsets);
+    }
+
+    private static bool TryFindNextMatch(
+        string input,
+        int inputOffset,
+        IReadOnlyList<string> secrets,
+        SearchValues<string> searchValues,
+        StringComparison comparison,
+        out int matchIndex,
+        out string matchedSecret)
+    {
+        var relativeMatchIndex = input.AsSpan(inputOffset).IndexOfAny(searchValues);
+        if (relativeMatchIndex < 0)
+        {
+            matchIndex = -1;
+            matchedSecret = string.Empty;
+            return false;
+        }
+
+        matchIndex = inputOffset + relativeMatchIndex;
+        var matchingInput = input.AsSpan(matchIndex);
+        foreach (var secret in secrets)
+        {
+            if (matchingInput.StartsWith(secret, comparison))
+            {
+                matchedSecret = secret;
+                return true;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "SearchValues returned a position without a matching secret.");
     }
 
     private static MappedObfuscatedOutput CreateUnchangedSourceMap(string input)
@@ -543,6 +551,27 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
 
         public int GetSuffixByteCount(int sourceOffset) =>
             Utf8ByteCount - SourceToOutputByteOffsets[sourceOffset];
+
+        public int GetSourceOffsetForOutputSuffix(int suffixByteCount)
+        {
+            var outputStart = Utf8ByteCount - suffixByteCount;
+            var low = 0;
+            var high = SourceToOutputByteOffsets.Count;
+            while (low < high)
+            {
+                var middle = low + ((high - low) / 2);
+                if (SourceToOutputByteOffsets[middle] < outputStart)
+                {
+                    low = middle + 1;
+                }
+                else
+                {
+                    high = middle;
+                }
+            }
+
+            return low;
+        }
     }
 
     internal readonly record struct SecretRegistrationState(long Version, bool HasSecrets);

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -36,6 +36,8 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
 
     public bool HasSecrets => GetRegistrationState().HasSecrets;
 
+    internal bool CaseInsensitive => _maskingOptions.Value.CaseInsensitive;
+
     public SecretObfuscator(
         ISecretProvider secretProvider,
         IOptions<SecretMaskingOptions> maskingOptions)

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -125,6 +125,31 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             preserveExistingMasks: true);
     }
 
+    internal MappedObfuscatedOutput ObfuscatePreservingMasksWithSourceMap(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return new MappedObfuscatedOutput(string.Empty, [0]);
+        }
+
+        var options = _maskingOptions.Value;
+        var maskValue = GetMaskValue(options);
+        var caseInsensitive = options.CaseInsensitive;
+        var secretCache = GetSecretCache(null, options, caseInsensitive);
+        if (secretCache.SearchValues is null
+            || !input.AsSpan().ContainsAny(secretCache.SearchValues))
+        {
+            return CreateUnchangedSourceMap(input);
+        }
+
+        return ObfuscateMatchesWithSourceMap(
+            input,
+            secretCache.Secrets,
+            secretCache.SearchValues,
+            maskValue,
+            caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+    }
+
     internal SecretRegistrationState GetRegistrationState()
     {
         var cache = GetRegisteredSecretCache(_maskingOptions.Value.CaseInsensitive);
@@ -320,6 +345,138 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         return new SecretObfuscationResult(result.ToString(), inputOffset);
     }
 
+    private static MappedObfuscatedOutput ObfuscateMatchesWithSourceMap(
+        string input,
+        IReadOnlyList<string> secrets,
+        SearchValues<string> searchValues,
+        string maskValue,
+        StringComparison comparison)
+    {
+        var existingMaskRanges = GetMaskRanges(input, maskValue);
+        var maskRangeIndex = 0;
+        var sourceToOutputByteOffsets = new int[input.Length + 1];
+        var result = new StringBuilder(input.Length);
+        var inputOffset = 0;
+        var outputByteCount = 0;
+        while (inputOffset < input.Length)
+        {
+            var remainingInput = input.AsSpan(inputOffset);
+            var relativeMatchIndex = remainingInput.IndexOfAny(searchValues);
+            if (relativeMatchIndex < 0)
+            {
+                break;
+            }
+
+            var matchIndex = inputOffset + relativeMatchIndex;
+            AppendUnchangedWithSourceMap(
+                result,
+                input,
+                inputOffset,
+                matchIndex,
+                sourceToOutputByteOffsets,
+                ref outputByteCount);
+
+            var matchingInput = input.AsSpan(matchIndex);
+            string? matchedSecret = null;
+            foreach (var secret in secrets)
+            {
+                if (matchingInput.StartsWith(secret, comparison))
+                {
+                    matchedSecret = secret;
+                    break;
+                }
+            }
+
+            if (matchedSecret is null)
+            {
+                throw new InvalidOperationException("SearchValues returned a position without a matching secret.");
+            }
+
+            var matchEnd = matchIndex + matchedSecret.Length;
+            if (IsContainedInExistingMask(
+                    existingMaskRanges,
+                    ref maskRangeIndex,
+                    matchIndex,
+                    matchedSecret.Length))
+            {
+                AppendUnchangedWithSourceMap(
+                    result,
+                    input,
+                    matchIndex,
+                    matchEnd,
+                    sourceToOutputByteOffsets,
+                    ref outputByteCount);
+            }
+            else
+            {
+                for (var index = matchIndex; index < matchEnd; index++)
+                {
+                    sourceToOutputByteOffsets[index] = outputByteCount;
+                }
+
+                result.Append(maskValue);
+                outputByteCount += Encoding.UTF8.GetByteCount(maskValue);
+                sourceToOutputByteOffsets[matchEnd] = outputByteCount;
+            }
+
+            inputOffset = matchEnd;
+        }
+
+        AppendUnchangedWithSourceMap(
+            result,
+            input,
+            inputOffset,
+            input.Length,
+            sourceToOutputByteOffsets,
+            ref outputByteCount);
+        return new MappedObfuscatedOutput(result.ToString(), sourceToOutputByteOffsets);
+    }
+
+    private static MappedObfuscatedOutput CreateUnchangedSourceMap(string input)
+    {
+        var sourceToOutputByteOffsets = new int[input.Length + 1];
+        var outputByteCount = 0;
+        AppendUnchangedWithSourceMap(
+            result: null,
+            input,
+            0,
+            input.Length,
+            sourceToOutputByteOffsets,
+            ref outputByteCount);
+        return new MappedObfuscatedOutput(input, sourceToOutputByteOffsets);
+    }
+
+    private static void AppendUnchangedWithSourceMap(
+        StringBuilder? result,
+        string input,
+        int start,
+        int end,
+        int[] sourceToOutputByteOffsets,
+        ref int outputByteCount)
+    {
+        result?.Append(input, start, end - start);
+        for (var index = start; index < end;)
+        {
+            sourceToOutputByteOffsets[index] = outputByteCount;
+            var status = Rune.DecodeFromUtf16(input.AsSpan(index, end - index), out var rune, out var consumed);
+            if (status != OperationStatus.Done)
+            {
+                rune = Rune.ReplacementChar;
+                consumed = 1;
+            }
+
+            for (var continuation = 1; continuation < consumed; continuation++)
+            {
+                sourceToOutputByteOffsets[index + continuation] = outputByteCount;
+            }
+
+            outputByteCount += rune.Utf8SequenceLength;
+            index += consumed;
+        }
+
+        sourceToOutputByteOffsets[end] = outputByteCount;
+    }
+
     private static bool IsContainedInExistingMask(
         IReadOnlyList<(int Start, int End)> ranges,
         ref int rangeIndex,
@@ -377,6 +534,16 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         string[] Secrets,
         IReadOnlySet<string> ExactSecrets,
         SearchValues<string>? SearchValues);
+
+    internal sealed record MappedObfuscatedOutput(
+        string Value,
+        IReadOnlyList<int> SourceToOutputByteOffsets)
+    {
+        public int Utf8ByteCount => SourceToOutputByteOffsets[^1];
+
+        public int GetSuffixByteCount(int sourceOffset) =>
+            Utf8ByteCount - SourceToOutputByteOffsets[sourceOffset];
+    }
 
     internal readonly record struct SecretRegistrationState(long Version, bool HasSecrets);
 }

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -64,7 +64,7 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
 
         var options = _maskingOptions.Value;
         // Ensure mask value is never empty to avoid removing secrets without masking
-        var maskValue = string.IsNullOrWhiteSpace(options.MaskValue) ? "**********" : options.MaskValue;
+        var maskValue = GetMaskValue(options);
         var caseInsensitive = options.CaseInsensitive;
 
         var secretCache = GetSecretCache(optionsObject, options, caseInsensitive);
@@ -80,6 +80,29 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
             secretCache.SearchValues,
             maskValue,
             caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+    }
+
+    internal string ObfuscatePreservingMasks(string input)
+    {
+        var maskValue = GetMaskValue(_maskingOptions.Value);
+        var maskIndex = input.IndexOf(maskValue, StringComparison.Ordinal);
+        if (maskIndex < 0)
+        {
+            return Obfuscate(input, null);
+        }
+
+        var result = new StringBuilder(input.Length);
+        var inputOffset = 0;
+        while (maskIndex >= 0)
+        {
+            result.Append(Obfuscate(input[inputOffset..maskIndex], null));
+            result.Append(maskValue);
+            inputOffset = maskIndex + maskValue.Length;
+            maskIndex = input.IndexOf(maskValue, inputOffset, StringComparison.Ordinal);
+        }
+
+        result.Append(Obfuscate(input[inputOffset..], null));
+        return result.ToString();
     }
 
     internal SecretRegistrationState GetRegistrationState()
@@ -175,6 +198,9 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
             return newCache;
         }
     }
+
+    private static string GetMaskValue(SecretMaskingOptions options) =>
+        string.IsNullOrWhiteSpace(options.MaskValue) ? "**********" : options.MaskValue;
 
     private static SecretCache CreateSecretCache(
         IEnumerable<string> secrets,

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -41,6 +41,8 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
 
+    internal bool CaseInsensitive => _maskingOptions.Value.CaseInsensitive;
+
     public SecretObfuscator(
         ISecretProvider secretProvider,
         IOptions<SecretMaskingOptions> maskingOptions)

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -114,6 +114,16 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         return new SecretRegistrationState(cache.Version, cache.SearchValues is not null);
     }
 
+    internal bool CanSafelyPreserveMasks(IReadOnlyList<string> secrets)
+    {
+        var maskValue = GetMaskValue(_maskingOptions.Value);
+        var comparison = CaseInsensitive
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return secrets.All(secret =>
+            string.IsNullOrEmpty(secret) || !maskValue.Contains(secret, comparison));
+    }
+
     internal SecretCache GetSecretCache(
         object? optionsObject,
         SecretMaskingOptions options,

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -282,31 +282,19 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         var inputOffset = 0;
         while (inputOffset < input.Length)
         {
-            var remainingInput = input.AsSpan(inputOffset);
-            var relativeMatchIndex = remainingInput.IndexOfAny(searchValues);
-            if (relativeMatchIndex < 0)
+            if (!TryFindNextMatch(
+                    input,
+                    inputOffset,
+                    secrets,
+                    searchValues,
+                    comparison,
+                    out var matchIndex,
+                    out var matchedSecret))
             {
                 break;
             }
 
-            var matchIndex = inputOffset + relativeMatchIndex;
             result.Append(input, inputOffset, matchIndex - inputOffset);
-
-            var matchingInput = input.AsSpan(matchIndex);
-            string? matchedSecret = null;
-            foreach (var secret in secrets)
-            {
-                if (matchingInput.StartsWith(secret, comparison))
-                {
-                    matchedSecret = secret;
-                    break;
-                }
-            }
-
-            if (matchedSecret is null)
-            {
-                throw new InvalidOperationException("SearchValues returned a position without a matching secret.");
-            }
 
             if (IsContainedInExistingMask(
                     existingMaskRanges,
@@ -343,14 +331,18 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         var outputByteCount = 0;
         while (inputOffset < input.Length)
         {
-            var remainingInput = input.AsSpan(inputOffset);
-            var relativeMatchIndex = remainingInput.IndexOfAny(searchValues);
-            if (relativeMatchIndex < 0)
+            if (!TryFindNextMatch(
+                    input,
+                    inputOffset,
+                    secrets,
+                    searchValues,
+                    comparison,
+                    out var matchIndex,
+                    out var matchedSecret))
             {
                 break;
             }
 
-            var matchIndex = inputOffset + relativeMatchIndex;
             AppendUnchangedWithSourceMap(
                 result,
                 input,
@@ -358,22 +350,6 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
                 matchIndex,
                 sourceToOutputByteOffsets,
                 ref outputByteCount);
-
-            var matchingInput = input.AsSpan(matchIndex);
-            string? matchedSecret = null;
-            foreach (var secret in secrets)
-            {
-                if (matchingInput.StartsWith(secret, comparison))
-                {
-                    matchedSecret = secret;
-                    break;
-                }
-            }
-
-            if (matchedSecret is null)
-            {
-                throw new InvalidOperationException("SearchValues returned a position without a matching secret.");
-            }
 
             var matchEnd = matchIndex + matchedSecret.Length;
             if (IsContainedInExistingMask(
@@ -413,6 +389,38 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
             sourceToOutputByteOffsets,
             ref outputByteCount);
         return new MappedObfuscatedOutput(result.ToString(), sourceToOutputByteOffsets);
+    }
+
+    private static bool TryFindNextMatch(
+        string input,
+        int inputOffset,
+        IReadOnlyList<string> secrets,
+        SearchValues<string> searchValues,
+        StringComparison comparison,
+        out int matchIndex,
+        out string matchedSecret)
+    {
+        var relativeMatchIndex = input.AsSpan(inputOffset).IndexOfAny(searchValues);
+        if (relativeMatchIndex < 0)
+        {
+            matchIndex = -1;
+            matchedSecret = string.Empty;
+            return false;
+        }
+
+        matchIndex = inputOffset + relativeMatchIndex;
+        var matchingInput = input.AsSpan(matchIndex);
+        foreach (var secret in secrets)
+        {
+            if (matchingInput.StartsWith(secret, comparison))
+            {
+                matchedSecret = secret;
+                return true;
+            }
+        }
+
+        throw new InvalidOperationException(
+            "SearchValues returned a position without a matching secret.");
     }
 
     private static MappedObfuscatedOutput CreateUnchangedSourceMap(string input)
@@ -526,6 +534,27 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
 
         public int GetSuffixByteCount(int sourceOffset) =>
             Utf8ByteCount - SourceToOutputByteOffsets[sourceOffset];
+
+        public int GetSourceOffsetForOutputSuffix(int suffixByteCount)
+        {
+            var outputStart = Utf8ByteCount - suffixByteCount;
+            var low = 0;
+            var high = SourceToOutputByteOffsets.Count;
+            while (low < high)
+            {
+                var middle = low + ((high - low) / 2);
+                if (SourceToOutputByteOffsets[middle] < outputStart)
+                {
+                    low = middle + 1;
+                }
+                else
+                {
+                    high = middle;
+                }
+            }
+
+            return low;
+        }
     }
 
     internal readonly record struct SecretRegistrationState(long Version, bool HasSecrets);

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -101,25 +101,28 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
 
     internal string ObfuscatePreservingMasks(string input)
     {
-        var maskValue = GetMaskValue(_maskingOptions.Value);
-        var maskIndex = input.IndexOf(maskValue, StringComparison.Ordinal);
-        if (maskIndex < 0)
+        if (string.IsNullOrEmpty(input))
         {
-            return Obfuscate(input, null);
+            return string.Empty;
         }
 
-        var result = new StringBuilder(input.Length);
-        var inputOffset = 0;
-        while (maskIndex >= 0)
+        var options = _maskingOptions.Value;
+        var maskValue = GetMaskValue(options);
+        var caseInsensitive = options.CaseInsensitive;
+        var secretCache = GetSecretCache(null, options, caseInsensitive);
+        if (secretCache.SearchValues is null
+            || !input.AsSpan().ContainsAny(secretCache.SearchValues))
         {
-            result.Append(Obfuscate(input[inputOffset..maskIndex], null));
-            result.Append(maskValue);
-            inputOffset = maskIndex + maskValue.Length;
-            maskIndex = input.IndexOf(maskValue, inputOffset, StringComparison.Ordinal);
+            return input;
         }
 
-        result.Append(Obfuscate(input[inputOffset..], null));
-        return result.ToString();
+        return ObfuscateMatches(
+            input,
+            secretCache.Secrets,
+            secretCache.SearchValues,
+            maskValue,
+            caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal,
+            preserveExistingMasks: true);
     }
 
     internal SecretRegistrationState GetRegistrationState()
@@ -250,8 +253,13 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         IReadOnlyList<string> secrets,
         SearchValues<string> searchValues,
         string maskValue,
-        StringComparison comparison)
+        StringComparison comparison,
+        bool preserveExistingMasks = false)
     {
+        var existingMaskRanges = preserveExistingMasks
+            ? GetMaskRanges(input, maskValue)
+            : [];
+        var maskRangeIndex = 0;
         var result = new StringBuilder(input.Length);
         var inputOffset = 0;
         while (inputOffset < input.Length)
@@ -282,6 +290,17 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
                 throw new InvalidOperationException("SearchValues returned a position without a matching secret.");
             }
 
+            if (IsContainedInExistingMask(
+                    existingMaskRanges,
+                    ref maskRangeIndex,
+                    matchIndex,
+                    matchedSecret.Length))
+            {
+                result.Append(input, matchIndex, matchedSecret.Length);
+                inputOffset = matchIndex + matchedSecret.Length;
+                continue;
+            }
+
             result.Append(maskValue);
             inputOffset = matchIndex + matchedSecret.Length;
         }
@@ -289,6 +308,44 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         result.Append(input, inputOffset, input.Length - inputOffset);
 
         return new SecretObfuscationResult(result.ToString(), inputOffset);
+    }
+
+    private static bool IsContainedInExistingMask(
+        IReadOnlyList<(int Start, int End)> ranges,
+        ref int rangeIndex,
+        int matchIndex,
+        int matchLength)
+    {
+        while (rangeIndex < ranges.Count && ranges[rangeIndex].End <= matchIndex)
+        {
+            rangeIndex++;
+        }
+
+        var matchEnd = matchIndex + matchLength;
+        for (var index = rangeIndex;
+             index < ranges.Count && ranges[index].Start <= matchIndex;
+             index++)
+        {
+            if (matchEnd <= ranges[index].End)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyList<(int Start, int End)> GetMaskRanges(string input, string maskValue)
+    {
+        var ranges = new List<(int Start, int End)>();
+        for (var index = input.IndexOf(maskValue, StringComparison.Ordinal);
+             index >= 0;
+             index = input.IndexOf(maskValue, index + 1, StringComparison.Ordinal))
+        {
+            ranges.Add((index, index + maskValue.Length));
+        }
+
+        return ranges;
     }
 
     private sealed class OptionsSecretCache

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -81,7 +81,7 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
 
         var options = _maskingOptions.Value;
         // Ensure mask value is never empty to avoid removing secrets without masking
-        var maskValue = string.IsNullOrWhiteSpace(options.MaskValue) ? "**********" : options.MaskValue;
+        var maskValue = GetMaskValue(options);
         var caseInsensitive = options.CaseInsensitive;
 
         var secretCache = GetSecretCache(optionsObject, options, caseInsensitive);
@@ -97,6 +97,29 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             secretCache.SearchValues,
             maskValue,
             caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+    }
+
+    internal string ObfuscatePreservingMasks(string input)
+    {
+        var maskValue = GetMaskValue(_maskingOptions.Value);
+        var maskIndex = input.IndexOf(maskValue, StringComparison.Ordinal);
+        if (maskIndex < 0)
+        {
+            return Obfuscate(input, null);
+        }
+
+        var result = new StringBuilder(input.Length);
+        var inputOffset = 0;
+        while (maskIndex >= 0)
+        {
+            result.Append(Obfuscate(input[inputOffset..maskIndex], null));
+            result.Append(maskValue);
+            inputOffset = maskIndex + maskValue.Length;
+            maskIndex = input.IndexOf(maskValue, inputOffset, StringComparison.Ordinal);
+        }
+
+        result.Append(Obfuscate(input[inputOffset..], null));
+        return result.ToString();
     }
 
     internal SecretRegistrationState GetRegistrationState()
@@ -192,6 +215,9 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             return newCache;
         }
     }
+
+    private static string GetMaskValue(SecretMaskingOptions options) =>
+        string.IsNullOrWhiteSpace(options.MaskValue) ? "**********" : options.MaskValue;
 
     private static SecretCache CreateSecretCache(
         IEnumerable<string> secrets,

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -131,6 +131,16 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
         return new SecretRegistrationState(cache.Version, cache.SearchValues is not null);
     }
 
+    internal bool CanSafelyPreserveMasks(IReadOnlyList<string> secrets)
+    {
+        var maskValue = GetMaskValue(_maskingOptions.Value);
+        var comparison = CaseInsensitive
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return secrets.All(secret =>
+            string.IsNullOrEmpty(secret) || !maskValue.Contains(secret, comparison));
+    }
+
     internal SecretCache GetSecretCache(
         object? optionsObject,
         SecretMaskingOptions options,

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -84,25 +84,28 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
 
     internal string ObfuscatePreservingMasks(string input)
     {
-        var maskValue = GetMaskValue(_maskingOptions.Value);
-        var maskIndex = input.IndexOf(maskValue, StringComparison.Ordinal);
-        if (maskIndex < 0)
+        if (string.IsNullOrEmpty(input))
         {
-            return Obfuscate(input, null);
+            return string.Empty;
         }
 
-        var result = new StringBuilder(input.Length);
-        var inputOffset = 0;
-        while (maskIndex >= 0)
+        var options = _maskingOptions.Value;
+        var maskValue = GetMaskValue(options);
+        var caseInsensitive = options.CaseInsensitive;
+        var secretCache = GetSecretCache(null, options, caseInsensitive);
+        if (secretCache.SearchValues is null
+            || !input.AsSpan().ContainsAny(secretCache.SearchValues))
         {
-            result.Append(Obfuscate(input[inputOffset..maskIndex], null));
-            result.Append(maskValue);
-            inputOffset = maskIndex + maskValue.Length;
-            maskIndex = input.IndexOf(maskValue, inputOffset, StringComparison.Ordinal);
+            return input;
         }
 
-        result.Append(Obfuscate(input[inputOffset..], null));
-        return result.ToString();
+        return ObfuscateMatches(
+            input,
+            secretCache.Secrets,
+            secretCache.SearchValues,
+            maskValue,
+            caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal,
+            preserveExistingMasks: true);
     }
 
     internal SecretRegistrationState GetRegistrationState()
@@ -233,8 +236,13 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         IReadOnlyList<string> secrets,
         SearchValues<string> searchValues,
         string maskValue,
-        StringComparison comparison)
+        StringComparison comparison,
+        bool preserveExistingMasks = false)
     {
+        var existingMaskRanges = preserveExistingMasks
+            ? GetMaskRanges(input, maskValue)
+            : [];
+        var maskRangeIndex = 0;
         var result = new StringBuilder(input.Length);
         var inputOffset = 0;
         while (inputOffset < input.Length)
@@ -265,6 +273,17 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
                 throw new InvalidOperationException("SearchValues returned a position without a matching secret.");
             }
 
+            if (IsContainedInExistingMask(
+                    existingMaskRanges,
+                    ref maskRangeIndex,
+                    matchIndex,
+                    matchedSecret.Length))
+            {
+                result.Append(input, matchIndex, matchedSecret.Length);
+                inputOffset = matchIndex + matchedSecret.Length;
+                continue;
+            }
+
             result.Append(maskValue);
             inputOffset = matchIndex + matchedSecret.Length;
         }
@@ -272,6 +291,44 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         result.Append(input, inputOffset, input.Length - inputOffset);
 
         return result.ToString();
+    }
+
+    private static bool IsContainedInExistingMask(
+        IReadOnlyList<(int Start, int End)> ranges,
+        ref int rangeIndex,
+        int matchIndex,
+        int matchLength)
+    {
+        while (rangeIndex < ranges.Count && ranges[rangeIndex].End <= matchIndex)
+        {
+            rangeIndex++;
+        }
+
+        var matchEnd = matchIndex + matchLength;
+        for (var index = rangeIndex;
+             index < ranges.Count && ranges[index].Start <= matchIndex;
+             index++)
+        {
+            if (matchEnd <= ranges[index].End)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IReadOnlyList<(int Start, int End)> GetMaskRanges(string input, string maskValue)
+    {
+        var ranges = new List<(int Start, int End)>();
+        for (var index = input.IndexOf(maskValue, StringComparison.Ordinal);
+             index >= 0;
+             index = input.IndexOf(maskValue, index + 1, StringComparison.Ordinal))
+        {
+            ranges.Add((index, index + maskValue.Length));
+        }
+
+        return ranges;
     }
 
     private sealed class OptionsSecretCache

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -108,6 +108,31 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
             preserveExistingMasks: true);
     }
 
+    internal MappedObfuscatedOutput ObfuscatePreservingMasksWithSourceMap(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return new MappedObfuscatedOutput(string.Empty, [0]);
+        }
+
+        var options = _maskingOptions.Value;
+        var maskValue = GetMaskValue(options);
+        var caseInsensitive = options.CaseInsensitive;
+        var secretCache = GetSecretCache(null, options, caseInsensitive);
+        if (secretCache.SearchValues is null
+            || !input.AsSpan().ContainsAny(secretCache.SearchValues))
+        {
+            return CreateUnchangedSourceMap(input);
+        }
+
+        return ObfuscateMatchesWithSourceMap(
+            input,
+            secretCache.Secrets,
+            secretCache.SearchValues,
+            maskValue,
+            caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+    }
+
     internal SecretRegistrationState GetRegistrationState()
     {
         var cache = GetRegisteredSecretCache(_maskingOptions.Value.CaseInsensitive);
@@ -303,6 +328,138 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         return result.ToString();
     }
 
+    private static MappedObfuscatedOutput ObfuscateMatchesWithSourceMap(
+        string input,
+        IReadOnlyList<string> secrets,
+        SearchValues<string> searchValues,
+        string maskValue,
+        StringComparison comparison)
+    {
+        var existingMaskRanges = GetMaskRanges(input, maskValue);
+        var maskRangeIndex = 0;
+        var sourceToOutputByteOffsets = new int[input.Length + 1];
+        var result = new StringBuilder(input.Length);
+        var inputOffset = 0;
+        var outputByteCount = 0;
+        while (inputOffset < input.Length)
+        {
+            var remainingInput = input.AsSpan(inputOffset);
+            var relativeMatchIndex = remainingInput.IndexOfAny(searchValues);
+            if (relativeMatchIndex < 0)
+            {
+                break;
+            }
+
+            var matchIndex = inputOffset + relativeMatchIndex;
+            AppendUnchangedWithSourceMap(
+                result,
+                input,
+                inputOffset,
+                matchIndex,
+                sourceToOutputByteOffsets,
+                ref outputByteCount);
+
+            var matchingInput = input.AsSpan(matchIndex);
+            string? matchedSecret = null;
+            foreach (var secret in secrets)
+            {
+                if (matchingInput.StartsWith(secret, comparison))
+                {
+                    matchedSecret = secret;
+                    break;
+                }
+            }
+
+            if (matchedSecret is null)
+            {
+                throw new InvalidOperationException("SearchValues returned a position without a matching secret.");
+            }
+
+            var matchEnd = matchIndex + matchedSecret.Length;
+            if (IsContainedInExistingMask(
+                    existingMaskRanges,
+                    ref maskRangeIndex,
+                    matchIndex,
+                    matchedSecret.Length))
+            {
+                AppendUnchangedWithSourceMap(
+                    result,
+                    input,
+                    matchIndex,
+                    matchEnd,
+                    sourceToOutputByteOffsets,
+                    ref outputByteCount);
+            }
+            else
+            {
+                for (var index = matchIndex; index < matchEnd; index++)
+                {
+                    sourceToOutputByteOffsets[index] = outputByteCount;
+                }
+
+                result.Append(maskValue);
+                outputByteCount += Encoding.UTF8.GetByteCount(maskValue);
+                sourceToOutputByteOffsets[matchEnd] = outputByteCount;
+            }
+
+            inputOffset = matchEnd;
+        }
+
+        AppendUnchangedWithSourceMap(
+            result,
+            input,
+            inputOffset,
+            input.Length,
+            sourceToOutputByteOffsets,
+            ref outputByteCount);
+        return new MappedObfuscatedOutput(result.ToString(), sourceToOutputByteOffsets);
+    }
+
+    private static MappedObfuscatedOutput CreateUnchangedSourceMap(string input)
+    {
+        var sourceToOutputByteOffsets = new int[input.Length + 1];
+        var outputByteCount = 0;
+        AppendUnchangedWithSourceMap(
+            result: null,
+            input,
+            0,
+            input.Length,
+            sourceToOutputByteOffsets,
+            ref outputByteCount);
+        return new MappedObfuscatedOutput(input, sourceToOutputByteOffsets);
+    }
+
+    private static void AppendUnchangedWithSourceMap(
+        StringBuilder? result,
+        string input,
+        int start,
+        int end,
+        int[] sourceToOutputByteOffsets,
+        ref int outputByteCount)
+    {
+        result?.Append(input, start, end - start);
+        for (var index = start; index < end;)
+        {
+            sourceToOutputByteOffsets[index] = outputByteCount;
+            var status = Rune.DecodeFromUtf16(input.AsSpan(index, end - index), out var rune, out var consumed);
+            if (status != OperationStatus.Done)
+            {
+                rune = Rune.ReplacementChar;
+                consumed = 1;
+            }
+
+            for (var continuation = 1; continuation < consumed; continuation++)
+            {
+                sourceToOutputByteOffsets[index + continuation] = outputByteCount;
+            }
+
+            outputByteCount += rune.Utf8SequenceLength;
+            index += consumed;
+        }
+
+        sourceToOutputByteOffsets[end] = outputByteCount;
+    }
+
     private static bool IsContainedInExistingMask(
         IReadOnlyList<(int Start, int End)> ranges,
         ref int rangeIndex,
@@ -360,6 +517,16 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         string[] Secrets,
         IReadOnlySet<string> ExactSecrets,
         SearchValues<string>? SearchValues);
+
+    internal sealed record MappedObfuscatedOutput(
+        string Value,
+        IReadOnlyList<int> SourceToOutputByteOffsets)
+    {
+        public int Utf8ByteCount => SourceToOutputByteOffsets[^1];
+
+        public int GetSuffixByteCount(int sourceOffset) =>
+            Utf8ByteCount - SourceToOutputByteOffsets[sourceOffset];
+    }
 
     internal readonly record struct SecretRegistrationState(long Version, bool HasSecrets);
 }

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -122,7 +122,7 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
             secretCache.SearchValues,
             maskValue,
             caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal,
-            preserveExistingMasks: true);
+            preserveExistingMasks: true).Output;
     }
 
     internal MappedObfuscatedOutput ObfuscatePreservingMasksWithSourceMap(string input)

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -147,18 +147,20 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     /// <inheritdoc />
     public bool TryExecuteIfVersionCurrent(long expectedVersion, Action action)
     {
-        lock (_secretsLock)
-        {
-            if (Version != expectedVersion)
+        var executed = false;
+        ExecuteWithStableSecrets(
+            action,
+            candidateAction =>
             {
-                return false;
-            }
+                if (Version != expectedVersion)
+                {
+                    return;
+                }
 
-            // Keep the action inside this lock: callers use it for small synchronous
-            // publication steps that must remain atomic with the version check.
-            action();
-            return true;
-        }
+                candidateAction();
+                executed = true;
+            });
+        return executed;
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -154,6 +154,8 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
                 return false;
             }
 
+            // Keep the action inside this lock: callers use it for small synchronous
+            // publication steps that must remain atomic with the version check.
             action();
             return true;
         }

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -86,26 +86,26 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             return;
         }
 
-        var patterns = SecretMaskingPatternGenerator.Generate(secret);
-        RegisterNativeMaskPatterns(patterns);
-
-        var minimumLength = Math.Max(1, _maskingOptions.Value.MinimumSecretLength);
-        if (secret.Length < minimumLength)
-        {
-            if (_shortSecretWarnings.TryAdd(secret, 0))
-            {
-                _logger.LogWarning(
-                    "A secret with length {SecretLength} is shorter than MinimumSecretLength {MinimumSecretLength}. " +
-                    "Framework log masking is disabled for this value; native build-system masking was requested.",
-                    secret.Length,
-                    minimumLength);
-            }
-
-            return;
-        }
-
         lock (_secretsLock)
         {
+            var patterns = SecretMaskingPatternGenerator.Generate(secret);
+            RegisterNativeMaskPatterns(patterns);
+
+            var minimumLength = Math.Max(1, _maskingOptions.Value.MinimumSecretLength);
+            if (secret.Length < minimumLength)
+            {
+                if (_shortSecretWarnings.TryAdd(secret, 0))
+                {
+                    _logger.LogWarning(
+                        "A secret with length {SecretLength} is shorter than MinimumSecretLength {MinimumSecretLength}. " +
+                        "Framework log masking is disabled for this value; native build-system masking was requested.",
+                        secret.Length,
+                        minimumLength);
+                }
+
+                return;
+            }
+
             if (patterns.All(_secrets.Contains))
             {
                 return;
@@ -120,6 +120,21 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             }
 
             Interlocked.Increment(ref _version);
+        }
+    }
+
+    /// <inheritdoc />
+    public bool TryExecuteIfVersionCurrent(long expectedVersion, Action action)
+    {
+        lock (_secretsLock)
+        {
+            if (Version != expectedVersion)
+            {
+                return false;
+            }
+
+            action();
+            return true;
         }
     }
 

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -133,6 +133,8 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
                 return false;
             }
 
+            // Keep the action inside this lock: callers use it for small synchronous
+            // publication steps that must remain atomic with the version check.
             action();
             return true;
         }

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -145,6 +145,21 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     }
 
     /// <inheritdoc />
+    public bool TryExecuteIfVersionCurrent(long expectedVersion, Action action)
+    {
+        lock (_secretsLock)
+        {
+            if (Version != expectedVersion)
+            {
+                return false;
+            }
+
+            action();
+            return true;
+        }
+    }
+
+    /// <inheritdoc />
     public void AddSecrets(IEnumerable<string?> secrets)
     {
         foreach (var secret in secrets)

--- a/src/ModularPipelines/Models/ModuleOutputExcerpt.cs
+++ b/src/ModularPipelines/Models/ModuleOutputExcerpt.cs
@@ -1,0 +1,22 @@
+namespace ModularPipelines.Models;
+
+/// <summary>
+/// Contains a size-capped tail of a module's masked output.
+/// </summary>
+public sealed record ModuleOutputExcerpt
+{
+    /// <summary>
+    /// Gets the retained standard-output and informational-log tail.
+    /// </summary>
+    public string? StdoutTail { get; init; }
+
+    /// <summary>
+    /// Gets the retained standard-error tail.
+    /// </summary>
+    public string? StderrTail { get; init; }
+
+    /// <summary>
+    /// Gets the number of UTF-8 bytes discarded from the start of the combined output.
+    /// </summary>
+    public long TruncatedBytes { get; init; }
+}

--- a/src/ModularPipelines/Models/ModuleOutputExcerpt.cs
+++ b/src/ModularPipelines/Models/ModuleOutputExcerpt.cs
@@ -5,6 +5,8 @@ namespace ModularPipelines.Models;
 /// </summary>
 public sealed record ModuleOutputExcerpt
 {
+    internal long? SecretPatternsVersion { get; init; }
+
     /// <summary>
     /// Gets the retained standard-output and informational-log tail.
     /// </summary>

--- a/src/ModularPipelines/Models/ModuleRunReport.cs
+++ b/src/ModularPipelines/Models/ModuleRunReport.cs
@@ -53,6 +53,11 @@ public sealed record ModuleRunReport
     public RunReportExceptionDetails? Exception { get; init; }
 
     /// <summary>
+    /// Gets the optional size-capped, secret-masked module output excerpt.
+    /// </summary>
+    public ModuleOutputExcerpt? Output { get; init; }
+
+    /// <summary>
     /// Gets the number of commands attempted by the module.
     /// </summary>
     public int CommandCount { get; init; }

--- a/src/ModularPipelines/Models/PipelineRunReport.cs
+++ b/src/ModularPipelines/Models/PipelineRunReport.cs
@@ -10,7 +10,7 @@ public sealed record PipelineRunReport
     /// <summary>
     /// Gets the current run report schema version.
     /// </summary>
-    public const int CurrentSchemaVersion = 3;
+    public const int CurrentSchemaVersion = 4;
 
     /// <summary>
     /// Gets the schema version used by this report.

--- a/src/ModularPipelines/Options/RunReportOptions.cs
+++ b/src/ModularPipelines/Options/RunReportOptions.cs
@@ -6,6 +6,18 @@ namespace ModularPipelines.Options;
 public sealed record RunReportOptions
 {
     /// <summary>
+    /// Gets a value indicating whether module output excerpts are included in reports and history.
+    /// Output is secret-masked and retained from the tail within
+    /// <see cref="MaxOutputBytesPerModule"/>.
+    /// </summary>
+    public bool IncludeModuleOutput { get; init; }
+
+    /// <summary>
+    /// Gets the shared UTF-8 byte limit for each module's standard-output and standard-error tails.
+    /// </summary>
+    public int MaxOutputBytesPerModule { get; init; } = 8 * 1024;
+
+    /// <summary>
     /// Gets an optional stable identity used to partition retained history.
     /// When omitted, an identity is derived from the registered module types.
     /// </summary>

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -140,6 +140,13 @@ internal class OptionsValidator : IOptionsValidator
                 $"RunReport.HistoryRetention ({options.HistoryRetention})."));
         }
 
+        if (options.IncludeModuleOutput && options.MaxOutputBytesPerModule <= 0)
+        {
+            result.AddError(new ValidationError(
+                ValidationErrorCategory.Options,
+                $"RunReport.MaxOutputBytesPerModule must be positive. Current value: {options.MaxOutputBytesPerModule}"));
+        }
+
         if (options.HistoryRetention > 0
             && string.IsNullOrWhiteSpace(options.HistoryDirectory))
         {

--- a/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
@@ -180,9 +180,28 @@ public class ConsoleCoordinatorTests
         await Assert.That(AnsiConsole.Console).IsSameReferenceAs(originalConsole);
     }
 
+    [Test]
+    public async Task GetModuleBuffer_DoesNotUseDisposedLoggerFactory()
+    {
+        var loggerFactory = LoggerFactory.Create(static _ => { });
+        var coordinator = CreateCoordinator(
+            Mock.Of<IOutputCoordinator>(),
+            new PipelineOptions
+            {
+                RunReport = new RunReportOptions { IncludeModuleOutput = true },
+            },
+            loggerFactory);
+        loggerFactory.Dispose();
+
+        var buffer = coordinator.GetModuleBuffer(typeof(ConsoleCoordinatorTests));
+
+        await Assert.That(buffer).IsNotNull();
+    }
+
     private static ConsoleCoordinator CreateCoordinator(
         IOutputCoordinator outputCoordinator,
-        PipelineOptions? options = null)
+        PipelineOptions? options = null,
+        ILoggerFactory? loggerFactory = null)
     {
         var secretProvider = new Mock<ISecretProvider>();
         secretProvider.SetupGet(provider => provider.Secrets).Returns([]);
@@ -211,7 +230,7 @@ public class ConsoleCoordinatorTests
             secretObfuscator.Object,
             secretProvider.Object,
             Microsoft.Extensions.Options.Options.Create(options ?? new PipelineOptions()),
-            NullLoggerFactory.Instance,
+            loggerFactory ?? NullLoggerFactory.Instance,
             Mock.Of<IBuildSystemDetector>(),
             Mock.Of<IServiceProvider>(),
             outputCoordinator,

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -11,6 +11,36 @@ namespace ModularPipelines.UnitTests.Console;
 public class ModuleOutputBufferTests
 {
     [Test]
+    public async Task OutputExcerptSurvivesConsoleFlush()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            outputExcerptMaximumBytes: 1024);
+        buffer.WriteLine("retained output");
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        await Assert.That(buffer.GetOutputExcerpt()!.StdoutTail).Contains("retained output");
+    }
+
+    [Test]
+    public async Task OutputExcerptIsDisabledByDefault()
+    {
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+
+        buffer.WriteLine("ordinary output");
+
+        await Assert.That(buffer.GetOutputExcerpt()).IsNull();
+    }
+
+    [Test]
     public async Task Flush_Writes_Group_Commands_Without_Markup_Rendering()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -229,6 +229,40 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task BufferedLogEvent_DoesNotEnumerateArbitraryStructuredState()
+    {
+        var state = new ThrowingEnumerableLogState();
+
+        var logEvent = new BufferedLogEvent<ThrowingEnumerableLogState>(
+            LogLevel.Information,
+            default,
+            state,
+            state,
+            null,
+            static (_, _) => "safe message",
+            new PassthroughSecretObfuscator());
+
+        await Assert.That(logEvent.Stream).IsEqualTo(ModuleOutputStream.StandardOutput);
+    }
+
+    [Test]
+    public async Task BufferedLogEvent_RecognizesIndexedCommandErrorState()
+    {
+        KeyValuePair<string, object?>[] state = [new("CommandError", true)];
+
+        var logEvent = new BufferedLogEvent<KeyValuePair<string, object?>[]>(
+            LogLevel.Error,
+            default,
+            state,
+            state,
+            null,
+            static (_, _) => "command error",
+            new PassthroughSecretObfuscator());
+
+        await Assert.That(logEvent.Stream).IsEqualTo(ModuleOutputStream.StandardError);
+    }
+
+    [Test]
     public async Task BufferedLogEvent_FormatsOnceAndObfuscatesEveryTime()
     {
         var formatterCalls = 0;
@@ -1077,6 +1111,16 @@ public class ModuleOutputBufferTests
     {
         public string Obfuscate(string? input, object? optionsObject)
             => input?.Replace("secret", "***", StringComparison.Ordinal) ?? string.Empty;
+    }
+
+    private sealed class ThrowingEnumerableLogState
+        : IEnumerable<KeyValuePair<string, object?>>
+    {
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() =>
+            throw new InvalidOperationException("State must not be enumerated during buffering.");
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
+            GetEnumerator();
     }
 
     private sealed class RecordingLogger : ILogger

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -230,6 +230,40 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task BufferedLogEvent_DoesNotEnumerateArbitraryStructuredState()
+    {
+        var state = new ThrowingEnumerableLogState();
+
+        var logEvent = new BufferedLogEvent<ThrowingEnumerableLogState>(
+            LogLevel.Information,
+            default,
+            state,
+            state,
+            null,
+            static (_, _) => "safe message",
+            new PassthroughSecretObfuscator());
+
+        await Assert.That(logEvent.Stream).IsEqualTo(ModuleOutputStream.StandardOutput);
+    }
+
+    [Test]
+    public async Task BufferedLogEvent_RecognizesIndexedCommandErrorState()
+    {
+        KeyValuePair<string, object?>[] state = [new("CommandError", true)];
+
+        var logEvent = new BufferedLogEvent<KeyValuePair<string, object?>[]>(
+            LogLevel.Error,
+            default,
+            state,
+            state,
+            null,
+            static (_, _) => "command error",
+            new PassthroughSecretObfuscator());
+
+        await Assert.That(logEvent.Stream).IsEqualTo(ModuleOutputStream.StandardError);
+    }
+
+    [Test]
     public async Task BufferedLogEvent_FormatsOnceAndObfuscatesEveryTime()
     {
         var formatterCalls = 0;
@@ -1088,6 +1122,16 @@ public class ModuleOutputBufferTests
     {
         public string Obfuscate(string? input, object? optionsObject)
             => input?.Replace("secret", "***", StringComparison.Ordinal) ?? string.Empty;
+    }
+
+    private sealed class ThrowingEnumerableLogState
+        : IEnumerable<KeyValuePair<string, object?>>
+    {
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() =>
+            throw new InvalidOperationException("State must not be enumerated during buffering.");
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() =>
+            GetEnumerator();
     }
 
     private sealed class RecordingLogger : ILogger

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -10,6 +10,36 @@ namespace ModularPipelines.UnitTests.Console;
 public class ModuleOutputBufferTests
 {
     [Test]
+    public async Task OutputExcerptSurvivesConsoleFlush()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            typeof(ModuleOutputBufferTests),
+            outputExcerptMaximumBytes: 1024);
+        buffer.WriteLine("retained output");
+
+        await buffer.FlushToAsync(
+            writer,
+            new DefaultFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        await Assert.That(buffer.GetOutputExcerpt()!.StdoutTail).Contains("retained output");
+    }
+
+    [Test]
+    public async Task OutputExcerptIsDisabledByDefault()
+    {
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+
+        buffer.WriteLine("ordinary output");
+
+        await Assert.That(buffer.GetOutputExcerpt()).IsNull();
+    }
+
+    [Test]
     public async Task Flush_Writes_Group_Commands_Without_Markup_Rendering()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -122,6 +122,36 @@ public class ModuleOutputExcerptBufferTests
     }
 
     [Test]
+    public async Task PreservesChunkRecencyWhenLateMasksExpand()
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(2);
+        secretProvider
+            .Setup(provider => provider.GetSnapshot())
+            .Returns(new SecretSnapshot(2, ["a"]));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 30,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append("a", ModuleOutputStream.StandardOutput);
+        buffer.Append("a", ModuleOutputStream.StandardError);
+        buffer.Append("a", ModuleOutputStream.StandardOutput);
+
+        var excerpt = buffer.CreateExcerpt()!;
+        var maskedChunk = "**********" + Environment.NewLine;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StderrTail).IsEqualTo(maskedChunk);
+            await Assert.That(excerpt.StdoutTail).EndsWith(maskedChunk);
+            await Assert.That(Encoding.UTF8.GetByteCount(excerpt.StdoutTail!)).IsEqualTo(18);
+        }
+    }
+
+    [Test]
     public async Task DoesNotCountLateMaskContractionAsTruncation()
     {
         const string secret = "late-secret";

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -310,6 +310,33 @@ public class ModuleOutputExcerptBufferTests
     }
 
     [Test]
+    public async Task KeepsCompleteExcerptWhenUnrelatedSecretExceedsCap()
+    {
+        const string secret = "123456789";
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(2);
+        secretProvider
+            .Setup(provider => provider.GetSnapshot())
+            .Returns(new SecretSnapshot(2, [secret]));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 8,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append("ok", ModuleOutputStream.StandardOutput);
+
+        var excerpt = buffer.CreateExcerpt()!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StdoutTail).IsEqualTo("ok" + Environment.NewLine);
+            await Assert.That(excerpt.TruncatedBytes).IsEqualTo(0);
+        }
+    }
+
+    [Test]
     public async Task CountsUtf8BoundaryBytesAsTruncated()
     {
         var maximumBytes = Encoding.UTF8.GetByteCount(Environment.NewLine) + 1;

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -490,4 +490,33 @@ public class ModuleOutputExcerptBufferTests
             await Assert.That(excerpt.TruncatedBytes).IsEqualTo(0);
         }
     }
+
+    [Test]
+    public async Task CoalescesManySmallWritesBeforeMaskedSuffixAnalysis()
+    {
+        const int maximumBytes = 8192;
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(0);
+        secretProvider
+            .Setup(provider => provider.GetSnapshot())
+            .Returns(new SecretSnapshot(0, []));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes,
+            secretObfuscator,
+            secretProvider.Object);
+
+        for (var index = 0; index < maximumBytes * 2; index++)
+        {
+            buffer.Append("x", ModuleOutputStream.StandardOutput);
+        }
+
+        var excerpt = buffer.CreateExcerpt()!;
+
+        await Assert.That(Encoding.UTF8.GetByteCount(excerpt.StdoutTail!))
+            .IsLessThanOrEqualTo(maximumBytes);
+        await Assert.That(excerpt.StdoutTail).EndsWith("x" + Environment.NewLine);
+    }
 }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -327,7 +327,7 @@ public class ModuleOutputExcerptBufferTests
     [Test]
     public async Task PreservesExistingMaskDuringExcerptObfuscation()
     {
-        const string secret = "*";
+        const string secret = "already-masked-secret";
         const string maskedOutput = "diagnostic **********";
         var expected = maskedOutput + Environment.NewLine;
         var secretProvider = new Mock<ISecretProvider>();
@@ -351,6 +351,29 @@ public class ModuleOutputExcerptBufferTests
             await Assert.That(excerpt.StdoutTail).IsEqualTo(expected);
             await Assert.That(excerpt.TruncatedBytes).IsEqualTo(0);
         }
+    }
+
+    [Test]
+    public async Task OmitsExcerptWhenMaskValueContainsLateSecret()
+    {
+        const string secret = "REDACT";
+        var snapshot = new SecretSnapshot(0, []);
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => snapshot.Version);
+        secretProvider.Setup(provider => provider.GetSnapshot()).Returns(() => snapshot);
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(
+                new SecretMaskingOptions { MaskValue = "[REDACTED]" }));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 64,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append("[REDACTED]", ModuleOutputStream.StandardOutput);
+
+        snapshot = new SecretSnapshot(2, [secret]);
+
+        await Assert.That(buffer.CreateExcerpt()).IsNull();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -96,6 +96,60 @@ public class ModuleOutputExcerptBufferTests
     }
 
     [Test]
+    public async Task RecomputesTailBudgetAfterLateMaskExpansion()
+    {
+        var snapshot = new SecretSnapshot(0, []);
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => snapshot.Version);
+        secretProvider.Setup(provider => provider.GetSnapshot()).Returns(() => snapshot);
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 8192,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append("a", ModuleOutputStream.StandardOutput);
+
+        snapshot = new SecretSnapshot(2, ["a"]);
+        var excerpt = buffer.CreateExcerpt()!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StdoutTail).IsEqualTo("**********" + Environment.NewLine);
+            await Assert.That(excerpt.TruncatedBytes).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task DoesNotCountLateMaskContractionAsTruncation()
+    {
+        const string secret = "late-secret";
+        var snapshot = new SecretSnapshot(0, []);
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => snapshot.Version);
+        secretProvider.Setup(provider => provider.GetSnapshot()).Returns(() => snapshot);
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(
+                new SecretMaskingOptions { MaskValue = "***" }));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 64,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append(secret, ModuleOutputStream.StandardOutput);
+
+        snapshot = new SecretSnapshot(2, [secret]);
+        var excerpt = buffer.CreateExcerpt()!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StdoutTail).IsEqualTo("***" + Environment.NewLine);
+            await Assert.That(excerpt.TruncatedBytes).IsEqualTo(0);
+        }
+    }
+
+    [Test]
     public async Task OmitsExcerptWhenMaskingContractionReachesTrimmedBoundary()
     {
         const string secret = "late-secret";

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -1,5 +1,8 @@
 using System.Text;
 using ModularPipelines.Console;
+using ModularPipelines.Engine;
+using ModularPipelines.Options;
+using Moq;
 
 namespace ModularPipelines.UnitTests.Console;
 
@@ -60,5 +63,87 @@ public class ModuleOutputExcerptBufferTests
             await Assert.That(excerpt.StdoutTail).DoesNotContain("�");
             await Assert.That(excerpt.TruncatedBytes).IsEqualTo(5);
         }
+    }
+
+    [Test]
+    public async Task MasksLateRegisteredSecretBeforeSelectingTail()
+    {
+        const string secret = "late-secret";
+        var snapshot = new SecretSnapshot(0, []);
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => snapshot.Version);
+        secretProvider.Setup(provider => provider.GetSnapshot()).Returns(() => snapshot);
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(
+                new SecretMaskingOptions { MaskValue = "***" }));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 16,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append($"prefix {secret} suffix", ModuleOutputStream.StandardOutput);
+
+        snapshot = new SecretSnapshot(2, [secret]);
+        var excerpt = buffer.CreateExcerpt();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt).IsNotNull();
+            await Assert.That(excerpt!.StdoutTail).Contains("***");
+            await Assert.That(excerpt.StdoutTail).DoesNotContain("secret");
+            await Assert.That(Encoding.UTF8.GetByteCount(excerpt.StdoutTail!)).IsLessThanOrEqualTo(16);
+        }
+    }
+
+    [Test]
+    public async Task OmitsExcerptWhenSecretExceedsSafeBoundaryContext()
+    {
+        const string secret = "long-secret";
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(2);
+        secretProvider
+            .Setup(provider => provider.GetSnapshot())
+            .Returns(new SecretSnapshot(2, [secret]));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 8,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append($"prefix {secret} suffix", ModuleOutputStream.StandardOutput);
+
+        await Assert.That(buffer.CreateExcerpt()).IsNull();
+    }
+
+    [Test]
+    public async Task OmitsExcerptWhenSecretsChangeDuringMasking()
+    {
+        var version = 2L;
+        var snapshotCalls = 0;
+        var snapshot = new SecretSnapshot(version, ["registered-secret"]);
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => version);
+        secretProvider
+            .Setup(provider => provider.GetSnapshot())
+            .Returns(() =>
+            {
+                if (++snapshotCalls == 2)
+                {
+                    version = 4;
+                }
+
+                return snapshot;
+            });
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 32,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append("registered-secret suffix", ModuleOutputStream.StandardOutput);
+
+        await Assert.That(buffer.CreateExcerpt()).IsNull();
     }
 }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -1,0 +1,64 @@
+using System.Text;
+using ModularPipelines.Console;
+
+namespace ModularPipelines.UnitTests.Console;
+
+public class ModuleOutputExcerptBufferTests
+{
+    [Test]
+    public async Task SeparatesStandardOutputAndStandardError()
+    {
+        var buffer = new ModuleOutputExcerptBuffer(1024);
+
+        buffer.Append("normal output", ModuleOutputStream.StandardOutput);
+        buffer.Append("error output", ModuleOutputStream.StandardError);
+
+        var excerpt = buffer.CreateExcerpt();
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt!.StdoutTail).IsEqualTo("normal output" + Environment.NewLine);
+            await Assert.That(excerpt.StderrTail).IsEqualTo("error output" + Environment.NewLine);
+            await Assert.That(excerpt.TruncatedBytes).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task AppliesOneUtf8TailLimitAcrossBothStreams()
+    {
+        const int maximumBytes = 10;
+        var buffer = new ModuleOutputExcerptBuffer(maximumBytes);
+
+        buffer.Append("old output", ModuleOutputStream.StandardOutput);
+        buffer.Append("🙂new", ModuleOutputStream.StandardError);
+
+        var excerpt = buffer.CreateExcerpt()!;
+        var retainedBytes = Encoding.UTF8.GetByteCount(excerpt.StdoutTail ?? string.Empty)
+                            + Encoding.UTF8.GetByteCount(excerpt.StderrTail ?? string.Empty);
+        using (Assert.Multiple())
+        {
+            await Assert.That(retainedBytes).IsLessThanOrEqualTo(maximumBytes);
+            await Assert.That(excerpt.StderrTail).EndsWith("🙂new" + Environment.NewLine);
+            await Assert.That(excerpt.StdoutTail).DoesNotContain("old output");
+            await Assert.That(excerpt.StdoutTail ?? string.Empty).DoesNotContain("�");
+            await Assert.That(excerpt.StderrTail).DoesNotContain("�");
+            await Assert.That(excerpt.TruncatedBytes).IsGreaterThan(0);
+        }
+    }
+
+    [Test]
+    public async Task RetainsValidUnicodeWhenTailStartsAtSurrogatePair()
+    {
+        var expectedTail = "🙂" + Environment.NewLine;
+        var buffer = new ModuleOutputExcerptBuffer(Encoding.UTF8.GetByteCount(expectedTail));
+
+        buffer.Append("12345🙂", ModuleOutputStream.StandardOutput);
+
+        var excerpt = buffer.CreateExcerpt()!;
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StdoutTail).IsEqualTo(expectedTail);
+            await Assert.That(excerpt.StdoutTail).DoesNotContain("�");
+            await Assert.That(excerpt.TruncatedBytes).IsEqualTo(5);
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -306,6 +306,34 @@ public class ModuleOutputExcerptBufferTests
     }
 
     [Test]
+    public async Task ReallocatesUtf8BoundaryWasteToOlderOtherStream()
+    {
+        var maximumBytes = Encoding.UTF8.GetByteCount(Environment.NewLine) + 3;
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(0);
+        secretProvider
+            .Setup(provider => provider.GetSnapshot())
+            .Returns(new SecretSnapshot(0, []));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append("A", ModuleOutputStream.StandardOutput);
+        buffer.Append("🙂", ModuleOutputStream.StandardError);
+
+        var excerpt = buffer.CreateExcerpt()!;
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StdoutTail).IsEqualTo("A" + Environment.NewLine);
+            await Assert.That(excerpt.StderrTail).IsEqualTo(Environment.NewLine);
+            await Assert.That(excerpt.TruncatedBytes).IsEqualTo(4);
+        }
+    }
+
+    [Test]
     public async Task OmitsExcerptWhenCaseInsensitiveMatchCanExceedBoundaryContext()
     {
         const string secret = "SSSS";

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -152,6 +152,34 @@ public class ModuleOutputExcerptBufferTests
     }
 
     [Test]
+    public async Task ReallocatesFullMaskedBudgetByChunkRecency()
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(2);
+        secretProvider
+            .Setup(provider => provider.GetSnapshot())
+            .Returns(new SecretSnapshot(2, ["a"]));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 10,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append("aaaa", ModuleOutputStream.StandardOutput);
+        buffer.Append("a", ModuleOutputStream.StandardError);
+
+        var excerpt = buffer.CreateExcerpt()!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StdoutTail).IsNull();
+            await Assert.That(Encoding.UTF8.GetByteCount(excerpt.StderrTail!)).IsEqualTo(10);
+            await Assert.That(excerpt.StderrTail).EndsWith(Environment.NewLine);
+        }
+    }
+
+    [Test]
     public async Task DoesNotCountLateMaskContractionAsTruncation()
     {
         const string secret = "late-secret";

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -350,4 +350,28 @@ public class ModuleOutputExcerptBufferTests
             await Assert.That(excerpt.TruncatedBytes).IsEqualTo(0);
         }
     }
+
+    [Test]
+    public async Task MasksLateSecretContainingExistingMaskValue()
+    {
+        const string secret = "prefix**********suffix";
+        var snapshot = new SecretSnapshot(0, []);
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => snapshot.Version);
+        secretProvider.Setup(provider => provider.GetSnapshot()).Returns(() => snapshot);
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 64,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append(secret, ModuleOutputStream.StandardOutput);
+
+        snapshot = new SecretSnapshot(2, [secret]);
+
+        var excerpt = buffer.CreateExcerpt()!;
+        await Assert.That(excerpt.StdoutTail).IsEqualTo(
+            $"**********{Environment.NewLine}");
+    }
 }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -124,6 +124,7 @@ public class ModuleOutputExcerptBufferTests
     [Test]
     public async Task PreservesChunkRecencyWhenLateMasksExpand()
     {
+        const int maximumBytes = 30;
         var secretProvider = new Mock<ISecretProvider>();
         secretProvider.SetupGet(provider => provider.Version).Returns(2);
         secretProvider
@@ -133,7 +134,7 @@ public class ModuleOutputExcerptBufferTests
             secretProvider.Object,
             Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
         var buffer = new ModuleOutputExcerptBuffer(
-            maximumBytes: 30,
+            maximumBytes,
             secretObfuscator,
             secretProvider.Object);
         buffer.Append("a", ModuleOutputStream.StandardOutput);
@@ -142,12 +143,13 @@ public class ModuleOutputExcerptBufferTests
 
         var excerpt = buffer.CreateExcerpt()!;
         var maskedChunk = "**********" + Environment.NewLine;
+        var remainingStdoutBytes = maximumBytes - Encoding.UTF8.GetByteCount(maskedChunk);
 
         using (Assert.Multiple())
         {
             await Assert.That(excerpt.StderrTail).IsEqualTo(maskedChunk);
             await Assert.That(excerpt.StdoutTail).EndsWith(maskedChunk);
-            await Assert.That(Encoding.UTF8.GetByteCount(excerpt.StdoutTail!)).IsEqualTo(18);
+            await Assert.That(Encoding.UTF8.GetByteCount(excerpt.StdoutTail!)).IsEqualTo(remainingStdoutBytes);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -210,6 +210,40 @@ public class ModuleOutputExcerptBufferTests
     }
 
     [Test]
+    public async Task ReallocatesFreedMaskedBytesToNewerOtherStreamChunks()
+    {
+        var secret = $"abc{Environment.NewLine}def";
+        var snapshot = new SecretSnapshot(0, []);
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => snapshot.Version);
+        secretProvider.Setup(provider => provider.GetSnapshot()).Returns(() => snapshot);
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(
+                new SecretMaskingOptions { MaskValue = "*" }));
+        const int maximumBytes = 10;
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append("abc", ModuleOutputStream.StandardOutput);
+        buffer.Append("12345678", ModuleOutputStream.StandardError);
+        buffer.Append("def", ModuleOutputStream.StandardOutput);
+
+        snapshot = new SecretSnapshot(2, [secret]);
+        var excerpt = buffer.CreateExcerpt()!;
+        var stdoutBytes = Encoding.UTF8.GetByteCount(excerpt.StdoutTail!);
+        var stderrBytes = Encoding.UTF8.GetByteCount(excerpt.StderrTail!);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StdoutTail).IsEqualTo("*" + Environment.NewLine);
+            await Assert.That(stdoutBytes + stderrBytes).IsEqualTo(maximumBytes);
+            await Assert.That(stderrBytes).IsEqualTo(maximumBytes - stdoutBytes);
+        }
+    }
+
+    [Test]
     public async Task OmitsExcerptWhenMaskingContractionReachesTrimmedBoundary()
     {
         const string secret = "late-secret";

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -519,4 +519,38 @@ public class ModuleOutputExcerptBufferTests
             .IsLessThanOrEqualTo(maximumBytes);
         await Assert.That(excerpt.StdoutTail).EndsWith("x" + Environment.NewLine);
     }
+
+    [Test]
+    public async Task HandlesManyAlternatingWritesWithOneMaskedScanPerStream()
+    {
+        const int maximumBytes = 8192;
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(2);
+        secretProvider
+            .Setup(provider => provider.GetSnapshot())
+            .Returns(new SecretSnapshot(2, ["never-matches"]));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes,
+            secretObfuscator,
+            secretProvider.Object);
+
+        for (var index = 0; index < maximumBytes * 2; index++)
+        {
+            var stream = index % 2 == 0
+                ? ModuleOutputStream.StandardOutput
+                : ModuleOutputStream.StandardError;
+            buffer.Append("x", stream);
+        }
+
+        var excerpt = buffer.CreateExcerpt()!;
+        var retainedBytes = Encoding.UTF8.GetByteCount(excerpt.StdoutTail!)
+                            + Encoding.UTF8.GetByteCount(excerpt.StderrTail!);
+
+        await Assert.That(retainedBytes).IsLessThanOrEqualTo(maximumBytes);
+        await Assert.That(excerpt.StdoutTail).EndsWith("x" + Environment.NewLine);
+        await Assert.That(excerpt.StderrTail).EndsWith("x" + Environment.NewLine);
+    }
 }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -9,6 +9,24 @@ namespace ModularPipelines.UnitTests.Console;
 public class ModuleOutputExcerptBufferTests
 {
     [Test]
+    public async Task Unterminated_Output_Does_Not_Add_Newline_At_Byte_Cap()
+    {
+        var buffer = new ModuleOutputExcerptBuffer(maximumBytes: 1);
+
+        buffer.Append(
+            "A",
+            ModuleOutputStream.StandardOutput,
+            appendNewLine: false);
+        var excerpt = buffer.CreateExcerpt()!;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StdoutTail).IsEqualTo("A");
+            await Assert.That(excerpt.TruncatedBytes).IsEqualTo(0);
+        }
+    }
+
+    [Test]
     public async Task SeparatesStandardOutputAndStandardError()
     {
         var buffer = new ModuleOutputExcerptBuffer(1024);

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -117,6 +117,22 @@ public class ModuleOutputExcerptBufferTests
     }
 
     [Test]
+    public async Task CountsUtf8BoundaryBytesAsTruncated()
+    {
+        var maximumBytes = Encoding.UTF8.GetByteCount(Environment.NewLine) + 1;
+        var buffer = new ModuleOutputExcerptBuffer(maximumBytes);
+
+        buffer.Append("🙂", ModuleOutputStream.StandardOutput);
+
+        var excerpt = buffer.CreateExcerpt()!;
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StdoutTail).IsEqualTo(Environment.NewLine);
+            await Assert.That(excerpt.TruncatedBytes).IsEqualTo(4);
+        }
+    }
+
+    [Test]
     public async Task OmitsExcerptWhenCaseInsensitiveMatchCanExceedBoundaryContext()
     {
         const string secret = "SSSS";

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -321,4 +321,33 @@ public class ModuleOutputExcerptBufferTests
 
         await Assert.That(buffer.CreateExcerpt()).IsNull();
     }
+
+    [Test]
+    public async Task PreservesExistingMaskDuringExcerptObfuscation()
+    {
+        const string secret = "*";
+        const string maskedOutput = "diagnostic **********";
+        var expected = maskedOutput + Environment.NewLine;
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(2);
+        secretProvider
+            .Setup(provider => provider.GetSnapshot())
+            .Returns(new SecretSnapshot(2, [secret]));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var buffer = new ModuleOutputExcerptBuffer(
+            Encoding.UTF8.GetByteCount(expected),
+            secretObfuscator,
+            secretProvider.Object);
+
+        buffer.Append(maskedOutput, ModuleOutputStream.StandardOutput);
+
+        var excerpt = buffer.CreateExcerpt()!;
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StdoutTail).IsEqualTo(expected);
+            await Assert.That(excerpt.TruncatedBytes).IsEqualTo(0);
+        }
+    }
 }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -117,6 +117,28 @@ public class ModuleOutputExcerptBufferTests
     }
 
     [Test]
+    public async Task OmitsExcerptWhenCaseInsensitiveMatchCanExceedBoundaryContext()
+    {
+        const string secret = "SSSS";
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(2);
+        secretProvider
+            .Setup(provider => provider.GetSnapshot())
+            .Returns(new SecretSnapshot(2, [secret]));
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(
+                new SecretMaskingOptions { CaseInsensitive = true }));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 4,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append("prefixſſſſ", ModuleOutputStream.StandardOutput);
+
+        await Assert.That(buffer.CreateExcerpt()).IsNull();
+    }
+
+    [Test]
     public async Task OmitsExcerptWhenSecretsChangeDuringMasking()
     {
         var version = 2L;

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -96,6 +96,31 @@ public class ModuleOutputExcerptBufferTests
     }
 
     [Test]
+    public async Task OmitsExcerptWhenMaskingContractionReachesTrimmedBoundary()
+    {
+        const string secret = "late-secret";
+        var snapshot = new SecretSnapshot(0, []);
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => snapshot.Version);
+        secretProvider.Setup(provider => provider.GetSnapshot()).Returns(() => snapshot);
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(
+                new SecretMaskingOptions { MaskValue = "***" }));
+        var buffer = new ModuleOutputExcerptBuffer(
+            maximumBytes: 16,
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append(
+            $"AAAA{secret}{secret}{secret}",
+            ModuleOutputStream.StandardOutput);
+
+        snapshot = new SecretSnapshot(2, [secret]);
+
+        await Assert.That(buffer.CreateExcerpt()).IsNull();
+    }
+
+    [Test]
     public async Task OmitsExcerptWhenSecretExceedsSafeBoundaryContext()
     {
         const string secret = "long-secret";

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -399,4 +399,33 @@ public class ModuleOutputExcerptBufferTests
         await Assert.That(excerpt.StdoutTail).IsEqualTo(
             $"**********{Environment.NewLine}");
     }
+
+    [Test]
+    public async Task RebalancesExpandedMaskAcrossAppendBoundaries()
+    {
+        var secret = $"abc{Environment.NewLine}def";
+        var snapshot = new SecretSnapshot(0, []);
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => snapshot.Version);
+        secretProvider.Setup(provider => provider.GetSnapshot()).Returns(() => snapshot);
+        var secretObfuscator = new SecretObfuscator(
+            secretProvider.Object,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+        var expected = $"**********{Environment.NewLine}";
+        var buffer = new ModuleOutputExcerptBuffer(
+            Encoding.UTF8.GetByteCount(expected),
+            secretObfuscator,
+            secretProvider.Object);
+        buffer.Append("abc", ModuleOutputStream.StandardOutput);
+        buffer.Append("def", ModuleOutputStream.StandardOutput);
+
+        snapshot = new SecretSnapshot(2, [secret]);
+
+        var excerpt = buffer.CreateExcerpt()!;
+        using (Assert.Multiple())
+        {
+            await Assert.That(excerpt.StdoutTail).IsEqualTo(expected);
+            await Assert.That(excerpt.TruncatedBytes).IsEqualTo(0);
+        }
+    }
 }

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputExcerptBufferTests.cs
@@ -258,6 +258,8 @@ public class ModuleOutputExcerptBufferTests
             await Assert.That(excerpt.StdoutTail).IsEqualTo("*" + Environment.NewLine);
             await Assert.That(stdoutBytes + stderrBytes).IsEqualTo(maximumBytes);
             await Assert.That(stderrBytes).IsEqualTo(maximumBytes - stdoutBytes);
+            await Assert.That(excerpt.TruncatedBytes).IsEqualTo(
+                Encoding.UTF8.GetByteCount($"12345678{Environment.NewLine}") - stderrBytes);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -45,7 +45,7 @@ public class OutputCoordinatorTests
 
         await Assert.That(directOutput.ToString()).Contains("replayed log");
         await Assert.That(directOutput.ToString()).DoesNotContain("partial");
-        bufferedOutput.Verify(x => x.WriteLine("partial"), Times.Once);
+        bufferedOutput.Verify(x => x.Write("partial"), Times.Once);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -46,7 +46,7 @@ public class OutputCoordinatorTests
 
         await Assert.That(directOutput.ToString()).Contains("replayed log");
         await Assert.That(directOutput.ToString()).DoesNotContain("partial");
-        bufferedOutput.Verify(x => x.WriteLine("partial"), Times.Once);
+        bufferedOutput.Verify(x => x.Write("partial"), Times.Once);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
@@ -14,6 +14,69 @@ namespace ModularPipelines.UnitTests.Engine;
 public class ExecutionOrchestratorTests
 {
     [Test]
+    public async Task FlushesConsoleBeforeCompletingRunReport()
+    {
+        var organizedModules = new OrganizedModules([], []);
+        var summary = new PipelineSummary(
+            [],
+            [],
+            TimeSpan.Zero,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        var pipelineInitializer = new Mock<IPipelineInitializer>();
+        pipelineInitializer
+            .Setup(x => x.Initialize(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(organizedModules);
+        var ignoredModuleResultRegistrar = new Mock<IIgnoredModuleResultRegistrar>();
+        ignoredModuleResultRegistrar
+            .Setup(x => x.RegisterIgnoredModuleResultsAsync(organizedModules))
+            .ReturnsAsync(organizedModules);
+        var pipelineExecutor = new Mock<IPipelineExecutor>();
+        pipelineExecutor
+            .Setup(x => x.ExecuteAsync(It.IsAny<List<IModule>>(), organizedModules))
+            .ReturnsAsync(summary);
+        var outputScope = new Mock<IPipelineOutputScope>();
+        outputScope.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        var outputCoordinator = new Mock<IPipelineOutputCoordinator>();
+        outputCoordinator.Setup(x => x.InitializeAsync()).ReturnsAsync(outputScope.Object);
+        var consoleWasFlushed = false;
+        outputCoordinator
+            .Setup(x => x.FlushConsoleAsync())
+            .Callback(() => consoleWasFlushed = true)
+            .Returns(Task.CompletedTask);
+        var moduleDisposeExecutor = new Mock<IModuleDisposeExecutor>();
+        moduleDisposeExecutor.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        var wasFlushedBeforeReport = false;
+        var runReportService = new Mock<IRunReportService>();
+        runReportService
+            .Setup(x => x.CompleteAsync(
+                It.IsAny<PipelineSummary>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback(() => wasFlushedBeforeReport = consoleWasFlushed)
+            .ReturnsAsync(new PipelineRunReport());
+        using var engineCancellationToken =
+            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+        var orchestrator = new ExecutionOrchestrator(
+            pipelineInitializer.Object,
+            moduleDisposeExecutor.Object,
+            pipelineExecutor.Object,
+            outputCoordinator.Object,
+            ignoredModuleResultRegistrar.Object,
+            Mock.Of<IModuleResultRegistry>(),
+            Mock.Of<IPipelineSummaryFactory>(),
+            engineCancellationToken,
+            Mock.Of<IThreadPoolConfigurator>(),
+            Mock.Of<IExceptionRethrowService>(),
+            OptionsFactory.Create(new PipelineOptions()),
+            Mock.Of<ILogger<ExecutionOrchestrator>>(),
+            runReportService.Object);
+        await orchestrator.ExecuteAsync();
+
+        await Assert.That(wasFlushedBeforeReport).IsTrue();
+    }
+
+    [Test]
     [Arguments(false)]
     [Arguments(true)]
     public async Task CallerCancellationToken_IsPassedToRunReport_AndRegistrationIsDisposed(

--- a/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ExecutionOrchestratorTests.cs
@@ -77,6 +77,65 @@ public class ExecutionOrchestratorTests
     }
 
     [Test]
+    public async Task ConsoleFlushFailureDoesNotPreventRunReportCompletion()
+    {
+        var organizedModules = new OrganizedModules([], []);
+        var summary = new PipelineSummary(
+            [],
+            [],
+            TimeSpan.Zero,
+            DateTimeOffset.UtcNow,
+            DateTimeOffset.UtcNow);
+        var pipelineInitializer = new Mock<IPipelineInitializer>();
+        pipelineInitializer.Setup(x => x.Initialize(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(organizedModules);
+        var ignoredModuleResultRegistrar = new Mock<IIgnoredModuleResultRegistrar>();
+        ignoredModuleResultRegistrar.Setup(x => x.RegisterIgnoredModuleResultsAsync(organizedModules))
+            .ReturnsAsync(organizedModules);
+        var pipelineExecutor = new Mock<IPipelineExecutor>();
+        pipelineExecutor.Setup(x => x.ExecuteAsync(It.IsAny<List<IModule>>(), organizedModules))
+            .ReturnsAsync(summary);
+        var outputScope = new Mock<IPipelineOutputScope>();
+        outputScope.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        var outputCoordinator = new Mock<IPipelineOutputCoordinator>();
+        outputCoordinator.Setup(x => x.InitializeAsync()).ReturnsAsync(outputScope.Object);
+        outputCoordinator.SetupSequence(x => x.FlushConsoleAsync())
+            .Returns(Task.FromException(new IOException("broken console")))
+            .Returns(Task.CompletedTask);
+        var moduleDisposeExecutor = new Mock<IModuleDisposeExecutor>();
+        moduleDisposeExecutor.Setup(x => x.DisposeAsync()).Returns(ValueTask.CompletedTask);
+        var runReportService = new Mock<IRunReportService>();
+        runReportService.Setup(x => x.CompleteAsync(
+                It.IsAny<PipelineSummary>(),
+                It.IsAny<Exception?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PipelineRunReport());
+        using var engineCancellationToken =
+            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+        var orchestrator = new ExecutionOrchestrator(
+            pipelineInitializer.Object,
+            moduleDisposeExecutor.Object,
+            pipelineExecutor.Object,
+            outputCoordinator.Object,
+            ignoredModuleResultRegistrar.Object,
+            Mock.Of<IModuleResultRegistry>(),
+            Mock.Of<IPipelineSummaryFactory>(),
+            engineCancellationToken,
+            Mock.Of<IThreadPoolConfigurator>(),
+            Mock.Of<IExceptionRethrowService>(),
+            OptionsFactory.Create(new PipelineOptions()),
+            Mock.Of<ILogger<ExecutionOrchestrator>>(),
+            runReportService.Object);
+
+        await orchestrator.ExecuteAsync();
+
+        runReportService.Verify(x => x.CompleteAsync(
+            It.IsAny<PipelineSummary>(),
+            It.IsAny<Exception?>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
     [Arguments(false)]
     [Arguments(true)]
     public async Task CallerCancellationToken_IsPassedToRunReport_AndRegistrationIsDisposed(

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -47,6 +47,24 @@ public class PipelineOutputCoordinatorTests
     }
 
     [Test]
+    public async Task FlushWriters_FlushesErrorAfterOutputFailure()
+    {
+        var outputException = new IOException("output flush failed");
+        var output = new FlushTrackingWriter(outputException);
+        var error = new FlushTrackingWriter();
+
+        var exception = await Assert.ThrowsAsync<IOException>(() =>
+            PipelineOutputCoordinator.FlushWritersAsync(output, error));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception).IsSameReferenceAs(outputException);
+            await Assert.That(output.FlushCount).IsEqualTo(1);
+            await Assert.That(error.FlushCount).IsEqualTo(1);
+        }
+    }
+
+    [Test]
     public async Task Dispose_SchedulesBuffersCreatedByRetainedWriteFlush()
     {
         var events = new List<string>();
@@ -281,6 +299,19 @@ public class PipelineOutputCoordinatorTests
         {
             events.Add("progress");
             return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FlushTrackingWriter(Exception? exception = null) : StringWriter
+    {
+        public int FlushCount { get; private set; }
+
+        public override Task FlushAsync()
+        {
+            FlushCount++;
+            return exception is null
+                ? Task.CompletedTask
+                : Task.FromException(exception);
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -931,7 +931,8 @@ public class RunReportTests
         });
         var store = new FileSystemRunHistoryStore(
             options,
-            NullLogger<FileSystemRunHistoryStore>.Instance);
+            NullLogger<FileSystemRunHistoryStore>.Instance,
+            CreateReportFactory());
 
         try
         {
@@ -976,7 +977,8 @@ public class RunReportTests
                     HistoryRetention = 2,
                 },
             }),
-            new StringLogger<FileSystemRunHistoryStore>(log));
+            new StringLogger<FileSystemRunHistoryStore>(log),
+            CreateReportFactory());
 
         try
         {
@@ -1058,7 +1060,8 @@ public class RunReportTests
         });
         var store = new FileSystemRunHistoryStore(
             options,
-            NullLogger<FileSystemRunHistoryStore>.Instance);
+            NullLogger<FileSystemRunHistoryStore>.Instance,
+            CreateReportFactory());
 
         try
         {
@@ -1155,7 +1158,8 @@ public class RunReportTests
         });
         var store = new FileSystemRunHistoryStore(
             options,
-            NullLogger<FileSystemRunHistoryStore>.Instance);
+            NullLogger<FileSystemRunHistoryStore>.Instance,
+            CreateReportFactory());
 
         try
         {
@@ -1200,7 +1204,8 @@ public class RunReportTests
                     GlobalHistoryRetention = 1,
                 },
             }),
-            NullLogger<FileSystemRunHistoryStore>.Instance);
+            NullLogger<FileSystemRunHistoryStore>.Instance,
+            CreateReportFactory());
         var legacyFile = Path.Combine(
             directory,
             "modularpipelines-run-legacy-202608021300000000000-00000000000000000000000000000000.json");
@@ -1415,7 +1420,8 @@ public class RunReportTests
                     HistoryRetention = 2,
                 },
             }),
-            new StringLogger<FileSystemRunHistoryStore>(log));
+            new StringLogger<FileSystemRunHistoryStore>(log),
+            CreateReportFactory());
 
         try
         {
@@ -1471,7 +1477,8 @@ public class RunReportTests
                     HistoryRetention = 4,
                 },
             }),
-            new StringLogger<FileSystemRunHistoryStore>(log));
+            new StringLogger<FileSystemRunHistoryStore>(log),
+            CreateReportFactory());
 
         try
         {
@@ -1576,7 +1583,11 @@ public class RunReportTests
                     HistoryRetention = historyRetention,
                 },
             }),
-            NullLogger<FileSystemRunHistoryStore>.Instance);
+            NullLogger<FileSystemRunHistoryStore>.Instance,
+            CreateReportFactory());
+
+    private static PipelineRunReportFactory CreateReportFactory() =>
+        new(new CommandExecutionCounter(), new PassthroughSecretObfuscator());
 
     private static PipelineOptions CreateReportingOptions(string reportPath) =>
         new()
@@ -1722,6 +1733,40 @@ public class RunReportTests
         {
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    [Test]
+    public async Task ReportSerializationOmitsOutputThatBecomesStaleDuringSerialization()
+    {
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupSequence(provider => provider.Version)
+            .Returns(2)
+            .Returns(2)
+            .Returns(4)
+            .Returns(4);
+        var reportFactory = new PipelineRunReportFactory(
+            new CommandExecutionCounter(),
+            new PassthroughSecretObfuscator(),
+            secretProvider: secretProvider.Object);
+        var report = new PipelineRunReport
+        {
+            Modules =
+            [
+                new ModuleRunReport
+                {
+                    Output = new ModuleOutputExcerpt
+                    {
+                        StdoutTail = "late-secret-suffix",
+                        SecretPatternsVersion = 2,
+                    },
+                },
+            ],
+        };
+
+        var serialized = reportFactory.SerializeWithValidatedOutputExcerpts(report);
+        var persisted = RunReportJsonSerializer.Deserialize(serialized);
+
+        await Assert.That(persisted!.Modules.Single().Output).IsNull();
     }
 
     [Test]
@@ -2208,6 +2253,7 @@ public class RunReportTests
                 },
             }),
             NullLogger<FileSystemRunHistoryStore>.Instance,
+            CreateReportFactory(),
             new RunReportPathResolver(directory));
 
         try

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -236,6 +236,36 @@ public class RunReportTests
             new(_completion.Task);
     }
 
+    private sealed class DelayedSecretRegisteringRunReportEnricher(Action registerSecret)
+        : IRunReportEnricher
+    {
+        private readonly TaskCompletionSource _release = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _started = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Completion { get; private set; } = Task.CompletedTask;
+
+        public Task Started => _started.Task;
+
+        public void Release() => _release.TrySetResult();
+
+        public ValueTask EnrichAsync(
+            RunReportEnrichmentContext context,
+            CancellationToken cancellationToken)
+        {
+            Completion = CompleteAsync();
+            _started.TrySetResult();
+            return new ValueTask(Completion);
+        }
+
+        private async Task CompleteAsync()
+        {
+            await _release.Task.ConfigureAwait(false);
+            registerSecret();
+        }
+    }
+
     private sealed class CommandCountingRunReportEnricher(
         ICommandExecutionCounter commandExecutionCounter) : IRunReportEnricher
     {
@@ -1690,6 +1720,74 @@ public class RunReportTests
         }
         finally
         {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunReportOmitsOutputWhenTimedOutEnricherCanRegisterSecretsLater()
+    {
+        var directory = CreateTemporaryDirectory();
+        var reportPath = Path.Combine(directory, "report.json");
+        var module = new SuccessfulModule();
+        var start = DateTimeOffset.UtcNow;
+        var summary = new PipelineSummary(
+            [module],
+            [CreateResult(module, start, TimeSpan.FromSeconds(1))],
+            TimeSpan.FromSeconds(1),
+            start,
+            start.AddSeconds(1));
+        var outputProvider = new Mock<IModuleOutputExcerptProvider>();
+        outputProvider.Setup(provider => provider.GetModuleOutputExcerpt(typeof(SuccessfulModule)))
+            .Returns(new ModuleOutputExcerpt
+            {
+                StdoutTail = "late-secret-suffix",
+                SecretPatternsVersion = 2,
+            });
+        var version = 2L;
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => version);
+        var enricher = new DelayedSecretRegisteringRunReportEnricher(() => version = 4);
+        var distributedOptions = OptionsFactory.Create(new DistributedOptions());
+        var commandExecutionCounter = new CommandExecutionCounter();
+        var service = new RunReportService(
+            Mock.Of<IRunHistoryStore>(),
+            new PipelineRunReportFactory(
+                commandExecutionCounter,
+                new PassthroughSecretObfuscator(),
+                outputProvider.Object,
+                secretProvider: secretProvider.Object),
+            Mock.Of<IBuildSystemDetector>(),
+            OptionsFactory.Create(CreateReportingOptions(reportPath)),
+            distributedOptions,
+            new RoleDetector(distributedOptions),
+            Mock.Of<IDistributedCoordinator>(),
+            commandExecutionCounter,
+            NullLogger<RunReportService>.Instance,
+            enricherTimeout: TimeSpan.FromMilliseconds(25),
+            runReportEnrichers: [enricher]);
+
+        try
+        {
+            var completion = service.CompleteAsync(summary);
+            await enricher.Started.WaitAsync(TimeSpan.FromSeconds(2));
+            var report = await completion.WaitAsync(TimeSpan.FromSeconds(2));
+            var persisted = RunReportJsonSerializer.Deserialize(
+                await File.ReadAllTextAsync(reportPath));
+
+            enricher.Release();
+            await enricher.Completion.WaitAsync(TimeSpan.FromSeconds(2));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(report.Modules.Single().Output).IsNull();
+                await Assert.That(persisted!.Modules.Single().Output).IsNull();
+                await Assert.That(version).IsEqualTo(4);
+            }
+        }
+        finally
+        {
+            enricher.Release();
             Directory.Delete(directory, recursive: true);
         }
     }

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1825,6 +1825,53 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task ReportPersistenceOmitsOutputThatBecomesStaleDuringPublication()
+    {
+        var directory = CreateTemporaryDirectory();
+        var path = Path.Combine(directory, "report.json");
+        var version = 2L;
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => version);
+        secretProvider
+            .Setup(provider => provider.TryExecuteIfVersionCurrent(2, It.IsAny<Action>()))
+            .Returns<long, Action>((_, _) =>
+            {
+                version = 4;
+                return false;
+            });
+        var reportFactory = new PipelineRunReportFactory(
+            new CommandExecutionCounter(),
+            new PassthroughSecretObfuscator(),
+            secretProvider: secretProvider.Object);
+        var report = new PipelineRunReport
+        {
+            Modules =
+            [
+                new ModuleRunReport
+                {
+                    Output = new ModuleOutputExcerpt
+                    {
+                        StdoutTail = "late-secret-suffix",
+                        SecretPatternsVersion = 2,
+                    },
+                },
+            ],
+        };
+
+        try
+        {
+            await reportFactory.WriteWithValidatedOutputExcerptsAsync(path, report);
+            var persisted = RunReportJsonSerializer.Deserialize(await File.ReadAllTextAsync(path));
+
+            await Assert.That(persisted!.Modules.Single().Output).IsNull();
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task RunReportOmitsOutputWhenTimedOutEnricherCanRegisterSecretsLater()
     {
         var directory = CreateTemporaryDirectory();

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -3324,6 +3324,45 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task RunReportDoesNotRemaskCurrentVersionExcerpt()
+    {
+        var module = new SuccessfulModule();
+        var start = DateTimeOffset.UtcNow;
+        var summary = new PipelineSummary(
+            [module],
+            [CreateResult(module, start, TimeSpan.FromSeconds(1))],
+            TimeSpan.FromSeconds(1),
+            start,
+            start.AddSeconds(1));
+        var outputProvider = new Mock<IModuleOutputExcerptProvider>();
+        outputProvider
+            .Setup(x => x.GetModuleOutputExcerpt(typeof(SuccessfulModule)))
+            .Returns(new ModuleOutputExcerpt
+            {
+                StdoutTail = "X**********",
+                TruncatedBytes = 0,
+                SecretPatternsVersion = 2,
+            });
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(2);
+        var obfuscator = new Mock<ISecretObfuscator>(MockBehavior.Strict);
+
+        var report = new PipelineRunReportFactory(
+                Mock.Of<ICommandExecutionCounter>(),
+                obfuscator.Object,
+                outputProvider.Object,
+                secretProvider: secretProvider.Object)
+            .Create(summary, null, "current-version-output");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(report.Modules.Single().Output!.StdoutTail)
+                .IsEqualTo("X**********");
+            await Assert.That(report.Modules.Single().Output!.TruncatedBytes).IsEqualTo(0);
+        }
+    }
+
+    [Test]
     public async Task RunReportRemaskingPreservesSharedOutputByteLimit()
     {
         var module = new SuccessfulModule();

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1793,6 +1793,75 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task CustomHistoryStoreDoesNotReceiveOutputExcerpts()
+    {
+        var module = new SuccessfulModule();
+        var start = DateTimeOffset.UtcNow;
+        var summary = new PipelineSummary(
+            [module],
+            [CreateResult(module, start, TimeSpan.FromSeconds(1))],
+            TimeSpan.FromSeconds(1),
+            start,
+            start.AddSeconds(1));
+        var outputProvider = new Mock<IModuleOutputExcerptProvider>();
+        outputProvider.Setup(provider => provider.GetModuleOutputExcerpt(typeof(SuccessfulModule)))
+            .Returns(new ModuleOutputExcerpt
+            {
+                StdoutTail = "late-secret-suffix",
+                SecretPatternsVersion = 2,
+            });
+        var version = 2L;
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => version);
+        PipelineRunReport? savedReport = null;
+        var historyStore = new Mock<IRunHistoryStore>();
+        historyStore.Setup(store => store.GetRunsAsync(
+                It.IsAny<RunHistoryQuery>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(EmptyReports());
+        historyStore.Setup(store => store.SaveAsync(
+                It.IsAny<PipelineRunReport>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<PipelineRunReport, CancellationToken>((report, _) =>
+            {
+                version = 4;
+                savedReport = report;
+            })
+            .Returns(Task.CompletedTask);
+        var distributedOptions = OptionsFactory.Create(new DistributedOptions());
+        var commandExecutionCounter = new CommandExecutionCounter();
+        var service = new RunReportService(
+            historyStore.Object,
+            new PipelineRunReportFactory(
+                commandExecutionCounter,
+                new PassthroughSecretObfuscator(),
+                outputProvider.Object,
+                secretProvider: secretProvider.Object),
+            Mock.Of<IBuildSystemDetector>(),
+            OptionsFactory.Create(new PipelineOptions
+            {
+                RunReport = new RunReportOptions
+                {
+                    AutoWriteInCi = false,
+                    HistoryRetention = 1,
+                },
+            }),
+            distributedOptions,
+            new RoleDetector(distributedOptions),
+            Mock.Of<IDistributedCoordinator>(),
+            commandExecutionCounter,
+            NullLogger<RunReportService>.Instance);
+
+        var report = await service.CompleteAsync(summary);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(report.Modules.Single().Output).IsNotNull();
+            await Assert.That(savedReport!.Modules.Single().Output).IsNull();
+        }
+    }
+
+    [Test]
     public async Task HistoryPersistenceInvokesRunReportEnrichersWithoutReportFile()
     {
         PipelineRunReport? savedReport = null;

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1346,7 +1346,7 @@ public class RunReportTests
     [Test]
     public async Task FileSystemHistoryStoreAcceptsAdditiveOlderSchemas()
     {
-        const int expectedCurrentSchemaVersion = 3;
+        const int expectedCurrentSchemaVersion = 4;
 
         using (Assert.Multiple())
         {
@@ -1354,8 +1354,9 @@ public class RunReportTests
             await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(1, expectedCurrentSchemaVersion)).IsTrue();
             await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(2, expectedCurrentSchemaVersion)).IsTrue();
             await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(3, expectedCurrentSchemaVersion)).IsTrue();
+            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(4, expectedCurrentSchemaVersion)).IsTrue();
             await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(0, expectedCurrentSchemaVersion)).IsFalse();
-            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(4, expectedCurrentSchemaVersion)).IsFalse();
+            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(5, expectedCurrentSchemaVersion)).IsFalse();
         }
     }
 
@@ -3317,6 +3318,52 @@ public class RunReportTests
         {
             await Assert.That(report.Modules.Single().Output!.StdoutTail).IsEqualTo("***");
             await Assert.That(report.Modules.Single().Output!.StderrTail).IsEqualTo("***");
+        }
+    }
+
+    [Test]
+    public async Task RunReportRemaskingPreservesSharedOutputByteLimit()
+    {
+        var module = new SuccessfulModule();
+        var start = DateTimeOffset.UtcNow;
+        var summary = new PipelineSummary(
+            [module],
+            [CreateResult(module, start, TimeSpan.FromSeconds(1))],
+            TimeSpan.FromSeconds(1),
+            start,
+            start.AddSeconds(1));
+        var outputProvider = new Mock<IModuleOutputExcerptProvider>();
+        outputProvider
+            .Setup(x => x.GetModuleOutputExcerpt(typeof(SuccessfulModule)))
+            .Returns(new ModuleOutputExcerpt
+            {
+                StdoutTail = "secret",
+                StderrTail = "secret",
+                TruncatedBytes = 5,
+            });
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) => value?.Replace("secret", "[MASKED]") ?? string.Empty);
+        var options = Microsoft.Extensions.Options.Options.Create(new PipelineOptions
+        {
+            RunReport = new RunReportOptions { MaxOutputBytesPerModule = 12 },
+        });
+
+        var report = new PipelineRunReportFactory(
+                Mock.Of<ICommandExecutionCounter>(),
+                obfuscator.Object,
+                outputProvider.Object,
+                options)
+            .Create(summary, null, "output-remasking-limit");
+        var output = report.Modules.Single().Output!;
+        var retainedBytes = Encoding.UTF8.GetByteCount(output.StdoutTail ?? string.Empty)
+                            + Encoding.UTF8.GetByteCount(output.StderrTail ?? string.Empty);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(retainedBytes).IsLessThanOrEqualTo(12);
+            await Assert.That(output.TruncatedBytes).IsEqualTo(9);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1770,6 +1770,61 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task ReportPersistenceOmitsOutputThatBecomesStaleDuringWrite()
+    {
+        var directory = CreateTemporaryDirectory();
+        var path = Path.Combine(directory, "report.json");
+        var version = 2L;
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => version);
+        var reportFactory = new PipelineRunReportFactory(
+            new CommandExecutionCounter(),
+            new PassthroughSecretObfuscator(),
+            secretProvider: secretProvider.Object);
+        var report = new PipelineRunReport
+        {
+            Modules =
+            [
+                new ModuleRunReport
+                {
+                    Output = new ModuleOutputExcerpt
+                    {
+                        StdoutTail = "late-secret-suffix",
+                        SecretPatternsVersion = 2,
+                    },
+                },
+            ],
+        };
+        var writeCount = 0;
+
+        try
+        {
+            await reportFactory.WriteWithValidatedOutputExcerptsAsync(
+                path,
+                report,
+                async (temporaryPath, contents, cancellationToken) =>
+                {
+                    await File.WriteAllTextAsync(temporaryPath, contents, cancellationToken);
+                    if (Interlocked.Increment(ref writeCount) == 1)
+                    {
+                        version = 4;
+                    }
+                });
+            var persisted = RunReportJsonSerializer.Deserialize(await File.ReadAllTextAsync(path));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(writeCount).IsEqualTo(2);
+                await Assert.That(persisted!.Modules.Single().Output).IsNull();
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task RunReportOmitsOutputWhenTimedOutEnricherCanRegisterSecretsLater()
     {
         var directory = CreateTemporaryDirectory();

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1793,8 +1793,10 @@ public class RunReportTests
     }
 
     [Test]
-    public async Task CustomHistoryStoreDoesNotReceiveOutputExcerpts()
+    public async Task CustomHistoryStoreOmitsOutputExcerptsFromAllReports()
     {
+        var directory = CreateTemporaryDirectory();
+        var reportPath = Path.Combine(directory, "report.json");
         var module = new SuccessfulModule();
         var start = DateTimeOffset.UtcNow;
         var summary = new PipelineSummary(
@@ -1843,6 +1845,7 @@ public class RunReportTests
                 RunReport = new RunReportOptions
                 {
                     AutoWriteInCi = false,
+                    ReportPath = reportPath,
                     HistoryRetention = 1,
                 },
             }),
@@ -1852,12 +1855,22 @@ public class RunReportTests
             commandExecutionCounter,
             NullLogger<RunReportService>.Instance);
 
-        var report = await service.CompleteAsync(summary);
-
-        using (Assert.Multiple())
+        try
         {
-            await Assert.That(report.Modules.Single().Output).IsNotNull();
-            await Assert.That(savedReport!.Modules.Single().Output).IsNull();
+            var report = await service.CompleteAsync(summary);
+            var persistedReport = RunReportJsonSerializer.Deserialize(
+                await File.ReadAllTextAsync(reportPath));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(report.Modules.Single().Output).IsNull();
+                await Assert.That(savedReport!.Modules.Single().Output).IsNull();
+                await Assert.That(persistedReport!.Modules.Single().Output).IsNull();
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -248,6 +248,17 @@ public class RunReportTests
         }
     }
 
+    private sealed class CallbackRunReportEnricher(Action callback) : IRunReportEnricher
+    {
+        public ValueTask EnrichAsync(
+            RunReportEnrichmentContext context,
+            CancellationToken cancellationToken)
+        {
+            callback();
+            return ValueTask.CompletedTask;
+        }
+    }
+
     [Test]
     public async Task WriteRunReportPersistsSchemaHistoryDeltasAndCommandCounts()
     {
@@ -1615,6 +1626,66 @@ public class RunReportTests
                     .IsEqualTo("https://ci.example/**********-run");
                 await Assert.That(report.Correlation.Hostname).IsEqualTo(Environment.MachineName);
                 await Assert.That(report.Correlation.BuildSystem).IsEqualTo(BuildSystem.GitHubActions);
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task RunReportOmitsOutputMadeStaleByEnricherSecretRegistration()
+    {
+        var directory = CreateTemporaryDirectory();
+        var reportPath = Path.Combine(directory, "report.json");
+        var module = new SuccessfulModule();
+        var start = DateTimeOffset.UtcNow;
+        var summary = new PipelineSummary(
+            [module],
+            [CreateResult(module, start, TimeSpan.FromSeconds(1))],
+            TimeSpan.FromSeconds(1),
+            start,
+            start.AddSeconds(1));
+        var outputProvider = new Mock<IModuleOutputExcerptProvider>();
+        outputProvider.Setup(provider => provider.GetModuleOutputExcerpt(typeof(SuccessfulModule)))
+            .Returns(new ModuleOutputExcerpt
+            {
+                StdoutTail = "late-secret-suffix",
+                SecretPatternsVersion = 2,
+            });
+        var version = 2L;
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(provider => provider.Version).Returns(() => version);
+        var distributedOptions = OptionsFactory.Create(new DistributedOptions());
+        var commandExecutionCounter = new CommandExecutionCounter();
+        var reportFactory = new PipelineRunReportFactory(
+            commandExecutionCounter,
+            new PassthroughSecretObfuscator(),
+            outputProvider.Object,
+            secretProvider: secretProvider.Object);
+        var service = new RunReportService(
+            Mock.Of<IRunHistoryStore>(),
+            reportFactory,
+            Mock.Of<IBuildSystemDetector>(),
+            OptionsFactory.Create(CreateReportingOptions(reportPath)),
+            distributedOptions,
+            new RoleDetector(distributedOptions),
+            Mock.Of<IDistributedCoordinator>(),
+            commandExecutionCounter,
+            NullLogger<RunReportService>.Instance,
+            runReportEnrichers: [new CallbackRunReportEnricher(() => version = 4)]);
+
+        try
+        {
+            var report = await service.CompleteAsync(summary);
+            var persisted = RunReportJsonSerializer.Deserialize(
+                await File.ReadAllTextAsync(reportPath));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(report.Modules.Single().Output).IsNull();
+                await Assert.That(persisted!.Modules.Single().Output).IsNull();
             }
         }
         finally

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -4,8 +4,10 @@ using System.Runtime.Loader;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Configuration;
+using ModularPipelines.Console;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.DependencyInjection;
@@ -82,6 +84,19 @@ public class RunReportTests
             IModuleContext context,
             CancellationToken cancellationToken) =>
             Task.FromResult<string?>("success");
+    }
+
+    private sealed class OutputExcerptModule(ISecretRegistry secretRegistry) : Module<string>
+    {
+        protected internal override Task<string?> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            secretRegistry.AddSecret("module-output-secret");
+            context.Logger.LogInformation("{CommandOutput}", "stdout module-output-secret");
+            context.Logger.LogInformation("{CommandError}", "stderr module-output-secret");
+            return Task.FromResult<string?>("success");
+        }
     }
 
     private sealed class GenericModule<T> : Module<string>
@@ -3178,6 +3193,131 @@ public class RunReportTests
 
         await Assert.That(result.Errors.Select(error => error.Message))
             .Contains(message => message.Contains("HistoryRetention", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public async Task RunReportJsonRoundTripPreservesModuleOutputExcerpt()
+    {
+        var report = new PipelineRunReport
+        {
+            Modules =
+            [
+                new ModuleRunReport
+                {
+                    Output = new ModuleOutputExcerpt
+                    {
+                        StdoutTail = "stdout tail",
+                        StderrTail = "stderr tail",
+                        TruncatedBytes = 42,
+                    },
+                },
+            ],
+        };
+
+        var deserialized = RunReportJsonSerializer.Deserialize(
+            RunReportJsonSerializer.Serialize(report));
+        var output = deserialized!.Modules.Single().Output;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output!.StdoutTail).IsEqualTo("stdout tail");
+            await Assert.That(output.StderrTail).IsEqualTo("stderr tail");
+            await Assert.That(output.TruncatedBytes).IsEqualTo(42);
+        }
+    }
+
+    [Test]
+    public async Task RunReportOptionsRejectNonPositiveOutputLimit()
+    {
+        var result = new OptionsValidator().ValidateOptions(new PipelineOptions
+        {
+            RunReport = new RunReportOptions
+            {
+                IncludeModuleOutput = true,
+                MaxOutputBytesPerModule = 0,
+            },
+        });
+
+        await Assert.That(result.Errors.Select(error => error.Message))
+            .Contains(message => message.Contains("MaxOutputBytesPerModule", StringComparison.Ordinal));
+    }
+
+    [Test]
+    public async Task RunReportOptionsIgnoreOutputLimitWhenOutputIsDisabled()
+    {
+        var result = new OptionsValidator().ValidateOptions(new PipelineOptions
+        {
+            RunReport = new RunReportOptions { MaxOutputBytesPerModule = 0 },
+        });
+
+        await Assert.That(result.Errors).IsEmpty();
+    }
+
+    [Test]
+    public async Task RunReportIncludesMaskedModuleOutputWhenEnabled()
+    {
+        using var builder = Pipeline.CreateBuilder();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            Console = options.Console with { PrintLogo = false, PrintResults = false },
+            RunReport = options.RunReport with
+            {
+                AutoWriteInCi = false,
+                HistoryRetention = 0,
+                IncludeModuleOutput = true,
+                MaxOutputBytesPerModule = 1024,
+            },
+        });
+        builder.AddModule<OutputExcerptModule>();
+
+        var summary = await builder.ExecutePipelineAsync();
+        var output = summary.RunReport!.Modules.Single().Output;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).IsNotNull();
+            await Assert.That(output!.StdoutTail).Contains("stdout");
+            await Assert.That(output.StderrTail).Contains("stderr");
+            await Assert.That(output.StdoutTail).DoesNotContain("module-output-secret");
+            await Assert.That(output.StderrTail).DoesNotContain("module-output-secret");
+        }
+    }
+
+    [Test]
+    public async Task RunReportMasksOutputAgainAtCreation()
+    {
+        var module = new SuccessfulModule();
+        var start = DateTimeOffset.UtcNow;
+        var summary = new PipelineSummary(
+            [module],
+            [CreateResult(module, start, TimeSpan.FromSeconds(1))],
+            TimeSpan.FromSeconds(1),
+            start,
+            start.AddSeconds(1));
+        var outputProvider = new Mock<IModuleOutputExcerptProvider>();
+        outputProvider
+            .Setup(x => x.GetModuleOutputExcerpt(typeof(SuccessfulModule)))
+            .Returns(new ModuleOutputExcerpt
+            {
+                StdoutTail = "late-secret",
+                StderrTail = "late-secret",
+            });
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) => value?.Replace("late-secret", "***") ?? string.Empty);
+
+        var report = new PipelineRunReportFactory(
+                Mock.Of<ICommandExecutionCounter>(),
+                obfuscator.Object,
+                outputProvider.Object)
+            .Create(summary, null, "output-remasking");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(report.Modules.Single().Output!.StdoutTail).IsEqualTo("***");
+            await Assert.That(report.Modules.Single().Output!.StderrTail).IsEqualTo("***");
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -3228,14 +3228,16 @@ public class RunReportTests
     }
 
     [Test]
-    public async Task RunReportOptionsRejectNonPositiveOutputLimit()
+    [Arguments(0)]
+    [Arguments(-1)]
+    public async Task RunReportOptionsRejectNonPositiveOutputLimit(int maximumBytes)
     {
         var result = new OptionsValidator().ValidateOptions(new PipelineOptions
         {
             RunReport = new RunReportOptions
             {
                 IncludeModuleOutput = true,
-                MaxOutputBytesPerModule = 0,
+                MaxOutputBytesPerModule = maximumBytes,
             },
         });
 

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -3368,6 +3368,41 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task RunReportOmitsOutputWhenSecretsChangeDuringFinalMasking()
+    {
+        var module = new SuccessfulModule();
+        var start = DateTimeOffset.UtcNow;
+        var summary = new PipelineSummary(
+            [module],
+            [CreateResult(module, start, TimeSpan.FromSeconds(1))],
+            TimeSpan.FromSeconds(1),
+            start,
+            start.AddSeconds(1));
+        var outputProvider = new Mock<IModuleOutputExcerptProvider>();
+        outputProvider
+            .Setup(x => x.GetModuleOutputExcerpt(typeof(SuccessfulModule)))
+            .Returns(new ModuleOutputExcerpt
+            {
+                StdoutTail = "secret-suffix",
+                SecretPatternsVersion = 2,
+            });
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider
+            .SetupSequence(provider => provider.Version)
+            .Returns(2)
+            .Returns(4);
+
+        var report = new PipelineRunReportFactory(
+                Mock.Of<ICommandExecutionCounter>(),
+                new PassthroughSecretObfuscator(),
+                outputProvider.Object,
+                secretProvider: secretProvider.Object)
+            .Create(summary, null, "output-remasking-race");
+
+        await Assert.That(report.Modules.Single().Output).IsNull();
+    }
+
+    [Test]
     public async Task RunReportOptionsRejectNegativeGlobalRetention()
     {
         var result = new OptionsValidator().ValidateOptions(new PipelineOptions

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -428,7 +428,7 @@ public class SecretMaskingPatternTests
             releaseFlush.TrySetResult();
             await childFlush.WaitAsync(TimeSpan.FromSeconds(5));
 
-            outputBuffer.Verify(x => x.WriteLine("pending"), Times.Once);
+            outputBuffer.Verify(x => x.Write("pending"), Times.Once);
         }
     }
 
@@ -743,7 +743,8 @@ public class SecretMaskingPatternTests
         writer.WriteLine("y");
 
         outputBuffer.Verify(x => x.WriteLine(It.Is<string>(value => value.Contains("abc"))), Times.Never);
-        outputBuffer.Verify(x => x.WriteLine(It.Is<string>(value => value.Contains("**********"))), Times.Once);
+        outputBuffer.Verify(x => x.Write(It.Is<string>(value => value.Contains("**********"))), Times.Once);
+        outputBuffer.Verify(x => x.WriteLine("y"), Times.Once);
     }
 
     [Test]


### PR DESCRIPTION
Closes #3748

## Summary
- add opt-in `ModuleRunReport.Output` excerpts with separate stdout/stderr tails
- enforce one tail-biased UTF-8 byte budget per module without retaining raw process output
- capture only masked module buffers, then mask again during report creation
- document configuration and advance the run-report schema to version 4

## Validation
- `ModuleOutputExcerptBufferTests`: 23/23
- `ModuleOutputBufferTests`: 32/32
- `RunReportTests`: 93 passed, 1 Windows-only skip
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run reports can include optional, size-limited excerpts of module standard output and error output.
  * Excerpts preserve separate streams, indicate truncation, and mask sensitive values.
  * Added configuration for enabling excerpts and setting per-module output limits.
  * Updated the run report schema to version 4.

* **Bug Fixes**
  * Improved preservation and categorization of standard output versus error output.

* **Documentation**
  * Added guidance for configuring module output excerpts in run reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

