### PR TITLE
Validate command models eagerly

### DIFF
--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -825,6 +825,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     0,
                     property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                     false,
+                    false,
                     false));
             }
         }
@@ -885,7 +886,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 0,
                 property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 false,
-                false);
+                false,
+                attribute.ConstructorArguments.Length > 0);
         }
 
         if (attributeName == CliFlagAttributeFullName)
@@ -907,6 +909,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 0,
                 property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 IsSupportedFlagType(property.Type),
+                false,
                 false);
         }
 
@@ -928,7 +931,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             GetManualOperandCount(property.Type),
             property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
             IsSupportedOptionalValueType(property.Type, allowsLegacyOptionalValues),
-            allowsLegacyOptionalValues);
+            allowsLegacyOptionalValues,
+            false);
     }
 
     private static bool IsSupportedFlagType(ITypeSymbol propertyType)
@@ -1313,7 +1317,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     sb.AppendLine($"                        PrependOptionTerminator = {BooleanLiteral(property.BooleanValue)},");
                     sb.AppendLine($"                        PrependOptionTerminatorIfValueStartsWithDash = {BooleanLiteral(property.PrependOptionTerminatorIfValueStartsWithDash)},");
                     sb.AppendLine($"                        Required = {BooleanLiteral(property.IsRequired)},");
-                    sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)} }},");
+                    sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)}, HasExplicitPosition = {BooleanLiteral(property.HasExplicitArgumentPosition)} }},");
                     break;
                 case PropertyKind.Flag:
                     sb.AppendLine("                new global::ModularPipelines.Helpers.Internal.FlagPart(");
@@ -2073,7 +2077,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         int ManualOperandCount,
         string AccessorTypeName,
         bool IsSupportedPropertyType,
-        bool AllowsLegacyOptionalValues);
+        bool AllowsLegacyOptionalValues,
+        bool HasExplicitArgumentPosition);
 
     private enum PropertyKind
     {

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -14,7 +14,9 @@ namespace ModularPipelines.SourceGenerator;
 public sealed class CommandOptionsGenerator : IIncrementalGenerator
 {
     private const int RuntimeMetadataSchemaVersion = 1;
+    private const string CliOptionValueFullName = "ModularPipelines.Models.CliOptionValue";
     private const string CliValuePairFullName = "ModularPipelines.Models.CliValuePair";
+    private const string GeneratedCodeAttributeFullName = "System.CodeDom.Compiler.GeneratedCodeAttribute";
 
     internal const string CommandLineToolOptionsFullName = "ModularPipelines.Options.CommandLineToolOptions";
     internal const string OptionsNamespace = "Microsoft.Extensions.Options";
@@ -821,7 +823,9 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     false,
                     false,
                     0,
-                    property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+                    property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                    false,
+                    false));
             }
         }
 
@@ -879,7 +883,9 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 GetNamedBool(attribute, "PrependOptionTerminatorIfValueStartsWithDash"),
                 isGlobalOption,
                 0,
-                property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+                property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                false,
+                false);
         }
 
         if (attributeName == CliFlagAttributeFullName)
@@ -899,9 +905,12 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                 false,
                 isGlobalOption,
                 0,
-                property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+                property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                IsSupportedFlagType(property.Type),
+                false);
         }
 
+        var allowsLegacyOptionalValues = IsLegacyGeneratedOption(property);
         return new PropertyMetadata(
             property.Name,
             PropertyKind.Option,
@@ -917,8 +926,61 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             false,
             isGlobalOption,
             GetManualOperandCount(property.Type),
-            property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+            property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+            IsSupportedOptionalValueType(property.Type, allowsLegacyOptionalValues),
+            allowsLegacyOptionalValues);
     }
+
+    private static bool IsSupportedFlagType(ITypeSymbol propertyType)
+    {
+        propertyType = UnwrapNullable(propertyType);
+        return propertyType.SpecialType is SpecialType.System_Boolean or SpecialType.System_Int32;
+    }
+
+    private static bool IsSupportedOptionalValueType(
+        ITypeSymbol propertyType,
+        bool allowsLegacyOptionalValues)
+    {
+        propertyType = UnwrapNullable(propertyType);
+        return IsType(propertyType, CliOptionValueFullName)
+               || IsEnumerableOf(propertyType, CliOptionValueFullName)
+               || (allowsLegacyOptionalValues
+                   && (propertyType.SpecialType == SpecialType.System_String
+                       || IsEnumerableOf(propertyType, "string")));
+    }
+
+    private static bool IsEnumerableOf(ITypeSymbol propertyType, string elementTypeName)
+    {
+        if (propertyType is IArrayTypeSymbol arrayType)
+        {
+            return IsType(arrayType.ElementType, elementTypeName);
+        }
+
+        return propertyType is INamedTypeSymbol namedType
+               && namedType.AllInterfaces
+                   .Append(namedType)
+                   .Any(type => type.OriginalDefinition.SpecialType
+                                == SpecialType.System_Collections_Generic_IEnumerable_T
+                                && IsType(type.TypeArguments[0], elementTypeName));
+    }
+
+    private static bool IsType(ITypeSymbol type, string typeName) =>
+        typeName == "string"
+            ? type.SpecialType == SpecialType.System_String
+            : type.WithNullableAnnotation(NullableAnnotation.None).ToDisplayString() == typeName;
+
+    private static ITypeSymbol UnwrapNullable(ITypeSymbol propertyType) =>
+        propertyType is INamedTypeSymbol nullableType
+        && nullableType.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+        && nullableType.TypeArguments.Length == 1
+            ? nullableType.TypeArguments[0]
+            : propertyType;
+
+    private static bool IsLegacyGeneratedOption(IPropertySymbol property) =>
+        property.ContainingType.GetAttributes().Any(static attribute =>
+            attribute.AttributeClass?.ToDisplayString() == GeneratedCodeAttributeFullName
+            && attribute.ConstructorArguments.FirstOrDefault().Value as string
+                == "ModularPipelines.OptionsGenerator");
 
     private static int GetManualOperandCount(ITypeSymbol propertyType)
     {
@@ -1261,7 +1323,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     sb.AppendLine($"                        ShortForm = {NullableLiteral(property.ShortForm)},");
                     sb.AppendLine($"                        PreferShortForm = {BooleanLiteral(property.BooleanValue)},");
                     sb.AppendLine($"                        Phase = global::ModularPipelines.Attributes.CommandLinePhase.{property.Phase},");
-                    sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)} }},");
+                    sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)}, IsSupportedPropertyType = {BooleanLiteral(property.IsSupportedPropertyType)} }},");
                     break;
                 case PropertyKind.Option:
                     sb.AppendLine("                new global::ModularPipelines.Helpers.Internal.OptionPart(");
@@ -1274,7 +1336,7 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
                     sb.AppendLine($"                        ValueArity = (global::ModularPipelines.Attributes.CliOptionValueArity){property.ValueArity},");
                     sb.AppendLine($"                        GroupValues = {BooleanLiteral(property.GroupValues)},");
                     sb.AppendLine($"                        Phase = global::ModularPipelines.Attributes.CommandLinePhase.{property.Phase},");
-                    sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)}, ManualOperandCount = {property.ManualOperandCount} }},");
+                    sb.AppendLine($"                    }}) {{ IsGlobalOption = {BooleanLiteral(property.IsGlobalOption)}, ManualOperandCount = {property.ManualOperandCount}, AllowsLegacyOptionalValues = {BooleanLiteral(property.AllowsLegacyOptionalValues)}, IsSupportedPropertyType = {BooleanLiteral(property.IsSupportedPropertyType)} }},");
                     break;
             }
         }
