### PR TITLE
Reduce CoordinatedTextWriter secret-scan contention

### DIFF
--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -215,11 +215,14 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        var patterns = ObfuscateWithCurrentPatterns(
-            state,
-            preservePotentialLongerMatch: true,
-            out var retainedPrefixLength);
-        FlushSafeOutput(state, retainedPrefixLength, shouldBuffer, patterns.Version);
+        ExecuteWithStableSecrets(() =>
+        {
+            var patterns = ObfuscateWithCurrentPatterns(
+                state,
+                preservePotentialLongerMatch: true,
+                out var retainedPrefixLength);
+            FlushSafeOutput(state, retainedPrefixLength, shouldBuffer, patterns.Version);
+        });
     }
 
     private SecretPatterns ObfuscateWithCurrentPatterns(
@@ -730,6 +733,17 @@ internal class CoordinatedTextWriter : TextWriter
             ? output
             : _secretObfuscator.Obfuscate(output, null);
 
+    private void ExecuteWithStableSecrets(Action processOutput)
+    {
+        if (_secretProvider is ISecretEmissionGuard emissionGuard)
+        {
+            emissionGuard.ExecuteWithStableSecrets(processOutput);
+            return;
+        }
+
+        processOutput();
+    }
+
     /// <inheritdoc />
     public override void Flush()
     {
@@ -757,18 +771,7 @@ internal class CoordinatedTextWriter : TextWriter
                         continue;
                     }
 
-                    var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
-                    var patterns = ObfuscateWithCurrentPatterns(
-                        state,
-                        preservePotentialLongerMatch: false,
-                        out _);
-                    FlushSafePrefix(
-                        state,
-                        state.Buffer.Length,
-                        shouldBuffer,
-                        patterns.Version);
-                    FlushPartialLine(state, shouldBuffer, patterns.Version);
-                    state.ShouldBuffer = null;
+                    FlushBufferedState(state);
                 }
             }
         }
@@ -776,6 +779,25 @@ internal class CoordinatedTextWriter : TextWriter
         {
             _flushLock.ExitWriteLock();
         }
+    }
+
+    private void FlushBufferedState(LineBufferState state)
+    {
+        ExecuteWithStableSecrets(() =>
+        {
+            var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
+            var patterns = ObfuscateWithCurrentPatterns(
+                state,
+                preservePotentialLongerMatch: false,
+                out _);
+            FlushSafePrefix(
+                state,
+                state.Buffer.Length,
+                shouldBuffer,
+                patterns.Version);
+            FlushPartialLine(state, shouldBuffer, patterns.Version);
+            state.ShouldBuffer = null;
+        });
     }
 
     /// <summary>
@@ -808,30 +830,7 @@ internal class CoordinatedTextWriter : TextWriter
                         continue;
                     }
 
-                    var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
-                    var patterns = ObfuscateWithCurrentPatterns(
-                        state,
-                        preservePotentialLongerMatch: false,
-                        out var retainedLength);
-                    FlushSafeOutput(
-                        state,
-                        retainedLength,
-                        shouldBuffer,
-                        patterns.Version);
-
-                    if (shouldBuffer)
-                    {
-                        FlushPartialPrefix(
-                            state,
-                            state.Buffer.Length - retainedLength,
-                            shouldBuffer,
-                            patterns.Version);
-                    }
-
-                    if (state.Buffer.Length == 0)
-                    {
-                        state.ShouldBuffer = null;
-                    }
+                    FlushAvailableState(state);
                 }
             }
         }
@@ -839,6 +838,37 @@ internal class CoordinatedTextWriter : TextWriter
         {
             _flushLock.ExitWriteLock();
         }
+    }
+
+    private void FlushAvailableState(LineBufferState state)
+    {
+        ExecuteWithStableSecrets(() =>
+        {
+            var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
+            var patterns = ObfuscateWithCurrentPatterns(
+                state,
+                preservePotentialLongerMatch: false,
+                out var retainedLength);
+            FlushSafeOutput(
+                state,
+                retainedLength,
+                shouldBuffer,
+                patterns.Version);
+
+            if (shouldBuffer)
+            {
+                FlushPartialPrefix(
+                    state,
+                    state.Buffer.Length - retainedLength,
+                    shouldBuffer,
+                    patterns.Version);
+            }
+
+            if (state.Buffer.Length == 0)
+            {
+                state.ShouldBuffer = null;
+            }
+        });
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -24,11 +24,18 @@ namespace ModularPipelines.Console;
 /// <b>Thread Safety:</b> This class is thread-safe. All operations are either
 /// read-only or delegated to thread-safe components.
 /// </para>
+/// <para>
+/// <b>Lock ordering:</b> Operations acquire the flush lock before a line-buffer lock.
+/// Tracked obfuscation may then acquire the secret-emission guard and pattern-cache lock
+/// before the output lock. Custom obfuscation uses its serialization lock outside both
+/// the secret-emission guard and output lock. Locks must not be acquired in reverse order.
+/// </para>
 /// </remarks>
 [ExcludeFromCodeCoverage]
 internal class CoordinatedTextWriter : TextWriter
 {
     private static readonly AsyncLocal<bool> DirectWriteScope = new();
+    private static readonly AsyncLocal<int> CustomObfuscationDepth = new();
 
     private readonly IConsoleCoordinator _coordinator;
     private readonly TextWriter _realConsole;
@@ -40,7 +47,7 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly object _customObfuscatorLock = new();
     private readonly object _secretPatternsLock = new();
     private readonly SemaphoreSlim _outputLock = new(1, 1);
-    private readonly ReaderWriterLockSlim _flushLock = new(LockRecursionPolicy.NoRecursion);
+    private readonly ReaderWriterLockSlim _flushLock = new(LockRecursionPolicy.SupportsRecursion);
     private SecretPatterns _secretPatterns = new([], null);
     private long _secretPatternsVersion = long.MinValue;
 
@@ -216,14 +223,20 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        ExecuteWithStableSecrets(() =>
-        {
-            var patterns = ObfuscateWithCurrentPatterns(
-                state,
-                preservePotentialLongerMatch: true,
-                out var retainedPrefixLength);
-            FlushSafeOutput(state, retainedPrefixLength, shouldBuffer, patterns.Version);
-        });
+        ExecuteWithStableSecrets(
+            (Writer: this, State: state, ShouldBuffer: shouldBuffer),
+            static context =>
+            {
+                var patterns = context.Writer.ObfuscateWithCurrentPatterns(
+                    context.State,
+                    preservePotentialLongerMatch: true,
+                    out var retainedPrefixLength);
+                context.Writer.FlushSafeOutput(
+                    context.State,
+                    retainedPrefixLength,
+                    context.ShouldBuffer,
+                    patterns.Version);
+            });
     }
 
     private SecretPatterns ObfuscateWithCurrentPatterns(
@@ -250,7 +263,10 @@ internal class CoordinatedTextWriter : TextWriter
     private LineBufferState GetLineBufferState()
     {
         var moduleType = ModuleLogger.CurrentModuleType.Value;
-        var key = new LineBufferKey(moduleType, DirectWriteScope.Value);
+        var key = new LineBufferKey(
+            moduleType,
+            DirectWriteScope.Value,
+            CustomObfuscationDepth.Value);
 
         lock (_lineBufferLock)
         {
@@ -277,8 +293,10 @@ internal class CoordinatedTextWriter : TextWriter
     private SecretPatterns GetSecretPatterns()
     {
         var version = _secretProvider.Version;
+        var comparison = GetPatternComparison();
         if ((version & 1) == 0
             && Volatile.Read(ref _secretPatternsVersion) == version
+            && Volatile.Read(ref _secretPatterns).Comparison == comparison
             && _secretProvider.Version == version)
         {
             return Volatile.Read(ref _secretPatterns);
@@ -287,12 +305,13 @@ internal class CoordinatedTextWriter : TextWriter
         lock (_secretPatternsLock)
         {
             var snapshot = _secretProvider.GetSnapshot();
-            if (_secretPatternsVersion == snapshot.Version)
+            comparison = GetPatternComparison();
+            if (_secretPatternsVersion == snapshot.Version
+                && _secretPatterns.Comparison == comparison)
             {
                 return _secretPatterns;
             }
 
-            var comparison = GetPatternComparison();
             var comparer = comparison == StringComparison.Ordinal
                 ? StringComparer.Ordinal
                 : StringComparer.OrdinalIgnoreCase;
@@ -426,10 +445,9 @@ internal class CoordinatedTextWriter : TextWriter
         return match.Index < retainedPrefixStart
                && !HasCompletePatternBetween(
                    pending,
-                   patterns.Values,
+                   patterns,
                    match.Index + 1,
-                   retainedPrefixStart,
-                   patterns.Comparison);
+                   retainedPrefixStart);
     }
 
     private static string? GetPendingWithPatternCandidate(
@@ -561,21 +579,30 @@ internal class CoordinatedTextWriter : TextWriter
 
     private static bool HasCompletePatternBetween(
         string input,
-        IReadOnlyList<string> patterns,
+        SecretPatterns patterns,
         int startIndex,
-        int endIndex,
-        StringComparison comparison)
+        int endIndex)
     {
-        for (var index = startIndex; index < endIndex; index++)
+        while (startIndex < endIndex)
         {
-            var safeInput = input.AsSpan(index, endIndex - index);
-            foreach (var pattern in patterns)
+            var relativeIndex = input.AsSpan(startIndex, endIndex - startIndex)
+                .IndexOfAny(patterns.SearchValues!);
+            if (relativeIndex < 0)
             {
-                if (safeInput.StartsWith(pattern, comparison))
+                return false;
+            }
+
+            var index = startIndex + relativeIndex;
+            var safeInput = input.AsSpan(index, endIndex - index);
+            foreach (var pattern in patterns.Values)
+            {
+                if (safeInput.StartsWith(pattern, patterns.Comparison))
                 {
                     return true;
                 }
             }
+
+            startIndex = index + 1;
         }
 
         return false;
@@ -649,15 +676,9 @@ internal class CoordinatedTextWriter : TextWriter
 
         var output = state.Buffer.ToString(0, length);
         state.Buffer.Remove(0, length);
-        _outputLock.Wait();
-        try
-        {
-            _realConsole.Write(ObfuscateCustomOutput(output, secretPatternsVersion));
-        }
-        finally
-        {
-            _outputLock.Release();
-        }
+        WriteToRealConsole(
+            ObfuscateCustomOutput(output, secretPatternsVersion),
+            appendNewLine: false);
     }
 
     private void WriteCompletedLine(
@@ -674,15 +695,9 @@ internal class CoordinatedTextWriter : TextWriter
         }
         else
         {
-            _outputLock.Wait();
-            try
-            {
-                _realConsole.WriteLine(ObfuscateCustomOutput(line, secretPatternsVersion));
-            }
-            finally
-            {
-                _outputLock.Release();
-            }
+            WriteToRealConsole(
+                ObfuscateCustomOutput(line, secretPatternsVersion),
+                appendNewLine: true);
         }
     }
 
@@ -716,15 +731,29 @@ internal class CoordinatedTextWriter : TextWriter
         }
         else
         {
-            _outputLock.Wait();
-            try
+            WriteToRealConsole(
+                ObfuscateCustomOutput(pending, secretPatternsVersion),
+                appendNewLine: false);
+        }
+    }
+
+    private void WriteToRealConsole(string output, bool appendNewLine)
+    {
+        _outputLock.Wait();
+        try
+        {
+            if (appendNewLine)
             {
-                _realConsole.Write(ObfuscateCustomOutput(pending, secretPatternsVersion));
+                _realConsole.WriteLine(output);
             }
-            finally
+            else
             {
-                _outputLock.Release();
+                _realConsole.Write(output);
             }
+        }
+        finally
+        {
+            _outputLock.Release();
         }
     }
 
@@ -739,20 +768,29 @@ internal class CoordinatedTextWriter : TextWriter
 
         lock (_customObfuscatorLock)
         {
-            return _secretObfuscator.Obfuscate(output, null);
+            var previousDepth = CustomObfuscationDepth.Value;
+            CustomObfuscationDepth.Value = previousDepth + 1;
+            try
+            {
+                return _secretObfuscator.Obfuscate(output, null);
+            }
+            finally
+            {
+                CustomObfuscationDepth.Value = previousDepth;
+            }
         }
     }
 
-    private void ExecuteWithStableSecrets(Action processOutput)
+    private void ExecuteWithStableSecrets<TState>(TState state, Action<TState> processOutput)
     {
         if (_secretObfuscator is ITrackedSecretObfuscator
             && _secretProvider is ISecretEmissionGuard emissionGuard)
         {
-            emissionGuard.ExecuteWithStableSecrets(processOutput);
+            emissionGuard.ExecuteWithStableSecrets(state, processOutput);
             return;
         }
 
-        processOutput();
+        processOutput(state);
     }
 
     /// <inheritdoc />
@@ -782,7 +820,7 @@ internal class CoordinatedTextWriter : TextWriter
                         continue;
                     }
 
-                    FlushBufferedState(state);
+                    FlushState(state, retainPotentialPrefix: false);
                 }
             }
         }
@@ -790,25 +828,6 @@ internal class CoordinatedTextWriter : TextWriter
         {
             _flushLock.ExitWriteLock();
         }
-    }
-
-    private void FlushBufferedState(LineBufferState state)
-    {
-        ExecuteWithStableSecrets(() =>
-        {
-            var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
-            var patterns = ObfuscateWithCurrentPatterns(
-                state,
-                preservePotentialLongerMatch: false,
-                out _);
-            FlushSafePrefix(
-                state,
-                state.Buffer.Length,
-                shouldBuffer,
-                patterns.Version);
-            FlushPartialLine(state, shouldBuffer, patterns.Version);
-            state.ShouldBuffer = null;
-        });
     }
 
     /// <summary>
@@ -841,7 +860,7 @@ internal class CoordinatedTextWriter : TextWriter
                         continue;
                     }
 
-                    FlushAvailableState(state);
+                    FlushState(state, retainPotentialPrefix: true);
                 }
             }
         }
@@ -851,35 +870,52 @@ internal class CoordinatedTextWriter : TextWriter
         }
     }
 
-    private void FlushAvailableState(LineBufferState state)
+    private void FlushState(LineBufferState state, bool retainPotentialPrefix)
     {
-        ExecuteWithStableSecrets(() =>
-        {
-            var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
-            var patterns = ObfuscateWithCurrentPatterns(
-                state,
-                preservePotentialLongerMatch: false,
-                out var retainedLength);
-            FlushSafeOutput(
-                state,
-                retainedLength,
-                shouldBuffer,
-                patterns.Version);
-
-            if (shouldBuffer)
+        ExecuteWithStableSecrets(
+            (Writer: this, State: state, RetainPotentialPrefix: retainPotentialPrefix),
+            static context =>
             {
-                FlushPartialPrefix(
-                    state,
-                    state.Buffer.Length - retainedLength,
+                var shouldBuffer = context.State.ShouldBuffer ?? context.Writer.ShouldBuffer();
+                var patterns = context.Writer.ObfuscateWithCurrentPatterns(
+                    context.State,
+                    preservePotentialLongerMatch: false,
+                    out var retainedLength);
+                if (!context.RetainPotentialPrefix)
+                {
+                    context.Writer.FlushSafePrefix(
+                        context.State,
+                        context.State.Buffer.Length,
+                        shouldBuffer,
+                        patterns.Version);
+                    context.Writer.FlushPartialLine(
+                        context.State,
+                        shouldBuffer,
+                        patterns.Version);
+                    context.State.ShouldBuffer = null;
+                    return;
+                }
+
+                context.Writer.FlushSafeOutput(
+                    context.State,
+                    retainedLength,
                     shouldBuffer,
                     patterns.Version);
-            }
 
-            if (state.Buffer.Length == 0)
-            {
-                state.ShouldBuffer = null;
-            }
-        });
+                if (shouldBuffer)
+                {
+                    context.Writer.FlushPartialPrefix(
+                        context.State,
+                        context.State.Buffer.Length - retainedLength,
+                        shouldBuffer,
+                        patterns.Version);
+                }
+
+                if (context.State.Buffer.Length == 0)
+                {
+                    context.State.ShouldBuffer = null;
+                }
+            });
     }
 
     /// <inheritdoc />
@@ -947,7 +983,10 @@ internal class CoordinatedTextWriter : TextWriter
         public bool? ShouldBuffer { get; set; }
     }
 
-    private readonly record struct LineBufferKey(Type? ModuleType, bool IsDirectWrite);
+    private readonly record struct LineBufferKey(
+        Type? ModuleType,
+        bool IsDirectWrite,
+        int CustomObfuscationDepth);
 
     private sealed record SecretPatterns(
         string[] Values,

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -287,20 +287,21 @@ internal class CoordinatedTextWriter : TextWriter
             }
 
             var secret = pending.Substring(match.Index, match.Length);
-            var obfuscatedSecret = _secretObfuscator.Obfuscate(secret, null);
-            if (string.Equals(obfuscatedSecret, secret, StringComparison.Ordinal))
+            var obfuscation = _secretObfuscator is ITrackedSecretObfuscator trackedObfuscator
+                ? trackedObfuscator.ObfuscateWithConsumption(secret, null)
+                : GetFallbackObfuscation(secret);
+            if (obfuscation.ConsumedInputLength == 0)
             {
                 searchIndex = match.Index + 1;
                 continue;
             }
 
-            var unchangedSuffixLength = GetUnchangedSuffixLength(secret, obfuscatedSecret);
-            var consumedLength = match.Length - unchangedSuffixLength;
-            var obfuscatedLength = obfuscatedSecret.Length - unchangedSuffixLength;
+            var unconsumedLength = match.Length - obfuscation.ConsumedInputLength;
+            var obfuscatedLength = obfuscation.Output.Length - unconsumedLength;
             output.Append(pending, outputIndex, match.Index - outputIndex);
-            output.Append(obfuscatedSecret, 0, obfuscatedLength);
-            retainedPrefixInvalidated |= match.Index + consumedLength > retainedPrefixStart;
-            outputIndex = match.Index + consumedLength;
+            output.Append(obfuscation.Output, 0, obfuscatedLength);
+            retainedPrefixInvalidated |= match.Index + obfuscation.ConsumedInputLength > retainedPrefixStart;
+            outputIndex = match.Index + obfuscation.ConsumedInputLength;
             searchIndex = outputIndex;
             replaced = true;
         }
@@ -316,17 +317,13 @@ internal class CoordinatedTextWriter : TextWriter
             : retainedPrefixLength;
     }
 
-    private static int GetUnchangedSuffixLength(string input, string obfuscated)
+    private SecretObfuscationResult GetFallbackObfuscation(string input)
     {
-        var maximumLength = Math.Min(input.Length, obfuscated.Length);
-        var suffixLength = 0;
-        while (suffixLength < maximumLength
-               && input[^(suffixLength + 1)] == obfuscated[^(suffixLength + 1)])
-        {
-            suffixLength++;
-        }
-
-        return suffixLength == input.Length ? 0 : suffixLength;
+        var output = _secretObfuscator.Obfuscate(input, null);
+        var consumedInputLength = string.Equals(output, input, StringComparison.Ordinal)
+            ? 0
+            : input.Length;
+        return new SecretObfuscationResult(output, consumedInputLength);
     }
 
     private void FlushSafeOutput(LineBufferState state, int retainedLength, bool shouldBuffer)

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -772,12 +772,7 @@ internal class CoordinatedTextWriter : TextWriter
         }
         finally
         {
-            activeOutputWriters.Remove(this);
-            if (activeOutputWriters.Count == 0)
-            {
-                _activeOutputWriters = null;
-            }
-
+            RemoveActiveOutputWriter(activeOutputWriters);
             _outputLock.Release();
         }
     }
@@ -979,6 +974,8 @@ internal class CoordinatedTextWriter : TextWriter
     private void FlushRealConsole()
     {
         _outputLock.Wait();
+        var activeOutputWriters = _activeOutputWriters ??= [];
+        activeOutputWriters.Add(this);
         try
         {
             // Always flush real console (needed for Spectre.Console internals)
@@ -986,6 +983,7 @@ internal class CoordinatedTextWriter : TextWriter
         }
         finally
         {
+            RemoveActiveOutputWriter(activeOutputWriters);
             _outputLock.Release();
         }
     }
@@ -993,13 +991,37 @@ internal class CoordinatedTextWriter : TextWriter
     private async Task FlushRealConsoleAsync()
     {
         await _outputLock.WaitAsync().ConfigureAwait(false);
+        var activeOutputWriters = _activeOutputWriters ??= [];
+        activeOutputWriters.Add(this);
         try
         {
-            await _realConsole.FlushAsync().ConfigureAwait(false);
+            Task flushTask;
+            try
+            {
+                flushTask = _realConsole.FlushAsync();
+            }
+            finally
+            {
+                // Thread-static reentrancy only covers callbacks made synchronously
+                // while the underlying asynchronous flush is invoked.
+                RemoveActiveOutputWriter(activeOutputWriters);
+            }
+
+            await flushTask.ConfigureAwait(false);
         }
         finally
         {
             _outputLock.Release();
+        }
+    }
+
+    private void RemoveActiveOutputWriter(HashSet<CoordinatedTextWriter> activeOutputWriters)
+    {
+        activeOutputWriters.Remove(this);
+        if (activeOutputWriters.Count == 0
+            && ReferenceEquals(_activeOutputWriters, activeOutputWriters))
+        {
+            _activeOutputWriters = null;
         }
     }
 

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -37,9 +37,11 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly ISecretProvider _secretProvider;
     private readonly Dictionary<LineBufferKey, LineBufferState> _lineBuffers = [];
     private readonly object _lineBufferLock = new();
+    private readonly object _secretPatternsLock = new();
     private readonly object _outputLock = new();
+    private readonly ReaderWriterLockSlim _flushLock = new(LockRecursionPolicy.NoRecursion);
     private SecretPatterns _secretPatterns = new([], null);
-    private long? _secretPatternsVersion;
+    private long _secretPatternsVersion = long.MinValue;
 
     /// <summary>
     /// Initialises a new instance of the <see cref="CoordinatedTextWriter"/> class.
@@ -70,10 +72,18 @@ internal class CoordinatedTextWriter : TextWriter
     /// <inheritdoc />
     public override void WriteLine(string? value)
     {
-        var state = GetLineBufferState();
-        lock (state.SyncRoot)
+        _flushLock.EnterReadLock();
+        try
         {
-            WriteCore(state, (value ?? string.Empty).AsSpan(), appendNewLine: true);
+            var state = GetLineBufferState();
+            lock (state.SyncRoot)
+            {
+                WriteCore(state, (value ?? string.Empty).AsSpan(), appendNewLine: true);
+            }
+        }
+        finally
+        {
+            _flushLock.ExitReadLock();
         }
     }
 
@@ -91,22 +101,38 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        var state = GetLineBufferState();
-        lock (state.SyncRoot)
+        _flushLock.EnterReadLock();
+        try
         {
-            WriteCore(state, value.AsSpan(), appendNewLine: false);
+            var state = GetLineBufferState();
+            lock (state.SyncRoot)
+            {
+                WriteCore(state, value.AsSpan(), appendNewLine: false);
+            }
+        }
+        finally
+        {
+            _flushLock.ExitReadLock();
         }
     }
 
     /// <inheritdoc />
     public override void Write(char value)
     {
-        var state = GetLineBufferState();
-        lock (state.SyncRoot)
+        _flushLock.EnterReadLock();
+        try
         {
-            var shouldBuffer = GetBufferMode(state, ShouldBuffer());
-            state.Buffer.Append(value);
-            ProcessPendingOutput(state, shouldBuffer, shouldProcess: value == '\n');
+            var state = GetLineBufferState();
+            lock (state.SyncRoot)
+            {
+                var shouldBuffer = GetBufferMode(state, ShouldBuffer());
+                state.Buffer.Append(value);
+                ProcessPendingOutput(state, shouldBuffer, shouldProcess: value == '\n');
+            }
+        }
+        finally
+        {
+            _flushLock.ExitReadLock();
         }
     }
 
@@ -115,20 +141,36 @@ internal class CoordinatedTextWriter : TextWriter
     {
         ArgumentNullException.ThrowIfNull(buffer);
 
-        var state = GetLineBufferState();
-        lock (state.SyncRoot)
+        _flushLock.EnterReadLock();
+        try
         {
-            WriteCore(state, buffer.AsSpan(index, count), appendNewLine: false);
+            var state = GetLineBufferState();
+            lock (state.SyncRoot)
+            {
+                WriteCore(state, buffer.AsSpan(index, count), appendNewLine: false);
+            }
+        }
+        finally
+        {
+            _flushLock.ExitReadLock();
         }
     }
 
     /// <inheritdoc />
     public override void Write(ReadOnlySpan<char> buffer)
     {
-        var state = GetLineBufferState();
-        lock (state.SyncRoot)
+        _flushLock.EnterReadLock();
+        try
         {
-            WriteCore(state, buffer, appendNewLine: false);
+            var state = GetLineBufferState();
+            lock (state.SyncRoot)
+            {
+                WriteCore(state, buffer, appendNewLine: false);
+            }
+        }
+        finally
+        {
+            _flushLock.ExitReadLock();
         }
     }
 
@@ -208,30 +250,35 @@ internal class CoordinatedTextWriter : TextWriter
 
     private SecretPatterns GetSecretPatterns()
     {
-        lock (_lineBufferLock)
+        var version = _secretProvider.Version;
+        if ((version & 1) == 0
+            && Volatile.Read(ref _secretPatternsVersion) == version
+            && _secretProvider.Version == version)
         {
-            var version = _secretProvider.Version;
-            if (_secretPatternsVersion is not null
-                && (version & 1) == 0
-                && _secretPatternsVersion == version
-                && _secretProvider.Version == version)
+            return Volatile.Read(ref _secretPatterns);
+        }
+
+        lock (_secretPatternsLock)
+        {
+            var snapshot = _secretProvider.GetSnapshot();
+            if (_secretPatternsVersion == snapshot.Version)
             {
                 return _secretPatterns;
             }
 
-            var snapshot = _secretProvider.GetSnapshot();
             var values = (snapshot.Secrets ?? [])
                 .Where(pattern => !string.IsNullOrEmpty(pattern))
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderByDescending(pattern => pattern.Length)
                 .ToArray();
-            _secretPatterns = new SecretPatterns(
+            var patterns = new SecretPatterns(
                 values,
                 values.Length == 0
                     ? null
                     : SearchValues.Create(values, StringComparison.OrdinalIgnoreCase));
-            _secretPatternsVersion = snapshot.Version;
-            return _secretPatterns;
+            Volatile.Write(ref _secretPatterns, patterns);
+            Volatile.Write(ref _secretPatternsVersion, snapshot.Version);
+            return patterns;
         }
     }
 
@@ -251,8 +298,8 @@ internal class CoordinatedTextWriter : TextWriter
             return retainedPrefixLength;
         }
 
-        var pending = state.Buffer.ToString();
-        if (pending.AsSpan().IndexOfAny(patterns.SearchValues) < 0)
+        var pending = GetPendingWithPatternCandidate(state.Buffer, patterns.SearchValues);
+        if (pending is null)
         {
             return retainedPrefixLength;
         }
@@ -325,6 +372,30 @@ internal class CoordinatedTextWriter : TextWriter
         return retainedPrefixInvalidated
             ? GetPotentialPatternPrefixLength(state.Buffer, patterns.Values)
             : retainedPrefixLength;
+    }
+
+    private static string? GetPendingWithPatternCandidate(
+        StringBuilder buffer,
+        SearchValues<string> searchValues)
+    {
+        var chunks = buffer.GetChunks();
+        if (!chunks.MoveNext())
+        {
+            return null;
+        }
+
+        var firstChunk = chunks.Current.Span;
+        if (!chunks.MoveNext())
+        {
+            return firstChunk.IndexOfAny(searchValues) >= 0
+                ? buffer.ToString()
+                : null;
+        }
+
+        var pending = buffer.ToString();
+        return pending.AsSpan().IndexOfAny(searchValues) >= 0
+            ? pending
+            : null;
     }
 
     private void FlushSafeOutput(LineBufferState state, int retainedLength, bool shouldBuffer)
@@ -417,7 +488,7 @@ internal class CoordinatedTextWriter : TextWriter
         return 0;
     }
 
