### PR TITLE
Classify missing modules by exception type

### DIFF
--- a/src/ModularPipelines/Engine/ModuleRetriever.cs
+++ b/src/ModularPipelines/Engine/ModuleRetriever.cs
@@ -86,7 +86,7 @@ internal class ModuleRetriever
     {
         if (_modules.Count == 0)
         {
-            throw new PipelineException("No modules have been registered");
+            throw new NoModulesRegisteredException();
         }
 
         // Dynamic dependencies and metadata must be registered before conditions and cascade skipping are evaluated.

--- a/src/ModularPipelines/Engine/PipelinePlanner.cs
+++ b/src/ModularPipelines/Engine/PipelinePlanner.cs
@@ -70,7 +70,7 @@ internal sealed class PipelinePlanner
     {
         if (_modules.Count == 0)
         {
-            throw new PipelineException("No modules have been registered");
+            throw new NoModulesRegisteredException();
         }
 
         await _registrationEventExecutor.InvokeRegistrationEventsAsync(_modules).ConfigureAwait(false);

--- a/src/ModularPipelines/Exceptions/NoModulesRegisteredException.cs
+++ b/src/ModularPipelines/Exceptions/NoModulesRegisteredException.cs
@@ -1,0 +1,4 @@
+namespace ModularPipelines.Exceptions;
+
+internal sealed class NoModulesRegisteredException()
+    : PipelineException("No modules have been registered");

--- a/src/ModularPipelines/PipelineBuilder.cs
+++ b/src/ModularPipelines/PipelineBuilder.cs
@@ -233,7 +233,7 @@ public sealed class PipelineBuilder : IDisposable
                 : ValidationResult.Success();
             return (pipeline, validationResult, null);
         }
-        catch (PipelineException ex) when (ex.Message.Contains("No modules"))
+        catch (NoModulesRegisteredException ex)
         {
             return (
                 pipeline,

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -194,6 +194,14 @@ public class ValidationTests
         }
     }
 
+    private sealed class ThrowingPipelineExceptionValidator : IPipelineValidator
+    {
+        public int Order => int.MaxValue;
+
+        public ValidationResult Validate(IServiceProvider services) =>
+            throw new PipelineException("No modules can be serialized.");
+    }
+
     [Test]
     public async Task ValidateAsync_WithValidConfiguration_ReturnsNoErrors()
     {
@@ -222,6 +230,18 @@ public class ValidationTests
         // Assert
         await Assert.That(result.HasErrors).IsTrue();
         await Assert.That(result.Errors.Any(e => e.Category == ValidationErrorCategory.ModuleConfiguration)).IsTrue();
+    }
+
+    [Test]
+    public async Task ValidateAsync_DoesNotClassifyUnrelatedPipelineExceptionByMessage()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.AddModule<SimpleModule>();
+        builder.Services.AddSingleton<IPipelineValidator, ThrowingPipelineExceptionValidator>();
+
+        var exception = await Assert.ThrowsAsync<PipelineException>(() => builder.ValidateAsync());
+
+        await Assert.That(exception!.Message).IsEqualTo("No modules can be serialized.");
     }
 
     [Test]


### PR DESCRIPTION
Closes #3771

## Summary
- add an internal `NoModulesRegisteredException`
- throw it from both empty-module discovery paths
- catch the dedicated type during builder validation instead of matching exception text
- prove an unrelated `PipelineException` containing “No modules” still propagates

## Validation
- `ValidationTests`: 40/40 passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors
- targeted formatting and `git diff --check` passed

The unit-test project currently needs the pending stale `PipelineOptions.Console` correction from #3864 to compile; that unrelated temporary local adjustment was removed and is not part of this PR.