### PR TITLE
Prune stale atomic report temp files

### DIFF
--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -66,7 +66,9 @@ path and registered module types. History is bounded: after each save, the defau
 owned files beyond the configured limit for that pipeline.
 Report and history I/O failures are logged as warnings and do not replace a pipeline failure.
 Report and history files are published atomically, so cancellation or a failed write cannot replace
-a complete report with partial JSON.
+a complete report with partial JSON. After each successful history save, the built-in store also
+removes atomic-write temporary files older than 24 hours while leaving recent files for concurrent
+writers.
 
 CI agents are often ephemeral, so restore the history directory from a cache before running the
 pipeline. For example, a GitHub Actions workflow can restore the newest cache for its branch and

--- a/src/ModularPipelines/Engine/AtomicFileWriter.cs
+++ b/src/ModularPipelines/Engine/AtomicFileWriter.cs
@@ -2,6 +2,10 @@ namespace ModularPipelines.Engine;
 
 internal static class AtomicFileWriter
 {
+    private const string TemporaryFilePrefix = ".modularpipelines-";
+    private const string TemporaryFileSuffix = ".tmp";
+    internal const string TemporaryFilePattern = TemporaryFilePrefix + "*" + TemporaryFileSuffix;
+
     public static Task WriteAllTextAsync(
         string path,
         string contents,
@@ -23,7 +27,7 @@ internal static class AtomicFileWriter
             ?? throw new ArgumentException("The path must include a directory.", nameof(path));
         var temporaryPath = Path.Combine(
             directory,
-            $".modularpipelines-{Guid.NewGuid():N}.tmp");
+            $"{TemporaryFilePrefix}{Guid.NewGuid():N}{TemporaryFileSuffix}");
 
         try
         {

--- a/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
@@ -14,6 +14,7 @@ internal sealed class FileSystemRunHistoryStore(
 {
     private const string OwnedFilePrefix = "modularpipelines-run-";
     private const int MinimumCompatibleSchemaVersion = 1;
+    private static readonly TimeSpan StaleTemporaryFileAge = TimeSpan.FromDays(1);
 
     public Task<PipelineRunReport?> GetLatestAsync(
         string pipelineIdentity,
@@ -145,6 +146,8 @@ internal sealed class FileSystemRunHistoryStore(
                 cancellationToken)
             .ConfigureAwait(false);
 
+        PruneStaleTemporaryFiles(directory, cancellationToken);
+
         var staleFiles = Directory
             .EnumerateFiles(directory, $"{filePrefix}*.json", SearchOption.TopDirectoryOnly)
             .OrderByDescending(static file => Path.GetFileName(file), StringComparer.Ordinal)
@@ -160,6 +163,29 @@ internal sealed class FileSystemRunHistoryStore(
             catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
             {
                 logger.LogWarning(exception, "Could not prune pipeline run history file {HistoryFile}", staleFile);
+            }
+        }
+    }
+
+    private void PruneStaleTemporaryFiles(string directory, CancellationToken cancellationToken)
+    {
+        var staleBefore = DateTime.UtcNow - StaleTemporaryFileAge;
+        foreach (var temporaryFile in Directory.EnumerateFiles(
+                     directory,
+                     AtomicFileWriter.TemporaryFilePattern,
+                     SearchOption.TopDirectoryOnly))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                if (File.GetLastWriteTimeUtc(temporaryFile) <= staleBefore)
+                {
+                    File.Delete(temporaryFile);
+                }
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                logger.LogWarning(exception, "Could not prune temporary run history file {HistoryFile}", temporaryFile);
             }
         }
     }

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -815,6 +815,41 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task FileSystemHistoryStorePrunesOnlyStaleOwnedTemporaryFiles()
+    {
+        var directory = CreateTemporaryDirectory();
+        var store = CreateHistoryStore(directory, historyRetention: 1);
+        var staleTemporaryFile = Path.Combine(directory, ".modularpipelines-stale.tmp");
+        var recentTemporaryFile = Path.Combine(directory, ".modularpipelines-recent.tmp");
+        var unrelatedTemporaryFile = Path.Combine(directory, "unrelated.tmp");
+
+        try
+        {
+            await File.WriteAllTextAsync(staleTemporaryFile, "stale");
+            File.SetLastWriteTimeUtc(staleTemporaryFile, DateTime.UtcNow.AddDays(-2));
+            await File.WriteAllTextAsync(recentTemporaryFile, "recent");
+            await File.WriteAllTextAsync(unrelatedTemporaryFile, "unrelated");
+
+            await store.SaveAsync(new PipelineRunReport
+            {
+                PipelineIdentity = "pipeline-a",
+                End = DateTimeOffset.UtcNow,
+            });
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(File.Exists(staleTemporaryFile)).IsFalse();
+                await Assert.That(File.Exists(recentTemporaryFile)).IsTrue();
+                await Assert.That(File.Exists(unrelatedTemporaryFile)).IsTrue();
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task FileSystemHistoryStorePartitionsRetentionByPipelineIdentity()
     {
         var directory = CreateTemporaryDirectory();


### PR DESCRIPTION
Follow-up to #3831 review feedback.\n\n## Summary\n- prune owned atomic-write temp files older than 24 hours after successful history saves\n- retain recent temp files to avoid racing concurrent writers\n- leave unrelated temp files untouched\n- document the cleanup behavior\n\n## Validation\n- RunReportTests: 51 passed\n- focused post-main test: 1 passed\n- ModularPipelines.slnx Release build: 0 warnings, 0 errors