### PR TITLE
Seed artifacts in isolated module tests

### DIFF
--- a/docs/docs/how-to/testing.md
+++ b/docs/docs/how-to/testing.md
@@ -64,6 +64,25 @@ completed before the target module starts. Calls such as
 If a required dependency has no seeded result, `ExecuteAsync` fails immediately
 and names the missing dependency instead of waiting for the module timeout.
 
+## Seed consumed artifacts
+
+Seed each artifact declared by the module before executing it:
+
+```csharp
+var run = await ModuleTester.For<DeployModule, string>()
+    .WithDependencyResult<BuildModule, BuildArtifact>(buildArtifact)
+    .WithArtifact<BuildModule>("application", "artifact contents")
+    .ExecuteAsync();
+```
+
+The harness writes a seeded single-file artifact to the declaration's `RestorePath`, using the
+artifact name as the file name. Binary contents can be passed as a `byte[]`. A consumed artifact
+that was not seeded fails the run before the module body executes.
+
+The isolated harness does not exercise artifact upload/download, archive extraction, or produced
+artifact glob matching. Assert files produced through `context.Files` via `run.FileSystem`; use an
+integration pipeline test when the artifact transport lifecycle itself is under test.
+
 ## Intercept and inspect commands
 
 Commands never start real processes unless you explicitly replace the test

--- a/src/ModularPipelines.Testing/ModuleTester.cs
+++ b/src/ModularPipelines.Testing/ModuleTester.cs
@@ -1,7 +1,9 @@
 using Mediator;
+using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.Console;
@@ -52,6 +54,7 @@ public class ModuleTestBuilder<TModule>
 {
     private readonly List<Action<PipelineBuilder>> _registrations = [];
     private readonly List<IDependencySeed> _dependencySeeds = [];
+    private readonly Dictionary<(Type ProducerModule, string ArtifactName), byte[]> _artifactSeeds = [];
     private Func<CommandInvocation, CancellationToken, ValueTask<CommandResult>>? _commandHandler;
 
     /// <summary>
@@ -79,6 +82,40 @@ public class ModuleTestBuilder<TModule>
     {
         _registrations.Add(static builder => builder.AddModule<TDependency>());
         _dependencySeeds.Add(new DependencySeed<TDependency, TResult>(value));
+        return this;
+    }
+
+    /// <summary>
+    /// Seeds a single-file artifact consumed by the module.
+    /// </summary>
+    /// <typeparam name="TProducer">The module that declares the produced artifact.</typeparam>
+    /// <param name="artifactName">The artifact name from <see cref="ConsumesArtifactAttribute"/>.</param>
+    /// <param name="contents">The UTF-8 artifact contents.</param>
+    /// <returns>This builder.</returns>
+    public ModuleTestBuilder<TModule> WithArtifact<TProducer>(
+        string artifactName,
+        string contents)
+        where TProducer : class, IModule
+    {
+        ArgumentNullException.ThrowIfNull(contents);
+        return WithArtifact<TProducer>(artifactName, Encoding.UTF8.GetBytes(contents));
+    }
+
+    /// <summary>
+    /// Seeds a single-file artifact consumed by the module.
+    /// </summary>
+    /// <typeparam name="TProducer">The module that declares the produced artifact.</typeparam>
+    /// <param name="artifactName">The artifact name from <see cref="ConsumesArtifactAttribute"/>.</param>
+    /// <param name="contents">The binary artifact contents.</param>
+    /// <returns>This builder.</returns>
+    public ModuleTestBuilder<TModule> WithArtifact<TProducer>(
+        string artifactName,
+        byte[] contents)
+        where TProducer : class, IModule
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactName);
+        ArgumentNullException.ThrowIfNull(contents);
+        _artifactSeeds[(typeof(TProducer), artifactName)] = contents.ToArray();
         return this;
     }
 
@@ -191,6 +228,7 @@ public class ModuleTestBuilder<TModule>
             estimatedTimeProvider);
         var executionPipeline = pipeline.Services.GetRequiredService<IModuleExecutionPipeline>();
         var executor = ModuleExecutionDelegateFactory.GetExecutor(module.ResultType);
