### PR TITLE
Fix concurrent cache entry replacement

### DIFF
--- a/src/ModularPipelines/Caching/FileSystemModuleCache.cs
+++ b/src/ModularPipelines/Caching/FileSystemModuleCache.cs
@@ -23,10 +23,25 @@ public sealed class FileSystemModuleCache : IModuleCacheStore
     {
         cancellationToken.ThrowIfCancellationRequested();
         var path = GetEntryPath(fingerprint);
-        Stream? stream = File.Exists(path)
-            ? new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 64 * 1024, FileOptions.Asynchronous)
-            : null;
-        return Task.FromResult(stream);
+        try
+        {
+            Stream stream = new FileStream(
+                path,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read | FileShare.Delete,
+                64 * 1024,
+                FileOptions.Asynchronous);
+            return Task.FromResult<Stream?>(stream);
+        }
+        catch (FileNotFoundException)
+        {
+            return Task.FromResult<Stream?>(null);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return Task.FromResult<Stream?>(null);
+        }
     }
 
     /// <inheritdoc />
@@ -51,7 +66,7 @@ public sealed class FileSystemModuleCache : IModuleCacheStore
                 await output.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            File.Move(temporary, destination, overwrite: true);
+            Publish(temporary, destination);
         }
         finally
         {
@@ -64,5 +79,31 @@ public sealed class FileSystemModuleCache : IModuleCacheStore
         ModuleCacheFingerprint.Validate(fingerprint);
 
         return Path.Combine(_cacheDirectory, $"{fingerprint.ToLowerInvariant()}.zip");
+    }
+
+    private static void Publish(string temporary, string destination)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            File.Move(temporary, destination, overwrite: true);
+            return;
+        }
+
+        var backup = $"{temporary}.bak";
+        try
+        {
+            try
+            {
+                File.Replace(temporary, destination, backup, ignoreMetadataErrors: true);
+            }
+            catch (FileNotFoundException)
+            {
+                File.Move(temporary, destination, overwrite: true);
+            }
+        }
+        finally
+        {
+            File.Delete(backup);
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Caching/FileSystemModuleCacheTests.cs
+++ b/test/ModularPipelines.UnitTests/Caching/FileSystemModuleCacheTests.cs
@@ -1,0 +1,70 @@
+using System.Text;
+using ModularPipelines.Caching;
+using ModularPipelines.UnitTests.Attributes;
+using OptionsFactory = Microsoft.Extensions.Options.Options;
+
+namespace ModularPipelines.UnitTests.Caching;
+
+public class FileSystemModuleCacheTests
+{
+    [Test]
+    public async Task OpenReadAsync_Returns_Null_When_Entry_Does_Not_Exist()
+    {
+        var cache = new FileSystemModuleCache(OptionsFactory.Create(new ModuleCacheOptions
+        {
+            CacheDirectory = Path.Combine(
+                Path.GetTempPath(),
+                $"modular-pipelines-cache-{Guid.NewGuid():N}"),
+        }));
+
+        var stream = await cache.OpenReadAsync(new string('a', 64), CancellationToken.None);
+
+        await Assert.That(stream).IsNull();
+    }
+
+    [Test]
+    [WindowsOnlyTest]
+    public async Task WriteAsync_Replaces_Entry_While_Read_Stream_Is_Open()
+    {
+        var cacheDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"modular-pipelines-cache-{Guid.NewGuid():N}");
+        var cache = new FileSystemModuleCache(OptionsFactory.Create(new ModuleCacheOptions
+        {
+            CacheDirectory = cacheDirectory,
+        }));
+        var fingerprint = new string('a', 64);
+
+        try
+        {
+            await using (var initialContent = CreateStream("initial"))
+            {
+                await cache.WriteAsync(fingerprint, initialContent, CancellationToken.None);
+            }
+
+            await using (var existingReader = await cache.OpenReadAsync(
+                             fingerprint,
+                             CancellationToken.None))
+            {
+                await using var replacementContent = CreateStream("replacement");
+                await cache.WriteAsync(fingerprint, replacementContent, CancellationToken.None);
+
+                using var reader = new StreamReader(existingReader!, Encoding.UTF8);
+                await Assert.That(await reader.ReadToEndAsync()).IsEqualTo("initial");
+            }
+
+            await using var replacementReader = await cache.OpenReadAsync(
+                fingerprint,
+                CancellationToken.None);
+            using var replacementTextReader = new StreamReader(replacementReader!, Encoding.UTF8);
+            await Assert.That(await replacementTextReader.ReadToEndAsync()).IsEqualTo("replacement");
+        }
+        finally
+        {
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    private static MemoryStream CreateStream(string contents) =>
+        new(Encoding.UTF8.GetBytes(contents));
+}


### PR DESCRIPTION
Closes #3807.

Allows cache readers to share deletion, removes the existence-check TOCTOU window, and uses Windows atomic replacement for entries that are currently open.

Validation:
- FileSystemModuleCacheTests: 2/2 passed on Windows
- lightweight core Release build: 0 warnings, 0 errors