### PR TITLE
Group PipelineOptions subsystem settings

### DIFF
--- a/docs/docs/how-to/console-progress.md
+++ b/docs/docs/how-to/console-progress.md
@@ -20,7 +20,10 @@ entry threshold still protects against unbounded buffering:
 ```csharp
 builder.ConfigurePipelineOptions(options => options with
 {
-    ModuleOutputFlushInterval = TimeSpan.FromSeconds(30),
+    Console = options.Console with
+    {
+        ModuleOutputFlushInterval = TimeSpan.FromSeconds(30),
+    },
 });
 ```
 
@@ -29,10 +32,13 @@ To keep all output buffered until each module completes, disable both triggers:
 ```csharp
 builder.ConfigurePipelineOptions(options => options with
 {
-    ModuleOutputFlushInterval = TimeSpan.Zero,
-    ModuleOutputFlushThreshold = 0,
+    Console = options.Console with
+    {
+        ModuleOutputFlushInterval = TimeSpan.Zero,
+        ModuleOutputFlushThreshold = 0,
+    },
 });
 ```
 
-`ModuleOutputFlushThreshold` counts entries, not bytes. Its default is 1,000 entries per
+`Console.ModuleOutputFlushThreshold` counts entries, not bytes. Its default is 1,000 entries per
 module.

--- a/docs/docs/how-to/logging.md
+++ b/docs/docs/how-to/logging.md
@@ -72,13 +72,19 @@ using var builder = Pipeline.CreateBuilder(args);
 // All commands will use Silent logging unless overridden
 builder.ConfigurePipelineOptions(options => options with
 {
-    DefaultLoggingOptions = CommandLoggingOptions.Silent,
+    Commands = options.Commands with
+    {
+        Logging = CommandLoggingOptions.Silent,
+    },
 });
 
 // Or use Diagnostic for debugging
 builder.ConfigurePipelineOptions(options => options with
 {
-    DefaultLoggingOptions = CommandLoggingOptions.Diagnostic,
+    Commands = options.Commands with
+    {
+        Logging = CommandLoggingOptions.Diagnostic,
+    },
 });
 
 await builder.ExecutePipelineAsync();
@@ -135,5 +141,5 @@ new CommandExecutionOptions
 Logging settings are resolved in this order (highest to lowest priority):
 
 1. **Per-Call**: `CommandExecutionOptions.LogSettings` on individual command calls
-2. **Global Default**: `DefaultLoggingOptions` configured at pipeline level
+2. **Global Default**: `Commands.Logging` configured at pipeline level
 3. **System Default**: `CommandLoggingOptions.Default` (Normal verbosity)

