### PR TITLE
Report missing command executables

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -250,7 +250,7 @@ internal sealed class Command : ICommandContext
             LogInterceptedCommand(options, executionOptions, inputToLog.Value, result);
             if (result.ExitCode != 0 && executionOptions.ThrowOnNonZeroExitCode)
             {
-                throw new CommandException(CreateFailureResult(
+                throw CommandException.FromObfuscatedResult(CreateFailureResult(
                     command,
                     executionOptions,
                     result.CommandInput,
@@ -425,7 +425,7 @@ internal sealed class Command : ICommandContext
                         command.WorkingDirPath));
                 var failure = loggingFailures.CombineWith(e);
 
-                throw new CommandException(
+                throw CommandException.FromObfuscatedResult(
                     CreateFailureResult(
                         command,
                         execOpts,
@@ -502,7 +502,7 @@ internal sealed class Command : ICommandContext
                     command.WorkingDirPath));
             if (commandFailure is not null && loggingFailures.HasFailures)
             {
-                throw new CommandException(
+                throw CommandException.FromObfuscatedResult(
                     commandFailure.Result,
                     loggingFailures.CombineWith(commandFailure));
             }
@@ -552,16 +552,37 @@ internal sealed class Command : ICommandContext
             return CreateTimeoutException(execOpts, combinedFailure);
         }
 
-        return new CommandException(
-            CreateFailureResult(
-                command,
-                execOpts,
-                input,
-                -1,
-                duration,
-                standardOutput,
-                standardError),
-            combinedFailure);
+        var result = CreateFailureResult(
+            command,
+            execOpts,
+            input,
+            -1,
+            duration,
+            standardOutput,
+            standardError);
+        return IsExecutableNotFound(executionFailure)
+            ? new ToolNotFoundException(
+                _secretObfuscator.Obfuscate(command.TargetFilePath, execOpts),
+                result,
+                combinedFailure)
+            : CommandException.FromObfuscatedResult(result, combinedFailure);
+    }
+
+    private static bool IsExecutableNotFound(Exception exception)
+    {
+        if (exception is Win32Exception { NativeErrorCode: 2 })
+        {
+            return true;
+        }
+
+        if (exception is AggregateException aggregateException
+            && aggregateException.InnerExceptions.Any(IsExecutableNotFound))
+        {
+            return true;
+        }
+
+        return exception.InnerException is not null
+               && IsExecutableNotFound(exception.InnerException);
     }
 
     private static TimeoutException CreateTimeoutException(
@@ -619,7 +640,7 @@ internal sealed class Command : ICommandContext
         string standardError)
     {
         return result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode
-            ? new CommandException(CreateFailureResult(
+            ? CommandException.FromObfuscatedResult(CreateFailureResult(
                 command,
                 execOpts,
                 input,

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -26,6 +26,9 @@ namespace ModularPipelines.Context;
 /// </summary>
 internal sealed class Command : ICommandContext
 {
+    // Win32 ERROR_FILE_NOT_FOUND and Unix ENOENT both use native error code 2.
+    private const int FileNotFoundNativeErrorCode = 2;
+
     private readonly ICommandLogger _commandLogger;
     private readonly ICommandLineBuilder _commandLineBuilder;
     private readonly IEnumerable<ICommandInterceptor> _commandInterceptors;
@@ -250,7 +253,7 @@ internal sealed class Command : ICommandContext
             LogInterceptedCommand(options, executionOptions, inputToLog.Value, result);
             if (result.ExitCode != 0 && executionOptions.ThrowOnNonZeroExitCode)
             {
-                throw CommandException.FromObfuscatedResult(CreateFailureResult(
+                throw CommandException.FromAlreadyObfuscatedResult(CreateFailureResult(
                     command,
                     executionOptions,
                     result.CommandInput,
@@ -425,7 +428,7 @@ internal sealed class Command : ICommandContext
                         command.WorkingDirPath));
                 var failure = loggingFailures.CombineWith(e);
 
-                throw CommandException.FromObfuscatedResult(
+                throw CommandException.FromAlreadyObfuscatedResult(
                     CreateFailureResult(
                         command,
                         execOpts,
@@ -502,7 +505,7 @@ internal sealed class Command : ICommandContext
                     command.WorkingDirPath));
             if (commandFailure is not null && loggingFailures.HasFailures)
             {
-                throw CommandException.FromObfuscatedResult(
+                throw CommandException.FromAlreadyObfuscatedResult(
                     commandFailure.Result,
                     loggingFailures.CombineWith(commandFailure));
             }
@@ -565,20 +568,19 @@ internal sealed class Command : ICommandContext
                 _secretObfuscator.Obfuscate(command.TargetFilePath, execOpts),
                 result,
                 combinedFailure)
-            : CommandException.FromObfuscatedResult(result, combinedFailure);
+            : CommandException.FromAlreadyObfuscatedResult(result, combinedFailure);
     }
 
     private static bool IsExecutableNotFound(Exception exception)
     {
-        if (exception is Win32Exception { NativeErrorCode: 2 })
+        if (exception is Win32Exception { NativeErrorCode: FileNotFoundNativeErrorCode })
         {
             return true;
         }
 
-        if (exception is AggregateException aggregateException
-            && aggregateException.InnerExceptions.Any(IsExecutableNotFound))
+        if (exception is AggregateException aggregateException)
         {
-            return true;
+            return aggregateException.InnerExceptions.Any(IsExecutableNotFound);
         }
 
         return exception.InnerException is not null
@@ -640,7 +642,7 @@ internal sealed class Command : ICommandContext
         string standardError)
     {
         return result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode
-            ? CommandException.FromObfuscatedResult(CreateFailureResult(
+            ? CommandException.FromAlreadyObfuscatedResult(CreateFailureResult(
                 command,
                 execOpts,
                 input,

--- a/src/ModularPipelines/Exceptions/CommandException.cs
+++ b/src/ModularPipelines/Exceptions/CommandException.cs
@@ -44,7 +44,8 @@ public class CommandException : PipelineException
     {
     }
 
-    internal static CommandException FromObfuscatedResult(
+    // CommandInput is embedded in the message, so callers must pass an already-obfuscated result.
+    internal static CommandException FromAlreadyObfuscatedResult(
         CommandResult result,
         Exception? innerException = null) =>
         new(

--- a/src/ModularPipelines/Exceptions/CommandException.cs
+++ b/src/ModularPipelines/Exceptions/CommandException.cs
@@ -9,7 +9,8 @@ namespace ModularPipelines.Exceptions;
 /// <para>
 /// This exception is thrown by command execution methods when the underlying process
 /// returns a non-zero exit code. Framework-thrown exceptions expose an obfuscated
-/// command result for debugging without including command output in the exception message.
+/// command result for debugging and include its command input, but not command output,
+/// in the exception message.
 /// </para>
 /// <para><b>Properties available:</b></para>
 /// <list type="bullet">
@@ -39,7 +40,26 @@ public class CommandException : PipelineException
     /// <param name="result">The result of the failed command.</param>
     /// <param name="innerException">The inner exception that caused this command failure.</param>
     public CommandException(CommandResult result, Exception? innerException = null)
-        : base($"Command failed with exit code {result.ExitCode}.", innerException)
+        : this($"Command failed with exit code {result.ExitCode}.", result, innerException)
+    {
+    }
+
+    internal static CommandException FromObfuscatedResult(
+        CommandResult result,
+        Exception? innerException = null) =>
+        new(
+            $"Command '{result.CommandInput}' failed with exit code {result.ExitCode}.",
+            result,
+            innerException);
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="CommandException"/> class with a custom message.
+    /// </summary>
+    /// <param name="message">The message that describes the command failure.</param>
+    /// <param name="result">The result of the failed command.</param>
+    /// <param name="innerException">The inner exception that caused this command failure.</param>
+    protected CommandException(string message, CommandResult result, Exception? innerException = null)
+        : base(message, innerException)
     {
         Result = result;
     }

--- a/src/ModularPipelines/Exceptions/PipelineException.cs
+++ b/src/ModularPipelines/Exceptions/PipelineException.cs
@@ -26,6 +26,7 @@ namespace ModularPipelines.Exceptions;
 /// <item><see cref="PipelineValidationException"/> - Pipeline validation failed</item>
 /// <item><see cref="PluginVersionMismatchException"/> - Plugin version incompatibility</item>
 /// <item><see cref="SubModuleFailedException"/> - Sub-module execution failed</item>
+/// <item><see cref="ToolNotFoundException"/> - A command executable could not be found</item>
 /// </list>
 /// <para><b>Handling example:</b></para>
 /// <code>

--- a/src/ModularPipelines/Exceptions/ToolNotFoundException.cs
+++ b/src/ModularPipelines/Exceptions/ToolNotFoundException.cs
@@ -1,0 +1,33 @@
+using ModularPipelines.Models;
+
+namespace ModularPipelines.Exceptions;
+
+/// <summary>
+/// Thrown when a command cannot start because its executable was not found.
+/// </summary>
+public sealed class ToolNotFoundException : CommandException
+{
+    /// <summary>
+    /// Initialises a new instance of the <see cref="ToolNotFoundException"/> class.
+    /// </summary>
+    /// <param name="executable">The executable that could not be found.</param>
+    /// <param name="result">The result captured for the failed command start.</param>
+    /// <param name="innerException">The native process-start failure.</param>
+    public ToolNotFoundException(
+        string executable,
+        CommandResult result,
+        Exception? innerException = null)
+        : base(
+            $"Executable '{executable}' was not found on PATH. "
+            + "Install it or add it to PATH; see context.Installers for scripted installation.",
+            result,
+            innerException)
+    {
+        Executable = executable;
+    }
+
+    /// <summary>
+    /// Gets the executable that could not be found.
+    /// </summary>
+    public string Executable { get; }
+}

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -163,7 +163,27 @@ public class CommandTests : TestBase
             await Assert.That(exception.Result.StandardOutput).DoesNotContain(secret);
             await Assert.That(exception.Result.StandardError).DoesNotContain(secret);
             await Assert.That(exception.Result.EnvironmentVariables["MP_TEST_SECRET"]).DoesNotContain(secret);
-            await Assert.That(exception.Message).IsEqualTo("Command failed with exit code 42.");
+            await Assert.That(exception.Message).Contains(exception.Result.CommandInput);
+            await Assert.That(exception.Message).DoesNotContain(secret);
+        }
+    }
+
+    [Test]
+    public async Task Missing_Executable_Throws_Actionable_Exception()
+    {
+        var executable = $"modular-pipelines-missing-{Guid.NewGuid():N}";
+        var command = await GetService<ICommandContext>();
+
+        var exception = await Assert.ThrowsAsync<ToolNotFoundException>(() =>
+            command.ExecuteCommandLineToolAsync(new GenericCommandLineToolOptions(executable)));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Executable).IsEqualTo(executable);
+            await Assert.That(exception.Result.ExitCode).IsEqualTo(-1);
+            await Assert.That(exception.Result.CommandInput).Contains(executable);
+            await Assert.That(exception.Message).Contains($"Executable '{executable}' was not found on PATH");
+            await Assert.That(exception.Message).Contains("context.Installers");
         }
     }
 


### PR DESCRIPTION
## Summary
- throw an actionable ToolNotFoundException for native executable-not-found start failures
- retain the obfuscated CommandResult and original process-start failure
- include sanitized command input in framework-created CommandException messages while preserving the public constructor's no-input behavior

## Validation
- missing executable regression: 1 passed
- CommandException constructor regression: 1 passed
- obfuscated failed-command regression: 1 passed
- ModularPipelines.slnx Release build: 0 warnings, 0 errors

Closes #3767