@@ -2009,7 +2071,9 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
         bool PrependOptionTerminatorIfValueStartsWithDash,
         bool IsGlobalOption,
         int ManualOperandCount,
-        string AccessorTypeName);
+        string AccessorTypeName,
+        bool IsSupportedPropertyType,
+        bool AllowsLegacyOptionalValues);
 
     private enum PropertyKind
     {

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -13,7 +13,7 @@ namespace ModularPipelines.SourceGenerator;
 [Generator]
 public sealed class CommandOptionsGenerator : IIncrementalGenerator
 {
-    private const int RuntimeMetadataSchemaVersion = 1;
+    private const int RuntimeMetadataSchemaVersion = 2;
     private const string CliOptionValueFullName = "ModularPipelines.Models.CliOptionValue";
     private const string CliValuePairFullName = "ModularPipelines.Models.CliValuePair";
     private const string GeneratedCodeAttributeFullName = "System.CodeDom.Compiler.GeneratedCodeAttribute";
@@ -1345,7 +1345,8 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             }
         }
 
-        sb.AppendLine("            });");
+        sb.AppendLine("            },");
+        sb.AppendLine($"            {RuntimeMetadataSchemaVersion});");
     }
 
     private static void AppendSecretRegistration(StringBuilder sb, TypeMetadata item)

--- a/src/ModularPipelines.SourceGenerator/GeneratedOptionsRegistrationAnalyzer.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratedOptionsRegistrationAnalyzer.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace ModularPipelines.SourceGenerator;
 
@@ -269,10 +270,37 @@ public sealed class GeneratedOptionsRegistrationAnalyzer : DiagnosticAnalyzer
         {
             "RegisterCommandOptions" when method.Parameters.Length == 3
                                           && method.Parameters[2].Type.SpecialType
-                                          == SpecialType.System_Int32 => MetadataCoverage.CommandOptions,
+                                          == SpecialType.System_Int32
+                                          && HasCurrentCommandMetadataSchemaVersion(
+                                              context,
+                                              invocation,
+                                              method) => MetadataCoverage.CommandOptions,
             "RegisterSecrets" => MetadataCoverage.Secrets,
             _ => MetadataCoverage.None,
         };
+    }
+
+    private static bool HasCurrentCommandMetadataSchemaVersion(
+        SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax invocation,
+        IMethodSymbol method)
+    {
+        if (context.SemanticModel.GetOperation(invocation, context.CancellationToken)
+                is not IInvocationOperation invocationOperation
+            || invocationOperation.Arguments.FirstOrDefault(
+                static argument => argument.Parameter?.Ordinal == 2) is not { } schemaArgument
+            || !schemaArgument.Value.ConstantValue.HasValue
+            || schemaArgument.Value.ConstantValue.Value is not int registeredSchemaVersion)
+        {
+            return false;
+        }
+
+        return method.ContainingType
+                   .GetMembers("CurrentCommandMetadataSchemaVersion")
+                   .OfType<IFieldSymbol>()
+                   .FirstOrDefault(static field => field.HasConstantValue)
+                   ?.ConstantValue is int currentSchemaVersion
+               && registeredSchemaVersion == currentSchemaVersion;
     }
 
     private static MetadataCoverage GetRequiredCoverage(ITypeSymbol type) =>

--- a/src/ModularPipelines.SourceGenerator/GeneratedOptionsRegistrationAnalyzer.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratedOptionsRegistrationAnalyzer.cs
@@ -267,7 +267,9 @@ public sealed class GeneratedOptionsRegistrationAnalyzer : DiagnosticAnalyzer
 
         return method.Name switch
         {
-            "RegisterCommandOptions" => MetadataCoverage.CommandOptions,
+            "RegisterCommandOptions" when method.Parameters.Length == 3
+                                          && method.Parameters[2].Type.SpecialType
+                                          == SpecialType.System_Int32 => MetadataCoverage.CommandOptions,
             "RegisterSecrets" => MetadataCoverage.Secrets,
             _ => MetadataCoverage.None,
         };

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -303,6 +303,14 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         object rawValue,
         Type optionsType)
     {
+        if (optionPart.Attribute.GroupValues
+            && optionPart.Attribute.Format != OptionFormat.SpaceSeparated)
+        {
+            throw new InvalidOperationException(
+                $"Grouped CLI option property '{optionsType.FullName}.{optionPart.PropertyName}' "
+                + "must use OptionFormat.SpaceSeparated.");
+        }
+
         if (optionPart.Attribute.ValueArity == CliOptionValueArity.Optional)
         {
             if (optionPart.Attribute.GroupValues)
@@ -318,6 +326,14 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         }
 
         var valuePairs = GetOptionValuePairs(rawValue);
+        if (valuePairs is not null
+            && optionPart.Attribute.Format != OptionFormat.SpaceSeparated)
+        {
+            throw new InvalidOperationException(
+                $"CliValuePair CLI option property '{optionsType.FullName}.{optionPart.PropertyName}' "
+                + "must use OptionFormat.SpaceSeparated.");
+        }
+
         if (optionPart.Attribute.GroupValues)
         {
             var groupedValues = valuePairs is null

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -412,11 +412,6 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
                 $"Grouped option '{GetEffectiveName(optionPart.Attribute)}' must use a space separator.");
         }
 
-        foreach (var optionValue in optionValues.Where(static value => !value.IsBare))
-        {
-            ValidateOptionalValue(optionValue, optionsType, optionPart);
-        }
-
         args.Add(GetEffectiveName(optionPart.Attribute));
         args.AddRange(optionValues
             .Where(static value => !value.IsBare)

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -303,13 +303,7 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         object rawValue,
         Type optionsType)
     {
-        if (optionPart.Attribute.GroupValues
-            && optionPart.Attribute.Format != OptionFormat.SpaceSeparated)
-        {
-            throw new InvalidOperationException(
-                $"Grouped CLI option property '{optionsType.FullName}.{optionPart.PropertyName}' "
-                + "must use OptionFormat.SpaceSeparated.");
-        }
+        ValidateGroupedOptionFormat(optionPart, optionsType);
 
         if (optionPart.Attribute.ValueArity == CliOptionValueArity.Optional)
         {
@@ -326,13 +320,7 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         }
 
         var valuePairs = GetOptionValuePairs(rawValue);
-        if (valuePairs is not null
-            && optionPart.Attribute.Format != OptionFormat.SpaceSeparated)
-        {
-            throw new InvalidOperationException(
-                $"CliValuePair CLI option property '{optionsType.FullName}.{optionPart.PropertyName}' "
-                + "must use OptionFormat.SpaceSeparated.");
-        }
+        ValidateValuePairOptionFormat(optionPart, valuePairs, optionsType);
 
         if (optionPart.Attribute.GroupValues)
         {
@@ -349,7 +337,40 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
             return;
         }
 
-        var values = GetValues(rawValue);
+        AddRequiredOptionValues(args, optionPart, GetValues(rawValue), optionsType);
+    }
+
+    private static void ValidateGroupedOptionFormat(OptionPart optionPart, Type optionsType)
+    {
+        if (optionPart.Attribute.GroupValues
+            && optionPart.Attribute.Format != OptionFormat.SpaceSeparated)
+        {
+            throw new InvalidOperationException(
+                $"Grouped CLI option property '{optionsType.FullName}.{optionPart.PropertyName}' "
+                + "must use OptionFormat.SpaceSeparated.");
+        }
+    }
+
+    private static void ValidateValuePairOptionFormat(
+        OptionPart optionPart,
+        IEnumerable<CliValuePair>? valuePairs,
+        Type optionsType)
+    {
+        if (valuePairs is not null
+            && optionPart.Attribute.Format != OptionFormat.SpaceSeparated)
+        {
+            throw new InvalidOperationException(
+                $"CliValuePair CLI option property '{optionsType.FullName}.{optionPart.PropertyName}' "
+                + "must use OptionFormat.SpaceSeparated.");
+        }
+    }
+
+    private static void AddRequiredOptionValues(
+        List<string> args,
+        OptionPart optionPart,
+        IReadOnlyCollection<string> values,
+        Type optionsType)
+    {
         if (values.Count == 0)
         {
             return;

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -375,6 +375,11 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
                 $"Grouped option '{GetEffectiveName(optionPart.Attribute)}' must use a space separator.");
         }
 