+        var effectiveFileSystem = pipeline.Services.GetRequiredService<IFileSystemProvider>();
 
         await using var loggerScope = new ModuleLoggerScope(logger, typeof(TModule));
 
@@ -202,7 +240,7 @@ public class ModuleTestBuilder<TModule>
                     module,
                     executionContext,
                     moduleContext,
-                    prepareExecutionAsync: null,
+                    token => RestoreConsumedArtifactsAsync(module, effectiveFileSystem, token),
                     finalizeExecutionAsync: null,
                     completeModule: true,
                     cancellationToken: CancellationToken.None)
@@ -216,8 +254,37 @@ public class ModuleTestBuilder<TModule>
         pipeline.Services.GetRequiredService<IModuleResultRegistry>()
             .RegisterResult(typeof(TModule), result);
 
-        var effectiveFileSystem = pipeline.Services.GetRequiredService<IFileSystemProvider>();
         return new ExecutionOutcome(result, recorder.Commands, effectiveFileSystem);
+    }
+
+    private async Task RestoreConsumedArtifactsAsync(
+        IModule module,
+        IFileSystemProvider fileSystem,
+        CancellationToken cancellationToken)
+    {
+        var attributes = module.GetType()
+            .GetCustomAttributes(typeof(ConsumesArtifactAttribute), inherit: true)
+            .Cast<ConsumesArtifactAttribute>();
+        foreach (var attribute in attributes)
+        {
+            if (!_artifactSeeds.TryGetValue(
+                    (attribute.ProducerModule, attribute.ArtifactName),
+                    out var contents))
+            {
+                throw new InvalidOperationException(
+                    $"Artifact '{attribute.ArtifactName}' from module "
+                    + $"'{attribute.ProducerModule.FullName}' was not seeded for consumer "
+                    + $"'{module.GetType().Name}'. Call WithArtifact to seed it.");
+            }
+
+            var restorePath = attribute.RestorePath ?? Environment.CurrentDirectory;
+            fileSystem.CreateDirectory(restorePath);
+            await fileSystem.WriteAllBytesAsync(
+                    fileSystem.Combine(restorePath, attribute.ArtifactName),
+                    contents,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 
     private static IModuleLogger GetModuleLogger(IServiceProvider services)
@@ -322,6 +389,26 @@ public sealed class ModuleTestBuilder<TModule, TResult> : ModuleTestBuilder<TMod
         where TDependency : Module<TDependencyResult>
     {
         base.WithDependencyResult<TDependency, TDependencyResult>(value);
+        return this;
+    }
+
+    /// <inheritdoc cref="ModuleTestBuilder{TModule}.WithArtifact{TProducer}(string,string)"/>
+    public new ModuleTestBuilder<TModule, TResult> WithArtifact<TProducer>(
+        string artifactName,
+        string contents)
+        where TProducer : class, IModule
+    {
+        base.WithArtifact<TProducer>(artifactName, contents);
+        return this;
+    }
+
+    /// <inheritdoc cref="ModuleTestBuilder{TModule}.WithArtifact{TProducer}(string,byte[])"/>
+    public new ModuleTestBuilder<TModule, TResult> WithArtifact<TProducer>(
+        string artifactName,
+        byte[] contents)
+        where TProducer : class, IModule
+    {
+        base.WithArtifact<TProducer>(artifactName, contents);
         return this;
     }
 

--- a/src/ModularPipelines.Testing/ModuleTester.cs
+++ b/src/ModularPipelines.Testing/ModuleTester.cs
@@ -3,7 +3,9 @@ using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using ModularPipelines.Attributes;
+using ModularPipelines.Caching;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.Console;
@@ -229,6 +231,9 @@ public class ModuleTestBuilder<TModule>
         var executionPipeline = pipeline.Services.GetRequiredService<IModuleExecutionPipeline>();
         var executor = ModuleExecutionDelegateFactory.GetExecutor(module.ResultType);
         var effectiveFileSystem = pipeline.Services.GetRequiredService<IFileSystemProvider>();
+        var workingDirectory = pipeline.Services
+            .GetRequiredService<IOptions<ModuleCacheOptions>>()
+            .Value.WorkingDirectory;
 
         await using var loggerScope = new ModuleLoggerScope(logger, typeof(TModule));
 
@@ -240,7 +245,11 @@ public class ModuleTestBuilder<TModule>
                     module,
                     executionContext,
                     moduleContext,
-                    token => RestoreConsumedArtifactsAsync(module, effectiveFileSystem, token),
+                    token => RestoreConsumedArtifactsAsync(
+                        module,
+                        effectiveFileSystem,
+                        workingDirectory,
+                        token),
                     finalizeExecutionAsync: null,
                     completeModule: true,
                     cancellationToken: CancellationToken.None)
@@ -260,6 +269,7 @@ public class ModuleTestBuilder<TModule>
     private async Task RestoreConsumedArtifactsAsync(
         IModule module,
         IFileSystemProvider fileSystem,
+        string workingDirectory,
         CancellationToken cancellationToken)
     {
         var attributes = module.GetType()
@@ -277,7 +287,9 @@ public class ModuleTestBuilder<TModule>
                     + $"'{module.GetType().Name}'. Call WithArtifact to seed it.");
             }
 
-            var restorePath = attribute.RestorePath ?? Environment.CurrentDirectory;
+            var restorePath = ResolveArtifactRestorePath(
+                attribute.RestorePath,
+                workingDirectory);
             fileSystem.CreateDirectory(restorePath);
             await fileSystem.WriteAllBytesAsync(
                     fileSystem.Combine(restorePath, attribute.ArtifactName),
@@ -285,6 +297,18 @@ public class ModuleTestBuilder<TModule>
                     cancellationToken)
                 .ConfigureAwait(false);
         }
