### PR TITLE
Render non-null CLI strings literally

### DIFF
--- a/src/ModularPipelines/Attributes/CliArgumentAttribute.cs
+++ b/src/ModularPipelines/Attributes/CliArgumentAttribute.cs
@@ -49,7 +49,8 @@ public sealed class CliArgumentAttribute : Attribute
     public bool PrependOptionTerminatorIfValueStartsWithDash { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether this argument must have a non-empty value.
+    /// Gets or sets a value indicating whether this argument must be present.
+    /// Empty and whitespace values are rendered literally when present.
     /// </summary>
     public bool Required { get; set; }
 

--- a/src/ModularPipelines/Attributes/CliOptionAttribute.cs
+++ b/src/ModularPipelines/Attributes/CliOptionAttribute.cs
@@ -52,7 +52,7 @@ public sealed class CliOptionAttribute(string name) : Attribute
     /// Gets or sets whether this option requires a value.
     /// For <see cref="CliOptionValueArity.Optional"/>, a null property omits the option,
     /// <see cref="ModularPipelines.Models.CliOptionValue.Bare"/> renders the bare option, and a value renders
-    /// the option with that value.
+    /// the option with that value. Non-null string values are rendered literally, including empty and whitespace values.
     /// </summary>
     public CliOptionValueArity ValueArity { get; set; } = CliOptionValueArity.Required;
 

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -157,10 +157,10 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         foreach (var argumentPart in argumentParts)
         {
             var values = argumentValues[argumentPart];
-            if (argumentPart.Attribute.Required && IsEmpty(values))
+            if (argumentPart.Attribute.Required && values.Count == 0)
             {
                 throw new ArgumentException(
-                    $"Required CLI argument '{optionsType.Name}.{argumentPart.PropertyName}' cannot be null or empty.",
+                    $"Required CLI argument '{optionsType.Name}.{argumentPart.PropertyName}' cannot be null.",
                     argumentPart.PropertyName);
             }
 
@@ -180,9 +180,6 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
             args.AddRange(values);
         }
     }
-
-    private static bool IsEmpty(IReadOnlyCollection<string> values) =>
-        values.Count == 0 || values.All(string.IsNullOrWhiteSpace);
 
     private sealed record RenderedPhase(
         IReadOnlyList<string> Arguments,
@@ -344,11 +341,6 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
 
         foreach (var value in values)
         {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                throw CreateEmptyRequiredValueException(optionsType, optionPart);
-            }
-
             AddOptionValue(args, optionPart, value);
         }
     }
@@ -470,11 +462,11 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         Type optionsType,
         OptionPart optionPart)
     {
-        if (string.IsNullOrWhiteSpace(optionValue.Value))
+        if (optionValue.Value is null)
         {
             throw new InvalidOperationException(
                 $"Optional-value CLI option property '{optionsType.FullName}.{optionPart.PropertyName}' "
-                + $"must use {nameof(CliOptionValue)}.{nameof(CliOptionValue.Bare)} or a non-empty value.");
+                + $"must use {nameof(CliOptionValue)}.{nameof(CliOptionValue.Bare)} or an explicit value.");
         }
     }
 
@@ -512,9 +504,9 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
             return;
         }
 
-        if (renderedValues.Any(string.IsNullOrWhiteSpace))
+        if (renderedValues.Any(static value => value is null))
         {
-            throw CreateEmptyRequiredValueException(optionsType, optionPart);
+            throw CreateNullRequiredValueException(optionsType, optionPart);
         }
 
         args.Add(GetEffectiveName(optionPart.Attribute));
@@ -547,10 +539,9 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         var optionName = GetEffectiveName(optionPart.Attribute);
         foreach (var pair in pairs)
         {
-            if (string.IsNullOrWhiteSpace(pair.First)
-                || pair.Second is null)
+            if (pair.First is null || pair.Second is null)
             {
-                throw CreateEmptyRequiredValueException(optionsType, optionPart);
+                throw CreateNullRequiredValueException(optionsType, optionPart);
             }
 
             args.Add(optionName);
@@ -559,12 +550,12 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         }
     }
 