+        foreach (var optionValue in optionValues.Where(static value => !value.IsBare))
+        {
+            ValidateOptionalValue(optionValue, optionsType, optionPart);
+        }
+
         args.Add(GetEffectiveName(optionPart.Attribute));
         args.AddRange(optionValues
             .Where(static value => !value.IsBare)
@@ -386,7 +391,9 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         Type optionsType,
         OptionPart optionPart)
     {
-        var isLegacyGeneratedOption = IsLegacyGeneratedOption(optionsType, optionPart);
+        var isLegacyGeneratedOption = optionPart.AllowsLegacyOptionalValues
+                                      || (optionPart.IsSupportedPropertyType is null
+                                          && IsLegacyGeneratedOption(optionsType, optionPart));
         return rawValue switch
         {
             CliOptionValue optionValue => [optionValue],
@@ -472,12 +479,6 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         IEnumerable<string?> values,
         Type optionsType)
     {
-        if (GetSeparator(optionPart.Attribute) != " ")
-        {
-            throw new InvalidOperationException(
-                $"Grouped option '{GetEffectiveName(optionPart.Attribute)}' must use a space separator.");
-        }
-
         var renderedValues = values.ToList();
         if (renderedValues.Count == 0)
         {
@@ -509,13 +510,6 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         IEnumerable<CliValuePair> pairs,
         Type optionsType)
     {
-        if (GetSeparator(optionPart.Attribute) != " ")
-        {
-            throw new InvalidOperationException(
-                $"Two-operand CLI option property '{optionPart.PropertyName}' must use "
-                + $"{nameof(OptionFormat)}.{nameof(OptionFormat.SpaceSeparated)}.");
-        }
-
         var optionName = GetEffectiveName(optionPart.Attribute);
         foreach (var pair in pairs)
         {

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -213,20 +213,23 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         Type optionsType,
         IReadOnlyList<PropertyCommandLinePart> parts)
     {
-        var positions = new Dictionary<(bool IsGlobalScope, CommandLinePhase Phase, int Position), string>();
-        foreach (var argument in parts.OfType<ArgumentPart>().Where(static argument => argument.HasExplicitPosition))
+        var positions = new Dictionary<
+            (bool IsGlobalScope, CommandLinePhase Phase, int Position),
+            (string PropertyName, bool HasExplicitPosition)>();
+        foreach (var argument in parts.OfType<ArgumentPart>())
         {
             var isGlobalScope = argument.Phase != CommandLinePhase.Terminal && argument.IsGlobalOption;
             var key = (isGlobalScope, argument.Phase, argument.Attribute.Position);
-            if (positions.TryGetValue(key, out var existingProperty))
+            if (positions.TryGetValue(key, out var existing)
+                && (existing.HasExplicitPosition || argument.HasExplicitPosition))
             {
                 throw new InvalidOperationException(
                     $"{optionsType.Name} defines CLI argument position {argument.Attribute.Position} "
                     + $"more than once in phase {argument.Phase} on properties "
-                    + $"'{existingProperty}' and '{argument.PropertyName}'.");
+                    + $"'{existing.PropertyName}' and '{argument.PropertyName}'.");
             }
 
-            positions.Add(key, argument.PropertyName);
+            positions.TryAdd(key, (argument.PropertyName, argument.HasExplicitPosition));
         }
     }
 

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -51,6 +51,9 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 parts.Add(new ArgumentPart(property.Name, property.GetValue, argument)
                 {
                     IsGlobalOption = IsGlobalOption(property),
+                    HasExplicitPosition = property.CustomAttributes.Any(static attribute =>
+                        attribute.AttributeType == typeof(CliArgumentAttribute)
+                        && attribute.ConstructorArguments.Count > 0),
                 });
             }
             else if (property.GetCustomAttribute<CliFlagAttribute>() is { } flag)
@@ -185,10 +188,10 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         Type optionsType,
         IReadOnlyList<PropertyCommandLinePart> parts)
     {
-        var positions = new Dictionary<(CommandLinePhase Phase, int Position), string>();
-        foreach (var argument in parts.OfType<ArgumentPart>())
+        var positions = new Dictionary<(bool IsGlobalOption, CommandLinePhase Phase, int Position), string>();
+        foreach (var argument in parts.OfType<ArgumentPart>().Where(static argument => argument.HasExplicitPosition))
         {
-            var key = (argument.Phase, argument.Attribute.Position);
+            var key = (argument.IsGlobalOption, argument.Phase, argument.Attribute.Position);
             if (positions.TryGetValue(key, out var existingProperty))
             {
                 throw new InvalidOperationException(

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -51,9 +51,7 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 parts.Add(new ArgumentPart(property.Name, property.GetValue, argument)
                 {
                     IsGlobalOption = IsGlobalOption(property),
-                    HasExplicitPosition = property.CustomAttributes.Any(static attribute =>
-                        attribute.AttributeType == typeof(CliArgumentAttribute)
-                        && attribute.ConstructorArguments.Count > 0),
+                    HasExplicitPosition = HasExplicitArgumentPosition(property),
                 });
             }
             else if (property.GetCustomAttribute<CliFlagAttribute>() is { } flag)
@@ -143,6 +141,33 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 && declaredProperty?.GetMethod?.GetBaseDefinition().Equals(baseAccessor) == true)
             {
                 return true;
+            }
+        }
+
+        return false;
+    }
+
+    [RequiresUnreferencedCode("Reflection fallback requires CLI-attributed properties.")]
+    private static bool HasExplicitArgumentPosition(PropertyInfo property)
+    {
+        var baseAccessor = property.GetMethod?.GetBaseDefinition();
+        for (var currentType = property.DeclaringType; currentType is not null; currentType = currentType.BaseType)
+        {
+            var declaredProperty = currentType == property.DeclaringType
+                ? property
+                : currentType.GetProperty(
+                    property.Name,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            if (declaredProperty?.GetMethod?.GetBaseDefinition().Equals(baseAccessor) != true)
+            {
+                continue;
+            }
+
+            var argument = declaredProperty.CustomAttributes.FirstOrDefault(static attribute =>
+                attribute.AttributeType == typeof(CliArgumentAttribute));
+            if (argument is not null)
+            {
+                return argument.ConstructorArguments.Count > 0;
             }
         }
 

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -188,10 +188,11 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         Type optionsType,
         IReadOnlyList<PropertyCommandLinePart> parts)
     {
-        var positions = new Dictionary<(bool IsGlobalOption, CommandLinePhase Phase, int Position), string>();
+        var positions = new Dictionary<(bool IsGlobalScope, CommandLinePhase Phase, int Position), string>();
         foreach (var argument in parts.OfType<ArgumentPart>().Where(static argument => argument.HasExplicitPosition))
         {
-            var key = (argument.IsGlobalOption, argument.Phase, argument.Attribute.Position);
+            var isGlobalScope = argument.Phase != CommandLinePhase.Terminal && argument.IsGlobalOption;
+            var key = (isGlobalScope, argument.Phase, argument.Attribute.Position);
             if (positions.TryGetValue(key, out var existingProperty))
             {
                 throw new InvalidOperationException(

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -1,3 +1,4 @@
+using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -34,7 +35,7 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 model = BuildModel(type);
             }
 
-            ValidateUniqueSwitches(type, model);
+            ValidateModel(type, model);
             return new CommandModel(model);
         }).Value;
     }
@@ -57,14 +58,20 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                 parts.Add(new FlagPart(property.Name, property.GetValue, flag)
                 {
                     IsGlobalOption = IsGlobalOption(property),
+                    IsSupportedPropertyType = IsSupportedFlagType(property.PropertyType),
                 });
             }
             else if (property.GetCustomAttribute<CliOptionAttribute>() is { } option)
             {
+                var allowsLegacyOptionalValues = IsLegacyGeneratedOption(property);
                 parts.Add(new OptionPart(property.Name, property.GetValue, option)
                 {
                     IsGlobalOption = IsGlobalOption(property),
                     ManualOperandCount = GetManualOperandCount(property.PropertyType),
+                    AllowsLegacyOptionalValues = allowsLegacyOptionalValues,
+                    IsSupportedPropertyType = IsSupportedOptionalValueType(
+                        property.PropertyType,
+                        allowsLegacyOptionalValues),
                 });
             }
         }
