### PR TITLE
Read latest run history first

### DIFF
--- a/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
@@ -35,29 +35,49 @@ internal sealed class FileSystemRunHistoryStore(
             return null;
         }
 
-        PipelineRunReport? latestReport = null;
         var incompatibleSchemaLogged = false;
-        foreach (var file in Directory.EnumerateFiles(
-                     directory,
-                     $"{GetPipelineFilePrefix(pipelineIdentity)}*.json",
-                     SearchOption.TopDirectoryOnly))
+        var files = Directory
+            .EnumerateFiles(
+                directory,
+                $"{GetPipelineFilePrefix(pipelineIdentity)}*.json",
+                SearchOption.TopDirectoryOnly)
+            .OrderByDescending(GetHistoryTimestamp)
+            .ThenByDescending(static file => Path.GetFileName(file), StringComparer.Ordinal);
+        foreach (var file in files)
         {
             cancellationToken.ThrowIfCancellationRequested();
             try
             {
-                var json = await File.ReadAllTextAsync(file, cancellationToken).ConfigureAwait(false);
-                if (!TryDeserializeCompatibleReport(json, ref incompatibleSchemaLogged, out var report))
+                await using var stream = new FileStream(
+                    file,
+                    new FileStreamOptions
+                    {
+                        Access = FileAccess.Read,
+                        Mode = FileMode.Open,
+                        Options = FileOptions.Asynchronous | FileOptions.SequentialScan,
+                        Share = FileShare.Read | FileShare.Delete,
+                    });
+                var (report, incompatibleSchemaVersion) = await ReadReportAsync(stream, cancellationToken)
+                    .ConfigureAwait(false);
+                if (incompatibleSchemaVersion is { } schemaVersion)
                 {
+                    if (!incompatibleSchemaLogged)
+                    {
+                        logger.LogWarning(
+                            "Skipped pipeline run history with schema version {SchemaVersion}; supported versions are {MinimumSchemaVersion} through {CurrentSchemaVersion}",
+                            schemaVersion,
+                            MinimumCompatibleSchemaVersion,
+                            PipelineRunReport.CurrentSchemaVersion);
+                        incompatibleSchemaLogged = true;
+                    }
+
                     continue;
                 }
 
-                if (string.Equals(
-                        report.PipelineIdentity,
-                        pipelineIdentity,
-                        StringComparison.Ordinal)
-                    && (latestReport is null || report.End > latestReport.End))
+                if (report is not null
+                    && string.Equals(report.PipelineIdentity, pipelineIdentity, StringComparison.Ordinal))
                 {
-                    latestReport = report;
+                    return report;
                 }
             }
             catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or System.Text.Json.JsonException)
@@ -66,41 +86,26 @@ internal sealed class FileSystemRunHistoryStore(
             }
         }
 
-        return latestReport;
+        return null;
     }
 
-    private bool TryDeserializeCompatibleReport(
-        string json,
-        ref bool incompatibleSchemaLogged,
-        out PipelineRunReport report)
+    private static async Task<(PipelineRunReport? Report, int? IncompatibleSchemaVersion)> ReadReportAsync(
+        Stream stream,
+        CancellationToken cancellationToken)
     {
-        using var document = JsonDocument.Parse(json);
+        using var document = await JsonDocument.ParseAsync(
+                stream,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
         var schemaVersion = ReadSchemaVersion(document.RootElement);
         if (!IsSchemaVersionCompatible(schemaVersion))
         {
-            if (!incompatibleSchemaLogged)
-            {
-                logger.LogWarning(
-                    "Skipped pipeline run history with schema version {SchemaVersion}; supported versions are {MinimumSchemaVersion} through {CurrentSchemaVersion}",
-                    schemaVersion,
-                    MinimumCompatibleSchemaVersion,
-                    PipelineRunReport.CurrentSchemaVersion);
-                incompatibleSchemaLogged = true;
-            }
-
-            report = null!;
-            return false;
+            return (null, schemaVersion);
         }
 
-        var deserializedReport = RunReportJsonSerializer.Deserialize(json);
-        if (deserializedReport is null)
-        {
-            report = null!;
-            return false;
-        }
-
-        report = deserializedReport;
-        return true;
+        return (
+            document.RootElement.Deserialize(RunReportJsonContext.Default.PipelineRunReport),
+            null);
     }
 
     private static int ReadSchemaVersion(JsonElement root)

--- a/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
+++ b/src/ModularPipelines/Engine/FileSystemRunHistoryStore.cs
@@ -36,13 +36,9 @@ internal sealed class FileSystemRunHistoryStore(
         }
 
         var incompatibleSchemaLogged = false;
-        var files = Directory
-            .EnumerateFiles(
-                directory,
-                $"{GetPipelineFilePrefix(pipelineIdentity)}*.json",
-                SearchOption.TopDirectoryOnly)
-            .OrderByDescending(GetHistoryTimestamp)
-            .ThenByDescending(static file => Path.GetFileName(file), StringComparer.Ordinal);
+        var files = GetHistoryFilesNewestFirst(
+            directory,
+            $"{GetPipelineFilePrefix(pipelineIdentity)}*.json");
         foreach (var file in files)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -177,10 +173,7 @@ internal sealed class FileSystemRunHistoryStore(
         {
             return;
         }
-        var staleFiles = Directory
-            .EnumerateFiles(directory, searchPattern, SearchOption.TopDirectoryOnly)
-            .OrderByDescending(GetHistoryTimestamp)
-            .ThenByDescending(static file => Path.GetFileName(file), StringComparer.Ordinal)
+        var staleFiles = GetHistoryFilesNewestFirst(directory, searchPattern)
             .Skip(retention)
             .ToArray();
         foreach (var staleFile in staleFiles)
@@ -196,6 +189,14 @@ internal sealed class FileSystemRunHistoryStore(
             }
         }
     }