-    private static int GetPotentialPatternPrefixLength(StringBuilder input, IReadOnlyList<string> patterns)
+    private int GetPotentialPatternPrefixLength(StringBuilder input, IReadOnlyList<string> patterns)
     {
         if (input.Length == 0 || patterns.Count == 0)
         {
@@ -431,7 +502,7 @@ internal class CoordinatedTextWriter : TextWriter
         {
             Span<char> suffixBuffer = stackalloc char[suffixLength];
             input.CopyTo(input.Length - suffixLength, suffixBuffer, suffixLength);
-            return FindPotentialPatternPrefixLength(suffixBuffer, patterns);
+            return FindPotentialPatternPrefixLength(suffixBuffer, patterns, GetPatternComparison());
         }
 
         var rentedBuffer = ArrayPool<char>.Shared.Rent(suffixLength);
@@ -439,7 +510,7 @@ internal class CoordinatedTextWriter : TextWriter
         {
             var suffixBuffer = rentedBuffer.AsSpan(0, suffixLength);
             input.CopyTo(input.Length - suffixLength, suffixBuffer, suffixLength);
-            return FindPotentialPatternPrefixLength(suffixBuffer, patterns);
+            return FindPotentialPatternPrefixLength(suffixBuffer, patterns, GetPatternComparison());
         }
         finally
         {
@@ -449,7 +520,8 @@ internal class CoordinatedTextWriter : TextWriter
 
     private static int FindPotentialPatternPrefixLength(
         ReadOnlySpan<char> suffixBuffer,
-        IReadOnlyList<string> patterns)
+        IReadOnlyList<string> patterns,
+        StringComparison comparison)
     {
         for (var length = suffixBuffer.Length; length > 0; length--)
         {
@@ -457,7 +529,7 @@ internal class CoordinatedTextWriter : TextWriter
             foreach (var pattern in patterns)
             {
                 if (pattern.Length > length
-                    && pattern.AsSpan().StartsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                    && pattern.AsSpan().StartsWith(suffix, comparison))
                 {
                     return length;
                 }
@@ -466,6 +538,11 @@ internal class CoordinatedTextWriter : TextWriter
 
         return 0;
     }
+
+    private StringComparison GetPatternComparison() =>
+        _secretObfuscator is ITrackedSecretObfuscator trackedObfuscator
+            ? trackedObfuscator.PatternComparison
+            : StringComparison.OrdinalIgnoreCase;
 
     private void FlushDirectPrefix(LineBufferState state, int length)
     {
@@ -535,39 +612,47 @@ internal class CoordinatedTextWriter : TextWriter
     /// <inheritdoc />
     public override void Flush()
     {
-        LineBufferState[] states;
-        lock (_lineBufferLock)
+        _flushLock.EnterWriteLock();
+        try
         {
-            states = _lineBuffers.Values.ToArray();
-        }
-
-        var patterns = GetSecretPatterns();
-        foreach (var state in states)
-        {
-            lock (state.SyncRoot)
+            LineBufferState[] states;
+            lock (_lineBufferLock)
             {
-                if (state.Buffer.Length == 0)
-                {
-                    continue;
-                }
+                states = _lineBuffers.Values.ToArray();
+            }
 
-                var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
-                var retainedPrefixLength = GetPotentialPatternPrefixLength(state.Buffer, patterns.Values);
-                ObfuscateCompletePatterns(
-                    state,
-                    patterns,
-                    retainedPrefixLength,
-                    preservePotentialLongerMatch: false);
-                FlushSafePrefix(state, state.Buffer.Length, shouldBuffer);
-                FlushPartialLine(state, shouldBuffer);
-                state.ShouldBuffer = null;
+            var patterns = GetSecretPatterns();
+            foreach (var state in states)
+            {
+                lock (state.SyncRoot)
+                {
+                    if (state.Buffer.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
+                    var retainedPrefixLength = GetPotentialPatternPrefixLength(state.Buffer, patterns.Values);
+                    ObfuscateCompletePatterns(
+                        state,
+                        patterns,
+                        retainedPrefixLength,
+                        preservePotentialLongerMatch: false);
+                    FlushSafePrefix(state, state.Buffer.Length, shouldBuffer);
+                    FlushPartialLine(state, shouldBuffer);
+                    state.ShouldBuffer = null;
+                }
+            }
+
+            // Always flush real console (needed for Spectre.Console internals)
+            lock (_outputLock)
+            {
+                _realConsole.Flush();
             }
         }
-
-        // Always flush real console (needed for Spectre.Console internals)
-        lock (_outputLock)
+        finally
         {
-            _realConsole.Flush();
+            _flushLock.ExitWriteLock();
         }
     }
 
@@ -577,46 +662,54 @@ internal class CoordinatedTextWriter : TextWriter
     /// </summary>
     internal Task FlushAvailableAsync()
     {
-        LineBufferState[] states;
-        lock (_lineBufferLock)
+        _flushLock.EnterWriteLock();
+        try
         {
-            states = _lineBuffers.Values.ToArray();
-        }
-
-        var patterns = GetSecretPatterns();
-        foreach (var state in states)
-        {
-            lock (state.SyncRoot)
+            LineBufferState[] states;
+            lock (_lineBufferLock)
             {
-                if (state.Buffer.Length == 0)
-                {
-                    continue;
-                }
+                states = _lineBuffers.Values.ToArray();
+            }
 
-                var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
-                var retainedLength = GetPotentialPatternPrefixLength(state.Buffer, patterns.Values);
-                retainedLength = ObfuscateCompletePatterns(
-                    state,
-                    patterns,
-                    retainedLength,
-                    preservePotentialLongerMatch: false);
-                FlushSafeOutput(state, retainedLength, shouldBuffer);
-
-                if (shouldBuffer)
+            var patterns = GetSecretPatterns();
+            foreach (var state in states)
+            {
+                lock (state.SyncRoot)
                 {
-                    FlushPartialPrefix(state, state.Buffer.Length - retainedLength, shouldBuffer);
-                }
+                    if (state.Buffer.Length == 0)
+                    {
+                        continue;
+                    }
 
-                if (state.Buffer.Length == 0)
-                {
-                    state.ShouldBuffer = null;
+                    var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
+                    var retainedLength = GetPotentialPatternPrefixLength(state.Buffer, patterns.Values);
+                    retainedLength = ObfuscateCompletePatterns(
+                        state,
+                        patterns,
+                        retainedLength,
+                        preservePotentialLongerMatch: false);
+                    FlushSafeOutput(state, retainedLength, shouldBuffer);
+
+                    if (shouldBuffer)
+                    {
+                        FlushPartialPrefix(state, state.Buffer.Length - retainedLength, shouldBuffer);
+                    }
+
+                    if (state.Buffer.Length == 0)
+                    {
+                        state.ShouldBuffer = null;
+                    }
                 }
             }
-        }
 
-        lock (_outputLock)
+            lock (_outputLock)
+            {
+                _realConsole.Flush();
+            }
+        }
+        finally
         {
-            _realConsole.Flush();
+            _flushLock.ExitWriteLock();
         }
 
         return Task.CompletedTask;
@@ -662,7 +755,7 @@ internal class CoordinatedTextWriter : TextWriter
 
     private readonly record struct LineBufferKey(Type? ModuleType, bool IsDirectWrite);
 
-    private readonly record struct SecretPatterns(string[] Values, SearchValues<string>? SearchValues);
+    private sealed record SecretPatterns(string[] Values, SearchValues<string>? SearchValues);
 
     private sealed class DirectWriteScopeRestorer(bool previousValue) : IDisposable
     {

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -835,6 +835,12 @@ internal class CoordinatedTextWriter : TextWriter
     /// <inheritdoc />
     public override void Flush()
     {
+        if (IsReentrantOutputWrite())
+        {
+            _realConsole.Flush();
+            return;
+        }
+
         FlushBufferedOutput();
         FlushRealConsole();
     }
@@ -960,6 +966,12 @@ internal class CoordinatedTextWriter : TextWriter
     /// <inheritdoc />
     public override async Task FlushAsync()
     {
+        if (IsReentrantOutputWrite())
+        {
+            await _realConsole.FlushAsync().ConfigureAwait(false);
+            return;
+        }
+
         FlushBufferedOutput();
         await FlushRealConsoleAsync().ConfigureAwait(false);
     }

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -259,6 +259,7 @@ internal class CoordinatedTextWriter : TextWriter
         bool preservePotentialLongerMatch,
         out int retainedPrefixLength)
     {
+        string? unmodifiedBuffer = null;
         while (true)
         {
             var patterns = GetSecretPatterns();
@@ -267,11 +268,19 @@ internal class CoordinatedTextWriter : TextWriter
                 state,
                 patterns,
                 retainedPrefixLength,
-                preservePotentialLongerMatch);
+                preservePotentialLongerMatch,
+                out var bufferBeforeObfuscation);
             if (_secretProvider.Version == patterns.Version
                 && GetPatternComparison() == patterns.Comparison)
             {
                 return patterns;
+            }
+
+            unmodifiedBuffer ??= bufferBeforeObfuscation;
+            if (unmodifiedBuffer is not null)
+            {
+                state.Buffer.Clear();
+                state.Buffer.Append(unmodifiedBuffer);
             }
         }
     }
@@ -354,8 +363,10 @@ internal class CoordinatedTextWriter : TextWriter
         LineBufferState state,
         SecretPatterns patterns,
         int retainedPrefixLength,
-        bool preservePotentialLongerMatch = true)
+        bool preservePotentialLongerMatch,
+        out string? bufferBeforeObfuscation)
     {
+        bufferBeforeObfuscation = null;
         if (state.Buffer.Length == 0 || patterns.SearchValues is null)
         {
             return retainedPrefixLength;
@@ -420,6 +431,7 @@ internal class CoordinatedTextWriter : TextWriter
 
         if (replaced)
         {
+            bufferBeforeObfuscation = pending;
             output.Append(pending, outputIndex, pending.Length - outputIndex);
             state.Buffer.Clear();
             state.Buffer.Append(output);
@@ -857,12 +869,27 @@ internal class CoordinatedTextWriter : TextWriter
     {
         if (IsReentrantOutputWrite())
         {
+            FlushReentrantOutput();
             _realConsole.Flush();
             return;
         }
 
         FlushBufferedOutput();
         FlushRealConsole();
+    }
+
+    private void FlushReentrantOutput()
+    {
+        // The outer write still owns a recursive read lock, so a full flush cannot
+        // upgrade to the write lock. Drain only this reentrant context's state.
+        var state = GetLineBufferState();
+        lock (state.SyncRoot)
+        {
+            if (state.Buffer.Length > 0)
+            {
+                FlushState(state, retainPotentialPrefix: false);
+            }
+        }
     }
 
     private void FlushBufferedOutput()
@@ -988,6 +1015,7 @@ internal class CoordinatedTextWriter : TextWriter
     {
         if (IsReentrantOutputWrite())
         {
+            FlushReentrantOutput();
             await _realConsole.FlushAsync().ConfigureAwait(false);
             return;
         }

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -37,7 +37,8 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly ISecretProvider _secretProvider;
     private readonly Dictionary<LineBufferKey, LineBufferState> _lineBuffers = [];
     private readonly object _lineBufferLock = new();
-    private string[] _secretPatterns = [];
+    private readonly object _outputLock = new();
+    private SecretPatterns _secretPatterns = new([], null);
     private long? _secretPatternsVersion;
 
     /// <summary>
@@ -69,9 +70,10 @@ internal class CoordinatedTextWriter : TextWriter
     /// <inheritdoc />
     public override void WriteLine(string? value)
     {
-        lock (_lineBufferLock)
+        var state = GetLineBufferState();
+        lock (state.SyncRoot)
         {
-            WriteCore((value ?? string.Empty).AsSpan(), appendNewLine: true);
+            WriteCore(state, (value ?? string.Empty).AsSpan(), appendNewLine: true);
         }
     }
 
@@ -89,18 +91,19 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        lock (_lineBufferLock)
+        var state = GetLineBufferState();
+        lock (state.SyncRoot)
         {
-            WriteCore(value.AsSpan(), appendNewLine: false);
+            WriteCore(state, value.AsSpan(), appendNewLine: false);
         }
     }
 
     /// <inheritdoc />
     public override void Write(char value)
     {
-        lock (_lineBufferLock)
+        var state = GetLineBufferState();
+        lock (state.SyncRoot)
         {
-            var state = GetLineBufferState();
             var shouldBuffer = GetBufferMode(state, ShouldBuffer());
             state.Buffer.Append(value);
             ProcessPendingOutput(state, shouldBuffer, shouldProcess: value == '\n');
@@ -112,18 +115,20 @@ internal class CoordinatedTextWriter : TextWriter
     {
         ArgumentNullException.ThrowIfNull(buffer);
 
-        lock (_lineBufferLock)
+        var state = GetLineBufferState();
+        lock (state.SyncRoot)
         {
-            WriteCore(buffer.AsSpan(index, count), appendNewLine: false);
+            WriteCore(state, buffer.AsSpan(index, count), appendNewLine: false);
         }
     }
 
     /// <inheritdoc />
     public override void Write(ReadOnlySpan<char> buffer)
     {
-        lock (_lineBufferLock)
+        var state = GetLineBufferState();
+        lock (state.SyncRoot)
         {
-            WriteCore(buffer, appendNewLine: false);
+            WriteCore(state, buffer, appendNewLine: false);
         }
     }
 
@@ -145,9 +150,8 @@ internal class CoordinatedTextWriter : TextWriter
         }
     }
 
-    private void WriteCore(ReadOnlySpan<char> value, bool appendNewLine)
+    private void WriteCore(LineBufferState state, ReadOnlySpan<char> value, bool appendNewLine)
     {
-        var state = GetLineBufferState();
         var shouldBuffer = GetBufferMode(state, ShouldBuffer());
         state.Buffer.Append(value);
 
@@ -170,8 +174,9 @@ internal class CoordinatedTextWriter : TextWriter
         }
 
         var patterns = GetSecretPatterns();
-        ObfuscateCompletePatterns(state, patterns);
-        FlushSafeOutput(state, patterns, shouldBuffer);
+        var retainedPrefixLength = GetPotentialPatternPrefixLength(state.Buffer, patterns.Values);
+        retainedPrefixLength = ObfuscateCompletePatterns(state, patterns, retainedPrefixLength);
+        FlushSafeOutput(state, retainedPrefixLength, shouldBuffer);
     }
 
     private LineBufferState GetLineBufferState()
@@ -179,13 +184,16 @@ internal class CoordinatedTextWriter : TextWriter
         var moduleType = ModuleLogger.CurrentModuleType.Value;
         var key = new LineBufferKey(moduleType, DirectWriteScope.Value);
 
-        if (!_lineBuffers.TryGetValue(key, out var state))
+        lock (_lineBufferLock)
         {
-            state = new LineBufferState(moduleType);
-            _lineBuffers.Add(key, state);
-        }
+            if (!_lineBuffers.TryGetValue(key, out var state))
+            {
+                state = new LineBufferState(moduleType);
+                _lineBuffers.Add(key, state);
+            }
 
-        return state;
+            return state;
+        }
     }
 
     private static bool GetBufferMode(LineBufferState state, bool requestedBufferMode)
@@ -198,42 +206,56 @@ internal class CoordinatedTextWriter : TextWriter
         return state.ShouldBuffer.Value;
     }
 
-    private string[] GetSecretPatterns()
+    private SecretPatterns GetSecretPatterns()
     {
-        var version = _secretProvider.Version;
-        if (_secretPatternsVersion is not null
-            && (version & 1) == 0
-            && _secretPatternsVersion == version
-            && _secretProvider.Version == version)
+        lock (_lineBufferLock)
         {
+            var version = _secretProvider.Version;
+            if (_secretPatternsVersion is not null
+                && (version & 1) == 0
+                && _secretPatternsVersion == version
+                && _secretProvider.Version == version)
+            {
+                return _secretPatterns;
+            }
+
+            var snapshot = _secretProvider.GetSnapshot();
+            var values = (snapshot.Secrets ?? [])
+                .Where(pattern => !string.IsNullOrEmpty(pattern))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderByDescending(pattern => pattern.Length)
+                .ToArray();
+            _secretPatterns = new SecretPatterns(
+                values,
+                values.Length == 0
+                    ? null
+                    : SearchValues.Create(values, StringComparison.OrdinalIgnoreCase));
+            _secretPatternsVersion = snapshot.Version;
             return _secretPatterns;
         }
-
-        var snapshot = _secretProvider.GetSnapshot();
-        _secretPatterns = (snapshot.Secrets ?? [])
-            .Where(pattern => !string.IsNullOrEmpty(pattern))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderByDescending(pattern => pattern.Length)
-            .ToArray();
-        _secretPatternsVersion = snapshot.Version;
-        return _secretPatterns;
     }
 
-    private void ObfuscateCompletePatterns(
+    private int ObfuscateCompletePatterns(
         LineBufferState state,
-        IReadOnlyList<string> patterns,
+        SecretPatterns patterns,
+        int retainedPrefixLength,
         bool preservePotentialLongerMatch = true)
     {
-        if (state.Buffer.Length == 0 || patterns.Count == 0)
+        if (state.Buffer.Length == 0 || patterns.SearchValues is null)
         {
-            return;
+            return retainedPrefixLength;
         }
 
-        var retainedPrefixLength = GetPotentialPatternPrefixLength(state.Buffer, patterns);
         var pending = state.Buffer.ToString();
+        if (pending.AsSpan().IndexOfAny(patterns.SearchValues) < 0)
+        {
+            return retainedPrefixLength;
+        }
+
         var output = new StringBuilder(pending.Length);
         var searchIndex = 0;
         var replaced = false;
+        var retainedPrefixInvalidated = false;
         var retainedPrefixStart = pending.Length - retainedPrefixLength;
 
         while (searchIndex < pending.Length)
@@ -256,6 +278,7 @@ internal class CoordinatedTextWriter : TextWriter
             output.Append(pending, searchIndex, match.Index - searchIndex);
             var secret = pending.Substring(match.Index, match.Length);
             output.Append(_secretObfuscator.Obfuscate(secret, null));
+            retainedPrefixInvalidated |= match.Index + match.Length > retainedPrefixStart;
             searchIndex = match.Index + match.Length;
             replaced = true;
         }
@@ -265,14 +288,14 @@ internal class CoordinatedTextWriter : TextWriter
             state.Buffer.Clear();
             state.Buffer.Append(output);
         }
+
+        return retainedPrefixInvalidated
+            ? GetPotentialPatternPrefixLength(state.Buffer, patterns.Values)
+            : retainedPrefixLength;
     }
 
-    private void FlushSafeOutput(LineBufferState state, IReadOnlyList<string> patterns, bool shouldBuffer)
+    private void FlushSafeOutput(LineBufferState state, int retainedLength, bool shouldBuffer)
     {
-        var retainedLength = patterns.Count == 0
-            ? 0
-            : GetPotentialPatternPrefixLength(state.Buffer, patterns);
-
         FlushSafePrefix(state, state.Buffer.Length - retainedLength, shouldBuffer);
 
         if (state.Buffer.Length == 0)
@@ -316,23 +339,26 @@ internal class CoordinatedTextWriter : TextWriter
 
     private static (int Index, int Length) FindFirstPattern(
         string input,
-        IReadOnlyList<string> patterns,
+        SecretPatterns patterns,
         int startIndex)
     {
-        var firstIndex = -1;
-        var longestMatch = 0;
-
-        foreach (var pattern in patterns)
+        var relativeIndex = input.AsSpan(startIndex).IndexOfAny(patterns.SearchValues!);
+        if (relativeIndex < 0)
         {
-            var index = input.IndexOf(pattern, startIndex, StringComparison.OrdinalIgnoreCase);
-            if (index >= 0 && (firstIndex < 0 || index < firstIndex || (index == firstIndex && pattern.Length > longestMatch)))
+            return (-1, 0);
+        }
+
+        var firstIndex = startIndex + relativeIndex;
+        var matchingInput = input.AsSpan(firstIndex);
+        foreach (var pattern in patterns.Values)
+        {
+            if (matchingInput.StartsWith(pattern, StringComparison.OrdinalIgnoreCase))
             {
-                firstIndex = index;
-                longestMatch = pattern.Length;
+                return (firstIndex, pattern.Length);
             }
         }
 
-        return (firstIndex, longestMatch);
+        throw new InvalidOperationException("SearchValues returned a position without a matching secret.");
     }
 
     private static int GetPotentialPatternPrefixLength(StringBuilder input, IReadOnlyList<string> patterns)
@@ -394,20 +420,24 @@ internal class CoordinatedTextWriter : TextWriter
 
         var output = state.Buffer.ToString(0, length);
         state.Buffer.Remove(0, length);
-        _realConsole.Write(_secretObfuscator.Obfuscate(output, null));
+        lock (_outputLock)
+        {
+            _realConsole.Write(output);
+        }
     }
 
     private void WriteCompletedLine(string line, bool shouldBuffer, Type? moduleType)
     {
-        var obfuscated = _secretObfuscator.Obfuscate(line, null);
-
         if (shouldBuffer)
         {
-            RouteToBuffer(obfuscated, moduleType);
+            RouteToBuffer(line, moduleType);
         }
         else
         {
-            _realConsole.WriteLine(obfuscated);
+            lock (_outputLock)
+            {
+                _realConsole.WriteLine(line);
+            }
         }
     }
 
@@ -425,28 +455,46 @@ internal class CoordinatedTextWriter : TextWriter
 
         var pending = state.Buffer.ToString(0, length);
         state.Buffer.Remove(0, length);
-        var obfuscated = _secretObfuscator.Obfuscate(pending, null);
 
         if (shouldBuffer)
         {
-            RouteToBuffer(obfuscated, state.ModuleType);
+            RouteToBuffer(pending, state.ModuleType);
         }
         else
         {
-            _realConsole.Write(obfuscated);
+            lock (_outputLock)
+            {
+                _realConsole.Write(pending);
+            }
         }
     }
 
     /// <inheritdoc />
     public override void Flush()
     {
-        // Flush any partial line in the buffer
+        LineBufferState[] states;
         lock (_lineBufferLock)
         {
-            foreach (var state in _lineBuffers.Values.Where(state => state.Buffer.Length > 0))
+            states = _lineBuffers.Values.ToArray();
+        }
+
+        var patterns = GetSecretPatterns();
+        foreach (var state in states)
+        {
+            lock (state.SyncRoot)
             {
+                if (state.Buffer.Length == 0)
+                {
+                    continue;
+                }
+
                 var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
-                ObfuscateCompletePatterns(state, GetSecretPatterns());
+                var retainedPrefixLength = GetPotentialPatternPrefixLength(state.Buffer, patterns.Values);
+                ObfuscateCompletePatterns(
+                    state,
+                    patterns,
+                    retainedPrefixLength,
+                    preservePotentialLongerMatch: false);
                 FlushSafePrefix(state, state.Buffer.Length, shouldBuffer);
                 FlushPartialLine(state, shouldBuffer);
                 state.ShouldBuffer = null;
@@ -454,7 +502,10 @@ internal class CoordinatedTextWriter : TextWriter
         }
 
         // Always flush real console (needed for Spectre.Console internals)
-        _realConsole.Flush();
+        lock (_outputLock)
+        {
+            _realConsole.Flush();
+        }
     }
 
     /// <summary>
@@ -463,20 +514,33 @@ internal class CoordinatedTextWriter : TextWriter
     /// </summary>
     internal Task FlushAvailableAsync()
     {
+        LineBufferState[] states;
         lock (_lineBufferLock)
         {
-            var patterns = GetSecretPatterns();
-            foreach (var state in _lineBuffers.Values.Where(state => state.Buffer.Length > 0))
+            states = _lineBuffers.Values.ToArray();
+        }
+
+        var patterns = GetSecretPatterns();
+        foreach (var state in states)
+        {
+            lock (state.SyncRoot)
             {
+                if (state.Buffer.Length == 0)
+                {
+                    continue;
+                }
+
                 var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
-                ObfuscateCompletePatterns(state, patterns, preservePotentialLongerMatch: false);
-                FlushSafeOutput(state, patterns, shouldBuffer);
+                var retainedLength = GetPotentialPatternPrefixLength(state.Buffer, patterns.Values);
+                retainedLength = ObfuscateCompletePatterns(
+                    state,
+                    patterns,
+                    retainedLength,
+                    preservePotentialLongerMatch: false);
+                FlushSafeOutput(state, retainedLength, shouldBuffer);
 
                 if (shouldBuffer)
                 {
-                    var retainedLength = patterns.Length == 0
-                        ? 0
-                        : GetPotentialPatternPrefixLength(state.Buffer, patterns);
                     FlushPartialPrefix(state, state.Buffer.Length - retainedLength, shouldBuffer);
                 }
 
@@ -487,14 +551,19 @@ internal class CoordinatedTextWriter : TextWriter
             }
         }
 
-        return _realConsole.FlushAsync();
+        lock (_outputLock)
+        {
+            _realConsole.Flush();
+        }
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
     public override Task FlushAsync()
     {
         Flush();
-        return _realConsole.FlushAsync();
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
@@ -519,6 +588,8 @@ internal class CoordinatedTextWriter : TextWriter
 
     private sealed class LineBufferState(Type? moduleType)
     {
+        public object SyncRoot { get; } = new();
+
         public Type? ModuleType { get; } = moduleType;
 
         public StringBuilder Buffer { get; } = new();
@@ -527,6 +598,8 @@ internal class CoordinatedTextWriter : TextWriter
     }
 
     private readonly record struct LineBufferKey(Type? ModuleType, bool IsDirectWrite);
+
+    private readonly record struct SecretPatterns(string[] Values, SearchValues<string>? SearchValues);
 
     private sealed class DirectWriteScopeRestorer(bool previousValue) : IDisposable
     {

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -294,10 +294,13 @@ internal class CoordinatedTextWriter : TextWriter
                 continue;
             }
 
+            var unchangedSuffixLength = GetUnchangedSuffixLength(secret, obfuscatedSecret);
+            var consumedLength = match.Length - unchangedSuffixLength;
+            var obfuscatedLength = obfuscatedSecret.Length - unchangedSuffixLength;
             output.Append(pending, outputIndex, match.Index - outputIndex);
-            output.Append(obfuscatedSecret);
-            retainedPrefixInvalidated |= match.Index + match.Length > retainedPrefixStart;
-            outputIndex = match.Index + match.Length;
+            output.Append(obfuscatedSecret, 0, obfuscatedLength);
+            retainedPrefixInvalidated |= match.Index + consumedLength > retainedPrefixStart;
+            outputIndex = match.Index + consumedLength;
             searchIndex = outputIndex;
             replaced = true;
         }
@@ -311,6 +314,19 @@ internal class CoordinatedTextWriter : TextWriter
         return retainedPrefixInvalidated
             ? GetPotentialPatternPrefixLength(state.Buffer, patterns.Values)
             : retainedPrefixLength;
+    }
+
+    private static int GetUnchangedSuffixLength(string input, string obfuscated)
+    {
+        var maximumLength = Math.Min(input.Length, obfuscated.Length);
+        var suffixLength = 0;
+        while (suffixLength < maximumLength
+               && input[^(suffixLength + 1)] == obfuscated[^(suffixLength + 1)])
+        {
+            suffixLength++;
+        }
+
+        return suffixLength == input.Length ? 0 : suffixLength;
     }
 
     private void FlushSafeOutput(LineBufferState state, int retainedLength, bool shouldBuffer)

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -36,7 +36,6 @@ internal class CoordinatedTextWriter : TextWriter
 {
     private static readonly AsyncLocal<ActiveOutputWriter?> ActiveOutputWriterScope = new();
     private static readonly AsyncLocal<bool> DirectWriteScope = new();
-    private static readonly AsyncLocal<int> CustomObfuscationDepth = new();
 
     private readonly IConsoleCoordinator _coordinator;
     private readonly TextWriter _realConsole;
@@ -47,6 +46,7 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly object _lineBufferLock = new();
     private readonly object _customObfuscatorLock = new();
     private readonly object _secretPatternsLock = new();
+    private readonly AsyncLocal<int> _customObfuscationDepth = new();
     private readonly SemaphoreSlim _outputLock = new(1, 1);
     private readonly ReaderWriterLockSlim _flushLock = new(LockRecursionPolicy.SupportsRecursion);
     private SecretPatterns _secretPatterns = new([], null);
@@ -291,7 +291,7 @@ internal class CoordinatedTextWriter : TextWriter
         var key = new LineBufferKey(
             moduleType,
             DirectWriteScope.Value,
-            CustomObfuscationDepth.Value,
+            _customObfuscationDepth.Value,
             IsReentrantOutputWrite());
 
         lock (_lineBufferLock)
@@ -839,15 +839,15 @@ internal class CoordinatedTextWriter : TextWriter
 
         lock (_customObfuscatorLock)
         {
-            var previousDepth = CustomObfuscationDepth.Value;
-            CustomObfuscationDepth.Value = previousDepth + 1;
+            var previousDepth = _customObfuscationDepth.Value;
+            _customObfuscationDepth.Value = previousDepth + 1;
             try
             {
                 return _secretObfuscator.Obfuscate(output, null);
             }
             finally
             {
-                CustomObfuscationDepth.Value = previousDepth;
+                _customObfuscationDepth.Value = previousDepth;
             }
         }
     }
@@ -874,7 +874,7 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        if (CustomObfuscationDepth.Value > 0)
+        if (_customObfuscationDepth.Value > 0)
         {
             FlushReentrantOutput();
             FlushRealConsole();
@@ -1027,7 +1027,7 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        if (CustomObfuscationDepth.Value > 0)
+        if (_customObfuscationDepth.Value > 0)
         {
             FlushReentrantOutput();
             await FlushRealConsoleAsync().ConfigureAwait(false);

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -874,6 +874,13 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
+        if (CustomObfuscationDepth.Value > 0)
+        {
+            FlushReentrantOutput();
+            FlushRealConsole();
+            return;
+        }
+
         FlushBufferedOutput();
         FlushRealConsole();
     }
@@ -1017,6 +1024,13 @@ internal class CoordinatedTextWriter : TextWriter
         {
             FlushReentrantOutput();
             await _realConsole.FlushAsync().ConfigureAwait(false);
+            return;
+        }
+
+        if (CustomObfuscationDepth.Value > 0)
+        {
+            FlushReentrantOutput();
+            await FlushRealConsoleAsync().ConfigureAwait(false);
             return;
         }
 

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -320,15 +320,9 @@ internal class CoordinatedTextWriter : TextWriter
             }
 
             var matchEnd = match.Index + match.Length;
-            var isCompleteSelfOverlappingMatch = matchEnd == pending.Length
-                && match.Index < retainedPrefixStart
-                && pending.AsSpan(match.Index, retainedPrefixLength).Equals(
-                    pending.AsSpan(retainedPrefixStart),
-                    StringComparison.OrdinalIgnoreCase);
             if (preservePotentialLongerMatch
                 && retainedPrefixLength > 0
-                && matchEnd > retainedPrefixStart
-                && !isCompleteSelfOverlappingMatch)
+                && matchEnd > retainedPrefixStart)
             {
                 var safeMatchLength = FindLongestPatternEndingAtOrBefore(
                     pending,
@@ -337,11 +331,22 @@ internal class CoordinatedTextWriter : TextWriter
                     retainedPrefixStart);
                 if (safeMatchLength == 0)
                 {
-                    searchIndex = match.Index + 1;
-                    continue;
+                    var hasLaterSafeMatch = HasCompletePatternBetween(
+                        pending,
+                        patterns.Values,
+                        match.Index + 1,
+                        retainedPrefixStart,
+                        trackedObfuscator.PatternComparison);
+                    if (match.Index >= retainedPrefixStart || hasLaterSafeMatch)
+                    {
+                        searchIndex = match.Index + 1;
+                        continue;
+                    }
                 }
-
-                match = (match.Index, safeMatchLength);
+                else
+                {
+                    match = (match.Index, safeMatchLength);
+                }
             }
 
             var secret = pending.Substring(match.Index, match.Length);
@@ -486,6 +491,28 @@ internal class CoordinatedTextWriter : TextWriter
         }
 
         return 0;
+    }
+
+    private static bool HasCompletePatternBetween(
+        string input,
+        IReadOnlyList<string> patterns,
+        int startIndex,
+        int endIndex,
+        StringComparison comparison)
+    {
+        for (var index = startIndex; index < endIndex; index++)
+        {
+            var safeInput = input.AsSpan(index, endIndex - index);
+            foreach (var pattern in patterns)
+            {
+                if (safeInput.StartsWith(pattern, comparison))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 
     private int GetPotentialPatternPrefixLength(StringBuilder input, IReadOnlyList<string> patterns)

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -270,7 +270,8 @@ internal class CoordinatedTextWriter : TextWriter
                 patterns,
                 retainedPrefixLength,
                 preservePotentialLongerMatch);
-            if (_secretProvider.Version == patterns.Version)
+            if (_secretProvider.Version == patterns.Version
+                && GetPatternComparison() == patterns.Comparison)
             {
                 return patterns;
             }
@@ -993,26 +994,18 @@ internal class CoordinatedTextWriter : TextWriter
         await _outputLock.WaitAsync().ConfigureAwait(false);
         var activeOutputWriters = _activeOutputWriters ??= [];
         activeOutputWriters.Add(this);
+        Task flushTask;
         try
         {
-            Task flushTask;
-            try
-            {
-                flushTask = _realConsole.FlushAsync();
-            }
-            finally
-            {
-                // Thread-static reentrancy only covers callbacks made synchronously
-                // while the underlying asynchronous flush is invoked.
-                RemoveActiveOutputWriter(activeOutputWriters);
-            }
-
-            await flushTask.ConfigureAwait(false);
+            flushTask = _realConsole.FlushAsync();
         }
         finally
         {
+            RemoveActiveOutputWriter(activeOutputWriters);
             _outputLock.Release();
         }
+
+        await flushTask.ConfigureAwait(false);
     }
 
     private void RemoveActiveOutputWriter(HashSet<CoordinatedTextWriter> activeOutputWriters)

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -745,7 +745,8 @@ internal class CoordinatedTextWriter : TextWriter
 
     private void ExecuteWithStableSecrets(Action processOutput)
     {
-        if (_secretProvider is ISecretEmissionGuard emissionGuard)
+        if (_secretObfuscator is ITrackedSecretObfuscator
+            && _secretProvider is ISecretEmissionGuard emissionGuard)
         {
             emissionGuard.ExecuteWithStableSecrets(processOutput);
             return;

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -38,7 +38,7 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly Dictionary<LineBufferKey, LineBufferState> _lineBuffers = [];
     private readonly object _lineBufferLock = new();
     private readonly object _secretPatternsLock = new();
-    private readonly object _outputLock = new();
+    private readonly SemaphoreSlim _outputLock = new(1, 1);
     private readonly ReaderWriterLockSlim _flushLock = new(LockRecursionPolicy.NoRecursion);
     private SecretPatterns _secretPatterns = new([], null);
     private long _secretPatternsVersion = long.MinValue;
@@ -215,10 +215,32 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        var patterns = GetSecretPatterns();
-        var retainedPrefixLength = GetPotentialPatternPrefixLength(state.Buffer, patterns.Values);
-        retainedPrefixLength = ObfuscateCompletePatterns(state, patterns, retainedPrefixLength);
-        FlushSafeOutput(state, retainedPrefixLength, shouldBuffer);
+        var patterns = ObfuscateWithCurrentPatterns(
+            state,
+            preservePotentialLongerMatch: true,
+            out var retainedPrefixLength);
+        FlushSafeOutput(state, retainedPrefixLength, shouldBuffer, patterns.Version);
+    }
+
+    private SecretPatterns ObfuscateWithCurrentPatterns(
+        LineBufferState state,
+        bool preservePotentialLongerMatch,
+        out int retainedPrefixLength)
+    {
+        while (true)
+        {
+            var patterns = GetSecretPatterns();
+            retainedPrefixLength = GetPotentialPatternPrefixLength(state.Buffer, patterns.Values);
+            retainedPrefixLength = ObfuscateCompletePatterns(
+                state,
+                patterns,
+                retainedPrefixLength,
+                preservePotentialLongerMatch);
+            if (_secretProvider.Version == patterns.Version)
+            {
+                return patterns;
+            }
+        }
     }
 
     private LineBufferState GetLineBufferState()
@@ -266,16 +288,22 @@ internal class CoordinatedTextWriter : TextWriter
                 return _secretPatterns;
             }
 
+            var comparison = GetPatternComparison();
+            var comparer = comparison == StringComparison.Ordinal
+                ? StringComparer.Ordinal
+                : StringComparer.OrdinalIgnoreCase;
             var values = (snapshot.Secrets ?? [])
                 .Where(pattern => !string.IsNullOrEmpty(pattern))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Distinct(comparer)
                 .OrderByDescending(pattern => pattern.Length)
                 .ToArray();
             var patterns = new SecretPatterns(
                 values,
                 values.Length == 0
                     ? null
-                    : SearchValues.Create(values, StringComparison.OrdinalIgnoreCase));
+                    : SearchValues.Create(values, comparison),
+                comparison,
+                snapshot.Version);
             Volatile.Write(ref _secretPatterns, patterns);
             Volatile.Write(ref _secretPatternsVersion, snapshot.Version);
             return patterns;
@@ -319,34 +347,17 @@ internal class CoordinatedTextWriter : TextWriter
                 break;
             }
 
-            var matchEnd = match.Index + match.Length;
-            if (preservePotentialLongerMatch
-                && retainedPrefixLength > 0
-                && matchEnd > retainedPrefixStart)
-            {
-                var safeMatchLength = FindLongestPatternEndingAtOrBefore(
+            if (!TrySelectMaskableMatch(
                     pending,
-                    patterns.Values,
-                    match.Index,
-                    retainedPrefixStart);
-                if (safeMatchLength == 0)
-                {
-                    var hasLaterSafeMatch = HasCompletePatternBetween(
-                        pending,
-                        patterns.Values,
-                        match.Index + 1,
-                        retainedPrefixStart,
-                        trackedObfuscator.PatternComparison);
-                    if (match.Index >= retainedPrefixStart || hasLaterSafeMatch)
-                    {
-                        searchIndex = match.Index + 1;
-                        continue;
-                    }
-                }
-                else
-                {
-                    match = (match.Index, safeMatchLength);
-                }
+                    patterns,
+                    preservePotentialLongerMatch,
+                    retainedPrefixInvalidated,
+                    retainedPrefixLength,
+                    retainedPrefixStart,
+                    ref match))
+            {
+                searchIndex = match.Index + 1;
+                continue;
             }
 
             var secret = pending.Substring(match.Index, match.Length);
@@ -379,6 +390,44 @@ internal class CoordinatedTextWriter : TextWriter
             : retainedPrefixLength;
     }
 
+    private static bool TrySelectMaskableMatch(
+        string pending,
+        SecretPatterns patterns,
+        bool preservePotentialLongerMatch,
+        bool retainedPrefixInvalidated,
+        int retainedPrefixLength,
+        int retainedPrefixStart,
+        ref (int Index, int Length) match)
+    {
+        if (!preservePotentialLongerMatch
+            || retainedPrefixInvalidated
+            || retainedPrefixLength == 0
+            || match.Index + match.Length <= retainedPrefixStart)
+        {
+            return true;
+        }
+
+        var safeMatchLength = FindLongestPatternEndingAtOrBefore(
+            pending,
+            patterns.Values,
+            match.Index,
+            retainedPrefixStart,
+            patterns.Comparison);
+        if (safeMatchLength > 0)
+        {
+            match = (match.Index, safeMatchLength);
+            return true;
+        }
+
+        return match.Index < retainedPrefixStart
+               && !HasCompletePatternBetween(
+                   pending,
+                   patterns.Values,
+                   match.Index + 1,
+                   retainedPrefixStart,
+                   patterns.Comparison);
+    }
+
     private static string? GetPendingWithPatternCandidate(
         StringBuilder buffer,
         SearchValues<string> searchValues)
@@ -403,9 +452,17 @@ internal class CoordinatedTextWriter : TextWriter
             : null;
     }
 
-    private void FlushSafeOutput(LineBufferState state, int retainedLength, bool shouldBuffer)
+    private void FlushSafeOutput(
+        LineBufferState state,
+        int retainedLength,
+        bool shouldBuffer,
+        long secretPatternsVersion)
     {
-        FlushSafePrefix(state, state.Buffer.Length - retainedLength, shouldBuffer);
+        FlushSafePrefix(
+            state,
+            state.Buffer.Length - retainedLength,
+            shouldBuffer,
+            secretPatternsVersion);
 
         if (state.Buffer.Length == 0)
         {
@@ -413,7 +470,11 @@ internal class CoordinatedTextWriter : TextWriter
         }
     }
 
-    private void FlushSafePrefix(LineBufferState state, int safeLength, bool shouldBuffer)
+    private void FlushSafePrefix(
+        LineBufferState state,
+        int safeLength,
+        bool shouldBuffer,
+        long secretPatternsVersion)
     {
         var consumedLength = 0;
         for (var index = 0; index < safeLength; index++)
@@ -430,7 +491,7 @@ internal class CoordinatedTextWriter : TextWriter
             }
 
             var line = state.Buffer.ToString(consumedLength, lineLength);
-            WriteCompletedLine(line, shouldBuffer, state.ModuleType);
+            WriteCompletedLine(line, shouldBuffer, state.ModuleType, secretPatternsVersion);
             consumedLength = index + 1;
         }
 
@@ -442,7 +503,7 @@ internal class CoordinatedTextWriter : TextWriter
 
         if (!shouldBuffer)
         {
-            FlushDirectPrefix(state, safeLength);
+            FlushDirectPrefix(state, safeLength, secretPatternsVersion);
         }
     }
 
