### PR TITLE
Mask escaped secret command arguments

### DIFF
--- a/src/ModularPipelines/Engine/SecretMaskingPatternGenerator.cs
+++ b/src/ModularPipelines/Engine/SecretMaskingPatternGenerator.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using CliWrap.Builders;
 
 namespace ModularPipelines.Engine;
 
@@ -21,6 +22,23 @@ internal static class SecretMaskingPatternGenerator
             jsonEscaped,
         };
 
+        AddArgumentEscapedPatterns(patterns, secret);
+
+        var commandScriptEscaped = secret.Replace("\"", "\"\"");
+        patterns.Add(commandScriptEscaped);
+        AddArgumentEscapedPatterns(patterns, commandScriptEscaped);
+
         return patterns.ToArray();
+    }
+
+    private static void AddArgumentEscapedPatterns(ISet<string> patterns, string secret)
+    {
+        var escaped = ArgumentsBuilder.Escape(secret);
+        patterns.Add(escaped);
+
+        if (escaped.Length >= 2 && escaped[0] == '"' && escaped[^1] == '"')
+        {
+            patterns.Add(escaped[1..^1]);
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1,3 +1,4 @@
+using CliWrap;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Attributes;
 using ModularPipelines.Console;
@@ -56,6 +57,34 @@ public class SecretMaskingPatternTests
             await Assert.That(obfuscator.Obfuscate(pattern, new SecretOptions()))
                 .IsEqualTo("**********");
         }
+    }
+
+    [Test]
+    [Arguments("abc\"def")]
+    [Arguments("abc\\\"def")]
+    [Arguments("abc \\")]
+    public async Task CliWrapEscapedCommandInput_MasksEmbeddedSecret(string secret)
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret(secret);
+        var commandInput = Cli.Wrap("tool")
+            .WithArguments([$"--value={secret}"])
+            .ToString();
+
+        await Assert.That(CreateObfuscator(provider).Obfuscate(commandInput, null))
+            .IsEqualTo("tool \"--value=**********\"");
+    }
+
+    [Test]
+    public async Task CommandScriptEscapedSecret_IsMasked()
+    {
+        const string secret = "abc\"def";
+        var provider = CreateProvider(out _);
+        provider.AddSecret(secret);
+        var commandScriptEscaped = secret.Replace("\"", "\"\"");
+
+        await Assert.That(CreateObfuscator(provider).Obfuscate($"before {commandScriptEscaped} after", null))
+            .IsEqualTo("before ********** after");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- register CliWrap-rendered secret variants, including embedded quoted-argument content
- register Windows command-script quote-doubled variants
- cover quotes, escaped quotes, and trailing backslashes with real CliWrap rendering

## Validation
- `SecretMaskingPatternTests`: 27 passed
- targeted whitespace verification passed
- core Release build passed with 0 warnings and 0 errors

Closes #3775