@@ -137,6 +144,88 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         }
 
         return false;
+    }
+
+    private static bool IsSupportedFlagType(Type propertyType)
+    {
+        propertyType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+        return propertyType == typeof(bool) || propertyType == typeof(int);
+    }
+
+    private static bool IsSupportedOptionalValueType(
+        Type propertyType,
+        bool allowsLegacyOptionalValues)
+    {
+        propertyType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+        return propertyType == typeof(ModularPipelines.Models.CliOptionValue)
+               || propertyType.IsAssignableTo(typeof(IEnumerable<ModularPipelines.Models.CliOptionValue>))
+               || (allowsLegacyOptionalValues
+                   && (propertyType == typeof(string)
+                       || propertyType.IsAssignableTo(typeof(IEnumerable<string>))));
+    }
+
+    private static bool IsLegacyGeneratedOption(PropertyInfo property) =>
+        property.DeclaringType?.GetCustomAttribute<GeneratedCodeAttribute>(inherit: false)?.Tool
+        == "ModularPipelines.OptionsGenerator";
+
+    private static void ValidateModel(
+        Type optionsType,
+        IReadOnlyList<PropertyCommandLinePart> parts)
+    {
+        ValidateUniqueSwitches(optionsType, parts);
+        ValidateUniqueArgumentPositions(optionsType, parts);
+
+        foreach (var part in parts)
+        {
+            ValidateProperty(optionsType, part);
+        }
+    }
+
+    private static void ValidateUniqueArgumentPositions(
+        Type optionsType,
+        IReadOnlyList<PropertyCommandLinePart> parts)
+    {
+        var positions = new Dictionary<(CommandLinePhase Phase, int Position), string>();
+        foreach (var argument in parts.OfType<ArgumentPart>())
+        {
+            var key = (argument.Phase, argument.Attribute.Position);
+            if (positions.TryGetValue(key, out var existingProperty))
+            {
+                throw new InvalidOperationException(
+                    $"{optionsType.Name} defines CLI argument position {argument.Attribute.Position} "
+                    + $"more than once in phase {argument.Phase} on properties "
+                    + $"'{existingProperty}' and '{argument.PropertyName}'.");
+            }
+
+            positions.Add(key, argument.PropertyName);
+        }
+    }
+
+    private static void ValidateProperty(Type optionsType, PropertyCommandLinePart part)
+    {
+        var propertyName = $"{optionsType.FullName ?? optionsType.Name}.{part.PropertyName}";
+        switch (part)
+        {
+            case FlagPart { IsSupportedPropertyType: false }:
+                throw new InvalidOperationException(
+                    $"CLI flag property '{propertyName}' must use bool, bool?, int, or int?.");
+            case OptionPart { Attribute.GroupValues: true } groupedOption
+                when groupedOption.Attribute.Format != OptionFormat.SpaceSeparated:
+                throw new InvalidOperationException(
+                    $"Grouped CLI option property '{propertyName}' must use OptionFormat.SpaceSeparated.");
+            case OptionPart { ManualOperandCount: 2 } valuePairOption
+                when valuePairOption.Attribute.Format != OptionFormat.SpaceSeparated:
+                throw new InvalidOperationException(
+                    $"CliValuePair CLI option property '{propertyName}' must use OptionFormat.SpaceSeparated.");
+            case OptionPart
+            {
+                Attribute.ValueArity: CliOptionValueArity.Optional,
+                IsSupportedPropertyType: false,
+            }:
+                throw new InvalidOperationException(
+                    $"Optional-value CLI option property '{propertyName}' must use "
+                    + "CliOptionValue or IEnumerable<CliOptionValue>.");
+        }
     }
 
     private static void ValidateUniqueSwitches(

--- a/src/ModularPipelines/Helpers/Internal/GeneratedCommandMetadata.cs
+++ b/src/ModularPipelines/Helpers/Internal/GeneratedCommandMetadata.cs
@@ -10,6 +10,8 @@ namespace ModularPipelines.Helpers.Internal;
 /// </summary>
 public static class GeneratedCommandMetadata
 {
+    internal const int CurrentSchemaVersion = 2;
+
     private static readonly ConditionalWeakTable<Type, CommandMetadata> Models = [];
     private static readonly ConditionalWeakTable<Assembly, ProcessedAssembly> ProcessedAssemblies = [];
     private static readonly ConditionalWeakTable<Assembly, ExternalCommandMetadata> ExternalModels = [];
@@ -56,14 +58,26 @@ public static class GeneratedCommandMetadata
     }
 
     /// <summary>
-    /// Registers the generated command model for an options type.
+    /// Preserves the schema-1 registration signature emitted by earlier generator versions.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static void Register(
         Type optionsType,
         IReadOnlyList<PropertyCommandLinePart> model)
     {
-        RegisterCore(optionsType, model, isComplete: true, isLegacy: false);
+        RegisterCore(optionsType, model, isComplete: true, schemaVersion: 1);
+    }
+
+    /// <summary>
+    /// Registers the generated command model and its metadata schema version.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void Register(
+        Type optionsType,
+        IReadOnlyList<PropertyCommandLinePart> model,
+        int schemaVersion)
+    {
+        RegisterCore(optionsType, model, isComplete: true, schemaVersion);
     }
 
     /// <summary>