-    private static InvalidOperationException CreateEmptyRequiredValueException(
+    private static InvalidOperationException CreateNullRequiredValueException(
         Type optionsType,
         OptionPart optionPart) =>
         new(
             $"Required CLI option property '{optionsType.FullName}.{optionPart.PropertyName}' "
-            + "cannot be empty or whitespace.");
+            + "cannot contain null values.");
 
     private static string GetEffectiveName(CliFlagAttribute attribute) =>
         attribute.PreferShortForm && !string.IsNullOrEmpty(attribute.ShortForm)

--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -160,7 +160,7 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
             if (argumentPart.Attribute.Required && values.Count == 0)
             {
                 throw new ArgumentException(
-                    $"Required CLI argument '{optionsType.Name}.{argumentPart.PropertyName}' cannot be null.",
+                    $"Required CLI argument '{optionsType.Name}.{argumentPart.PropertyName}' cannot be null or empty.",
                     argumentPart.PropertyName);
             }
 
@@ -353,7 +353,7 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
     {
         foreach (var optionValue in GetOptionalValues(rawValue, optionsType, optionPart))
         {
-            AddOptionalValue(args, optionPart, optionValue, optionsType);
+            AddOptionalValue(args, optionPart, optionValue);
         }
     }
 
@@ -373,11 +373,6 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         {
             throw new InvalidOperationException(
                 $"Grouped option '{GetEffectiveName(optionPart.Attribute)}' must use a space separator.");
-        }
-
-        foreach (var optionValue in optionValues.Where(static value => !value.IsBare))
-        {
-            ValidateOptionalValue(optionValue, optionsType, optionPart);
         }
 
         args.Add(GetEffectiveName(optionPart.Attribute));
@@ -444,8 +439,7 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
     private static void AddOptionalValue(
         List<string> args,
         OptionPart optionPart,
-        CliOptionValue optionValue,
-        Type optionsType)
+        CliOptionValue optionValue)
     {
         if (optionValue.IsBare)
         {
@@ -453,21 +447,7 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
             return;
         }
 
-        ValidateOptionalValue(optionValue, optionsType, optionPart);
         AddOptionValue(args, optionPart, optionValue.Value!);
-    }
-
-    private static void ValidateOptionalValue(
-        CliOptionValue optionValue,
-        Type optionsType,
-        OptionPart optionPart)
-    {
-        if (optionValue.Value is null)
-        {
-            throw new InvalidOperationException(
-                $"Optional-value CLI option property '{optionsType.FullName}.{optionPart.PropertyName}' "
-                + $"must use {nameof(CliOptionValue)}.{nameof(CliOptionValue.Bare)} or an explicit value.");
-        }
     }
 
     private static void AddOptionValue(List<string> args, OptionPart optionPart, string value)
@@ -489,7 +469,7 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
     private static void AddGroupedOption(
         List<string> args,
         OptionPart optionPart,
-        IEnumerable<string> values,
+        IEnumerable<string?> values,
         Type optionsType)
     {
         if (GetSeparator(optionPart.Attribute) != " ")
@@ -510,7 +490,7 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         }
 
         args.Add(GetEffectiveName(optionPart.Attribute));
-        args.AddRange(renderedValues);
+        args.AddRange(renderedValues.Select(static value => value!));
     }
 
     private static IEnumerable<CliValuePair>? GetOptionValuePairs(object rawValue)
@@ -539,14 +519,16 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
         var optionName = GetEffectiveName(optionPart.Attribute);
         foreach (var pair in pairs)
         {
-            if (pair.First is null || pair.Second is null)
+            var first = pair.First;
+            var second = pair.Second;
+            if (first is null || second is null)
             {
                 throw CreateNullRequiredValueException(optionsType, optionPart);
             }
 
             args.Add(optionName);
-            args.Add(pair.First);
-            args.Add(pair.Second);
+            args.Add(first);
+            args.Add(second);
         }
     }
 

--- a/src/ModularPipelines/Models/CliOptionValue.cs
+++ b/src/ModularPipelines/Models/CliOptionValue.cs
@@ -29,10 +29,9 @@ public sealed record CliOptionValue
     public bool IsBare { get; }
 
     /// <summary>
-    /// Creates an option value from a non-empty string, or preserves a null value so the option is omitted.
+    /// Creates an explicit option value from a string, or preserves a null value so the option is omitted.
     /// </summary>
     /// <param name="value">The value to render.</param>
-    /// <exception cref="ArgumentException"><paramref name="value"/> is empty or whitespace.</exception>
     [return: NotNullIfNotNull(nameof(value))]
     public static implicit operator CliOptionValue?(string? value)
     {
@@ -41,7 +40,6 @@ public sealed record CliOptionValue
             return null;
         }
 
