### PR TITLE
Normalize secret value pair masking

### DIFF
--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -244,10 +244,12 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             yield break;
         }
 
-        if (propertyValue is not IEnumerable<KeyValue> keyValues)
+        var keyValues = propertyValue switch
         {
-            yield break;
-        }
+            KeyValue keyValue => [keyValue],
+            IEnumerable<KeyValue> values => values,
+            _ => [],
+        };
 
         foreach (var keyValue in keyValues)
         {
@@ -409,6 +411,13 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
 
     private static IEnumerable<string?> NormalizeSecrets(object? value)
     {
+        if (value is CliValuePair pair)
+        {
+            yield return pair.First;
+            yield return pair.Second;
+            yield break;
+        }
+
         if (value is string || value is IEnumerable<char> || value is not IEnumerable enumerable)
         {
             yield return NormalizeSecret(value);
@@ -417,7 +426,15 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
 
         foreach (var item in enumerable)
         {
-            yield return NormalizeSecret(item);
+            if (item is CliValuePair itemPair)
+            {
+                yield return itemPair.First;
+                yield return itemPair.Second;
+            }
+            else
+            {
+                yield return NormalizeSecret(item);
+            }
         }
     }
 
@@ -432,6 +449,7 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             ReadOnlyMemory<char> characters => characters.ToString(),
             IEnumerable<char> characters => new string(characters.ToArray()),
             CliOptionValue optionValue => optionValue.Value,
+            KeyValue keyValue => keyValue.Value,
             _ => value.ToString(),
         };
     }

--- a/test/ModularPipelines.UnitTests/Attributes/SecretValueNormalizationTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/SecretValueNormalizationTests.cs
@@ -73,6 +73,27 @@ internal sealed class GeneratedKeyedSecretOptions
     ];
 }
 
+internal sealed class GeneratedPairSecretOptions
+{
+    [SecretValue]
+    public CliValuePair Pair { get; init; } = new("pair-name", "pair-secret");
+
+    [SecretValue]
+    public IReadOnlyList<CliValuePair> Pairs { get; init; } =
+    [
+        new("collection-name", "collection-secret"),
+    ];
+
+    [SecretValue]
+    public KeyValue KeyValue { get; init; } = new("key-value-name", "key-value-secret");
+}
+
+internal sealed class GeneratedSingleKeyedSecretOptions
+{
+    [SecretValue("token")]
+    public KeyValue Value { get; init; } = new("auth.token", "single-keyed-secret");
+}
+
 public class SecretValueNormalizationTests
 {
     private sealed class PrivateNoSecretsOptions;
@@ -442,6 +463,33 @@ public class SecretValueNormalizationTests
             "snake-secret",
             "kebab-secret",
         ]);
+    }
+
+    [Test]
+    public async Task GeneratedMetadata_NormalizesCliValuePairsAndKeyValues()
+    {
+        var provider = CreateProvider(out _);
+
+        var secrets = provider.GetSecretsInObject(new GeneratedPairSecretOptions()).ToList();
+
+        await Assert.That(secrets).IsEquivalentTo(
+        [
+            "pair-name",
+            "pair-secret",
+            "collection-name",
+            "collection-secret",
+            "key-value-secret",
+        ]);
+    }
+
+    [Test]
+    public async Task KeyedSecrets_AcceptSingleKeyValue()
+    {
+        var provider = CreateProvider(out _);
+
+        var secrets = provider.GetSecretsInObject(new GeneratedSingleKeyedSecretOptions()).ToList();
+
+        await Assert.That(secrets).IsEquivalentTo(["single-keyed-secret"]);
     }
 
     private static SecretProvider CreateProvider(out Mock<IBuildSystemSecretMasker> nativeMasker)


### PR DESCRIPTION
## Summary
- normalize scalar and collection `CliValuePair` secrets into their rendered operands
- normalize unkeyed `KeyValue` secrets to the rendered value
- support keyed secret discovery on a single `KeyValue`

## Test plan
- [x] `SecretValueNormalizationTests` (23/23)
- [x] `SecretMaskingTests` (13/13)
- [x] `LoggingSecretTests` (3/3)
- [x] core Release build (0 warnings, 0 errors)

Closes #3781