@@ -75,18 +89,18 @@ public static class GeneratedCommandMetadata
         IReadOnlyList<PropertyCommandLinePart> model,
         bool isComplete = true)
     {
-        RegisterCore(optionsType, model, isComplete, isLegacy: true);
+        RegisterCore(optionsType, model, isComplete, schemaVersion: 0);
     }
 
     private static void RegisterCore(
         Type optionsType,
         IReadOnlyList<PropertyCommandLinePart> model,
         bool isComplete,
-        bool isLegacy)
+        int schemaVersion)
     {
         try
         {
-            Models.Add(optionsType, new CommandMetadata(model, isComplete, isLegacy));
+            Models.Add(optionsType, new CommandMetadata(model, isComplete, schemaVersion));
         }
         catch (ArgumentException exception)
         {
@@ -97,8 +111,7 @@ public static class GeneratedCommandMetadata
     }
 
     /// <summary>
-    /// Registers command metadata emitted by a consuming assembly for an external options type.
-    /// Registrations are scoped weakly to the consumer so collectible assemblies are not retained.
+    /// Preserves the schema-1 external registration signature emitted by earlier generator versions.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static void RegisterExternal(
@@ -106,18 +119,31 @@ public static class GeneratedCommandMetadata
         Type optionsType,
         IReadOnlyList<PropertyCommandLinePart> model)
     {
+        RegisterExternal(consumerAssembly, optionsType, model, schemaVersion: 1);
+    }
+
+    /// <summary>
+    /// Registers versioned command metadata emitted by a consuming assembly for an external options type.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static void RegisterExternal(
+        Assembly consumerAssembly,
+        Type optionsType,
+        IReadOnlyList<PropertyCommandLinePart> model,
+        int schemaVersion)
+    {
         var registrations = ExternalModels.GetValue(
             consumerAssembly,
             static _ => new ExternalCommandMetadata());
         registrations.Models.TryAdd(
             optionsType,
-            new CommandMetadata(model, IsComplete: true, IsLegacy: false));
+            new CommandMetadata(model, IsComplete: true, schemaVersion));
     }
 
     internal static bool TryGet(Type optionsType, out IReadOnlyList<PropertyCommandLinePart> model)
     {
         Models.TryGetValue(optionsType, out var directMetadata);
-        if (directMetadata is { IsComplete: true, IsLegacy: false })
+        if (directMetadata is { IsComplete: true, SchemaVersion: CurrentSchemaVersion })
         {
             model = directMetadata.Model;
             return true;
@@ -126,7 +152,7 @@ public static class GeneratedCommandMetadata
         foreach (var registrations in ExternalModels)
         {
             if (registrations.Value.Models.TryGetValue(optionsType, out var metadata)
-                && metadata.IsComplete)
+                && metadata is { IsComplete: true, SchemaVersion: CurrentSchemaVersion })
             {
                 model = metadata.Model;
                 return true;
@@ -161,7 +187,7 @@ public static class GeneratedCommandMetadata
     private sealed record CommandMetadata(
         IReadOnlyList<PropertyCommandLinePart> Model,
         bool IsComplete,
-        bool IsLegacy);
+        int SchemaVersion);
 
     private sealed class ExternalCommandMetadata
     {

--- a/src/ModularPipelines/Helpers/Internal/PropertyCommandLinePart.cs
+++ b/src/ModularPipelines/Helpers/Internal/PropertyCommandLinePart.cs
@@ -31,6 +31,11 @@ public sealed record ArgumentPart(
     Func<object, object?> Getter,
     CliArgumentAttribute Attribute) : PropertyCommandLinePart(PropertyName, Getter)
 {
+    /// <summary>
+    /// Gets a value indicating whether the argument position was explicitly supplied.
+    /// </summary>
+    public bool HasExplicitPosition { get; init; }
+
     /// <inheritdoc />
     public override CommandLinePhase Phase => Attribute.Phase;
 }

--- a/src/ModularPipelines/Helpers/Internal/PropertyCommandLinePart.cs
+++ b/src/ModularPipelines/Helpers/Internal/PropertyCommandLinePart.cs
@@ -8,6 +8,11 @@ namespace ModularPipelines.Helpers.Internal;
 public abstract record PropertyCommandLinePart(string PropertyName, Func<object, object?> Getter)
 {
     /// <summary>
+    /// Gets whether the property's type is supported by its CLI attribute, when known.
+    /// </summary>
+    public bool? IsSupportedPropertyType { get; init; }
+
+    /// <summary>
     /// Gets a value indicating whether the property belongs before command parts.
     /// </summary>
     public bool IsGlobalOption { get; init; }
@@ -50,6 +55,11 @@ public sealed record OptionPart(
     Func<object, object?> Getter,
     CliOptionAttribute Attribute) : PropertyCommandLinePart(PropertyName, Getter)
 {
+    /// <summary>
+    /// Gets a value indicating whether legacy generated string optional values are supported.
+    /// </summary>
+    public bool AllowsLegacyOptionalValues { get; init; }
+
     /// <summary>
     /// Gets the number of separate operands consumed by one manual occurrence of this option.
     /// </summary>

--- a/src/ModularPipelines/Metadata/RuntimeMetadataRegistry.cs
+++ b/src/ModularPipelines/Metadata/RuntimeMetadataRegistry.cs
@@ -16,6 +16,11 @@ namespace ModularPipelines.Metadata;
 public static class RuntimeMetadataRegistry
 {
     /// <summary>
+    /// Gets the command metadata schema required by this runtime.
+    /// </summary>
+    public const int CurrentCommandMetadataSchemaVersion = GeneratedCommandMetadata.CurrentSchemaVersion;
+
+    /// <summary>
     /// Registers command metadata for a type emitted by another source generator.
     /// </summary>
     /// <param name="optionsType">The exact generated options type.</param>
@@ -27,6 +32,22 @@ public static class RuntimeMetadataRegistry
         ArgumentNullException.ThrowIfNull(optionsType);
         ArgumentNullException.ThrowIfNull(model);
         GeneratedCommandMetadata.Register(optionsType, model);
+    }
+
+    /// <summary>
+    /// Registers versioned command metadata for a type emitted by another source generator.
+    /// </summary>
+    /// <param name="optionsType">The exact generated options type.</param>
+    /// <param name="model">The generated command-property model.</param>
+    /// <param name="schemaVersion">The metadata schema used to create <paramref name="model"/>.</param>
+    public static void RegisterCommandOptions(
+        Type optionsType,
+        IReadOnlyList<PropertyCommandLinePart> model,
+        int schemaVersion)
+    {
+        ArgumentNullException.ThrowIfNull(optionsType);
+        ArgumentNullException.ThrowIfNull(model);
+        GeneratedCommandMetadata.Register(optionsType, model, schemaVersion);
     }
 
     /// <summary>

--- a/test/ModularPipelines.SourceGenerator.UnitTests/GeneratedOptionsRegistrationAnalyzerTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/GeneratedOptionsRegistrationAnalyzerTests.cs
@@ -191,6 +191,49 @@ public class GeneratedOptionsRegistrationAnalyzerTests
     }
 
     [Test]
+    public async Task Trimmed_Host_Rejects_Stale_Peer_Command_Metadata_Schema()
+    {
+        var diagnostics = await GeneratorTestHarness.RunWithPeerGeneratorAndAnalyzer(
+            new CommandOptionsGenerator(),
+            new PeerSourceGenerator(
+                "StalePeerCommandOptions.cs",
+                """
+                using ModularPipelines.Metadata;
+                using ModularPipelines.Options;
+
+                public sealed class StalePeerCommandOptions : CommandLineToolOptions;
+
+                public static class StalePeerRegistration
+                {
+                    public static void Add()
+                    {
+                        RuntimeMetadataRegistry.RegisterCommandOptions(
+                            typeof(StalePeerCommandOptions),
+                            new object(),
+                            1);
+                        RuntimeMetadataRegistry.RegisterSecrets(
+                            typeof(StalePeerCommandOptions),
+                            new object());
+                    }
+                }
+                """),
+            new GeneratedOptionsRegistrationAnalyzer(),
+            Infrastructure,
+            "public sealed class Host;",
+            new Dictionary<string, string>
+            {
+                ["build_property.PublishAot"] = "true",
+            });
+
+        var diagnostic = diagnostics.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(diagnostic.Id).IsEqualTo("MPG0017");
+            await Assert.That(diagnostic.GetMessage()).Contains("StalePeerCommandOptions");
+        }
+    }
+
+    [Test]
     public async Task Trimmed_Host_Rejects_Direct_Peer_Generated_Command_Options()
     {
         var diagnostics = await GeneratorTestHarness.RunWithPeerGeneratorAndAnalyzer(

--- a/test/ModularPipelines.SourceGenerator.UnitTests/GeneratedOptionsRegistrationAnalyzerTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/GeneratedOptionsRegistrationAnalyzerTests.cs
@@ -33,7 +33,9 @@ public class GeneratedOptionsRegistrationAnalyzerTests
         {
             public static class RuntimeMetadataRegistry
             {
+                public const int CurrentCommandMetadataSchemaVersion = 2;
                 public static void RegisterCommandOptions(System.Type type, object model) { }
+                public static void RegisterCommandOptions(System.Type type, object model, int schemaVersion) { }
                 public static void RegisterSecrets(System.Type type, object accessors) { }
             }
         }
@@ -127,7 +129,8 @@ public class GeneratedOptionsRegistrationAnalyzerTests
                     {
                         RuntimeMetadataRegistry.RegisterCommandOptions(
                             typeof(PeerCommandOptions),
-                            new object());
+                            new object(),
+                            RuntimeMetadataRegistry.CurrentCommandMetadataSchemaVersion);
                         RuntimeMetadataRegistry.RegisterSecrets(
                             typeof(PeerCommandOptions),
                             new object());
@@ -143,6 +146,48 @@ public class GeneratedOptionsRegistrationAnalyzerTests
             });
 
         await Assert.That(diagnostics).IsEmpty();
+    }
+
+    [Test]
+    public async Task Trimmed_Host_Rejects_Legacy_Peer_Command_Metadata()
+    {
+        var diagnostics = await GeneratorTestHarness.RunWithPeerGeneratorAndAnalyzer(
+            new CommandOptionsGenerator(),
+            new PeerSourceGenerator(
+                "LegacyPeerCommandOptions.cs",
+                """
+                using ModularPipelines.Metadata;
+                using ModularPipelines.Options;
+
+                public sealed class LegacyPeerCommandOptions : CommandLineToolOptions;
+
+                public static class LegacyPeerRegistration
+                {
+                    public static void Add()
+                    {
+                        RuntimeMetadataRegistry.RegisterCommandOptions(
+                            typeof(LegacyPeerCommandOptions),
+                            new object());
+                        RuntimeMetadataRegistry.RegisterSecrets(
+                            typeof(LegacyPeerCommandOptions),
+                            new object());
+                    }
+                }
+                """),
+            new GeneratedOptionsRegistrationAnalyzer(),
+            Infrastructure,
+            "public sealed class Host;",
+            new Dictionary<string, string>
+            {
+                ["build_property.PublishAot"] = "true",
+            });
+
+        var diagnostic = diagnostics.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(diagnostic.Id).IsEqualTo("MPG0017");
+            await Assert.That(diagnostic.GetMessage()).Contains("LegacyPeerCommandOptions");
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
@@ -494,7 +494,7 @@ public class IncompleteMetadataDiagnosticTests
     }
 
     [Test]
-    public async Task Trimmed_Host_Rescans_Legacy_Metadata_Marker()
+    public async Task Trimmed_Host_Rescans_Previous_Metadata_Schema()
     {
         var result = GeneratorTestHarness.RunWithExternalAssembly(
             new CommandOptionsGenerator(),
@@ -502,7 +502,10 @@ public class IncompleteMetadataDiagnosticTests
             """
             namespace ModularPipelines.Generated
             {
-                internal static class RuntimeMetadataRegistration;
+                internal static class RuntimeMetadataRegistration
+                {
+                    public const int SchemaVersion = 1;
+                }
             }
 
             namespace External
@@ -541,7 +544,7 @@ public class IncompleteMetadataDiagnosticTests
             {
                 internal static class RuntimeMetadataRegistration
                 {
-                    public const int SchemaVersion = 1;
+                    public const int SchemaVersion = 2;
                 }
             }
 
@@ -585,7 +588,7 @@ public class IncompleteMetadataDiagnosticTests
             {
                 internal static class RuntimeMetadataRegistration
                 {
-                    public const int SchemaVersion = 1;
+                    public const int SchemaVersion = 2;
                 }
             }
 
@@ -631,7 +634,7 @@ public class IncompleteMetadataDiagnosticTests
             {
                 internal static class RuntimeMetadataRegistration
                 {
-                    public const int SchemaVersion = 1;
+                    public const int SchemaVersion = 2;
                 }
             }
 

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -723,6 +723,15 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task CommandModel_Rejects_Mixed_Implicit_And_Explicit_Argument_Positions()
+    {
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithMixedArgumentPositions()))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("First")
+            .And.HasMessageContaining("Second");
+    }
+
+    [Test]
     public async Task CommandModel_Preserves_Shipped_Multi_Operand_Options()
     {
         var arguments = BuildArguments(
@@ -1101,6 +1110,15 @@ public class CliAttributeTests
         public string? First { get; set; }
 
         [CliArgument]
+        public string? Second { get; set; }
+    }
+
+    internal record TestCliOptionsWithMixedArgumentPositions : CommandLineToolOptions
+    {
+        [CliArgument]
+        public string? First { get; set; }
+
+        [CliArgument(0)]
         public string? Second { get; set; }
     }
 

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -686,6 +686,16 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task CommandModel_Rejects_Terminal_Argument_Positions_Across_Scopes()
+    {
+        await Assert.That(() =>
+                new CommandModelProvider().GetCommandModel(typeof(TestCliOptionsWithScopedTerminalPositions)))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("Global")
+            .And.HasMessageContaining("Command");
+    }
+
+    [Test]
     public async Task Parser_Handles_CliArgument_After_Options()
     {
         var options = new TestCliOptionsWithArgumentAfterOptions
@@ -1030,6 +1040,19 @@ public class CliAttributeTests
     internal record TestCliOptionsWithScopedArgumentPositions : TestCliGlobalArgumentOptions
     {
         [CliArgument(0)]
+        public string? Command { get; set; }
+    }
+
+    [CliGlobalOptions]
+    internal record TestCliGlobalTerminalArgumentOptions : CommandLineToolOptions
+    {
+        [CliArgument(0, Phase = CommandLinePhase.Terminal)]
+        public string? Global { get; set; }
+    }
+
+    internal record TestCliOptionsWithScopedTerminalPositions : TestCliGlobalTerminalArgumentOptions
+    {
+        [CliArgument(0, Phase = CommandLinePhase.Terminal)]
         public string? Command { get; set; }
     }
 

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -657,6 +657,35 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task CommandModel_Preserves_Legacy_Default_Argument_Positions()
+    {
+        var arguments = BuildArguments(new TestCliOptionsWithLegacyDefaultArgumentPositions
+        {
+            First = "first",
+            Second = "second",
+        });
+
+        await Assert.That(string.Join('|', arguments)).IsEqualTo("first|second");
+    }
+
+    [Test]
+    public async Task CommandModel_Preserves_Shipped_Multi_Operand_Options()
+    {
+        var arguments = BuildArguments(
+            new ModularPipelines.Options.Linux.AptGet.AptGetInstallOptions("curl"));
+
+        await Assert.That(string.Join('|', arguments)).IsEqualTo("--assume-yes|install|curl");
+    }
+
+    [Test]
+    public async Task CommandModel_Allows_Argument_Positions_In_Separate_Scopes()
+    {
+        await Assert.That(() =>
+                new CommandModelProvider().GetCommandModel(typeof(TestCliOptionsWithScopedArgumentPositions)))
+            .ThrowsNothing();
+    }
+
+    [Test]
     public async Task Parser_Handles_CliArgument_After_Options()
     {
         var options = new TestCliOptionsWithArgumentAfterOptions
@@ -980,6 +1009,28 @@ public class CliAttributeTests
 
         [CliArgument(0)]
         public string? Second { get; set; }
+    }
+
+    internal record TestCliOptionsWithLegacyDefaultArgumentPositions : CommandLineToolOptions
+    {
+        [CliArgument]
+        public string? First { get; set; }
+
+        [CliArgument]
+        public string? Second { get; set; }
+    }
+
+    [CliGlobalOptions]
+    internal record TestCliGlobalArgumentOptions : CommandLineToolOptions
+    {
+        [CliArgument(0)]
+        public string? Global { get; set; }
+    }
+
+    internal record TestCliOptionsWithScopedArgumentPositions : TestCliGlobalArgumentOptions
+    {
+        [CliArgument(0)]
+        public string? Command { get; set; }
     }
 
     internal record TestCliOptionsWithEarlyTerminator : CommandLineToolOptions

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -231,14 +231,12 @@ public class CliAttributeTests
     [Test]
     public async Task Parser_Rejects_Grouped_Value_Pairs_With_NonSpace_Separator()
     {
-        var options = new TestCliOptionsWithInvalidGroupedPairs
-        {
-            Values = [new("first", "one")],
-        };
+        var options = new TestCliOptionsWithInvalidGroupedPairs();
 
         await Assert.That(() => BuildArguments(options))
             .Throws<InvalidOperationException>()
-            .And.HasMessageContaining("must use a space separator");
+            .And.HasMessageContaining(
+                $"{typeof(TestCliOptionsWithInvalidGroupedPairs).FullName}.Values");
     }
 
     [Test]
@@ -259,14 +257,12 @@ public class CliAttributeTests
     [Test]
     public async Task Parser_Rejects_NonSpace_Separated_Value_Pairs()
     {
-        var options = new TestCliOptionsWithInvalidValuePairFormat
-        {
-            Values = [new CliValuePair("name", "Ada")],
-        };
+        var options = new TestCliOptionsWithInvalidValuePairFormat();
 
         await Assert.That(() => BuildArguments(options))
             .Throws<InvalidOperationException>()
-            .And.HasMessageContaining("OptionFormat.SpaceSeparated");
+            .And.HasMessageContaining(
+                $"{typeof(TestCliOptionsWithInvalidValuePairFormat).FullName}.Values");
     }
 
     [Test]
@@ -311,11 +307,12 @@ public class CliAttributeTests
     [Test]
     public async Task Parser_Rejects_Grouped_Values_With_NonSpace_Separator()
     {
-        var options = new TestCliOptionsWithInvalidGroupedValues { Values = ["first", "second"] };
+        var options = new TestCliOptionsWithInvalidGroupedValues();
 
         await Assert.That(() => BuildArguments(options))
             .Throws<InvalidOperationException>()
-            .And.HasMessageContaining("must use a space separator");
+            .And.HasMessageContaining(
+                $"{typeof(TestCliOptionsWithInvalidGroupedValues).FullName}.Values");
     }
 
     [Test]
@@ -510,21 +507,23 @@ public class CliAttributeTests
     [Test]
     public async Task Parser_Rejects_Handwritten_Legacy_Optional_String_Value()
     {
-        var options = new TestCliOptionsWithHandwrittenLegacyOptionalValue { Output = "json" };
+        var options = new TestCliOptionsWithHandwrittenLegacyOptionalValue();
 
         await Assert.That(() => BuildArguments(options))
             .Throws<InvalidOperationException>()
-            .And.HasMessageContaining(nameof(CliOptionValue));
+            .And.HasMessageContaining(
+                $"{typeof(TestCliOptionsWithHandwrittenLegacyOptionalValue).FullName}.Output");
     }
 
     [Test]
     public async Task Parser_Rejects_Unrelated_Generated_Legacy_Optional_String_Value()
     {
-        var options = new TestCliOptionsWithUnrelatedGeneratedLegacyOptionalValue { Output = "json" };
+        var options = new TestCliOptionsWithUnrelatedGeneratedLegacyOptionalValue();
 
         await Assert.That(() => BuildArguments(options))
             .Throws<InvalidOperationException>()
-            .And.HasMessageContaining(nameof(CliOptionValue));
+            .And.HasMessageContaining(
+                $"{typeof(TestCliOptionsWithUnrelatedGeneratedLegacyOptionalValue).FullName}.Output");
     }
 
     [Test]
@@ -627,6 +626,34 @@ public class CliAttributeTests
     {
         await Assert.That(() => BuildArguments(new TestCliOptionsWithDuplicateSwitch()))
             .Throws<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task CommandModel_Rejects_Unsupported_Flag_Type_When_Unset()
+    {
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithInvalidFlagType()))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining(
+                $"{typeof(TestCliOptionsWithInvalidFlagType).FullName}.Force");
+    }
+
+    [Test]
+    public async Task Reflection_CommandModel_Rejects_Unsupported_Flag_Type()
+    {
+        var optionsType = typeof(ReflectionInvalidFlagOptions<string>);
+
+        await Assert.That(() => new CommandModelProvider().GetCommandModel(optionsType))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining($"{optionsType.FullName}.Force");
+    }
+
+    [Test]
+    public async Task CommandModel_Rejects_Duplicate_Argument_Positions_In_Phase()
+    {
+        await Assert.That(() => BuildArguments(new TestCliOptionsWithDuplicateArgumentPosition()))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("First")
+            .And.HasMessageContaining("Second");
     }
 
     [Test]
@@ -931,6 +958,27 @@ public class CliAttributeTests
         public bool? First { get; set; }
 
         [CliOption("--duplicate")]
+        public string? Second { get; set; }
+    }
+
+    internal record TestCliOptionsWithInvalidFlagType : CommandLineToolOptions
+    {
+        [CliFlag("--force")]
+        public string? Force { get; set; }
+    }
+
+    private sealed record ReflectionInvalidFlagOptions<T> : CommandLineToolOptions
+    {
+        [CliFlag("--force")]
+        public T? Force { get; init; }
+    }
+
+    internal record TestCliOptionsWithDuplicateArgumentPosition : CommandLineToolOptions
+    {
+        [CliArgument(0)]
+        public string? First { get; set; }
+
+        [CliArgument(0)]
         public string? Second { get; set; }
     }
 

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -296,7 +296,8 @@ public class CliAttributeTests
                     nameof(RegisteredValuePairOptions<string>.Values),
                     static options => ((RegisteredValuePairOptions<string>) options).Values,
                     new CliOptionAttribute("--arg") { Format = OptionFormat.EqualsSeparated }),
-            ]);
+            ],
+            GeneratedCommandMetadata.CurrentSchemaVersion);
         var model = new CommandModelProvider().GetCommandModel(optionsType);
         var options = new RegisteredValuePairOptions<string>
         {

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -266,6 +266,49 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task Public_Builder_Rejects_HandBuilt_Grouped_NonSpace_Option()
+    {
+        PropertyCommandLinePart[] model =
+        [
+            new OptionPart(
+                "Values",
+                static _ => new[] { "first", "second" },
+                new CliOptionAttribute("--values")
+                {
+                    Format = OptionFormat.EqualsSeparated,
+                    GroupValues = true,
+                }),
+        ];
+
+        await Assert.That(() => new CommandArgumentBuilder().BuildArguments(model, new object()))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("OptionFormat.SpaceSeparated");
+    }
+
+    [Test]
+    public async Task Registered_Metadata_Rejects_Value_Pair_NonSpace_Option()
+    {
+        var optionsType = typeof(RegisteredValuePairOptions<string>);
+        GeneratedCommandMetadata.Register(
+            optionsType,
+            [
+                new OptionPart(
+                    nameof(RegisteredValuePairOptions<string>.Values),
+                    static options => ((RegisteredValuePairOptions<string>) options).Values,
+                    new CliOptionAttribute("--arg") { Format = OptionFormat.EqualsSeparated }),
+            ]);
+        var model = new CommandModelProvider().GetCommandModel(optionsType);
+        var options = new RegisteredValuePairOptions<string>
+        {
+            Values = [new CliValuePair("name", "value")],
+        };
+
+        await Assert.That(() => new CommandArgumentBuilder().BuildArguments(model, options))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("OptionFormat.SpaceSeparated");
+    }
+
+    [Test]
     public async Task Parser_Omits_Empty_Required_Option_Collections()
     {
         var options = new TestCliOptionsWithMultipleValues { Values = [] };
@@ -648,6 +691,17 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task Reflection_CommandModel_Rejects_Inherited_Duplicate_Argument_Position()
+    {
+        var optionsType = typeof(ReflectionDuplicateOverrideArgumentOptions<string>);
+
+        await Assert.That(() => new CommandModelProvider().GetCommandModel(optionsType))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("First")
+            .And.HasMessageContaining("Second");
+    }
+
+    [Test]
     public async Task CommandModel_Rejects_Duplicate_Argument_Positions_In_Phase()
     {
         await Assert.That(() => BuildArguments(new TestCliOptionsWithDuplicateArgumentPosition()))
@@ -1010,6 +1064,26 @@ public class CliAttributeTests
     {
         [CliFlag("--force")]
         public T? Force { get; init; }
+    }
+
+    private record ReflectionExplicitArgumentBase<T> : CommandLineToolOptions
+    {
+        [CliArgument(0)]
+        public virtual string? First { get; init; }
+    }
+
+    private sealed record ReflectionDuplicateOverrideArgumentOptions<T>
+        : ReflectionExplicitArgumentBase<T>
+    {
+        public override string? First { get; init; }
+
+        [CliArgument(0)]
+        public string? Second { get; init; }
+    }
+
+    private sealed record RegisteredValuePairOptions<T> : CommandLineToolOptions
+    {
+        public IReadOnlyList<CliValuePair>? Values { get; init; }
     }
 
     internal record TestCliOptionsWithDuplicateArgumentPosition : CommandLineToolOptions

--- a/test/ModularPipelines.UnitTests/Attributes/GeneratedRuntimeMetadataTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/GeneratedRuntimeMetadataTests.cs
@@ -292,7 +292,10 @@ public class GeneratedRuntimeMetadataTests
             new("Token", static _ => "secret"),
         };
 
-        RuntimeMetadataRegistry.RegisterCommandOptions(type, commandModel);
+        RuntimeMetadataRegistry.RegisterCommandOptions(
+            type,
+            commandModel,
+            RuntimeMetadataRegistry.CurrentCommandMetadataSchemaVersion);
         RuntimeMetadataRegistry.RegisterSecrets(type, secretAccessors);
 
         using (Assert.Multiple())
@@ -368,11 +371,16 @@ public class GeneratedRuntimeMetadataTests
         var firstModel = new List<PropertyCommandLinePart>();
 
         var consumerAssembly = typeof(GeneratedRuntimeMetadataTests).Assembly;
-        GeneratedCommandMetadata.RegisterExternal(consumerAssembly, type, firstModel);
         GeneratedCommandMetadata.RegisterExternal(
             consumerAssembly,
             type,
-            new List<PropertyCommandLinePart>());
+            firstModel,
+            GeneratedCommandMetadata.CurrentSchemaVersion);
+        GeneratedCommandMetadata.RegisterExternal(
+            consumerAssembly,
+            type,
+            new List<PropertyCommandLinePart>(),
+            GeneratedCommandMetadata.CurrentSchemaVersion);
 
         var found = GeneratedCommandMetadata.TryGet(type, out var registeredModel);
         using (Assert.Multiple())
@@ -562,12 +570,13 @@ public class GeneratedRuntimeMetadataTests
         var legacySecretModel = new List<SecretPropertyAccessor>();
         var rescannedSecretModel = new List<SecretPropertyAccessor>();
         var consumerAssembly = typeof(GeneratedRuntimeMetadataTests).Assembly;
-        GeneratedCommandMetadata.Register(commandType, legacyCommandModel, isComplete: true);
+        GeneratedCommandMetadata.Register(commandType, legacyCommandModel);
         GeneratedSecretMetadata.Register(secretType, legacySecretModel, isComplete: true);
         GeneratedCommandMetadata.RegisterExternal(
             consumerAssembly,
             commandType,
-            rescannedCommandModel);
+            rescannedCommandModel,
+            GeneratedCommandMetadata.CurrentSchemaVersion);
         GeneratedSecretMetadata.RegisterExternal(
             consumerAssembly,
             secretType,
@@ -621,12 +630,16 @@ public class GeneratedRuntimeMetadataTests
         var currentSecretModel = new List<SecretPropertyAccessor>();
         var rescannedSecretModel = new List<SecretPropertyAccessor>();
         var consumerAssembly = typeof(GeneratedRuntimeMetadataTests).Assembly;
-        GeneratedCommandMetadata.Register(commandType, currentCommandModel);
+        GeneratedCommandMetadata.Register(
+            commandType,
+            currentCommandModel,
+            GeneratedCommandMetadata.CurrentSchemaVersion);
         GeneratedSecretMetadata.Register(secretType, currentSecretModel);
         GeneratedCommandMetadata.RegisterExternal(
             consumerAssembly,
             commandType,
-            rescannedCommandModel);
+            rescannedCommandModel,
+            GeneratedCommandMetadata.CurrentSchemaVersion);
         GeneratedSecretMetadata.RegisterExternal(
             consumerAssembly,
             secretType,
@@ -724,7 +737,7 @@ public class GeneratedRuntimeMetadataTests
             .CreateType()!;
 
         GeneratedCommandMetadata.RegisterAssembly(assembly);
-        GeneratedCommandMetadata.Register(type, []);
+        GeneratedCommandMetadata.Register(type, [], GeneratedCommandMetadata.CurrentSchemaVersion);
         GeneratedSecretMetadata.RegisterAssembly(assembly);
         GeneratedSecretMetadata.Register(type, []);
 
@@ -756,7 +769,8 @@ public class GeneratedRuntimeMetadataTests
         GeneratedCommandMetadata.RegisterExternal(
             assembly,
             sharedOptionsType,
-            [new FlagPart("Value", getter, new CliFlagAttribute("--value"))]);
+            [new FlagPart("Value", getter, new CliFlagAttribute("--value"))],
+            GeneratedCommandMetadata.CurrentSchemaVersion);
         GeneratedSecretMetadata.RegisterExternal(
             assembly,
             sharedOptionsType,


### PR DESCRIPTION
## Summary

- validate CLI flag, optional-value, grouped-value, and `CliValuePair` property shapes when command metadata is cached
- reject duplicate positional argument indexes within the same semantic phase
- emit the required type-compatibility facts in generated metadata while preserving legacy generated optional-string support
- remove renderer checks made unreachable by validated command models

## Breaking change

Invalid CLI attribute/property combinations now fail when command metadata is first requested, even when the corresponding option value is null or unset.

## Validation

- `CliAttributeTests`: 63 passed
- reflection-fallback validation test: passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors
- changed-file whitespace verification and `git diff --check`: passed

The standalone source-generator test project exceeded the required local 2 GB agent guard before execution. The normal unit-test project also has a pre-existing stale `RunReportTests` initializer on `main`; it was temporarily adapted only for local execution and fully reverted before this PR.

Closes #3779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for command-line arguments, flags, and options.
  * Added clearer error messages identifying affected option properties.
  * Improved compatibility with legacy generated options and optional values.
  * Allowed grouped and multi-operand options to use non-space separators.
  * Added validation for duplicate or conflicting argument positions.
  * Improved handling of generated command metadata across schema versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->