--- a/docs/docs/how-to/pipeline-host.md
+++ b/docs/docs/how-to/pipeline-host.md
@@ -106,9 +106,12 @@ builder.ConfigurePipelineOptions(options => options with
     IgnoreCategories = ["Experimental"],
 
     // Display options
-    ShowProgressInConsole = true,
-    PrintResults = true,
-    PrintLogo = true,
+    Console = options.Console with
+    {
+        ShowProgress = true,
+        PrintResults = true,
+        PrintLogo = true,
+    },
 
     // Concurrency settings
     Concurrency = new ConcurrencyOptions

--- a/src/ModularPipelines.Testing/ModuleTester.cs
+++ b/src/ModularPipelines.Testing/ModuleTester.cs
@@ -134,10 +134,13 @@ public class ModuleTestBuilder<TModule>
 
         builder.ConfigurePipelineOptions(options => options with
         {
-            ShowProgressInConsole = false,
-            PrintResults = false,
-            PrintLogo = false,
-            PrintDependencyChains = false,
+            Console = options.Console with
+            {
+                ShowProgress = false,
+                PrintResults = false,
+                PrintLogo = false,
+                PrintDependencyChains = false,
+            },
             ThrowOnPipelineFailure = false,
         });
         builder.Services.AddLogging(logging => logging.ClearProviders());

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -90,7 +90,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         _unattributedBuffer = new ModuleOutputBuffer(
             "Pipeline",
             typeof(void),
-            _options.Value.ModuleOutputFlushThreshold,
+            _options.Value.Console.ModuleOutputFlushThreshold,
             RequestThresholdFlush,
             isSpectreEnabled: logLevel => _loggerControl.WouldRender(
                 OutputLoggerCategories.Pipeline,
@@ -124,7 +124,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                     ? AnsiConsole.Create(
                         CreateAnsiConsoleSettings(_originalConsoleOut, _buildSystemDetector.IsKnownBuildAgent))
                     : _ansiConsole;
-                configuredAnsiConsole.Profile.Capabilities.Interactive = _options.Value.ShowProgressInConsole;
+                configuredAnsiConsole.Profile.Capabilities.Interactive = _options.Value.Console.ShowProgress;
                 if (UsesGlobalAnsiConsole)
                 {
                     AnsiConsole.Console = configuredAnsiConsole;
@@ -244,7 +244,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
         OrganizedModules modules,
         CancellationToken cancellationToken)
     {
-        if (!_options.Value.ShowProgressInConsole)
+        if (!_options.Value.Console.ShowProgress)
         {
             // Return a no-op session if progress is disabled
             // Explicitly ensure deferred output is disabled for consistency
@@ -297,7 +297,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
             moduleType,
             t => new ModuleOutputBuffer(
                 t,
-                _options.Value.ModuleOutputFlushThreshold,
+                _options.Value.Console.ModuleOutputFlushThreshold,
                 RequestThresholdFlush,
                 isSpectreEnabled: logLevel => _loggerControl.WouldRender(
                     OutputLoggerCategories.ForModule(t),
@@ -659,7 +659,7 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
 
     private void ConfigureConsoleWidth()
     {
-        var configuredWidth = _options.Value.ConsoleWidth;
+        var configuredWidth = _options.Value.Console.Width;
 
         if (configuredWidth.HasValue)
         {

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -649,7 +649,7 @@ internal sealed class Command : ICommandContext
     private string GetTelemetryCommandInput(string inputToLog, CommandExecutionOptions options)
     {
         var loggingOptions = options.LogSettings
-                             ?? _pipelineOptions.Value.DefaultLoggingOptions
+                             ?? _pipelineOptions.Value.Commands.Logging
                              ?? CommandLoggingOptions.Default;
         return loggingOptions.Verbosity == CommandLogVerbosity.Silent
                || !loggingOptions.ShowCommandArguments

--- a/src/ModularPipelines/Engine/DependencyPrinter.cs
+++ b/src/ModularPipelines/Engine/DependencyPrinter.cs
@@ -31,7 +31,7 @@ internal class DependencyPrinter : IDependencyPrinter
 
     public void PrintDependencyChains()
     {
-        if (!_options.Value.PrintDependencyChains)
+        if (!_options.Value.Console.PrintDependencyChains)
         {
             return;
         }

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -653,7 +653,7 @@ internal class ModuleRunner : IModuleRunner
             // Store execution context results in module state
             moduleState.TrySetSkipResult(executionContext.SkipResult);
 
-            if (!_pipelineOptions.Value.ShowProgressInConsole)
+            if (!_pipelineOptions.Value.Console.ShowProgress)
             {
                 await _moduleDisposer.DisposeAsync(moduleState).ConfigureAwait(false);
             }

--- a/src/ModularPipelines/Engine/Executors/ModuleDisposeExecutor.cs
+++ b/src/ModularPipelines/Engine/Executors/ModuleDisposeExecutor.cs
@@ -28,7 +28,7 @@ internal class ModuleDisposeExecutor : IModuleDisposeExecutor
 
     public async ValueTask DisposeAsync()
     {
-        if (!_options.Value.ShowProgressInConsole)
+        if (!_options.Value.Console.ShowProgress)
         {
             // If not an interactive console, we'll dispose each module as it finishes, to print its output
             // Otherwise we'll do it here, so we don't mess up the Progress printer

--- a/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
+++ b/src/ModularPipelines/Engine/Executors/PipelineOutputCoordinator.cs
@@ -57,7 +57,7 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
     /// <inheritdoc />
     public async Task<IPipelineOutputScope> InitializeAsync()
     {
-        var liveFlushInterval = _options.Value.ModuleOutputFlushInterval;
+        var liveFlushInterval = _options.Value.Console.ModuleOutputFlushInterval;
         ValidateLiveFlushInterval(liveFlushInterval);
 
         // Install console coordination before starting progress
@@ -104,13 +104,13 @@ internal class PipelineOutputCoordinator : IPipelineOutputCoordinator
     private static void ValidateLiveFlushInterval(TimeSpan liveFlushInterval)
     {
         if (liveFlushInterval < TimeSpan.Zero
-            || liveFlushInterval > PipelineOptions.MaximumModuleOutputFlushInterval)
+            || liveFlushInterval > PipelineConsoleOptions.MaximumModuleOutputFlushInterval)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(liveFlushInterval),
                 liveFlushInterval,
                 $"The interval must be between {TimeSpan.Zero} and " +
-                $"{PipelineOptions.MaximumModuleOutputFlushInterval}.");
+                $"{PipelineConsoleOptions.MaximumModuleOutputFlushInterval}.");
         }
     }
 

--- a/src/ModularPipelines/Engine/LogoPrinter.cs
+++ b/src/ModularPipelines/Engine/LogoPrinter.cs
@@ -37,7 +37,7 @@ internal sealed class LogoPrinter(IOptions<PipelineOptions> options) : ILogoPrin
 
     public void PrintLogo()
     {
-        if (!_options.Value.PrintLogo)
+        if (!_options.Value.Console.PrintLogo)
         {
             return;
         }

--- a/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
+++ b/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
@@ -27,7 +27,7 @@ internal class SpectreResultsPrinter : IResultsPrinter
 
     public void PrintResults(PipelineSummary pipelineSummary)
     {
-        if (!_options.Value.PrintResults)
+        if (!_options.Value.Console.PrintResults)
         {
             return;
         }

--- a/src/ModularPipelines/Http/Http.cs
+++ b/src/ModularPipelines/Http/Http.cs
@@ -32,7 +32,7 @@ internal class Http : IHttpContext
 
         // Priority: options property > pipeline default > HttpClient timeout
         var effectiveTimeout = httpOptions.Timeout
-                               ?? _pipelineOptions.Value.DefaultHttpTimeout
+                               ?? _pipelineOptions.Value.Http.Timeout
                                ?? GetFiniteTimeout(httpClient);
 
         // Create timeout token if timeout is specified
@@ -176,9 +176,9 @@ internal class Http : IHttpContext
             return httpOptions.LogSettings;
         }
 
-        if (_pipelineOptions.Value.DefaultHttpLoggingOptions is not null)
+        if (_pipelineOptions.Value.Http.Logging is not null)
         {
-            return _pipelineOptions.Value.DefaultHttpLoggingOptions;
+            return _pipelineOptions.Value.Http.Logging;
         }
 
         return HttpLoggingOptions.Default;

--- a/src/ModularPipelines/Http/ResilienceHttpHandler.cs
+++ b/src/ModularPipelines/Http/ResilienceHttpHandler.cs
@@ -27,7 +27,7 @@ internal class ResilienceHttpHandler : DelegatingHandler
     /// <inheritdoc/>
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var options = _pipelineOptions.Value.DefaultHttpResilienceOptions ?? HttpResilienceOptions.Default;
+        var options = _pipelineOptions.Value.Http.Resilience ?? HttpResilienceOptions.Default;
 
         if (options.MaxRetryAttempts <= 0)
         {

--- a/src/ModularPipelines/Logging/CommandLogger.cs
+++ b/src/ModularPipelines/Logging/CommandLogger.cs
@@ -128,7 +128,7 @@ internal class CommandLogger : ICommandLogger, ICommandOutputLogger
             return execOpts.LogSettings;
         }
 
-        return _pipelineOptions.Value.DefaultLoggingOptions ?? CommandLoggingOptions.Default;
+        return _pipelineOptions.Value.Commands.Logging ?? CommandLoggingOptions.Default;
     }
 
     private void LogDryRunCommand(CommandLoggingOptions options, string workingDirectory, string? input)

--- a/src/ModularPipelines/Options/CommandLoggingOptions.cs
+++ b/src/ModularPipelines/Options/CommandLoggingOptions.cs
@@ -4,7 +4,7 @@ namespace ModularPipelines.Options;
 /// Options for customizing command execution logging.
 /// </summary>
 /// <remarks>
-/// <para>Set via <see cref="CommandExecutionOptions.LogSettings"/> or <see cref="PipelineOptions.DefaultLoggingOptions"/>.</para>
+/// <para>Set via <see cref="CommandExecutionOptions.LogSettings"/> or <see cref="PipelineCommandOptions.Logging"/>.</para>
 /// <para>Verbosity levels control what is logged automatically:</para>
 /// <list type="bullet">
 /// <item><description><see cref="CommandLogVerbosity.Silent"/> - No logging</description></item>

--- a/src/ModularPipelines/Options/HttpLoggingOptions.cs
+++ b/src/ModularPipelines/Options/HttpLoggingOptions.cs
@@ -6,7 +6,7 @@ namespace ModularPipelines.Options;
 /// Options for customizing HTTP request/response logging.
 /// </summary>
 /// <remarks>
-/// <para>Set via <see cref="HttpOptions.LogSettings"/> or <see cref="PipelineOptions.DefaultHttpLoggingOptions"/>.</para>
+/// <para>Set via <see cref="HttpOptions.LogSettings"/> or <see cref="PipelineHttpOptions.Logging"/>.</para>
 /// <para>Controls what parts of HTTP requests and responses are logged:</para>
 /// <list type="bullet">
 /// <item><description><see cref="LogRequest"/> - Log request method, URL, and version</description></item>

--- a/src/ModularPipelines/Options/HttpResilienceOptions.cs
+++ b/src/ModularPipelines/Options/HttpResilienceOptions.cs
@@ -6,7 +6,7 @@ namespace ModularPipelines.Options;
 /// Options for configuring HTTP resilience behavior (retry policies for transient failures).
 /// </summary>
 /// <remarks>
-/// <para>Configure via <see cref="PipelineOptions.DefaultHttpResilienceOptions"/> for global defaults,
+/// <para>Configure via <see cref="PipelineHttpOptions.Resilience"/> for global defaults,
 /// or create custom options for specific use cases.</para>
 /// <para>Default behavior:</para>
 /// <list type="bullet">

--- a/src/ModularPipelines/Options/PipelineCommandOptions.cs
+++ b/src/ModularPipelines/Options/PipelineCommandOptions.cs
@@ -1,0 +1,37 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ModularPipelines.Options;
+
+/// <summary>
+/// Configures global defaults for command execution and logging.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed record PipelineCommandOptions
+{
+    private CommandExecutionOptions? _defaultExecutionOptions;
+
+    /// <summary>
+    /// Gets the default logging options for all commands.
+    /// Per-call <see cref="CommandExecutionOptions.LogSettings"/> takes precedence.
+    /// </summary>
+    public CommandLoggingOptions? Logging { get; init; }
+
+    /// <summary>
+    /// Gets the default execution options for all commands.
+    /// Per-call options take precedence over these global defaults.
+    /// </summary>
+    public CommandExecutionOptions? Execution
+    {
+        get => _defaultExecutionOptions;
+        init => _defaultExecutionOptions = value is null
+            ? null
+            : value with
+            {
+                EnvironmentVariables = value.EnvironmentVariables is null
+                    ? null
+                    : new ReadOnlyDictionary<string, string?>(
+                        new Dictionary<string, string?>(value.EnvironmentVariables)),
+            };
+    }
+}

--- a/src/ModularPipelines/Options/PipelineConsoleOptions.cs
+++ b/src/ModularPipelines/Options/PipelineConsoleOptions.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics.CodeAnalysis;
+using Spectre.Console;
+
+namespace ModularPipelines.Options;
+
+/// <summary>
+/// Configures pipeline console rendering and output flushing.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed record PipelineConsoleOptions
+{
+    /// <summary>
+    /// Gets a value indicating whether to show progress information in the console.
+    /// </summary>
+    public bool ShowProgress { get; init; } = AnsiConsole.Profile.Capabilities.Interactive;
+
+    /// <summary>
+    /// Gets a value indicating whether to print execution results to the console.
+    /// </summary>
+    public bool PrintResults { get; init; } = true;
+
+    /// <summary>
+    /// Gets a value indicating whether to print the ModularPipelines logo.
+    /// </summary>
+    public bool PrintLogo { get; init; } = true;
+
+    /// <summary>
+    /// Gets a value indicating whether to print module dependency chains.
+    /// </summary>
+    public bool PrintDependencyChains { get; init; } = true;
+
+    /// <summary>
+    /// Gets the console width for output rendering.
+    /// When set to a value, that width is used for all console output.
+    /// When null (default), the width is auto-detected: 160 characters for known CI environments,
+    /// or the terminal's detected width for local execution.
+    /// </summary>
+    /// <remarks>
+    /// Spectre.Console defaults to 80 characters when it cannot detect the terminal width,
+    /// which is common in CI environments where output is redirected. Known CI environments
+    /// automatically use 160 characters unless overridden.
+    /// </remarks>
+    public int? Width { get; init; }
+
+    /// <summary>
+    /// Gets how often buffered output from still-running modules is written to the console.
+    /// Set to <see cref="TimeSpan.Zero"/> to disable time-based flushing.
+    /// </summary>
+    /// <remarks>
+    /// Periodic flushing preserves diagnostic output when a process is killed before pipeline
+    /// teardown can run. Size-triggered flushing remains controlled separately by
+    /// <see cref="ModuleOutputFlushThreshold"/>. The default is one minute.
+    /// </remarks>
+    public TimeSpan ModuleOutputFlushInterval { get; init; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Gets the number of buffered output entries that triggers an immediate incremental flush.
+    /// Set to 0 to disable size-triggered flushing.
+    /// </summary>
+    /// <remarks>
+    /// The default is 1,000 entries per module. This limits retained output between periodic flushes
+    /// without changing the order or final completion status of module output.
+    /// </remarks>
+    public int ModuleOutputFlushThreshold { get; init; } = 1_000;
+
+    internal static TimeSpan MaximumModuleOutputFlushInterval { get; } =
+        TimeSpan.FromMilliseconds(uint.MaxValue - 1);
+}

--- a/src/ModularPipelines/Options/PipelineHttpOptions.cs
+++ b/src/ModularPipelines/Options/PipelineHttpOptions.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace ModularPipelines.Options;
+
+/// <summary>
+/// Configures global defaults for pipeline HTTP requests.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed record PipelineHttpOptions
+{
+    /// <summary>
+    /// Gets the default logging options for all HTTP requests.
+    /// Per-request <see cref="HttpOptions.LogSettings"/> takes precedence.
+    /// </summary>
+    public HttpLoggingOptions? Logging { get; init; }
+
+    /// <summary>
+    /// Gets the default timeout for all HTTP requests.
+    /// Per-request <see cref="HttpOptions.Timeout"/> takes precedence.
+    /// A null value uses the default <see cref="HttpClient"/> timeout.
+    /// </summary>
+    public TimeSpan? Timeout { get; init; }
+
+    /// <summary>
+    /// Gets the default resilience options for all HTTP requests.
+    /// </summary>
+    public HttpResilienceOptions? Resilience { get; init; }
+}

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -1,6 +1,4 @@
-using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
-using Spectre.Console;
 
 namespace ModularPipelines.Options;
 
@@ -35,7 +33,7 @@ namespace ModularPipelines.Options;
 /// </list>
 /// <para>
 /// <strong>Example:</strong>
-/// If <see cref="DefaultLoggingOptions"/> is set globally, it applies to all command executions.
+/// If <see cref="PipelineCommandOptions.Logging"/> is set globally, it applies to all command executions.
 /// However, if a specific command call passes <see cref="CommandExecutionOptions.LogSettings"/>,
 /// that per-call setting takes precedence for that execution only.
 /// </para>
@@ -53,12 +51,26 @@ public record PipelineOptions
     private IReadOnlyList<string>? _ignoreCategories;
     private IReadOnlyList<string>? _targetModules;
     private IReadOnlyList<string>? _skippedModules;
-    private CommandExecutionOptions? _defaultExecutionOptions;
 
     /// <summary>
     /// Gets machine-readable run report and local history settings.
     /// </summary>
     public RunReportOptions RunReport { get; init; } = new();
+
+    /// <summary>
+    /// Gets console rendering and output flushing settings.
+    /// </summary>
+    public PipelineConsoleOptions Console { get; init; } = new();
+
+    /// <summary>
+    /// Gets global HTTP request defaults.
+    /// </summary>
+    public PipelineHttpOptions Http { get; init; } = new();
+
+    /// <summary>
+    /// Gets global command execution and logging defaults.
+    /// </summary>
+    public PipelineCommandOptions Commands { get; init; } = new();
 
     /// <summary>
     /// Gets a value indicating whether running the pipeline should print a plan without executing modules.
@@ -129,26 +141,6 @@ public record PipelineOptions
     }
 
     /// <summary>
-    /// Gets a value indicating whether to show progress information in the console.
-    /// </summary>
-    public bool ShowProgressInConsole { get; init; } = AnsiConsole.Profile.Capabilities.Interactive;
-
-    /// <summary>
-    /// Gets a value indicating whether to print execution results to the console.
-    /// </summary>
-    public bool PrintResults { get; init; } = true;
-
-    /// <summary>
-    /// Gets a value indicating whether to print the ModularPipelines logo.
-    /// </summary>
-    public bool PrintLogo { get; init; } = true;
-
-    /// <summary>
-    /// Gets a value indicating whether to print module dependency chains.
-    /// </summary>
-    public bool PrintDependencyChains { get; init; } = true;
-
-    /// <summary>
     /// Gets a value indicating whether assemblies whose filenames contain
     /// <c>ModularPipeline</c> are eagerly loaded from the application directory.
     /// </summary>
@@ -175,139 +167,10 @@ public record PipelineOptions
     public int DefaultRetryCount { get; init; }
 
     /// <summary>
-    /// Gets the default logging options for all commands.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <strong>Configuration Precedence (highest to lowest):</strong>
-    /// </para>
-    /// <list type="number">
-    /// <item><see cref="CommandExecutionOptions.LogSettings"/> - Per-call override (highest priority)</item>
-    /// <item>This <see cref="DefaultLoggingOptions"/> - Global default</item>
-    /// <item>System defaults (lowest priority)</item>
-    /// </list>
-    /// </remarks>
-    public CommandLoggingOptions? DefaultLoggingOptions { get; init; }
-
-    /// <summary>
-    /// Gets the default HTTP logging options for all HTTP requests.
-    /// Controls what parts of HTTP requests and responses are logged (headers, body, etc.).
-    /// Use <see cref="HttpLoggingOptions.None"/> to disable all logging,
-    /// <see cref="HttpLoggingOptions.Minimal"/> for URL/status only,
-    /// <see cref="HttpLoggingOptions.Headers"/> for headers without body,
-    /// or <see cref="HttpLoggingOptions.Full"/> for complete logging.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <strong>Configuration Precedence (highest to lowest):</strong>
-    /// </para>
-    /// <list type="number">
-    /// <item><see cref="HttpOptions.LogSettings"/> - Per-request override (highest priority)</item>
-    /// <item>This <see cref="DefaultHttpLoggingOptions"/> - Global default</item>
-    /// <item><see cref="HttpLoggingOptions.Default"/> - System default (lowest priority)</item>
-    /// </list>
-    /// </remarks>
-    public HttpLoggingOptions? DefaultHttpLoggingOptions { get; init; }
-
-    /// <summary>
-    /// Gets the default timeout for all HTTP requests.
-    /// When set, HTTP requests will be cancelled if they exceed this duration,
-    /// unless overridden by <see cref="HttpOptions.Timeout"/> on individual requests.
-    /// If not set (null), HTTP requests will use the default HttpClient timeout.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <strong>Configuration Precedence (highest to lowest):</strong>
-    /// </para>
-    /// <list type="number">
-    /// <item><see cref="HttpOptions.Timeout"/> - Per-request override (highest priority)</item>
-    /// <item>This <see cref="DefaultHttpTimeout"/> - Global default</item>
-    /// <item>HttpClient default timeout - System default (lowest priority)</item>
-    /// </list>
-    /// </remarks>
-    public TimeSpan? DefaultHttpTimeout { get; init; }
-
-    /// <summary>
-    /// Gets the default HTTP resilience options for all HTTP requests.
-    /// Controls retry behavior for transient failures (network errors, 5xx server errors).
-    /// Use <see cref="HttpResilienceOptions.None"/> to disable retries,
-    /// <see cref="HttpResilienceOptions.Default"/> for standard retry behavior (3 retries with exponential backoff),
-    /// <see cref="HttpResilienceOptions.Aggressive"/> for more retries with shorter delays,
-    /// or <see cref="HttpResilienceOptions.Conservative"/> for fewer retries with longer delays.
-    /// </summary>
-    public HttpResilienceOptions? DefaultHttpResilienceOptions { get; init; }
-
-    /// <summary>
     /// Gets the concurrency options for module execution.
     /// Controls parallelism limits and resource-based throttling.
     /// </summary>
     public ConcurrencyOptions Concurrency { get; init; } = new();
-
-    /// <summary>
-    /// Gets the console width for output rendering.
-    /// When set to a value, that width is used for all console output.
-    /// When null (default), the width is auto-detected: 160 characters for known CI environments,
-    /// or the terminal's detected width for local execution.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Spectre.Console defaults to 80 characters when it cannot detect the terminal width,
-    /// which is common in CI environments where output is redirected. This can cause
-    /// tables and other formatted output to wrap unnecessarily.
-    /// </para>
-    /// <para>
-    /// Known CI environments (GitHub Actions, Azure Pipelines, TeamCity, GitLab, Jenkins,
-    /// Bitbucket, Travis CI, AppVeyor) automatically use 160 characters unless overridden.
-    /// </para>
-    /// </remarks>
-    public int? ConsoleWidth { get; init; }
-
-    /// <summary>
-    /// Gets how often buffered output from still-running modules is written to the console.
-    /// Set to <see cref="TimeSpan.Zero"/> to disable time-based flushing.
-    /// </summary>
-    /// <remarks>
-    /// Periodic flushing preserves diagnostic output when a process is killed before pipeline
-    /// teardown can run. Size-triggered flushing remains controlled separately by
-    /// <see cref="ModuleOutputFlushThreshold"/>. The default is one minute.
-    /// </remarks>
-    public TimeSpan ModuleOutputFlushInterval { get; init; } = TimeSpan.FromMinutes(1);
-
-    /// <summary>
-    /// Gets the number of buffered output entries that triggers an immediate incremental flush.
-    /// Set to 0 to disable size-triggered flushing.
-    /// </summary>
-    /// <remarks>
-    /// The default is 1,000 entries per module. This limits retained output between periodic flushes
-    /// without changing the order or final completion status of module output. The threshold counts
-    /// entries and does not impose a byte-size cap.
-    /// </remarks>
-    public int ModuleOutputFlushThreshold { get; init; } = 1_000;
-
-    /// <summary>
-    /// Gets the default execution options for all commands.
-    /// When set, these options apply to all command executions unless overridden per-call.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <strong>Configuration Precedence:</strong>
-    /// Per-call options always take precedence over these global defaults.
-    /// Properties set on per-call <see cref="CommandExecutionOptions"/> override matching properties here.
-    /// </para>
-    /// </remarks>
-    public CommandExecutionOptions? DefaultExecutionOptions
-    {
-        get => _defaultExecutionOptions;
-        init => _defaultExecutionOptions = value is null
-            ? null
-            : value with
-            {
-                EnvironmentVariables = value.EnvironmentVariables is null
-                    ? null
-                    : new ReadOnlyDictionary<string, string?>(
-                        new Dictionary<string, string?>(value.EnvironmentVariables)),
-            };
-    }
 
     /// <summary>
     /// Gets a value indicating whether to throw a <see cref="Exceptions.PipelineFailedException"/>
@@ -325,7 +188,4 @@ public record PipelineOptions
     /// </para>
     /// </remarks>
     public bool ThrowOnPipelineFailure { get; init; } = true;
-
-    internal static TimeSpan MaximumModuleOutputFlushInterval { get; } =
-        TimeSpan.FromMilliseconds(uint.MaxValue - 1);
 }

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -48,25 +48,26 @@ internal class OptionsValidator : IOptionsValidator
                 $"DefaultModuleTimeout cannot be negative. Current value: {options.DefaultModuleTimeout}"));
         }
 
-        if (options.ModuleOutputFlushInterval < TimeSpan.Zero)
+        var consoleOptions = options.Console;
+        if (consoleOptions.ModuleOutputFlushInterval < TimeSpan.Zero)
         {
             result.AddError(new ValidationError(
                 ValidationErrorCategory.Options,
-                $"ModuleOutputFlushInterval cannot be negative. Current value: {options.ModuleOutputFlushInterval}"));
+                $"Console.ModuleOutputFlushInterval cannot be negative. Current value: {consoleOptions.ModuleOutputFlushInterval}"));
         }
-        else if (options.ModuleOutputFlushInterval > PipelineOptions.MaximumModuleOutputFlushInterval)
+        else if (consoleOptions.ModuleOutputFlushInterval > PipelineConsoleOptions.MaximumModuleOutputFlushInterval)
         {
             result.AddError(new ValidationError(
                 ValidationErrorCategory.Options,
-                $"ModuleOutputFlushInterval cannot exceed {PipelineOptions.MaximumModuleOutputFlushInterval}. " +
-                $"Current value: {options.ModuleOutputFlushInterval}"));
+                $"Console.ModuleOutputFlushInterval cannot exceed {PipelineConsoleOptions.MaximumModuleOutputFlushInterval}. " +
+                $"Current value: {consoleOptions.ModuleOutputFlushInterval}"));
         }
 
-        if (options.ModuleOutputFlushThreshold < 0)
+        if (consoleOptions.ModuleOutputFlushThreshold < 0)
         {
             result.AddError(new ValidationError(
                 ValidationErrorCategory.Options,
-                $"ModuleOutputFlushThreshold cannot be negative. Current value: {options.ModuleOutputFlushThreshold}"));
+                $"Console.ModuleOutputFlushThreshold cannot be negative. Current value: {consoleOptions.ModuleOutputFlushThreshold}"));
         }
 
         if (options.RunReport.HistoryRetention < 0)
