### PR TITLE
Fix stale run-report test options

### DIFF
--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1480,8 +1480,6 @@ public class RunReportTests
         using var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
-            PrintLogo = false,
-            PrintResults = false,
             RunReport = CreateReportingOptions(Path.Combine(directory, "report.json")).RunReport,
         });
         builder.AddModule<SuccessfulModule>();

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1480,6 +1480,7 @@ public class RunReportTests
         using var builder = Pipeline.CreateBuilder();
         builder.ConfigurePipelineOptions(options => options with
         {
+            Console = options.Console with { PrintLogo = false, PrintResults = false },
             RunReport = CreateReportingOptions(Path.Combine(directory, "report.json")).RunReport,
         });
         builder.AddModule<SuccessfulModule>();


### PR DESCRIPTION
## Summary
- remove stale `PrintLogo` and `PrintResults` initializers after those pipeline options were removed
- restore compilation for the core unit-test project and queued PR CI

## Validation
- `RunReportTests/BuilderRegistrationInvokesRunReportEnricher`: 1/1 passed
- targeted formatter passed