@@ -461,7 +522,7 @@ internal class CoordinatedTextWriter : TextWriter
         var matchingInput = input.AsSpan(firstIndex);
         foreach (var pattern in patterns.Values)
         {
-            if (matchingInput.StartsWith(pattern, StringComparison.OrdinalIgnoreCase))
+            if (matchingInput.StartsWith(pattern, patterns.Comparison))
             {
                 return (firstIndex, pattern.Length);
             }
@@ -474,7 +535,8 @@ internal class CoordinatedTextWriter : TextWriter
         string input,
         IReadOnlyList<string> patterns,
         int startIndex,
-        int endIndex)
+        int endIndex,
+        StringComparison comparison)
     {
         if (startIndex >= endIndex)
         {
@@ -484,7 +546,7 @@ internal class CoordinatedTextWriter : TextWriter
         var safeInput = input.AsSpan(startIndex, endIndex - startIndex);
         foreach (var pattern in patterns)
         {
-            if (safeInput.StartsWith(pattern, StringComparison.OrdinalIgnoreCase))
+            if (safeInput.StartsWith(pattern, comparison))
             {
                 return pattern.Length;
             }
@@ -571,73 +633,111 @@ internal class CoordinatedTextWriter : TextWriter
             ? trackedObfuscator.PatternComparison
             : StringComparison.OrdinalIgnoreCase;
 
-    private void FlushDirectPrefix(LineBufferState state, int length)
+    private void FlushDirectPrefix(
+        LineBufferState state,
+        int length,
+        long secretPatternsVersion)
     {
         if (length <= 0)
         {
             return;
         }
 
-        var output = ObfuscateCustomOutput(state.Buffer.ToString(0, length));
+        var output = state.Buffer.ToString(0, length);
         state.Buffer.Remove(0, length);
-        lock (_outputLock)
+        _outputLock.Wait();
+        try
         {
-            _realConsole.Write(output);
+            _realConsole.Write(ObfuscateCustomOutput(output, secretPatternsVersion));
+        }
+        finally
+        {
+            _outputLock.Release();
         }
     }
 
-    private void WriteCompletedLine(string line, bool shouldBuffer, Type? moduleType)
+    private void WriteCompletedLine(
+        string line,
+        bool shouldBuffer,
+        Type? moduleType,
+        long secretPatternsVersion)
     {
-        line = ObfuscateCustomOutput(line);
-
         if (shouldBuffer)
         {
-            RouteToBuffer(line, moduleType);
+            RouteToBuffer(
+                ObfuscateCustomOutput(line, secretPatternsVersion),
+                moduleType);
         }
         else
         {
-            lock (_outputLock)
+            _outputLock.Wait();
+            try
             {
-                _realConsole.WriteLine(line);
+                _realConsole.WriteLine(ObfuscateCustomOutput(line, secretPatternsVersion));
+            }
+            finally
+            {
+                _outputLock.Release();
             }
         }
     }
 
-    private void FlushPartialLine(LineBufferState state, bool shouldBuffer)
+    private void FlushPartialLine(
+        LineBufferState state,
+        bool shouldBuffer,
+        long secretPatternsVersion)
     {
-        FlushPartialPrefix(state, state.Buffer.Length, shouldBuffer);
+        FlushPartialPrefix(state, state.Buffer.Length, shouldBuffer, secretPatternsVersion);
     }
 
-    private void FlushPartialPrefix(LineBufferState state, int length, bool shouldBuffer)
+    private void FlushPartialPrefix(
+        LineBufferState state,
+        int length,
+        bool shouldBuffer,
+        long secretPatternsVersion)
     {
         if (length <= 0)
         {
             return;
         }
 
-        var pending = ObfuscateCustomOutput(state.Buffer.ToString(0, length));
+        var pending = state.Buffer.ToString(0, length);
         state.Buffer.Remove(0, length);
 
         if (shouldBuffer)
         {
-            RouteToBuffer(pending, state.ModuleType);
+            RouteToBuffer(
+                ObfuscateCustomOutput(pending, secretPatternsVersion),
+                state.ModuleType);
         }
         else
         {
-            lock (_outputLock)
+            _outputLock.Wait();
+            try
             {
-                _realConsole.Write(pending);
+                _realConsole.Write(ObfuscateCustomOutput(pending, secretPatternsVersion));
+            }
+            finally
+            {
+                _outputLock.Release();
             }
         }
     }
 
-    private string ObfuscateCustomOutput(string output) =>
+    private string ObfuscateCustomOutput(string output, long secretPatternsVersion) =>
         _secretObfuscator is ITrackedSecretObfuscator
+        && _secretProvider.Version == secretPatternsVersion
             ? output
             : _secretObfuscator.Obfuscate(output, null);
 
     /// <inheritdoc />
     public override void Flush()
+    {
+        FlushBufferedOutput();
+        FlushRealConsole();
+    }
+
+    private void FlushBufferedOutput()
     {
         _flushLock.EnterWriteLock();
         try
@@ -648,7 +748,6 @@ internal class CoordinatedTextWriter : TextWriter
                 states = _lineBuffers.Values.ToArray();
             }
 
-            var patterns = GetSecretPatterns();
             foreach (var state in states)
             {
                 lock (state.SyncRoot)
@@ -659,22 +758,18 @@ internal class CoordinatedTextWriter : TextWriter
                     }
 
                     var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
-                    var retainedPrefixLength = GetPotentialPatternPrefixLength(state.Buffer, patterns.Values);
-                    ObfuscateCompletePatterns(
+                    var patterns = ObfuscateWithCurrentPatterns(
                         state,
-                        patterns,
-                        retainedPrefixLength,
-                        preservePotentialLongerMatch: false);
-                    FlushSafePrefix(state, state.Buffer.Length, shouldBuffer);
-                    FlushPartialLine(state, shouldBuffer);
+                        preservePotentialLongerMatch: false,
+                        out _);
+                    FlushSafePrefix(
+                        state,
+                        state.Buffer.Length,
+                        shouldBuffer,
+                        patterns.Version);
+                    FlushPartialLine(state, shouldBuffer, patterns.Version);
                     state.ShouldBuffer = null;
                 }
-            }
-
-            // Always flush real console (needed for Spectre.Console internals)
-            lock (_outputLock)
-            {
-                _realConsole.Flush();
             }
         }
         finally
@@ -687,7 +782,13 @@ internal class CoordinatedTextWriter : TextWriter
     /// Flushes output that cannot be a prefix of a registered secret while retaining
     /// incomplete secret prefixes for subsequent writes.
     /// </summary>
-    internal Task FlushAvailableAsync()
+    internal async Task FlushAvailableAsync()
+    {
+        FlushAvailableOutput();
+        await FlushRealConsoleAsync().ConfigureAwait(false);
+    }
+
+    private void FlushAvailableOutput()
     {
         _flushLock.EnterWriteLock();
         try
@@ -698,7 +799,6 @@ internal class CoordinatedTextWriter : TextWriter
                 states = _lineBuffers.Values.ToArray();
             }
 
-            var patterns = GetSecretPatterns();
             foreach (var state in states)
             {
                 lock (state.SyncRoot)
@@ -709,17 +809,23 @@ internal class CoordinatedTextWriter : TextWriter
                     }
 
                     var shouldBuffer = state.ShouldBuffer ?? ShouldBuffer();
-                    var retainedLength = GetPotentialPatternPrefixLength(state.Buffer, patterns.Values);
-                    retainedLength = ObfuscateCompletePatterns(
+                    var patterns = ObfuscateWithCurrentPatterns(
                         state,
-                        patterns,
+                        preservePotentialLongerMatch: false,
+                        out var retainedLength);
+                    FlushSafeOutput(
+                        state,
                         retainedLength,
-                        preservePotentialLongerMatch: false);
-                    FlushSafeOutput(state, retainedLength, shouldBuffer);
+                        shouldBuffer,
+                        patterns.Version);
 
                     if (shouldBuffer)
                     {
-                        FlushPartialPrefix(state, state.Buffer.Length - retainedLength, shouldBuffer);
+                        FlushPartialPrefix(
+                            state,
+                            state.Buffer.Length - retainedLength,
+                            shouldBuffer,
+                            patterns.Version);
                     }
 
                     if (state.Buffer.Length == 0)
@@ -728,25 +834,45 @@ internal class CoordinatedTextWriter : TextWriter
                     }
                 }
             }
-
-            lock (_outputLock)
-            {
-                _realConsole.Flush();
-            }
         }
         finally
         {
             _flushLock.ExitWriteLock();
         }
-
-        return Task.CompletedTask;
     }
 
     /// <inheritdoc />
-    public override Task FlushAsync()
+    public override async Task FlushAsync()
     {
-        Flush();
-        return Task.CompletedTask;
+        FlushBufferedOutput();
+        await FlushRealConsoleAsync().ConfigureAwait(false);
+    }
+
+    private void FlushRealConsole()
+    {
+        _outputLock.Wait();
+        try
+        {
+            // Always flush real console (needed for Spectre.Console internals)
+            _realConsole.Flush();
+        }
+        finally
+        {
+            _outputLock.Release();
+        }
+    }
+
+    private async Task FlushRealConsoleAsync()
+    {
+        await _outputLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await _realConsole.FlushAsync().ConfigureAwait(false);
+        }
+        finally
+        {
+            _outputLock.Release();
+        }
     }
 
     /// <inheritdoc />
@@ -782,7 +908,11 @@ internal class CoordinatedTextWriter : TextWriter
 
     private readonly record struct LineBufferKey(Type? ModuleType, bool IsDirectWrite);
 
-    private sealed record SecretPatterns(string[] Values, SearchValues<string>? SearchValues);
+    private sealed record SecretPatterns(
+        string[] Values,
+        SearchValues<string>? SearchValues,
+        StringComparison Comparison = StringComparison.OrdinalIgnoreCase,
+        long Version = long.MinValue);
 
     private sealed class DirectWriteScopeRestorer(bool previousValue) : IDisposable
     {

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -49,10 +49,13 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly HashSet<LineBufferState> _pendingScopedLineBuffers = [];
     private readonly object _lineBufferLock = new();
     private readonly object _customObfuscatorLock = new();
+    private readonly object _deferredOutputLock = new();
     private readonly object _secretPatternsLock = new();
     private readonly AsyncLocal<CustomObfuscationScope?> _customObfuscationScope = new();
+    private readonly Queue<DeferredOutputWrite> _deferredOutputWrites = [];
     private readonly SemaphoreSlim _outputLock = new(1, 1);
     private readonly ReaderWriterLockSlim _flushLock = new(LockRecursionPolicy.SupportsRecursion);
+    private bool _isAsyncFlushActive;
     private SecretPatterns _secretPatterns = new([], null);
     private long _secretPatternsVersion = long.MinValue;
 
@@ -796,6 +799,11 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
+        if (TryDeferOutputWrite(output, appendNewLine))
+        {
+            return;
+        }
+
         _outputLock.Wait();
         var activeOutputWriter = EnterActiveOutputWriter();
         try
@@ -818,6 +826,63 @@ internal class CoordinatedTextWriter : TextWriter
         else
         {
             _realConsole.Write(output);
+        }
+    }
+
+    private bool TryDeferOutputWrite(string output, bool appendNewLine)
+    {
+        lock (_deferredOutputLock)
+        {
+            if (!_isAsyncFlushActive)
+            {
+                return false;
+            }
+
+            // An asynchronous sink can suppress ExecutionContext flow before awaiting
+            // work that writes through this writer. That callback cannot see the active
+            // writer scope, so queue its processed output instead of waiting on our lease.
+            _deferredOutputWrites.Enqueue(new DeferredOutputWrite(output, appendNewLine));
+            return true;
+        }
+    }
+
+    private void BeginDeferringOutputWrites()
+    {
+        lock (_deferredOutputLock)
+        {
+            _isAsyncFlushActive = true;
+        }
+    }
+
+    private void DrainDeferredOutputWrites()
+    {
+        while (true)
+        {
+            DeferredOutputWrite[] pending;
+            lock (_deferredOutputLock)
+            {
+                if (_deferredOutputWrites.Count == 0)
+                {
+                    _isAsyncFlushActive = false;
+                    return;
+                }
+
+                pending = _deferredOutputWrites.ToArray();
+                _deferredOutputWrites.Clear();
+            }
+
+            foreach (var write in pending)
+            {
+                WriteToRealConsoleCore(write.Output, write.AppendNewLine);
+            }
+        }
+    }
+
+    private void StopDeferringOutputWrites()
+    {
+        lock (_deferredOutputLock)
+        {
+            _isAsyncFlushActive = false;
         }
     }
 
@@ -1116,14 +1181,23 @@ internal class CoordinatedTextWriter : TextWriter
     {
         await _outputLock.WaitAsync().ConfigureAwait(false);
         var activeOutputWriter = EnterActiveOutputWriter();
+        BeginDeferringOutputWrites();
         try
         {
             await _realConsole.FlushAsync().ConfigureAwait(false);
         }
         finally
         {
-            ExitActiveOutputWriter(activeOutputWriter);
-            _outputLock.Release();
+            try
+            {
+                DrainDeferredOutputWrites();
+            }
+            finally
+            {
+                StopDeferringOutputWrites();
+                ExitActiveOutputWriter(activeOutputWriter);
+                _outputLock.Release();
+            }
         }
     }
 
@@ -1161,6 +1235,8 @@ internal class CoordinatedTextWriter : TextWriter
 
         public void Deactivate() => Volatile.Write(ref _isActive, 0);
     }
+
+    private readonly record struct DeferredOutputWrite(string Output, bool AppendNewLine);
 
     private LineBufferState[] GetLineBufferStates()
     {

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -253,6 +253,7 @@ internal class CoordinatedTextWriter : TextWriter
         }
 
         var output = new StringBuilder(pending.Length);
+        var outputIndex = 0;
         var searchIndex = 0;
         var replaced = false;
         var retainedPrefixInvalidated = false;
@@ -263,7 +264,7 @@ internal class CoordinatedTextWriter : TextWriter
             var match = FindFirstPattern(pending, patterns, searchIndex);
             if (match.Index < 0)
             {
-                output.Append(pending, searchIndex, pending.Length - searchIndex);
+                output.Append(pending, outputIndex, pending.Length - outputIndex);
                 break;
             }
 
@@ -271,15 +272,16 @@ internal class CoordinatedTextWriter : TextWriter
                 && retainedPrefixLength > 0
                 && match.Index + match.Length > retainedPrefixStart)
             {
-                output.Append(pending, searchIndex, pending.Length - searchIndex);
-                break;
+                searchIndex = match.Index + 1;
+                continue;
             }
 
-            output.Append(pending, searchIndex, match.Index - searchIndex);
+            output.Append(pending, outputIndex, match.Index - outputIndex);
             var secret = pending.Substring(match.Index, match.Length);
             output.Append(_secretObfuscator.Obfuscate(secret, null));
             retainedPrefixInvalidated |= match.Index + match.Length > retainedPrefixStart;
-            searchIndex = match.Index + match.Length;
+            outputIndex = match.Index + match.Length;
+            searchIndex = outputIndex;
             replaced = true;
         }
 

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -272,8 +272,18 @@ internal class CoordinatedTextWriter : TextWriter
                 && retainedPrefixLength > 0
                 && match.Index + match.Length > retainedPrefixStart)
             {
-                searchIndex = match.Index + 1;
-                continue;
+                var safeMatchLength = FindLongestPatternEndingAtOrBefore(
+                    pending,
+                    patterns.Values,
+                    match.Index,
+                    retainedPrefixStart);
+                if (safeMatchLength == 0)
+                {
+                    searchIndex = match.Index + 1;
+                    continue;
+                }
+
+                match = (match.Index, safeMatchLength);
             }
 
             output.Append(pending, outputIndex, match.Index - outputIndex);
@@ -361,6 +371,29 @@ internal class CoordinatedTextWriter : TextWriter
         }
 
         throw new InvalidOperationException("SearchValues returned a position without a matching secret.");
+    }
+
+    private static int FindLongestPatternEndingAtOrBefore(
+        string input,
+        IReadOnlyList<string> patterns,
+        int startIndex,
+        int endIndex)
+    {
+        if (startIndex >= endIndex)
+        {
+            return 0;
+        }
+
+        var safeInput = input.AsSpan(startIndex, endIndex - startIndex);
+        foreach (var pattern in patterns)
+        {
+            if (safeInput.StartsWith(pattern, StringComparison.OrdinalIgnoreCase))
+            {
+                return pattern.Length;
+            }
+        }
+
+        return 0;
     }
 
     private static int GetPotentialPatternPrefixLength(StringBuilder input, IReadOnlyList<string> patterns)

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -763,14 +763,14 @@ internal class CoordinatedTextWriter : TextWriter
         }
 
         _outputLock.Wait();
-        var previousActiveOutputWriter = EnterActiveOutputWriter();
+        var activeOutputWriter = EnterActiveOutputWriter();
         try
         {
             WriteToRealConsoleCore(output, appendNewLine);
         }
         finally
         {
-            ActiveOutputWriterScope.Value = previousActiveOutputWriter;
+            ExitActiveOutputWriter(activeOutputWriter);
             _outputLock.Release();
         }
     }
@@ -793,7 +793,8 @@ internal class CoordinatedTextWriter : TextWriter
              activeOutputWriter != null;
              activeOutputWriter = activeOutputWriter.Parent)
         {
-            if (ReferenceEquals(activeOutputWriter.Writer, this))
+            if (activeOutputWriter.IsActive
+                && ReferenceEquals(activeOutputWriter.Writer, this))
             {
                 return true;
             }
@@ -802,11 +803,17 @@ internal class CoordinatedTextWriter : TextWriter
         return false;
     }
 
-    private ActiveOutputWriter? EnterActiveOutputWriter()
+    private ActiveOutputWriter EnterActiveOutputWriter()
     {
-        var previousActiveOutputWriter = ActiveOutputWriterScope.Value;
-        ActiveOutputWriterScope.Value = new ActiveOutputWriter(this, previousActiveOutputWriter);
-        return previousActiveOutputWriter;
+        var activeOutputWriter = new ActiveOutputWriter(this, ActiveOutputWriterScope.Value);
+        ActiveOutputWriterScope.Value = activeOutputWriter;
+        return activeOutputWriter;
+    }
+
+    private static void ExitActiveOutputWriter(ActiveOutputWriter activeOutputWriter)
+    {
+        activeOutputWriter.Deactivate();
+        ActiveOutputWriterScope.Value = activeOutputWriter.Parent;
     }
 
     private string ObfuscateCustomOutput(string output, long secretPatternsVersion)
@@ -992,7 +999,7 @@ internal class CoordinatedTextWriter : TextWriter
     private void FlushRealConsole()
     {
         _outputLock.Wait();
-        var previousActiveOutputWriter = EnterActiveOutputWriter();
+        var activeOutputWriter = EnterActiveOutputWriter();
         try
         {
             // Always flush real console (needed for Spectre.Console internals)
@@ -1000,7 +1007,7 @@ internal class CoordinatedTextWriter : TextWriter
         }
         finally
         {
-            ActiveOutputWriterScope.Value = previousActiveOutputWriter;
+            ExitActiveOutputWriter(activeOutputWriter);
             _outputLock.Release();
         }
     }
@@ -1008,14 +1015,14 @@ internal class CoordinatedTextWriter : TextWriter
     private async Task FlushRealConsoleAsync()
     {
         await _outputLock.WaitAsync().ConfigureAwait(false);
-        var previousActiveOutputWriter = EnterActiveOutputWriter();
+        var activeOutputWriter = EnterActiveOutputWriter();
         try
         {
             await _realConsole.FlushAsync().ConfigureAwait(false);
         }
         finally
         {
-            ActiveOutputWriterScope.Value = previousActiveOutputWriter;
+            ExitActiveOutputWriter(activeOutputWriter);
             _outputLock.Release();
         }
     }
@@ -1040,9 +1047,20 @@ internal class CoordinatedTextWriter : TextWriter
 
     private bool ShouldBuffer() => !DirectWriteScope.Value && _shouldBuffer();
 
-    private sealed record ActiveOutputWriter(
-        CoordinatedTextWriter Writer,
-        ActiveOutputWriter? Parent);
+    private sealed class ActiveOutputWriter(
+        CoordinatedTextWriter writer,
+        ActiveOutputWriter? parent)
+    {
+        private int _isActive = 1;
+
+        public CoordinatedTextWriter Writer { get; } = writer;
+
+        public ActiveOutputWriter? Parent { get; } = parent;
+
+        public bool IsActive => Volatile.Read(ref _isActive) != 0;
+
+        public void Deactivate() => Volatile.Write(ref _isActive, 0);
+    }
 
     private sealed class LineBufferState(Type? moduleType)
     {

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -253,7 +253,7 @@ internal class CoordinatedTextWriter : TextWriter
                     context.State,
                     retainedPrefixLength,
                     context.ShouldBuffer,
-                    patterns.Version);
+                    patterns);
             });
     }
 
@@ -515,13 +515,13 @@ internal class CoordinatedTextWriter : TextWriter
         LineBufferState state,
         int retainedLength,
         bool shouldBuffer,
-        long secretPatternsVersion)
+        SecretPatterns secretPatterns)
     {
         FlushSafePrefix(
             state,
             state.Buffer.Length - retainedLength,
             shouldBuffer,
-            secretPatternsVersion);
+            secretPatterns);
 
         if (state.Buffer.Length == 0)
         {
@@ -533,7 +533,7 @@ internal class CoordinatedTextWriter : TextWriter
         LineBufferState state,
         int safeLength,
         bool shouldBuffer,
-        long secretPatternsVersion)
+        SecretPatterns secretPatterns)
     {
         var consumedLength = 0;
         for (var index = 0; index < safeLength; index++)
@@ -550,7 +550,7 @@ internal class CoordinatedTextWriter : TextWriter
             }
 
             var line = state.Buffer.ToString(consumedLength, lineLength);
-            WriteCompletedLine(line, shouldBuffer, state.ModuleType, secretPatternsVersion);
+            WriteCompletedLine(line, shouldBuffer, state.ModuleType, secretPatterns);
             consumedLength = index + 1;
         }
 
@@ -562,7 +562,7 @@ internal class CoordinatedTextWriter : TextWriter
 
         if (!shouldBuffer)
         {
-            FlushDirectPrefix(state, safeLength, secretPatternsVersion);
+            FlushDirectPrefix(state, safeLength, secretPatterns);
         }
     }
 
@@ -704,7 +704,7 @@ internal class CoordinatedTextWriter : TextWriter
     private void FlushDirectPrefix(
         LineBufferState state,
         int length,
-        long secretPatternsVersion)
+        SecretPatterns secretPatterns)
     {
         if (length <= 0)
         {
@@ -714,7 +714,7 @@ internal class CoordinatedTextWriter : TextWriter
         var output = state.Buffer.ToString(0, length);
         state.Buffer.Remove(0, length);
         WriteToRealConsole(
-            ObfuscateCustomOutput(output, secretPatternsVersion),
+            ObfuscateCustomOutput(output, secretPatterns),
             appendNewLine: false);
     }
 
@@ -722,18 +722,18 @@ internal class CoordinatedTextWriter : TextWriter
         string line,
         bool shouldBuffer,
         Type? moduleType,
-        long secretPatternsVersion)
+        SecretPatterns secretPatterns)
     {
         if (shouldBuffer)
         {
             RouteToBuffer(
-                ObfuscateCustomOutput(line, secretPatternsVersion),
+                ObfuscateCustomOutput(line, secretPatterns),
                 moduleType);
         }
         else
         {
             WriteToRealConsole(
-                ObfuscateCustomOutput(line, secretPatternsVersion),
+                ObfuscateCustomOutput(line, secretPatterns),
                 appendNewLine: true);
         }
     }
@@ -741,16 +741,16 @@ internal class CoordinatedTextWriter : TextWriter
     private void FlushPartialLine(
         LineBufferState state,
         bool shouldBuffer,
-        long secretPatternsVersion)
+        SecretPatterns secretPatterns)
     {
-        FlushPartialPrefix(state, state.Buffer.Length, shouldBuffer, secretPatternsVersion);
+        FlushPartialPrefix(state, state.Buffer.Length, shouldBuffer, secretPatterns);
     }
 
     private void FlushPartialPrefix(
         LineBufferState state,
         int length,
         bool shouldBuffer,
-        long secretPatternsVersion)
+        SecretPatterns secretPatterns)
     {
         if (length <= 0)
         {
@@ -763,13 +763,13 @@ internal class CoordinatedTextWriter : TextWriter
         if (shouldBuffer)
         {
             RouteToBuffer(
-                ObfuscateCustomOutput(pending, secretPatternsVersion),
+                ObfuscateCustomOutput(pending, secretPatterns),
                 state.ModuleType);
         }
         else
         {
             WriteToRealConsole(
-                ObfuscateCustomOutput(pending, secretPatternsVersion),
+                ObfuscateCustomOutput(pending, secretPatterns),
                 appendNewLine: false);
         }
     }
@@ -863,11 +863,12 @@ internal class CoordinatedTextWriter : TextWriter
         ActiveOutputWriterScope.Value = activeOutputWriter.Parent;
     }
 
-    private string ObfuscateCustomOutput(string output, long secretPatternsVersion)
+    private string ObfuscateCustomOutput(string output, SecretPatterns secretPatterns)
     {
         if (_secretObfuscator is ITrackedSecretObfuscator)
         {
-            return _secretProvider.Version == secretPatternsVersion
+            return _secretProvider.Version == secretPatterns.Version
+                && GetPatternComparison() == secretPatterns.Comparison
                 ? output
                 : _secretObfuscator.Obfuscate(output, null);
         }
@@ -1036,11 +1037,11 @@ internal class CoordinatedTextWriter : TextWriter
                         context.State,
                         context.State.Buffer.Length,
                         shouldBuffer,
-                        patterns.Version);
+                        patterns);
                     context.Writer.FlushPartialLine(
                         context.State,
                         shouldBuffer,
-                        patterns.Version);
+                        patterns);
                     context.State.ShouldBuffer = null;
                     return;
                 }
@@ -1049,7 +1050,7 @@ internal class CoordinatedTextWriter : TextWriter
                     context.State,
                     retainedLength,
                     shouldBuffer,
-                    patterns.Version);
+                    patterns);
 
                 if (shouldBuffer)
                 {
@@ -1057,7 +1058,7 @@ internal class CoordinatedTextWriter : TextWriter
                         context.State,
                         context.State.Buffer.Length - retainedLength,
                         shouldBuffer,
-                        patterns.Version);
+                        patterns);
                 }
 
                 if (context.State.Buffer.Length == 0)

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -46,6 +46,7 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly Dictionary<LineBufferKey, LineBufferState> _lineBuffers = [];
     private readonly ConditionalWeakTable<object, Dictionary<LineBufferKey, LineBufferState>>
         _scopedLineBuffers = [];
+    private readonly HashSet<LineBufferState> _pendingScopedLineBuffers = [];
     private readonly object _lineBufferLock = new();
     private readonly object _customObfuscatorLock = new();
     private readonly object _secretPatternsLock = new();
@@ -140,6 +141,7 @@ internal class CoordinatedTextWriter : TextWriter
                 var shouldBuffer = GetBufferMode(state, ShouldBuffer());
                 state.Buffer.Append(value);
                 ProcessPendingOutput(state, shouldBuffer, shouldProcess: value == '\n');
+                UpdateScopedLineBufferRetention(state);
             }
         }
         finally
@@ -228,10 +230,13 @@ internal class CoordinatedTextWriter : TextWriter
         {
             state.Buffer.Append(Environment.NewLine);
             ProcessPendingOutput(state, shouldBuffer, shouldProcess: true);
-            return;
+        }
+        else
+        {
+            ProcessPendingOutput(state, shouldBuffer, shouldProcess: false);
         }
 
-        ProcessPendingOutput(state, shouldBuffer, shouldProcess: false);
+        UpdateScopedLineBufferRetention(state);
     }
 
     private void ProcessPendingOutput(LineBufferState state, bool shouldBuffer, bool shouldProcess)
@@ -306,7 +311,7 @@ internal class CoordinatedTextWriter : TextWriter
                 : _scopedLineBuffers.GetValue(primaryScope, static _ => []);
             if (!lineBuffers.TryGetValue(key, out var state))
             {
-                state = new LineBufferState(moduleType);
+                state = new LineBufferState(moduleType, primaryScope is not null);
                 lineBuffers.Add(key, state);
             }
 
@@ -1066,6 +1071,8 @@ internal class CoordinatedTextWriter : TextWriter
                     context.State.ShouldBuffer = null;
                 }
             });
+
+        UpdateScopedLineBufferRetention(state);
     }
 
     /// <inheritdoc />
@@ -1160,10 +1167,31 @@ internal class CoordinatedTextWriter : TextWriter
         lock (_lineBufferLock)
         {
             return _lineBuffers.Values
-                .Concat(_scopedLineBuffers.SelectMany(static entry => entry.Value.Values))
+                .Concat(_pendingScopedLineBuffers)
                 .ToArray();
         }
     }
+
+    private void UpdateScopedLineBufferRetention(LineBufferState state)
+    {
+        if (!state.IsScoped)
+        {
+            return;
+        }
+
+        lock (_lineBufferLock)
+        {
+            if (state.Buffer.Length == 0)
+            {
+                _pendingScopedLineBuffers.Remove(state);
+            }
+            else
+            {
+                _pendingScopedLineBuffers.Add(state);
+            }
+        }
+    }
+
     private sealed class CustomObfuscationScope(CustomObfuscationScope? parent)
     {
         private int _isActive = 1;
@@ -1175,11 +1203,13 @@ internal class CoordinatedTextWriter : TextWriter
         public void Deactivate() => Volatile.Write(ref _isActive, 0);
     }
 
-    private sealed class LineBufferState(Type? moduleType)
+    private sealed class LineBufferState(Type? moduleType, bool isScoped)
     {
         public object SyncRoot { get; } = new();
 
         public Type? ModuleType { get; } = moduleType;
+
+        public bool IsScoped { get; } = isScoped;
 
         public StringBuilder Buffer { get; } = new();
 

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -272,9 +272,16 @@ internal class CoordinatedTextWriter : TextWriter
                 break;
             }
 
+            var matchEnd = match.Index + match.Length;
+            var isCompleteSelfOverlappingMatch = matchEnd == pending.Length
+                && match.Index < retainedPrefixStart
+                && pending.AsSpan(match.Index, retainedPrefixLength).Equals(
+                    pending.AsSpan(retainedPrefixStart),
+                    StringComparison.OrdinalIgnoreCase);
             if (preservePotentialLongerMatch
                 && retainedPrefixLength > 0
-                && match.Index + match.Length > retainedPrefixStart)
+                && matchEnd > retainedPrefixStart
+                && !isCompleteSelfOverlappingMatch)
             {
                 var safeMatchLength = FindLongestPatternEndingAtOrBefore(
                     pending,

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -286,9 +286,16 @@ internal class CoordinatedTextWriter : TextWriter
                 match = (match.Index, safeMatchLength);
             }
 
-            output.Append(pending, outputIndex, match.Index - outputIndex);
             var secret = pending.Substring(match.Index, match.Length);
-            output.Append(_secretObfuscator.Obfuscate(secret, null));
+            var obfuscatedSecret = _secretObfuscator.Obfuscate(secret, null);
+            if (string.Equals(obfuscatedSecret, secret, StringComparison.Ordinal))
+            {
+                searchIndex = match.Index + 1;
+                continue;
+            }
+
+            output.Append(pending, outputIndex, match.Index - outputIndex);
+            output.Append(obfuscatedSecret);
             retainedPrefixInvalidated |= match.Index + match.Length > retainedPrefixStart;
             outputIndex = match.Index + match.Length;
             searchIndex = outputIndex;

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -46,7 +46,7 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly object _lineBufferLock = new();
     private readonly object _customObfuscatorLock = new();
     private readonly object _secretPatternsLock = new();
-    private readonly AsyncLocal<int> _customObfuscationDepth = new();
+    private readonly AsyncLocal<CustomObfuscationScope?> _customObfuscationScope = new();
     private readonly SemaphoreSlim _outputLock = new(1, 1);
     private readonly ReaderWriterLockSlim _flushLock = new(LockRecursionPolicy.SupportsRecursion);
     private SecretPatterns _secretPatterns = new([], null);
@@ -291,8 +291,8 @@ internal class CoordinatedTextWriter : TextWriter
         var key = new LineBufferKey(
             moduleType,
             DirectWriteScope.Value,
-            _customObfuscationDepth.Value,
-            GetReentrantOutputWriteDepth());
+            GetCustomObfuscationScopeDepth(),
+            GetOutputWriteScopeDepth());
 
         lock (_lineBufferLock)
         {
@@ -810,6 +810,22 @@ internal class CoordinatedTextWriter : TextWriter
 
     private bool IsReentrantOutputWrite() => GetReentrantOutputWriteDepth() > 0;
 
+    private int GetOutputWriteScopeDepth()
+    {
+        var depth = 0;
+        for (var activeOutputWriter = ActiveOutputWriterScope.Value;
+             activeOutputWriter != null;
+             activeOutputWriter = activeOutputWriter.Parent)
+        {
+            if (ReferenceEquals(activeOutputWriter.Writer, this))
+            {
+                depth++;
+            }
+        }
+
+        return depth;
+    }
+
     private int GetReentrantOutputWriteDepth()
     {
         var depth = 0;
@@ -851,17 +867,57 @@ internal class CoordinatedTextWriter : TextWriter
 
         lock (_customObfuscatorLock)
         {
-            var previousDepth = _customObfuscationDepth.Value;
-            _customObfuscationDepth.Value = previousDepth + 1;
+            var customObfuscationScope = EnterCustomObfuscationScope();
             try
             {
                 return _secretObfuscator.Obfuscate(output, null);
             }
             finally
             {
-                _customObfuscationDepth.Value = previousDepth;
+                ExitCustomObfuscationScope(customObfuscationScope);
             }
         }
+    }
+
+    private bool IsReentrantCustomObfuscation()
+    {
+        for (var scope = _customObfuscationScope.Value;
+             scope != null;
+             scope = scope.Parent)
+        {
+            if (scope.IsActive)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private int GetCustomObfuscationScopeDepth()
+    {
+        var depth = 0;
+        for (var scope = _customObfuscationScope.Value;
+             scope != null;
+             scope = scope.Parent)
+        {
+            depth++;
+        }
+
+        return depth;
+    }
+
+    private CustomObfuscationScope EnterCustomObfuscationScope()
+    {
+        var scope = new CustomObfuscationScope(_customObfuscationScope.Value);
+        _customObfuscationScope.Value = scope;
+        return scope;
+    }
+
+    private void ExitCustomObfuscationScope(CustomObfuscationScope scope)
+    {
+        scope.Deactivate();
+        _customObfuscationScope.Value = scope.Parent;
     }
 
     private void ExecuteWithStableSecrets<TState>(TState state, Action<TState> processOutput)
@@ -886,7 +942,7 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        if (_customObfuscationDepth.Value > 0)
+        if (IsReentrantCustomObfuscation())
         {
             FlushReentrantOutput();
             FlushRealConsole();
@@ -1039,7 +1095,7 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        if (_customObfuscationDepth.Value > 0)
+        if (IsReentrantCustomObfuscation())
         {
             FlushReentrantOutput();
             await FlushRealConsoleAsync().ConfigureAwait(false);
@@ -1110,6 +1166,17 @@ internal class CoordinatedTextWriter : TextWriter
         public CoordinatedTextWriter Writer { get; } = writer;
 
         public ActiveOutputWriter? Parent { get; } = parent;
+
+        public bool IsActive => Volatile.Read(ref _isActive) != 0;
+
+        public void Deactivate() => Volatile.Write(ref _isActive, 0);
+    }
+
+    private sealed class CustomObfuscationScope(CustomObfuscationScope? parent)
+    {
+        private int _isActive = 1;
+
+        public CustomObfuscationScope? Parent { get; } = parent;
 
         public bool IsActive => Volatile.Read(ref _isActive) != 0;
 

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -292,7 +292,7 @@ internal class CoordinatedTextWriter : TextWriter
             moduleType,
             DirectWriteScope.Value,
             _customObfuscationDepth.Value,
-            IsReentrantOutputWrite());
+            GetReentrantOutputWriteDepth());
 
         lock (_lineBufferLock)
         {
@@ -770,7 +770,16 @@ internal class CoordinatedTextWriter : TextWriter
     {
         if (IsReentrantOutputWrite())
         {
-            WriteToRealConsoleCore(output, appendNewLine);
+            var reentrantOutputWriter = EnterActiveOutputWriter();
+            try
+            {
+                WriteToRealConsoleCore(output, appendNewLine);
+            }
+            finally
+            {
+                ExitActiveOutputWriter(reentrantOutputWriter);
+            }
+
             return;
         }
 
@@ -799,8 +808,11 @@ internal class CoordinatedTextWriter : TextWriter
         }
     }
 
-    private bool IsReentrantOutputWrite()
+    private bool IsReentrantOutputWrite() => GetReentrantOutputWriteDepth() > 0;
+
+    private int GetReentrantOutputWriteDepth()
     {
+        var depth = 0;
         for (var activeOutputWriter = ActiveOutputWriterScope.Value;
              activeOutputWriter != null;
              activeOutputWriter = activeOutputWriter.Parent)
@@ -808,11 +820,11 @@ internal class CoordinatedTextWriter : TextWriter
             if (activeOutputWriter.IsActive
                 && ReferenceEquals(activeOutputWriter.Writer, this))
             {
-                return true;
+                depth++;
             }
         }
 
-        return false;
+        return depth;
     }
 
     private ActiveOutputWriter EnterActiveOutputWriter()
@@ -1119,7 +1131,7 @@ internal class CoordinatedTextWriter : TextWriter
         Type? ModuleType,
         bool IsDirectWrite,
         int CustomObfuscationDepth,
-        bool IsReentrantOutputWrite);
+        int ReentrantOutputWriteDepth);
 
     private sealed record SecretPatterns(
         string[] Values,

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -34,6 +34,9 @@ namespace ModularPipelines.Console;
 [ExcludeFromCodeCoverage]
 internal class CoordinatedTextWriter : TextWriter
 {
+    [ThreadStatic]
+    private static HashSet<CoordinatedTextWriter>? _activeOutputWriters;
+
     private static readonly AsyncLocal<bool> DirectWriteScope = new();
     private static readonly AsyncLocal<int> CustomObfuscationDepth = new();
 
@@ -203,17 +206,31 @@ internal class CoordinatedTextWriter : TextWriter
     private void WriteCore(LineBufferState state, ReadOnlySpan<char> value, bool appendNewLine)
     {
         var shouldBuffer = GetBufferMode(state, ShouldBuffer());
-        state.Buffer.Append(value);
+        var consumedLength = 0;
+        while (consumedLength < value.Length)
+        {
+            var newlineIndex = value[consumedLength..].IndexOf('\n');
+            if (newlineIndex < 0)
+            {
+                break;
+            }
+
+            var segmentLength = newlineIndex + 1;
+            state.Buffer.Append(value.Slice(consumedLength, segmentLength));
+            consumedLength += segmentLength;
+            ProcessPendingOutput(state, shouldBuffer, shouldProcess: true);
+        }
+
+        state.Buffer.Append(value[consumedLength..]);
 
         if (appendNewLine)
         {
             state.Buffer.Append(Environment.NewLine);
+            ProcessPendingOutput(state, shouldBuffer, shouldProcess: true);
+            return;
         }
 
-        ProcessPendingOutput(
-            state,
-            shouldBuffer,
-            shouldProcess: appendNewLine || value.Contains('\n'));
+        ProcessPendingOutput(state, shouldBuffer, shouldProcess: false);
     }
 
     private void ProcessPendingOutput(LineBufferState state, bool shouldBuffer, bool shouldProcess)
@@ -266,7 +283,8 @@ internal class CoordinatedTextWriter : TextWriter
         var key = new LineBufferKey(
             moduleType,
             DirectWriteScope.Value,
-            CustomObfuscationDepth.Value);
+            CustomObfuscationDepth.Value,
+            IsReentrantOutputWrite());
 
         lock (_lineBufferLock)
         {
@@ -739,23 +757,44 @@ internal class CoordinatedTextWriter : TextWriter
 
     private void WriteToRealConsole(string output, bool appendNewLine)
     {
+        if (IsReentrantOutputWrite())
+        {
+            WriteToRealConsoleCore(output, appendNewLine);
+            return;
+        }
+
         _outputLock.Wait();
+        var activeOutputWriters = _activeOutputWriters ??= [];
+        activeOutputWriters.Add(this);
         try
         {
-            if (appendNewLine)
-            {
-                _realConsole.WriteLine(output);
-            }
-            else
-            {
-                _realConsole.Write(output);
-            }
+            WriteToRealConsoleCore(output, appendNewLine);
         }
         finally
         {
+            activeOutputWriters.Remove(this);
+            if (activeOutputWriters.Count == 0)
+            {
+                _activeOutputWriters = null;
+            }
+
             _outputLock.Release();
         }
     }
+
+    private void WriteToRealConsoleCore(string output, bool appendNewLine)
+    {
+        if (appendNewLine)
+        {
+            _realConsole.WriteLine(output);
+        }
+        else
+        {
+            _realConsole.Write(output);
+        }
+    }
+
+    private bool IsReentrantOutputWrite() => _activeOutputWriters?.Contains(this) is true;
 
     private string ObfuscateCustomOutput(string output, long secretPatternsVersion)
     {
@@ -986,7 +1025,8 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly record struct LineBufferKey(
         Type? ModuleType,
         bool IsDirectWrite,
-        int CustomObfuscationDepth);
+        int CustomObfuscationDepth,
+        bool IsReentrantOutputWrite);
 
     private sealed record SecretPatterns(
         string[] Values,

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -34,9 +34,7 @@ namespace ModularPipelines.Console;
 [ExcludeFromCodeCoverage]
 internal class CoordinatedTextWriter : TextWriter
 {
-    [ThreadStatic]
-    private static HashSet<CoordinatedTextWriter>? _activeOutputWriters;
-
+    private static readonly AsyncLocal<ActiveOutputWriter?> ActiveOutputWriterScope = new();
     private static readonly AsyncLocal<bool> DirectWriteScope = new();
     private static readonly AsyncLocal<int> CustomObfuscationDepth = new();
 
@@ -765,15 +763,14 @@ internal class CoordinatedTextWriter : TextWriter
         }
 
         _outputLock.Wait();
-        var activeOutputWriters = _activeOutputWriters ??= [];
-        activeOutputWriters.Add(this);
+        var previousActiveOutputWriter = EnterActiveOutputWriter();
         try
         {
             WriteToRealConsoleCore(output, appendNewLine);
         }
         finally
         {
-            RemoveActiveOutputWriter(activeOutputWriters);
+            ActiveOutputWriterScope.Value = previousActiveOutputWriter;
             _outputLock.Release();
         }
     }
@@ -790,7 +787,27 @@ internal class CoordinatedTextWriter : TextWriter
         }
     }
 