@@ -94,11 +95,11 @@ internal class OptionsValidator : IOptionsValidator
         }
 
         // Validate HTTP timeout if set
-        if (options.DefaultHttpTimeout.HasValue && options.DefaultHttpTimeout.Value <= TimeSpan.Zero)
+        if (options.Http.Timeout is { } httpTimeout && httpTimeout <= TimeSpan.Zero)
         {
             result.AddError(new ValidationError(
                 ValidationErrorCategory.Options,
-                $"DefaultHttpTimeout must be positive. Current value: {options.DefaultHttpTimeout.Value}"));
+                $"Http.Timeout must be positive. Current value: {httpTimeout}"));
         }
 
         // Validate conflicting category filters

--- a/test/ModularPipelines.TestHelpers/TestPipelineBuilder.cs
+++ b/test/ModularPipelines.TestHelpers/TestPipelineBuilder.cs
@@ -23,11 +23,17 @@ public static class TestPipelineBuilder
 
         builder.ConfigurePipelineOptions(options => options with
         {
-            DefaultLoggingOptions = testHostSettings.CommandLogging,
-            ShowProgressInConsole = testHostSettings.ShowProgressInConsole,
-            PrintResults = false,
-            PrintLogo = false,
-            PrintDependencyChains = false,
+            Commands = options.Commands with
+            {
+                Logging = testHostSettings.CommandLogging,
+            },
+            Console = options.Console with
+            {
+                ShowProgress = testHostSettings.ShowProgressInConsole,
+                PrintResults = false,
+                PrintLogo = false,
+                PrintDependencyChains = false,
+            },
             ThrowOnPipelineFailure = false, // Tests handle failures explicitly
         });
 

