### PR TITLE
Standardize asynchronous API naming

### DIFF
--- a/docs/docs/examples/azure-example.md
+++ b/docs/docs/examples/azure-example.md
@@ -20,9 +20,10 @@ public class ProvisionUserAssignedIdentityModule : Module<UserAssignedIdentityRe
 {
     protected override async Task<UserAssignedIdentityResource> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var userAssignedIdentityProvisionResponse = await context.Tools.Azure.Provisioner.Security.UserAssignedIdentity(
+        var userAssignedIdentityProvisionResponse = await context.Tools.Azure.Provisioner.Security.UserAssignedIdentityAsync(
             new AzureResourceIdentifier("MySubscription", "MyResourceGroup", "MyUserIdentity"),
-            new UserAssignedIdentityData(AzureLocation.UKSouth)
+            new UserAssignedIdentityData(AzureLocation.UKSouth),
+            cancellationToken
         );
 
         return userAssignedIdentityProvisionResponse.Value;
@@ -37,9 +38,10 @@ public class ProvisionBlobStorageAccountModule : Module<StorageAccountResource>
 {
     protected override async Task<StorageAccountResource> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var blobStorageAccountProvisionResponse = await context.Tools.Azure.Provisioner.Storage.StorageAccount(
+        var blobStorageAccountProvisionResponse = await context.Tools.Azure.Provisioner.Storage.StorageAccountAsync(
             new AzureResourceIdentifier("MySubscription", "MyResourceGroup", "MyStorage"),
-            new StorageAccountCreateOrUpdateContent(new StorageSku(StorageSkuName.StandardGrs), StorageKind.BlobStorage, AzureLocation.UKSouth)
+            new StorageAccountCreateOrUpdateContent(new StorageSku(StorageSkuName.StandardGrs), StorageKind.BlobStorage, AzureLocation.UKSouth),
+            cancellationToken
         );
 
         return blobStorageAccountProvisionResponse.Value;
@@ -57,10 +59,11 @@ public class ProvisionBlobStorageContainerModule : Module<BlobContainerResource>
     {
         var blobStorageAccount = await context.GetModule<ProvisionBlobStorageAccountModule>();
 
-        var blobContainerProvisionResponse = await context.Tools.Azure.Provisioner.Storage.BlobContainer(
+        var blobContainerProvisionResponse = await context.Tools.Azure.Provisioner.Storage.BlobContainerAsync(
             blobStorageAccount.Value.Id,
             "MyContainer",
-            new BlobContainerData()
+            new BlobContainerData(),
+            cancellationToken
         );
 
         return blobContainerProvisionResponse.Value;
@@ -81,9 +84,10 @@ public class AssignAccessToBlobStorageModule : Module<RoleAssignmentResource>
 
         var storageAccount = await context.GetModule<ProvisionBlobStorageAccountModule>();
 
-        var roleAssignmentResource = await context.Tools.Azure.Provisioner.Security.RoleAssignment(
+        var roleAssignmentResource = await context.Tools.Azure.Provisioner.Security.RoleAssignmentAsync(
             storageAccount.Value.Id,
-            new RoleAssignmentCreateOrUpdateContent(WellKnownRoleDefinitions.BlobStorageOwnerDefinitionId, userAssignedIdentity.Value.Data.PrincipalId!.Value)
+            new RoleAssignmentCreateOrUpdateContent(WellKnownRoleDefinitions.BlobStorageOwnerDefinitionId, userAssignedIdentity.Value.Data.PrincipalId!.Value),
+            cancellationToken
         );
 
         return roleAssignmentResource.Value;
@@ -106,7 +110,7 @@ public class ProvisionAzureFunction : Module<WebSiteResource>
         var storageAccount = await context.GetModule<ProvisionBlobStorageAccountModule>();
         var blobContainer = await context.GetModule<ProvisionBlobStorageContainerModule>();
 
-        var functionProvisionResponse = await context.Tools.Azure.Provisioner.Compute.WebSite(
+        var functionProvisionResponse = await context.Tools.Azure.Provisioner.Compute.WebSiteAsync(
             new AzureResourceIdentifier("MySubscription", "MyResourceGroup", "MyFunction"),
             new WebSiteData(AzureLocation.UKSouth)
             {
@@ -131,7 +135,8 @@ public class ProvisionAzureFunction : Module<WebSiteResource>
                     }
                 }
                 // ... Other properties
-            }
+            },
+            cancellationToken
         );
 
         return functionProvisionResponse.Value;

--- a/docs/docs/examples/dotnet-test-build-publish.md
+++ b/docs/docs/examples/dotnet-test-build-publish.md
@@ -41,7 +41,7 @@ public class NugetVersionGeneratorModule : Module<string>
         IModuleContext context,
         CancellationToken cancellationToken)
     {
-        var version = await context.Tools.Git.Versioning.GetGitVersioningInformation();
+        var version = await context.Tools.Git.Versioning.GetVersioningInformationAsync(cancellationToken);
         return version.FullSemVer
             ?? throw new InvalidOperationException("GitVersion did not return a semantic version.");
     }

--- a/docs/docs/how-to/sub-modules.md
+++ b/docs/docs/how-to/sub-modules.md
@@ -26,7 +26,7 @@ public class PackProjectsModule : Module<CommandResult[]>
     {
         var packageVersion = await context.GetModule<NugetVersionGeneratorModule>();
 
-        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync()
+        var repositoryInfo = await context.Tools.Git.Information.GetInfoAsync(cancellationToken)
             ?? throw new InvalidOperationException("Git repository information is unavailable.");
         var projects = repositoryInfo.Root
             .GetFiles(x =>
@@ -40,7 +40,7 @@ public class PackProjectsModule : Module<CommandResult[]>
     {
         foreach (var project in projects)
         {
-            yield return await context.SubModule(project.Name, () => context.Tools.DotNet.PackAsync(new DotNetPackOptions
+            yield return await context.SubModuleAsync(project.Name, () => context.Tools.DotNet.PackAsync(new DotNetPackOptions
             {
                 TargetPath = project,
                 Configuration = Configuration.Release,
@@ -49,7 +49,7 @@ public class PackProjectsModule : Module<CommandResult[]>
                     $"PackageVersion={packageVersion}",
                     $"Version={packageVersion}",
                 },
-            }, cancellationToken));
+            }, cancellationToken), cancellationToken);
         }
     }
 }

--- a/src/ModularPipelines.Azure/Provisioning/AzureProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/AzureProvisioner.cs
@@ -38,7 +38,7 @@ internal class AzureProvisioner : BaseAzureProvisioner, IAzureProvisioner
         Gateways = gateways;
     }
 
-    public async Task<ArmOperation<ResourceGroupResource>> ResourceGroup(AzureSubscriptionIdentifier azureSubscriptionIdentifier, string resourceGroupName, ResourceGroupData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<ResourceGroupResource>> ResourceGroupAsync(AzureSubscriptionIdentifier azureSubscriptionIdentifier, string resourceGroupName, ResourceGroupData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureSubscriptionIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(resourceGroupName);
@@ -50,7 +50,7 @@ internal class AzureProvisioner : BaseAzureProvisioner, IAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, resourceGroupName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<KeyVaultResource>> KeyVault(AzureResourceIdentifier azureResourceIdentifier, KeyVaultCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<KeyVaultResource>> KeyVaultAsync(AzureResourceIdentifier azureResourceIdentifier, KeyVaultCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -60,7 +60,7 @@ internal class AzureProvisioner : BaseAzureProvisioner, IAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<RedisResource>> Redis(AzureResourceIdentifier azureResourceIdentifier, RedisCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<RedisResource>> RedisAsync(AzureResourceIdentifier azureResourceIdentifier, RedisCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -70,7 +70,7 @@ internal class AzureProvisioner : BaseAzureProvisioner, IAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<ContainerRegistryResource>> ContainerRegistry(AzureResourceIdentifier azureResourceIdentifier, ContainerRegistryData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<ContainerRegistryResource>> ContainerRegistryAsync(AzureResourceIdentifier azureResourceIdentifier, ContainerRegistryData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -80,7 +80,7 @@ internal class AzureProvisioner : BaseAzureProvisioner, IAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<AppConfigurationStoreResource>> AppConfiguration(AzureResourceIdentifier azureResourceIdentifier, AppConfigurationStoreData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<AppConfigurationStoreResource>> AppConfigurationAsync(AzureResourceIdentifier azureResourceIdentifier, AppConfigurationStoreData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -90,7 +90,7 @@ internal class AzureProvisioner : BaseAzureProvisioner, IAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<OperationalInsightsWorkspaceResource>> OperationalInsightsWorkspace(AzureResourceIdentifier azureResourceIdentifier, OperationalInsightsWorkspaceData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<OperationalInsightsWorkspaceResource>> OperationalInsightsWorkspaceAsync(AzureResourceIdentifier azureResourceIdentifier, OperationalInsightsWorkspaceData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -100,7 +100,7 @@ internal class AzureProvisioner : BaseAzureProvisioner, IAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<OperationalInsightsClusterResource>> OperationalInsightsCluster(AzureResourceIdentifier azureResourceIdentifier, OperationalInsightsClusterData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<OperationalInsightsClusterResource>> OperationalInsightsClusterAsync(AzureResourceIdentifier azureResourceIdentifier, OperationalInsightsClusterData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -110,7 +110,7 @@ internal class AzureProvisioner : BaseAzureProvisioner, IAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<ApplicationInsightsComponentResource>> ApplicationInsights(AzureResourceIdentifier azureResourceIdentifier, ApplicationInsightsComponentData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<ApplicationInsightsComponentResource>> ApplicationInsightsAsync(AzureResourceIdentifier azureResourceIdentifier, ApplicationInsightsComponentData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);

--- a/src/ModularPipelines.Azure/Provisioning/Compute/AzureComputeProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/Compute/AzureComputeProvisioner.cs
@@ -11,7 +11,7 @@ public class AzureComputeProvisioner : BaseAzureProvisioner
     {
     }
 
-    public async Task<ArmOperation<AppServicePlanResource>> AppServicePlan(AzureResourceIdentifier azureResourceIdentifier, AppServicePlanData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<AppServicePlanResource>> AppServicePlanAsync(AzureResourceIdentifier azureResourceIdentifier, AppServicePlanData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -21,7 +21,7 @@ public class AzureComputeProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<WebSiteResource>> WebSite(AzureResourceIdentifier azureResourceIdentifier, WebSiteData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<WebSiteResource>> WebSiteAsync(AzureResourceIdentifier azureResourceIdentifier, WebSiteData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -31,7 +31,7 @@ public class AzureComputeProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<WebSiteSlotResource>> WebSiteSlot(AzureResourceIdentifier azureResourceIdentifier, WebSiteData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<WebSiteSlotResource>> WebSiteSlotAsync(AzureResourceIdentifier azureResourceIdentifier, WebSiteData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -43,7 +43,7 @@ public class AzureComputeProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<SiteFunctionResource>> WebSiteDeployment(AzureResourceIdentifier azureResourceIdentifier, FunctionEnvelopeData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<SiteFunctionResource>> WebSiteDeploymentAsync(AzureResourceIdentifier azureResourceIdentifier, FunctionEnvelopeData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -55,7 +55,7 @@ public class AzureComputeProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<StaticSiteResource>> StaticSite(AzureResourceIdentifier azureResourceIdentifier, StaticSiteData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<StaticSiteResource>> StaticSiteAsync(AzureResourceIdentifier azureResourceIdentifier, StaticSiteData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -65,7 +65,7 @@ public class AzureComputeProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<AppServiceDomainResource>> AppServiceDomain(AzureResourceIdentifier azureResourceIdentifier, AppServiceDomainData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<AppServiceDomainResource>> AppServiceDomainAsync(AzureResourceIdentifier azureResourceIdentifier, AppServiceDomainData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -75,7 +75,7 @@ public class AzureComputeProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<AppServiceEnvironmentResource>> AppServiceEnvironment(AzureResourceIdentifier azureResourceIdentifier, AppServiceEnvironmentData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<AppServiceEnvironmentResource>> AppServiceEnvironmentAsync(AzureResourceIdentifier azureResourceIdentifier, AppServiceEnvironmentData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);

--- a/src/ModularPipelines.Azure/Provisioning/Compute/AzureKubernetesProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/Compute/AzureKubernetesProvisioner.cs
@@ -11,7 +11,7 @@ public class AzureKubernetesProvisioner : BaseAzureProvisioner
     {
     }
 
-    public async Task<ArmOperation<KubeEnvironmentResource>> KubeEnvironment(AzureResourceIdentifier azureResourceIdentifier, KubeEnvironmentData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<KubeEnvironmentResource>> KubeEnvironmentAsync(AzureResourceIdentifier azureResourceIdentifier, KubeEnvironmentData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);

--- a/src/ModularPipelines.Azure/Provisioning/Compute/AzureTrafficAndLoadBalancerProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/Compute/AzureTrafficAndLoadBalancerProvisioner.cs
@@ -12,7 +12,7 @@ public class AzureTrafficAndLoadBalancerProvisioner : BaseAzureProvisioner
     {
     }
 
-    public async Task<ArmOperation<TrafficManagerProfileResource>> TrafficManagerProfile(AzureResourceIdentifier azureResourceIdentifier, TrafficManagerProfileData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<TrafficManagerProfileResource>> TrafficManagerProfileAsync(AzureResourceIdentifier azureResourceIdentifier, TrafficManagerProfileData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -22,7 +22,7 @@ public class AzureTrafficAndLoadBalancerProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<LoadBalancerResource>> LoadBalancer(AzureResourceIdentifier azureResourceIdentifier, LoadBalancerData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<LoadBalancerResource>> LoadBalancerAsync(AzureResourceIdentifier azureResourceIdentifier, LoadBalancerData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -32,7 +32,7 @@ public class AzureTrafficAndLoadBalancerProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<ApplicationGatewayResource>> ApplicationGateway(AzureResourceIdentifier azureResourceIdentifier, ApplicationGatewayData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<ApplicationGatewayResource>> ApplicationGatewayAsync(AzureResourceIdentifier azureResourceIdentifier, ApplicationGatewayData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);

--- a/src/ModularPipelines.Azure/Provisioning/Containers/AzureContainerProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/Containers/AzureContainerProvisioner.cs
@@ -11,7 +11,7 @@ public class AzureContainerProvisioner : BaseAzureProvisioner
     {
     }
 
-    public async Task<ArmOperation<ContainerRegistryResource>> ContainerRegistry(AzureResourceIdentifier azureResourceIdentifier, ContainerRegistryData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<ContainerRegistryResource>> ContainerRegistryAsync(AzureResourceIdentifier azureResourceIdentifier, ContainerRegistryData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);

--- a/src/ModularPipelines.Azure/Provisioning/Cosmos/AzureCosmosProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/Cosmos/AzureCosmosProvisioner.cs
@@ -15,7 +15,7 @@ public class AzureCosmosProvisioner : BaseAzureProvisioner
         Sql = sql;
     }
 
-    public async Task<ArmOperation<CosmosDBAccountResource>> Account(
+    public async Task<ArmOperation<CosmosDBAccountResource>> AccountAsync(
         AzureResourceIdentifier azureResourceIdentifier, CosmosDBAccountCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);

--- a/src/ModularPipelines.Azure/Provisioning/Cosmos/AzureCosmosSqlProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/Cosmos/AzureCosmosSqlProvisioner.cs
@@ -12,7 +12,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
     {
     }
 
-    public async Task<ArmOperation<CosmosDBSqlDatabaseResource>> Database(
+    public async Task<ArmOperation<CosmosDBSqlDatabaseResource>> DatabaseAsync(
         AzureResourceIdentifier azureResourceIdentifier, string databaseName, CosmosDBSqlDatabaseCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
@@ -25,7 +25,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await account.Value.GetCosmosDBSqlDatabases().CreateOrUpdateAsync(WaitUntil.Completed, databaseName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<CosmosDBSqlRoleAssignmentResource>> RoleAssignment(
+    public async Task<ArmOperation<CosmosDBSqlRoleAssignmentResource>> RoleAssignmentAsync(
         AzureResourceIdentifier azureResourceIdentifier, string databaseName, CosmosDBSqlRoleAssignmentCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
@@ -38,7 +38,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await account.Value.GetCosmosDBSqlRoleAssignments().CreateOrUpdateAsync(WaitUntil.Completed, databaseName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<CosmosDBSqlRoleDefinitionResource>> RoleDefinition(
+    public async Task<ArmOperation<CosmosDBSqlRoleDefinitionResource>> RoleDefinitionAsync(
         AzureResourceIdentifier azureResourceIdentifier, string databaseName, CosmosDBSqlRoleDefinitionCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
@@ -51,7 +51,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await account.Value.GetCosmosDBSqlRoleDefinitions().CreateOrUpdateAsync(WaitUntil.Completed, databaseName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<CosmosDBSqlContainerResource>> Container(
+    public async Task<ArmOperation<CosmosDBSqlContainerResource>> ContainerAsync(
         AzureResourceIdentifier azureResourceIdentifier, string databaseName, string containerName, CosmosDBSqlContainerCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
@@ -65,7 +65,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await database.Value.GetCosmosDBSqlContainers().CreateOrUpdateAsync(WaitUntil.Completed, containerName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<CosmosDBSqlTriggerResource>> Trigger(
+    public async Task<ArmOperation<CosmosDBSqlTriggerResource>> TriggerAsync(
         AzureResourceIdentifier azureResourceIdentifier, string databaseName, string containerName, string triggerName, CosmosDBSqlTriggerCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
@@ -80,7 +80,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await container.Value.GetCosmosDBSqlTriggers().CreateOrUpdateAsync(WaitUntil.Completed, triggerName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<CosmosDBSqlStoredProcedureResource>> StoredProcedure(
+    public async Task<ArmOperation<CosmosDBSqlStoredProcedureResource>> StoredProcedureAsync(
         AzureResourceIdentifier azureResourceIdentifier, string databaseName, string containerName, string storedProcedureName, CosmosDBSqlStoredProcedureCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
@@ -95,7 +95,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await container.Value.GetCosmosDBSqlStoredProcedures().CreateOrUpdateAsync(WaitUntil.Completed, storedProcedureName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<CosmosDBSqlUserDefinedFunctionResource>> UserDefinedFunction(
+    public async Task<ArmOperation<CosmosDBSqlUserDefinedFunctionResource>> UserDefinedFunctionAsync(
         AzureResourceIdentifier azureResourceIdentifier, string databaseName, string containerName, string functionName, CosmosDBSqlUserDefinedFunctionCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
@@ -110,7 +110,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await container.Value.GetCosmosDBSqlUserDefinedFunctions().CreateOrUpdateAsync(WaitUntil.Completed, functionName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<CosmosDBSqlDatabaseThroughputSettingResource>> DatabaseThroughputSetting(
+    public async Task<ArmOperation<CosmosDBSqlDatabaseThroughputSettingResource>> DatabaseThroughputSettingAsync(
         AzureResourceIdentifier azureResourceIdentifier, string databaseName, ThroughputSettingsUpdateData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
@@ -123,7 +123,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await database.Value.GetCosmosDBSqlDatabaseThroughputSetting().CreateOrUpdateAsync(WaitUntil.Completed, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<CosmosDBSqlContainerThroughputSettingResource>> ContainerThroughputSetting(
+    public async Task<ArmOperation<CosmosDBSqlContainerThroughputSettingResource>> ContainerThroughputSettingAsync(
         AzureResourceIdentifier azureResourceIdentifier, string databaseName, string containerName, ThroughputSettingsUpdateData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
@@ -137,7 +137,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await container.Value.GetCosmosDBSqlContainerThroughputSetting().CreateOrUpdateAsync(WaitUntil.Completed, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<CosmosDBSqlClientEncryptionKeyResource>> EncryptionKey(
+    public async Task<ArmOperation<CosmosDBSqlClientEncryptionKeyResource>> EncryptionKeyAsync(
         AzureResourceIdentifier azureResourceIdentifier, string databaseName, string encryptionKeyName, CosmosDBSqlClientEncryptionKeyCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
@@ -151,7 +151,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await database.Value.GetCosmosDBSqlClientEncryptionKeys().CreateOrUpdateAsync(WaitUntil.Completed, encryptionKeyName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<CosmosDBTableResource>> Table(
+    public async Task<ArmOperation<CosmosDBTableResource>> TableAsync(
         AzureResourceIdentifier azureResourceIdentifier, string databaseName, CosmosDBTableCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
@@ -164,7 +164,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await account.Value.GetCosmosDBTables().CreateOrUpdateAsync(WaitUntil.Completed, databaseName, properties, cancellationToken);
     }
 
-    public async Task<Response<CosmosDBSqlContainerResource>> GetContainer(AzureResourceIdentifier azureResourceIdentifier, string databaseName, string containerName, CancellationToken cancellationToken = default)
+    public async Task<Response<CosmosDBSqlContainerResource>> GetContainerAsync(AzureResourceIdentifier azureResourceIdentifier, string databaseName, string containerName, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
@@ -176,7 +176,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await database.Value.GetCosmosDBSqlContainerAsync(containerName, cancellationToken);
     }
 
-    public async Task<Response<CosmosDBSqlDatabaseResource>> GetDatabase(AzureResourceIdentifier azureResourceIdentifier, string databaseName, CancellationToken cancellationToken = default)
+    public async Task<Response<CosmosDBSqlDatabaseResource>> GetDatabaseAsync(AzureResourceIdentifier azureResourceIdentifier, string databaseName, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
@@ -187,7 +187,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         return await account.Value.GetCosmosDBSqlDatabaseAsync(databaseName, cancellationToken);
     }
 
-    public async Task<Response<CosmosDBAccountResource>> GetAccount(AzureResourceIdentifier azureResourceIdentifier, CancellationToken cancellationToken = default)
+    public async Task<Response<CosmosDBAccountResource>> GetAccountAsync(AzureResourceIdentifier azureResourceIdentifier, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);

--- a/src/ModularPipelines.Azure/Provisioning/Cosmos/AzureCosmosSqlProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/Cosmos/AzureCosmosSqlProvisioner.cs
@@ -20,7 +20,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentNullException.ThrowIfNull(properties);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var account = await GetAccount(azureResourceIdentifier, cancellationToken);
+        var account = await GetAccountAsync(azureResourceIdentifier, cancellationToken);
 
         return await account.Value.GetCosmosDBSqlDatabases().CreateOrUpdateAsync(WaitUntil.Completed, databaseName, properties, cancellationToken);
     }
@@ -33,7 +33,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentNullException.ThrowIfNull(properties);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var account = await GetAccount(azureResourceIdentifier, cancellationToken);
+        var account = await GetAccountAsync(azureResourceIdentifier, cancellationToken);
 
         return await account.Value.GetCosmosDBSqlRoleAssignments().CreateOrUpdateAsync(WaitUntil.Completed, databaseName, properties, cancellationToken);
     }
@@ -46,7 +46,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentNullException.ThrowIfNull(properties);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var account = await GetAccount(azureResourceIdentifier, cancellationToken);
+        var account = await GetAccountAsync(azureResourceIdentifier, cancellationToken);
 
         return await account.Value.GetCosmosDBSqlRoleDefinitions().CreateOrUpdateAsync(WaitUntil.Completed, databaseName, properties, cancellationToken);
     }
@@ -60,7 +60,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentNullException.ThrowIfNull(properties);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var database = await GetDatabase(azureResourceIdentifier, databaseName, cancellationToken);
+        var database = await GetDatabaseAsync(azureResourceIdentifier, databaseName, cancellationToken);
 
         return await database.Value.GetCosmosDBSqlContainers().CreateOrUpdateAsync(WaitUntil.Completed, containerName, properties, cancellationToken);
     }
@@ -75,7 +75,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentNullException.ThrowIfNull(properties);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var container = await GetContainer(azureResourceIdentifier, databaseName, containerName, cancellationToken);
+        var container = await GetContainerAsync(azureResourceIdentifier, databaseName, containerName, cancellationToken);
 
         return await container.Value.GetCosmosDBSqlTriggers().CreateOrUpdateAsync(WaitUntil.Completed, triggerName, properties, cancellationToken);
     }
@@ -90,7 +90,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentNullException.ThrowIfNull(properties);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var container = await GetContainer(azureResourceIdentifier, databaseName, containerName, cancellationToken);
+        var container = await GetContainerAsync(azureResourceIdentifier, databaseName, containerName, cancellationToken);
 
         return await container.Value.GetCosmosDBSqlStoredProcedures().CreateOrUpdateAsync(WaitUntil.Completed, storedProcedureName, properties, cancellationToken);
     }
@@ -105,7 +105,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentNullException.ThrowIfNull(properties);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var container = await GetContainer(azureResourceIdentifier, databaseName, containerName, cancellationToken);
+        var container = await GetContainerAsync(azureResourceIdentifier, databaseName, containerName, cancellationToken);
 
         return await container.Value.GetCosmosDBSqlUserDefinedFunctions().CreateOrUpdateAsync(WaitUntil.Completed, functionName, properties, cancellationToken);
     }
@@ -118,7 +118,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentNullException.ThrowIfNull(properties);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var database = await GetDatabase(azureResourceIdentifier, databaseName, cancellationToken);
+        var database = await GetDatabaseAsync(azureResourceIdentifier, databaseName, cancellationToken);
 
         return await database.Value.GetCosmosDBSqlDatabaseThroughputSetting().CreateOrUpdateAsync(WaitUntil.Completed, properties, cancellationToken);
     }
@@ -132,7 +132,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentNullException.ThrowIfNull(properties);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var container = await GetContainer(azureResourceIdentifier, databaseName, containerName, cancellationToken);
+        var container = await GetContainerAsync(azureResourceIdentifier, databaseName, containerName, cancellationToken);
 
         return await container.Value.GetCosmosDBSqlContainerThroughputSetting().CreateOrUpdateAsync(WaitUntil.Completed, properties, cancellationToken);
     }
@@ -146,7 +146,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentNullException.ThrowIfNull(properties);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var database = await GetDatabase(azureResourceIdentifier, databaseName, cancellationToken);
+        var database = await GetDatabaseAsync(azureResourceIdentifier, databaseName, cancellationToken);
 
         return await database.Value.GetCosmosDBSqlClientEncryptionKeys().CreateOrUpdateAsync(WaitUntil.Completed, encryptionKeyName, properties, cancellationToken);
     }
@@ -159,7 +159,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentNullException.ThrowIfNull(properties);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var account = await GetAccount(azureResourceIdentifier, cancellationToken);
+        var account = await GetAccountAsync(azureResourceIdentifier, cancellationToken);
 
         return await account.Value.GetCosmosDBTables().CreateOrUpdateAsync(WaitUntil.Completed, databaseName, properties, cancellationToken);
     }
@@ -171,7 +171,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var database = await GetDatabase(azureResourceIdentifier, databaseName, cancellationToken);
+        var database = await GetDatabaseAsync(azureResourceIdentifier, databaseName, cancellationToken);
 
         return await database.Value.GetCosmosDBSqlContainerAsync(containerName, cancellationToken);
     }
@@ -182,7 +182,7 @@ public class AzureCosmosSqlProvisioner : BaseAzureProvisioner
         ArgumentException.ThrowIfNullOrWhiteSpace(databaseName);
         ArgumentException.ThrowIfNullOrWhiteSpace(azureResourceIdentifier.ResourceName);
 
-        var account = await GetAccount(azureResourceIdentifier, cancellationToken);
+        var account = await GetAccountAsync(azureResourceIdentifier, cancellationToken);
 
         return await account.Value.GetCosmosDBSqlDatabaseAsync(databaseName, cancellationToken);
     }

--- a/src/ModularPipelines.Azure/Provisioning/Gateways/AzureGatewayProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/Gateways/AzureGatewayProvisioner.cs
@@ -11,7 +11,7 @@ public class AzureGatewayProvisioner : BaseAzureProvisioner
     {
     }
 
-    public async Task<ArmOperation<ApplicationGatewayResource>> ApplicationGateway(AzureResourceIdentifier azureResourceIdentifier, ApplicationGatewayData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<ApplicationGatewayResource>> ApplicationGatewayAsync(AzureResourceIdentifier azureResourceIdentifier, ApplicationGatewayData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -21,7 +21,7 @@ public class AzureGatewayProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<VirtualNetworkGatewayResource>> VirtualNetworkGateway(AzureResourceIdentifier azureResourceIdentifier, VirtualNetworkGatewayData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<VirtualNetworkGatewayResource>> VirtualNetworkGatewayAsync(AzureResourceIdentifier azureResourceIdentifier, VirtualNetworkGatewayData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -31,7 +31,7 @@ public class AzureGatewayProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<NatGatewayResource>> NatGateway(AzureResourceIdentifier azureResourceIdentifier, NatGatewayData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<NatGatewayResource>> NatGatewayAsync(AzureResourceIdentifier azureResourceIdentifier, NatGatewayData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -41,7 +41,7 @@ public class AzureGatewayProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<VpnGatewayResource>> VpnGateway(AzureResourceIdentifier azureResourceIdentifier, VpnGatewayData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<VpnGatewayResource>> VpnGatewayAsync(AzureResourceIdentifier azureResourceIdentifier, VpnGatewayData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -51,7 +51,7 @@ public class AzureGatewayProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<VirtualNetworkGatewayConnectionResource>> VpnGateway(AzureResourceIdentifier azureResourceIdentifier, VirtualNetworkGatewayConnectionData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<VirtualNetworkGatewayConnectionResource>> VpnGatewayAsync(AzureResourceIdentifier azureResourceIdentifier, VirtualNetworkGatewayConnectionData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -61,7 +61,7 @@ public class AzureGatewayProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<ExpressRouteGatewayResource>> GetExpressRouteGateway(AzureResourceIdentifier azureResourceIdentifier, ExpressRouteGatewayData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<ExpressRouteGatewayResource>> GetExpressRouteGatewayAsync(AzureResourceIdentifier azureResourceIdentifier, ExpressRouteGatewayData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -71,7 +71,7 @@ public class AzureGatewayProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<P2SVpnGatewayResource>> P2SVpnGateway(AzureResourceIdentifier azureResourceIdentifier, P2SVpnGatewayData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<P2SVpnGatewayResource>> P2SVpnGatewayAsync(AzureResourceIdentifier azureResourceIdentifier, P2SVpnGatewayData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -81,7 +81,7 @@ public class AzureGatewayProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<LocalNetworkGatewayResource>> LocalNetworkGateway(AzureResourceIdentifier azureResourceIdentifier, LocalNetworkGatewayData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<LocalNetworkGatewayResource>> LocalNetworkGatewayAsync(AzureResourceIdentifier azureResourceIdentifier, LocalNetworkGatewayData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);

--- a/src/ModularPipelines.Azure/Provisioning/IAzureProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/IAzureProvisioner.cs
@@ -21,21 +21,21 @@ namespace ModularPipelines.Azure.Provisioning;
 
 public interface IAzureProvisioner
 {
-    Task<ArmOperation<ResourceGroupResource>> ResourceGroup(AzureSubscriptionIdentifier azureSubscriptionIdentifier, string resourceGroupName, ResourceGroupData properties, CancellationToken cancellationToken = default);
+    Task<ArmOperation<ResourceGroupResource>> ResourceGroupAsync(AzureSubscriptionIdentifier azureSubscriptionIdentifier, string resourceGroupName, ResourceGroupData properties, CancellationToken cancellationToken = default);
 
-    Task<ArmOperation<KeyVaultResource>> KeyVault(AzureResourceIdentifier azureResourceIdentifier, KeyVaultCreateOrUpdateContent properties, CancellationToken cancellationToken = default);
+    Task<ArmOperation<KeyVaultResource>> KeyVaultAsync(AzureResourceIdentifier azureResourceIdentifier, KeyVaultCreateOrUpdateContent properties, CancellationToken cancellationToken = default);
 
-    Task<ArmOperation<RedisResource>> Redis(AzureResourceIdentifier azureResourceIdentifier, RedisCreateOrUpdateContent properties, CancellationToken cancellationToken = default);
+    Task<ArmOperation<RedisResource>> RedisAsync(AzureResourceIdentifier azureResourceIdentifier, RedisCreateOrUpdateContent properties, CancellationToken cancellationToken = default);
 
-    Task<ArmOperation<ContainerRegistryResource>> ContainerRegistry(AzureResourceIdentifier azureResourceIdentifier, ContainerRegistryData properties, CancellationToken cancellationToken = default);
+    Task<ArmOperation<ContainerRegistryResource>> ContainerRegistryAsync(AzureResourceIdentifier azureResourceIdentifier, ContainerRegistryData properties, CancellationToken cancellationToken = default);
 
-    Task<ArmOperation<AppConfigurationStoreResource>> AppConfiguration(AzureResourceIdentifier azureResourceIdentifier, AppConfigurationStoreData properties, CancellationToken cancellationToken = default);
+    Task<ArmOperation<AppConfigurationStoreResource>> AppConfigurationAsync(AzureResourceIdentifier azureResourceIdentifier, AppConfigurationStoreData properties, CancellationToken cancellationToken = default);
 
-    Task<ArmOperation<OperationalInsightsWorkspaceResource>> OperationalInsightsWorkspace(AzureResourceIdentifier azureResourceIdentifier, OperationalInsightsWorkspaceData properties, CancellationToken cancellationToken = default);
+    Task<ArmOperation<OperationalInsightsWorkspaceResource>> OperationalInsightsWorkspaceAsync(AzureResourceIdentifier azureResourceIdentifier, OperationalInsightsWorkspaceData properties, CancellationToken cancellationToken = default);
 
-    Task<ArmOperation<OperationalInsightsClusterResource>> OperationalInsightsCluster(AzureResourceIdentifier azureResourceIdentifier, OperationalInsightsClusterData properties, CancellationToken cancellationToken = default);
+    Task<ArmOperation<OperationalInsightsClusterResource>> OperationalInsightsClusterAsync(AzureResourceIdentifier azureResourceIdentifier, OperationalInsightsClusterData properties, CancellationToken cancellationToken = default);
 
-    Task<ArmOperation<ApplicationInsightsComponentResource>> ApplicationInsights(AzureResourceIdentifier azureResourceIdentifier, ApplicationInsightsComponentData properties, CancellationToken cancellationToken = default);
+    Task<ArmOperation<ApplicationInsightsComponentResource>> ApplicationInsightsAsync(AzureResourceIdentifier azureResourceIdentifier, ApplicationInsightsComponentData properties, CancellationToken cancellationToken = default);
 
     AzureComputeProvisioner Compute { get; }
 

--- a/src/ModularPipelines.Azure/Provisioning/Network/AzureNetworkProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/Network/AzureNetworkProvisioner.cs
@@ -11,7 +11,7 @@ public class AzureNetworkProvisioner : BaseAzureProvisioner
     {
     }
 
-    public async Task<ArmOperation<VirtualNetworkResource>> VirtualNetwork(AzureResourceIdentifier azureResourceIdentifier, VirtualNetworkData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<VirtualNetworkResource>> VirtualNetworkAsync(AzureResourceIdentifier azureResourceIdentifier, VirtualNetworkData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -21,7 +21,7 @@ public class AzureNetworkProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<SubnetResource>> Subnet(AzureResourceIdentifier azureResourceIdentifier, string subnetName, SubnetData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<SubnetResource>> SubnetAsync(AzureResourceIdentifier azureResourceIdentifier, string subnetName, SubnetData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(subnetName);
@@ -33,7 +33,7 @@ public class AzureNetworkProvisioner : BaseAzureProvisioner
         return await virtualNetwork.Value.GetSubnets().CreateOrUpdateAsync(WaitUntil.Completed, subnetName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<PrivateLinkServiceResource>> PrivateLinkService(AzureResourceIdentifier azureResourceIdentifier, string subnetName, PrivateLinkServiceData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<PrivateLinkServiceResource>> PrivateLinkServiceAsync(AzureResourceIdentifier azureResourceIdentifier, string subnetName, PrivateLinkServiceData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -43,7 +43,7 @@ public class AzureNetworkProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<PrivateEndpointResource>> PrivateEndpoint(AzureResourceIdentifier azureResourceIdentifier, string subnetName, PrivateEndpointData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<PrivateEndpointResource>> PrivateEndpointAsync(AzureResourceIdentifier azureResourceIdentifier, string subnetName, PrivateEndpointData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -53,7 +53,7 @@ public class AzureNetworkProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<WebApplicationFirewallPolicyResource>> WebApplicationFirewallPolicy(AzureResourceIdentifier azureResourceIdentifier, string subnetName, WebApplicationFirewallPolicyData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<WebApplicationFirewallPolicyResource>> WebApplicationFirewallPolicyAsync(AzureResourceIdentifier azureResourceIdentifier, string subnetName, WebApplicationFirewallPolicyData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);

--- a/src/ModularPipelines.Azure/Provisioning/PubSub/AzureServiceBusProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/PubSub/AzureServiceBusProvisioner.cs
@@ -11,7 +11,7 @@ public class AzureServiceBusProvisioner : BaseAzureProvisioner
     {
     }
 
-    public async Task<ArmOperation<ServiceBusNamespaceResource>> Namespace(AzureResourceIdentifier azureResourceIdentifier, ServiceBusNamespaceData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<ServiceBusNamespaceResource>> NamespaceAsync(AzureResourceIdentifier azureResourceIdentifier, ServiceBusNamespaceData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -21,7 +21,7 @@ public class AzureServiceBusProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<MigrationConfigurationResource>> MigrationConfiguration(AzureResourceIdentifier azureResourceIdentifier, string queueName, MigrationConfigurationData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<MigrationConfigurationResource>> MigrationConfigurationAsync(AzureResourceIdentifier azureResourceIdentifier, string queueName, MigrationConfigurationData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
@@ -34,7 +34,7 @@ public class AzureServiceBusProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, queueName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<ServiceBusQueueResource>> Queue(AzureResourceIdentifier azureResourceIdentifier, string queueName, ServiceBusQueueData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<ServiceBusQueueResource>> QueueAsync(AzureResourceIdentifier azureResourceIdentifier, string queueName, ServiceBusQueueData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(queueName);
@@ -47,7 +47,7 @@ public class AzureServiceBusProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, queueName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<ServiceBusTopicResource>> Topic(AzureResourceIdentifier azureResourceIdentifier, string topicName, ServiceBusTopicData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<ServiceBusTopicResource>> TopicAsync(AzureResourceIdentifier azureResourceIdentifier, string topicName, ServiceBusTopicData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
@@ -60,7 +60,7 @@ public class AzureServiceBusProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, topicName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<ServiceBusSubscriptionResource>> Subscription(AzureResourceIdentifier azureResourceIdentifier, string topicName, string subscriptionName, ServiceBusSubscriptionData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<ServiceBusSubscriptionResource>> SubscriptionAsync(AzureResourceIdentifier azureResourceIdentifier, string topicName, string subscriptionName, ServiceBusSubscriptionData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(topicName);
@@ -76,7 +76,7 @@ public class AzureServiceBusProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, subscriptionName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<ServiceBusTopicAuthorizationRuleResource>> TopicAuthorizationRule(
+    public async Task<ArmOperation<ServiceBusTopicAuthorizationRuleResource>> TopicAuthorizationRuleAsync(
         AzureResourceIdentifier azureResourceIdentifier, string topicName, string authorizationRuleName,
         ServiceBusAuthorizationRuleData properties, CancellationToken cancellationToken = default)
     {
@@ -94,7 +94,7 @@ public class AzureServiceBusProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, authorizationRuleName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<ServiceBusNamespaceAuthorizationRuleResource>> NamespaceAuthorizationRule(
+    public async Task<ArmOperation<ServiceBusNamespaceAuthorizationRuleResource>> NamespaceAuthorizationRuleAsync(
         AzureResourceIdentifier azureResourceIdentifier, string authorizationRuleName,
         ServiceBusAuthorizationRuleData properties, CancellationToken cancellationToken = default)
     {
@@ -109,7 +109,7 @@ public class AzureServiceBusProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, authorizationRuleName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<ServiceBusQueueAuthorizationRuleResource>> QueueAuthorizationRule(
+    public async Task<ArmOperation<ServiceBusQueueAuthorizationRuleResource>> QueueAuthorizationRuleAsync(
         AzureResourceIdentifier azureResourceIdentifier, string queueName, string authorizationRuleName,
         ServiceBusAuthorizationRuleData properties, CancellationToken cancellationToken = default)
     {

--- a/src/ModularPipelines.Azure/Provisioning/Security/AzureSecurityProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/Security/AzureSecurityProvisioner.cs
@@ -15,7 +15,7 @@ public class AzureSecurityProvisioner : BaseAzureProvisioner
     {
     }
 
-    public async Task<ArmOperation<UserAssignedIdentityResource>> UserAssignedIdentity(AzureResourceIdentifier azureResourceIdentifier, UserAssignedIdentityData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<UserAssignedIdentityResource>> UserAssignedIdentityAsync(AzureResourceIdentifier azureResourceIdentifier, UserAssignedIdentityData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -25,7 +25,7 @@ public class AzureSecurityProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<RoleAssignmentResource>> RoleAssignment(AzureResourceIdentifier azureResourceIdentifier, RoleAssignmentCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<RoleAssignmentResource>> RoleAssignmentAsync(AzureResourceIdentifier azureResourceIdentifier, RoleAssignmentCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -35,7 +35,7 @@ public class AzureSecurityProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<RoleManagementPolicyAssignmentResource>> RoleManagementPolicyAssignment(AzureResourceIdentifier azureResourceIdentifier, RoleManagementPolicyAssignmentData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<RoleManagementPolicyAssignmentResource>> RoleManagementPolicyAssignmentAsync(AzureResourceIdentifier azureResourceIdentifier, RoleManagementPolicyAssignmentData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -45,7 +45,7 @@ public class AzureSecurityProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<AuthorizationRoleDefinitionResource>> AuthorizationRoleDefinition(AzureScope scope, ResourceIdentifier roleDefinitionIdentifier, AuthorizationRoleDefinitionData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<AuthorizationRoleDefinitionResource>> AuthorizationRoleDefinitionAsync(AzureScope scope, ResourceIdentifier roleDefinitionIdentifier, AuthorizationRoleDefinitionData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(scope);
         ArgumentNullException.ThrowIfNull(roleDefinitionIdentifier);

--- a/src/ModularPipelines.Azure/Provisioning/Storage/AzureStorageProvisioner.cs
+++ b/src/ModularPipelines.Azure/Provisioning/Storage/AzureStorageProvisioner.cs
@@ -12,7 +12,7 @@ public class AzureStorageProvisioner : BaseAzureProvisioner
     {
     }
 
-    public async Task<ArmOperation<StorageAccountResource>> StorageAccount(AzureResourceIdentifier azureResourceIdentifier, StorageAccountCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<StorageAccountResource>> StorageAccountAsync(AzureResourceIdentifier azureResourceIdentifier, StorageAccountCreateOrUpdateContent properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -22,7 +22,7 @@ public class AzureStorageProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, azureResourceIdentifier.ResourceName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<BlobServiceResource>> BlobService(AzureResourceIdentifier azureResourceIdentifier, BlobServiceData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<BlobServiceResource>> BlobServiceAsync(AzureResourceIdentifier azureResourceIdentifier, BlobServiceData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -32,7 +32,7 @@ public class AzureStorageProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<BlobContainerResource>> BlobContainer(AzureResourceIdentifier azureResourceIdentifier, string containerName, BlobContainerData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<BlobContainerResource>> BlobContainerAsync(AzureResourceIdentifier azureResourceIdentifier, string containerName, BlobContainerData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(containerName);
@@ -42,7 +42,7 @@ public class AzureStorageProvisioner : BaseAzureProvisioner
         return await GetStorageAccount(azureResourceIdentifier).GetBlobService().GetBlobContainers().CreateOrUpdateAsync(WaitUntil.Completed, containerName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<TableServiceResource>> TableService(AzureResourceIdentifier azureResourceIdentifier, TableServiceData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<TableServiceResource>> TableServiceAsync(AzureResourceIdentifier azureResourceIdentifier, TableServiceData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -52,7 +52,7 @@ public class AzureStorageProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<TableResource>> Table(AzureResourceIdentifier azureResourceIdentifier, string tableName, TableData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<TableResource>> TableAsync(AzureResourceIdentifier azureResourceIdentifier, string tableName, TableData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
@@ -62,7 +62,7 @@ public class AzureStorageProvisioner : BaseAzureProvisioner
         return await GetStorageAccount(azureResourceIdentifier).GetTableService().GetTables().CreateOrUpdateAsync(WaitUntil.Completed, tableName, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<FileServiceResource>> FileService(AzureResourceIdentifier azureResourceIdentifier, FileServiceData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<FileServiceResource>> FileServiceAsync(AzureResourceIdentifier azureResourceIdentifier, FileServiceData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -72,7 +72,7 @@ public class AzureStorageProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<FileShareResource>> FileShare(AzureResourceIdentifier azureResourceIdentifier, string fileShareName, FileShareData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<FileShareResource>> FileShareAsync(AzureResourceIdentifier azureResourceIdentifier, string fileShareName, FileShareData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(fileShareName);
@@ -82,7 +82,7 @@ public class AzureStorageProvisioner : BaseAzureProvisioner
         return await GetStorageAccount(azureResourceIdentifier).GetFileService().GetFileShares().CreateOrUpdateAsync(WaitUntil.Completed, fileShareName, properties, expand: null, cancellationToken);
     }
 
-    public async Task<ArmOperation<QueueServiceResource>> QueueService(AzureResourceIdentifier azureResourceIdentifier, QueueServiceData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<QueueServiceResource>> QueueServiceAsync(AzureResourceIdentifier azureResourceIdentifier, QueueServiceData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentNullException.ThrowIfNull(properties);
@@ -92,7 +92,7 @@ public class AzureStorageProvisioner : BaseAzureProvisioner
             .CreateOrUpdateAsync(WaitUntil.Completed, properties, cancellationToken);
     }
 
-    public async Task<ArmOperation<StorageQueueResource>> StorageQueue(AzureResourceIdentifier azureResourceIdentifier, string storageQueueName, StorageQueueData properties, CancellationToken cancellationToken = default)
+    public async Task<ArmOperation<StorageQueueResource>> StorageQueueAsync(AzureResourceIdentifier azureResourceIdentifier, string storageQueueName, StorageQueueData properties, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(azureResourceIdentifier);
         ArgumentException.ThrowIfNullOrWhiteSpace(storageQueueName);

--- a/src/ModularPipelines.Build/Modules/NugetVersionGeneratorModule.cs
+++ b/src/ModularPipelines.Build/Modules/NugetVersionGeneratorModule.cs
@@ -20,7 +20,7 @@ public class NugetVersionGeneratorModule : Module<string>
 
     protected override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
     {
-        var gitVersionInformation = await context.Git().Versioning.GetGitVersioningInformation();
+        var gitVersionInformation = await context.Git().Versioning.GetVersioningInformationAsync(cancellationToken);
 
         var version = _publishSettings.Value.IsAlpha
             ? $"{gitVersionInformation.FullSemVer}-alpha{gitVersionInformation.CommitsSinceVersionSourcePadded!}"

--- a/src/ModularPipelines.Examples/Modules/Launch/FinalCountdownModule.cs
+++ b/src/ModularPipelines.Examples/Modules/Launch/FinalCountdownModule.cs
@@ -36,7 +36,7 @@ public class FinalCountdownModule : Module<CountdownStatus>
         context.Logger.LogDebug("Ground power disconnect confirmed");
 
         // Simulate countdown with SubModules for visibility
-        await context.SubModule("T-10 seconds", async () =>
+        await context.SubModuleAsync("T-10 seconds", async () =>
         {
             context.Logger.LogInformation("T-10... Main engine start sequence initiated");
             context.Logger.LogDebug("Fuel prevalves opening...");
@@ -53,9 +53,9 @@ public class FinalCountdownModule : Module<CountdownStatus>
             context.Logger.LogInformation("T-6... Engine 3 ignition confirmed");
             await Task.Delay(TimeSpan.FromMilliseconds(200), cancellationToken);
             return true;
-        });
+        }, cancellationToken);
 
-        await context.SubModule("T-5 seconds", async () =>
+        await context.SubModuleAsync("T-5 seconds", async () =>
         {
             context.Logger.LogInformation("T-5... All engines at full thrust");
             context.Logger.LogDebug("Engine 1 thrust: 100%");
@@ -74,9 +74,9 @@ public class FinalCountdownModule : Module<CountdownStatus>
             await Task.Delay(TimeSpan.FromMilliseconds(250), cancellationToken);
             context.Logger.LogInformation("T-1... Guidance is internal");
             return true;
-        });
+        }, cancellationToken);
 
-        await context.SubModule("T-0 seconds", async () =>
+        await context.SubModuleAsync("T-0 seconds", async () =>
         {
             context.Logger.LogInformation("T-0... LIFTOFF!");
             context.Logger.LogDebug("Hold-down clamps released");
@@ -88,7 +88,7 @@ public class FinalCountdownModule : Module<CountdownStatus>
             context.Logger.LogDebug("Throttling down for Max Q...");
             await Task.Delay(TimeSpan.FromMilliseconds(400), cancellationToken);
             return true;
-        });
+        }, cancellationToken);
 
         return new CountdownStatus(
             SecondsRemaining: 0,

--- a/src/ModularPipelines.Examples/Modules/Launch/TelemetryStreamModule.cs
+++ b/src/ModularPipelines.Examples/Modules/Launch/TelemetryStreamModule.cs
@@ -26,7 +26,7 @@ public class TelemetryStreamModule : Module<TelemetryData>
         context.Logger.LogDebug("Frame sync acquired");
 
         // Simulate telemetry updates with SubModules
-        await context.SubModule("Telemetry T+30s", async () =>
+        await context.SubModuleAsync("Telemetry T+30s", async () =>
         {
             context.Logger.LogInformation("T+30s: First stage powered flight");
             context.Logger.LogDebug("Altitude: 15 km");
@@ -39,9 +39,9 @@ public class TelemetryStreamModule : Module<TelemetryData>
             context.Logger.LogDebug("Trajectory deviation: 0.02°");
             await Task.Delay(TimeSpan.FromMilliseconds(400), cancellationToken);
             return true;
-        });
+        }, cancellationToken);
 
-        await context.SubModule("Telemetry T+60s", async () =>
+        await context.SubModuleAsync("Telemetry T+60s", async () =>
         {
             context.Logger.LogInformation("T+60s: Approaching Max-Q");
             context.Logger.LogDebug("Altitude: 50 km");
@@ -53,9 +53,9 @@ public class TelemetryStreamModule : Module<TelemetryData>
             context.Logger.LogDebug("Downrange distance: 45 km");
             await Task.Delay(TimeSpan.FromMilliseconds(400), cancellationToken);
             return true;
-        });
+        }, cancellationToken);
 
-        await context.SubModule("Telemetry T+90s", async () =>
+        await context.SubModuleAsync("Telemetry T+90s", async () =>
         {
             context.Logger.LogInformation("T+90s: MECO - Main Engine Cutoff");
             context.Logger.LogDebug("Altitude: 120 km");
@@ -66,9 +66,9 @@ public class TelemetryStreamModule : Module<TelemetryData>
             context.Logger.LogDebug("Stage separation pyros: ARMED");
             await Task.Delay(TimeSpan.FromMilliseconds(400), cancellationToken);
             return true;
-        });
+        }, cancellationToken);
 
-        await context.SubModule("Telemetry T+120s", async () =>
+        await context.SubModuleAsync("Telemetry T+120s", async () =>
         {
             context.Logger.LogInformation("T+120s: Stage separation and S2 ignition");
             context.Logger.LogDebug("Stage separation confirmed");
@@ -81,7 +81,7 @@ public class TelemetryStreamModule : Module<TelemetryData>
             context.Logger.LogDebug("Fairing halves tracking confirmed");
             await Task.Delay(TimeSpan.FromMilliseconds(400), cancellationToken);
             return true;
-        });
+        }, cancellationToken);
 
         var missionElapsed = DateTime.UtcNow - launch.LaunchTime;
 

--- a/src/ModularPipelines.Examples/Modules/Propulsion/PropulsionDiagnosticsModule.cs
+++ b/src/ModularPipelines.Examples/Modules/Propulsion/PropulsionDiagnosticsModule.cs
@@ -16,7 +16,7 @@ public class PropulsionDiagnosticsModule : Module<PropulsionStatus>
         context.Logger.LogDebug("Loading engine telemetry baseline parameters...");
 
         // Use SubModules to check each engine individually
-        var engine1 = await context.SubModule("Engine 1 Diagnostics", async () =>
+        var engine1 = await context.SubModuleAsync("Engine 1 Diagnostics", async () =>
         {
             context.Logger.LogInformation("Engine 1: Starting diagnostic sequence...");
             context.Logger.LogDebug("Engine 1: Checking fuel injector pressure...");
@@ -30,9 +30,9 @@ public class PropulsionDiagnosticsModule : Module<PropulsionStatus>
             context.Logger.LogDebug("Engine 1: Turbopump RPM: 35,420 - NOMINAL");
             context.Logger.LogInformation("Engine 1: Diagnostic sequence complete - PASS");
             return new EngineStatus(1, true, 25.0, 101.3);
-        });
+        }, cancellationToken);
 
-        var engine2 = await context.SubModule("Engine 2 Diagnostics", async () =>
+        var engine2 = await context.SubModuleAsync("Engine 2 Diagnostics", async () =>
         {
             context.Logger.LogInformation("Engine 2: Starting diagnostic sequence...");
             context.Logger.LogDebug("Engine 2: Checking fuel injector pressure...");
@@ -46,9 +46,9 @@ public class PropulsionDiagnosticsModule : Module<PropulsionStatus>
             context.Logger.LogDebug("Engine 2: Turbopump RPM: 35,380 - NOMINAL");
             context.Logger.LogInformation("Engine 2: Diagnostic sequence complete - PASS");
             return new EngineStatus(2, true, 24.8, 101.1);
-        });
+        }, cancellationToken);
 
-        var engine3 = await context.SubModule("Engine 3 Diagnostics", async () =>
+        var engine3 = await context.SubModuleAsync("Engine 3 Diagnostics", async () =>
         {
             context.Logger.LogInformation("Engine 3: Starting diagnostic sequence...");
             context.Logger.LogDebug("Engine 3: Checking fuel injector pressure...");
@@ -62,7 +62,7 @@ public class PropulsionDiagnosticsModule : Module<PropulsionStatus>
             context.Logger.LogDebug("Engine 3: Turbopump RPM: 35,445 - NOMINAL");
             context.Logger.LogInformation("Engine 3: Diagnostic sequence complete - PASS");
             return new EngineStatus(3, true, 25.2, 101.5);
-        });
+        }, cancellationToken);
 
         // Additional diagnostic delay
         context.Logger.LogDebug("Running cross-engine synchronization check...");

--- a/src/ModularPipelines.Git/GitVersioning.cs
+++ b/src/ModularPipelines.Git/GitVersioning.cs
@@ -15,7 +15,7 @@ namespace ModularPipelines.Git;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>Thread Safety:</b> This class is thread-safe. The <see cref="GetGitVersioningInformation"/>
+/// <b>Thread Safety:</b> This class is thread-safe. The <see cref="GetVersioningInformationAsync"/>
 /// method can be called concurrently from multiple threads without external synchronization.
 /// </para>
 /// <para>
@@ -50,9 +50,10 @@ internal class GitVersioning : IGitVersioning
         _temporaryFolder = fileSystemContext.CreateTemporaryFolder();
     }
 
-    public async Task<GitVersionInformation> GetGitVersioningInformation()
+    public async Task<GitVersionInformation> GetVersioningInformationAsync(
+        CancellationToken cancellationToken = default)
     {
-        await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
+        await _semaphoreSlim.WaitAsync(cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -61,7 +62,7 @@ internal class GitVersioning : IGitVersioning
                 return _prefetchedGitVersionInformation;
             }
 
-            var repositoryInfo = await _gitInformation.GetInfoAsync().ConfigureAwait(false)
+            var repositoryInfo = await _gitInformation.GetInfoAsync(cancellationToken).ConfigureAwait(false)
                 ?? throw new InvalidOperationException("Git repository information is unavailable.");
 
             await _command.ExecuteCommandLineToolAsync(new GenericCommandLineToolOptions("dotnet")
@@ -74,9 +75,9 @@ internal class GitVersioning : IGitVersioning
                     "GitVersion.Tool",
                     "--version", "6.*"
                 ],
-            }).ConfigureAwait(false);
+            }, cancellationToken: cancellationToken).ConfigureAwait(false);
 
-            await TryWriteConfigurationFile(repositoryInfo.Root).ConfigureAwait(false);
+            await TryWriteConfigurationFileAsync(repositoryInfo.Root, cancellationToken).ConfigureAwait(false);
 
             var gitVersionOutput = await _command.ExecuteCommandLineToolAsync(
                 new GenericCommandLineToolOptions(Path.Combine(_temporaryFolder, "dotnet-gitversion"))
@@ -89,7 +90,8 @@ internal class GitVersioning : IGitVersioning
                 new CommandExecutionOptions
                 {
                     WorkingDirectory = repositoryInfo.Root.Path,
-                }).ConfigureAwait(false);
+                },
+                cancellationToken).ConfigureAwait(false);
 
             return _prefetchedGitVersionInformation ??=
                 JsonSerializer.Deserialize<GitVersionInformation>(gitVersionOutput.StandardOutput)!;
@@ -100,7 +102,7 @@ internal class GitVersioning : IGitVersioning
         }
     }
 
-    private async Task TryWriteConfigurationFile(Folder root)
+    private async Task TryWriteConfigurationFileAsync(Folder root, CancellationToken cancellationToken)
     {
         try
         {
@@ -113,11 +115,11 @@ internal class GitVersioning : IGitVersioning
                     mode: ContinuousDeployment
                     strategies:
                       - Mainline
-                    """
-                ).ConfigureAwait(false);
+                    """,
+                    cancellationToken).ConfigureAwait(false);
             }
         }
-        catch (Exception e) when (e is not (OutOfMemoryException or StackOverflowException))
+        catch (Exception e) when (e is not (OperationCanceledException or OutOfMemoryException or StackOverflowException))
         {
             _moduleLoggerProvider.GetLogger().LogWarning(e, "Error defining GitVersion.yml configuration");
         }

--- a/src/ModularPipelines.Git/IGitVersioning.cs
+++ b/src/ModularPipelines.Git/IGitVersioning.cs
@@ -4,5 +4,5 @@ namespace ModularPipelines.Git;
 
 public interface IGitVersioning
 {
-    Task<GitVersionInformation> GetGitVersioningInformation();
+    Task<GitVersionInformation> GetVersioningInformationAsync(CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Context/Domains/Installers/ILinuxInstallerContext.cs
+++ b/src/ModularPipelines/Context/Domains/Installers/ILinuxInstallerContext.cs
@@ -12,6 +12,9 @@ public interface ILinuxInstallerContext
     /// Installs a Debian package using dpkg.
     /// </summary>
     /// <param name="options">The options specifying the package file and installation parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="CommandResult"/> containing the result of the dpkg installation command.</returns>
-    Task<CommandResult> InstallFromDpkgAsync(DpkgInstallOptions options);
+    Task<CommandResult> InstallFromDpkgAsync(
+        DpkgInstallOptions options,
+        CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Context/Domains/Installers/IMacInstallerContext.cs
+++ b/src/ModularPipelines/Context/Domains/Installers/IMacInstallerContext.cs
@@ -12,6 +12,9 @@ public interface IMacInstallerContext
     /// Installs software using Homebrew package manager.
     /// </summary>
     /// <param name="macBrewOptions">The options specifying the package name and installation parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="CommandResult"/> containing the result of the Homebrew installation command.</returns>
-    Task<CommandResult> InstallFromBrewAsync(MacBrewOptions macBrewOptions);
+    Task<CommandResult> InstallFromBrewAsync(
+        MacBrewOptions macBrewOptions,
+        CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Context/Domains/Installers/IPredefinedInstallersContext.cs
+++ b/src/ModularPipelines/Context/Domains/Installers/IPredefinedInstallersContext.cs
@@ -11,26 +11,29 @@ public interface IPredefinedInstallersContext
     /// <summary>
     /// Installs the Chocolatey package manager for Windows.
     /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The result of the installation command.</returns>
-    Task<CommandResult> ChocolateyAsync();
+    Task<CommandResult> ChocolateyAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Installs PowerShell 7 on the current system.
     /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The result of the installation command.</returns>
     /// <remarks>
     /// On Windows, downloads and installs the MSI package.
     /// On macOS, installs via Homebrew.
     /// On Linux, installs the deb package.
     /// </remarks>
-    Task<CommandResult> Powershell7Async();
+    Task<CommandResult> Powershell7Async(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Installs Node Version Manager (nvm).
     /// </summary>
     /// <param name="version">Optional specific version to install.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The nvm executable file, or null if installation failed.</returns>
-    Task<File?> Nvm(string? version = null);
+    Task<File?> NvmAsync(string? version = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Installs Node.js using nvm.
@@ -39,6 +42,7 @@ public interface IPredefinedInstallersContext
     /// The Node.js version to install. Defaults to "--lts" for the latest LTS version.
     /// Supports formats like "18.0.0", "v18", "--lts", "--latest", "lts/argon", etc.
     /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The result of the installation command.</returns>
-    Task<CommandResult> NodeAsync(string version = "--lts");
+    Task<CommandResult> NodeAsync(string version = "--lts", CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Context/Domains/Installers/IWindowsInstallerContext.cs
+++ b/src/ModularPipelines/Context/Domains/Installers/IWindowsInstallerContext.cs
@@ -12,13 +12,19 @@ public interface IWindowsInstallerContext
     /// Installs software from an MSI (Windows Installer) package.
     /// </summary>
     /// <param name="msiInstallerOptions">The options specifying the MSI file path and installation parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="CommandResult"/> containing the result of the MSI installation command.</returns>
-    Task<CommandResult> InstallMsiAsync(MsiInstallerOptions msiInstallerOptions);
+    Task<CommandResult> InstallMsiAsync(
+        MsiInstallerOptions msiInstallerOptions,
+        CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Installs software from an executable installer.
     /// </summary>
     /// <param name="exeInstallerOptions">The options specifying the executable file path and installation parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A <see cref="CommandResult"/> containing the result of the executable installation command.</returns>
-    Task<CommandResult> InstallExeAsync(ExeInstallerOptions exeInstallerOptions);
+    Task<CommandResult> InstallExeAsync(
+        ExeInstallerOptions exeInstallerOptions,
+        CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Context/IModuleContext.cs
+++ b/src/ModularPipelines/Context/IModuleContext.cs
@@ -198,14 +198,16 @@ public interface IModuleContext : IPipelineContext
     /// <typeparam name="T">The result type of the sub-operation.</typeparam>
     /// <param name="name">A descriptive name for the sub-operation.</param>
     /// <param name="action">The async operation to execute.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The result of the sub-operation.</returns>
-    Task<T> SubModule<T>(string name, Func<Task<T>> action);
+    Task<T> SubModuleAsync<T>(string name, Func<Task<T>> action, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Tracks a sub-operation within the current module for progress display.
     /// </summary>
     /// <param name="name">A descriptive name for the sub-operation.</param>
     /// <param name="action">The async operation to execute.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A task representing the sub-operation.</returns>
-    Task SubModule(string name, Func<Task> action);
+    Task SubModuleAsync(string name, Func<Task> action, CancellationToken cancellationToken = default);
 }

--- a/src/ModularPipelines/Context/LinuxInstaller.cs
+++ b/src/ModularPipelines/Context/LinuxInstaller.cs
@@ -18,14 +18,18 @@ internal class LinuxInstaller : ILinuxInstallerContext
         _aptGet = aptGet;
     }
 
-    public virtual async Task<CommandResult> InstallFromDpkgAsync(DpkgInstallOptions options)
+    public virtual async Task<CommandResult> InstallFromDpkgAsync(
+        DpkgInstallOptions options,
+        CancellationToken cancellationToken = default)
     {
-        var linuxInstallationResult = await _command.ExecuteCommandLineToolAsync(options).ConfigureAwait(false);
+        var linuxInstallationResult = await _command.ExecuteCommandLineToolAsync(
+            options,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         await _aptGet.InstallAsync(new AptGetInstallOptions
         {
             FixBroken = true,
-        }).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
 
         return linuxInstallationResult;
     }

--- a/src/ModularPipelines/Context/MacInstaller.cs
+++ b/src/ModularPipelines/Context/MacInstaller.cs
@@ -14,8 +14,12 @@ internal class MacInstaller : IMacInstallerContext
         _command = command;
     }
 
-    public virtual async Task<CommandResult> InstallFromBrewAsync(MacBrewOptions macBrewOptions)
+    public virtual async Task<CommandResult> InstallFromBrewAsync(
+        MacBrewOptions macBrewOptions,
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(macBrewOptions).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineToolAsync(
+            macBrewOptions,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/ModularPipelines/Context/ModuleContext.cs
+++ b/src/ModularPipelines/Context/ModuleContext.cs
@@ -109,17 +109,22 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
         return _executionContext.MatrixTarget;
     }
 
-    public Task<T> SubModule<T>(string name, Func<Task<T>> action) => ExecuteSubModule(name, action);
+    public Task<T> SubModuleAsync<T>(string name, Func<Task<T>> action, CancellationToken cancellationToken = default) =>
+        ExecuteSubModuleAsync(name, action, cancellationToken);
 
-    public Task SubModule(string name, Func<Task> action) =>
-        ExecuteSubModule(name, async () =>
+    public Task SubModuleAsync(string name, Func<Task> action, CancellationToken cancellationToken = default) =>
+        ExecuteSubModuleAsync(name, async () =>
         {
             await action().ConfigureAwait(false);
             return 0;
-        });
+        }, cancellationToken);
 
-    private async Task<T> ExecuteSubModule<T>(string name, Func<Task<T>> action)
+    private async Task<T> ExecuteSubModuleAsync<T>(
+        string name,
+        Func<Task<T>> action,
+        CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var moduleType = _currentModule.GetType();
         var tracker = new SubModuleTracker(name, moduleType);
         var estimates = await _subModuleEstimations.Value.ConfigureAwait(false);
@@ -128,7 +133,8 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
             ?.EstimatedDuration ?? DefaultSubModuleEstimatedDuration;
 
         await _mediator.Publish(
-            new SubModuleCreatedNotification(_currentModule, tracker, estimatedDuration))
+            new SubModuleCreatedNotification(_currentModule, tracker, estimatedDuration),
+            cancellationToken)
             .ConfigureAwait(false);
 
         try
@@ -146,7 +152,8 @@ internal class ModuleContext : IModuleContext, IInternalPipelineContext
             }
 
             await _mediator.Publish(
-                new SubModuleCompletedNotification(_currentModule, tracker, isSuccessful))
+                new SubModuleCompletedNotification(_currentModule, tracker, isSuccessful),
+                cancellationToken)
                 .ConfigureAwait(false);
         }
     }

--- a/src/ModularPipelines/Context/PredefinedInstallers.cs
+++ b/src/ModularPipelines/Context/PredefinedInstallers.cs
@@ -88,7 +88,7 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> ChocolateyAsync()
+    public virtual async Task<CommandResult> ChocolateyAsync(CancellationToken cancellationToken = default)
     {
         var result = await _command.ExecuteCommandLineToolAsync(new GenericCommandLineToolOptions("powershell.exe")
         {
@@ -102,7 +102,7 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
                 "-Command",
                 "[System.Net.ServicePointManager]::SecurityProtocol = 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))",
             ],
-        }).ConfigureAwait(false);
+        }, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var allUsersProfile = _environmentVariables.GetEnvironmentVariable("ALLUSERSPROFILE")
                               ?? Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
@@ -112,7 +112,7 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> Powershell7Async()
+    public virtual async Task<CommandResult> Powershell7Async(CancellationToken cancellationToken = default)
     {
         var operatingSystem = _environmentContext.OperatingSystem;
 
@@ -121,28 +121,31 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
             var arch = _environmentContext.Is64BitOperatingSystem ? "x64" : "x86";
             var url = $"https://github.com/PowerShell/PowerShell/releases/download/v{Versions.PowerShell7}/PowerShell-{Versions.PowerShell7}-win-{arch}.msi";
 
-            return await _windowsInstaller.InstallMsiAsync(new MsiInstallerOptions(url)).ConfigureAwait(false);
+            return await _windowsInstaller.InstallMsiAsync(new MsiInstallerOptions(url), cancellationToken).ConfigureAwait(false);
         }
 
         if (operatingSystem == OperatingSystemIdentifier.MacOS)
         {
-            return await _macInstaller.InstallFromBrewAsync(new MacBrewOptions("powershell")).ConfigureAwait(false);
+            return await _macInstaller.InstallFromBrewAsync(new MacBrewOptions("powershell"), cancellationToken).ConfigureAwait(false);
         }
 
         var linuxUrl = $"https://github.com/PowerShell/PowerShell/releases/download/v{Versions.PowerShell7}/powershell_{Versions.PowerShell7}-1.deb_amd64.deb";
-        var linuxFile = await _downloader.DownloadFileAsync(new DownloadFileOptions(new Uri(linuxUrl))).ConfigureAwait(false);
+        var linuxFile = await _downloader.DownloadFileAsync(
+            new DownloadFileOptions(new Uri(linuxUrl)),
+            cancellationToken).ConfigureAwait(false);
 
-        return await _linuxInstaller.InstallFromDpkgAsync(new DpkgInstallOptions(linuxFile)).ConfigureAwait(false);
+        return await _linuxInstaller.InstallFromDpkgAsync(new DpkgInstallOptions(linuxFile), cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    public async Task<File?> Nvm(string? version = null)
+    public async Task<File?> NvmAsync(string? version = null, CancellationToken cancellationToken = default)
     {
         if (_environmentContext.OperatingSystem == OperatingSystemIdentifier.Windows)
         {
             var nvmWindowsUrl = $"https://github.com/coreybutler/nvm-windows/releases/download/{Versions.NvmWindows}/nvm-noinstall.zip";
             var zipFile = await _downloader.DownloadFileAsync(
-                new DownloadFileOptions(new Uri(nvmWindowsUrl))).ConfigureAwait(false);
+                new DownloadFileOptions(new Uri(nvmWindowsUrl)),
+                cancellationToken).ConfigureAwait(false);
 
             var newFolder = _zip.UnZipToFolder(zipFile, Folder.CreateTemporaryFolder());
 
@@ -154,7 +157,7 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
                                                                path: {nodejsPath}
                                                                arch: 64
                                                                proxy: none
-                                                               """).ConfigureAwait(false);
+                                                               """, cancellationToken).ConfigureAwait(false);
 
             var symLinkFolder = newFolder.CreateFolder("nvm_symlink").GetFolder(Guid.NewGuid().ToString("N"));
 
@@ -168,20 +171,23 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
 
         var nvmLinuxUrl = $"https://raw.githubusercontent.com/nvm-sh/nvm/v{Versions.NvmLinux}/install.sh";
         var bashScript = await _downloader.DownloadFileAsync(
-            new DownloadFileOptions(new Uri(nvmLinuxUrl))).ConfigureAwait(false);
+            new DownloadFileOptions(new Uri(nvmLinuxUrl)),
+            cancellationToken).ConfigureAwait(false);
 
-        await _bash.FromFileAsync(new BashFileOptions(bashScript)).ConfigureAwait(false);
+        await _bash.FromFileAsync(new BashFileOptions(bashScript), cancellationToken).ConfigureAwait(false);
 
         var nvmDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nvm");
         return new File(nvmDir);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<CommandResult> NodeAsync(string version = "--lts")
+    public virtual async Task<CommandResult> NodeAsync(
+        string version = "--lts",
+        CancellationToken cancellationToken = default)
     {
         ValidateNodeVersion(version);
 
-        await Nvm().ConfigureAwait(false);
+        await NvmAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 
         if (_environmentContext.OperatingSystem == OperatingSystemIdentifier.Windows)
         {
@@ -189,13 +195,14 @@ public partial class PredefinedInstallers : IPredefinedInstallersContext
             return await _command.ExecuteCommandLineToolAsync(new GenericCommandLineToolOptions("nvm")
             {
                 Arguments = ["install", version],
-            }).ConfigureAwait(false);
+            }, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         // Linux/Mac: Use shell escaping since BashCommandOptions uses string interpolation.
         var escapedVersion = ShellArgumentEscaper.Escape(version);
         return await _bash.CommandAsync(new BashCommandOptions(
-            $"export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && nvm install {escapedVersion}"))
+            $"export NVM_DIR=\"$HOME/.nvm\" && [ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\" && nvm install {escapedVersion}"),
+            cancellationToken)
             .ConfigureAwait(false);
     }
 

--- a/src/ModularPipelines/Context/WindowsInstaller.cs
+++ b/src/ModularPipelines/Context/WindowsInstaller.cs
@@ -14,13 +14,21 @@ internal class WindowsInstaller : IWindowsInstallerContext
         _command = command;
     }
 
-    public virtual async Task<CommandResult> InstallMsiAsync(MsiInstallerOptions msiInstallerOptions)
+    public virtual async Task<CommandResult> InstallMsiAsync(
+        MsiInstallerOptions msiInstallerOptions,
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(msiInstallerOptions).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineToolAsync(
+            msiInstallerOptions,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
-    public virtual async Task<CommandResult> InstallExeAsync(ExeInstallerOptions exeInstallerOptions)
+    public virtual async Task<CommandResult> InstallExeAsync(
+        ExeInstallerOptions exeInstallerOptions,
+        CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(exeInstallerOptions).ConfigureAwait(false);
+        return await _command.ExecuteCommandLineToolAsync(
+            exeInstallerOptions,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 }

--- a/test/ModularPipelines.Azure.UnitTests/AzureComputeProvisionerContractTests.cs
+++ b/test/ModularPipelines.Azure.UnitTests/AzureComputeProvisionerContractTests.cs
@@ -1,5 +1,7 @@
+using System.Reflection;
 using Azure.ResourceManager;
 using Azure.ResourceManager.AppService;
+using ModularPipelines.Azure.Provisioning;
 using ModularPipelines.Azure.Provisioning.Compute;
 using ModularPipelines.Azure.Scopes;
 
@@ -8,10 +10,29 @@ namespace ModularPipelines.UnitTests;
 public class AzureComputeProvisionerContractTests
 {
     [Test]
-    public async Task AppServiceDomain_Preserves_AppService_Sdk_Contract()
+    public async Task ProvisionerAsyncMethods_FollowAsyncContract()
+    {
+        var methods = typeof(IAzureProvisioner).Assembly
+            .GetTypes()
+            .Where(type => type.Namespace?.StartsWith(
+                "ModularPipelines.Azure.Provisioning",
+                StringComparison.Ordinal) == true)
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            .Where(method => typeof(Task).IsAssignableFrom(method.ReturnType))
+            .ToArray();
+
+        await Assert.That(methods).IsNotEmpty();
+        await Assert.That(methods.All(method => method.Name.EndsWith("Async", StringComparison.Ordinal))).IsTrue();
+        await Assert.That(methods.All(
+            method => method.GetParameters().LastOrDefault()?.ParameterType == typeof(CancellationToken))).IsTrue();
+    }
+
+    [Test]
+    public async Task AppServiceDomainAsync_Preserves_AppService_Sdk_Contract()
     {
         var method = typeof(AzureComputeProvisioner).GetMethod(
-            nameof(AzureComputeProvisioner.AppServiceDomain),
+            nameof(AzureComputeProvisioner.AppServiceDomainAsync),
             [
                 typeof(AzureResourceIdentifier),
                 typeof(AppServiceDomainData),

--- a/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
+++ b/test/ModularPipelines.DocumentationSnippets/CurrentApiSnippets.cs
@@ -188,7 +188,7 @@ public static class CurrentApiSnippets
             IModuleContext context,
             CancellationToken cancellationToken)
         {
-            var version = await context.Tools.Git.Versioning.GetGitVersioningInformation();
+            var version = await context.Tools.Git.Versioning.GetVersioningInformationAsync(cancellationToken);
             return version.FullSemVer
                    ?? throw new InvalidOperationException(
                        "GitVersion did not return a semantic version.");

--- a/test/ModularPipelines.Git.UnitTests/GitCancellationTokenApiTests.cs
+++ b/test/ModularPipelines.Git.UnitTests/GitCancellationTokenApiTests.cs
@@ -3,6 +3,19 @@ namespace ModularPipelines.Git.UnitTests;
 public class GitCancellationTokenApiTests
 {
     [Test]
+    public async Task VersioningApi_IsAsyncAndCancellable()
+    {
+        var method = typeof(IGitVersioning).GetMethod(
+            nameof(IGitVersioning.GetVersioningInformationAsync));
+
+        await Assert.That(method).IsNotNull();
+        await Assert.That(method!.ReturnType)
+            .IsEqualTo(typeof(Task<ModularPipelines.Git.Models.GitVersionInformation>));
+        await Assert.That(method.GetParameters().Single().ParameterType)
+            .IsEqualTo(typeof(CancellationToken));
+    }
+
+    [Test]
     public async Task PublicMethods_UseStandardCancellationTokenParameterName()
     {
         var nonstandardParameters = typeof(IGitCommands).Assembly

--- a/test/ModularPipelines.UnitTests/Context/ContextHierarchyTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextHierarchyTests.cs
@@ -123,13 +123,16 @@ public class ContextHierarchyTests
     }
 
     [Test]
-    public async Task IModuleContext_ShouldHaveSubModuleMethods()
+    public async Task IModuleContext_ShouldHaveSubModuleAsyncMethods()
     {
         var moduleContextType = typeof(IModuleContext);
 
-        // Check for SubModule methods
-        var subModuleMethods = moduleContextType.GetMethods().Where(m => m.Name == "SubModule").ToArray();
-        await Assert.That(subModuleMethods.Length).IsGreaterThanOrEqualTo(1)
-            .Because("IModuleContext should have SubModule methods");
+        var subModuleMethods = moduleContextType.GetMethods()
+            .Where(m => m.Name == "SubModuleAsync")
+            .ToArray();
+
+        await Assert.That(subModuleMethods).Count().IsEqualTo(2);
+        await Assert.That(subModuleMethods.All(
+            method => method.GetParameters()[^1].ParameterType == typeof(CancellationToken))).IsTrue();
     }
 }

--- a/test/ModularPipelines.UnitTests/Context/ModuleContextSubModuleTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ModuleContextSubModuleTests.cs
@@ -12,7 +12,7 @@ namespace ModularPipelines.UnitTests.Context;
 public class ModuleContextSubModuleTests
 {
     [Test]
-    public async Task SubModule_PublishesLifecycleAndSavesDuration()
+    public async Task SubModuleAsync_PublishesLifecycleAndSavesDuration()
     {
         var module = Mock.Of<IModule>();
         var executionContext = new ModuleExecutionContext(module, module.GetType());
@@ -40,7 +40,7 @@ public class ModuleContextSubModuleTests
             .Returns(Task.CompletedTask);
         var context = CreateContext(module, executionContext, mediator.Object, estimatedTimeProvider.Object);
 
-        var result = await context.SubModule("Compile", () => Task.FromResult(42));
+        var result = await context.SubModuleAsync("Compile", () => Task.FromResult(42));
 
         await Assert.That(result).IsEqualTo(42);
         await Assert.That(created).IsNotNull();
@@ -56,7 +56,7 @@ public class ModuleContextSubModuleTests
     }
 
     [Test]
-    public async Task SubModule_FailurePublishesCompletionWithoutSavingDuration()
+    public async Task SubModuleAsync_FailurePublishesCompletionWithoutSavingDuration()
     {
         var module = Mock.Of<IModule>();
         var executionContext = new ModuleExecutionContext(module, module.GetType());
@@ -80,7 +80,7 @@ public class ModuleContextSubModuleTests
         var context = CreateContext(module, executionContext, mediator.Object, estimatedTimeProvider.Object);
 
         var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => context.SubModule<int>("Fail", () => Task.FromException<int>(expectedException)));
+            () => context.SubModuleAsync<int>("Fail", () => Task.FromException<int>(expectedException)));
 
         await Assert.That(exception).IsSameReferenceAs(expectedException);
         await Assert.That(created).IsNotNull();
@@ -93,7 +93,7 @@ public class ModuleContextSubModuleTests
     }
 
     [Test]
-    public async Task SubModule_LoadsEstimatesOncePerModuleExecution()
+    public async Task SubModuleAsync_LoadsEstimatesOncePerModuleExecution()
     {
         var module = Mock.Of<IModule>();
         var executionContext = new ModuleExecutionContext(module, module.GetType());
@@ -115,12 +115,38 @@ public class ModuleContextSubModuleTests
         var context = CreateContext(module, executionContext, mediator.Object, estimatedTimeProvider.Object);
 
         await Task.WhenAll(
-            context.SubModule("First", () => Task.CompletedTask),
-            context.SubModule("Second", () => Task.CompletedTask));
+            context.SubModuleAsync("First", () => Task.CompletedTask),
+            context.SubModuleAsync("Second", () => Task.CompletedTask));
 
         estimatedTimeProvider.Verify(
             x => x.GetSubModuleEstimatedTimesAsync(module.GetType()),
             Times.Once);
+    }
+
+    [Test]
+    public async Task SubModuleAsync_CancelledToken_DoesNotRunAction()
+    {
+        var module = Mock.Of<IModule>();
+        var actionWasRun = false;
+        using var cancellationTokenSource = new CancellationTokenSource();
+        await cancellationTokenSource.CancelAsync();
+        var context = CreateContext(
+            module,
+            new ModuleExecutionContext(module, module.GetType()),
+            Mock.Of<IMediator>(),
+            Mock.Of<ISafeModuleEstimatedTimeProvider>());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            context.SubModuleAsync(
+                "Cancelled",
+                () =>
+                {
+                    actionWasRun = true;
+                    return Task.CompletedTask;
+                },
+                cancellationTokenSource.Token));
+
+        await Assert.That(actionWasRun).IsFalse();
     }
 
     private static ModuleContext CreateContext(

--- a/test/ModularPipelines.UnitTests/Helpers/PredefinedInstallersTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/PredefinedInstallersTests.cs
@@ -19,6 +19,8 @@ public class PredefinedInstallersTests
     {
         const string allUsersProfile = @"C:\ProgramData";
         CommandLineToolOptions? capturedOptions = null;
+        CancellationToken capturedCancellationToken = default;
+        using var cancellationTokenSource = new CancellationTokenSource();
         var result = CreateResult();
         var command = new Mock<ICommandContext>();
         command.Setup(context => context.ExecuteCommandLineToolAsync(
@@ -26,7 +28,11 @@ public class PredefinedInstallersTests
                 It.IsAny<CommandExecutionOptions?>(),
                 It.IsAny<CancellationToken>()))
             .Callback<CommandLineToolOptions, CommandExecutionOptions?, CancellationToken>(
-                (options, _, _) => capturedOptions = options)
+                (options, _, cancellationToken) =>
+                {
+                    capturedOptions = options;
+                    capturedCancellationToken = cancellationToken;
+                })
             .ReturnsAsync(result);
         var environmentVariables = new Mock<IEnvironmentVariablesContext>();
         environmentVariables.Setup(context => context.GetEnvironmentVariable(
@@ -40,7 +46,7 @@ public class PredefinedInstallersTests
             Mock.Of<IBashContext>(),
             environmentVariables.Object);
 
-        var actualResult = await installer.ChocolateyAsync();
+        var actualResult = await installer.ChocolateyAsync(cancellationTokenSource.Token);
 
         var options = (GenericCommandLineToolOptions) capturedOptions!;
         var arguments = options.Arguments!.ToArray();
@@ -51,6 +57,7 @@ public class PredefinedInstallersTests
             await Assert.That(arguments).Contains("-Command");
             await Assert.That(arguments).DoesNotContain("&&");
             await Assert.That(arguments).DoesNotContain("SET");
+            await Assert.That(capturedCancellationToken).IsEqualTo(cancellationTokenSource.Token);
         }
 
         environmentVariables.Verify(context => context.AddToPath(


### PR DESCRIPTION
Closes #3766

Summary:
- rename remaining Task-returning APIs to the Async convention
- add and propagate CancellationToken parameters through module, installer, and Git versioning paths
- standardize the entire Azure provisioner family and current docs
- add API/cancellation contract coverage

Validation:
- core Release build: passed
- Git solution Release build: passed
- documentation snippets Release build: passed
- ModuleContextSubModuleTests: 4 passed
- ContextHierarchy async contract: 1 passed
- PredefinedInstallersTests: 2 passed
- GitCancellationTokenApiTests: 2 passed
- Azure solution build: local agent process-tree limit exceeded 2 GB; CI will validate