### PR TITLE
Remove legacy string-based optional CLI values

### DIFF
--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -16,7 +16,6 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
     private const int RuntimeMetadataSchemaVersion = 2;
     private const string CliOptionValueFullName = "ModularPipelines.Models.CliOptionValue";
     private const string CliValuePairFullName = "ModularPipelines.Models.CliValuePair";
-    private const string GeneratedCodeAttributeFullName = "System.CodeDom.Compiler.GeneratedCodeAttribute";
 
     internal const string CommandLineToolOptionsFullName = "ModularPipelines.Options.CommandLineToolOptions";
     internal const string OptionsNamespace = "Microsoft.Extensions.Options";
@@ -825,7 +824,6 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     0,
                     property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                     false,
-                    false,
                     false));
             }
         }
@@ -886,7 +884,6 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 0,
                 property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 false,
-                false,
                 attribute.ConstructorArguments.Length > 0);
         }
 
@@ -909,11 +906,9 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 0,
                 property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 IsSupportedFlagType(property.Type),
-                false,
                 false);
         }
 
-        var allowsLegacyOptionalValues = IsLegacyGeneratedOption(property);
         return new PropertyMetadata(
             property.Name,
             PropertyKind.Option,
@@ -930,8 +925,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             isGlobalOption,
             GetManualOperandCount(property.Type),
             property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-            IsSupportedOptionalValueType(property.Type, allowsLegacyOptionalValues),
-            allowsLegacyOptionalValues,
+            IsSupportedOptionalValueType(property.Type),
             false);
     }
 
@@ -941,16 +935,11 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         return propertyType.SpecialType is SpecialType.System_Boolean or SpecialType.System_Int32;
     }
 
-    private static bool IsSupportedOptionalValueType(
-        ITypeSymbol propertyType,
-        bool allowsLegacyOptionalValues)
+    private static bool IsSupportedOptionalValueType(ITypeSymbol propertyType)
     {
         propertyType = UnwrapNullable(propertyType);
         return IsType(propertyType, CliOptionValueFullName)
-               || IsEnumerableOf(propertyType, CliOptionValueFullName)
-               || (allowsLegacyOptionalValues
-                   && (propertyType.SpecialType == SpecialType.System_String
-                       || IsEnumerableOf(propertyType, "string")));
+               || IsEnumerableOf(propertyType, CliOptionValueFullName);
     }
 
     private static bool IsEnumerableOf(ITypeSymbol propertyType, string elementTypeName)
@@ -979,12 +968,6 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         && nullableType.TypeArguments.Length == 1
             ? nullableType.TypeArguments[0]
             : propertyType;
-
-    private static bool IsLegacyGeneratedOption(IPropertySymbol property) =>
-        property.ContainingType.GetAttributes().Any(static attribute =>
-            attribute.AttributeClass?.ToDisplayString() == GeneratedCodeAttributeFullName
-            && attribute.ConstructorArguments.FirstOrDefault().Value as string
-                == "ModularPipelines.OptionsGenerator");
 
     private static int GetManualOperandCount(ITypeSymbol propertyType)
     {
@@ -1340,7 +1323,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     sb.AppendLine($"                        ValueArity = (global::ModularPipelines.Attributes.CliOptionValueArity){property.ValueArity},");
                     sb.AppendLine($"                        GroupValues = {BooleanLiteral(property.GroupValues)},");
                     sb.AppendLine($"                        Phase = global::ModularPipelines.Attributes.CommandLinePhase.{property.Phase},");
-                    sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)}, ManualOperandCount = {property.ManualOperandCount}, AllowsLegacyOptionalValues = {BooleanLiteral(property.AllowsLegacyOptionalValues)}, IsSupportedPropertyType = {BooleanLiteral(property.IsSupportedPropertyType)} }},");
+                    sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)}, ManualOperandCount = {property.ManualOperandCount}, IsSupportedPropertyType = {BooleanLiteral(property.IsSupportedPropertyType)} }},");
                     break;
             }
         }
@@ -2078,7 +2061,6 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         int ManualOperandCount,
         string AccessorTypeName,
         bool IsSupportedPropertyType,
-        bool AllowsLegacyOptionalValues,
         bool HasExplicitArgumentPosition);
 
     private enum PropertyKind

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -13,7 +13,7 @@ namespace ModularPipelines.SourceGenerator;
 [Generator]
 public sealed class CommandOptionsGenerator : IIncrementalGenerator
 {
-    private const int RuntimeMetadataSchemaVersion = 2;
+    private const int RuntimeMetadataSchemaVersion = 3;
     private const string CliOptionValueFullName = "ModularPipelines.Models.CliOptionValue";
     private const string CliValuePairFullName = "ModularPipelines.Models.CliValuePair";
 

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -13,7 +13,8 @@ namespace ModularPipelines.SourceGenerator;
 [Generator]
 public sealed class CommandOptionsGenerator : IIncrementalGenerator
 {
-    private const int RuntimeMetadataSchemaVersion = 3;
+    private const int RuntimeMetadataSchemaVersion = 2;
+    private const int CommandMetadataSchemaVersion = 3;
     private const string CliOptionValueFullName = "ModularPipelines.Models.CliOptionValue";
     private const string CliValuePairFullName = "ModularPipelines.Models.CliValuePair";
 
@@ -1093,6 +1094,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         sb.AppendLine("internal static class RuntimeMetadataRegistration");
         sb.AppendLine("{");
         sb.AppendLine($"    public const int SchemaVersion = {RuntimeMetadataSchemaVersion};");
+        sb.AppendLine($"    public const int CommandSchemaVersion = {CommandMetadataSchemaVersion};");
         sb.AppendLine();
         sb.AppendLine("    [global::System.Runtime.CompilerServices.ModuleInitializer]");
         sb.AppendLine("    [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]");
@@ -1329,7 +1331,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         }
 
         sb.AppendLine("            },");
-        sb.AppendLine($"            {RuntimeMetadataSchemaVersion});");
+        sb.AppendLine($"            {CommandMetadataSchemaVersion});");
     }
 
     private static void AppendSecretRegistration(StringBuilder sb, TypeMetadata item)