--- a/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ConsoleCoordinatorTests.cs
@@ -128,7 +128,10 @@ public class ConsoleCoordinatorTests
             .Returns(Task.CompletedTask);
         var coordinator = CreateCoordinator(
             outputCoordinator.Object,
-            new PipelineOptions { ModuleOutputFlushThreshold = 2 });
+            new PipelineOptions
+            {
+                Console = new PipelineConsoleOptions { ModuleOutputFlushThreshold = 2 },
+            });
         var buffer = coordinator.GetModuleBuffer(typeof(ConsoleCoordinatorTests));
 
         buffer.WriteLine("first");
@@ -158,7 +161,10 @@ public class ConsoleCoordinatorTests
         var originalConsole = AnsiConsole.Console;
         var coordinator = CreateCoordinator(
             Mock.Of<IOutputCoordinator>(),
-            new PipelineOptions { ShowProgressInConsole = showProgress });
+            new PipelineOptions
+            {
+                Console = new PipelineConsoleOptions { ShowProgress = showProgress },
+            });
 
         try
         {

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorDeferredFlushTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorDeferredFlushTests.cs
@@ -34,7 +34,7 @@ public class OutputCoordinatorDeferredFlushTests : TestBase
         var host = await TestPipelineBuilder.Create()
             .ConfigurePipelineOptions(options => options with
             {
-                ShowProgressInConsole = false,
+                Console = options.Console with { ShowProgress = false },
             })
             .AddModule<Module1>()
             .BuildAsync();
@@ -52,7 +52,7 @@ public class OutputCoordinatorDeferredFlushTests : TestBase
         var host = await TestPipelineBuilder.Create()
             .ConfigurePipelineOptions(options => options with
             {
-                ShowProgressInConsole = false,
+                Console = options.Console with { ShowProgress = false },
             })
             .AddModule<Module1>()
             .AddModule<Module2>()

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -60,7 +60,10 @@ public class HttpTests : TestBase
         var result = await GetServiceWithPipelineConfiguration<IHttpContext>(builder =>
             builder.ConfigurePipelineOptions(options => options with
             {
-                DefaultHttpTimeout = useRequestTimeout ? null : timeout,
+                Http = options.Http with
+                {
+                    Timeout = useRequestTimeout ? null : timeout,
+                },
             }));
         using var response = await result.T.SendAsync(new HttpOptions(
             new HttpRequestMessage(HttpMethod.Get, "https://example.test/stalled-body"))
@@ -302,11 +305,11 @@ public class HttpTests : TestBase
         await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await http.SendAsync(new HttpOptions(
                     new HttpRequestMessage(HttpMethod.Get, "https://example.test/legacy-logger"))
-                {
-                    HttpClient = httpClient,
-                    LoggingType = HttpLoggingType.Response,
-                    Timeout = timeout,
-                })
+            {
+                HttpClient = httpClient,
+                LoggingType = HttpLoggingType.Response,
+                Timeout = timeout,
+            })
                 .WaitAsync(TestHostSettings.DefaultTestTimeout));
     }
 