+
+    private static IEnumerable<string> GetHistoryFilesNewestFirst(
+        string directory,
+        string searchPattern) =>
+        Directory
+            .EnumerateFiles(directory, searchPattern, SearchOption.TopDirectoryOnly)
+            .OrderByDescending(GetHistoryTimestamp)
+            .ThenByDescending(static file => Path.GetFileName(file), StringComparer.Ordinal);
 
     private static DateTime GetHistoryTimestamp(string path)
     {

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -906,6 +906,53 @@ public class RunReportTests
     }
 
     [Test]
+    public async Task FileSystemHistoryStoreStopsAfterNewestCompatibleReport()
+    {
+        var directory = CreateTemporaryDirectory();
+        var log = new StringBuilder();
+        var store = new FileSystemRunHistoryStore(
+            OptionsFactory.Create(new PipelineOptions
+            {
+                RunReport = new RunReportOptions
+                {
+                    HistoryDirectory = directory,
+                    HistoryRetention = 2,
+                },
+            }),
+            new StringLogger<FileSystemRunHistoryStore>(log));
+
+        try
+        {
+            for (var second = 1; second <= 2; second++)
+            {
+                await store.SaveAsync(new PipelineRunReport
+                {
+                    PipelineIdentity = "pipeline-a",
+                    End = new DateTimeOffset(2026, 8, 2, 12, 0, second, TimeSpan.Zero),
+                });
+            }
+
+            var oldestFile = Directory
+                .GetFiles(directory, "modularpipelines-run-*.json")
+                .OrderBy(Path.GetFileName, StringComparer.Ordinal)
+                .First();
+            await File.WriteAllTextAsync(oldestFile, "not json");
+
+            var latest = await store.GetLatestAsync("pipeline-a");
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(latest?.End.Second).IsEqualTo(2);
+                await Assert.That(log.ToString()).IsEmpty();
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task FileSystemHistoryStorePrunesOnlyStaleOwnedTemporaryFiles()
     {
         var directory = CreateTemporaryDirectory();
@@ -1258,25 +1305,29 @@ public class RunReportTests
 
         try
         {
-            await store.SaveAsync(new PipelineRunReport
+            for (var second = 1; second <= 4; second++)
             {
-                PipelineIdentity = "pipeline-a",
-                End = new DateTimeOffset(2026, 8, 2, 12, 0, 1, TimeSpan.Zero),
-            });
-            var validReportFile = Directory
-                .GetFiles(directory, "modularpipelines-run-*.json")
-                .Single();
+                await store.SaveAsync(new PipelineRunReport
+                {
+                    PipelineIdentity = "pipeline-a",
+                    End = new DateTimeOffset(2026, 8, 2, 12, 0, second, TimeSpan.Zero),
+                });
+            }
+
             var invalidReports = new[]
             {
                 "[]",
                 "{ \"schemaVersion\": \"future\" }",
                 "{ \"schemaVersion\": 2147483648 }",
             };
+            var newestFiles = Directory
+                .GetFiles(directory, "modularpipelines-run-*.json")
+                .OrderByDescending(Path.GetFileName, StringComparer.Ordinal)
+                .Take(invalidReports.Length)
+                .ToArray();
             for (var index = 0; index < invalidReports.Length; index++)
             {
-                await File.WriteAllTextAsync(
-                    $"{validReportFile}.invalid-{index}.json",
-                    invalidReports[index]);
+                await File.WriteAllTextAsync(newestFiles[index], invalidReports[index]);
             }
 
             var latest = await store.GetLatestAsync("pipeline-a");


### PR DESCRIPTION
Closes #3754

## Summary
- order matching history files newest-first using their encoded timestamps
- return after the first compatible report for the requested pipeline identity
- deserialize from an asynchronous `FileStream` while preserving the forward-schema compatibility gate
- cover early exit and newest-invalid fallback behavior

## Validation
- `build ModularPipelines.slnx -c Release` (0 warnings, 0 errors)
- 11 `FileSystemHistoryStore*` tests passed
- formatting verification passed for both changed files
- `git diff --check` passed

The unit-test project currently needs the pending `PipelineOptions.Console` initializer correction from #3844 to compile; that unrelated temporary local adjustment was removed and is not part of this PR.