### PR TITLE
Transfer builder resources to pipeline ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Then configure and execute the pipeline from `Program.cs`:
 using ModularPipelines;
 using ModularPipelines.Extensions;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 await builder.ExecutePipelineAsync();
 ```
 

--- a/docs/docs/distributed/getting-started.md
+++ b/docs/docs/distributed/getting-started.md
@@ -33,7 +33,7 @@ In your `Program.cs`, enable distributed mode and register the Redis coordinator
 using ModularPipelines.Distributed.Extensions;
 using ModularPipelines.Distributed.Redis.Extensions;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 // Parse instance info from arguments or environment
 var instanceIndex = int.Parse(
@@ -124,7 +124,7 @@ using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
 using Microsoft.Extensions.DependencyInjection;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 var instanceIndex = int.Parse(
     Environment.GetEnvironmentVariable("INSTANCE_INDEX") ?? "0");

--- a/docs/docs/distributed/github-actions.md
+++ b/docs/docs/distributed/github-actions.md
@@ -141,7 +141,7 @@ using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
 using Microsoft.Extensions.DependencyInjection;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 var instanceIndex = int.Parse(
     Environment.GetEnvironmentVariable("INSTANCE_INDEX") ?? "0");

--- a/docs/docs/examples/dotnet-test-build-publish.md
+++ b/docs/docs/examples/dotnet-test-build-publish.md
@@ -25,7 +25,7 @@ using ModularPipelines.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<NugetVersionGeneratorModule>()

--- a/docs/docs/examples/single-file-csharp.md
+++ b/docs/docs/examples/single-file-csharp.md
@@ -30,7 +30,7 @@ Install the .NET 10 SDK, then follow these steps:
     using ModularPipelines.Models;
     using ModularPipelines.Modules;
 
-    using var builder = Pipeline.CreateBuilder(args);
+    var builder = Pipeline.CreateBuilder(args);
 
     builder
         .AddModule<UpdateDotnetWorkloads>()

--- a/docs/docs/fundamentals.md
+++ b/docs/docs/fundamentals.md
@@ -10,13 +10,10 @@ sidebar_position: 2
 Your pipeline is created using `Pipeline.CreateBuilder()`. This follows the ASP.NET Core minimal API pattern, providing direct access to `Configuration`, `Services`, and `Options`. Setup should feel familiar if you've used ASP.NET Core.
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<MyModule>();
 await builder.ExecutePipelineAsync();
 ```
-
-`PipelineBuilder` owns its content-root file provider, so keep it in a `using`
-scope until configuration and execution are complete.
 
 ## Modules
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -59,7 +59,7 @@ using ModularPipelines.Extensions;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<BuildModule>();
 
 await builder.ExecutePipelineAsync();

--- a/docs/docs/how-to/categories.md
+++ b/docs/docs/how-to/categories.md
@@ -27,7 +27,7 @@ configured by an earlier call or by command-line options. Pass the complete filt
 ## Example of Running Specific Categories
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()
@@ -44,7 +44,7 @@ await builder.ExecutePipelineAsync();
 ## Example of Ignoring Specific Categories
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/command-line.md
+++ b/docs/docs/how-to/command-line.md
@@ -9,7 +9,7 @@ Pass the application's `args` to `Pipeline.CreateBuilder(args)` to enable the
 built-in pipeline command line:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<BuildModule>()