+    }
+
+    private static string ResolveArtifactRestorePath(
+        string? restorePath,
+        string workingDirectory)
+    {
+        var normalizedWorkingDirectory = Path.GetFullPath(workingDirectory);
+        var configuredRestorePath = restorePath ?? normalizedWorkingDirectory;
+        return Path.GetFullPath(
+            Path.IsPathRooted(configuredRestorePath)
+                ? configuredRestorePath
+                : Path.Combine(normalizedWorkingDirectory, configuredRestorePath));
     }
 
     private static IModuleLogger GetModuleLogger(IServiceProvider services)

--- a/test/ModularPipelines.Testing.UnitTests/ModuleTesterTests.cs
+++ b/test/ModularPipelines.Testing.UnitTests/ModuleTesterTests.cs
@@ -1,3 +1,4 @@
+using ModularPipelines.Attributes;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
@@ -153,6 +154,38 @@ public class ModuleTesterTests
             .Throws<InvalidOperationException>();
 
         await Assert.That(exception!.Message).Contains(nameof(DependencyModule));
+    }
+
+    [Test]
+    public async Task MissingConsumedArtifactFailsBeforeModuleExecution()
+    {
+        var run = await ModuleTester.For<ArtifactConsumerModule, string>()
+            .WithDependencyResult<ArtifactProducerModule, string>("producer result")
+            .ExecuteAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(run.Exception).IsTypeOf<InvalidOperationException>();
+            await Assert.That(run.Exception!.Message).Contains("Call WithArtifact to seed it");
+        }
+    }
+
+    [Test]
+    public async Task SeedsConsumedArtifactInVirtualFileSystem()
+    {
+        var fileSystem = new InMemoryFileSystemProvider();
+        var run = await ModuleTester.For<ArtifactConsumerModule, string>()
+            .WithService<IFileSystemProvider>(fileSystem)
+            .WithDependencyResult<ArtifactProducerModule, string>("producer result")
+            .WithArtifact<ArtifactProducerModule>("application", "artifact contents")
+            .ExecuteAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(run.Value).IsEqualTo("artifact contents");
+            await Assert.That(run.Exception).IsNull();
+            await Assert.That(run.FileSystem).IsSameReferenceAs(fileSystem);
+        }
     }
 
     [Test]