-    private bool IsReentrantOutputWrite() => _activeOutputWriters?.Contains(this) is true;
+    private bool IsReentrantOutputWrite()
+    {
+        for (var activeOutputWriter = ActiveOutputWriterScope.Value;
+             activeOutputWriter != null;
+             activeOutputWriter = activeOutputWriter.Parent)
+        {
+            if (ReferenceEquals(activeOutputWriter.Writer, this))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private ActiveOutputWriter? EnterActiveOutputWriter()
+    {
+        var previousActiveOutputWriter = ActiveOutputWriterScope.Value;
+        ActiveOutputWriterScope.Value = new ActiveOutputWriter(this, previousActiveOutputWriter);
+        return previousActiveOutputWriter;
+    }
 
     private string ObfuscateCustomOutput(string output, long secretPatternsVersion)
     {
@@ -975,8 +992,7 @@ internal class CoordinatedTextWriter : TextWriter
     private void FlushRealConsole()
     {
         _outputLock.Wait();
-        var activeOutputWriters = _activeOutputWriters ??= [];
-        activeOutputWriters.Add(this);
+        var previousActiveOutputWriter = EnterActiveOutputWriter();
         try
         {
             // Always flush real console (needed for Spectre.Console internals)
@@ -984,7 +1000,7 @@ internal class CoordinatedTextWriter : TextWriter
         }
         finally
         {
-            RemoveActiveOutputWriter(activeOutputWriters);
+            ActiveOutputWriterScope.Value = previousActiveOutputWriter;
             _outputLock.Release();
         }
     }
@@ -992,29 +1008,15 @@ internal class CoordinatedTextWriter : TextWriter
     private async Task FlushRealConsoleAsync()
     {
         await _outputLock.WaitAsync().ConfigureAwait(false);
-        var activeOutputWriters = _activeOutputWriters ??= [];
-        activeOutputWriters.Add(this);
-        Task flushTask;
+        var previousActiveOutputWriter = EnterActiveOutputWriter();
         try
         {
-            flushTask = _realConsole.FlushAsync();
+            await _realConsole.FlushAsync().ConfigureAwait(false);
         }
         finally
         {
-            RemoveActiveOutputWriter(activeOutputWriters);
+            ActiveOutputWriterScope.Value = previousActiveOutputWriter;
             _outputLock.Release();
-        }
-
-        await flushTask.ConfigureAwait(false);
-    }
-
-    private void RemoveActiveOutputWriter(HashSet<CoordinatedTextWriter> activeOutputWriters)
-    {
-        activeOutputWriters.Remove(this);
-        if (activeOutputWriters.Count == 0
-            && ReferenceEquals(_activeOutputWriters, activeOutputWriters))
-        {
-            _activeOutputWriters = null;
         }
     }
 
@@ -1037,6 +1039,10 @@ internal class CoordinatedTextWriter : TextWriter
     }
 
     private bool ShouldBuffer() => !DirectWriteScope.Value && _shouldBuffer();
+
+    private sealed record ActiveOutputWriter(
+        CoordinatedTextWriter Writer,
+        ActiveOutputWriter? Parent);
 
     private sealed class LineBufferState(Type? moduleType)
     {

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -37,6 +37,7 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly ISecretProvider _secretProvider;
     private readonly Dictionary<LineBufferKey, LineBufferState> _lineBuffers = [];
     private readonly object _lineBufferLock = new();
+    private readonly object _customObfuscatorLock = new();
     private readonly object _secretPatternsLock = new();
     private readonly SemaphoreSlim _outputLock = new(1, 1);
     private readonly ReaderWriterLockSlim _flushLock = new(LockRecursionPolicy.NoRecursion);
@@ -727,11 +728,20 @@ internal class CoordinatedTextWriter : TextWriter
         }
     }
 
-    private string ObfuscateCustomOutput(string output, long secretPatternsVersion) =>
-        _secretObfuscator is ITrackedSecretObfuscator
-        && _secretProvider.Version == secretPatternsVersion
-            ? output
-            : _secretObfuscator.Obfuscate(output, null);
+    private string ObfuscateCustomOutput(string output, long secretPatternsVersion)
+    {
+        if (_secretObfuscator is ITrackedSecretObfuscator)
+        {
+            return _secretProvider.Version == secretPatternsVersion
+                ? output
+                : _secretObfuscator.Obfuscate(output, null);
+        }
+
+        lock (_customObfuscatorLock)
+        {
+            return _secretObfuscator.Obfuscate(output, null);
+        }
+    }
 
     private void ExecuteWithStableSecrets(Action processOutput)
     {

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -52,10 +52,12 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly object _deferredOutputLock = new();
     private readonly object _secretPatternsLock = new();
     private readonly AsyncLocal<CustomObfuscationScope?> _customObfuscationScope = new();
+    private readonly Queue<DeferredInputWrite> _deferredInputWrites = [];
     private readonly Queue<DeferredOutputWrite> _deferredOutputWrites = [];
     private readonly SemaphoreSlim _outputLock = new(1, 1);
     private readonly ReaderWriterLockSlim _flushLock = new(LockRecursionPolicy.SupportsRecursion);
-    private bool _isAsyncFlushActive;
+    private volatile bool _isOutputSinkActive;
+    private bool _isDeferredInputDrainActive;
     private SecretPatterns _secretPatterns = new([], null);
     private long _secretPatternsVersion = long.MinValue;
 
@@ -88,18 +90,21 @@ internal class CoordinatedTextWriter : TextWriter
     /// <inheritdoc />
     public override void WriteLine(string? value)
     {
-        _flushLock.EnterReadLock();
+        if (TryDeferInputWrite((value ?? string.Empty).AsSpan(), appendNewLine: true))
+        {
+            return;
+        }
+
         try
         {
-            var state = GetLineBufferState();
-            lock (state.SyncRoot)
-            {
-                WriteCore(state, (value ?? string.Empty).AsSpan(), appendNewLine: true);
-            }
+            WriteSynchronized(
+                GetLineBufferState(),
+                (value ?? string.Empty).AsSpan(),
+                appendNewLine: true);
         }
         finally
         {
-            _flushLock.ExitReadLock();
+            DrainDeferredInputWrites();
         }
     }
 
@@ -117,39 +122,39 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        _flushLock.EnterReadLock();
+        if (TryDeferInputWrite(value.AsSpan(), appendNewLine: false))
+        {
+            return;
+        }
+
         try
         {
-            var state = GetLineBufferState();
-            lock (state.SyncRoot)
-            {
-                WriteCore(state, value.AsSpan(), appendNewLine: false);
-            }
+            WriteSynchronized(GetLineBufferState(), value.AsSpan(), appendNewLine: false);
         }
         finally
         {
-            _flushLock.ExitReadLock();
+            DrainDeferredInputWrites();
         }
     }
 
     /// <inheritdoc />
     public override void Write(char value)
     {
-        _flushLock.EnterReadLock();
+        if (TryDeferInputWrite(stackalloc char[] { value }, appendNewLine: false))
+        {
+            return;
+        }
+
         try
         {
-            var state = GetLineBufferState();
-            lock (state.SyncRoot)
-            {
-                var shouldBuffer = GetBufferMode(state, ShouldBuffer());
-                state.Buffer.Append(value);
-                ProcessPendingOutput(state, shouldBuffer, shouldProcess: value == '\n');
-                UpdateScopedLineBufferRetention(state);
-            }
+            WriteSynchronized(
+                GetLineBufferState(),
+                stackalloc char[] { value },
+                appendNewLine: false);
         }
         finally
         {
-            _flushLock.ExitReadLock();
+            DrainDeferredInputWrites();
         }
     }
 
@@ -157,32 +162,51 @@ internal class CoordinatedTextWriter : TextWriter
     public override void Write(char[] buffer, int index, int count)
     {
         ArgumentNullException.ThrowIfNull(buffer);
+        var value = buffer.AsSpan(index, count);
+        if (TryDeferInputWrite(value, appendNewLine: false))
+        {
+            return;
+        }
 
-        _flushLock.EnterReadLock();
         try
         {
-            var state = GetLineBufferState();
-            lock (state.SyncRoot)
-            {
-                WriteCore(state, buffer.AsSpan(index, count), appendNewLine: false);
-            }
+            WriteSynchronized(GetLineBufferState(), value, appendNewLine: false);
         }
         finally
         {
-            _flushLock.ExitReadLock();
+            DrainDeferredInputWrites();
         }
     }
 
     /// <inheritdoc />
     public override void Write(ReadOnlySpan<char> buffer)
     {
+        if (TryDeferInputWrite(buffer, appendNewLine: false))
+        {
+            return;
+        }
+
+        try
+        {
+            WriteSynchronized(GetLineBufferState(), buffer, appendNewLine: false);
+        }
+        finally
+        {
+            DrainDeferredInputWrites();
+        }
+    }
+
+    private void WriteSynchronized(
+        LineBufferState state,
+        ReadOnlySpan<char> value,
+        bool appendNewLine)
+    {
         _flushLock.EnterReadLock();
         try
         {
-            var state = GetLineBufferState();
             lock (state.SyncRoot)
             {
-                WriteCore(state, buffer, appendNewLine: false);
+                WriteCore(state, value, appendNewLine);
             }
         }
         finally
@@ -806,14 +830,14 @@ internal class CoordinatedTextWriter : TextWriter
 
         _outputLock.Wait();
         var activeOutputWriter = EnterActiveOutputWriter();
+        BeginDeferringOutputWrites();
         try
         {
             WriteToRealConsoleCore(output, appendNewLine);
         }
         finally
         {
-            ExitActiveOutputWriter(activeOutputWriter);
-            _outputLock.Release();
+            CompleteOutputWrite(activeOutputWriter);
         }
     }
 
@@ -833,16 +857,79 @@ internal class CoordinatedTextWriter : TextWriter
     {
         lock (_deferredOutputLock)
         {
-            if (!_isAsyncFlushActive)
+            if (!_isOutputSinkActive)
             {
                 return false;
             }
 
-            // An asynchronous sink can suppress ExecutionContext flow before awaiting
-            // work that writes through this writer. That callback cannot see the active
-            // writer scope, so queue its processed output instead of waiting on our lease.
+            // A sink can suppress ExecutionContext flow before waiting for work that
+            // writes through this writer. That callback cannot see the active writer
+            // scope, so queue its processed output instead of waiting on our lease.
             _deferredOutputWrites.Enqueue(new DeferredOutputWrite(output, appendNewLine));
             return true;
+        }
+    }
+
+    private bool TryDeferInputWrite(ReadOnlySpan<char> value, bool appendNewLine)
+    {
+        if (IsReentrantOutputWrite() || !_isOutputSinkActive)
+        {
+            return false;
+        }
+
+        var state = GetLineBufferState();
+        lock (_deferredOutputLock)
+        {
+            if (!_isOutputSinkActive)
+            {
+                return false;
+            }
+
+            _deferredInputWrites.Enqueue(
+                new DeferredInputWrite(value.ToString(), appendNewLine, state));
+            return true;
+        }
+    }
+
+    private void DrainDeferredInputWrites()
+    {
+        lock (_deferredOutputLock)
+        {
+            if (_isDeferredInputDrainActive)
+            {
+                return;
+            }
+
+            _isDeferredInputDrainActive = true;
+        }
+
+        while (true)
+        {
+            DeferredInputWrite write;
+            lock (_deferredOutputLock)
+            {
+                if (_deferredInputWrites.Count == 0)
+                {
+                    _isDeferredInputDrainActive = false;
+                    return;
+                }
+
+                write = _deferredInputWrites.Dequeue();
+            }
+
+            try
+            {
+                WriteSynchronized(write.State, write.Output.AsSpan(), write.AppendNewLine);
+            }
+            catch
+            {
+                lock (_deferredOutputLock)
+                {
+                    _isDeferredInputDrainActive = false;
+                }
+
+                throw;
+            }
         }
     }
 
@@ -850,7 +937,7 @@ internal class CoordinatedTextWriter : TextWriter
     {
         lock (_deferredOutputLock)
         {
-            _isAsyncFlushActive = true;
+            _isOutputSinkActive = true;
         }
     }
 
@@ -863,7 +950,7 @@ internal class CoordinatedTextWriter : TextWriter
             {
                 if (_deferredOutputWrites.Count == 0)
                 {
-                    _isAsyncFlushActive = false;
+                    _isOutputSinkActive = false;
                     return;
                 }
 
@@ -882,7 +969,21 @@ internal class CoordinatedTextWriter : TextWriter
     {
         lock (_deferredOutputLock)
         {
-            _isAsyncFlushActive = false;
+            _isOutputSinkActive = false;
+        }
+    }
+
+    private void CompleteOutputWrite(ActiveOutputWriter activeOutputWriter)
+    {
+        try
+        {
+            DrainDeferredOutputWrites();
+        }
+        finally
+        {
+            StopDeferringOutputWrites();
+            ExitActiveOutputWriter(activeOutputWriter);
+            _outputLock.Release();
         }
     }
 
@@ -1000,22 +1101,29 @@ internal class CoordinatedTextWriter : TextWriter
     /// <inheritdoc />
     public override void Flush()
     {
-        if (IsReentrantOutputWrite())
+        try
         {
-            FlushReentrantOutput();
-            _realConsole.Flush();
-            return;
-        }
+            if (IsReentrantOutputWrite())
+            {
+                FlushReentrantOutput();
+                _realConsole.Flush();
+                return;
+            }
 
-        if (IsCustomObfuscationActive())
-        {
-            FlushReentrantOutput();
+            if (IsCustomObfuscationActive())
+            {
+                FlushReentrantOutput();
+                FlushRealConsole();
+                return;
+            }
+
+            FlushBufferedOutput();
             FlushRealConsole();
-            return;
         }
-
-        FlushBufferedOutput();
-        FlushRealConsole();
+        finally
+        {
+            DrainDeferredInputWrites();
+        }
     }
 
     private void FlushReentrantOutput()
@@ -1143,28 +1251,36 @@ internal class CoordinatedTextWriter : TextWriter
     /// <inheritdoc />
     public override async Task FlushAsync()
     {
-        if (IsReentrantOutputWrite())
+        try
         {
-            FlushReentrantOutput();
-            await _realConsole.FlushAsync().ConfigureAwait(false);
-            return;
-        }
+            if (IsReentrantOutputWrite())
+            {
+                FlushReentrantOutput();
+                await _realConsole.FlushAsync().ConfigureAwait(false);
+                return;
+            }
 
-        if (IsCustomObfuscationActive())
-        {
-            FlushReentrantOutput();
+            if (IsCustomObfuscationActive())
+            {
+                FlushReentrantOutput();
+                await FlushRealConsoleAsync().ConfigureAwait(false);
+                return;
+            }
+
+            FlushBufferedOutput();
             await FlushRealConsoleAsync().ConfigureAwait(false);
-            return;
         }
-
-        FlushBufferedOutput();
-        await FlushRealConsoleAsync().ConfigureAwait(false);
+        finally
+        {
+            DrainDeferredInputWrites();
+        }
     }
 
     private void FlushRealConsole()
     {
         _outputLock.Wait();
         var activeOutputWriter = EnterActiveOutputWriter();
+        BeginDeferringOutputWrites();
         try
         {
             // Always flush real console (needed for Spectre.Console internals)
@@ -1172,8 +1288,7 @@ internal class CoordinatedTextWriter : TextWriter
         }
         finally
         {
-            ExitActiveOutputWriter(activeOutputWriter);
-            _outputLock.Release();
+            CompleteOutputWrite(activeOutputWriter);
         }
     }
 
@@ -1188,16 +1303,7 @@ internal class CoordinatedTextWriter : TextWriter
         }
         finally
         {
-            try
-            {
-                DrainDeferredOutputWrites();
-            }
-            finally
-            {
-                StopDeferringOutputWrites();
-                ExitActiveOutputWriter(activeOutputWriter);
-                _outputLock.Release();
-            }
+            CompleteOutputWrite(activeOutputWriter);
         }
     }
 
@@ -1235,6 +1341,11 @@ internal class CoordinatedTextWriter : TextWriter
 
         public void Deactivate() => Volatile.Write(ref _isActive, 0);
     }
+
+    private readonly record struct DeferredInputWrite(
+        string Output,
+        bool AppendNewLine,
+        LineBufferState State);
 
     private readonly record struct DeferredOutputWrite(string Output, bool AppendNewLine);
 

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 using ModularPipelines.Engine;
 using ModularPipelines.Logging;
@@ -43,6 +44,8 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly ISecretObfuscator _secretObfuscator;
     private readonly ISecretProvider _secretProvider;
     private readonly Dictionary<LineBufferKey, LineBufferState> _lineBuffers = [];
+    private readonly ConditionalWeakTable<object, Dictionary<LineBufferKey, LineBufferState>>
+        _scopedLineBuffers = [];
     private readonly object _lineBufferLock = new();
     private readonly object _customObfuscatorLock = new();
     private readonly object _secretPatternsLock = new();
@@ -288,18 +291,23 @@ internal class CoordinatedTextWriter : TextWriter
     private LineBufferState GetLineBufferState()
     {
         var moduleType = ModuleLogger.CurrentModuleType.Value;
+        var customObfuscationScope = _customObfuscationScope.Value;
+        var outputWriteScope = GetOutputWriteBufferScope();
+        var primaryScope = (object?) outputWriteScope ?? customObfuscationScope;
         var key = new LineBufferKey(
             moduleType,
             DirectWriteScope.Value,
-            GetCustomObfuscationScopeDepth(),
-            GetOutputWriteScopeDepth());
+            outputWriteScope is null ? null : customObfuscationScope);
 
         lock (_lineBufferLock)
         {
-            if (!_lineBuffers.TryGetValue(key, out var state))
+            var lineBuffers = primaryScope is null
+                ? _lineBuffers
+                : _scopedLineBuffers.GetValue(primaryScope, static _ => []);
+            if (!lineBuffers.TryGetValue(key, out var state))
             {
                 state = new LineBufferState(moduleType);
-                _lineBuffers.Add(key, state);
+                lineBuffers.Add(key, state);
             }
 
             return state;
@@ -810,22 +818,6 @@ internal class CoordinatedTextWriter : TextWriter
 
     private bool IsReentrantOutputWrite() => GetReentrantOutputWriteDepth() > 0;
 
-    private int GetOutputWriteScopeDepth()
-    {
-        var depth = 0;
-        for (var activeOutputWriter = ActiveOutputWriterScope.Value;
-             activeOutputWriter != null;
-             activeOutputWriter = activeOutputWriter.Parent)
-        {
-            if (ReferenceEquals(activeOutputWriter.Writer, this))
-            {
-                depth++;
-            }
-        }
-
-        return depth;
-    }
-
     private int GetReentrantOutputWriteDepth()
     {
         var depth = 0;
@@ -841,6 +833,21 @@ internal class CoordinatedTextWriter : TextWriter
         }
 
         return depth;
+    }
+
+    private ActiveOutputWriter? GetOutputWriteBufferScope()
+    {
+        for (var activeOutputWriter = ActiveOutputWriterScope.Value;
+             activeOutputWriter != null;
+             activeOutputWriter = activeOutputWriter.Parent)
+        {
+            if (ReferenceEquals(activeOutputWriter.Writer, this))
+            {
+                return activeOutputWriter;
+            }
+        }
+
+        return null;
     }
 
     private ActiveOutputWriter EnterActiveOutputWriter()
@@ -867,44 +874,16 @@ internal class CoordinatedTextWriter : TextWriter
 
         lock (_customObfuscatorLock)
         {
-            var customObfuscationScope = EnterCustomObfuscationScope();
+            var scope = EnterCustomObfuscationScope();
             try
             {
                 return _secretObfuscator.Obfuscate(output, null);
             }
             finally
             {
-                ExitCustomObfuscationScope(customObfuscationScope);
+                ExitCustomObfuscationScope(scope);
             }
         }
