### PR TITLE
Preserve manual argument and terminator ordering

### DIFF
--- a/src/ModularPipelines/Context/CommandLineBuilder.cs
+++ b/src/ModularPipelines/Context/CommandLineBuilder.cs
@@ -91,18 +91,25 @@ internal sealed class CommandLineBuilder(
             commandSpecificModel,
             terminatorEmittedBeforeProperties);
 
+        var modelEmittedOptionTerminator = emittedOptionTerminator;
+        var terminalArgumentTerminatorState = emittedOptionTerminator
+                                              || options.ArgumentsContainOptionTerminator;
+        var terminalArgumentArgs = _commandArgumentBuilder.BuildArguments(
+            [.. terminalCommandModel.Where(static part => part is ArgumentPart)],
+            options,
+            ref terminalArgumentTerminatorState,
+            out var terminalArgumentOptionTerminatorIndex);
+        modelEmittedOptionTerminator |= terminalArgumentOptionTerminatorIndex is not null;
+
         // Keep recognized manual options ahead of a marker emitted by a structured argument
         // or declared in the manual arguments or run settings; leave manual positional operands in place.
-        var pendingTerminatorState = emittedOptionTerminator
+        var pendingTerminatorState = modelEmittedOptionTerminator
                                      || options.ArgumentsContainOptionTerminator;
         var runSettingsArgs = _commandArgumentBuilder.BuildArguments(
             RunSettingsCommandModel,
             options,
             ref pendingTerminatorState);
-        var terminalArgumentArgs = _commandArgumentBuilder.BuildArguments(
-            [.. terminalCommandModel.Where(static part => part is ArgumentPart)],
-            options,
-            ref pendingTerminatorState);
+        ValidateRunSettingsTerminator(modelEmittedOptionTerminator, runSettingsArgs);
         var terminalAdditionalArgs = GetAdditionalArguments(
                 additionalArguments,
                 CommandLinePhase.Terminal)
@@ -123,7 +130,7 @@ internal sealed class CommandLineBuilder(
             manualArgs,
             extractedManualOptions,
             terminatorEmittedBeforeProperties,
-            emittedOptionTerminator,
+            modelEmittedOptionTerminator,
             hasOptionTerminator);
         var hasRenderedCommandOptions = ContainsRecognizedManualOption(
             propertyArgs,
@@ -170,6 +177,18 @@ internal sealed class CommandLineBuilder(
         allArgs.AddRange(terminalOptionArgs);
 
         return new CommandLine(tool, allArgs);
+    }
+
+    private static void ValidateRunSettingsTerminator(
+        bool modelEmittedOptionTerminator,
+        IReadOnlyCollection<string> runSettingsArgs)
+    {
+        if (modelEmittedOptionTerminator && runSettingsArgs.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(CommandLineToolOptions.RunSettings)} cannot be combined with a structured "
+                + "argument that emits an end-of-options marker. Remove one of the '--' sources.");
+        }
     }
 
     private List<string> BuildNonTerminalArguments(

--- a/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/CommandLineBuilderTests.cs
@@ -57,6 +57,35 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
+    public async Task Build_Hoists_Recognized_Manual_Option_Before_Passthrough_Terminator()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var result = builder.Build(new TestTerminalOptions
+        {
+            Arguments = ["--compact"],
+            ArgumentsContainToolOptions = true,
+            Filter = "-1",
+        });
+
+        await Assert.That(result.ToString()).IsEqualTo("jq --compact -- -1");
+    }
+
+    [Test]
+    public async Task Build_Preserves_Manual_Arguments_After_Ordinary_Passthrough_Values()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var result = builder.Build(new TestPositionalOptions
+        {
+            Arguments = ["--custom-flag"],
+            ConfigPath = "config.json",
+        });
+
+        await Assert.That(result.ToString()).IsEqualTo("processor config.json --custom-flag");
+    }
+
+    [Test]
     public async Task Build_Rejects_Terminal_Options_With_RunSettings()
     {
         var builder = await GetService<ICommandLineBuilder>();
@@ -277,18 +306,19 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_RunSettings_Terminator_Precedes_Terminal_Argument()
+    public async Task Build_Rejects_RunSettings_When_Terminal_Argument_Emits_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
-        var result = builder.Build(new TestTerminalOptions
+        CommandLine Build() => builder.Build(new TestTerminalOptions
         {
             RunSettings = ["--filter", "Category=Unit"],
             TerminalArgument = "-x",
         });
 
-        await Assert.That(result.ToString())
-            .IsEqualTo("jq -- --filter Category=Unit -x");
+        await Assert.That(Build)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("RunSettings");
     }
 
     [Test]
@@ -304,6 +334,21 @@ public class CommandLineBuilderTests : TestBase
         });
 
         await Assert.That(result.ToString()).IsEqualTo("jq -- -1 extra");
+    }
+
+    [Test]
+    public async Task Build_Manual_Terminator_Is_Reused_For_Terminal_Argument()
+    {
+        var builder = await GetService<ICommandLineBuilder>();
+
+        var result = builder.Build(new TestTerminalOptions
+        {
+            Arguments = ["--", "input"],
+            ArgumentsContainOptionTerminator = true,
+            TerminalArgument = "-x",
+        });
+
+        await Assert.That(result.ToString()).IsEqualTo("jq -- input -x");
     }
 
     [Test]
@@ -707,17 +752,19 @@ public class CommandLineBuilderTests : TestBase
     }
 
     [Test]
-    public async Task Build_Property_Terminator_Is_Reused_For_RunSettings()
+    public async Task Build_Rejects_RunSettings_When_Passthrough_Argument_Emits_Terminator()
     {
         var builder = await GetService<ICommandLineBuilder>();
 
-        var result = builder.Build(new TestTerminalOptions
+        CommandLine Build() => builder.Build(new TestTerminalOptions
         {
             Filter = "-1",
             RunSettings = ["extra"],
         });
 
-        await Assert.That(result.ToString()).IsEqualTo("jq -- -1 extra");
+        await Assert.That(Build)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("RunSettings");
     }
 
     [Test]
@@ -1127,7 +1174,7 @@ public class CommandLineBuilderTests : TestBase
     [CliTool("jq")]
     private record TestLegacyEndOfOptionsOptions : CommandLineToolOptions
     {
-        [CliFlag("--", Phase = (CommandLinePhase)2)]
+        [CliFlag("--", Phase = (CommandLinePhase) 2)]
         public bool? EndOfOptions { get; set; }
 
         [CliArgument(0, PrependOptionTerminatorIfValueStartsWithDash = true)]


### PR DESCRIPTION
## Summary
- keep structured pass-through operands before ordinary manual `Arguments`
- hoist recognized manual tool options safely while preserving explicit option/terminator ordering
- reuse manual terminators for terminal arguments and reject conflicting `RunSettings`
- retain current phase-aware `AdditionalArguments` behavior from `main`

## Test plan
- `CommandLineBuilderTests` (62 passed)
- `ModularPipelines.Jq.UnitTests` (18 passed)
- `ModularPipelines.Rust.UnitTests` (3 passed)
- core Release build (0 warnings, 0 errors)
- changed-file whitespace verification

Closes #3776