@@ -1466,13 +1468,17 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             RuntimeMetadataRegistrationFullName);
         var runtimeMetadataSchemaVersion = GetRuntimeMetadataSchemaVersion(
             runtimeMetadataRegistration);
+        var commandMetadataSchemaVersion = GetRuntimeMetadataSchemaVersion(
+                                               runtimeMetadataRegistration,
+                                               "CommandSchemaVersion")
+                                           ?? runtimeMetadataSchemaVersion;
         var requiresSecretReflectionFallback = runtimeMetadataRegistration is not null
                                                && !Equals(
                                                    runtimeMetadataSchemaVersion,
                                                    RuntimeMetadataSchemaVersion);
-        var hasCurrentRuntimeMetadata = Equals(
-            runtimeMetadataSchemaVersion,
-            RuntimeMetadataSchemaVersion);
+        var hasCurrentCommandMetadata = Equals(
+            commandMetadataSchemaVersion,
+            CommandMetadataSchemaVersion);
         return GetTypes(assembly.GlobalNamespace)
             .Select(type => GetExternalTypeCandidate(
                 type,
@@ -1481,7 +1487,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 usedOptionsTypes,
                 incompleteTypeNames,
                 requiresSecretReflectionFallback,
-                hasCurrentRuntimeMetadata))
+                hasCurrentCommandMetadata))
             .OfType<TypeMetadataCandidate>();
     }
 
@@ -1492,11 +1498,11 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         ISet<OptionsTypeIdentity> usedOptionsTypes,
         ISet<string> incompleteTypeNames,
         bool requiresSecretReflectionFallback,
-        bool hasCurrentRuntimeMetadata)
+        bool hasCurrentCommandMetadata)
     {
         var metadataName = GetMetadataName(type);
         var isObservedOptionsType = IsObservedOptionsType(type, usedOptionsTypes);
-        var requiresRescan = !hasCurrentRuntimeMetadata
+        var requiresRescan = !hasCurrentCommandMetadata
                              || incompleteTypeNames.Contains(metadataName)
                              || isObservedOptionsType;
         if (!requiresRescan && !includeAllRuntimeMetadata)
@@ -1595,9 +1601,11 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                        || metadata.UseTypeForEmptySecretCoverage));
     }
 
-    private static object? GetRuntimeMetadataSchemaVersion(INamedTypeSymbol? registration) =>
+    private static object? GetRuntimeMetadataSchemaVersion(
+        INamedTypeSymbol? registration,
+        string fieldName = "SchemaVersion") =>
         registration?
-            .GetMembers("SchemaVersion")
+            .GetMembers(fieldName)
             .OfType<IFieldSymbol>()
             .FirstOrDefault(static field => field.HasConstantValue)?
             .ConstantValue;

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -1,4 +1,3 @@
-using System.CodeDom.Compiler;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -423,49 +422,12 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         Type optionsType,
         OptionPart optionPart)
     {
-        var isLegacyGeneratedOption = optionPart.AllowsLegacyOptionalValues
-                                      || (optionPart.IsSupportedPropertyType is null
-                                          && IsLegacyGeneratedOption(optionsType, optionPart));
         return rawValue switch
         {
             CliOptionValue optionValue => [optionValue],
             IEnumerable<CliOptionValue> values => values.OfType<CliOptionValue>(),
-            // Preserve compatibility with generated option packages that predate CliOptionValue.
-            string value when isLegacyGeneratedOption => [ToLegacyOptionalValue(value)],
-            IEnumerable<string> values when isLegacyGeneratedOption => values
-                .OfType<string>()
-                .Select(ToLegacyOptionalValue),
             _ => throw CreateInvalidOptionalValueTypeException(optionsType, optionPart),
         };
-    }
-
-    private static CliOptionValue ToLegacyOptionalValue(string value)
-        => string.IsNullOrWhiteSpace(value) ? CliOptionValue.Bare : value;
-
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2070",
-        Justification = "Legacy generated options retain their public CLI properties for reflection-based compatibility.")]
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2075",
-        Justification = "Legacy generated option base types retain their public CLI properties for reflection-based compatibility.")]
-    private static bool IsLegacyGeneratedOption(Type optionsType, OptionPart optionPart)
-    {
-        for (var currentType = optionsType; currentType is not null; currentType = currentType.BaseType)
-        {
-            var property = currentType.GetProperty(
-                optionPart.PropertyName,
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-
-            if (property is not null)
-            {
-                return currentType.GetCustomAttribute<GeneratedCodeAttribute>(inherit: false)?.Tool
-                    == "ModularPipelines.OptionsGenerator";
-            }
-        }
-
-        return false;
     }
 
     private static InvalidOperationException CreateInvalidOptionalValueTypeException(

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -254,7 +254,8 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         PropertyCommandLinePart part,
         Func<Type, bool> isSupported)
     {
-        if (part.IsSupportedPropertyType is { } knownResult)
+        if (part is not OptionPart { AllowsLegacyOptionalValues: true }
+            && part.IsSupportedPropertyType is { } knownResult)
         {
             return knownResult;
         }

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -21,7 +21,7 @@ internal sealed class CommandModelProvider : ICommandModelProvider
     {
         return _cache.GetValue(optionsType, static type =>
         {
-            if (!GeneratedCommandMetadata.TryGet(type, out var model))
+            if (!GeneratedCommandMetadata.TryGet(type, out var model, out var schemaVersion))
             {
                 if (GeneratedCommandMetadata.IsGeneratedMetadataRequired(type.Assembly)
                     || !RuntimeFeature.IsDynamicCodeSupported
@@ -32,9 +32,15 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 }
 
                 model = BuildModel(type);
+                schemaVersion = GeneratedCommandMetadata.CurrentSchemaVersion;
+            }
+            else if (schemaVersion < GeneratedCommandMetadata.CurrentSchemaVersion
+                     && !RuntimeFeature.IsDynamicCodeSupported)
+            {
+                throw new MissingCommandMetadataException(type);
             }
 
-            ValidateModel(type, model);
+            ValidateModel(type, model, schemaVersion);
             return new CommandModel(model);
         }).Value;
     }
@@ -184,14 +190,15 @@ internal sealed class CommandModelProvider : ICommandModelProvider
 
     private static void ValidateModel(
         Type optionsType,
-        IReadOnlyList<PropertyCommandLinePart> parts)
+        IReadOnlyList<PropertyCommandLinePart> parts,
+        int schemaVersion)
     {
         ValidateUniqueSwitches(optionsType, parts);
         ValidateUniqueArgumentPositions(optionsType, parts);
 
         foreach (var part in parts)
         {
-            ValidateProperty(optionsType, part);
+            ValidateProperty(optionsType, part, schemaVersion);
         }
     }
 
@@ -219,7 +226,10 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         }
     }
 
