### PR TITLE
Correct module cache hashing docs

### DIFF
--- a/docs/docs/how-to/module-caching.md
+++ b/docs/docs/how-to/module-caching.md
@@ -96,7 +96,8 @@ builder.AddModuleCache<FileSystemModuleCache>(options =>
 });
 ```
 
-The file limit prevents unexpectedly broad globs. File hashes use a persistent modification-time and size index; changed files are hashed concurrently.
+The file limit prevents unexpectedly broad globs. Input files are content-hashed concurrently on
+every fingerprint calculation, up to `MaximumHashConcurrency` files at a time.
 
 ## Transfer artifacts between modules
 


### PR DESCRIPTION
Closes #3806.

Corrects the module-caching guide to describe actual behavior: input files are content-hashed on every fingerprint calculation, with concurrency bounded by MaximumHashConcurrency.

Validation: git diff --check