@@ -331,11 +334,11 @@ public class HttpTests : TestBase
 
         await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await http.SendAsync(new HttpOptions(request)
-                {
-                    HttpClient = httpClient,
-                    LoggingType = HttpLoggingType.Request,
-                    Timeout = timeout,
-                })
+            {
+                HttpClient = httpClient,
+                LoggingType = HttpLoggingType.Request,
+                Timeout = timeout,
+            })
                 .WaitAsync(TestHostSettings.DefaultTestTimeout));
     }
 
@@ -462,15 +465,15 @@ public class HttpTests : TestBase
         await Assert.ThrowsAsync<OperationCanceledException>(async () =>
             await http.SendAsync(new HttpOptions(
                     new HttpRequestMessage(HttpMethod.Get, "https://example.test/stalled-custom-log-body"))
+            {
+                HttpClient = httpClient,
+                LoggingType = HttpLoggingType.Response,
+                LogSettings = new HttpLoggingOptions
                 {
-                    HttpClient = httpClient,
-                    LoggingType = HttpLoggingType.Response,
-                    LogSettings = new HttpLoggingOptions
-                    {
-                        MaxBodySizeToLog = maxBodySizeToLog,
-                    },
-                    Timeout = timeout,
-                })
+                    MaxBodySizeToLog = maxBodySizeToLog,
+                },
+                Timeout = timeout,
+            })
                 .WaitAsync(TestHostSettings.DefaultTestTimeout));
     }
 