-    private static void ValidateProperty(Type optionsType, PropertyCommandLinePart part)
+    private static void ValidateProperty(
+        Type optionsType,
+        PropertyCommandLinePart part,
+        int schemaVersion)
     {
         var propertyName = $"{optionsType.FullName ?? optionsType.Name}.{part.PropertyName}";
         switch (part)
@@ -237,7 +247,12 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 throw new InvalidOperationException(
                     $"CliValuePair CLI option property '{propertyName}' must use OptionFormat.SpaceSeparated.");
             case OptionPart { Attribute.ValueArity: CliOptionValueArity.Optional } option
-                when !HasSupportedPropertyType(optionsType, option, IsSupportedOptionalValueType):
+                when !HasSupportedPropertyType(
+                    optionsType,
+                    option,
+                    IsSupportedOptionalValueType,
+                    trustKnownResult: schemaVersion >= GeneratedCommandMetadata.CurrentSchemaVersion
+                                      || !option.AllowsLegacyOptionalValues):
                 throw new InvalidOperationException(
                     $"Optional-value CLI option property '{propertyName}' must use "
                     + "CliOptionValue or IEnumerable<CliOptionValue>.");
@@ -247,14 +262,15 @@ internal sealed class CommandModelProvider : ICommandModelProvider
     [UnconditionalSuppressMessage(
         "Trimming",
         "IL2026",
-        Justification = "Schema-1 metadata getters preserve the referenced option properties; "
-                        + "reflection is used only when the support marker is absent.")]
+        Justification = "Legacy metadata getters preserve the referenced option properties; "
+                        + "reflection is used only when the support marker is absent or stale.")]
     private static bool HasSupportedPropertyType(
         Type optionsType,
         PropertyCommandLinePart part,
-        Func<Type, bool> isSupported)
+        Func<Type, bool> isSupported,
+        bool trustKnownResult = true)
     {
-        if (part.IsSupportedPropertyType is { } knownResult)
+        if (trustKnownResult && part.IsSupportedPropertyType is { } knownResult)
         {
             return knownResult;
         }

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -1,4 +1,3 @@
-using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -64,15 +63,11 @@ internal sealed class CommandModelProvider : ICommandModelProvider
             }
             else if (property.GetCustomAttribute<CliOptionAttribute>() is { } option)
             {
-                var allowsLegacyOptionalValues = IsLegacyGeneratedOption(property);
                 parts.Add(new OptionPart(property.Name, property.GetValue, option)
                 {
                     IsGlobalOption = IsGlobalOption(property),
                     ManualOperandCount = GetManualOperandCount(property.PropertyType),
-                    AllowsLegacyOptionalValues = allowsLegacyOptionalValues,
-                    IsSupportedPropertyType = IsSupportedOptionalValueType(
-                        property.PropertyType,
-                        allowsLegacyOptionalValues),
+                    IsSupportedPropertyType = IsSupportedOptionalValueType(property.PropertyType),
                 });
             }
         }
@@ -180,21 +175,12 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         return propertyType == typeof(bool) || propertyType == typeof(int);
     }
 
-    private static bool IsSupportedOptionalValueType(
-        Type propertyType,
-        bool allowsLegacyOptionalValues)
+    private static bool IsSupportedOptionalValueType(Type propertyType)
     {
         propertyType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
         return propertyType == typeof(ModularPipelines.Models.CliOptionValue)
-               || propertyType.IsAssignableTo(typeof(IEnumerable<ModularPipelines.Models.CliOptionValue>))
-               || (allowsLegacyOptionalValues
-                   && (propertyType == typeof(string)
-                       || propertyType.IsAssignableTo(typeof(IEnumerable<string>))));
+               || propertyType.IsAssignableTo(typeof(IEnumerable<ModularPipelines.Models.CliOptionValue>));
     }