-    }
-
-    private bool IsReentrantCustomObfuscation()
-    {
-        for (var scope = _customObfuscationScope.Value;
-             scope != null;
-             scope = scope.Parent)
-        {
-            if (scope.IsActive)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private int GetCustomObfuscationScopeDepth()
-    {
-        var depth = 0;
-        for (var scope = _customObfuscationScope.Value;
-             scope != null;
-             scope = scope.Parent)
-        {
-            depth++;
-        }
-
-        return depth;
     }
 
     private CustomObfuscationScope EnterCustomObfuscationScope()
@@ -918,6 +897,21 @@ internal class CoordinatedTextWriter : TextWriter
     {
         scope.Deactivate();
         _customObfuscationScope.Value = scope.Parent;
+    }
+
+    private bool IsCustomObfuscationActive()
+    {
+        for (var scope = _customObfuscationScope.Value;
+             scope != null;
+             scope = scope.Parent)
+        {
+            if (scope.IsActive)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void ExecuteWithStableSecrets<TState>(TState state, Action<TState> processOutput)
@@ -942,7 +936,7 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        if (IsReentrantCustomObfuscation())
+        if (IsCustomObfuscationActive())
         {
             FlushReentrantOutput();
             FlushRealConsole();
@@ -972,13 +966,7 @@ internal class CoordinatedTextWriter : TextWriter
         _flushLock.EnterWriteLock();
         try
         {
-            LineBufferState[] states;
-            lock (_lineBufferLock)
-            {
-                states = _lineBuffers.Values.ToArray();
-            }
-
-            foreach (var state in states)
+            foreach (var state in GetLineBufferStates())
             {
                 lock (state.SyncRoot)
                 {
@@ -1012,13 +1000,7 @@ internal class CoordinatedTextWriter : TextWriter
         _flushLock.EnterWriteLock();
         try
         {
-            LineBufferState[] states;
-            lock (_lineBufferLock)
-            {
-                states = _lineBuffers.Values.ToArray();
-            }
-
-            foreach (var state in states)
+            foreach (var state in GetLineBufferStates())
             {
                 lock (state.SyncRoot)
                 {
@@ -1095,7 +1077,7 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        if (IsReentrantCustomObfuscation())
+        if (IsCustomObfuscationActive())
         {
             FlushReentrantOutput();
             await FlushRealConsoleAsync().ConfigureAwait(false);
@@ -1172,6 +1154,15 @@ internal class CoordinatedTextWriter : TextWriter
         public void Deactivate() => Volatile.Write(ref _isActive, 0);
     }
 
+    private LineBufferState[] GetLineBufferStates()
+    {
+        lock (_lineBufferLock)
+        {
+            return _lineBuffers.Values
+                .Concat(_scopedLineBuffers.SelectMany(static entry => entry.Value.Values))
+                .ToArray();
+        }
+    }
     private sealed class CustomObfuscationScope(CustomObfuscationScope? parent)
     {
         private int _isActive = 1;
@@ -1197,8 +1188,7 @@ internal class CoordinatedTextWriter : TextWriter
     private readonly record struct LineBufferKey(
         Type? ModuleType,
         bool IsDirectWrite,
-        int CustomObfuscationDepth,
-        int ReentrantOutputWriteDepth);
+        CustomObfuscationScope? NestedCustomObfuscationScope);
 
     private sealed record SecretPatterns(
         string[] Values,

--- a/src/ModularPipelines/Console/CoordinatedTextWriter.cs
+++ b/src/ModularPipelines/Console/CoordinatedTextWriter.cs
@@ -246,6 +246,11 @@ internal class CoordinatedTextWriter : TextWriter
             return retainedPrefixLength;
         }
 
+        if (_secretObfuscator is not ITrackedSecretObfuscator trackedObfuscator)
+        {
+            return retainedPrefixLength;
+        }
+
         var pending = state.Buffer.ToString();
         if (pending.AsSpan().IndexOfAny(patterns.SearchValues) < 0)
         {
@@ -264,7 +269,6 @@ internal class CoordinatedTextWriter : TextWriter
             var match = FindFirstPattern(pending, patterns, searchIndex);
             if (match.Index < 0)
             {
-                output.Append(pending, outputIndex, pending.Length - outputIndex);
                 break;
             }
 
@@ -287,9 +291,7 @@ internal class CoordinatedTextWriter : TextWriter
             }
 
             var secret = pending.Substring(match.Index, match.Length);
-            var obfuscation = _secretObfuscator is ITrackedSecretObfuscator trackedObfuscator
-                ? trackedObfuscator.ObfuscateWithConsumption(secret, null)
-                : GetFallbackObfuscation(secret);
+            var obfuscation = trackedObfuscator.ObfuscateWithConsumption(secret, null);
             if (obfuscation.ConsumedInputLength == 0)
             {
                 searchIndex = match.Index + 1;
@@ -308,6 +310,7 @@ internal class CoordinatedTextWriter : TextWriter
 
         if (replaced)
         {
+            output.Append(pending, outputIndex, pending.Length - outputIndex);
             state.Buffer.Clear();
             state.Buffer.Append(output);
         }
@@ -315,15 +318,6 @@ internal class CoordinatedTextWriter : TextWriter
         return retainedPrefixInvalidated
             ? GetPotentialPatternPrefixLength(state.Buffer, patterns.Values)
             : retainedPrefixLength;
-    }
-
-    private SecretObfuscationResult GetFallbackObfuscation(string input)
-    {
-        var output = _secretObfuscator.Obfuscate(input, null);
-        var consumedInputLength = string.Equals(output, input, StringComparison.Ordinal)
-            ? 0
-            : input.Length;
-        return new SecretObfuscationResult(output, consumedInputLength);
     }
 
     private void FlushSafeOutput(LineBufferState state, int retainedLength, bool shouldBuffer)
@@ -473,7 +467,7 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        var output = state.Buffer.ToString(0, length);
+        var output = ObfuscateCustomOutput(state.Buffer.ToString(0, length));
         state.Buffer.Remove(0, length);
         lock (_outputLock)
         {
@@ -483,6 +477,8 @@ internal class CoordinatedTextWriter : TextWriter
 
     private void WriteCompletedLine(string line, bool shouldBuffer, Type? moduleType)
     {
+        line = ObfuscateCustomOutput(line);
+
         if (shouldBuffer)
         {
             RouteToBuffer(line, moduleType);
@@ -508,7 +504,7 @@ internal class CoordinatedTextWriter : TextWriter
             return;
         }
 
-        var pending = state.Buffer.ToString(0, length);
+        var pending = ObfuscateCustomOutput(state.Buffer.ToString(0, length));
         state.Buffer.Remove(0, length);
 
         if (shouldBuffer)
@@ -523,6 +519,11 @@ internal class CoordinatedTextWriter : TextWriter
             }
         }
     }
+
+    private string ObfuscateCustomOutput(string output) =>
+        _secretObfuscator is ITrackedSecretObfuscator
+            ? output
+            : _secretObfuscator.Obfuscate(output, null);
 
     /// <inheritdoc />
     public override void Flush()

--- a/src/ModularPipelines/Engine/ISecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/ISecretObfuscator.cs
@@ -22,3 +22,10 @@ public interface ISecretObfuscator
     /// <returns>The input with sensitive information obfuscated.</returns>
     string Obfuscate(string? input, object? optionsObject);
 }
+
+internal interface ITrackedSecretObfuscator : ISecretObfuscator
+{
+    SecretObfuscationResult ObfuscateWithConsumption(string? input, object? optionsObject);
+}
+
+internal readonly record struct SecretObfuscationResult(string Output, int ConsumedInputLength);

--- a/src/ModularPipelines/Engine/ISecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/ISecretObfuscator.cs
@@ -25,7 +25,17 @@ public interface ISecretObfuscator
 
 internal interface ITrackedSecretObfuscator : ISecretObfuscator
 {
+    StringComparison PatternComparison { get; }
+
     SecretObfuscationResult ObfuscateWithConsumption(string? input, object? optionsObject);
 }
 
+/// <summary>
+/// Describes tracked obfuscation output and how much source input it consumed.
+/// </summary>
+/// <param name="Output">The obfuscated output.</param>
+/// <param name="ConsumedInputLength">
+/// The number of input characters replaced in <paramref name="Output"/>. The remaining input
+/// characters appear unchanged at the end of <paramref name="Output"/>.
+/// </param>
 internal readonly record struct SecretObfuscationResult(string Output, int ConsumedInputLength);

--- a/src/ModularPipelines/Engine/ISecretProvider.cs
+++ b/src/ModularPipelines/Engine/ISecretProvider.cs
@@ -30,6 +30,7 @@ internal interface ISecretEmissionGuard
     /// <summary>
     /// Executes output processing against a stable registered-secret collection.
     /// Concurrent output may proceed together, while secret publication waits for it to finish.
+    /// Registrations made reentrantly by the output sink are published when the callback completes.
     /// </summary>
     /// <typeparam name="TState">The state passed to the output callback.</typeparam>
     /// <param name="state">The output state.</param>

--- a/src/ModularPipelines/Engine/ISecretProvider.cs
+++ b/src/ModularPipelines/Engine/ISecretProvider.cs
@@ -31,8 +31,10 @@ internal interface ISecretEmissionGuard
     /// Executes output processing against a stable registered-secret collection.
     /// Concurrent output may proceed together, while secret publication waits for it to finish.
     /// </summary>
+    /// <typeparam name="TState">The state passed to the output callback.</typeparam>
+    /// <param name="state">The output state.</param>
     /// <param name="processOutput">The output processing and emission to execute.</param>
-    void ExecuteWithStableSecrets(Action processOutput);
+    void ExecuteWithStableSecrets<TState>(TState state, Action<TState> processOutput);
 }
 
 internal readonly record struct SecretSnapshot(long Version, IReadOnlyList<string> Secrets);

--- a/src/ModularPipelines/Engine/ISecretProvider.cs
+++ b/src/ModularPipelines/Engine/ISecretProvider.cs
@@ -25,4 +25,14 @@ internal interface ISecretProvider
     IEnumerable<string> GetSecretsInObject(object? value);
 }
 
+internal interface ISecretEmissionGuard
+{
+    /// <summary>
+    /// Executes output processing against a stable registered-secret collection.
+    /// Concurrent output may proceed together, while secret publication waits for it to finish.
+    /// </summary>
+    /// <param name="processOutput">The output processing and emission to execute.</param>
+    void ExecuteWithStableSecrets(Action processOutput);
+}
+
 internal readonly record struct SecretSnapshot(long Version, IReadOnlyList<string> Secrets);

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -36,6 +36,11 @@ internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
 
     public bool HasSecrets => GetRegistrationState().HasSecrets;
 
+    StringComparison ITrackedSecretObfuscator.PatternComparison =>
+        _maskingOptions.Value.CaseInsensitive
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
     public SecretObfuscator(
         ISecretProvider secretProvider,
         IOptions<SecretMaskingOptions> maskingOptions)

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -23,7 +23,7 @@ namespace ModularPipelines.Engine;
 /// </para>
 /// </remarks>
 /// <threadsafety static="true" instance="true"/>
-internal class SecretObfuscator : ISecretObfuscator, IInitializer
+internal class SecretObfuscator : ITrackedSecretObfuscator, IInitializer
 {
     private readonly ISecretProvider _secretProvider;
     private readonly IOptions<SecretMaskingOptions> _maskingOptions;
@@ -55,9 +55,21 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
 
     public string Obfuscate(string? input, object? optionsObject)
     {
+        return ObfuscateWithConsumption(input, optionsObject).Output;
+    }
+
+    SecretObfuscationResult ITrackedSecretObfuscator.ObfuscateWithConsumption(
+        string? input,
+        object? optionsObject)
+    {
+        return ObfuscateWithConsumption(input, optionsObject);
+    }
+
+    private SecretObfuscationResult ObfuscateWithConsumption(string? input, object? optionsObject)
+    {
         if (string.IsNullOrEmpty(input))
         {
-            return string.Empty;
+            return new SecretObfuscationResult(string.Empty, 0);
         }
 
         var options = _maskingOptions.Value;
@@ -69,7 +81,7 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         if (secretCache.SearchValues is null ||
             !input.AsSpan().ContainsAny(secretCache.SearchValues))
         {
-            return input;
+            return new SecretObfuscationResult(input, 0);
         }
 
         return ObfuscateMatches(
@@ -200,7 +212,7 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
             searchValues);
     }
 
-    private static string ObfuscateMatches(
+    private static SecretObfuscationResult ObfuscateMatches(
         string input,
         IReadOnlyList<string> secrets,
         SearchValues<string> searchValues,
@@ -243,7 +255,7 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
 
         result.Append(input, inputOffset, input.Length - inputOffset);
 
-        return result.ToString();
+        return new SecretObfuscationResult(result.ToString(), inputOffset);
     }
 
     private sealed class OptionsSecretCache

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -34,8 +34,7 @@ namespace ModularPipelines.Engine;
 /// <threadsafety static="true" instance="true"/>
 internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRegistry, IInitializer
 {
-    [ThreadStatic]
-    private static DeferredRegistrationScope? _deferredRegistrationScope;
+    private static readonly AsyncLocal<DeferredRegistrationScope?> CurrentDeferredRegistrationScope = new();
 
     private static readonly ConditionalWeakTable<Assembly, SecretAttributeReference> SecretAttributeReferenceCache = [];
     private static readonly ConditionalWeakTable<Type, ReflectionAccessors> ReflectionAccessorsCache = [];
@@ -176,30 +175,35 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         var existingScope = FindDeferredRegistrationScope();
         if (existingScope is not null)
         {
-            PublishDeferredPatterns(existingScope);
+            if (_secretEmissionLock.IsReadLockHeld)
+            {
+                PublishDeferredPatterns(existingScope);
+            }
+
             processOutput(state);
             return;
         }
 
         _secretEmissionLock.EnterReadLock();
-        var previousScope = _deferredRegistrationScope;
+        var previousScope = CurrentDeferredRegistrationScope.Value;
         var scope = new DeferredRegistrationScope(this, previousScope);
-        _deferredRegistrationScope = scope;
+        CurrentDeferredRegistrationScope.Value = scope;
         try
         {
             processOutput(state);
         }
         finally
         {
-            _deferredRegistrationScope = previousScope;
+            var deferredPatterns = scope.CloseAndTakePatterns();
+            CurrentDeferredRegistrationScope.Value = previousScope;
             _secretEmissionLock.ExitReadLock();
-            PublishDeferredPatternsWithoutReadLock(scope);
+            PublishPatterns(deferredPatterns);
         }
     }
 
     private void PublishDeferredPatterns(DeferredRegistrationScope scope)
     {
-        if (scope.Patterns.Count == 0)
+        if (!scope.HasPatterns)
         {
             return;
         }
@@ -217,8 +221,11 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
 
     private void PublishDeferredPatternsWithoutReadLock(DeferredRegistrationScope scope)
     {
-        var deferredPatterns = scope.Patterns.ToArray();
-        scope.Patterns.Clear();
+        PublishPatterns(scope.TakePatterns());
+    }
+
+    private void PublishPatterns(IEnumerable<IReadOnlyList<string>> deferredPatterns)
+    {
         foreach (var patterns in deferredPatterns)
         {
             PublishPatterns(patterns);
@@ -227,21 +234,22 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
 
     private bool TryDeferRegistration(IReadOnlyList<string> patterns)
     {
-        var scope = FindDeferredRegistrationScope();
-        if (scope is null)
+        for (var scope = CurrentDeferredRegistrationScope.Value; scope is not null; scope = scope.Parent)
         {
-            return false;
+            if (ReferenceEquals(scope.Provider, this) && scope.TryAddPatterns(patterns))
+            {
+                return true;
+            }
         }
 
-        scope.Patterns.Add(patterns);
-        return true;
+        return false;
     }
 
     private DeferredRegistrationScope? FindDeferredRegistrationScope()
     {
-        for (var scope = _deferredRegistrationScope; scope is not null; scope = scope.Parent)
+        for (var scope = CurrentDeferredRegistrationScope.Value; scope is not null; scope = scope.Parent)
         {
-            if (ReferenceEquals(scope.Provider, this))
+            if (ReferenceEquals(scope.Provider, this) && scope.IsOpen)
             {
                 return scope;
             }
@@ -616,6 +624,68 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         SecretProvider Provider,
         DeferredRegistrationScope? Parent)
     {
-        public List<IReadOnlyList<string>> Patterns { get; } = [];
+        private readonly object _syncRoot = new();
+        private readonly List<IReadOnlyList<string>> _patterns = [];
+        private bool _isOpen = true;
+
+        public bool IsOpen
+        {
+            get
+            {
+                lock (_syncRoot)
+                {
+                    return _isOpen;
+                }
+            }
+        }
+
+        public bool HasPatterns
+        {
+            get
+            {
+                lock (_syncRoot)
+                {
+                    return _patterns.Count > 0;
+                }
+            }
+        }
+
+        public bool TryAddPatterns(IReadOnlyList<string> patterns)
+        {
+            lock (_syncRoot)
+            {
+                if (!_isOpen)
+                {
+                    return false;
+                }
+
+                _patterns.Add(patterns);
+                return true;
+            }
+        }
+
+        public IReadOnlyList<IReadOnlyList<string>> TakePatterns()
+        {
+            lock (_syncRoot)
+            {
+                return TakePatternsUnderLock();
+            }
+        }
+
+        public IReadOnlyList<IReadOnlyList<string>> CloseAndTakePatterns()
+        {
+            lock (_syncRoot)
+            {
+                _isOpen = false;
+                return TakePatternsUnderLock();
+            }
+        }
+
+        private IReadOnlyList<IReadOnlyList<string>> TakePatternsUnderLock()
+        {
+            var patterns = _patterns.ToArray();
+            _patterns.Clear();
+            return patterns;
+        }
     }
 }

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -58,6 +58,7 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     private long _nextDeferredSnapshotVersion;
     private long _deferredRegistrationBatch;
     private int _activeEmissionCount;
+    private bool _deferredPublicationInProgress;
     // Direct redactors and a registering worker's next emission must see deferred
     // patterns immediately. Existing emissions keep the snapshot captured by their scope.
     private SecretSnapshot? _deferredMaskingSnapshot;
@@ -219,7 +220,7 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             return secrets.Count == existingCount
                 ? existingSnapshot
                 : new SecretSnapshot(
-                    Interlocked.Decrement(ref _nextDeferredSnapshotVersion),
+                    GetNextDeferredSnapshotVersion(),
                     secrets.ToArray());
         }
     }
@@ -228,28 +229,58 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         bool ownsReadLock,
         long? unscopedRegistrationBatch)
     {
-        lock (_emissionStateLock)
+        if (!ownsReadLock)
         {
-            while (ownsReadLock
-                   && unscopedRegistrationBatch != _deferredRegistrationBatch
-                   && _deferredPatternsPendingPublication.Count != 0)
+            lock (_emissionStateLock)
             {
-                Monitor.Wait(_emissionStateLock);
+                _activeEmissionCount++;
             }
 
-            if (ownsReadLock)
-            {
-                _secretEmissionLock.EnterReadLock();
-            }
-
-            _activeEmissionCount++;
+            return;
         }
+
+        while (true)
+        {
+            lock (_emissionStateLock)
+            {
+                while (ShouldWaitForDeferredPublication(unscopedRegistrationBatch))
+                {
+                    Monitor.Wait(_emissionStateLock);
+                }
+            }
+
+            _secretEmissionLock.EnterReadLock();
+            bool shouldRetry;
+            lock (_emissionStateLock)
+            {
+                shouldRetry = ShouldWaitForDeferredPublication(unscopedRegistrationBatch);
+                if (!shouldRetry)
+                {
+                    _activeEmissionCount++;
+                }
+            }
+
+            if (!shouldRetry)
+            {
+                return;
+            }
+
+            _secretEmissionLock.ExitReadLock();
+        }
+    }
+
+    private bool ShouldWaitForDeferredPublication(long? unscopedRegistrationBatch)
+    {
+        return unscopedRegistrationBatch != _deferredRegistrationBatch
+               && (_deferredPublicationInProgress
+                   || _deferredPatternsPendingPublication.Count != 0);
     }
 
     private void ExitStableEmission(
         bool ownsReadLock,
         DeferredRegistrationScope scope)
     {
+        IReadOnlyList<string>[]? patternsToPublish;
         lock (_emissionStateLock)
         {
             var unclaimedPatterns = scope.CloseAndTakePatterns()
@@ -266,22 +297,62 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             {
                 UpdateDeferredMaskingSnapshot(unclaimedPatterns);
             }
-            _activeEmissionCount--;
-            if (ownsReadLock)
-            {
-                _secretEmissionLock.ExitReadLock();
-            }
 
-            if (_activeEmissionCount != 0)
+            _activeEmissionCount--;
+            patternsToPublish = TryBeginDeferredPublicationUnderLock();
+        }
+
+        if (ownsReadLock)
+        {
+            _secretEmissionLock.ExitReadLock();
+        }
+
+        if (patternsToPublish is not null)
+        {
+            PublishDeferredPatterns(patternsToPublish);
+        }
+    }
+
+    private IReadOnlyList<string>[]? TryBeginDeferredPublicationUnderLock()
+    {
+        if (_activeEmissionCount != 0
+            || _deferredPublicationInProgress
+            || _deferredPatternsPendingPublication.Count == 0)
+        {
+            return null;
+        }
+
+        _deferredPublicationInProgress = true;
+        var patternsToPublish = _deferredPatternsPendingPublication.ToArray();
+        _deferredPatternsPendingPublication.Clear();
+        return patternsToPublish;
+    }
+
+    private void PublishDeferredPatterns(IReadOnlyList<string>[] patternsToPublish)
+    {
+        while (true)
+        {
+            PublishPatterns(patternsToPublish);
+
+            lock (_emissionStateLock)
             {
+                if (_activeEmissionCount == 0
+                    && _deferredPatternsPendingPublication.Count != 0)
+                {
+                    patternsToPublish = _deferredPatternsPendingPublication.ToArray();
+                    _deferredPatternsPendingPublication.Clear();
+                    continue;
+                }
+
+                _deferredPublicationInProgress = false;
+                if (_deferredPatternsPendingPublication.Count == 0)
+                {
+                    _deferredMaskingSnapshot = null;
+                }
+
+                Monitor.PulseAll(_emissionStateLock);
                 return;
             }
-
-            var patternsToPublish = _deferredPatternsPendingPublication.ToArray();
-            _deferredPatternsPendingPublication.Clear();
-            PublishPatterns(patternsToPublish);
-            _deferredMaskingSnapshot = null;
-            Monitor.PulseAll(_emissionStateLock);
         }
     }
 
@@ -334,9 +405,12 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             .Distinct(StringComparer.Ordinal)
             .ToArray();
         _deferredMaskingSnapshot = new SecretSnapshot(
-            Interlocked.Decrement(ref _nextDeferredSnapshotVersion),
+            GetNextDeferredSnapshotVersion(),
             combinedSecrets);
     }
+
+    private long GetNextDeferredSnapshotVersion() =>
+        Interlocked.Add(ref _nextDeferredSnapshotVersion, -2);
 
     private long? GetUnscopedRegistrationBatch()
     {
@@ -386,7 +460,8 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     {
         for (var scope = CurrentDeferredRegistrationScope.Value; scope is not null; scope = scope.Parent)
         {
-            if (ReferenceEquals(scope.Provider, this) && scope.TryAddPatterns(patterns))
+            if (ReferenceEquals(scope.Provider, this)
+                && scope.TryAddPatterns(patterns, GetNextDeferredSnapshotVersion))
             {
                 return true;
             }
@@ -779,7 +854,7 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     {
         private readonly object _syncRoot = new();
         private readonly List<IReadOnlyList<string>> _patterns = [];
-        private readonly SecretSnapshot _snapshot;
+        private SecretSnapshot _snapshot;
         private bool _isOpen = true;
 
         public SecretProvider Provider { get; }
@@ -818,7 +893,9 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             }
         }
 
-        public bool TryAddPatterns(IReadOnlyList<string> patterns)
+        public bool TryAddPatterns(
+            IReadOnlyList<string> patterns,
+            Func<long> getNextSnapshotVersion)
         {
             lock (_syncRoot)
             {
@@ -828,6 +905,15 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
                 }
 
                 _patterns.Add(patterns);
+                var secrets = _snapshot.Secrets
+                    .Concat(patterns)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                if (secrets.Length != _snapshot.Secrets.Count)
+                {
+                    _snapshot = new SecretSnapshot(getNextSnapshotVersion(), secrets);
+                }
+
                 return true;
             }
         }

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -173,8 +173,10 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     {
         ArgumentNullException.ThrowIfNull(processOutput);
 
-        if (FindDeferredRegistrationScope() is not null)
+        var existingScope = FindDeferredRegistrationScope();
+        if (existingScope is not null)
         {
+            PublishDeferredPatterns(existingScope);
             processOutput(state);
             return;
         }
@@ -191,10 +193,35 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         {
             _deferredRegistrationScope = previousScope;
             _secretEmissionLock.ExitReadLock();
-            foreach (var patterns in scope.Patterns)
-            {
-                PublishPatterns(patterns);
-            }
+            PublishDeferredPatternsWithoutReadLock(scope);
+        }
+    }
+
+    private void PublishDeferredPatterns(DeferredRegistrationScope scope)
+    {
+        if (scope.Patterns.Count == 0)
+        {
+            return;
+        }
+
+        _secretEmissionLock.ExitReadLock();
+        try
+        {
+            PublishDeferredPatternsWithoutReadLock(scope);
+        }
+        finally
+        {
+            _secretEmissionLock.EnterReadLock();
+        }
+    }
+
+    private void PublishDeferredPatternsWithoutReadLock(DeferredRegistrationScope scope)
+    {
+        var deferredPatterns = scope.Patterns.ToArray();
+        scope.Patterns.Clear();
+        foreach (var patterns in deferredPatterns)
+        {
+            PublishPatterns(patterns);
         }
     }
 

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -209,6 +209,11 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     {
         lock (_emissionStateLock)
         {
+            while (ownsReadLock && _unscopedDeferredPatterns.Count != 0)
+            {
+                Monitor.Wait(_emissionStateLock);
+            }
+
             if (ownsReadLock)
             {
                 _secretEmissionLock.EnterReadLock();
@@ -242,6 +247,7 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             var patternsToPublish = _unscopedDeferredPatterns.ToArray();
             _unscopedDeferredPatterns.Clear();
             PublishPatterns(patternsToPublish);
+            Monitor.PulseAll(_emissionStateLock);
         }
     }
 

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -32,7 +32,7 @@ namespace ModularPipelines.Engine;
 /// </list>
 /// </remarks>
 /// <threadsafety static="true" instance="true"/>
-internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
+internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRegistry, IInitializer
 {
     private static readonly ConditionalWeakTable<Assembly, SecretAttributeReference> SecretAttributeReferenceCache = [];
     private static readonly ConditionalWeakTable<Type, ReflectionAccessors> ReflectionAccessorsCache = [];
@@ -47,6 +47,7 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
     private readonly ConcurrentDictionary<string, byte> _shortSecretWarnings = new();
     private readonly object _initLock = new();
     private readonly object _secretsLock = new();
+    private readonly ReaderWriterLockSlim _secretEmissionLock = new();
 
     private long _version;
     private volatile bool _initialized;
@@ -104,22 +105,30 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
             return;
         }
 
-        lock (_secretsLock)
+        _secretEmissionLock.EnterWriteLock();
+        try
         {
-            if (patterns.All(_secrets.Contains))
+            lock (_secretsLock)
             {
-                return;
-            }
+                if (patterns.All(_secrets.Contains))
+                {
+                    return;
+                }
 
-            // Odd versions mark an in-progress publication so readers cannot reuse
-            // a cache while the matching secret collection is being updated.
-            Interlocked.Increment(ref _version);
-            foreach (var pattern in patterns)
-            {
-                _secrets.Add(pattern);
-            }
+                // Odd versions mark an in-progress publication so readers cannot reuse
+                // a cache while the matching secret collection is being updated.
+                Interlocked.Increment(ref _version);
+                foreach (var pattern in patterns)
+                {
+                    _secrets.Add(pattern);
+                }
 
-            Interlocked.Increment(ref _version);
+                Interlocked.Increment(ref _version);
+            }
+        }
+        finally
+        {
+            _secretEmissionLock.ExitWriteLock();
         }
     }
 
@@ -144,6 +153,21 @@ internal class SecretProvider : ISecretProvider, ISecretRegistry, IInitializer
         lock (_secretsLock)
         {
             return new SecretSnapshot(Version, _secrets.ToArray());
+        }
+    }
+
+    public void ExecuteWithStableSecrets(Action processOutput)
+    {
+        ArgumentNullException.ThrowIfNull(processOutput);
+
+        _secretEmissionLock.EnterReadLock();
+        try
+        {
+            processOutput();
+        }
+        finally
+        {
+            _secretEmissionLock.ExitReadLock();
         }
     }
 

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -49,9 +49,12 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     private readonly ConcurrentDictionary<string, byte> _shortSecretWarnings = new();
     private readonly object _initLock = new();
     private readonly object _secretsLock = new();
+    private readonly object _emissionStateLock = new();
     private readonly ReaderWriterLockSlim _secretEmissionLock = new();
+    private readonly List<IReadOnlyList<string>> _unscopedDeferredPatterns = [];
 
     private long _version;
+    private int _activeEmissionCount;
     private volatile bool _initialized;
 
     /// <inheritdoc />
@@ -108,6 +111,11 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         }
 
         if (TryDeferRegistration(patterns))
+        {
+            return;
+        }
+
+        if (TryDeferUnscopedRegistration(patterns))
         {
             return;
         }
@@ -180,7 +188,8 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             return;
         }
 
-        _secretEmissionLock.EnterReadLock();
+        var ownsReadLock = existingScope is null;
+        EnterStableEmission(ownsReadLock);
         var previousScope = CurrentDeferredRegistrationScope.Value;
         var scope = new DeferredRegistrationScope(this, previousScope);
         CurrentDeferredRegistrationScope.Value = scope;
@@ -192,19 +201,61 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         {
             var deferredPatterns = scope.CloseAndTakePatterns();
             CurrentDeferredRegistrationScope.Value = previousScope;
-            _secretEmissionLock.ExitReadLock();
-            PublishOrDeferPatterns(deferredPatterns);
+            ExitStableEmission(ownsReadLock, deferredPatterns);
         }
     }
 
-    private void PublishOrDeferPatterns(IEnumerable<IReadOnlyList<string>> deferredPatterns)
+    private void EnterStableEmission(bool ownsReadLock)
     {
-        foreach (var patterns in deferredPatterns)
+        lock (_emissionStateLock)
         {
-            if (!TryDeferRegistration(patterns))
+            if (ownsReadLock)
             {
-                PublishPatterns(patterns);
+                _secretEmissionLock.EnterReadLock();
             }
+
+            _activeEmissionCount++;
+        }
+    }
+
+    private void ExitStableEmission(
+        bool ownsReadLock,
+        IReadOnlyList<IReadOnlyList<string>> deferredPatterns)
+    {
+        if (ownsReadLock)
+        {
+            _secretEmissionLock.ExitReadLock();
+        }
+
+        var unclaimedPatterns = deferredPatterns
+            .Where(patterns => !TryDeferRegistration(patterns))
+            .ToArray();
+        lock (_emissionStateLock)
+        {
+            _unscopedDeferredPatterns.AddRange(unclaimedPatterns);
+            _activeEmissionCount--;
+            if (_activeEmissionCount != 0)
+            {
+                return;
+            }
+
+            var patternsToPublish = _unscopedDeferredPatterns.ToArray();
+            _unscopedDeferredPatterns.Clear();
+            PublishPatterns(patternsToPublish);
+        }
+    }
+
+    private bool TryDeferUnscopedRegistration(IReadOnlyList<string> patterns)
+    {
+        lock (_emissionStateLock)
+        {
+            if (_activeEmissionCount == 0)
+            {
+                return false;
+            }
+
+            _unscopedDeferredPatterns.Add(patterns);
+            return true;
         }
     }
 

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -173,13 +173,9 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         ArgumentNullException.ThrowIfNull(processOutput);
 
         var existingScope = FindDeferredRegistrationScope();
-        if (existingScope is not null)
+        if (existingScope is not null && _secretEmissionLock.IsReadLockHeld)
         {
-            if (_secretEmissionLock.IsReadLockHeld)
-            {
-                PublishDeferredPatterns(existingScope);
-            }
-
+            PublishDeferredPatterns(existingScope);
             processOutput(state);
             return;
         }
@@ -197,7 +193,18 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             var deferredPatterns = scope.CloseAndTakePatterns();
             CurrentDeferredRegistrationScope.Value = previousScope;
             _secretEmissionLock.ExitReadLock();
-            PublishPatterns(deferredPatterns);
+            PublishOrDeferPatterns(deferredPatterns);
+        }
+    }
+
+    private void PublishOrDeferPatterns(IEnumerable<IReadOnlyList<string>> deferredPatterns)
+    {
+        foreach (var patterns in deferredPatterns)
+        {
+            if (!TryDeferRegistration(patterns))
+            {
+                PublishPatterns(patterns);
+            }
         }
     }
 

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -177,20 +177,15 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         ArgumentNullException.ThrowIfNull(processOutput);
 
         var existingScope = FindDeferredRegistrationScope();
-        if (existingScope is not null && _secretEmissionLock.IsReadLockHeld)
-        {
-            PublishDeferredPatterns(existingScope);
-            processOutput(state);
-            return;
-        }
-
         var ownsReadLock = existingScope is null;
         EnterStableEmission(ownsReadLock, GetUnscopedRegistrationBatch());
         var previousScope = CurrentDeferredRegistrationScope.Value;
         var scope = new DeferredRegistrationScope(
             this,
             previousScope,
-            existingScope?.Snapshot ?? GetMaskingSnapshot());
+            existingScope is null
+                ? GetMaskingSnapshot()
+                : GetNestedMaskingSnapshot(existingScope));
         CurrentDeferredRegistrationScope.Value = scope;
         try
         {
@@ -202,6 +197,27 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             CurrentDeferredRegistrationScope.Value = previousScope;
             ExitStableEmission(ownsReadLock, deferredPatterns);
         }
+    }
+
+    private SecretSnapshot GetNestedMaskingSnapshot(DeferredRegistrationScope existingScope)
+    {
+        var existingSnapshot = existingScope.Snapshot;
+        var secrets = existingSnapshot.Secrets.ToHashSet(StringComparer.Ordinal);
+        var existingCount = secrets.Count;
+        secrets.UnionWith(GetMaskingSnapshot().Secrets);
+        for (var scope = existingScope; scope is not null; scope = scope.Parent)
+        {
+            if (ReferenceEquals(scope.Provider, this))
+            {
+                scope.AddPatternsTo(secrets);
+            }
+        }
+
+        return secrets.Count == existingCount
+            ? existingSnapshot
+            : new SecretSnapshot(
+                Interlocked.Decrement(ref _nextDeferredSnapshotVersion),
+                secrets.ToArray());
     }
 
     private void EnterStableEmission(
@@ -352,33 +368,6 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
 
             Interlocked.Increment(ref _version);
         }
-    }
-
-    private void PublishDeferredPatterns(DeferredRegistrationScope scope)
-    {
-        if (!scope.HasPatterns)
-        {
-            return;
-        }
-
-        scope.ExecuteAfterDescendantsComplete(() =>
-        {
-            _secretEmissionLock.ExitReadLock();
-            try
-            {
-                PublishDeferredPatternsWithoutReadLock(scope);
-            }
-            finally
-            {
-                _secretEmissionLock.EnterReadLock();
-            }
-        });
-    }
-
-    private void PublishDeferredPatternsWithoutReadLock(DeferredRegistrationScope scope)
-    {
-        PublishPatterns(scope.TakePatterns());
-        scope.RefreshSnapshot(GetPublishedSnapshot());
     }
 
     private void PublishPatterns(IEnumerable<IReadOnlyList<string>> deferredPatterns)
@@ -786,10 +775,8 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     {
         private readonly object _syncRoot = new();
         private readonly List<IReadOnlyList<string>> _patterns = [];
-        private readonly DeferredRegistrationScope[] _trackedAncestors;
-        private int _activeDescendantCount;
+        private readonly SecretSnapshot _snapshot;
         private bool _isOpen = true;
-        private SecretSnapshot _snapshot;
 
         public SecretProvider Provider { get; }
 
@@ -814,11 +801,6 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             Provider = provider;
             Parent = parent;
             _snapshot = snapshot;
-            _trackedAncestors = GetTrackedAncestors(provider, parent);
-            foreach (var ancestor in _trackedAncestors)
-            {
-                ancestor.RegisterDescendant();
-            }
         }
 
         public bool IsOpen
@@ -828,17 +810,6 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
                 lock (_syncRoot)
                 {
                     return _isOpen;
-                }
-            }
-        }
-
-        public bool HasPatterns
-        {
-            get
-            {
-                lock (_syncRoot)
-                {
-                    return _patterns.Count > 0;
                 }
             }
         }
@@ -857,14 +828,6 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             }
         }
 
-        public IReadOnlyList<IReadOnlyList<string>> TakePatterns()
-        {
-            lock (_syncRoot)
-            {
-                return TakePatternsUnderLock();
-            }
-        }
-
         public IReadOnlyList<IReadOnlyList<string>> CloseAndTakePatterns()
         {
             IReadOnlyList<IReadOnlyList<string>> patterns;
@@ -874,32 +837,20 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
                 patterns = TakePatternsUnderLock();
             }
 
-            foreach (var ancestor in _trackedAncestors)
-            {
-                ancestor.UnregisterDescendant();
-            }
-
             return patterns;
         }
 
-        public void RefreshSnapshot(SecretSnapshot snapshot)
+        public void AddPatternsTo(ISet<string> secrets)
         {
             lock (_syncRoot)
             {
-                _snapshot = snapshot;
-            }
-        }
-
-        public void ExecuteAfterDescendantsComplete(Action action)
-        {
-            lock (_syncRoot)
-            {
-                while (_activeDescendantCount != 0)
+                foreach (var patterns in _patterns)
                 {
-                    Monitor.Wait(_syncRoot);
+                    foreach (var pattern in patterns)
+                    {
+                        secrets.Add(pattern);
+                    }
                 }
-
-                action();
             }
         }
 
@@ -908,42 +859,6 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             var patterns = _patterns.ToArray();
             _patterns.Clear();
             return patterns;
-        }
-
-        private void RegisterDescendant()
-        {
-            lock (_syncRoot)
-            {
-                _activeDescendantCount++;
-            }
-        }
-
-        private void UnregisterDescendant()
-        {
-            lock (_syncRoot)
-            {
-                _activeDescendantCount--;
-                if (_activeDescendantCount == 0)
-                {
-                    Monitor.PulseAll(_syncRoot);
-                }
-            }
-        }
-
-        private static DeferredRegistrationScope[] GetTrackedAncestors(
-            SecretProvider provider,
-            DeferredRegistrationScope? parent)
-        {
-            var ancestors = new List<DeferredRegistrationScope>();
-            for (var ancestor = parent; ancestor is not null; ancestor = ancestor.Parent)
-            {
-                if (ReferenceEquals(ancestor.Provider, provider))
-                {
-                    ancestors.Add(ancestor);
-                }
-            }
-
-            return ancestors.ToArray();
         }
     }
 }

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -35,6 +35,7 @@ namespace ModularPipelines.Engine;
 internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRegistry, IInitializer
 {
     private static readonly AsyncLocal<DeferredRegistrationScope?> CurrentDeferredRegistrationScope = new();
+    private static readonly AsyncLocal<UnscopedRegistrationContext?> CurrentUnscopedRegistrationContext = new();
 
     private static readonly ConditionalWeakTable<Assembly, SecretAttributeReference> SecretAttributeReferenceCache = [];
     private static readonly ConditionalWeakTable<Type, ReflectionAccessors> ReflectionAccessorsCache = [];
@@ -51,14 +52,20 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     private readonly object _secretsLock = new();
     private readonly object _emissionStateLock = new();
     private readonly ReaderWriterLockSlim _secretEmissionLock = new();
-    private readonly List<IReadOnlyList<string>> _unscopedDeferredPatterns = [];
+    private readonly List<IReadOnlyList<string>> _deferredPatternsPendingPublication = [];
 
     private long _version;
+    private long _nextDeferredSnapshotVersion;
+    private long _deferredRegistrationBatch;
     private int _activeEmissionCount;
+    // Direct redactors and a registering worker's next emission must see deferred
+    // patterns immediately. Existing emissions keep the snapshot captured by their scope.
+    private SecretSnapshot? _deferredMaskingSnapshot;
     private volatile bool _initialized;
 
     /// <inheritdoc />
-    public long Version => Volatile.Read(ref _version);
+    public long Version => FindDeferredRegistrationScope()?.Snapshot.Version
+                           ?? GetMaskingSnapshotVersion();
 
     /// <summary>
     /// Gets all registered secrets.
@@ -68,7 +75,7 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     /// Secrets added during enumeration will not be included in the current iteration.
     /// Each enumeration creates a new snapshot.
     /// </remarks>
-    public IEnumerable<string> Secrets => GetSnapshot().Secrets;
+    public IEnumerable<string> Secrets => GetPublishedSnapshot().Secrets;
 
     public SecretProvider(
         IOptionsProvider optionsProvider,
@@ -128,23 +135,7 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         _secretEmissionLock.EnterWriteLock();
         try
         {
-            lock (_secretsLock)
-            {
-                if (patterns.All(_secrets.Contains))
-                {
-                    return;
-                }
-
-                // Odd versions mark an in-progress publication so readers cannot reuse
-                // a cache while the matching secret collection is being updated.
-                Interlocked.Increment(ref _version);
-                foreach (var pattern in patterns)
-                {
-                    _secrets.Add(pattern);
-                }
-
-                Interlocked.Increment(ref _version);
-            }
+            PublishPatternsWithoutEmissionLock(patterns);
         }
         finally
         {
@@ -170,9 +161,14 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     /// <inheritdoc />
     public SecretSnapshot GetSnapshot()
     {
+        return FindDeferredRegistrationScope()?.Snapshot ?? GetMaskingSnapshot();
+    }
+
+    private SecretSnapshot GetPublishedSnapshot()
+    {
         lock (_secretsLock)
         {
-            return new SecretSnapshot(Version, _secrets.ToArray());
+            return new SecretSnapshot(Volatile.Read(ref _version), _secrets.ToArray());
         }
     }
 
@@ -189,9 +185,12 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         }
 
         var ownsReadLock = existingScope is null;
-        EnterStableEmission(ownsReadLock);
+        EnterStableEmission(ownsReadLock, GetUnscopedRegistrationBatch());
         var previousScope = CurrentDeferredRegistrationScope.Value;
-        var scope = new DeferredRegistrationScope(this, previousScope);
+        var scope = new DeferredRegistrationScope(
+            this,
+            previousScope,
+            existingScope?.Snapshot ?? GetMaskingSnapshot());
         CurrentDeferredRegistrationScope.Value = scope;
         try
         {
@@ -205,11 +204,15 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         }
     }
 
-    private void EnterStableEmission(bool ownsReadLock)
+    private void EnterStableEmission(
+        bool ownsReadLock,
+        long? unscopedRegistrationBatch)
     {
         lock (_emissionStateLock)
         {
-            while (ownsReadLock && _unscopedDeferredPatterns.Count != 0)
+            while (ownsReadLock
+                   && unscopedRegistrationBatch != _deferredRegistrationBatch
+                   && _deferredPatternsPendingPublication.Count != 0)
             {
                 Monitor.Wait(_emissionStateLock);
             }
@@ -237,16 +240,27 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             .ToArray();
         lock (_emissionStateLock)
         {
-            _unscopedDeferredPatterns.AddRange(unclaimedPatterns);
+            if (unclaimedPatterns.Length > 0
+                && _deferredPatternsPendingPublication.Count == 0)
+            {
+                _deferredRegistrationBatch++;
+            }
+
+            _deferredPatternsPendingPublication.AddRange(unclaimedPatterns);
+            if (unclaimedPatterns.Length > 0)
+            {
+                UpdateDeferredMaskingSnapshot(unclaimedPatterns);
+            }
             _activeEmissionCount--;
             if (_activeEmissionCount != 0)
             {
                 return;
             }
 
-            var patternsToPublish = _unscopedDeferredPatterns.ToArray();
-            _unscopedDeferredPatterns.Clear();
+            var patternsToPublish = _deferredPatternsPendingPublication.ToArray();
+            _deferredPatternsPendingPublication.Clear();
             PublishPatterns(patternsToPublish);
+            _deferredMaskingSnapshot = null;
             Monitor.PulseAll(_emissionStateLock);
         }
     }
@@ -260,8 +274,83 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
                 return false;
             }
 
-            _unscopedDeferredPatterns.Add(patterns);
+            if (_deferredPatternsPendingPublication.Count == 0)
+            {
+                _deferredRegistrationBatch++;
+            }
+
+            _deferredPatternsPendingPublication.Add(patterns);
+            UpdateDeferredMaskingSnapshot([patterns]);
+            CurrentUnscopedRegistrationContext.Value = new UnscopedRegistrationContext(
+                this,
+                _deferredRegistrationBatch,
+                CurrentUnscopedRegistrationContext.Value);
             return true;
+        }
+    }
+
+    private long GetMaskingSnapshotVersion()
+    {
+        lock (_emissionStateLock)
+        {
+            return _deferredMaskingSnapshot?.Version ?? Volatile.Read(ref _version);
+        }
+    }
+
+    private SecretSnapshot GetMaskingSnapshot()
+    {
+        lock (_emissionStateLock)
+        {
+            return _deferredMaskingSnapshot ?? GetPublishedSnapshot();
+        }
+    }
+
+    private void UpdateDeferredMaskingSnapshot(
+        IEnumerable<IReadOnlyList<string>> deferredPatterns)
+    {
+        var currentSecrets = _deferredMaskingSnapshot?.Secrets ?? GetPublishedSnapshot().Secrets;
+        var combinedSecrets = currentSecrets
+            .Concat(deferredPatterns.SelectMany(static patterns => patterns))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        _deferredMaskingSnapshot = new SecretSnapshot(
+            Interlocked.Decrement(ref _nextDeferredSnapshotVersion),
+            combinedSecrets);
+    }
+
+    private long? GetUnscopedRegistrationBatch()
+    {
+        for (var context = CurrentUnscopedRegistrationContext.Value;
+             context is not null;
+             context = context.Parent)
+        {
+            if (ReferenceEquals(context.Provider, this))
+            {
+                return context.Batch;
+            }
+        }
+
+        return null;
+    }
+
+    private void PublishPatternsWithoutEmissionLock(IReadOnlyList<string> patterns)
+    {
+        lock (_secretsLock)
+        {
+            if (patterns.All(_secrets.Contains))
+            {
+                return;
+            }
+
+            // Odd versions mark an in-progress publication so readers cannot reuse
+            // a cache while the matching secret collection is being updated.
+            Interlocked.Increment(ref _version);
+            foreach (var pattern in patterns)
+            {
+                _secrets.Add(pattern);
+            }
+
+            Interlocked.Increment(ref _version);
         }
     }
 