@@ -532,12 +535,12 @@ public class HttpTests : TestBase
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
                 await http.SendAsync(new HttpOptions(
                         new HttpRequestMessage(HttpMethod.Get, "https://example.test/stalled-error-body"))
-                    {
-                        HttpClient = useCustomClient ? httpClient : null,
-                        LoggingType = HttpLoggingType.None,
-                        ThrowOnNonSuccessStatusCode = true,
-                        Timeout = useConfiguredTimeout ? TimeSpan.FromMilliseconds(100) : null,
-                    },
+                {
+                    HttpClient = useCustomClient ? httpClient : null,
+                    LoggingType = HttpLoggingType.None,
+                    ThrowOnNonSuccessStatusCode = true,
+                    Timeout = useConfiguredTimeout ? TimeSpan.FromMilliseconds(100) : null,
+                },
                     useConfiguredTimeout ? CancellationToken.None : cancellationTokenSource.Token)
                     .WaitAsync(TestHostSettings.DefaultTestTimeout));
         }
@@ -627,10 +630,10 @@ public class HttpTests : TestBase
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
                 await http.SendAsync(new HttpOptions(
                         new HttpRequestMessage(HttpMethod.Get, "https://example.test/stalled-log-body"))
-                    {
-                        LoggingType = HttpLoggingType.Response,
-                        Timeout = timeout,
-                    })
+                {
+                    LoggingType = HttpLoggingType.Response,
+                    Timeout = timeout,
+                })
                     .WaitAsync(TestHostSettings.DefaultTestTimeout));
         }
         finally
@@ -657,11 +660,14 @@ public class HttpTests : TestBase
             moduleLoggerProvider.Object,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
-                DefaultHttpResilienceOptions = new HttpResilienceOptions
+                Http = new PipelineHttpOptions
                 {
-                    MaxRetryAttempts = 1,
-                    InitialDelay = TimeSpan.Zero,
-                    JitterFactor = 0,
+                    Resilience = new HttpResilienceOptions
+                    {
+                        MaxRetryAttempts = 1,
+                        InitialDelay = TimeSpan.Zero,
+                        JitterFactor = 0,
+                    },
                 },
             }))
         {
@@ -693,11 +699,14 @@ public class HttpTests : TestBase
             moduleLoggerProvider.Object,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
-                DefaultHttpResilienceOptions = new HttpResilienceOptions
+                Http = new PipelineHttpOptions
                 {
-                    MaxRetryAttempts = 1,
-                    InitialDelay = TimeSpan.Zero,
-                    JitterFactor = 0,
+                    Resilience = new HttpResilienceOptions
+                    {
+                        MaxRetryAttempts = 1,
+                        InitialDelay = TimeSpan.Zero,
+                        JitterFactor = 0,
+                    },
                 },
             }))
         {

--- a/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineOutputCoordinatorTests.cs
@@ -30,8 +30,11 @@ public class PipelineOutputCoordinatorTests
         const int expectedThreshold = 23;
         builder.ConfigurePipelineOptions(options => options with
         {
-            ModuleOutputFlushInterval = expectedInterval,
-            ModuleOutputFlushThreshold = expectedThreshold,
+            Console = options.Console with
+            {
+                ModuleOutputFlushInterval = expectedInterval,
+                ModuleOutputFlushThreshold = expectedThreshold,
+            },
         });
 
         await using var pipeline = await builder.BuildAsync();
@@ -39,8 +42,8 @@ public class PipelineOutputCoordinatorTests
             .GetRequiredService<Microsoft.Extensions.Options.IOptions<PipelineOptions>>()
             .Value;
 
-        await Assert.That(runtimeOptions.ModuleOutputFlushInterval).IsEqualTo(expectedInterval);
-        await Assert.That(runtimeOptions.ModuleOutputFlushThreshold).IsEqualTo(expectedThreshold);
+        await Assert.That(runtimeOptions.Console.ModuleOutputFlushInterval).IsEqualTo(expectedInterval);
+        await Assert.That(runtimeOptions.Console.ModuleOutputFlushThreshold).IsEqualTo(expectedThreshold);
     }
 
     [Test]
@@ -81,7 +84,7 @@ public class PipelineOutputCoordinatorTests
             outputCoordinator.Object,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
-                ModuleOutputFlushInterval = TimeSpan.Zero,
+                Console = new PipelineConsoleOptions { ModuleOutputFlushInterval = TimeSpan.Zero },
             }),
             Mock.Of<ILogger<PipelineOutputCoordinator>>());
         var scope = await coordinator.InitializeAsync();
@@ -124,7 +127,7 @@ public class PipelineOutputCoordinatorTests
             outputCoordinator.Object,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
-                ModuleOutputFlushInterval = TimeSpan.Zero,
+                Console = new PipelineConsoleOptions { ModuleOutputFlushInterval = TimeSpan.Zero },
             }),
             Mock.Of<ILogger<PipelineOutputCoordinator>>());
         var scope = await coordinator.InitializeAsync();
@@ -166,7 +169,7 @@ public class PipelineOutputCoordinatorTests
             outputCoordinator.Object,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
-                ModuleOutputFlushInterval = TimeSpan.Zero,
+                Console = new PipelineConsoleOptions { ModuleOutputFlushInterval = TimeSpan.Zero },
             }),
             Mock.Of<ILogger<PipelineOutputCoordinator>>());
         var scope = await coordinator.InitializeAsync();
@@ -215,7 +218,10 @@ public class PipelineOutputCoordinatorTests
             outputCoordinator.Object,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
-                ModuleOutputFlushInterval = TimeSpan.FromMilliseconds(10),
+                Console = new PipelineConsoleOptions
+                {
+                    ModuleOutputFlushInterval = TimeSpan.FromMilliseconds(10),
+                },
             }),
             Mock.Of<ILogger<PipelineOutputCoordinator>>());
 
@@ -255,7 +261,10 @@ public class PipelineOutputCoordinatorTests
             Mock.Of<IOutputCoordinator>(),
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
-                ModuleOutputFlushInterval = TimeSpan.FromMilliseconds(milliseconds),
+                Console = new PipelineConsoleOptions
+                {
+                    ModuleOutputFlushInterval = TimeSpan.FromMilliseconds(milliseconds),
+                },
             }),
             Mock.Of<ILogger<PipelineOutputCoordinator>>());
 

--- a/test/ModularPipelines.UnitTests/Engine/PipelineProgressTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/PipelineProgressTests.cs
@@ -114,8 +114,11 @@ public class PipelineProgressTests
                     .ConfigureServices(services => services.AddSingleton<IAnsiConsole>(console))
                     .ConfigurePipelineOptions((_, options) => options with
                     {
-                        PrintResults = false,
-                        ShowProgressInConsole = true,
+                        Console = options.Console with
+                        {
+                            PrintResults = false,
+                            ShowProgress = true,
+                        },
                     })
                     .AddModule<Module1>()
                     .AddModule<Module2>()

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1411,7 +1411,7 @@ public class RunReportTests
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, CancellationToken>((_, token) => readToken = token)
-            .ReturnsAsync((PipelineRunReport?)null);
+            .ReturnsAsync((PipelineRunReport?) null);
         historyStore.Setup(store => store.SaveAsync(
                 It.IsAny<PipelineRunReport>(),
                 It.IsAny<CancellationToken>()))