@@ -438,6 +471,33 @@ public class ModuleTesterTests
         {
             var dependency = await context.GetModule<DependencyModule>();
             return $"{dependency.Value} consumed";
+        }
+    }
+
+    [ProducesArtifact("application", "application")]
+    public sealed class ArtifactProducerModule : Module<string>
+    {
+        protected override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+            => throw new InvalidOperationException("Seeded producer must not execute.");
+    }
+
+    [ModularPipelines.Attributes.DependsOn<ArtifactProducerModule>]
+    [ConsumesArtifact(
+        typeof(ArtifactProducerModule),
+        "application",
+        RestorePath = "restored-artifacts")]
+    public sealed class ArtifactConsumerModule : Module<string>
+    {
+        protected override async Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            var artifact = context.Files.GetFile(
+                Path.Combine("restored-artifacts", "application"));
+            return await artifact.ReadAsync(cancellationToken)
+                ?? throw new InvalidOperationException("Seeded artifact was not restored.");
         }
     }
 

--- a/test/ModularPipelines.Testing.UnitTests/ModuleTesterTests.cs
+++ b/test/ModularPipelines.Testing.UnitTests/ModuleTesterTests.cs
@@ -1,4 +1,5 @@
 using ModularPipelines.Attributes;
+using ModularPipelines.Caching;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
@@ -7,6 +8,7 @@ using ModularPipelines.FileSystem;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
+using Microsoft.Extensions.Options;
 
 namespace ModularPipelines.Testing.UnitTests;
 
@@ -185,6 +187,37 @@ public class ModuleTesterTests
             await Assert.That(run.Value).IsEqualTo("artifact contents");
             await Assert.That(run.Exception).IsNull();
             await Assert.That(run.FileSystem).IsSameReferenceAs(fileSystem);
+        }
+    }
+
+    [Test]
+    public async Task ResolvesConsumedArtifactFromConfiguredWorkingDirectory()
+    {
+        var workingDirectory = Path.Combine(
+            Environment.CurrentDirectory,
+            $"module-tester-working-{Guid.NewGuid():N}");
+        var artifactPath = Path.Combine(
+            workingDirectory,
+            "restored-artifacts",
+            "application");
+        var fileSystem = new InMemoryFileSystemProvider();
+        var run = await ModuleTester.For<WorkingDirectoryArtifactConsumerModule, string>()
+            .WithService<IFileSystemProvider>(fileSystem)
+            .WithService<IOptions<ModuleCacheOptions>>(
+                Microsoft.Extensions.Options.Options.Create(new ModuleCacheOptions
+                {
+                    WorkingDirectory = workingDirectory,
+                }))
+            .WithService(new FilePath(artifactPath))
+            .WithDependencyResult<ArtifactProducerModule, string>("producer result")
+            .WithArtifact<ArtifactProducerModule>("application", "artifact contents")
+            .ExecuteAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(run.Value).IsEqualTo("artifact contents");
+            await Assert.That(run.Exception).IsNull();
+            await Assert.That(fileSystem.FileExists(artifactPath)).IsTrue();
         }
     }
 
@@ -496,6 +529,23 @@ public class ModuleTesterTests
         {
             var artifact = context.Files.GetFile(
                 Path.Combine("restored-artifacts", "application"));
+            return await artifact.ReadAsync(cancellationToken)
+                ?? throw new InvalidOperationException("Seeded artifact was not restored.");
+        }
+    }
+
+    [ModularPipelines.Attributes.DependsOn<ArtifactProducerModule>]
+    [ConsumesArtifact(
+        typeof(ArtifactProducerModule),
+        "application",
+        RestorePath = "restored-artifacts")]
+    public sealed class WorkingDirectoryArtifactConsumerModule(FilePath artifactPath) : Module<string>
+    {
+        protected override async Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            var artifact = context.Files.GetFile(artifactPath.Value);
             return await artifact.ReadAsync(cancellationToken)
                 ?? throw new InvalidOperationException("Seeded artifact was not restored.");
         }


### PR DESCRIPTION
Closes #3805.

Adds WithArtifact<TProducer> to seed consumed single-file artifacts into ModuleTester virtual filesystems. Missing seeds now fail in the execution prepare phase before module code runs. Documentation states which artifact transport behaviors remain integration-test concerns.

Validation:
- ModuleTesterTests: 24/24 passed
- ModularPipelines.Testing Release build: 0 warnings, 0 errors