-        ArgumentException.ThrowIfNullOrWhiteSpace(value);
         return new CliOptionValue(value, isBare: false);
     }
 }

--- a/src/ModularPipelines/Models/CliValuePair.cs
+++ b/src/ModularPipelines/Models/CliValuePair.cs
@@ -2,9 +2,10 @@ namespace ModularPipelines.Models;
 
 /// <summary>
 /// Represents two consecutive values belonging to one command-line option.
-/// Non-null operands are rendered literally, including empty and whitespace values.
+/// Null operands are rejected during argument construction. Non-null operands are rendered
+/// literally, including empty and whitespace values.
 /// </summary>
 /// <param name="First">The first option value.</param>
 /// <param name="Second">The second option value.</param>
 /// <example><c>--arg name value</c>.</example>
-public record CliValuePair(string First, string Second);
+public record CliValuePair(string? First, string? Second);

--- a/src/ModularPipelines/Models/CliValuePair.cs
+++ b/src/ModularPipelines/Models/CliValuePair.cs
@@ -2,6 +2,7 @@ namespace ModularPipelines.Models;
 
 /// <summary>
 /// Represents two consecutive values belonging to one command-line option.
+/// Non-null operands are rendered literally, including empty and whitespace values.
 /// </summary>
 /// <param name="First">The first option value.</param>
 /// <param name="Second">The second option value.</param>

--- a/test/ModularPipelines.TestHelpers/GeneratedOptionsSmokeTestHarness.cs
+++ b/test/ModularPipelines.TestHelpers/GeneratedOptionsSmokeTestHarness.cs
@@ -221,12 +221,12 @@ public static class GeneratedOptionsSmokeTestHarness
 
         if (value is CliValuePair pair)
         {
-            return [optionName, pair.First, pair.Second];
+            return [optionName, pair.First!, pair.Second!];
         }
 
         if (value is IEnumerable<CliValuePair> pairs)
         {
-            return [.. pairs.SelectMany(pairValue => new[] { optionName, pairValue.First, pairValue.Second })];
+            return [.. pairs.SelectMany(pairValue => new[] { optionName, pairValue.First!, pairValue.Second! })];
         }
 
         var separator = GetSeparator(option.Attribute);

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -416,11 +416,11 @@ public class CliAttributeTests
     {
         var repeated = new TestCliOptionsWithValuePairs
         {
-            Values = [new CliValuePair(null!, "value")],
+            Values = [new CliValuePair(null, "value")],
         };
         var grouped = new TestCliOptionsWithGroupedPairs
         {
-            Values = [new CliValuePair("name", null!)],
+            Values = [new CliValuePair("name", null)],
         };
 
         await Assert.That(() => BuildArguments(repeated))
@@ -671,7 +671,8 @@ public class CliAttributeTests
 
         await Assert.That(() => BuildArguments(options))
             .Throws<ArgumentException>()
-            .And.HasMessageContaining("TestCliOptionsWithRequiredArgument.Chart");
+            .And.HasMessageContaining("TestCliOptionsWithRequiredArgument.Chart")
+            .And.HasMessageContaining("cannot be null or empty");
     }
 
     [Test]
@@ -691,7 +692,8 @@ public class CliAttributeTests
 
         await Assert.That(() => BuildArguments(options))
             .Throws<ArgumentException>()
-            .And.HasMessageContaining("TestCliOptionsWithRequiredArgumentCollection.Files");
+            .And.HasMessageContaining("TestCliOptionsWithRequiredArgumentCollection.Files")
+            .And.HasMessageContaining("cannot be null or empty");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -280,13 +280,32 @@ public class CliAttributeTests
     [Test]
     [Arguments("")]
     [Arguments("   ")]