@@ -1576,8 +1576,7 @@ public class RunReportTests
             using var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
-                PrintLogo = false,
-                PrintResults = false,
+                Console = options.Console with { PrintLogo = false, PrintResults = false },
                 RunReport = options.RunReport with { ReportPath = reportPath },
             });
             builder.AddModule<SuccessfulModule>();
@@ -1618,8 +1617,7 @@ public class RunReportTests
             using var builder = Pipeline.CreateBuilder();
             builder.ConfigurePipelineOptions(options => options with
             {
-                PrintLogo = false,
-                PrintResults = false,
+                Console = options.Console with { PrintLogo = false, PrintResults = false },
                 RunReport = options.RunReport with { ReportPath = reportPath },
             });
             builder.AddModule<SuccessfulModule>();
@@ -1662,8 +1660,7 @@ public class RunReportTests
             {
                 builder.ConfigurePipelineOptions(options => options with
                 {
-                    PrintLogo = false,
-                    PrintResults = false,
+                    Console = options.Console with { PrintLogo = false, PrintResults = false },
                     RunReport = options.RunReport with
                     {
                         ReportPath = reportPath,
@@ -1684,8 +1681,7 @@ public class RunReportTests
             using var successfulBuilder = Pipeline.CreateBuilder();
             successfulBuilder.ConfigurePipelineOptions(options => options with
             {
-                PrintLogo = false,
-                PrintResults = false,
+                Console = options.Console with { PrintLogo = false, PrintResults = false },
                 RunReport = options.RunReport with
                 {
                     ReportPath = reportPath,
@@ -1801,8 +1797,7 @@ public class RunReportTests
             {
                 ExecutionMode = ExecutionMode.StopOnFirstException,
                 ThrowOnPipelineFailure = false,
-                PrintLogo = false,
-                PrintResults = false,
+                Console = options.Console with { PrintLogo = false, PrintResults = false },
                 RunReport = options.RunReport with { ReportPath = reportPath },
             });
             builder.AddModule<FailingModule>();
@@ -1841,8 +1836,7 @@ public class RunReportTests
             {
                 ExecutionMode = ExecutionMode.WaitForAllModules,
                 ThrowOnPipelineFailure = false,
-                PrintLogo = false,
-                PrintResults = false,
+                Console = options.Console with { PrintLogo = false, PrintResults = false },
                 RunReport = options.RunReport with { ReportPath = reportPath },
             });
             builder.AddModule<FailingModule>();
@@ -1883,8 +1877,7 @@ public class RunReportTests
             {
                 ExecutionMode = ExecutionMode.WaitForAllModules,
                 ThrowOnPipelineFailure = false,
-                PrintLogo = false,
-                PrintResults = false,
+                Console = options.Console with { PrintLogo = false, PrintResults = false },
                 RunReport = options.RunReport with { ReportPath = reportPath },
             });
             builder.AddModule<FailingModule>();
@@ -2339,8 +2332,7 @@ public class RunReportTests
         {
             ExecutionMode = ExecutionMode.WaitForAllModules,
             ThrowOnPipelineFailure = false,
-            PrintLogo = false,
-            PrintResults = false,
+            Console = options.Console with { PrintLogo = false, PrintResults = false },
             RunReport = options.RunReport with
             {
                 HistoryDirectory = historyPath,
@@ -2359,8 +2351,7 @@ public class RunReportTests
         using var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
-            PrintLogo = false,
-            PrintResults = false,
+            Console = options.Console with { PrintLogo = false, PrintResults = false },
             RunReport = options.RunReport with
             {
                 AutoWriteInCi = false,
@@ -2477,13 +2468,13 @@ public class RunReportTests
     }
 
     private static IModuleResult CreateHistoricalResult(IModule module, DateTimeOffset start) =>
-        (ModuleResult)CreateResult(module, start, TimeSpan.Zero) with
+        (ModuleResult) CreateResult(module, start, TimeSpan.Zero) with
         {
             ModuleStatus = Status.UsedHistory,
         };
 
     private static IModuleResult CreateCachedResult(IModule module, DateTimeOffset start) =>
-        (ModuleResult)CreateResult(module, start, TimeSpan.Zero) with
+        (ModuleResult) CreateResult(module, start, TimeSpan.Zero) with
         {
             ModuleStatus = Status.CachedResult,
         };
@@ -2510,7 +2501,7 @@ public class RunReportTests
     {
         var module = new SuccessfulModule();
         var start = new DateTimeOffset(2026, 8, 3, 12, 0, 0, TimeSpan.Zero);
-        var result = (ModuleResult)CreateResult(module, start, duration) with
+        var result = (ModuleResult) CreateResult(module, start, duration) with
         {
             ModuleStatus = status,
         };

--- a/test/ModularPipelines.UnitTests/Options/PipelineOptionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Options/PipelineOptionsTests.cs
@@ -23,6 +23,9 @@ public class PipelineOptionsTests
     [Test]
     [Arguments(typeof(PipelineBuilderOptions))]
     [Arguments(typeof(PipelineOptions))]
+    [Arguments(typeof(PipelineConsoleOptions))]
+    [Arguments(typeof(PipelineHttpOptions))]
+    [Arguments(typeof(PipelineCommandOptions))]
     [Arguments(typeof(ConcurrencyOptions))]
     [Arguments(typeof(HttpLoggingOptions))]
     [Arguments(typeof(HttpResilienceOptions))]
@@ -37,6 +40,41 @@ public class PipelineOptionsTests
             .Select(property => property.Name);
 
         await Assert.That(mutableProperties).IsEmpty();
+    }
+
+    [Test]
+    public async Task SubsystemSettings_AreGrouped()
+    {
+        var pipelineOptionsType = typeof(PipelineOptions);
+        var legacyPropertyNames = new HashSet<string>
+        {
+            "ShowProgressInConsole",
+            "PrintResults",
+            "PrintLogo",
+            "PrintDependencyChains",
+            "ConsoleWidth",
+            "ModuleOutputFlushInterval",
+            "ModuleOutputFlushThreshold",
+            "DefaultHttpLoggingOptions",
+            "DefaultHttpTimeout",
+            "DefaultHttpResilienceOptions",
+            "DefaultLoggingOptions",
+            "DefaultExecutionOptions",
+        };
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(pipelineOptionsType.GetProperty(nameof(PipelineOptions.Console))!.PropertyType)
+                .IsEqualTo(typeof(PipelineConsoleOptions));
+            await Assert.That(pipelineOptionsType.GetProperty(nameof(PipelineOptions.Http))!.PropertyType)
+                .IsEqualTo(typeof(PipelineHttpOptions));
+            await Assert.That(pipelineOptionsType.GetProperty(nameof(PipelineOptions.Commands))!.PropertyType)
+                .IsEqualTo(typeof(PipelineCommandOptions));
+            await Assert.That(pipelineOptionsType.GetProperties()
+                    .Select(property => property.Name)
+                    .Where(legacyPropertyNames.Contains))
+                .IsEmpty();
+        }
     }
 
     [Test]
@@ -80,7 +118,10 @@ public class PipelineOptionsTests
         {
             _ = new PipelineOptions
             {
-                ShowProgressInConsole = !originalInteractive,
+                Console = new PipelineConsoleOptions
+                {
+                    ShowProgress = !originalInteractive,
+                },
             };
 
             await Assert.That(AnsiConsole.Profile.Capabilities.Interactive)
@@ -95,7 +136,7 @@ public class PipelineOptionsTests
     [Test]
     public async Task DefaultProgressOption_UsesSpectreCapability()
     {
-        await Assert.That(new PipelineOptions().ShowProgressInConsole)
+        await Assert.That(new PipelineOptions().Console.ShowProgress)
             .IsEqualTo(AnsiConsole.Profile.Capabilities.Interactive);
     }
 
@@ -134,13 +175,16 @@ public class PipelineOptionsTests
         };
         var options = new PipelineOptions
         {
-            DefaultHttpLoggingOptions = new HttpLoggingOptions
+            Http = new PipelineHttpOptions
             {
-                SensitiveHeaderNames = sensitiveHeaders,
-            },
-            DefaultHttpResilienceOptions = new HttpResilienceOptions
-            {
-                RetryableStatusCodes = retryableStatusCodes,
+                Logging = new HttpLoggingOptions
+                {
+                    SensitiveHeaderNames = sensitiveHeaders,
+                },
+                Resilience = new HttpResilienceOptions
+                {
+                    RetryableStatusCodes = retryableStatusCodes,
+                },
             },
         };
 
@@ -149,17 +193,17 @@ public class PipelineOptionsTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(options.DefaultHttpLoggingOptions!.SensitiveHeaderNames)
+            await Assert.That(options.Http.Logging!.SensitiveHeaderNames)
                 .IsEquivalentTo(["X-Secret"]);
-            await Assert.That(options.DefaultHttpResilienceOptions!.RetryableStatusCodes)
+            await Assert.That(options.Http.Resilience!.RetryableStatusCodes)
                 .IsEquivalentTo([HttpStatusCode.ServiceUnavailable]);
             await Assert.That(
-                    ((ICollection<string>) options.DefaultHttpLoggingOptions.SensitiveHeaderNames)
+                    ((ICollection<string>) options.Http.Logging.SensitiveHeaderNames)
                     .IsReadOnly)
                 .IsTrue();
             await Assert.That(
                     ((ICollection<HttpStatusCode>)
-                        options.DefaultHttpResilienceOptions.RetryableStatusCodes)
+                        options.Http.Resilience.RetryableStatusCodes)
                     .IsReadOnly)
                 .IsTrue();
         }
@@ -174,16 +218,19 @@ public class PipelineOptionsTests
         };
         var options = new PipelineOptions
         {
-            DefaultExecutionOptions = new CommandExecutionOptions
+            Commands = new PipelineCommandOptions
             {
-                EnvironmentVariables = environmentVariables,
+                Execution = new CommandExecutionOptions
+                {
+                    EnvironmentVariables = environmentVariables,
+                },
             },
         };
 
         environmentVariables["ORIGINAL"] = "changed";
         environmentVariables["ADDED"] = "later";
 
-        var snapshot = options.DefaultExecutionOptions!.EnvironmentVariables!;
+        var snapshot = options.Commands.Execution!.EnvironmentVariables!;
         using (Assert.Multiple())
         {
             await Assert.That(snapshot["ORIGINAL"]).IsEqualTo("value");
@@ -230,8 +277,8 @@ public class PipelineOptionsTests
         var namedSetup = new ConfigureNamedOptions<PipelineOptions>(
             "custom",
             options => typeof(PipelineOptions)
-                .GetProperty(nameof(PipelineOptions.PrintLogo))!
-                .SetValue(options, false));
+                .GetProperty(nameof(PipelineOptions.Console))!
+                .SetValue(options, options.Console with { PrintLogo = false }));
         var factory = new PipelineOptionsFactory(
             source,
             [namedSetup],
@@ -243,9 +290,9 @@ public class PipelineOptionsTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(custom.PrintLogo).IsFalse();
-            await Assert.That(defaults.PrintLogo).IsTrue();
-            await Assert.That(source.PrintLogo).IsTrue();
+            await Assert.That(custom.Console.PrintLogo).IsFalse();
+            await Assert.That(defaults.Console.PrintLogo).IsTrue();
+            await Assert.That(source.Console.PrintLogo).IsTrue();
             await Assert.That(custom).IsNotSameReferenceAs(defaults);
             await Assert.That(custom).IsNotSameReferenceAs(source);
             await Assert.That(defaults).IsNotSameReferenceAs(source);

--- a/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Tracing/TelemetryIntegrationTests.cs
@@ -227,7 +227,10 @@ public class TelemetryIntegrationTests
         var builder = TestPipelineBuilder.Create()
             .ConfigurePipelineOptions(options => options with
             {
-                DefaultLoggingOptions = CommandLoggingOptions.Silent,
+                Commands = options.Commands with
+                {
+                    Logging = CommandLoggingOptions.Silent,
+                },
             });
         builder.Services.AddSingleton<ICommandInterceptor, SuccessfulCommandInterceptor>();
         await builder.AddModule<DefaultLoggingCommandModule>().ExecutePipelineAsync();

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -525,7 +525,10 @@ public class ValidationTests
         builder.AddModule<SimpleModule>();
         builder.ConfigurePipelineOptions(options => options with
         {
-            ModuleOutputFlushInterval = TimeSpan.FromSeconds(-1),
+            Console = options.Console with
+            {
+                ModuleOutputFlushInterval = TimeSpan.FromSeconds(-1),
+            },
         });
 
         var result = await builder.ValidateAsync();
@@ -543,7 +546,10 @@ public class ValidationTests
         builder.AddModule<SimpleModule>();
         builder.ConfigurePipelineOptions(options => options with
         {
-            ModuleOutputFlushInterval = TimeSpan.FromMilliseconds(uint.MaxValue),
+            Console = options.Console with
+            {
+                ModuleOutputFlushInterval = TimeSpan.FromMilliseconds(uint.MaxValue),
+            },
         });
 
         var result = await builder.ValidateAsync();
@@ -561,7 +567,7 @@ public class ValidationTests
         builder.Services.AddModule<SimpleModule>();
         builder.ConfigurePipelineOptions(options => options with
         {
-            ModuleOutputFlushThreshold = -1,
+            Console = options.Console with { ModuleOutputFlushThreshold = -1 },
         });
 
         var result = await builder.ValidateAsync();


### PR DESCRIPTION
Closes #3768.

## Summary
- group console rendering and flush settings under `PipelineOptions.Console`
- group HTTP logging, timeout, and resilience under `PipelineOptions.Http`
- group command logging and execution defaults under `PipelineOptions.Commands`
- update runtime consumers, test helpers, focused tests, and current documentation

## Validation
- `PipelineOptionsTests`: 19/19
- `ConsoleCoordinatorTests`: 6/6
- `PipelineOutputCoordinatorTests`: 7/7
- `HttpTests`: 39/39
- option validation tests: 17/17
- command telemetry regression: 1/1
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors
- `ModularPipelines.Testing.csproj` Release build: 0 warnings, 0 errors