-
-    private static bool IsLegacyGeneratedOption(PropertyInfo property) =>
-        property.DeclaringType?.GetCustomAttribute<GeneratedCodeAttribute>(inherit: false)?.Tool
-        == "ModularPipelines.OptionsGenerator";
 
     private static void ValidateModel(
         Type optionsType,

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -254,8 +254,7 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         PropertyCommandLinePart part,
         Func<Type, bool> isSupported)
     {
-        if (part is not OptionPart { AllowsLegacyOptionalValues: true }
-            && part.IsSupportedPropertyType is { } knownResult)
+        if (part.IsSupportedPropertyType is { } knownResult)
         {
             return knownResult;
         }

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -234,8 +234,7 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         var propertyName = $"{optionsType.FullName ?? optionsType.Name}.{part.PropertyName}";
         switch (part)
         {
-            case FlagPart flag
-                when !HasSupportedPropertyType(optionsType, flag, IsSupportedFlagType):
+            case FlagPart flag when flag.IsSupportedPropertyType is not true:
                 throw new InvalidOperationException(
                     $"CLI flag property '{propertyName}' must use bool, bool?, int, or int?.");
             case OptionPart { Attribute.GroupValues: true } groupedOption
@@ -247,37 +246,13 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 throw new InvalidOperationException(
                     $"CliValuePair CLI option property '{propertyName}' must use OptionFormat.SpaceSeparated.");
             case OptionPart { Attribute.ValueArity: CliOptionValueArity.Optional } option
-                when !HasSupportedPropertyType(
-                    optionsType,
-                    option,
-                    IsSupportedOptionalValueType,
-                    trustKnownResult: schemaVersion >= GeneratedCommandMetadata.CurrentSchemaVersion
-                                      || !option.AllowsLegacyOptionalValues):
+                when option.IsSupportedPropertyType is not true
+                     || (schemaVersion < GeneratedCommandMetadata.CurrentSchemaVersion
+                         && option.AllowsLegacyOptionalValues):
                 throw new InvalidOperationException(
                     $"Optional-value CLI option property '{propertyName}' must use "
                     + "CliOptionValue or IEnumerable<CliOptionValue>.");
         }
-    }
-
-    [UnconditionalSuppressMessage(
-        "Trimming",
-        "IL2026",
-        Justification = "Legacy metadata getters preserve the referenced option properties; "
-                        + "reflection is used only when the support marker is absent or stale.")]
-    private static bool HasSupportedPropertyType(
-        Type optionsType,
-        PropertyCommandLinePart part,
-        Func<Type, bool> isSupported,
-        bool trustKnownResult = true)
-    {
-        if (trustKnownResult && part.IsSupportedPropertyType is { } knownResult)
-        {
-            return knownResult;
-        }
-
-        return GetCommandProperties(optionsType)
-                   .FirstOrDefault(property => property.Name == part.PropertyName) is { } property
-               && isSupported(property.PropertyType);
     }
 
     private static void ValidateUniqueSwitches(

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -234,7 +234,10 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         var propertyName = $"{optionsType.FullName ?? optionsType.Name}.{part.PropertyName}";
         switch (part)
         {
-            case FlagPart flag when flag.IsSupportedPropertyType is not true:
+            case FlagPart flag
+                when flag.IsSupportedPropertyType is false
+                     || (schemaVersion >= GeneratedCommandMetadata.CurrentSchemaVersion
+                         && flag.IsSupportedPropertyType is null):
                 throw new InvalidOperationException(
                     $"CLI flag property '{propertyName}' must use bool, bool?, int, or int?.");
             case OptionPart { Attribute.GroupValues: true } groupedOption
@@ -246,9 +249,7 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 throw new InvalidOperationException(
                     $"CliValuePair CLI option property '{propertyName}' must use OptionFormat.SpaceSeparated.");
             case OptionPart { Attribute.ValueArity: CliOptionValueArity.Optional } option
-                when option.IsSupportedPropertyType is not true
-                     || (schemaVersion < GeneratedCommandMetadata.CurrentSchemaVersion
-                         && option.AllowsLegacyOptionalValues):
+                when option.IsSupportedPropertyType is not true:
                 throw new InvalidOperationException(
                     $"Optional-value CLI option property '{propertyName}' must use "
                     + "CliOptionValue or IEnumerable<CliOptionValue>.");

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -224,7 +224,8 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         var propertyName = $"{optionsType.FullName ?? optionsType.Name}.{part.PropertyName}";
         switch (part)
         {
-            case FlagPart { IsSupportedPropertyType: false }:
+            case FlagPart flag
+                when !HasSupportedPropertyType(optionsType, flag, IsSupportedFlagType):
                 throw new InvalidOperationException(
                     $"CLI flag property '{propertyName}' must use bool, bool?, int, or int?.");
             case OptionPart { Attribute.GroupValues: true } groupedOption
@@ -235,15 +236,32 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 when valuePairOption.Attribute.Format != OptionFormat.SpaceSeparated:
                 throw new InvalidOperationException(
                     $"CliValuePair CLI option property '{propertyName}' must use OptionFormat.SpaceSeparated.");
-            case OptionPart
-            {
-                Attribute.ValueArity: CliOptionValueArity.Optional,
-                IsSupportedPropertyType: false,
-            }:
+            case OptionPart { Attribute.ValueArity: CliOptionValueArity.Optional } option
+                when !HasSupportedPropertyType(optionsType, option, IsSupportedOptionalValueType):
                 throw new InvalidOperationException(
                     $"Optional-value CLI option property '{propertyName}' must use "
                     + "CliOptionValue or IEnumerable<CliOptionValue>.");
         }
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026",
+        Justification = "Schema-1 metadata getters preserve the referenced option properties; "
+                        + "reflection is used only when the support marker is absent.")]
+    private static bool HasSupportedPropertyType(
+        Type optionsType,
+        PropertyCommandLinePart part,
+        Func<Type, bool> isSupported)
+    {
+        if (part.IsSupportedPropertyType is { } knownResult)
+        {
+            return knownResult;
+        }
+
+        return GetCommandProperties(optionsType)
+                   .FirstOrDefault(property => property.Name == part.PropertyName) is { } property
+               && isSupported(property.PropertyType);
     }
 
     private static void ValidateUniqueSwitches(

--- a/src/ModularPipelines/Helpers/Internal/GeneratedCommandMetadata.cs
+++ b/src/ModularPipelines/Helpers/Internal/GeneratedCommandMetadata.cs
@@ -142,10 +142,19 @@ public static class GeneratedCommandMetadata
 
     internal static bool TryGet(Type optionsType, out IReadOnlyList<PropertyCommandLinePart> model)
     {
+        return TryGet(optionsType, out model, out _);
+    }
+
+    internal static bool TryGet(
+        Type optionsType,
+        out IReadOnlyList<PropertyCommandLinePart> model,
+        out int schemaVersion)
+    {
         Models.TryGetValue(optionsType, out var directMetadata);
         if (directMetadata is { IsComplete: true, SchemaVersion: CurrentSchemaVersion })
         {
             model = directMetadata.Model;
+            schemaVersion = directMetadata.SchemaVersion;
             return true;
         }
 
@@ -155,6 +164,7 @@ public static class GeneratedCommandMetadata
                 && metadata is { IsComplete: true, SchemaVersion: CurrentSchemaVersion })
             {
                 model = metadata.Model;
+                schemaVersion = metadata.SchemaVersion;
                 return true;
             }
         }