-    public async Task Parser_Rejects_Empty_Required_Option_Values(string value)
+    public async Task Parser_Renders_Literal_Required_Option_Values(string value)
     {
         var options = new TestCliOptionsWithOption { Namespace = value };
 
-        await Assert.That(() => BuildArguments(options))
-            .Throws<InvalidOperationException>()
-            .And.HasMessageContaining($"{typeof(TestCliOptionsWithOption).FullName}.Namespace");
+        await Assert.That(BuildArguments(options)).IsEquivalentTo(["--namespace", value]);
+    }
+
+    [Test]
+    public async Task Parser_Renders_Literal_Grouped_Option_Values()
+    {
+        var options = new TestCliOptionsWithGroupedValues { Values = ["", " "] };
+
+        await Assert.That(BuildArguments(options)).IsEquivalentTo(["--values", "", " "]);
+    }
+
+    [Test]
+    public async Task Parser_Renders_Literal_Value_Pair_Operands()
+    {
+        var options = new TestCliOptionsWithValuePairs
+        {
+            Values = [new CliValuePair("", " "), new CliValuePair(" ", "")],
+        };
+
+        await Assert.That(BuildArguments(options)).IsEquivalentTo(
+            ["--arg", "", " ", "--arg", " ", ""],
+            TUnit.Assertions.Enums.CollectionOrdering.Matching);
     }
 
     [Test]
@@ -367,6 +386,17 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task Parser_Renders_Literal_Optional_Values()
+    {
+        var options = new TestCliOptionsWithMultipleOptionalValues
+        {
+            Output = ["", " "],
+        };
+
+        await Assert.That(BuildArguments(options)).IsEquivalentTo(["--output=", "--output= "]);
+    }
+
+    [Test]
     public async Task Parser_Groups_Optional_Values_Into_One_Occurrence()
     {
         var options = new TestCliOptionsWithGroupedOptionalValues
@@ -379,6 +409,37 @@ public class CliAttributeTests
         await Assert.That(list).IsEquivalentTo(
             ["--output", "first", "second"],
             TUnit.Assertions.Enums.CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Parser_Rejects_Null_Value_Pair_Operands()
+    {
+        var repeated = new TestCliOptionsWithValuePairs
+        {
+            Values = [new CliValuePair(null!, "value")],
+        };
+        var grouped = new TestCliOptionsWithGroupedPairs
+        {
+            Values = [new CliValuePair("name", null!)],
+        };
+
+        await Assert.That(() => BuildArguments(repeated))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("cannot contain null values");
+        await Assert.That(() => BuildArguments(grouped))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("cannot contain null values");
+    }
+
+    [Test]
+    public async Task Parser_Groups_Literal_Optional_Values()
+    {
+        var options = new TestCliOptionsWithGroupedOptionalValues
+        {
+            Output = ["", " "],
+        };
+
+        await Assert.That(BuildArguments(options)).IsEquivalentTo(["--output", "", " "]);
     }
 
     [Test]
@@ -502,12 +563,15 @@ public class CliAttributeTests
     }
 
     [Test]
-    public async Task CliOptionValue_Implicitly_Converts_NonEmpty_Strings()
+    [Arguments("")]
+    [Arguments(" ")]
+    [Arguments("tests.txt")]
+    public async Task CliOptionValue_Implicitly_Converts_NonNull_Strings(string value)
     {
-        CliOptionValue optionValue = "tests.txt";
+        CliOptionValue optionValue = value;
 
         await Assert.That(optionValue.IsBare).IsFalse();
-        await Assert.That(optionValue.Value).IsEqualTo("tests.txt");
+        await Assert.That(optionValue.Value).IsEqualTo(value);
     }
 
     [Test]
@@ -611,13 +675,13 @@ public class CliAttributeTests
     }
 
     [Test]
-    public async Task Parser_Rejects_Blank_Required_CliArgument()
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task Parser_Renders_Literal_Required_CliArgument(string value)
     {
-        var options = new TestCliOptionsWithRequiredArgument { Chart = "   " };
+        var options = new TestCliOptionsWithRequiredArgument { Chart = value };
 
-        await Assert.That(() => BuildArguments(options))
-            .Throws<ArgumentException>()
-            .And.HasMessageContaining("cannot be null or empty");
+        await Assert.That(BuildArguments(options)).IsEquivalentTo([value]);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- define null as the only absent CLI string value
- render empty and whitespace values literally for options, grouped values, value pairs, and positionals
- keep CliOptionValue.Bare distinct from an explicit empty optional value
- update public API documentation and regression coverage

## Validation
- CliAttributeTests: 68/68 passed
- core Release build: 0 warnings, 0 errors
- targeted dotnet format passed
- current main has two stale RunReportTests initializers for removed PipelineOptions properties; they were excluded locally only to execute the focused tests and no workaround is committed

Closes #3780