@@ -120,7 +120,7 @@ To forward every argument to host configuration, disable pipeline command-line
 options:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
 {
     Args = args,
     EnableCommandLineOptions = false,

--- a/docs/docs/how-to/execution-and-dependencies.md
+++ b/docs/docs/how-to/execution-and-dependencies.md
@@ -47,7 +47,7 @@ public class Module2 : Module<string>
 When you declare a required dependency, you don't need to explicitly register it:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<Module2>(); // Module1 is auto-registered because Module2 depends on it
 
 await builder.ExecutePipelineAsync();

--- a/docs/docs/how-to/logging.md
+++ b/docs/docs/how-to/logging.md
@@ -67,7 +67,7 @@ await context.Tools.DotNet.BuildAsync(
 Set default logging for all commands at the pipeline level:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 // All commands will use Silent logging unless overridden
 builder.ConfigurePipelineOptions(options => options with

--- a/docs/docs/how-to/native-aot.md
+++ b/docs/docs/how-to/native-aot.md
@@ -16,7 +16,7 @@ JIT-compiled, or move their module declarations and registrations into a C# proj
 Use generic registration for every module:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<BuildModule>()

--- a/docs/docs/how-to/pipeline-host.md
+++ b/docs/docs/how-to/pipeline-host.md
@@ -18,7 +18,7 @@ The pipeline builder follows the ASP.NET Core minimal API pattern, providing dir
 ## Basic Example
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<BuildModule>()
@@ -36,7 +36,7 @@ for listing, selecting, skipping, and validating modules.
 Add configuration sources directly via the `Configuration` property:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
     .AddJsonFile("appsettings.json", optional: false)
@@ -53,7 +53,7 @@ builder.Services.Configure<MySettings>(builder.Configuration.GetSection("MySetti
 Modules are registered directly on `PipelineBuilder`. Every registration method returns the same builder for chaining:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 // Register modules
 builder
@@ -70,7 +70,7 @@ builder.AddModules(typeof(Module1), typeof(Module2), typeof(Module3));
 Use `builder.Environment` or `builder.Configuration` for conditional module registration:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration.AddJsonFile("appsettings.json");
 
@@ -94,7 +94,7 @@ builder.AddModule<AlwaysRunModule>();
 Configure pipeline behavior via the `Options` property:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.ConfigurePipelineOptions(options => options with
 {
@@ -123,7 +123,7 @@ builder.ConfigurePipelineOptions(options => options with
 The pipeline follows a two-step build-then-run pattern:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 builder.ConfigurePipelineOptions(options => options with
 {
     ExecutionMode = ExecutionMode.WaitForAllModules,
@@ -150,7 +150,7 @@ the returned summary after a module fails. Fail-fast mode rethrows the module ex
 `BuildAsync()` always validates the pipeline configuration before returning:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<MyModule>();
 
 try
@@ -172,7 +172,7 @@ catch (PipelineValidationException ex)
 ### Validate Without Running
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 builder.AddModule<MyModule>();
 
 var validation = await builder.ValidateAsync();
@@ -197,7 +197,7 @@ using ModularPipelines;
 using ModularPipelines.Extensions;
 using ModularPipelines.Options;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 // Configuration
 builder.Configuration
@@ -245,7 +245,7 @@ await builder.ExecutePipelineAsync();
 Register global hooks and pipeline requirements:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 // Global hooks (run before/after all modules)
 builder.AddPipelineGlobalHooks<MyGlobalHooks>();
@@ -263,7 +263,7 @@ builder.AddRequirement<GitRequirement>();
 For a more fluent API, extension methods are available:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 await builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/pipeline-modes.md
+++ b/docs/docs/how-to/pipeline-modes.md
@@ -15,7 +15,7 @@ If you want to run every module regardless, you can switch to `WaitForAllModules
 ## Example
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/retry-policy.md
+++ b/docs/docs/how-to/retry-policy.md
@@ -102,7 +102,7 @@ public class ResilientModule : Module<CommandResult>
 Retry policies are off by default. You can set a default retry count on the `PipelineOptions`:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/secrets.md
+++ b/docs/docs/how-to/secrets.md
@@ -34,7 +34,7 @@ When a configuration provider supplies a group of secrets, you can register ever
 that section without adding `[SecretValue]` to an options class:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder();
+var builder = Pipeline.CreateBuilder();
 
 builder.MaskConfigurationSection("Secrets");
 ```

--- a/docs/docs/how-to/storing-and-retrieving-results.md
+++ b/docs/docs/how-to/storing-and-retrieving-results.md
@@ -16,7 +16,7 @@ It's recommended to store and retrieve results using the Git commit SHA, as then
 ## Example Repository Class using Azure Blobs
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/time-estimator.md
+++ b/docs/docs/how-to/time-estimator.md
@@ -13,7 +13,7 @@ Then on subsequent runs, it'll ask you for an estimated time for a module. You g
 ## Example
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder
     .AddModule<Module1>()

--- a/docs/docs/how-to/timeouts.md
+++ b/docs/docs/how-to/timeouts.md
@@ -7,7 +7,7 @@ title: Timeouts
 Modules have a 30-minute timeout by default. Configure the pipeline default when your workloads need a different limit, or use `TimeSpan.Zero` to disable it:
 
 ```csharp
-using var builder = Pipeline.CreateBuilder();
+var builder = Pipeline.CreateBuilder();
 builder.ConfigurePipelineOptions(options => options with
 {
     DefaultModuleTimeout = TimeSpan.FromHours(2),

--- a/docs/docs/mp-packages/distributed-artifacts-s3.md
+++ b/docs/docs/mp-packages/distributed-artifacts-s3.md
@@ -20,7 +20,7 @@ Register the artifact store after enabling distributed mode:
 using ModularPipelines.Distributed.Artifacts.S3.Extensions;
 using ModularPipelines.Distributed.Extensions;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.AddDistributedMode(options => options.TotalInstances = 2);
 builder.AddS3DistributedArtifactStore(options =>

--- a/docs/docs/mp-packages/distributed-discovery-redis.md
+++ b/docs/docs/mp-packages/distributed-discovery-redis.md
@@ -21,7 +21,7 @@ using ModularPipelines.Distributed.Discovery.Redis;
 using ModularPipelines.Distributed.Extensions;
 using ModularPipelines.Distributed.SignalR.Extensions;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.AddDistributedMode(options => options.TotalInstances = 2);
 builder.AddSignalRDistributedCoordinator();

--- a/docs/docs/mp-packages/distributed-redis.md
+++ b/docs/docs/mp-packages/distributed-redis.md
@@ -20,7 +20,7 @@ Use the combined helper when Redis should provide both services:
 using ModularPipelines.Distributed.Redis.Extensions;
 using ModularPipelines.Distributed.Extensions;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.AddDistributedMode(options => options.TotalInstances = 2);
 builder.AddRedisDistributed(

--- a/docs/docs/mp-packages/distributed-signalr.md
+++ b/docs/docs/mp-packages/distributed-signalr.md
@@ -20,7 +20,7 @@ Register the coordinator after enabling distributed mode:
 using ModularPipelines.Distributed.SignalR.Extensions;
 using ModularPipelines.Distributed.Extensions;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.AddDistributedMode(options => options.TotalInstances = 2);
 builder.AddSignalRDistributedCoordinator(options =>

--- a/docs/docs/mp-packages/github.md
+++ b/docs/docs/mp-packages/github.md
@@ -62,7 +62,7 @@ Modular Pipelines' `GitHub()` automatically authenticates OctoKit client when:
 Configuring OctoKit auth using `GitHubOptions` is straightforward as it follows standard .NET practices for working with `IConfiguration` and `IOptions<T>`. When configuring your pipeline, use the usual practices for working with configuration to configure OctoKit auth:
 
 ```cs
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
     .AddJsonFile("appsettings.json")

--- a/src/ModularPipelines.Build/Program.cs
+++ b/src/ModularPipelines.Build/Program.cs
@@ -17,7 +17,7 @@ using ModularPipelines.Extensions;
 using Octokit;
 using Octokit.Internal;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 builder.ConfigurePipelineOptions(options => options with
 {
     LoadModularPipelineAssemblies = true,

--- a/src/ModularPipelines.Development.Analyzers/Readme.md
+++ b/src/ModularPipelines.Development.Analyzers/Readme.md
@@ -91,7 +91,7 @@ If you want to see how to get started, or want to know more about ModularPipelin
 ### Program.cs - Main method
 
 ```csharp
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.Services
     .Configure<NuGetSettings>(builder.Configuration.GetSection("NuGet"))

--- a/src/ModularPipelines.Examples/Program.cs
+++ b/src/ModularPipelines.Examples/Program.cs
@@ -8,7 +8,7 @@ using ModularPipelines.Examples.Modules.Systems;
 using ModularPipelines.Extensions;
 using ModularPipelines.Options;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
     .AddJsonFile("appsettings.json", optional: false)

--- a/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
+++ b/src/ModularPipelines.Templates/templates/modularpipeline/Program.cs
@@ -9,7 +9,7 @@ using TemplatePipeline.Settings;
 var pipelineDirectory = PipelineProjectDirectory.Find();
 Environment.CurrentDirectory = pipelineDirectory;
 
-using var builder = Pipeline.CreateBuilder(args);
+var builder = Pipeline.CreateBuilder(args);
 
 builder.Configuration
     .AddJsonFile(Path.Combine(pipelineDirectory, "appsettings.json"), optional: false)

--- a/src/ModularPipelines.Testing/ModuleTester.cs
+++ b/src/ModularPipelines.Testing/ModuleTester.cs
@@ -127,7 +127,7 @@ public class ModuleTestBuilder<TModule>
             recorder.SetHandler(_commandHandler);
         }
 
-        using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+        var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
         {
             EnableCommandLineOptions = false,
         });

--- a/src/ModularPipelines/Options/SecretMaskingOptions.cs
+++ b/src/ModularPipelines/Options/SecretMaskingOptions.cs
@@ -21,7 +21,7 @@ namespace ModularPipelines.Options;
 /// </remarks>
 /// <example>
 /// <code>
-/// using var builder = Pipeline.CreateBuilder();
+/// var builder = Pipeline.CreateBuilder();
 /// builder.Services.Configure&lt;SecretMaskingOptions&gt;(options =>
 /// {
 ///     options.CaseInsensitive = true;  // Match "Password", "PASSWORD", "password"

--- a/src/ModularPipelines/Pipeline.cs
+++ b/src/ModularPipelines/Pipeline.cs
@@ -12,7 +12,7 @@ public static class Pipeline
     /// <returns>A new pipeline builder instance.</returns>
     /// <example>
     /// <code>
-    /// using var builder = Pipeline.CreateBuilder(args);
+    /// var builder = Pipeline.CreateBuilder(args);
     ///
     /// builder.AddModule&lt;BuildModule&gt;();
     /// builder.ConfigurePipelineOptions(options => options with
@@ -36,7 +36,7 @@ public static class Pipeline
     /// <returns>A new pipeline builder instance.</returns>
     /// <example>
     /// <code>
-    /// using var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
+    /// var builder = Pipeline.CreateBuilder(new PipelineBuilderOptions
     /// {
     ///     Args = args,
     ///     EnvironmentName = "Development"

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -28,8 +28,7 @@ namespace ModularPipelines;
 /// A builder for configuring and creating a pipeline.
 /// </summary>
 /// <remarks>
-/// The caller owns the builder and should dispose it when finished, especially after using
-/// <see cref="IHostEnvironment.ContentRootFileProvider"/>.
+/// Resources created while configuring the builder are transferred to the built pipeline.
 /// </remarks>
 public sealed class PipelineBuilder : IDisposable
 {
@@ -37,6 +36,7 @@ public sealed class PipelineBuilder : IDisposable
     private readonly ServiceCollection _services;
     private readonly ConfigurationManager _configuration;
     private readonly PipelineHostEnvironment _environment;
+    private readonly PipelineBuilderResources _resources;
     private readonly PipelineCommandLineOptions _commandLineOptions;
     private PipelineOptions _options;
 
@@ -78,6 +78,7 @@ public sealed class PipelineBuilder : IDisposable
         }
 
         _environment = CreateHostEnvironment(options, args);
+        _resources = _environment.Resources;
         _hostBuilder.UseEnvironment(_environment.EnvironmentName);
         _hostBuilder.UseContentRoot(_environment.ContentRootPath);
 
@@ -122,12 +123,10 @@ public sealed class PipelineBuilder : IDisposable
     public IHostEnvironment Environment => _environment;
 
     /// <summary>
-    /// Releases resources owned by the cached host environment.
+    /// Retained for source compatibility. Resources are owned by the built pipeline.
     /// </summary>
     public void Dispose()
     {
-        (_environment.ContentRootFileProvider as IDisposable)?.Dispose();
-        GC.SuppressFinalize(this);
     }
 
     /// <summary>
@@ -300,12 +299,12 @@ public sealed class PipelineBuilder : IDisposable
             hostConfiguration[HostDefaults.ApplicationKey],
             Assembly.GetEntryAssembly()?.GetName().Name);
 
-        return new PipelineHostEnvironment
+        var resources = new PipelineBuilderResources(contentRootPath);
+        return new PipelineHostEnvironment(resources)
         {
             ApplicationName = applicationName,
             EnvironmentName = environmentName,
             ContentRootPath = contentRootPath,
-            ContentRootFileProvider = new PhysicalFileProvider(contentRootPath),
         };
     }
 
@@ -363,7 +362,7 @@ public sealed class PipelineBuilder : IDisposable
             }
         });
 
-        return await PipelineImpl.CreateAsync(_hostBuilder, initializePipeline).ConfigureAwait(false);
+        return await PipelineImpl.CreateAsync(_hostBuilder, _resources, initializePipeline).ConfigureAwait(false);
     }
 
     private void LoadModularPipelineAssembliesIfNotLoadedYet()
@@ -531,15 +530,21 @@ public sealed class PipelineBuilder : IDisposable
         }
     }
 
-    private sealed class PipelineHostEnvironment : IHostEnvironment
+    private sealed class PipelineHostEnvironment(PipelineBuilderResources resources) : IHostEnvironment
     {
+        internal PipelineBuilderResources Resources { get; } = resources;
+
         public string EnvironmentName { get; set; } = string.Empty;
 
         public string ApplicationName { get; set; } = string.Empty;
 
         public string ContentRootPath { get; set; } = string.Empty;
 
-        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+        public IFileProvider ContentRootFileProvider
+        {
+            get => Resources.ContentRootFileProvider;
+            set => Resources.ContentRootFileProvider = value;
+        }
     }
 
     /// <summary>

--- a/src/ModularPipelines/PipelineBuilderResources.cs
+++ b/src/ModularPipelines/PipelineBuilderResources.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.FileProviders;
+
+namespace ModularPipelines;
+
+internal sealed class PipelineBuilderResources(string contentRootPath) : IDisposable
+{
+    private readonly object _lock = new();
+    private IFileProvider? _contentRootFileProvider;
+    private bool _disposed;
+
+    public IFileProvider ContentRootFileProvider
+    {
+        get
+        {
+            lock (_lock)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                return _contentRootFileProvider ??= new PhysicalFileProvider(contentRootPath);
+            }
+        }
+
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+
+            IFileProvider? previousProvider;
+            lock (_lock)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+                if (ReferenceEquals(_contentRootFileProvider, value))
+                {
+                    return;
+                }
+
+                previousProvider = _contentRootFileProvider;
+                _contentRootFileProvider = value;
+            }
+
+            (previousProvider as IDisposable)?.Dispose();
+        }
+    }
+
+    ~PipelineBuilderResources()
+    {
+        Dispose(disposing: false);
+    }
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        IFileProvider? provider;
+        lock (_lock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            provider = _contentRootFileProvider;
+            _contentRootFileProvider = null;
+        }
+
+        try
+        {
+            (provider as IDisposable)?.Dispose();
+        }
+        catch when (!disposing)
+        {
+            // Finalizers must not surface cleanup failures.
+        }
+    }
+}

--- a/src/ModularPipelines/PipelineImpl.cs
+++ b/src/ModularPipelines/PipelineImpl.cs
@@ -27,6 +27,7 @@ internal sealed class PipelineImpl : IPipeline
     private const string DisposalExceptionDataKey = "ModularPipelines.PipelineDisposalException";
 
     private readonly IHost _host;
+    private readonly PipelineBuilderResources _builderResources;
     private readonly AsyncServiceScope _serviceScope;
     private readonly IDisposable _shutdownRegistration;
     private readonly object _disposeLock = new();
@@ -34,17 +35,21 @@ internal sealed class PipelineImpl : IPipeline
     private int _isSynchronousContainerDisposalActive;
     private Task? _disposeTask;
 
-    private PipelineImpl(IHost host)
+    private PipelineImpl(IHost host, PipelineBuilderResources builderResources)
     {
         _host = host;
+        _builderResources = builderResources;
         _serviceScope = host.Services.CreateAsyncScope();
 
         _shutdownRegistration = Disposer.RegisterOnShutdownWithUnregistration(this);
     }
 
-    internal static async Task<PipelineImpl> CreateAsync(IHostBuilder hostBuilder, bool initializePipeline)
+    internal static async Task<PipelineImpl> CreateAsync(
+        IHostBuilder hostBuilder,
+        PipelineBuilderResources builderResources,
+        bool initializePipeline)
     {
-        var pipeline = new PipelineImpl(hostBuilder.Build());
+        var pipeline = new PipelineImpl(hostBuilder.Build(), builderResources);
         var services = pipeline._host.Services;
 
         try
@@ -202,7 +207,7 @@ internal sealed class PipelineImpl : IPipeline
         try
         {
             _shutdownRegistration.Dispose();
-            Exception? scopeException = null;
+            var disposalExceptions = new List<Exception>();
             try
             {
                 ValueTask scopeDisposal;
@@ -220,7 +225,7 @@ internal sealed class PipelineImpl : IPipeline
             }
             catch (Exception exception)
             {
-                scopeException = exception;
+                disposalExceptions.Add(exception);
             }
 
             try
@@ -238,14 +243,28 @@ internal sealed class PipelineImpl : IPipeline
 
                 await hostDisposal.ConfigureAwait(false);
             }
-            catch (Exception hostException) when (scopeException is not null)
+            catch (Exception exception)
             {
-                throw new AggregateException(scopeException, hostException);
+                disposalExceptions.Add(exception);
             }
 
-            if (scopeException is not null)
+            try
             {
-                ExceptionDispatchInfo.Capture(scopeException).Throw();
+                _builderResources.Dispose();
+            }
+            catch (Exception exception)
+            {
+                disposalExceptions.Add(exception);
+            }
+
+            if (disposalExceptions.Count == 1)
+            {
+                ExceptionDispatchInfo.Capture(disposalExceptions[0]).Throw();
+            }
+
+            if (disposalExceptions.Count > 1)
+            {
+                throw new AggregateException(disposalExceptions);
             }
         }
         finally

--- a/src/ModularPipelines/Requirements/MacOSRequirement.cs
+++ b/src/ModularPipelines/Requirements/MacOSRequirement.cs
@@ -14,7 +14,7 @@ namespace ModularPipelines.Requirements;
 /// </para>
 /// <para><b>Example:</b></para>
 /// <code>
-/// using var builder = Pipeline.CreateBuilder();
+/// var builder = Pipeline.CreateBuilder();
 /// builder.Services.AddRequirement&lt;MacOSRequirement&gt;();
 /// builder.AddModule&lt;BuildMacAppModule&gt;();
 ///

--- a/src/ModularPipelines/Requirements/WindowsAdminRequirement.cs
+++ b/src/ModularPipelines/Requirements/WindowsAdminRequirement.cs
@@ -19,7 +19,7 @@ namespace ModularPipelines.Requirements;
 /// </para>
 /// <para><b>Example:</b></para>
 /// <code>
-/// using var builder = Pipeline.CreateBuilder();
+/// var builder = Pipeline.CreateBuilder();
 /// builder.Services.AddRequirement&lt;WindowsAdminRequirement&gt;();
 /// builder.AddModule&lt;InstallServiceModule&gt;();
 ///

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -41,7 +41,7 @@ public static class CurrentApiSnippets
 
     public static async Task<int> RunPipelineAndMapExitCode(string[] args)
     {
-        using var builder = Pipeline.CreateBuilder(args);
+        var builder = Pipeline.CreateBuilder(args);
         builder.ConfigurePipelineOptions(options => options with
         {
             ExecutionMode = ExecutionMode.WaitForAllModules,
@@ -57,7 +57,7 @@ public static class CurrentApiSnippets
 
     public static async Task VerifySuccessfulPipeline(string[] args)
     {
-        using var builder = Pipeline.CreateBuilder(args);
+        var builder = Pipeline.CreateBuilder(args);
         builder.ConfigurePipelineOptions(options => options with
         {
             ThrowOnPipelineFailure = false,
@@ -73,7 +73,7 @@ public static class CurrentApiSnippets
 
     public static async Task ConfigureSingleFilePipeline(string[] args)
     {
-        using var builder = Pipeline.CreateBuilder(args);
+        var builder = Pipeline.CreateBuilder(args);
         builder
             .AddModule<UpdateDotnetWorkloads>()
             .AddModule<CheckDotnetSdkModule>();
@@ -83,7 +83,7 @@ public static class CurrentApiSnippets
 
     public static async Task ConfigureTestPackPublishPipeline(string[] args)
     {
-        using var builder = Pipeline.CreateBuilder(args);
+        var builder = Pipeline.CreateBuilder(args);
         builder
             .AddModule<NugetVersionGeneratorModule>()
             .AddModule<RunUnitTestsModule>()

--- a/test/ModularPipelines.DocumentationSnippets/GettingStartedSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/GettingStartedSnippets.cs
@@ -10,7 +10,7 @@ public static class GettingStartedSnippets
 {
     public static async Task ConfigurePipeline(string[] args)
     {
-        using var builder = Pipeline.CreateBuilder(args);
+        var builder = Pipeline.CreateBuilder(args);
         builder.AddModule<BuildModule>();
 
         await builder.ExecutePipelineAsync();

--- a/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
+++ b/test/ModularPipelines.UnitTests/Documentation/DocumentationSnippetTests.cs
@@ -61,7 +61,7 @@ public class DocumentationSnippetTests
             .ConfigureAwait(false);
 
         await Assert.That(readme).Contains("dotnet add package ModularPipelines.DotNet");
-        await Assert.That(readme).Contains("using var builder = Pipeline.CreateBuilder(args);");
+        await Assert.That(readme).Contains("var builder = Pipeline.CreateBuilder(args);");
         await Assert.That(readme).Contains("await builder.ExecutePipelineAsync();");
     }
 

--- a/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Context;
 using ModularPipelines.Exceptions;
@@ -9,6 +10,7 @@ using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.Requirements;
 using ModularPipelines.TestHelpers;
+using Moq;
 
 namespace ModularPipelines.UnitTests.Registration;
 
@@ -171,6 +173,39 @@ public class PipelineBuilderRegistrationTests
         await Assert.That(builder.Environment.ApplicationName).IsEqualTo("CommandLineApp");
         await Assert.That(builder.Environment.EnvironmentName).IsEqualTo("CommandLineEnvironment");
         await Assert.That(builder.Environment.ContentRootPath).IsEqualTo(Path.GetFullPath(contentRoot));
+    }
+
+    [Test]
+    public async Task ContentRootFileProvider_IsOwnedByBuiltPipeline()
+    {
+        var fileProvider = new Mock<IFileProvider>();
+        var disposable = fileProvider.As<IDisposable>();
+        var builder = Pipeline.CreateBuilder();
+        builder.Environment.ContentRootFileProvider = fileProvider.Object;
+        builder.AddModule<TestModuleA>();
+
+        builder.Dispose();
+        disposable.Verify(x => x.Dispose(), Times.Never);
+
+        var pipeline = await builder.BuildAsync();
+        disposable.Verify(x => x.Dispose(), Times.Never);
+
+        await pipeline.DisposeAsync();
+        disposable.Verify(x => x.Dispose(), Times.Once);
+    }
+
+    [Test]
+    public async Task ContentRootFileProvider_IsDisposed_WhenPipelineBuildFails()
+    {
+        var fileProvider = new Mock<IFileProvider>();
+        var disposable = fileProvider.As<IDisposable>();
+        var builder = Pipeline.CreateBuilder();
+        builder.Environment.ContentRootFileProvider = fileProvider.Object;
+
+        await Assert.That(async () => await builder.BuildAsync())
+            .Throws<PipelineValidationException>();
+
+        disposable.Verify(x => x.Dispose(), Times.Once);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- lazily create the content-root file provider
- transfer provider disposal to the built pipeline while retaining a no-op builder disposal shim
- remove the builder disposal ceremony from public examples and templates

## Validation
- PipelineBuilderRegistrationTests: 15/15
- DocumentationSnippetTests: 4/4
- core Release build: 0 warnings, 0 errors

Closes #3769