@@ -289,6 +378,7 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     private void PublishDeferredPatternsWithoutReadLock(DeferredRegistrationScope scope)
     {
         PublishPatterns(scope.TakePatterns());
+        scope.RefreshSnapshot(GetPublishedSnapshot());
     }
 
     private void PublishPatterns(IEnumerable<IReadOnlyList<string>> deferredPatterns)
@@ -687,6 +777,11 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
 
     private sealed record ReflectionAccessors(IReadOnlyList<SecretPropertyAccessor> Value);
 
+    private sealed record UnscopedRegistrationContext(
+        SecretProvider Provider,
+        long Batch,
+        UnscopedRegistrationContext? Parent);
+
     private sealed class DeferredRegistrationScope
     {
         private readonly object _syncRoot = new();
@@ -694,17 +789,31 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         private readonly DeferredRegistrationScope[] _trackedAncestors;
         private int _activeDescendantCount;
         private bool _isOpen = true;
+        private SecretSnapshot _snapshot;
 
         public SecretProvider Provider { get; }
 
         public DeferredRegistrationScope? Parent { get; }
 
+        public SecretSnapshot Snapshot
+        {
+            get
+            {
+                lock (_syncRoot)
+                {
+                    return _snapshot;
+                }
+            }
+        }
+
         public DeferredRegistrationScope(
             SecretProvider provider,
-            DeferredRegistrationScope? parent)
+            DeferredRegistrationScope? parent,
+            SecretSnapshot snapshot)
         {
             Provider = provider;
             Parent = parent;
+            _snapshot = snapshot;
             _trackedAncestors = GetTrackedAncestors(provider, parent);
             foreach (var ancestor in _trackedAncestors)
             {
@@ -771,6 +880,14 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             }
 
             return patterns;
+        }
+
+        public void RefreshSnapshot(SecretSnapshot snapshot)
+        {
+            lock (_syncRoot)
+            {
+                _snapshot = snapshot;
+            }
         }
 
         public void ExecuteAfterDescendantsComplete(Action action)

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -34,6 +34,9 @@ namespace ModularPipelines.Engine;
 /// <threadsafety static="true" instance="true"/>
 internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRegistry, IInitializer
 {
+    [ThreadStatic]
+    private static DeferredRegistrationScope? _deferredRegistrationScope;
+
     private static readonly ConditionalWeakTable<Assembly, SecretAttributeReference> SecretAttributeReferenceCache = [];
     private static readonly ConditionalWeakTable<Type, ReflectionAccessors> ReflectionAccessorsCache = [];
 
@@ -105,6 +108,16 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             return;
         }
 
