### PR TITLE
Make pipeline validation async-only

### DIFF
--- a/src/ModularPipelines/Validation/ArtifactContractValidator.cs
+++ b/src/ModularPipelines/Validation/ArtifactContractValidator.cs
@@ -17,21 +17,6 @@ internal sealed class ArtifactContractValidator : IPipelineValidator
     public int Order => 250;
 
     /// <inheritdoc />
-    public ValidationResult Validate(IServiceProvider services)
-    {
-        var result = ValidateModules(services, services.GetServices<IModule>());
-        if (!result.HasErrors)
-        {
-            return result;
-        }
-
-        var modules = GetRunnableModulesForArtifactValidationAsync(services)
-            .GetAwaiter()
-            .GetResult();
-        return ValidateModules(services, modules.AvailableModules, modules.RunnableConsumerTypes);
-    }
-
-    /// <inheritdoc />
     public async Task<ValidationResult> ValidateAsync(IServiceProvider services)
     {
         var result = ValidateModules(services, services.GetServices<IModule>());

--- a/src/ModularPipelines/Validation/DependencyValidator.cs
+++ b/src/ModularPipelines/Validation/DependencyValidator.cs
@@ -16,22 +16,6 @@ internal class DependencyValidator : IDependencyValidator
     public int Order => 200;
 
     /// <inheritdoc />
-    public ValidationResult Validate(IServiceProvider services)
-    {
-        var result = ValidateDependencies(services, services.GetServices<IModule>());
-        if (!result.HasErrors)
-        {
-            return result;
-        }
-
-        var runnableModules = services.GetRequiredService<ModuleRetriever>()
-            .GetRunnableModulesForValidation()
-            .GetAwaiter()
-            .GetResult();
-        return ValidateDependencies(services, runnableModules);
-    }
-
-    /// <inheritdoc />
     public async Task<ValidationResult> ValidateAsync(IServiceProvider services)
     {
         var result = ValidateDependencies(services, services.GetServices<IModule>());

--- a/src/ModularPipelines/Validation/IPipelineValidator.cs
+++ b/src/ModularPipelines/Validation/IPipelineValidator.cs
@@ -11,17 +11,9 @@ public interface IPipelineValidator
     int Order { get; }
 
     /// <summary>
-    /// Validates the pipeline configuration.
-    /// </summary>
-    /// <param name="services">The service provider containing registered services.</param>
-    /// <returns>A validation result containing any errors found.</returns>
-    ValidationResult Validate(IServiceProvider services);
-
-    /// <summary>
     /// Asynchronously validates the pipeline configuration.
     /// </summary>
     /// <param name="services">The service provider containing registered services.</param>
     /// <returns>A validation result containing any errors found.</returns>
-    Task<ValidationResult> ValidateAsync(IServiceProvider services)
-        => Task.FromResult(Validate(services));
+    Task<ValidationResult> ValidateAsync(IServiceProvider services);
 }

--- a/src/ModularPipelines/Validation/ModuleConfigurationValidator.cs
+++ b/src/ModularPipelines/Validation/ModuleConfigurationValidator.cs
@@ -12,10 +12,10 @@ internal class ModuleConfigurationValidator : IModuleConfigurationValidator
     public int Order => 300;
 
     /// <inheritdoc />
-    public ValidationResult Validate(IServiceProvider services)
+    public Task<ValidationResult> ValidateAsync(IServiceProvider services)
     {
         var modules = services.GetServices<IModule>();
-        return ValidateModules(modules);
+        return Task.FromResult(ValidateModules(modules));
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Validation/ModuleSelectionValidator.cs
+++ b/src/ModularPipelines/Validation/ModuleSelectionValidator.cs
@@ -10,9 +10,6 @@ internal sealed class ModuleSelectionValidator(IOptions<PipelineOptions> options
 {
     public int Order => 250;
 
-    public ValidationResult Validate(IServiceProvider services) =>
-        ValidateAsync(services).GetAwaiter().GetResult();
-
     public async Task<ValidationResult> ValidateAsync(IServiceProvider services)
     {
         if (options.Value.TargetModules?.Count is not > 0

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -15,17 +15,17 @@ internal class OptionsValidator : IOptionsValidator
     public int Order => 100;
 
     /// <inheritdoc />
-    public ValidationResult Validate(IServiceProvider services)
+    public Task<ValidationResult> ValidateAsync(IServiceProvider services)
     {
         var optionsSnapshot = services.GetService<IOptions<PipelineOptions>>();
         if (optionsSnapshot?.Value == null)
         {
-            return ValidationResult.Success();
+            return Task.FromResult(ValidationResult.Success());
         }
 
-        return ValidateOptions(
+        return Task.FromResult(ValidateOptions(
             optionsSnapshot.Value,
-            GetRegisteredCategories(services));
+            GetRegisteredCategories(services)));
     }
 
     /// <inheritdoc />

--- a/test/ModularPipelines.UnitTests/Validation/ValidationInterfaceTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationInterfaceTests.cs
@@ -32,7 +32,7 @@ public class ValidationInterfaceTests
     }
 
     [Test]
-    public async Task IPipelineValidator_ShouldHaveOrderAndValidateMembers()
+    public async Task IPipelineValidator_ShouldHaveOrderAndValidateAsyncMembers()
     {
         var validatorType = typeof(IPipelineValidator);
 
@@ -40,11 +40,7 @@ public class ValidationInterfaceTests
         await Assert.That(orderProperty).IsNotNull()
             .Because("IPipelineValidator should have Order property");
 
-        var validateMethod = validatorType.GetMethod("Validate");
-        await Assert.That(validateMethod).IsNotNull()
-            .Because("IPipelineValidator should have Validate method");
-
-        var validateAsyncMethod = validatorType.GetMethod("ValidateAsync");
+        var validateAsyncMethod = validatorType.GetMethod(nameof(IPipelineValidator.ValidateAsync));
         await Assert.That(validateAsyncMethod).IsNotNull()
             .Because("IPipelineValidator should have ValidateAsync method");
     }

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -18,7 +18,8 @@ public class ValidationTests
     {
         public int Order => 0;
 
-        public ValidationResult Validate(IServiceProvider services) => ValidationResult.Success();
+        public Task<ValidationResult> ValidateAsync(IServiceProvider services) =>
+            Task.FromResult(ValidationResult.Success());
 
         public ValidationResult ValidateOptions(PipelineOptions options) =>
             ValidationResult.WithError(new ValidationError(
@@ -182,15 +183,26 @@ public class ValidationTests
 
         public bool IsDisposed { get; private set; }
 
-        public ValidationResult Validate(IServiceProvider services)
-        {
-            throw new InvalidOperationException("Custom validation failed.");
-        }
+        public Task<ValidationResult> ValidateAsync(IServiceProvider services) =>
+            Task.FromException<ValidationResult>(new InvalidOperationException("Custom validation failed."));
 
         public ValueTask DisposeAsync()
         {
             IsDisposed = true;
             return ValueTask.CompletedTask;
+        }
+    }
+
+    [Test]
+    public async Task PipelineValidatorContractIsAsyncOnly()
+    {
+        var methods = typeof(IPipelineValidator).GetMethods();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(methods.Any(method => method.Name == "Validate")).IsFalse();
+            await Assert.That(methods.Single(method => method.Name == nameof(IPipelineValidator.ValidateAsync)).ReturnType)
+                .IsEqualTo(typeof(Task<ValidationResult>));
         }
     }
 


### PR DESCRIPTION
Closes #3808

## Summary
- make `IPipelineValidator` async-only
- remove duplicated sync-over-async validation paths
- adapt synchronous validators with completed tasks and guard the public contract

## Validation
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors
- `ValidationTests`: 40/40 passed
- targeted formatter passed

The focused test project used the same temporary local omission of the unrelated stale run-report option initializers fixed separately by #3864; those lines were restored and are not part of this PR.