@@ -162,10 +172,12 @@ public static class GeneratedCommandMetadata
         if (directMetadata is { IsComplete: true })
         {
             model = directMetadata.Model;
+            schemaVersion = directMetadata.SchemaVersion;
             return true;
         }
 
         model = Array.Empty<PropertyCommandLinePart>();
+        schemaVersion = 0;
         return false;
     }
 

--- a/src/ModularPipelines/Helpers/Internal/GeneratedCommandMetadata.cs
+++ b/src/ModularPipelines/Helpers/Internal/GeneratedCommandMetadata.cs
@@ -10,7 +10,7 @@ namespace ModularPipelines.Helpers.Internal;
 /// </summary>
 public static class GeneratedCommandMetadata
 {
-    internal const int CurrentSchemaVersion = 2;
+    internal const int CurrentSchemaVersion = 3;
 
     private static readonly ConditionalWeakTable<Type, CommandMetadata> Models = [];
     private static readonly ConditionalWeakTable<Assembly, ProcessedAssembly> ProcessedAssemblies = [];

--- a/src/ModularPipelines/Helpers/Internal/PropertyCommandLinePart.cs
+++ b/src/ModularPipelines/Helpers/Internal/PropertyCommandLinePart.cs
@@ -61,11 +61,6 @@ public sealed record OptionPart(
     CliOptionAttribute Attribute) : PropertyCommandLinePart(PropertyName, Getter)
 {
     /// <summary>
-    /// Gets a value indicating whether legacy generated string optional values are supported.
-    /// </summary>
-    public bool AllowsLegacyOptionalValues { get; init; }
-
-    /// <summary>
     /// Gets the number of separate operands consumed by one manual occurrence of this option.
     /// </summary>
     public int ManualOperandCount { get; init; } = -1;

--- a/src/ModularPipelines/Helpers/Internal/PropertyCommandLinePart.cs
+++ b/src/ModularPipelines/Helpers/Internal/PropertyCommandLinePart.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Helpers.Internal;
@@ -60,6 +61,13 @@ public sealed record OptionPart(
     Func<object, object?> Getter,
     CliOptionAttribute Attribute) : PropertyCommandLinePart(PropertyName, Getter)
 {
+    /// <summary>
+    /// Gets the legacy optional-value compatibility marker.
+    /// Retained for binary compatibility with schema-2 generated metadata; ignored by validation.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public bool AllowsLegacyOptionalValues { get; init; }
+
     /// <summary>
     /// Gets the number of separate operands consumed by one manual occurrence of this option.
     /// </summary>

--- a/test/ModularPipelines.SourceGenerator.UnitTests/GeneratedOptionsRegistrationAnalyzerTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/GeneratedOptionsRegistrationAnalyzerTests.cs
@@ -33,7 +33,7 @@ public class GeneratedOptionsRegistrationAnalyzerTests
         {
             public static class RuntimeMetadataRegistry
             {
-                public const int CurrentCommandMetadataSchemaVersion = 2;
+                public const int CurrentCommandMetadataSchemaVersion = 3;
                 public static void RegisterCommandOptions(System.Type type, object model) { }
                 public static void RegisterCommandOptions(System.Type type, object model, int schemaVersion) { }
                 public static void RegisterSecrets(System.Type type, object accessors) { }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
@@ -570,6 +570,56 @@ public class IncompleteMetadataDiagnosticTests
     }
 
     [Test]
+    public async Task Trimmed_Host_Rescans_Legacy_Command_Without_Invalidating_Secret_Metadata()
+    {
+        var result = GeneratorTestHarness.RunWithExternalAssembly(
+            new CommandOptionsGenerator(),
+            CommandInfrastructure,
+            """
+            namespace ModularPipelines.Generated
+            {
+                internal static class RuntimeMetadataRegistration
+                {
+                    public const int SchemaVersion = 2;
+                }
+            }
+
+            namespace External
+            {
+                public class LegacyOptions
+                    : ModularPipelines.Options.CommandLineToolOptions
+                {
+                    [ModularPipelines.Attributes.SecretValue]
+                    protected string Token { get; } = "";
+
+                    [ModularPipelines.Attributes.CliOption("--output")]
+                    public string Output { get; } = "";
+                }
+            }
+            """,
+            """
+            public sealed class Consumer
+            {
+                public External.LegacyOptions Options { get; } = new();
+            }
+            """,
+            new Dictionary<string, string>
+            {
+                ["build_property.PublishAot"] = "true",
+            });
+
+        var generatedSource = result.GeneratedTrees.Single().ToString();
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics).IsEmpty();
+            await Assert.That(generatedSource).Contains(
+                "GeneratedCommandMetadata.RegisterExternal(");
+            await Assert.That(generatedSource).DoesNotContain(
+                "GeneratedSecretMetadata.RegisterExternal(assembly, typeof(global::External.LegacyOptions)");
+        }
+    }
+
+    [Test]
     public async Task Trimmed_Host_Trusts_Current_Metadata_Marker()
     {
         var result = GeneratorTestHarness.RunWithExternalAssembly(
@@ -580,7 +630,8 @@ public class IncompleteMetadataDiagnosticTests
             {
                 internal static class RuntimeMetadataRegistration
                 {
-                    public const int SchemaVersion = 3;
+                    public const int SchemaVersion = 2;
+                    public const int CommandSchemaVersion = 3;
                 }
             }
 
@@ -624,7 +675,8 @@ public class IncompleteMetadataDiagnosticTests
             {
                 internal static class RuntimeMetadataRegistration
                 {
-                    public const int SchemaVersion = 3;
+                    public const int SchemaVersion = 2;
+                    public const int CommandSchemaVersion = 3;
                 }
             }
 
@@ -670,7 +722,8 @@ public class IncompleteMetadataDiagnosticTests
             {
                 internal static class RuntimeMetadataRegistration
                 {
-                    public const int SchemaVersion = 3;
+                    public const int SchemaVersion = 2;
+                    public const int CommandSchemaVersion = 3;
                 }
             }
 

--- a/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
@@ -12,8 +12,17 @@ public class IncompleteMetadataDiagnosticTests
 
         namespace ModularPipelines.Attributes
         {
+            public enum CliOptionValueArity
+            {
+                Required,
+                Optional,
+            }
+
             [System.AttributeUsage(System.AttributeTargets.Property)]
-            public sealed class CliOptionAttribute(string name) : System.Attribute;
+            public sealed class CliOptionAttribute(string name) : System.Attribute
+            {
+                public CliOptionValueArity ValueArity { get; set; }
+            }
 
             [System.AttributeUsage(System.AttributeTargets.Property)]
             public sealed class CliFlagAttribute(string name) : System.Attribute;
@@ -158,6 +167,33 @@ public class IncompleteMetadataDiagnosticTests
             }
         }
         """;
+
+    [Test]
+    public async Task Generated_Legacy_Optional_Value_Metadata_Is_Unsupported()
+    {
+        var result = GeneratorTestHarness.Run(
+            new CommandOptionsGenerator(),
+            CommandInfrastructure,
+            """
+            [System.CodeDom.Compiler.GeneratedCode("ModularPipelines.OptionsGenerator", "3.0.0")]
+            public sealed class LegacyOptions
+                : ModularPipelines.Options.CommandLineToolOptions
+            {
+                [ModularPipelines.Attributes.CliOption(
+                    "--output",
+                    ValueArity = ModularPipelines.Attributes.CliOptionValueArity.Optional)]
+                public string? Output { get; set; }
+            }
+            """);
+
+        var generatedSource = result.GeneratedTrees.Single().ToString();
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics).IsEmpty();
+            await Assert.That(generatedSource).Contains("IsSupportedPropertyType = false");
+            await Assert.That(generatedSource).DoesNotContain("AllowsLegacyOptionalValues");
+        }
+    }
 
     [Test]
     public async Task Inaccessible_Command_Property_Reports_Diagnostic()

--- a/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
@@ -580,7 +580,7 @@ public class IncompleteMetadataDiagnosticTests
             {
                 internal static class RuntimeMetadataRegistration
                 {
-                    public const int SchemaVersion = 2;
+                    public const int SchemaVersion = 3;
                 }
             }
 
@@ -624,7 +624,7 @@ public class IncompleteMetadataDiagnosticTests
             {
                 internal static class RuntimeMetadataRegistration
                 {
-                    public const int SchemaVersion = 2;
+                    public const int SchemaVersion = 3;
                 }
             }
 
@@ -670,7 +670,7 @@ public class IncompleteMetadataDiagnosticTests
             {
                 internal static class RuntimeMetadataRegistration
                 {
-                    public const int SchemaVersion = 2;
+                    public const int SchemaVersion = 3;
                 }
             }
 

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -499,53 +499,36 @@ public class CliAttributeTests
     }
 
     [Test]
-    public async Task Parser_Preserves_Legacy_Multiple_Optional_String_Values()
+    public async Task Parser_Rejects_Generated_Legacy_Optional_String_Collection()
     {
         var options = new TestCliOptionsWithLegacyMultipleOptionalValues
         {
-            Output = [string.Empty, "json"],
+            Output = ["json"],
         };
 
-        var list = BuildArguments(options);
-
-        await Assert.That(list).IsEquivalentTo(
-            ["--output", "--output=json"],
-            TUnit.Assertions.Enums.CollectionOrdering.Matching);
+        await Assert.That(() => BuildArguments(options))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining(nameof(CliOptionValue));
     }
 
     [Test]
-    public async Task Parser_Skips_Null_Legacy_Repeatable_Optional_Values()
-    {
-        var options = new TestCliOptionsWithLegacyMultipleOptionalValues
-        {
-            Output = [string.Empty, null!, "json"],
-        };
-
-        var list = BuildArguments(options);
-
-        await Assert.That(list).IsEquivalentTo(
-            ["--output", "--output=json"],
-            TUnit.Assertions.Enums.CollectionOrdering.Matching);
-    }
-
-    [Test]
-    public async Task Parser_Preserves_Legacy_Scalar_Optional_String_Value()
+    public async Task Parser_Rejects_Generated_Legacy_Scalar_Optional_String_Value()
     {
         var options = new TestCliOptionsWithLegacyScalarOptionalValue { Output = "json" };
 
-        var list = BuildArguments(options);
-
-        await Assert.That(list).IsEquivalentTo(["--output=json"]);
+        await Assert.That(() => BuildArguments(options))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining(nameof(CliOptionValue));
     }
 
     [Test]
-    public async Task Parser_Preserves_Legacy_Optional_Value_From_Generated_Base_Type()
+    public async Task Parser_Rejects_Legacy_Optional_Value_From_Generated_Base_Type()
     {
         var options = new TestCliOptionsDerivedFromLegacyGeneratedOptions { Output = "json" };
 
-        var list = BuildArguments(options);
-
-        await Assert.That(list).IsEquivalentTo(["--output=json"]);
+        await Assert.That(() => BuildArguments(options))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining(nameof(CliOptionValue));
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -332,6 +332,33 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task Schema2_Metadata_Ignores_Legacy_Optional_Compatibility_Flag()
+    {
+        var optionsType = typeof(RegisteredLegacyOptionalOptions<Schema2MetadataMarker>);
+        GeneratedCommandMetadata.Register(
+            optionsType,
+            [
+                new OptionPart(
+                    nameof(RegisteredLegacyOptionalOptions<Schema2MetadataMarker>.Output),
+                    static options =>
+                        ((RegisteredLegacyOptionalOptions<Schema2MetadataMarker>) options).Output,
+                    new CliOptionAttribute("--output")
+                    {
+                        ValueArity = CliOptionValueArity.Optional,
+                    })
+                {
+                    AllowsLegacyOptionalValues = true,
+                    IsSupportedPropertyType = false,
+                },
+            ],
+            GeneratedCommandMetadata.CurrentSchemaVersion);
+
+        await Assert.That(() => new CommandModelProvider().GetCommandModel(optionsType))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining(nameof(CliOptionValue));
+    }
+
+    [Test]
     public async Task Parser_Omits_Empty_Required_Option_Collections()
     {
         var options = new TestCliOptionsWithMultipleValues { Values = [] };
@@ -1118,6 +1145,8 @@ public class CliAttributeTests
     }
 
     private sealed class Schema1MetadataMarker;
+
+    private sealed class Schema2MetadataMarker;
 
     internal record TestCliOptionsWithDuplicateArgumentPosition : CommandLineToolOptions
     {

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -376,7 +376,7 @@ public class CliAttributeTests
     }
 
     [Test]
-    public async Task Schema2_Direct_Metadata_Revalidates_Legacy_Optional_Marker()
+    public async Task Schema2_Direct_Metadata_Rejects_Legacy_Optional_Marker_Without_Reflection()
     {
         var optionsType = typeof(RegisteredLegacyOptionalOptions<Schema2JitMetadataMarker>);
         GeneratedCommandMetadata.Register(

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -376,7 +376,7 @@ public class CliAttributeTests
     }
 
     [Test]
-    public async Task Schema2_Direct_Metadata_Rejects_Legacy_Optional_Marker_Without_Reflection()
+    public async Task Schema2_Metadata_Defers_Ambiguous_Legacy_Optional_Validation_Until_Rendering()
     {
         var optionsType = typeof(RegisteredLegacyOptionalOptions<Schema2JitMetadataMarker>);
         GeneratedCommandMetadata.Register(
@@ -397,9 +397,70 @@ public class CliAttributeTests
             ],
             schemaVersion: 2);
 
-        await Assert.That(() => new CommandModelProvider().GetCommandModel(optionsType))
+        var model = new CommandModelProvider().GetCommandModel(optionsType);
+
+        await Assert.That(() => new CommandArgumentBuilder().BuildArguments(
+                model,
+                new RegisteredLegacyOptionalOptions<Schema2JitMetadataMarker>
+                {
+                    Output = "json",
+                }))
             .Throws<InvalidOperationException>()
             .And.HasMessageContaining(nameof(CliOptionValue));
+    }
+
+    [Test]
+    public async Task Schema2_Metadata_Accepts_Supported_Optional_Type()
+    {
+        var optionsType = typeof(RegisteredCurrentOptionalOptions<Schema2CurrentOptionalMarker>);
+        GeneratedCommandMetadata.Register(
+            optionsType,
+            [
+                new OptionPart(
+                    nameof(RegisteredCurrentOptionalOptions<Schema2CurrentOptionalMarker>.Output),
+                    static options =>
+                        ((RegisteredCurrentOptionalOptions<Schema2CurrentOptionalMarker>) options).Output,
+                    new CliOptionAttribute("--output")
+                    {
+                        ValueArity = CliOptionValueArity.Optional,
+                    })
+                {
+                    AllowsLegacyOptionalValues = true,
+                    IsSupportedPropertyType = true,
+                },
+            ],
+            schemaVersion: 2);
+
+        var model = new CommandModelProvider().GetCommandModel(optionsType);
+        var arguments = new CommandArgumentBuilder().BuildArguments(
+            model,
+            new RegisteredCurrentOptionalOptions<Schema2CurrentOptionalMarker>
+            {
+                Output = "json",
+            });
+
+        await Assert.That(arguments).IsEquivalentTo(["--output", "json"]);
+    }
+
+    [Test]
+    public async Task Schema1_Metadata_Accepts_Unknown_Supported_Flag_Type()
+    {
+        var optionsType = typeof(RegisteredFlagOptions<Schema1FlagMarker>);
+        GeneratedCommandMetadata.Register(
+            optionsType,
+            [
+                new FlagPart(
+                    nameof(RegisteredFlagOptions<Schema1FlagMarker>.Force),
+                    static options => ((RegisteredFlagOptions<Schema1FlagMarker>) options).Force,
+                    new CliFlagAttribute("--force")),
+            ]);
+
+        var model = new CommandModelProvider().GetCommandModel(optionsType);
+        var arguments = new CommandArgumentBuilder().BuildArguments(
+            model,
+            new RegisteredFlagOptions<Schema1FlagMarker> { Force = true });
+
+        await Assert.That(arguments).IsEquivalentTo(["--force"]);
     }
 
     [Test]
@@ -1188,11 +1249,25 @@ public class CliAttributeTests
         public string? Output { get; init; }
     }
 
+    private sealed record RegisteredCurrentOptionalOptions<T> : CommandLineToolOptions
+    {
+        public CliOptionValue? Output { get; init; }
+    }
+
+    private sealed record RegisteredFlagOptions<T> : CommandLineToolOptions
+    {
+        public bool Force { get; init; }
+    }
+
     private sealed class Schema1MetadataMarker;
 
     private sealed class Schema2MetadataMarker;
 
     private sealed class Schema2JitMetadataMarker;
+
+    private sealed class Schema2CurrentOptionalMarker;
+
+    private sealed class Schema1FlagMarker;
 
     internal record TestCliOptionsWithDuplicateArgumentPosition : CommandLineToolOptions
     {

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -332,7 +332,7 @@ public class CliAttributeTests
     }
 
     [Test]
-    public async Task Schema2_Metadata_Revalidates_Legacy_Optional_Compatibility_Flag()
+    public async Task Schema3_Metadata_Supersedes_Legacy_Schema2_Optional_Marker()
     {
         var optionsType = typeof(RegisteredLegacyOptionalOptions<Schema2MetadataMarker>);
         GeneratedCommandMetadata.Register(
@@ -349,6 +349,23 @@ public class CliAttributeTests
                 {
                     AllowsLegacyOptionalValues = true,
                     IsSupportedPropertyType = true,
+                },
+            ],
+            schemaVersion: 2);
+        GeneratedCommandMetadata.RegisterExternal(
+            typeof(CliAttributeTests).Assembly,
+            optionsType,
+            [
+                new OptionPart(
+                    nameof(RegisteredLegacyOptionalOptions<Schema2MetadataMarker>.Output),
+                    static options =>
+                        ((RegisteredLegacyOptionalOptions<Schema2MetadataMarker>) options).Output,
+                    new CliOptionAttribute("--output")
+                    {
+                        ValueArity = CliOptionValueArity.Optional,
+                    })
+                {
+                    IsSupportedPropertyType = false,
                 },
             ],
             GeneratedCommandMetadata.CurrentSchemaVersion);

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -512,6 +512,17 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task Parser_Rejects_Unset_Generated_Legacy_Optional_Values()
+    {
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithLegacyScalarOptionalValue()))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining(nameof(CliOptionValue));
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithLegacyMultipleOptionalValues()))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining(nameof(CliOptionValue));
+    }
+
+    [Test]
     public async Task Parser_Rejects_Generated_Legacy_Scalar_Optional_String_Value()
     {
         var options = new TestCliOptionsWithLegacyScalarOptionalValue { Output = "json" };

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -376,6 +376,33 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task Schema2_Direct_Metadata_Revalidates_Legacy_Optional_Marker()
+    {
+        var optionsType = typeof(RegisteredLegacyOptionalOptions<Schema2JitMetadataMarker>);
+        GeneratedCommandMetadata.Register(
+            optionsType,
+            [
+                new OptionPart(
+                    nameof(RegisteredLegacyOptionalOptions<Schema2JitMetadataMarker>.Output),
+                    static options =>
+                        ((RegisteredLegacyOptionalOptions<Schema2JitMetadataMarker>) options).Output,
+                    new CliOptionAttribute("--output")
+                    {
+                        ValueArity = CliOptionValueArity.Optional,
+                    })
+                {
+                    AllowsLegacyOptionalValues = true,
+                    IsSupportedPropertyType = true,
+                },
+            ],
+            schemaVersion: 2);
+
+        await Assert.That(() => new CommandModelProvider().GetCommandModel(optionsType))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining(nameof(CliOptionValue));
+    }
+
+    [Test]
     public async Task Parser_Omits_Empty_Required_Option_Collections()
     {
         var options = new TestCliOptionsWithMultipleValues { Values = [] };
@@ -1164,6 +1191,8 @@ public class CliAttributeTests
     private sealed class Schema1MetadataMarker;
 
     private sealed class Schema2MetadataMarker;
+
+    private sealed class Schema2JitMetadataMarker;
 
     internal record TestCliOptionsWithDuplicateArgumentPosition : CommandLineToolOptions
     {

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -310,6 +310,28 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task Schema1_Metadata_Rejects_Unset_Legacy_Optional_String()
+    {
+        var optionsType = typeof(RegisteredLegacyOptionalOptions<Schema1MetadataMarker>);
+        GeneratedCommandMetadata.Register(
+            optionsType,
+            [
+                new OptionPart(
+                    nameof(RegisteredLegacyOptionalOptions<Schema1MetadataMarker>.Output),
+                    static options =>
+                        ((RegisteredLegacyOptionalOptions<Schema1MetadataMarker>) options).Output,
+                    new CliOptionAttribute("--output")
+                    {
+                        ValueArity = CliOptionValueArity.Optional,
+                    }),
+            ]);
+
+        await Assert.That(() => new CommandModelProvider().GetCommandModel(optionsType))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining(nameof(CliOptionValue));
+    }
+
+    [Test]
     public async Task Parser_Omits_Empty_Required_Option_Collections()
     {
         var options = new TestCliOptionsWithMultipleValues { Values = [] };
@@ -1089,6 +1111,13 @@ public class CliAttributeTests
     {
         public IReadOnlyList<CliValuePair>? Values { get; init; }
     }
+
+    private sealed record RegisteredLegacyOptionalOptions<T> : CommandLineToolOptions
+    {
+        public string? Output { get; init; }
+    }
+
+    private sealed class Schema1MetadataMarker;
 
     internal record TestCliOptionsWithDuplicateArgumentPosition : CommandLineToolOptions
     {

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -332,7 +332,7 @@ public class CliAttributeTests
     }
 
     [Test]
-    public async Task Schema2_Metadata_Ignores_Legacy_Optional_Compatibility_Flag()
+    public async Task Schema2_Metadata_Revalidates_Legacy_Optional_Compatibility_Flag()
     {
         var optionsType = typeof(RegisteredLegacyOptionalOptions<Schema2MetadataMarker>);
         GeneratedCommandMetadata.Register(
@@ -348,7 +348,7 @@ public class CliAttributeTests
                     })
                 {
                     AllowsLegacyOptionalValues = true,
-                    IsSupportedPropertyType = false,
+                    IsSupportedPropertyType = true,
                 },
             ],
             GeneratedCommandMetadata.CurrentSchemaVersion);


### PR DESCRIPTION
## Summary
- remove reflection-based compatibility for generated string optional CLI values
- require CliOptionValue for every optional CLI value
- synchronize stale Helm, Pulumi, and Podman generated option artifacts with the generator contract
- update regression tests to reject legacy generated string properties

## Validation
- targeted dotnet format passed
- Helm solution Release build passed
- Helm unit tests passed (3/3)
- static scan confirms every generated optional property uses CliOptionValue and no legacy helper remains
- core test build is blocked on current main by RunReportTests references to removed PipelineOptions.PrintLogo and PrintResults
- Pulumi and Podman solution builds exceeded the 2 GB agent guard; CI will perform those checks

Closes #3777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optional command-line values now require the supported `CliOptionValue` format.
  * Legacy string-based optional values are rejected with a clear error message instead of being accepted or rendered.
  * Invalid values inherited from generated base types are also rejected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->