+        if (TryDeferRegistration(patterns))
+        {
+            return;
+        }
+
+        PublishPatterns(patterns);
+    }
+
+    private void PublishPatterns(IReadOnlyList<string> patterns)
+    {
         _secretEmissionLock.EnterWriteLock();
         try
         {
@@ -161,14 +174,36 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         ArgumentNullException.ThrowIfNull(processOutput);
 
         _secretEmissionLock.EnterReadLock();
+        var previousScope = _deferredRegistrationScope;
+        var scope = new DeferredRegistrationScope(this, previousScope);
+        _deferredRegistrationScope = scope;
         try
         {
             processOutput(state);
         }
         finally
         {
+            _deferredRegistrationScope = previousScope;
             _secretEmissionLock.ExitReadLock();
+            foreach (var patterns in scope.Patterns)
+            {
+                PublishPatterns(patterns);
+            }
         }
+    }
+
+    private bool TryDeferRegistration(IReadOnlyList<string> patterns)
+    {
+        for (var scope = _deferredRegistrationScope; scope is not null; scope = scope.Parent)
+        {
+            if (ReferenceEquals(scope.Provider, this))
+            {
+                scope.Patterns.Add(patterns);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     [UnconditionalSuppressMessage(
@@ -532,4 +567,11 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     private sealed record SecretAttributeReference(bool Value);
 
     private sealed record ReflectionAccessors(IReadOnlyList<SecretPropertyAccessor> Value);
+
+    private sealed record DeferredRegistrationScope(
+        SecretProvider Provider,
+        DeferredRegistrationScope? Parent)
+    {
+        public List<IReadOnlyList<string>> Patterns { get; } = [];
+    }
 }

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -173,6 +173,12 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
     {
         ArgumentNullException.ThrowIfNull(processOutput);
 
+        if (FindDeferredRegistrationScope() is not null)
+        {
+            processOutput(state);
+            return;
+        }
+
         _secretEmissionLock.EnterReadLock();
         var previousScope = _deferredRegistrationScope;
         var scope = new DeferredRegistrationScope(this, previousScope);
@@ -194,16 +200,27 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
 
     private bool TryDeferRegistration(IReadOnlyList<string> patterns)
     {
+        var scope = FindDeferredRegistrationScope();
+        if (scope is null)
+        {
+            return false;
+        }
+
+        scope.Patterns.Add(patterns);
+        return true;
+    }
+
+    private DeferredRegistrationScope? FindDeferredRegistrationScope()
+    {
         for (var scope = _deferredRegistrationScope; scope is not null; scope = scope.Parent)
         {
             if (ReferenceEquals(scope.Provider, this))
             {
-                scope.Patterns.Add(patterns);
-                return true;
+                return scope;
             }
         }
 
-        return false;
+        return null;
     }
 
     [UnconditionalSuppressMessage(

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -156,14 +156,14 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         }
     }
 
-    public void ExecuteWithStableSecrets(Action processOutput)
+    public void ExecuteWithStableSecrets<TState>(TState state, Action<TState> processOutput)
     {
         ArgumentNullException.ThrowIfNull(processOutput);
 
         _secretEmissionLock.EnterReadLock();
         try
         {
-            processOutput();
+            processOutput(state);
         }
         finally
         {

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -193,31 +193,35 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
         }
         finally
         {
-            var deferredPatterns = scope.CloseAndTakePatterns();
             CurrentDeferredRegistrationScope.Value = previousScope;
-            ExitStableEmission(ownsReadLock, deferredPatterns);
+            ExitStableEmission(ownsReadLock, scope);
         }
     }
 
     private SecretSnapshot GetNestedMaskingSnapshot(DeferredRegistrationScope existingScope)
     {
-        var existingSnapshot = existingScope.Snapshot;
-        var secrets = existingSnapshot.Secrets.ToHashSet(StringComparer.Ordinal);
-        var existingCount = secrets.Count;
-        secrets.UnionWith(GetMaskingSnapshot().Secrets);
-        for (var scope = existingScope; scope is not null; scope = scope.Parent)
+        // Scope draining moves patterns into the deferred snapshot under this lock.
+        // Hold it across both reads so every pattern is observed in one source.
+        lock (_emissionStateLock)
         {
-            if (ReferenceEquals(scope.Provider, this))
+            var existingSnapshot = existingScope.Snapshot;
+            var secrets = existingSnapshot.Secrets.ToHashSet(StringComparer.Ordinal);
+            var existingCount = secrets.Count;
+            secrets.UnionWith((_deferredMaskingSnapshot ?? GetPublishedSnapshot()).Secrets);
+            for (var scope = existingScope; scope is not null; scope = scope.Parent)
             {
-                scope.AddPatternsTo(secrets);
+                if (ReferenceEquals(scope.Provider, this))
+                {
+                    scope.AddPatternsTo(secrets);
+                }
             }
-        }
 
-        return secrets.Count == existingCount
-            ? existingSnapshot
-            : new SecretSnapshot(
-                Interlocked.Decrement(ref _nextDeferredSnapshotVersion),
-                secrets.ToArray());
+            return secrets.Count == existingCount
+                ? existingSnapshot
+                : new SecretSnapshot(
+                    Interlocked.Decrement(ref _nextDeferredSnapshotVersion),
+                    secrets.ToArray());
+        }
     }
 
     private void EnterStableEmission(
@@ -244,18 +248,13 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
 
     private void ExitStableEmission(
         bool ownsReadLock,
-        IReadOnlyList<IReadOnlyList<string>> deferredPatterns)
+        DeferredRegistrationScope scope)
     {
-        if (ownsReadLock)
-        {
-            _secretEmissionLock.ExitReadLock();
-        }
-
-        var unclaimedPatterns = deferredPatterns
-            .Where(patterns => !TryDeferRegistration(patterns))
-            .ToArray();
         lock (_emissionStateLock)
         {
+            var unclaimedPatterns = scope.CloseAndTakePatterns()
+                .Where(patterns => !TryDeferRegistration(patterns))
+                .ToArray();
             if (unclaimedPatterns.Length > 0
                 && _deferredPatternsPendingPublication.Count == 0)
             {
@@ -268,6 +267,11 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
                 UpdateDeferredMaskingSnapshot(unclaimedPatterns);
             }
             _activeEmissionCount--;
+            if (ownsReadLock)
+            {
+                _secretEmissionLock.ExitReadLock();
+            }
+
             if (_activeEmissionCount != 0)
             {
                 return;

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -372,12 +372,33 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
 
             _deferredPatternsPendingPublication.Add(patterns);
             UpdateDeferredMaskingSnapshot([patterns]);
-            CurrentUnscopedRegistrationContext.Value = new UnscopedRegistrationContext(
-                this,
-                _deferredRegistrationBatch,
-                CurrentUnscopedRegistrationContext.Value);
+            CurrentUnscopedRegistrationContext.Value = UpsertUnscopedRegistrationContext(
+                CurrentUnscopedRegistrationContext.Value,
+                _deferredRegistrationBatch);
             return true;
         }
+    }
+
+    private UnscopedRegistrationContext UpsertUnscopedRegistrationContext(
+        UnscopedRegistrationContext? context,
+        long batch)
+    {
+        if (context is null)
+        {
+            return new UnscopedRegistrationContext(this, batch, null);
+        }
+
+        if (ReferenceEquals(context.Provider, this))
+        {
+            return context.Batch == batch
+                ? context
+                : context with { Batch = batch };
+        }
+
+        var updatedParent = UpsertUnscopedRegistrationContext(context.Parent, batch);
+        return ReferenceEquals(updatedParent, context.Parent)
+            ? context
+            : context with { Parent = updatedParent };
     }
 
     private long GetMaskingSnapshotVersion()

--- a/src/ModularPipelines/Engine/SecretProvider.cs
+++ b/src/ModularPipelines/Engine/SecretProvider.cs
@@ -272,15 +272,18 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             return;
         }
 
-        _secretEmissionLock.ExitReadLock();
-        try
+        scope.ExecuteAfterDescendantsComplete(() =>
         {
-            PublishDeferredPatternsWithoutReadLock(scope);
-        }
-        finally
-        {
-            _secretEmissionLock.EnterReadLock();
-        }
+            _secretEmissionLock.ExitReadLock();
+            try
+            {
+                PublishDeferredPatternsWithoutReadLock(scope);
+            }
+            finally
+            {
+                _secretEmissionLock.EnterReadLock();
+            }
+        });
     }
 
     private void PublishDeferredPatternsWithoutReadLock(DeferredRegistrationScope scope)
@@ -684,13 +687,30 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
 
     private sealed record ReflectionAccessors(IReadOnlyList<SecretPropertyAccessor> Value);
 
-    private sealed record DeferredRegistrationScope(
-        SecretProvider Provider,
-        DeferredRegistrationScope? Parent)
+    private sealed class DeferredRegistrationScope
     {
         private readonly object _syncRoot = new();
         private readonly List<IReadOnlyList<string>> _patterns = [];
+        private readonly DeferredRegistrationScope[] _trackedAncestors;
+        private int _activeDescendantCount;
         private bool _isOpen = true;
+
+        public SecretProvider Provider { get; }
+
+        public DeferredRegistrationScope? Parent { get; }
+
+        public DeferredRegistrationScope(
+            SecretProvider provider,
+            DeferredRegistrationScope? parent)
+        {
+            Provider = provider;
+            Parent = parent;
+            _trackedAncestors = GetTrackedAncestors(provider, parent);
+            foreach (var ancestor in _trackedAncestors)
+            {
+                ancestor.RegisterDescendant();
+            }
+        }
 
         public bool IsOpen
         {
@@ -738,10 +758,31 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
 
         public IReadOnlyList<IReadOnlyList<string>> CloseAndTakePatterns()
         {
+            IReadOnlyList<IReadOnlyList<string>> patterns;
             lock (_syncRoot)
             {
                 _isOpen = false;
-                return TakePatternsUnderLock();
+                patterns = TakePatternsUnderLock();
+            }
+
+            foreach (var ancestor in _trackedAncestors)
+            {
+                ancestor.UnregisterDescendant();
+            }
+
+            return patterns;
+        }
+
+        public void ExecuteAfterDescendantsComplete(Action action)
+        {
+            lock (_syncRoot)
+            {
+                while (_activeDescendantCount != 0)
+                {
+                    Monitor.Wait(_syncRoot);
+                }
+
+                action();
             }
         }
 
@@ -750,6 +791,42 @@ internal class SecretProvider : ISecretProvider, ISecretEmissionGuard, ISecretRe
             var patterns = _patterns.ToArray();
             _patterns.Clear();
             return patterns;
+        }
+
+        private void RegisterDescendant()
+        {
+            lock (_syncRoot)
+            {
+                _activeDescendantCount++;
+            }
+        }
+
+        private void UnregisterDescendant()
+        {
+            lock (_syncRoot)
+            {
+                _activeDescendantCount--;
+                if (_activeDescendantCount == 0)
+                {
+                    Monitor.PulseAll(_syncRoot);
+                }
+            }
+        }
+
+        private static DeferredRegistrationScope[] GetTrackedAncestors(
+            SecretProvider provider,
+            DeferredRegistrationScope? parent)
+        {
+            var ancestors = new List<DeferredRegistrationScope>();
+            for (var ancestor = parent; ancestor is not null; ancestor = ancestor.Parent)
+            {
+                if (ReferenceEquals(ancestor.Provider, provider))
+                {
+                    ancestors.Add(ancestor);
+                }
+            }
+
+            return ancestors.ToArray();
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -241,6 +241,73 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task CustomObfuscatorCanWriteReentrantly()
+    {
+        var provider = CreateProvider(out _);
+        var obfuscator = new Mock<ISecretObfuscator>();
+        CoordinatedTextWriter? writer = null;
+        var isReentrantWrite = false;
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
+            .Returns((string input, object? _) =>
+            {
+                if (!isReentrantWrite)
+                {
+                    isReentrantWrite = true;
+                    try
+                    {
+                        writer!.WriteLine("custom diagnostic");
+                    }
+                    finally
+                    {
+                        isReentrantWrite = false;
+                    }
+                }
+
+                return input.Replace("custom-secret", "[masked]", StringComparison.Ordinal);
+            });
+        var realConsole = new StringWriter();
+
+        using (writer = new CoordinatedTextWriter(
+                   Mock.Of<IConsoleCoordinator>(),
+                   realConsole,
+                   () => false,
+                   obfuscator.Object,
+                   provider))
+        {
+            writer.WriteLine("custom-secret");
+        }
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"custom diagnostic{Environment.NewLine}[masked]{Environment.NewLine}");
+    }
+
+    [Test]
+    public async Task DirectConsoleWrite_RefreshesPatternsAfterComparisonChanges()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("ABC");
+        var maskingOptions = Microsoft.Extensions.Options.Options.Create(
+            new SecretMaskingOptions());
+        var obfuscator = new SecretObfuscator(provider, maskingOptions);
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            obfuscator,
+            provider);
+
+        writer.WriteLine("abc");
+        maskingOptions.Value.CaseInsensitive = true;
+        writer.WriteLine("abc");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"abc{Environment.NewLine}**********{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task DifferentModuleBuffers_ProcessConcurrently()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1288,6 +1288,58 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task StableSecretEmission_HoldsLeaseForInheritedWorker()
+    {
+        var provider = CreateProvider(out var nativeMasker);
+        using var workerStarted = new ManualResetEventSlim();
+        using var releaseWorker = new ManualResetEventSlim();
+        using var registrationStarted = new ManualResetEventSlim();
+        nativeMasker
+            .Setup(masker => masker.MaskSecrets(It.IsAny<IEnumerable<string>>()))
+            .Callback(() => registrationStarted.Set());
+        var worker = Task.CompletedTask;
+
+        provider.ExecuteWithStableSecrets(
+            provider,
+            outerProvider =>
+            {
+                worker = Task.Run(() => outerProvider.ExecuteWithStableSecrets(
+                    workerStarted,
+                    started =>
+                    {
+                        started.Set();
+                        if (!releaseWorker.Wait(TimeSpan.FromSeconds(10)))
+                        {
+                            throw new TimeoutException("Timed out waiting to release worker emission.");
+                        }
+                    }));
+                if (!workerStarted.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Timed out waiting for worker emission to start.");
+                }
+            });
+
+        var registration = Task.Run(() => provider.AddSecret("late-worker-secret"));
+        try
+        {
+            await Assert.That(registrationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(async () =>
+                    await registration.WaitAsync(TimeSpan.FromMilliseconds(500)))
+                .Throws<TimeoutException>();
+
+            releaseWorker.Set();
+            await Task.WhenAll(worker, registration).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            releaseWorker.Set();
+            await Task.WhenAll(worker, registration).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        await Assert.That(provider.Secrets).Contains("late-worker-secret");
+    }
+
+    [Test]
     public async Task FlushAsync_UsesUnderlyingAsynchronousFlush()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -210,6 +210,37 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task CustomObfuscatorCanRegisterDiscoveredSecret()
+    {
+        var provider = CreateProvider(out _);
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
+            .Returns((string input, object? _) =>
+            {
+                provider.AddSecret("discovered-secret");
+                return input;
+            });
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            obfuscator.Object,
+            provider);
+
+        writer.WriteLine("ordinary output");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(provider.Secrets).Contains("discovered-secret");
+            await Assert.That(realConsole.ToString())
+                .IsEqualTo($"ordinary output{Environment.NewLine}");
+        }
+    }
+
+    [Test]
     public async Task DifferentModuleBuffers_ProcessConcurrently()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1396,6 +1396,64 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task StableSecretEmission_DefersReentrantPublicationUntilInheritedWorkerCompletes()
+    {
+        const string discoveredSecret = "inherited-worker-deferred-secret";
+        var provider = CreateProvider(out _);
+        var obfuscator = CreateObfuscator(provider);
+        using var childScanned = new ManualResetEventSlim();
+        using var releaseChild = new ManualResetEventSlim();
+        using var nestedEmissionAttempted = new ManualResetEventSlim();
+        Task childEmission = Task.CompletedTask;
+        string? emittedOutput = null;
+
+        var outerEmission = Task.Run(() => provider.ExecuteWithStableSecrets(
+            provider,
+            outerProvider =>
+            {
+                childEmission = Task.Run(() => outerProvider.ExecuteWithStableSecrets(
+                    outerProvider,
+                    _ =>
+                    {
+                        var scannedOutput = obfuscator.Obfuscate(discoveredSecret, null);
+                        childScanned.Set();
+                        if (!releaseChild.Wait(TimeSpan.FromSeconds(10)))
+                        {
+                            throw new TimeoutException("Timed out waiting to release inherited worker.");
+                        }
+
+                        emittedOutput = scannedOutput;
+                    }));
+                if (!childScanned.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Timed out waiting for inherited worker scan.");
+                }
+
+                outerProvider.AddSecret(discoveredSecret);
+                nestedEmissionAttempted.Set();
+                outerProvider.ExecuteWithStableSecrets(outerProvider, static _ => { });
+            }));
+
+        try
+        {
+            await Assert.That(nestedEmissionAttempted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(outerEmission.Wait(TimeSpan.FromMilliseconds(250))).IsFalse();
+            await Assert.That(provider.Secrets).DoesNotContain(discoveredSecret);
+        }
+        finally
+        {
+            releaseChild.Set();
+            await Task.WhenAll(outerEmission, childEmission).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(emittedOutput).IsEqualTo(discoveredSecret);
+            await Assert.That(provider.Secrets).Contains(discoveredSecret);
+        }
+    }
+
+    [Test]
     public async Task StableSecretEmission_HoldsLeaseForInheritedWorker()
     {
         var provider = CreateProvider(out var nativeMasker);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -308,6 +308,34 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_RetriesWhenComparisonChangesDuringScan()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("ABC");
+        var comparisonReads = 0;
+        var obfuscator = new Mock<ITrackedSecretObfuscator>();
+        obfuscator.SetupGet(candidate => candidate.PatternComparison)
+            .Returns(() => Interlocked.Increment(ref comparisonReads) <= 2
+                ? StringComparison.Ordinal
+                : StringComparison.OrdinalIgnoreCase);
+        obfuscator.Setup(candidate => candidate.ObfuscateWithConsumption("abc", null))
+            .Returns(new SecretObfuscationResult("**********", 3));
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            obfuscator.Object,
+            provider);
+
+        writer.WriteLine("abc");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"**********{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task DifferentModuleBuffers_ProcessConcurrently()
     {
         var provider = CreateProvider(out _);
@@ -348,7 +376,7 @@ public class SecretMaskingPatternTests
         finally
         {
             releaseFirstWrite.Set();
-            await firstWrite;
+            await firstWrite.WaitAsync(TimeSpan.FromSeconds(5));
         }
 
         secondBuffer.Verify(x => x.WriteLine("ordinary output"), Times.Once);
@@ -1306,6 +1334,26 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task FlushAsync_AllowsReentrantSinkWriteAfterAwait()
+    {
+        var provider = CreateProvider(out _);
+        var realConsole = new AsyncWritingOnFlushStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        await writer.FlushAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"flush diagnostic{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);
@@ -1498,6 +1546,23 @@ public class SecretMaskingPatternTests
             }
 
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class AsyncWritingOnFlushStringWriter : StringWriter
+    {
+        private bool _hasWrittenDiagnostic;
+
+        public TextWriter? Writer { get; set; }
+
+        public override async Task FlushAsync()
+        {
+            await Task.Yield();
+            if (!_hasWrittenDiagnostic)
+            {
+                _hasWrittenDiagnostic = true;
+                Writer!.WriteLine("flush diagnostic");
+            }
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -336,6 +336,34 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_RestartsFromOriginalWhenComparisonBecomesOrdinal()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("ABC");
+        var comparisonReads = 0;
+        var obfuscator = new Mock<ITrackedSecretObfuscator>();
+        obfuscator.SetupGet(candidate => candidate.PatternComparison)
+            .Returns(() => Interlocked.Increment(ref comparisonReads) <= 2
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal);
+        obfuscator.Setup(candidate => candidate.ObfuscateWithConsumption("abc", null))
+            .Returns(new SecretObfuscationResult("**********", 3));
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            obfuscator.Object,
+            provider);
+
+        writer.WriteLine("abc");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"abc{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task DifferentModuleBuffers_ProcessConcurrently()
     {
         var provider = CreateProvider(out _);
@@ -1793,6 +1821,26 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task FlushAsync_ReentrantFlushDrainsPartialPrefix()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("secret");
+        var realConsole = new PartialWriteAndAsyncFlushStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        await writer.FlushAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("sec");
+    }
+
+    [Test]
     public async Task FlushAsync_ExcludesUnrelatedWritesUntilUnderlyingFlushCompletes()
     {
         var provider = CreateProvider(out _);
@@ -2009,6 +2057,25 @@ public class SecretMaskingPatternTests
         }
     }
 
+    private sealed class PartialWriteAndFlushStringWriter : StringWriter
+    {
+        private bool _hasFlushed;
+
+        public TextWriter? Writer { get; set; }
+
+        public override void WriteLine(string? value)
+        {
+            if (!_hasFlushed)
+            {
+                _hasFlushed = true;
+                Writer!.Write("sec");
+                Writer.Flush();
+            }
+
+            base.WriteLine(value);
+        }
+    }
+
     private sealed class SecretRegisteringReentrantWriter(
         ISecretRegistry secretRegistry,
         string secret) : StringWriter
@@ -2081,6 +2148,23 @@ public class SecretMaskingPatternTests
         }
     }
 
+    private sealed class PartialWriteAndAsyncFlushStringWriter : StringWriter
+    {
+        private bool _hasFlushed;
+
+        public TextWriter? Writer { get; set; }
+
+        public override async Task FlushAsync()
+        {
+            if (!_hasFlushed)
+            {
+                _hasFlushed = true;
+                Writer!.Write("sec");
+                await Writer.FlushAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
     private sealed class AsyncFlushTrackingWriter : StringWriter
     {
         public int AsyncFlushCount { get; private set; }
@@ -2097,6 +2181,27 @@ public class SecretMaskingPatternTests
             AsyncFlushCount++;
             return Task.CompletedTask;
         }
+    }
+
+    [Test]
+    public async Task DirectConsoleWrite_ReentrantFlushDrainsPartialPrefix()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("secret");
+        var realConsole = new PartialWriteAndFlushStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        writer.WriteLine("ordinary output");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"secordinary output{Environment.NewLine}");
     }
 
     private sealed class BlockingAsyncFlushStringWriter : StringWriter

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1724,6 +1724,50 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task StableSecretEmission_ReusesUnscopedRegistrationContext()
+    {
+        var provider = CreateProvider(out _);
+        using var emissionStarted = new ManualResetEventSlim();
+        using var releaseEmission = new ManualResetEventSlim();
+
+        var emission = Task.Run(() => provider.ExecuteWithStableSecrets(
+            emissionStarted,
+            started =>
+            {
+                started.Set();
+                if (!releaseEmission.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("Timed out waiting to release the emission.");
+                }
+            }));
+
+        try
+        {
+            await Assert.That(emissionStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            Task<int> registration;
+            using (ExecutionContext.SuppressFlow())
+            {
+                registration = Task.Run(() =>
+                {
+                    for (var index = 0; index < 100; index++)
+                    {
+                        provider.AddSecret($"unscoped-secret-{index}");
+                    }
+
+                    return GetUnscopedRegistrationContextDepth();
+                });
+            }
+
+            await Assert.That(await registration.WaitAsync(TimeSpan.FromSeconds(5))).IsEqualTo(1);
+        }
+        finally
+        {
+            releaseEmission.Set();
+            await emission.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    [Test]
     public async Task StableSecretEmission_RefreshesNestedSnapshotAfterUnflowedRegistration()
     {
         const string discoveredSecret = "unflowed-before-nested-emission-secret";
@@ -2192,6 +2236,28 @@ public class SecretMaskingPatternTests
 
         await Assert.That(realConsole.ToString()).IsEqualTo($"**********{Environment.NewLine}");
         outputBuffer.Verify(x => x.WriteLine(It.IsAny<string>()), Times.Never);
+    }
+
+    private static int GetUnscopedRegistrationContextDepth()
+    {
+        var contextHolder = typeof(SecretProvider)
+            .GetField(
+                "CurrentUnscopedRegistrationContext",
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(null)!;
+        var currentContext = contextHolder.GetType()
+            .GetProperty("Value")!
+            .GetValue(contextHolder);
+        var depth = 0;
+        while (currentContext is not null)
+        {
+            depth++;
+            currentContext = currentContext.GetType()
+                .GetProperty("Parent")!
+                .GetValue(currentContext);
+        }
+
+        return depth;
     }
 
     private static SecretProvider CreateProvider(

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1120,6 +1120,30 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_AllowsSinkToRegisterSecret()
+    {
+        const string discoveredSecret = "sink-discovered-secret";
+        var provider = CreateProvider(out _);
+        var realConsole = new SecretRegisteringStringWriter(provider, discoveredSecret);
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.WriteLine("ordinary output");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(realConsole.ToString())
+                .IsEqualTo($"ordinary output{Environment.NewLine}");
+            await Assert.That(provider.Secrets).Contains(discoveredSecret);
+        }
+    }
+
+    [Test]
     public async Task FlushAsync_UsesUnderlyingAsynchronousFlush()
     {
         var provider = CreateProvider(out _);
@@ -1224,6 +1248,17 @@ public class SecretMaskingPatternTests
                 throw new TimeoutException("Timed out waiting to release the console write.");
             }
 
+            base.WriteLine(value);
+        }
+    }
+
+    private sealed class SecretRegisteringStringWriter(
+        ISecretRegistry secretRegistry,
+        string secret) : StringWriter
+    {
+        public override void WriteLine(string? value)
+        {
+            secretRegistry.AddSecret(secret);
             base.WriteLine(value);
         }
     }

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1184,6 +1184,27 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_MasksSecretRegisteredBeforeReentrantSinkWrite()
+    {
+        const string discoveredSecret = "nested-sink-discovered-secret";
+        var provider = CreateProvider(out _);
+        var realConsole = new SecretRegisteringReentrantWriter(provider, discoveredSecret);
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        writer.WriteLine("ordinary output");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"**********{Environment.NewLine}ordinary output{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task DirectConsoleWrite_AllowsReentrantSinkFlush()
     {
         var provider = CreateProvider(out _);
@@ -1242,6 +1263,46 @@ public class SecretMaskingPatternTests
             await Assert.That(realConsole.AsyncFlushCount).IsEqualTo(1);
             await Assert.That(realConsole.SynchronousFlushCount).IsEqualTo(0);
         }
+    }
+
+    [Test]
+    public async Task Flush_AllowsReentrantSinkWrite()
+    {
+        var provider = CreateProvider(out _);
+        var realConsole = new WritingOnFlushStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        writer.Flush();
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"flush diagnostic{Environment.NewLine}");
+    }
+
+    [Test]
+    public async Task FlushAsync_AllowsSynchronousReentrantSinkWrite()
+    {
+        var provider = CreateProvider(out _);
+        var realConsole = new WritingOnAsyncFlushStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        await writer.FlushAsync();
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"flush diagnostic{Environment.NewLine}");
     }
 
     [Test]
@@ -1382,6 +1443,61 @@ public class SecretMaskingPatternTests
         public override void Flush()
         {
             FlushCount++;
+        }
+    }
+
+    private sealed class SecretRegisteringReentrantWriter(
+        ISecretRegistry secretRegistry,
+        string secret) : StringWriter
+    {
+        private bool _hasWrittenSecret;
+
+        public TextWriter? Writer { get; set; }
+
+        public override void WriteLine(string? value)
+        {
+            if (!_hasWrittenSecret)
+            {
+                _hasWrittenSecret = true;
+                secretRegistry.AddSecret(secret);
+                Writer!.WriteLine(secret);
+            }
+
+            base.WriteLine(value);
+        }
+    }
+
+    private sealed class WritingOnFlushStringWriter : StringWriter
+    {
+        private bool _hasWrittenDiagnostic;
+
+        public TextWriter? Writer { get; set; }
+
+        public override void Flush()
+        {
+            if (!_hasWrittenDiagnostic)
+            {
+                _hasWrittenDiagnostic = true;
+                Writer!.WriteLine("flush diagnostic");
+            }
+        }
+    }
+
+    private sealed class WritingOnAsyncFlushStringWriter : StringWriter
+    {
+        private bool _hasWrittenDiagnostic;
+
+        public TextWriter? Writer { get; set; }
+
+        public override Task FlushAsync()
+        {
+            if (!_hasWrittenDiagnostic)
+            {
+                _hasWrittenDiagnostic = true;
+                Writer!.WriteLine("flush diagnostic");
+            }
+
+            return Task.CompletedTask;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1419,6 +1419,27 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_AllowsReentrantSinkWriteWithoutExecutionContextFlow()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("diagnostic");
+        var realConsole = new UnflowedReentrantWritingStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        writer.WriteLine("ordinary output");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"ordinary output{Environment.NewLine}sink **********{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task DirectConsoleWrite_Isolates_Nested_Reentrant_Sink_Writes()
     {
         var provider = CreateProvider(out _);
@@ -1903,7 +1924,7 @@ public class SecretMaskingPatternTests
         using var childStarted = new ManualResetEventSlim();
         using var releaseChild = new ManualResetEventSlim();
         using var nestedCompleted = new ManualResetEventSlim();
-        Task childEmission = Task.CompletedTask;
+        var childEmission = Task.CompletedTask;
         string? emittedOutput = null;
 
         var outerEmission = Task.Run(() => provider.ExecuteWithStableSecrets(
@@ -2011,7 +2032,7 @@ public class SecretMaskingPatternTests
         using var childScanned = new ManualResetEventSlim();
         using var releaseChild = new ManualResetEventSlim();
         using var nestedEmissionCompleted = new ManualResetEventSlim();
-        Task childEmission = Task.CompletedTask;
+        var childEmission = Task.CompletedTask;
         string? emittedOutput = null;
 
         var outerEmission = Task.Run(() => provider.ExecuteWithStableSecrets(
@@ -2635,6 +2656,30 @@ public class SecretMaskingPatternTests
                 _hasWrittenDiagnostic = true;
                 Writer!.WriteLine("flush diagnostic");
             }
+        }
+    }
+
+    private sealed class UnflowedReentrantWritingStringWriter : StringWriter
+    {
+        private bool _hasWrittenDiagnostic;
+
+        public TextWriter? Writer { get; set; }
+
+        public override void WriteLine(string? value)
+        {
+            if (!_hasWrittenDiagnostic)
+            {
+                _hasWrittenDiagnostic = true;
+                Task diagnosticWrite;
+                using (ExecutionContext.SuppressFlow())
+                {
+                    diagnosticWrite = Task.Run(() => Writer!.WriteLine("sink diagnostic"));
+                }
+
+                diagnosticWrite.WaitAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+            }
+
+            base.WriteLine(value);
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -672,6 +672,33 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_DoesNotMistakeCustomMaskSuffixForUnconsumedInput()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("bAb");
+        var obfuscator = new SecretObfuscator(
+            provider,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
+            {
+                CaseInsensitive = true,
+                MaskValue = "ab",
+            }));
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            obfuscator,
+            provider);
+
+        writer.Write("babaBABb");
+        writer.Flush();
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("abaabb");
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -2194,6 +2194,26 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task FlushAsync_AllowsReentrantSinkWriteWithoutExecutionContextFlow()
+    {
+        var provider = CreateProvider(out _);
+        var realConsole = new UnflowedAsyncWritingOnFlushStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        await writer.FlushAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"flush diagnostic{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task FlushAsync_ReentrantFlushDrainsPartialPrefix()
     {
         var provider = CreateProvider(out _);
@@ -2237,8 +2257,8 @@ public class SecretMaskingPatternTests
 
         try
         {
-            await Task.Delay(TimeSpan.FromMilliseconds(100));
-            await Assert.That(writeTask.IsCompleted).IsFalse();
+            await writeTask.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(realConsole.ToString()).IsEmpty();
         }
         finally
         {
@@ -2614,6 +2634,27 @@ public class SecretMaskingPatternTests
             {
                 _hasWrittenDiagnostic = true;
                 Writer!.WriteLine("flush diagnostic");
+            }
+        }
+    }
+
+    private sealed class UnflowedAsyncWritingOnFlushStringWriter : StringWriter
+    {
+        private bool _hasWrittenDiagnostic;
+
+        public TextWriter? Writer { get; set; }
+
+        public override Task FlushAsync()
+        {
+            if (_hasWrittenDiagnostic)
+            {
+                return Task.CompletedTask;
+            }
+
+            _hasWrittenDiagnostic = true;
+            using (ExecutionContext.SuppressFlow())
+            {
+                return Task.Run(() => Writer!.WriteLine("flush diagnostic"));
             }
         }
     }

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1272,6 +1272,22 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task StableSecretEmission_AllowsCrossThreadRegistration()
+    {
+        const string discoveredSecret = "cross-thread-sink-discovered-secret";
+        var provider = CreateProvider(out _);
+
+        var emission = Task.Run(() => provider.ExecuteWithStableSecrets(
+            provider,
+            outerProvider => Task.Run(() => outerProvider.AddSecret(discoveredSecret))
+                .GetAwaiter()
+                .GetResult()));
+
+        await emission.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(provider.Secrets).Contains(discoveredSecret);
+    }
+
+    [Test]
     public async Task FlushAsync_UsesUnderlyingAsynchronousFlush()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -166,6 +166,7 @@ public class SecretMaskingPatternTests
         var provider = new Mock<ISecretProvider>();
         provider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, ["split-secret"]));
         var obfuscator = new Mock<ITrackedSecretObfuscator>();
+        obfuscator.SetupGet(x => x.PatternComparison).Returns(StringComparison.Ordinal);
         obfuscator
             .Setup(x => x.ObfuscateWithConsumption("split-secret", null))
             .Returns(new SecretObfuscationResult("**********", "split-secret".Length));
@@ -261,6 +262,7 @@ public class SecretMaskingPatternTests
         }
 
         secondBuffer.Verify(x => x.WriteLine("ordinary output"), Times.Once);
+        firstBuffer.Verify(x => x.WriteLine("**********"), Times.Once);
 
         void WriteForModule(Type moduleType, string value)
         {
@@ -763,6 +765,26 @@ public class SecretMaskingPatternTests
         writer.Flush();
 
         await Assert.That(realConsole.ToString()).IsEqualTo("ABC********************");
+    }
+
+    [Test]
+    public async Task DirectConsoleWrite_MasksCompleteMatchBeforeFalseCaseRetainedPrefix()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("AAAA");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("AAAAAa");
+        writer.Flush();
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("**********Aa");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -651,6 +651,27 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_RescansPartiallyObfuscatedCandidates()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("ABCDEF");
+        provider.AddSecret("abc");
+        provider.AddSecret("defx");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("abcdefx");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("********************");
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1144,6 +1144,21 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task StableSecretEmission_AllowsReentrantRegistration()
+    {
+        const string discoveredSecret = "nested-sink-discovered-secret";
+        var provider = CreateProvider(out _);
+
+        provider.ExecuteWithStableSecrets(
+            provider,
+            outerProvider => outerProvider.ExecuteWithStableSecrets(
+                outerProvider,
+                innerProvider => innerProvider.AddSecret(discoveredSecret)));
+
+        await Assert.That(provider.Secrets).Contains(discoveredSecret);
+    }
+
+    [Test]
     public async Task FlushAsync_UsesUnderlyingAsynchronousFlush()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -283,6 +283,57 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task CustomObfuscatorCanFlushReentrantly(bool useAsyncFlush)
+    {
+        var provider = CreateProvider(out _);
+        var obfuscator = new Mock<ISecretObfuscator>();
+        CoordinatedTextWriter? writer = null;
+        var isReentrantFlush = false;
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
+            .Returns((string input, object? _) =>
+            {
+                if (!isReentrantFlush)
+                {
+                    isReentrantFlush = true;
+                    try
+                    {
+                        if (useAsyncFlush)
+                        {
+                            writer!.FlushAsync().GetAwaiter().GetResult();
+                        }
+                        else
+                        {
+                            writer!.Flush();
+                        }
+                    }
+                    finally
+                    {
+                        isReentrantFlush = false;
+                    }
+                }
+
+                return input;
+            });
+        var realConsole = new StringWriter();
+
+        using (writer = new CoordinatedTextWriter(
+                   Mock.Of<IConsoleCoordinator>(),
+                   realConsole,
+                   () => false,
+                   obfuscator.Object,
+                   provider))
+        {
+            writer.WriteLine("ordinary output");
+        }
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"ordinary output{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task DirectConsoleWrite_RefreshesPatternsAfterComparisonChanges()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -746,6 +746,26 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_MasksSelfOverlappingMatchBeforeRetainedPrefix()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("abcabc");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("ABCabcabcabcabc");
+        writer.Flush();
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("ABC********************");
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1340,6 +1340,110 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task StableSecretEmission_ExposesUnflowedRegistrationToDirectMasking()
+    {
+        const string discoveredSecret = "unflowed-direct-masking-secret";
+        var provider = CreateProvider(out _);
+        var obfuscator = CreateObfuscator(provider);
+        string? directOutput = null;
+        string? stableOutput = null;
+
+        var emission = Task.Run(() => provider.ExecuteWithStableSecrets(
+            provider,
+            outerProvider =>
+            {
+                using var registrationCompleted = new ManualResetEventSlim();
+                Exception? registrationException = null;
+                ThreadPool.UnsafeQueueUserWorkItem(
+                    _ =>
+                    {
+                        try
+                        {
+                            outerProvider.AddSecret(discoveredSecret);
+                            directOutput = obfuscator.Obfuscate(discoveredSecret, null);
+                        }
+                        catch (Exception exception)
+                        {
+                            registrationException = exception;
+                        }
+                        finally
+                        {
+                            registrationCompleted.Set();
+                        }
+                    },
+                    null);
+                if (!registrationCompleted.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Timed out waiting for unflowed registration.");
+                }
+
+                if (registrationException is not null)
+                {
+                    throw new InvalidOperationException("Unflowed registration failed.", registrationException);
+                }
+
+                stableOutput = obfuscator.Obfuscate(discoveredSecret, null);
+            }));
+
+        await emission.WaitAsync(TimeSpan.FromSeconds(10));
+        using (Assert.Multiple())
+        {
+            await Assert.That(directOutput).IsEqualTo("**********");
+            await Assert.That(stableOutput).IsEqualTo(discoveredSecret);
+            await Assert.That(provider.Secrets).Contains(discoveredSecret);
+        }
+    }
+
+    [Test]
+    public async Task StableSecretEmission_AllowsUnflowedRegisteringWorkerToEmitNext()
+    {
+        const string discoveredSecret = "unflowed-register-then-emit-secret";
+        var provider = CreateProvider(out _);
+        var obfuscator = CreateObfuscator(provider);
+        string? emittedOutput = null;
+
+        var emission = Task.Run(() => provider.ExecuteWithStableSecrets(
+            provider,
+            outerProvider =>
+            {
+                using var workerCompleted = new ManualResetEventSlim();
+                Exception? workerException = null;
+                ThreadPool.UnsafeQueueUserWorkItem(
+                    _ =>
+                    {
+                        try
+                        {
+                            outerProvider.AddSecret(discoveredSecret);
+                            outerProvider.ExecuteWithStableSecrets(
+                                discoveredSecret,
+                                value => emittedOutput = obfuscator.Obfuscate(value, null));
+                        }
+                        catch (Exception exception)
+                        {
+                            workerException = exception;
+                        }
+                        finally
+                        {
+                            workerCompleted.Set();
+                        }
+                    },
+                    null);
+                if (!workerCompleted.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Timed out waiting for unflowed worker emission.");
+                }
+
+                if (workerException is not null)
+                {
+                    throw new InvalidOperationException("Unflowed worker emission failed.", workerException);
+                }
+            }));
+
+        await emission.WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.That(emittedOutput).IsEqualTo("**********");
+    }
+
+    [Test]
     public async Task StableSecretEmission_PublishesDeferredSecretsBeforeNextRootEmission()
     {
         const string discoveredSecret = "deferred-before-next-emission-secret";

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1035,7 +1035,7 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
-    public async Task DirectConsoleWrite_SerializesRegistrationDuringMasking()
+    public async Task DirectConsoleWrite_DefersRegistrationDuringMasking()
     {
         var provider = CreateProvider(out var nativeMasker);
         provider.AddSecret("known-secret");
@@ -1084,9 +1084,8 @@ public class SecretMaskingPatternTests
             await Assert.That(obfuscationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
             registration = Task.Run(() => provider.AddSecret("dynamic-secret"));
             await Assert.That(registrationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
-            await Assert.That(async () =>
-                    await registration.WaitAsync(TimeSpan.FromMilliseconds(500)))
-                .Throws<TimeoutException>();
+            await registration.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(provider.Secrets).DoesNotContain("dynamic-secret");
 
             releaseObfuscation.Set();
             await Task.WhenAll(write, registration).WaitAsync(TimeSpan.FromSeconds(5));
@@ -1099,13 +1098,14 @@ public class SecretMaskingPatternTests
 
         await Assert.That(realConsole.ToString())
             .IsEqualTo($"********** dynamic-secret{Environment.NewLine}");
+        await Assert.That(provider.Secrets).Contains("dynamic-secret");
         obfuscator.Verify(
             candidate => candidate.ObfuscateWithConsumption("dynamic-secret", null),
             Times.Never);
     }
 
     [Test]
-    public async Task DirectConsoleWrite_LinearizesWithSecretRegistration()
+    public async Task DirectConsoleWrite_DefersRegistrationUntilWriteCompletes()
     {
         var provider = CreateProvider(out var nativeMasker);
         using var writeStarted = new ManualResetEventSlim();
@@ -1130,9 +1130,8 @@ public class SecretMaskingPatternTests
             await Assert.That(writeStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
             registration = Task.Run(() => provider.AddSecret("dynamic-secret"));
             await Assert.That(registrationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
-            await Assert.That(async () =>
-                    await registration.WaitAsync(TimeSpan.FromMilliseconds(500)))
-                .Throws<TimeoutException>();
+            await registration.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(provider.Secrets).DoesNotContain("dynamic-secret");
 
             releaseWrite.Set();
             await Task.WhenAll(write, registration).WaitAsync(TimeSpan.FromSeconds(5));
@@ -1145,6 +1144,7 @@ public class SecretMaskingPatternTests
 
         await Assert.That(realConsole.ToString())
             .IsEqualTo($"dynamic-secret{Environment.NewLine}");
+        await Assert.That(provider.Secrets).Contains("dynamic-secret");
     }
 
     [Test]
@@ -1288,6 +1288,58 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task StableSecretEmission_AllowsUnflowedRegistrationBeforeInheritedEmission()
+    {
+        const string discoveredSecret = "unflowed-sink-discovered-secret";
+        var provider = CreateProvider(out _);
+
+        var emission = Task.Run(() => provider.ExecuteWithStableSecrets(
+            provider,
+            outerProvider =>
+            {
+                using var registrationCompleted = new ManualResetEventSlim();
+                Exception? registrationException = null;
+                ThreadPool.UnsafeQueueUserWorkItem(
+                    _ =>
+                    {
+                        try
+                        {
+                            outerProvider.AddSecret(discoveredSecret);
+                        }
+                        catch (Exception exception)
+                        {
+                            registrationException = exception;
+                        }
+                        finally
+                        {
+                            registrationCompleted.Set();
+                        }
+                    },
+                    null);
+                if (!registrationCompleted.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Timed out waiting for unflowed registration.");
+                }
+
+                if (registrationException is not null)
+                {
+                    throw new InvalidOperationException("Unflowed registration failed.", registrationException);
+                }
+
+                var inheritedEmission = Task.Run(() => outerProvider.ExecuteWithStableSecrets(
+                    outerProvider,
+                    static _ => { }));
+                if (!inheritedEmission.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Timed out waiting for inherited emission.");
+                }
+            }));
+
+        await emission.WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.That(provider.Secrets).Contains(discoveredSecret);
+    }
+
+    [Test]
     public async Task StableSecretEmission_HoldsLeaseForInheritedWorker()
     {
         var provider = CreateProvider(out var nativeMasker);
@@ -1323,9 +1375,8 @@ public class SecretMaskingPatternTests
         try
         {
             await Assert.That(registrationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
-            await Assert.That(async () =>
-                    await registration.WaitAsync(TimeSpan.FromMilliseconds(500)))
-                .Throws<TimeoutException>();
+            await registration.WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(provider.Secrets).DoesNotContain("late-worker-secret");
 
             releaseWorker.Set();
             await Task.WhenAll(worker, registration).WaitAsync(TimeSpan.FromSeconds(5));

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -2314,6 +2314,32 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task FireAndForgetSinkPartialWriteSurvivesScopeCollection()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("secret");
+        var realConsole = new PartialFireAndForgetWriteStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        writer.WriteLine("owner");
+        await realConsole.ChildCompleted.WaitAsync(TimeSpan.FromSeconds(5));
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        writer.Flush();
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"owner{Environment.NewLine}sec");
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);
@@ -2736,6 +2762,33 @@ public class SecretMaskingPatternTests
                     Writer.WriteLine("ret");
                 });
                 _prefixWritten.Task.GetAwaiter().GetResult();
+            }
+
+            base.WriteLine(value);
+        }
+    }
+
+    private sealed class PartialFireAndForgetWriteStringWriter : StringWriter
+    {
+        private readonly TaskCompletionSource _childCompleted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool _started;
+
+        public TextWriter? Writer { get; set; }
+
+        public Task ChildCompleted => _childCompleted.Task;
+
+        public override void WriteLine(string? value)
+        {
+            if (!_started)
+            {
+                _started = true;
+                _ = Task.Run(() =>
+                {
+                    Writer!.Write("sec");
+                    _childCompleted.TrySetResult();
+                });
+                _childCompleted.Task.GetAwaiter().GetResult();
             }
 
             base.WriteLine(value);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1340,6 +1340,62 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task StableSecretEmission_PublishesDeferredSecretsBeforeNextRootEmission()
+    {
+        const string discoveredSecret = "deferred-before-next-emission-secret";
+        var provider = CreateProvider(out _);
+        var obfuscator = CreateObfuscator(provider);
+        using var firstEmissionStarted = new ManualResetEventSlim();
+        using var releaseFirstEmission = new ManualResetEventSlim();
+        using var secondEmissionAttempted = new ManualResetEventSlim();
+        using var secondEmissionStarted = new ManualResetEventSlim();
+
+        var firstEmission = Task.Run(() => provider.ExecuteWithStableSecrets(
+            firstEmissionStarted,
+            started =>
+            {
+                started.Set();
+                if (!releaseFirstEmission.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("Timed out waiting to release first emission.");
+                }
+            }));
+
+        await Assert.That(firstEmissionStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+        provider.AddSecret(discoveredSecret);
+
+        string? emittedOutput = null;
+        Task secondEmission;
+        using (ExecutionContext.SuppressFlow())
+        {
+            secondEmission = Task.Run(() =>
+            {
+                secondEmissionAttempted.Set();
+                provider.ExecuteWithStableSecrets(
+                    secondEmissionStarted,
+                    started =>
+                    {
+                        started.Set();
+                        emittedOutput = obfuscator.Obfuscate(discoveredSecret, null);
+                    });
+            });
+        }
+
+        try
+        {
+            await Assert.That(secondEmissionAttempted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(secondEmissionStarted.Wait(TimeSpan.FromMilliseconds(250))).IsFalse();
+        }
+        finally
+        {
+            releaseFirstEmission.Set();
+            await Task.WhenAll(firstEmission, secondEmission).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        await Assert.That(emittedOutput).IsEqualTo("**********");
+    }
+
+    [Test]
     public async Task StableSecretEmission_HoldsLeaseForInheritedWorker()
     {
         var provider = CreateProvider(out var nativeMasker);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -610,6 +610,27 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_MasksShorterSameStartSecretBeforeRetainedPrefix()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("abc");
+        provider.AddSecret("abcdef");
+        provider.AddSecret("efxyZ");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("abcdefxy");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("**********d");
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1184,6 +1184,30 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_AllowsReentrantSinkFlush()
+    {
+        var provider = CreateProvider(out _);
+        var realConsole = new ReentrantFlushingStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        writer.WriteLine("ordinary output");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(realConsole.FlushCount).IsEqualTo(1);
+            await Assert.That(realConsole.ToString()).IsEqualTo(
+                $"ordinary output{Environment.NewLine}");
+        }
+    }
+
+    [Test]
     public async Task StableSecretEmission_AllowsReentrantRegistration()
     {
         const string discoveredSecret = "nested-sink-discovered-secret";
@@ -1333,6 +1357,31 @@ public class SecretMaskingPatternTests
             }
 
             base.WriteLine(value);
+        }
+    }
+
+    private sealed class ReentrantFlushingStringWriter : StringWriter
+    {
+        private bool _hasFlushed;
+
+        public TextWriter? Writer { get; set; }
+
+        public int FlushCount { get; private set; }
+
+        public override void WriteLine(string? value)
+        {
+            if (!_hasFlushed)
+            {
+                _hasFlushed = true;
+                Writer!.Flush();
+            }
+
+            base.WriteLine(value);
+        }
+
+        public override void Flush()
+        {
+            FlushCount++;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -161,6 +161,95 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public void CompletedOutput_OnlyObfuscatesActualSecretMatches()
+    {
+        var provider = new Mock<ISecretProvider>();
+        provider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, ["split-secret"]));
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
+            .Returns("**********");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            obfuscator.Object,
+            provider.Object);
+
+        writer.WriteLine("ordinary output");
+        writer.WriteLine("split-secret");
+
+        obfuscator.Verify(x => x.Obfuscate("split-secret", null), Times.Once);
+        obfuscator.Verify(x => x.Obfuscate("ordinary output", null), Times.Never);
+    }
+
+    [Test]
+    public async Task DifferentModuleBuffers_ProcessConcurrently()
+    {
+        var provider = new Mock<ISecretProvider>();
+        provider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, ["split-secret"]));
+        using var firstObfuscationStarted = new ManualResetEventSlim();
+        using var releaseFirstObfuscation = new ManualResetEventSlim();
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
+            .Returns((string input, object? _) =>
+            {
+                firstObfuscationStarted.Set();
+                if (!releaseFirstObfuscation.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("Timed out waiting to release the first module write.");
+                }
+
+                return "**********";
+            });
+        var firstBuffer = new Mock<IModuleOutputBuffer>();
+        var secondBuffer = new Mock<IModuleOutputBuffer>();
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetModuleBuffer(typeof(FirstModule))).Returns(firstBuffer.Object);
+        coordinator.Setup(x => x.GetModuleBuffer(typeof(SecondModule))).Returns(secondBuffer.Object);
+
+        using var writer = new CoordinatedTextWriter(
+            coordinator.Object,
+            new StringWriter(),
+            () => true,
+            obfuscator.Object,
+            provider.Object);
+
+        var firstWrite = Task.Run(() => WriteForModule(typeof(FirstModule), "split-secret"));
+        try
+        {
+            await Assert.That(firstObfuscationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+
+            var secondWrite = Task.Run(() => WriteForModule(typeof(SecondModule), "ordinary output"));
+            await secondWrite.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            releaseFirstObfuscation.Set();
+            await firstWrite;
+        }
+
+        secondBuffer.Verify(x => x.WriteLine("ordinary output"), Times.Once);
+
+        void WriteForModule(Type moduleType, string value)
+        {
+            var previousModule = ModuleLogger.CurrentModuleType.Value;
+            try
+            {
+                ModuleLogger.CurrentModuleType.Value = moduleType;
+                writer.WriteLine(value);
+            }
+            finally
+            {
+                ModuleLogger.CurrentModuleType.Value = previousModule;
+            }
+        }
+    }
+
+    [Test]
     public void BufferedConsoleWrites_RefreshPatternsAfterSecretRegistration()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1424,6 +1424,134 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task StableSecretEmission_ExposesScopedRegistrationToDirectMasking()
+    {
+        const string discoveredSecret = "scoped-direct-masking-secret";
+        var provider = CreateProvider(out _);
+        var obfuscator = CreateObfuscator(provider);
+        string? maskedOutput = null;
+
+        provider.ExecuteWithStableSecrets(
+            provider,
+            scopedProvider =>
+            {
+                scopedProvider.AddSecret(discoveredSecret);
+                maskedOutput = obfuscator.Obfuscate(discoveredSecret, null);
+            });
+
+        await Assert.That(maskedOutput).IsEqualTo("**********");
+    }
+
+    [Test]
+    public async Task StableSecretEmission_UsesEvenDeferredSnapshotVersions()
+    {
+        const string discoveredSecret = "even-deferred-version-secret";
+        var provider = CreateProvider(out _);
+        using var emissionStarted = new ManualResetEventSlim();
+        using var releaseEmission = new ManualResetEventSlim();
+
+        var emission = Task.Run(() => provider.ExecuteWithStableSecrets(
+            emissionStarted,
+            started =>
+            {
+                started.Set();
+                if (!releaseEmission.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("Timed out waiting to release the emission.");
+                }
+            }));
+
+        long deferredVersion;
+        try
+        {
+            await Assert.That(emissionStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            provider.AddSecret(discoveredSecret);
+            deferredVersion = provider.Version;
+        }
+        finally
+        {
+            releaseEmission.Set();
+            await emission.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(deferredVersion).IsLessThan(0);
+            await Assert.That(deferredVersion & 1).IsEqualTo(0);
+        }
+    }
+
+    [Test]
+    public async Task StableSecretEmission_DoesNotHoldStateLockWhileWaitingForReaderLock()
+    {
+        var provider = CreateProvider(out _);
+        var emissionLock = (ReaderWriterLockSlim) typeof(SecretProvider)
+            .GetField(
+                "_secretEmissionLock",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(provider)!;
+        using var firstEmissionStarted = new ManualResetEventSlim();
+        using var releaseFirstEmission = new ManualResetEventSlim();
+        using var writerAcquired = new ManualResetEventSlim();
+        using var releaseWriter = new ManualResetEventSlim();
+        using var contenderStarted = new ManualResetEventSlim();
+
+        var firstEmission = Task.Run(() => provider.ExecuteWithStableSecrets(
+            firstEmissionStarted,
+            started =>
+            {
+                started.Set();
+                if (!releaseFirstEmission.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("Timed out waiting to release the first emission.");
+                }
+            }));
+
+        await Assert.That(firstEmissionStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+        var queuedWriter = Task.Run(() =>
+        {
+            emissionLock.EnterWriteLock();
+            try
+            {
+                writerAcquired.Set();
+                if (!releaseWriter.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("Timed out waiting to release the queued writer.");
+                }
+            }
+            finally
+            {
+                emissionLock.ExitWriteLock();
+            }
+        });
+
+        await Assert.That(SpinWait.SpinUntil(
+            () => emissionLock.WaitingWriteCount > 0,
+            TimeSpan.FromSeconds(5))).IsTrue();
+        var contender = Task.Run(() => provider.ExecuteWithStableSecrets(
+            contenderStarted,
+            started => started.Set()));
+
+        try
+        {
+            await Assert.That(SpinWait.SpinUntil(
+                () => emissionLock.WaitingReadCount > 0,
+                TimeSpan.FromSeconds(5))).IsTrue();
+            releaseFirstEmission.Set();
+            await Assert.That(writerAcquired.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            releaseWriter.Set();
+            await Task.WhenAll(firstEmission, queuedWriter, contender)
+                .WaitAsync(TimeSpan.FromSeconds(5));
+            await Assert.That(contenderStarted.IsSet).IsTrue();
+        }
+        finally
+        {
+            releaseFirstEmission.Set();
+            releaseWriter.Set();
+        }
+    }
+
+    [Test]
     public async Task StableSecretEmission_AllowsCrossThreadRegistration()
     {
         const string discoveredSecret = "cross-thread-sink-discovered-secret";

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -334,6 +334,57 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task CustomObfuscatorFlushesOtherWriterNormally(bool useAsyncFlush)
+    {
+        var provider = CreateProvider(out _);
+        var obfuscator = new Mock<ISecretObfuscator>();
+        CoordinatedTextWriter? errorWriter = null;
+        string? errorDuringCallback = null;
+        var errorConsole = new StringWriter();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
+            .Returns((string input, object? _) =>
+            {
+                if (input == "stdout output")
+                {
+                    if (useAsyncFlush)
+                    {
+                        errorWriter!.FlushAsync().GetAwaiter().GetResult();
+                    }
+                    else
+                    {
+                        errorWriter!.Flush();
+                    }
+
+                    errorDuringCallback = errorConsole.ToString();
+                }
+
+                return input;
+            });
+
+        using (errorWriter = new CoordinatedTextWriter(
+                   Mock.Of<IConsoleCoordinator>(),
+                   errorConsole,
+                   () => false,
+                   obfuscator.Object,
+                   provider))
+        using (var outputWriter = new CoordinatedTextWriter(
+                   Mock.Of<IConsoleCoordinator>(),
+                   new StringWriter(),
+                   () => false,
+                   obfuscator.Object,
+                   provider))
+        {
+            errorWriter.Write("stderr prefix");
+            outputWriter.WriteLine("stdout output");
+        }
+
+        await Assert.That(errorDuringCallback).IsEqualTo("stderr prefix");
+    }
+
+    [Test]
     public async Task DirectConsoleWrite_RefreshesPatternsAfterComparisonChanges()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -631,6 +631,26 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_HonorsCaseSensitiveOverlappingSecrets()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("ABC");
+        provider.AddSecret("bcx");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("abcx");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("a**********");
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1444,6 +1444,108 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task StableSecretEmission_RefreshesNestedSnapshotAfterUnflowedRegistration()
+    {
+        const string discoveredSecret = "unflowed-before-nested-emission-secret";
+        var provider = CreateProvider(out _);
+        var obfuscator = CreateObfuscator(provider);
+        string? emittedOutput = null;
+
+        var emission = Task.Run(() => provider.ExecuteWithStableSecrets(
+            provider,
+            outerProvider =>
+            {
+                using var registrationCompleted = new ManualResetEventSlim();
+                Exception? registrationException = null;
+                ThreadPool.UnsafeQueueUserWorkItem(
+                    _ =>
+                    {
+                        try
+                        {
+                            outerProvider.AddSecret(discoveredSecret);
+                        }
+                        catch (Exception exception)
+                        {
+                            registrationException = exception;
+                        }
+                        finally
+                        {
+                            registrationCompleted.Set();
+                        }
+                    },
+                    null);
+                if (!registrationCompleted.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Timed out waiting for unflowed registration.");
+                }
+
+                if (registrationException is not null)
+                {
+                    throw new InvalidOperationException("Unflowed registration failed.", registrationException);
+                }
+
+                outerProvider.ExecuteWithStableSecrets(
+                    discoveredSecret,
+                    value => emittedOutput = obfuscator.Obfuscate(value, null));
+            }));
+
+        await emission.WaitAsync(TimeSpan.FromSeconds(10));
+        await Assert.That(emittedOutput).IsEqualTo("**********");
+    }
+
+    [Test]
+    public async Task StableSecretEmission_DoesNotWaitForInheritedEmissionBeforeNestedEmission()
+    {
+        const string discoveredSecret = "nested-before-inherited-completion-secret";
+        var provider = CreateProvider(out _);
+        var obfuscator = CreateObfuscator(provider);
+        using var childStarted = new ManualResetEventSlim();
+        using var releaseChild = new ManualResetEventSlim();
+        using var nestedCompleted = new ManualResetEventSlim();
+        Task childEmission = Task.CompletedTask;
+        string? emittedOutput = null;
+
+        var outerEmission = Task.Run(() => provider.ExecuteWithStableSecrets(
+            provider,
+            outerProvider =>
+            {
+                outerProvider.AddSecret(discoveredSecret);
+                childEmission = Task.Run(() => outerProvider.ExecuteWithStableSecrets(
+                    childStarted,
+                    started =>
+                    {
+                        started.Set();
+                        if (!releaseChild.Wait(TimeSpan.FromSeconds(10)))
+                        {
+                            throw new TimeoutException("Timed out waiting to release inherited emission.");
+                        }
+                    }));
+                if (!childStarted.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Timed out waiting for inherited emission.");
+                }
+
+                outerProvider.ExecuteWithStableSecrets(
+                    discoveredSecret,
+                    value => emittedOutput = obfuscator.Obfuscate(value, null));
+                nestedCompleted.Set();
+            }));
+
+        try
+        {
+            await Assert.That(childStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(nestedCompleted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+        }
+        finally
+        {
+            releaseChild.Set();
+            await Task.WhenAll(outerEmission, childEmission).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        await Assert.That(emittedOutput).IsEqualTo("**********");
+    }
+
+    [Test]
     public async Task StableSecretEmission_PublishesDeferredSecretsBeforeNextRootEmission()
     {
         const string discoveredSecret = "deferred-before-next-emission-secret";
@@ -1500,14 +1602,14 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
-    public async Task StableSecretEmission_DefersReentrantPublicationUntilInheritedWorkerCompletes()
+    public async Task StableSecretEmission_DefersPublicationWithoutWaitingForInheritedWorker()
     {
         const string discoveredSecret = "inherited-worker-deferred-secret";
         var provider = CreateProvider(out _);
         var obfuscator = CreateObfuscator(provider);
         using var childScanned = new ManualResetEventSlim();
         using var releaseChild = new ManualResetEventSlim();
-        using var nestedEmissionAttempted = new ManualResetEventSlim();
+        using var nestedEmissionCompleted = new ManualResetEventSlim();
         Task childEmission = Task.CompletedTask;
         string? emittedOutput = null;
 
@@ -1534,14 +1636,14 @@ public class SecretMaskingPatternTests
                 }
 
                 outerProvider.AddSecret(discoveredSecret);
-                nestedEmissionAttempted.Set();
                 outerProvider.ExecuteWithStableSecrets(outerProvider, static _ => { });
+                nestedEmissionCompleted.Set();
             }));
 
         try
         {
-            await Assert.That(nestedEmissionAttempted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
-            await Assert.That(outerEmission.Wait(TimeSpan.FromMilliseconds(250))).IsFalse();
+            await Assert.That(nestedEmissionCompleted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await outerEmission.WaitAsync(TimeSpan.FromSeconds(5));
             await Assert.That(provider.Secrets).DoesNotContain(discoveredSecret);
         }
         finally

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -486,6 +486,35 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_ReobfuscatesWhenComparisonChangesBeforeEmission()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("ABC");
+        var comparisonReads = 0;
+        var obfuscator = new Mock<ITrackedSecretObfuscator>();
+        obfuscator.SetupGet(candidate => candidate.PatternComparison)
+            .Returns(() => Interlocked.Increment(ref comparisonReads) <= 4
+                ? StringComparison.Ordinal
+                : StringComparison.OrdinalIgnoreCase);
+        obfuscator.Setup(candidate => candidate.Obfuscate("abc", null))
+            .Returns("**********");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            obfuscator.Object,
+            provider);
+
+        writer.WriteLine("abc");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"**********{Environment.NewLine}");
+        obfuscator.Verify(candidate => candidate.Obfuscate("abc", null), Times.Once);
+    }
+
+    [Test]
     public async Task DirectConsoleWrite_RestartsFromOriginalWhenComparisonBecomesOrdinal()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -768,6 +768,27 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_MasksCompleteSecretOverlappingAnotherSecretPrefix()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("abcdef");
+        provider.AddSecret("cdefgh");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("abcdef");
+        writer.Flush();
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("**********");
+    }
+
+    [Test]
     public async Task DirectConsoleWrite_MasksCompleteMatchBeforeFalseCaseRetainedPrefix()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -2213,6 +2213,74 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_PreservesFireAndForgetBufferIdentityAfterSinkLeaseExpires()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("secret");
+        var realConsole = new SplitFireAndForgetWriteStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        writer.WriteLine("trigger");
+        realConsole.ReleaseSuffix();
+        await realConsole.ChildTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"trigger{Environment.NewLine}**********");
+    }
+
+    [Test]
+    public async Task CustomObfuscator_FireAndForgetFlushExpiresReentrancy()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("secret");
+        var obfuscator = new Mock<ISecretObfuscator>();
+        var releaseChild = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task childTask = Task.CompletedTask;
+        CoordinatedTextWriter? writer = null;
+        var hasSpawnedChild = false;
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
+            .Returns((string input, object? _) =>
+            {
+                if (!hasSpawnedChild)
+                {
+                    hasSpawnedChild = true;
+                    childTask = Task.Run(async () =>
+                    {
+                        await releaseChild.Task.ConfigureAwait(false);
+                        await writer!.FlushAsync().ConfigureAwait(false);
+                    });
+                }
+
+                return input;
+            });
+        var realConsole = new StringWriter();
+
+        using (writer = new CoordinatedTextWriter(
+                   Mock.Of<IConsoleCoordinator>(),
+                   realConsole,
+                   () => false,
+                   obfuscator.Object,
+                   provider))
+        {
+            writer.WriteLine("trigger");
+            writer.Write("sec");
+            releaseChild.TrySetResult();
+            await childTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"trigger{Environment.NewLine}sec");
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);
@@ -2602,6 +2670,38 @@ public class SecretMaskingPatternTests
             else if (value == "child")
             {
                 _childEntered.TrySetResult();
+            }
+
+            base.WriteLine(value);
+        }
+    }
+
+    private sealed class SplitFireAndForgetWriteStringWriter : StringWriter
+    {
+        private readonly TaskCompletionSource _prefixWritten = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseSuffix = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TextWriter? Writer { get; set; }
+
+        public Task ChildTask { get; private set; } = Task.CompletedTask;
+
+        public void ReleaseSuffix() => _releaseSuffix.TrySetResult();
+
+        public override void WriteLine(string? value)
+        {
+            if (value == "trigger")
+            {
+                ChildTask = Task.Run(async () =>
+                {
+                    Writer!.Write("sec");
+                    _prefixWritten.TrySetResult();
+                    await _releaseSuffix.Task.ConfigureAwait(false);
+                    Writer.Write("ret");
+                });
+                if (!_prefixWritten.Task.Wait(TimeSpan.FromSeconds(5)))
+                {
+                    throw new TimeoutException("Timed out waiting for the split-write prefix.");
+                }
             }
 
             base.WriteLine(value);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1793,6 +1793,43 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task FlushAsync_ExcludesUnrelatedWritesUntilUnderlyingFlushCompletes()
+    {
+        var provider = CreateProvider(out _);
+        var realConsole = new BlockingAsyncFlushStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        var flushTask = writer.FlushAsync();
+        await realConsole.FlushStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Task writeTask;
+        using (ExecutionContext.SuppressFlow())
+        {
+            writeTask = Task.Run(() => writer.WriteLine("after flush"));
+        }
+
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await Assert.That(writeTask.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            realConsole.ReleaseFlush();
+            await Task.WhenAll(flushTask, writeTask).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"after flush{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);
@@ -2020,6 +2057,22 @@ public class SecretMaskingPatternTests
         {
             AsyncFlushCount++;
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class BlockingAsyncFlushStringWriter : StringWriter
+    {
+        private readonly TaskCompletionSource _flushStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseFlush = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task FlushStarted => _flushStarted.Task;
+
+        public void ReleaseFlush() => _releaseFlush.TrySetResult();
+
+        public override async Task FlushAsync()
+        {
+            _flushStarted.TrySetResult();
+            await _releaseFlush.Task.ConfigureAwait(false);
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -589,6 +589,27 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_MasksContainedSecretBeforeRetainedPrefix()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("abcXYZdef");
+        provider.AddSecret("XYZ");
+        provider.AddSecret("efGHI");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("helloabcXYZdef");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("helloabc**********d");
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -239,12 +239,12 @@ public class SecretMaskingPatternTests
             CreateObfuscator(provider),
             provider);
 
-        var firstWrite = Task.Run(() => WriteForModule(typeof(FirstModule), "split-secret"));
+        var firstWrite = Task.Run(() => WriteForModule(writer, typeof(FirstModule), "split-secret"));
         try
         {
             await Assert.That(firstWriteStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
 
-            var secondWrite = Task.Run(() => WriteForModule(typeof(SecondModule), "ordinary output"));
+            var secondWrite = Task.Run(() => WriteForModule(writer, typeof(SecondModule), "ordinary output"));
             await secondWrite.WaitAsync(TimeSpan.FromSeconds(5));
         }
         finally
@@ -255,20 +255,74 @@ public class SecretMaskingPatternTests
 
         secondBuffer.Verify(x => x.WriteLine("ordinary output"), Times.Once);
         firstBuffer.Verify(x => x.WriteLine("**********"), Times.Once);
+    }
 
-        void WriteForModule(Type moduleType, string value)
+    [Test]
+    public async Task DifferentModuleBuffers_SerializeCustomObfuscatorCalls()
+    {
+        var provider = CreateProvider(out _);
+        using var firstObfuscationStarted = new ManualResetEventSlim();
+        using var secondWriteStarted = new ManualResetEventSlim();
+        using var secondObfuscationStarted = new ManualResetEventSlim();
+        using var releaseFirstObfuscation = new ManualResetEventSlim();
+        var callCount = 0;
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
+            .Returns((string input, object? _) =>
+            {
+                if (Interlocked.Increment(ref callCount) == 1)
+                {
+                    firstObfuscationStarted.Set();
+                    if (!releaseFirstObfuscation.Wait(TimeSpan.FromSeconds(10)))
+                    {
+                        throw new TimeoutException("Timed out waiting to release the first obfuscation.");
+                    }
+                }
+                else
+                {
+                    secondObfuscationStarted.Set();
+                }
+
+                return input;
+            });
+        var firstBuffer = new Mock<IModuleOutputBuffer>();
+        var secondBuffer = new Mock<IModuleOutputBuffer>();
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetModuleBuffer(typeof(FirstModule))).Returns(firstBuffer.Object);
+        coordinator.Setup(x => x.GetModuleBuffer(typeof(SecondModule))).Returns(secondBuffer.Object);
+
+        using var writer = new CoordinatedTextWriter(
+            coordinator.Object,
+            new StringWriter(),
+            () => true,
+            obfuscator.Object,
+            provider);
+
+        var firstWrite = Task.Run(() => WriteForModule(writer, typeof(FirstModule), "first output"));
+        var secondWrite = Task.CompletedTask;
+        try
         {
-            var previousModule = ModuleLogger.CurrentModuleType.Value;
-            try
+            await Assert.That(firstObfuscationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            secondWrite = Task.Run(() =>
             {
-                ModuleLogger.CurrentModuleType.Value = moduleType;
-                writer.WriteLine(value);
-            }
-            finally
-            {
-                ModuleLogger.CurrentModuleType.Value = previousModule;
-            }
+                secondWriteStarted.Set();
+                WriteForModule(writer, typeof(SecondModule), "second output");
+            });
+            await Assert.That(secondWriteStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
+            await Assert.That(secondObfuscationStarted.IsSet).IsFalse();
         }
+        finally
+        {
+            releaseFirstObfuscation.Set();
+            await Task.WhenAll(firstWrite, secondWrite);
+        }
+
+        await Assert.That(secondObfuscationStarted.IsSet).IsTrue();
+        obfuscator.Verify(x => x.Obfuscate(It.IsAny<string>(), null), Times.Exactly(2));
+        firstBuffer.Verify(x => x.WriteLine("first output"), Times.Once);
+        secondBuffer.Verify(x => x.WriteLine("second output"), Times.Once);
     }
 
     [Test]
@@ -1029,6 +1083,20 @@ public class SecretMaskingPatternTests
         return new SecretObfuscator(
             provider,
             Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+    }
+
+    private static void WriteForModule(CoordinatedTextWriter writer, Type moduleType, string value)
+    {
+        var previousModule = ModuleLogger.CurrentModuleType.Value;
+        try
+        {
+            ModuleLogger.CurrentModuleType.Value = moduleType;
+            writer.WriteLine(value);
+        }
+        finally
+        {
+            ModuleLogger.CurrentModuleType.Value = previousModule;
+        }
     }
 
     private sealed class BlockingWriteStringWriter(

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -385,6 +385,54 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task CustomObfuscatorFireAndForgetFlushExpiresReentrancy()
+    {
+        var provider = CreateProvider(out _);
+        var outputBuffer = new Mock<IModuleOutputBuffer>();
+        var coordinator = new Mock<IConsoleCoordinator>();
+        coordinator.Setup(x => x.GetUnattributedBuffer()).Returns(outputBuffer.Object);
+        var releaseFlush = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var childFlush = Task.CompletedTask;
+        var started = 0;
+        CoordinatedTextWriter? writer = null;
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
+            .Returns((string input, object? _) =>
+            {
+                if (Interlocked.Exchange(ref started, 1) == 0)
+                {
+                    childFlush = Task.Run(async () =>
+                    {
+                        await releaseFlush.Task.ConfigureAwait(false);
+                        writer!.Flush();
+                    });
+                }
+
+                return input;
+            });
+
+        using (writer = new CoordinatedTextWriter(
+                   coordinator.Object,
+                   new StringWriter(),
+                   () => true,
+                   obfuscator.Object,
+                   provider))
+        {
+            writer.Write("pending");
+            using (CoordinatedTextWriter.BeginDirectWrite())
+            {
+                writer.WriteLine("trigger");
+            }
+
+            releaseFlush.TrySetResult();
+            await childFlush.WaitAsync(TimeSpan.FromSeconds(5));
+
+            outputBuffer.Verify(x => x.WriteLine("pending"), Times.Once);
+        }
+    }
+
+    [Test]
     public async Task DirectConsoleWrite_RefreshesPatternsAfterComparisonChanges()
     {
         var provider = CreateProvider(out _);
@@ -2213,11 +2261,11 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
-    public async Task DirectConsoleWrite_PreservesFireAndForgetBufferIdentityAfterSinkLeaseExpires()
+    public async Task FireAndForgetSinkWritePreservesBufferAcrossLeaseExpiry()
     {
         var provider = CreateProvider(out _);
         provider.AddSecret("secret");
-        var realConsole = new SplitFireAndForgetWriteStringWriter();
+        var realConsole = new SplitWriteAcrossOutputLeaseStringWriter();
 
         using var writer = new CoordinatedTextWriter(
             Mock.Of<IConsoleCoordinator>(),
@@ -2227,57 +2275,13 @@ public class SecretMaskingPatternTests
             provider);
         realConsole.Writer = writer;
 
-        writer.WriteLine("trigger");
+        writer.WriteLine("owner");
         realConsole.ReleaseSuffix();
         await realConsole.ChildTask.WaitAsync(TimeSpan.FromSeconds(5));
+        writer.Flush();
 
         await Assert.That(realConsole.ToString()).IsEqualTo(
-            $"trigger{Environment.NewLine}**********");
-    }
-
-    [Test]
-    public async Task CustomObfuscator_FireAndForgetFlushExpiresReentrancy()
-    {
-        var provider = CreateProvider(out _);
-        provider.AddSecret("secret");
-        var obfuscator = new Mock<ISecretObfuscator>();
-        var releaseChild = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        Task childTask = Task.CompletedTask;
-        CoordinatedTextWriter? writer = null;
-        var hasSpawnedChild = false;
-        obfuscator
-            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
-            .Returns((string input, object? _) =>
-            {
-                if (!hasSpawnedChild)
-                {
-                    hasSpawnedChild = true;
-                    childTask = Task.Run(async () =>
-                    {
-                        await releaseChild.Task.ConfigureAwait(false);
-                        await writer!.FlushAsync().ConfigureAwait(false);
-                    });
-                }
-
-                return input;
-            });
-        var realConsole = new StringWriter();
-
-        using (writer = new CoordinatedTextWriter(
-                   Mock.Of<IConsoleCoordinator>(),
-                   realConsole,
-                   () => false,
-                   obfuscator.Object,
-                   provider))
-        {
-            writer.WriteLine("trigger");
-            writer.Write("sec");
-            releaseChild.TrySetResult();
-            await childTask.WaitAsync(TimeSpan.FromSeconds(5));
-        }
-
-        await Assert.That(realConsole.ToString()).IsEqualTo(
-            $"trigger{Environment.NewLine}sec");
+            $"owner{Environment.NewLine}**********{Environment.NewLine}");
     }
 
     [Test]
@@ -2676,10 +2680,13 @@ public class SecretMaskingPatternTests
         }
     }
 
-    private sealed class SplitFireAndForgetWriteStringWriter : StringWriter
+    private sealed class SplitWriteAcrossOutputLeaseStringWriter : StringWriter
     {
-        private readonly TaskCompletionSource _prefixWritten = new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly TaskCompletionSource _releaseSuffix = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _prefixWritten = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseSuffix = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private bool _started;
 
         public TextWriter? Writer { get; set; }
 
@@ -2689,19 +2696,17 @@ public class SecretMaskingPatternTests
 
         public override void WriteLine(string? value)
         {
-            if (value == "trigger")
+            if (!_started)
             {
+                _started = true;
                 ChildTask = Task.Run(async () =>
                 {
                     Writer!.Write("sec");
                     _prefixWritten.TrySetResult();
                     await _releaseSuffix.Task.ConfigureAwait(false);
-                    Writer.Write("ret");
+                    Writer.WriteLine("ret");
                 });
-                if (!_prefixWritten.Task.Wait(TimeSpan.FromSeconds(5)))
-                {
-                    throw new TimeoutException("Timed out waiting for the split-write prefix.");
-                }
+                _prefixWritten.Task.GetAwaiter().GetResult();
             }
 
             base.WriteLine(value);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -165,10 +165,10 @@ public class SecretMaskingPatternTests
     {
         var provider = new Mock<ISecretProvider>();
         provider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, ["split-secret"]));
-        var obfuscator = new Mock<ISecretObfuscator>();
+        var obfuscator = new Mock<ITrackedSecretObfuscator>();
         obfuscator
-            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
-            .Returns("**********");
+            .Setup(x => x.ObfuscateWithConsumption("split-secret", null))
+            .Returns(new SecretObfuscationResult("**********", "split-secret".Length));
         var realConsole = new StringWriter();
 
         using var writer = new CoordinatedTextWriter(
@@ -181,8 +181,31 @@ public class SecretMaskingPatternTests
         writer.WriteLine("ordinary output");
         writer.WriteLine("split-secret");
 
-        obfuscator.Verify(x => x.Obfuscate("split-secret", null), Times.Once);
-        obfuscator.Verify(x => x.Obfuscate("ordinary output", null), Times.Never);
+        obfuscator.Verify(x => x.ObfuscateWithConsumption("split-secret", null), Times.Once);
+        obfuscator.Verify(x => x.ObfuscateWithConsumption("ordinary output", null), Times.Never);
+    }
+
+    [Test]
+    public async Task CustomObfuscatorProcessesOutputWithoutRegisteredPatterns()
+    {
+        var provider = CreateProvider(out _);
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
+            .Returns((string input, object? _) => input.Replace("custom-secret", "[masked]", StringComparison.Ordinal));
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            obfuscator.Object,
+            provider);
+
+        writer.WriteLine("before custom-secret after");
+
+        await Assert.That(realConsole.ToString())
+            .IsEqualTo($"before [masked] after{Environment.NewLine}");
     }
 
     [Test]
@@ -197,6 +220,11 @@ public class SecretMaskingPatternTests
             .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
             .Returns((string input, object? _) =>
             {
+                if (input != "split-secret")
+                {
+                    return input;
+                }
+
                 firstObfuscationStarted.Set();
                 if (!releaseFirstObfuscation.Wait(TimeSpan.FromSeconds(10)))
                 {
@@ -696,6 +724,25 @@ public class SecretMaskingPatternTests
         writer.Flush();
 
         await Assert.That(realConsole.ToString()).IsEqualTo("abaabb");
+    }
+
+    [Test]
+    public async Task DirectConsoleWrite_PreservesTailAfterCaseSensitiveFalseMatch()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("a");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("aA");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("**********A");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -809,6 +809,130 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_PreservesCaseDistinctPatternsAcrossWrites()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("abc");
+        provider.AddSecret("ABC");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("AB");
+        writer.Write("C");
+        writer.Flush();
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("**********");
+    }
+
+    [Test]
+    public async Task DirectConsoleWrite_RescansAfterRetainedPrefixIsInvalidated()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("token");
+        provider.AddSecret("secret");
+        provider.AddSecret("okensecretx");
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.Write("tokensecret");
+        writer.Flush();
+
+        await Assert.That(realConsole.ToString()).IsEqualTo("********************");
+    }
+
+    [Test]
+    public async Task DirectConsoleWrite_RescansWhenSecretsChangeBeforeEmission()
+    {
+        var provider = CreateProvider(out _);
+        provider.AddSecret("known-secret");
+        using var obfuscationStarted = new ManualResetEventSlim();
+        using var releaseObfuscation = new ManualResetEventSlim();
+        var obfuscator = new Mock<ITrackedSecretObfuscator>();
+        obfuscator.SetupGet(candidate => candidate.PatternComparison).Returns(StringComparison.Ordinal);
+        obfuscator
+            .Setup(candidate => candidate.ObfuscateWithConsumption(It.IsAny<string>(), null))
+            .Returns((string input, object? _) =>
+            {
+                if (input == "known-secret")
+                {
+                    obfuscationStarted.Set();
+                    if (!releaseObfuscation.Wait(TimeSpan.FromSeconds(10)))
+                    {
+                        throw new TimeoutException("Timed out waiting to release obfuscation.");
+                    }
+                }
+
+                return input is "known-secret" or "dynamic-secret"
+                    ? new SecretObfuscationResult("**********", input.Length)
+                    : new SecretObfuscationResult(input, 0);
+            });
+        obfuscator
+            .Setup(candidate => candidate.Obfuscate(It.IsAny<string>(), null))
+            .Returns((string input, object? _) =>
+                input.Replace("dynamic-secret", "**********", StringComparison.Ordinal));
+        var realConsole = new StringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            obfuscator.Object,
+            provider);
+
+        var write = Task.Run(() => writer.WriteLine("known-secret dynamic-secret"));
+        try
+        {
+            await Assert.That(obfuscationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            provider.AddSecret("dynamic-secret");
+        }
+        finally
+        {
+            releaseObfuscation.Set();
+            await write;
+        }
+
+        await Assert.That(realConsole.ToString())
+            .IsEqualTo($"********** **********{Environment.NewLine}");
+        obfuscator.Verify(
+            candidate => candidate.ObfuscateWithConsumption("dynamic-secret", null),
+            Times.Once);
+    }
+
+    [Test]
+    public async Task FlushAsync_UsesUnderlyingAsynchronousFlush()
+    {
+        var provider = CreateProvider(out _);
+        var realConsole = new AsyncFlushTrackingWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        await writer.FlushAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(realConsole.AsyncFlushCount).IsEqualTo(1);
+            await Assert.That(realConsole.SynchronousFlushCount).IsEqualTo(0);
+        }
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);
@@ -858,5 +982,23 @@ public class SecretMaskingPatternTests
         return new SecretObfuscator(
             provider,
             Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+    }
+
+    private sealed class AsyncFlushTrackingWriter : StringWriter
+    {
+        public int AsyncFlushCount { get; private set; }
+
+        public int SynchronousFlushCount { get; private set; }
+
+        public override void Flush()
+        {
+            SynchronousFlushCount++;
+        }
+
+        public override Task FlushAsync()
+        {
+            AsyncFlushCount++;
+            return Task.CompletedTask;
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1830,6 +1830,45 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task FlushAsync_ExpiresReentrancyForFireAndForgetSinkWork()
+    {
+        var provider = CreateProvider(out _);
+        var realConsole = new FireAndForgetFlushStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        await writer.FlushAsync();
+        Task ownerTask;
+        using (ExecutionContext.SuppressFlow())
+        {
+            ownerTask = Task.Run(() => writer.WriteLine("owner"));
+        }
+
+        await realConsole.OwnerEntered.WaitAsync(TimeSpan.FromSeconds(5));
+        realConsole.ReleaseChild();
+
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+            await Assert.That(realConsole.ChildEntered.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            realConsole.ReleaseOwner();
+            await Task.WhenAll(ownerTask, realConsole.ChildTask).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"owner{Environment.NewLine}child{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task PartialLine_Keeps_Its_Original_Destination_When_Buffering_Starts()
     {
         var provider = CreateProvider(out _);
@@ -2073,6 +2112,51 @@ public class SecretMaskingPatternTests
         {
             _flushStarted.TrySetResult();
             await _releaseFlush.Task.ConfigureAwait(false);
+        }
+    }
+
+    private sealed class FireAndForgetFlushStringWriter : StringWriter
+    {
+        private readonly TaskCompletionSource _ownerEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _childEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseOwner = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _releaseChild = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TextWriter? Writer { get; set; }
+
+        public Task OwnerEntered => _ownerEntered.Task;
+
+        public Task ChildEntered => _childEntered.Task;
+
+        public Task ChildTask { get; private set; } = Task.CompletedTask;
+
+        public void ReleaseOwner() => _releaseOwner.TrySetResult();
+
+        public void ReleaseChild() => _releaseChild.TrySetResult();
+
+        public override Task FlushAsync()
+        {
+            ChildTask = Task.Run(async () =>
+            {
+                await _releaseChild.Task.ConfigureAwait(false);
+                Writer!.WriteLine("child");
+            });
+            return Task.CompletedTask;
+        }
+
+        public override void WriteLine(string? value)
+        {
+            if (value == "owner")
+            {
+                _ownerEntered.TrySetResult();
+                _releaseOwner.Task.GetAwaiter().GetResult();
+            }
+            else if (value == "child")
+            {
+                _childEntered.TrySetResult();
+            }
+
+            base.WriteLine(value);
         }
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -262,8 +262,9 @@ public class SecretMaskingPatternTests
     {
         var provider = CreateProvider(out _);
         using var firstObfuscationStarted = new ManualResetEventSlim();
-        using var secondWriteStarted = new ManualResetEventSlim();
+        using var secondWriterStarted = new ManualResetEventSlim();
         using var secondObfuscationStarted = new ManualResetEventSlim();
+        using var secondBufferReached = new ManualResetEventSlim();
         using var releaseFirstObfuscation = new ManualResetEventSlim();
         var callCount = 0;
         var obfuscator = new Mock<ISecretObfuscator>();
@@ -288,6 +289,9 @@ public class SecretMaskingPatternTests
             });
         var firstBuffer = new Mock<IModuleOutputBuffer>();
         var secondBuffer = new Mock<IModuleOutputBuffer>();
+        secondBuffer
+            .Setup(x => x.WriteLine("second output"))
+            .Callback(() => secondBufferReached.Set());
         var coordinator = new Mock<IConsoleCoordinator>();
         coordinator.Setup(x => x.GetModuleBuffer(typeof(FirstModule))).Returns(firstBuffer.Object);
         coordinator.Setup(x => x.GetModuleBuffer(typeof(SecondModule))).Returns(secondBuffer.Object);
@@ -304,22 +308,28 @@ public class SecretMaskingPatternTests
         try
         {
             await Assert.That(firstObfuscationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
-            secondWrite = Task.Run(() =>
-            {
-                secondWriteStarted.Set();
-                WriteForModule(writer, typeof(SecondModule), "second output");
-            });
-            await Assert.That(secondWriteStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            secondWrite = Task.Factory.StartNew(
+                () =>
+                {
+                    secondWriterStarted.Set();
+                    WriteForModule(writer, typeof(SecondModule), "second output");
+                },
+                CancellationToken.None,
+                TaskCreationOptions.LongRunning,
+                TaskScheduler.Default);
+            await Assert.That(secondWriterStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
             await Task.Delay(TimeSpan.FromMilliseconds(200));
             await Assert.That(secondObfuscationStarted.IsSet).IsFalse();
+            await Assert.That(secondBufferReached.IsSet).IsFalse();
         }
         finally
         {
             releaseFirstObfuscation.Set();
-            await Task.WhenAll(firstWrite, secondWrite);
+            await Task.WhenAll(firstWrite, secondWrite).WaitAsync(TimeSpan.FromSeconds(5));
         }
 
         await Assert.That(secondObfuscationStarted.IsSet).IsTrue();
+        await Assert.That(secondBufferReached.IsSet).IsTrue();
         obfuscator.Verify(x => x.Obfuscate(It.IsAny<string>(), null), Times.Exactly(2));
         firstBuffer.Verify(x => x.WriteLine("first output"), Times.Once);
         secondBuffer.Verify(x => x.WriteLine("second output"), Times.Once);
@@ -718,7 +728,7 @@ public class SecretMaskingPatternTests
             Mock.Of<IConsoleCoordinator>(),
             realConsole,
             () => false,
-            CreateObfuscator(provider),
+            CreateObfuscator(provider, caseInsensitive: false),
             provider);
 
         writer.Write("abcx");
@@ -785,7 +795,7 @@ public class SecretMaskingPatternTests
             Mock.Of<IConsoleCoordinator>(),
             realConsole,
             () => false,
-            CreateObfuscator(provider),
+            CreateObfuscator(provider, caseInsensitive: false),
             provider);
 
         writer.Write("aA");
@@ -845,7 +855,7 @@ public class SecretMaskingPatternTests
             Mock.Of<IConsoleCoordinator>(),
             realConsole,
             () => false,
-            CreateObfuscator(provider),
+            CreateObfuscator(provider, caseInsensitive: false),
             provider);
 
         writer.Write("AAAAAa");
@@ -958,7 +968,7 @@ public class SecretMaskingPatternTests
         finally
         {
             releaseObfuscation.Set();
-            await Task.WhenAll(write, registration);
+            await Task.WhenAll(write, registration).WaitAsync(TimeSpan.FromSeconds(5));
         }
 
         await Assert.That(realConsole.ToString())
@@ -1004,7 +1014,7 @@ public class SecretMaskingPatternTests
         finally
         {
             releaseWrite.Set();
-            await Task.WhenAll(write, registration);
+            await Task.WhenAll(write, registration).WaitAsync(TimeSpan.FromSeconds(5));
         }
 
         await Assert.That(realConsole.ToString())
@@ -1078,11 +1088,16 @@ public class SecretMaskingPatternTests
             logger?.Object ?? Mock.Of<ILogger<SecretProvider>>());
     }
 
-    private static SecretObfuscator CreateObfuscator(ISecretProvider provider)
+    private static SecretObfuscator CreateObfuscator(
+        ISecretProvider provider,
+        bool caseInsensitive = false)
     {
         return new SecretObfuscator(
             provider,
-            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions
+            {
+                CaseInsensitive = caseInsensitive,
+            }));
     }
 
     private static void WriteForModule(CoordinatedTextWriter writer, Type moduleType, string value)

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1342,6 +1342,28 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_Isolates_Nested_Reentrant_Sink_Writes()
+    {
+        var provider = CreateProvider(out _);
+        var realConsole = new NestedReentrantWritingStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        writer.WriteLine("ordinary output");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"sink diagnostic 2{Environment.NewLine}"
+            + $"sink diagnostic 1{Environment.NewLine}"
+            + $"ordinary output{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task DirectConsoleWrite_MasksSecretRegisteredBeforeReentrantSinkWrite()
     {
         const string discoveredSecret = "nested-sink-discovered-secret";
@@ -2128,6 +2150,31 @@ public class SecretMaskingPatternTests
             {
                 _hasWrittenDiagnostic = true;
                 Writer!.WriteLine("sink diagnostic");
+            }
+
+            base.WriteLine(value);
+        }
+    }
+
+    private sealed class NestedReentrantWritingStringWriter : StringWriter
+    {
+        private int _depth;
+
+        public TextWriter? Writer { get; set; }
+
+        public override void WriteLine(string? value)
+        {
+            if (_depth < 2)
+            {
+                _depth++;
+                try
+                {
+                    Writer!.WriteLine($"sink diagnostic {_depth}");
+                }
+                finally
+                {
+                    _depth--;
+                }
             }
 
             base.WriteLine(value);

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -1144,6 +1144,46 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
+    public async Task DirectConsoleWrite_AppliesSinkSecretBeforeNextLine()
+    {
+        const string discoveredSecret = "sink-discovered-secret";
+        var provider = CreateProvider(out _);
+        var realConsole = new SecretRegisteringStringWriter(provider, discoveredSecret);
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        writer.WriteLine($"ordinary output{Environment.NewLine}{discoveredSecret}");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"ordinary output{Environment.NewLine}**********{Environment.NewLine}");
+    }
+
+    [Test]
+    public async Task DirectConsoleWrite_AllowsReentrantSinkWrite()
+    {
+        var provider = CreateProvider(out _);
+        var realConsole = new ReentrantWritingStringWriter();
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+        realConsole.Writer = writer;
+
+        writer.WriteLine("ordinary output");
+
+        await Assert.That(realConsole.ToString()).IsEqualTo(
+            $"sink diagnostic{Environment.NewLine}ordinary output{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task StableSecretEmission_AllowsReentrantRegistration()
     {
         const string discoveredSecret = "nested-sink-discovered-secret";
@@ -1274,6 +1314,24 @@ public class SecretMaskingPatternTests
         public override void WriteLine(string? value)
         {
             secretRegistry.AddSecret(secret);
+            base.WriteLine(value);
+        }
+    }
+
+    private sealed class ReentrantWritingStringWriter : StringWriter
+    {
+        private bool _hasWrittenDiagnostic;
+
+        public TextWriter? Writer { get; set; }
+
+        public override void WriteLine(string? value)
+        {
+            if (!_hasWrittenDiagnostic)
+            {
+                _hasWrittenDiagnostic = true;
+                Writer!.WriteLine("sink diagnostic");
+            }
+
             base.WriteLine(value);
         }
     }

--- a/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretMaskingPatternTests.cs
@@ -212,29 +212,21 @@ public class SecretMaskingPatternTests
     [Test]
     public async Task DifferentModuleBuffers_ProcessConcurrently()
     {
-        var provider = new Mock<ISecretProvider>();
-        provider.Setup(x => x.GetSnapshot()).Returns(new SecretSnapshot(0, ["split-secret"]));
-        using var firstObfuscationStarted = new ManualResetEventSlim();
-        using var releaseFirstObfuscation = new ManualResetEventSlim();
-        var obfuscator = new Mock<ISecretObfuscator>();
-        obfuscator
-            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
-            .Returns((string input, object? _) =>
+        var provider = CreateProvider(out _);
+        provider.AddSecret("split-secret");
+        using var firstWriteStarted = new ManualResetEventSlim();
+        using var releaseFirstWrite = new ManualResetEventSlim();
+        var firstBuffer = new Mock<IModuleOutputBuffer>();
+        firstBuffer
+            .Setup(x => x.WriteLine("**********"))
+            .Callback(() =>
             {
-                if (input != "split-secret")
-                {
-                    return input;
-                }
-
-                firstObfuscationStarted.Set();
-                if (!releaseFirstObfuscation.Wait(TimeSpan.FromSeconds(10)))
+                firstWriteStarted.Set();
+                if (!releaseFirstWrite.Wait(TimeSpan.FromSeconds(10)))
                 {
                     throw new TimeoutException("Timed out waiting to release the first module write.");
                 }
-
-                return "**********";
             });
-        var firstBuffer = new Mock<IModuleOutputBuffer>();
         var secondBuffer = new Mock<IModuleOutputBuffer>();
         var coordinator = new Mock<IConsoleCoordinator>();
         coordinator.Setup(x => x.GetModuleBuffer(typeof(FirstModule))).Returns(firstBuffer.Object);
@@ -244,20 +236,20 @@ public class SecretMaskingPatternTests
             coordinator.Object,
             new StringWriter(),
             () => true,
-            obfuscator.Object,
-            provider.Object);
+            CreateObfuscator(provider),
+            provider);
 
         var firstWrite = Task.Run(() => WriteForModule(typeof(FirstModule), "split-secret"));
         try
         {
-            await Assert.That(firstObfuscationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(firstWriteStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
 
             var secondWrite = Task.Run(() => WriteForModule(typeof(SecondModule), "ordinary output"));
             await secondWrite.WaitAsync(TimeSpan.FromSeconds(5));
         }
         finally
         {
-            releaseFirstObfuscation.Set();
+            releaseFirstWrite.Set();
             await firstWrite;
         }
 
@@ -853,12 +845,16 @@ public class SecretMaskingPatternTests
     }
 
     [Test]
-    public async Task DirectConsoleWrite_RescansWhenSecretsChangeBeforeEmission()
+    public async Task DirectConsoleWrite_SerializesRegistrationDuringMasking()
     {
-        var provider = CreateProvider(out _);
+        var provider = CreateProvider(out var nativeMasker);
         provider.AddSecret("known-secret");
         using var obfuscationStarted = new ManualResetEventSlim();
         using var releaseObfuscation = new ManualResetEventSlim();
+        using var registrationStarted = new ManualResetEventSlim();
+        nativeMasker
+            .Setup(masker => masker.MaskSecrets(It.IsAny<IEnumerable<string>>()))
+            .Callback(() => registrationStarted.Set());
         var obfuscator = new Mock<ITrackedSecretObfuscator>();
         obfuscator.SetupGet(candidate => candidate.PatternComparison).Returns(StringComparison.Ordinal);
         obfuscator
@@ -892,22 +888,73 @@ public class SecretMaskingPatternTests
             provider);
 
         var write = Task.Run(() => writer.WriteLine("known-secret dynamic-secret"));
+        var registration = Task.CompletedTask;
         try
         {
             await Assert.That(obfuscationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
-            provider.AddSecret("dynamic-secret");
+            registration = Task.Run(() => provider.AddSecret("dynamic-secret"));
+            await Assert.That(registrationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(async () =>
+                    await registration.WaitAsync(TimeSpan.FromMilliseconds(500)))
+                .Throws<TimeoutException>();
+
+            releaseObfuscation.Set();
+            await Task.WhenAll(write, registration).WaitAsync(TimeSpan.FromSeconds(5));
         }
         finally
         {
             releaseObfuscation.Set();
-            await write;
+            await Task.WhenAll(write, registration);
         }
 
         await Assert.That(realConsole.ToString())
-            .IsEqualTo($"********** **********{Environment.NewLine}");
+            .IsEqualTo($"********** dynamic-secret{Environment.NewLine}");
         obfuscator.Verify(
             candidate => candidate.ObfuscateWithConsumption("dynamic-secret", null),
-            Times.Once);
+            Times.Never);
+    }
+
+    [Test]
+    public async Task DirectConsoleWrite_LinearizesWithSecretRegistration()
+    {
+        var provider = CreateProvider(out var nativeMasker);
+        using var writeStarted = new ManualResetEventSlim();
+        using var releaseWrite = new ManualResetEventSlim();
+        using var registrationStarted = new ManualResetEventSlim();
+        nativeMasker
+            .Setup(masker => masker.MaskSecrets(It.IsAny<IEnumerable<string>>()))
+            .Callback(() => registrationStarted.Set());
+        var realConsole = new BlockingWriteStringWriter(writeStarted, releaseWrite);
+
+        using var writer = new CoordinatedTextWriter(
+            Mock.Of<IConsoleCoordinator>(),
+            realConsole,
+            () => false,
+            CreateObfuscator(provider),
+            provider);
+
+        var write = Task.Run(() => writer.WriteLine("dynamic-secret"));
+        var registration = Task.CompletedTask;
+        try
+        {
+            await Assert.That(writeStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            registration = Task.Run(() => provider.AddSecret("dynamic-secret"));
+            await Assert.That(registrationStarted.Wait(TimeSpan.FromSeconds(5))).IsTrue();
+            await Assert.That(async () =>
+                    await registration.WaitAsync(TimeSpan.FromMilliseconds(500)))
+                .Throws<TimeoutException>();
+
+            releaseWrite.Set();
+            await Task.WhenAll(write, registration).WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            releaseWrite.Set();
+            await Task.WhenAll(write, registration);
+        }
+
+        await Assert.That(realConsole.ToString())
+            .IsEqualTo($"dynamic-secret{Environment.NewLine}");
     }
 
     [Test]
@@ -982,6 +1029,22 @@ public class SecretMaskingPatternTests
         return new SecretObfuscator(
             provider,
             Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
+    }
+
+    private sealed class BlockingWriteStringWriter(
+        ManualResetEventSlim writeStarted,
+        ManualResetEventSlim releaseWrite) : StringWriter
+    {
+        public override void WriteLine(string? value)
+        {
+            writeStarted.Set();
+            if (!releaseWrite.Wait(TimeSpan.FromSeconds(10)))
+            {
+                throw new TimeoutException("Timed out waiting to release the console write.");
+            }
+
+            base.WriteLine(value);
+        }
     }
 
     private sealed class AsyncFlushTrackingWriter : StringWriter


### PR DESCRIPTION
## Summary
- cache a case-insensitive `SearchValues<string>` with each secret-pattern snapshot and use it for one-pass match discovery
- compute retained secret-prefix length once per processing pass and avoid re-obfuscating already-clean output
- replace the global writer lock with per-stream state locks while retaining serialized writes to the underlying console
- add regression tests for single-pass obfuscation and concurrent module-buffer processing

## Validation
- `SecretMaskingPatternTests`: 25 passed
- `OutputCoordinatorTests`: 19 passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors

Closes #3755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret masking for overlapping, partial, case-sensitive, and custom masking scenarios.
  * Prevented secret fragments during concurrent writes, flushes, and direct console output.
  * Preserved trailing output correctly after masking and direct console writes.
  * Ensured completed output is processed consistently before appearing in the console.
  * Improved asynchronous flushing and synchronization when secrets are registered during output processing.
* **Performance**
  * Improved repeated secret-pattern matching and enabled independent output streams to be processed concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->