### PR TITLE
Bound AlwaysRun scheduler progress waits

### DIFF
--- a/docs/docs/how-to/timeouts.md
+++ b/docs/docs/how-to/timeouts.md
@@ -22,6 +22,19 @@ builder.ConfigurePipelineOptions(options => options with
 
 You can override the pipeline default for one module using `Configure()`. Bear in mind some build runners, like GitHub Actions, have their own timeouts, so extending past these won't help.
 
+`AlwaysRun` teardown has a separate 30-second scheduler-progress watchdog. This prevents a
+constraint-deferred `AlwaysRun` module from waiting indefinitely for a hung active module, even
+when ordinary module timeouts are disabled. Configure it independently when needed:
+
+```csharp
+builder.ConfigurePipelineOptions(options => options with
+{
+    AlwaysRunProgressTimeout = TimeSpan.FromMinutes(1),
+});
+```
+
+Set `AlwaysRunProgressTimeout` to `TimeSpan.Zero` only when an unlimited teardown wait is intentional.
+
 ## Using ModuleConfiguration
 
 ```csharp

--- a/docs/docs/how-to/timeouts.md
+++ b/docs/docs/how-to/timeouts.md
@@ -34,6 +34,8 @@ builder.ConfigurePipelineOptions(options => options with
 ```
 
 Set `AlwaysRunProgressTimeout` to `TimeSpan.Zero` only when an unlimited teardown wait is intentional.
+The timeout is one cumulative budget for the entire `AlwaysRun` teardown wait, not a fresh budget
+for each retry, so increase it for pipelines whose blocking modules can legitimately run longer.
 
 ## Using ModuleConfiguration
 

--- a/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/AlwaysRunHandler.cs
@@ -21,7 +21,7 @@ internal class AlwaysRunHandler(
 {
     private readonly IModuleRunner _moduleRunner = moduleRunner;
     private readonly IParallelLimitProvider _parallelLimitProvider = parallelLimitProvider;
-    private readonly TimeSpan _schedulerProgressTimeout = pipelineOptions.Value.DefaultModuleTimeout;
+    private readonly TimeSpan _schedulerProgressTimeout = pipelineOptions.Value.AlwaysRunProgressTimeout;
     private readonly ILogger<AlwaysRunHandler> _logger = logger;
     private readonly TimeProvider _timeProvider = timeProvider;
 

--- a/src/ModularPipelines/Options/PipelineOptions.cs
+++ b/src/ModularPipelines/Options/PipelineOptions.cs
@@ -94,6 +94,12 @@ public record PipelineOptions
     public TimeSpan DefaultModuleTimeout { get; init; } = TimeSpan.FromMinutes(30);
 
     /// <summary>
+    /// Gets the maximum cumulative time to wait for scheduler progress before retrying deferred
+    /// <c>AlwaysRun</c> modules. Set to <see cref="TimeSpan.Zero"/> to disable this watchdog.
+    /// </summary>
+    public TimeSpan AlwaysRunProgressTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     /// Gets the collection of module categories to run exclusively, matched case-insensitively.
     /// If specified, only modules in these categories will run.
     /// </summary>

--- a/src/ModularPipelines/Validation/OptionsValidator.cs
+++ b/src/ModularPipelines/Validation/OptionsValidator.cs
@@ -48,6 +48,13 @@ internal class OptionsValidator : IOptionsValidator
                 $"DefaultModuleTimeout cannot be negative. Current value: {options.DefaultModuleTimeout}"));
         }
 
+        if (options.AlwaysRunProgressTimeout < TimeSpan.Zero)
+        {
+            result.AddError(new ValidationError(
+                ValidationErrorCategory.Options,
+                $"AlwaysRunProgressTimeout cannot be negative. Current value: {options.AlwaysRunProgressTimeout}"));
+        }
+
         var consoleOptions = options.Console;
         if (consoleOptions.ModuleOutputFlushInterval < TimeSpan.Zero)
         {

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -332,7 +332,7 @@ public class AlwaysRunHandlerTests
     }
 
     [Test]
-    public async Task WaitForAlwaysRunModulesAsync_TimesOutWhenModuleTimeoutsAreDisabled()
+    public async Task WaitForAlwaysRunModulesAsync_UsesDedicatedProgressTimeoutWhenModuleTimeoutsAreDisabled()
     {
         var timeProvider = TestPipelineBuilder.CreateFakeTimeProvider();
         var module = new FirstAlwaysRunModule();
@@ -358,10 +358,11 @@ public class AlwaysRunHandlerTests
                 CancellationToken.None))
             .Returns(Task.CompletedTask);
 
-        var handler = CreateHandler(
-            moduleRunner.Object,
-            timeProvider: timeProvider,
-            defaultModuleTimeout: TimeSpan.Zero);
+        var pipelineOptions = new PipelineOptions
+        {
+            DefaultModuleTimeout = TimeSpan.Zero,
+        };
+        var handler = CreateHandler(moduleRunner.Object, pipelineOptions, timeProvider);
         var handlerTask = handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [module, blocker]);
 
         await progressWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
@@ -418,7 +419,10 @@ public class AlwaysRunHandlerTests
 
         var handler = CreateHandler(
             moduleRunner.Object,
-            TimeSpan.FromMilliseconds(200),
+            new PipelineOptions
+            {
+                AlwaysRunProgressTimeout = TimeSpan.FromMilliseconds(200),
+            },
             timeProvider);
         var handlerTask = handler.WaitForAlwaysRunModulesAsync(
             scheduler.Object,
@@ -460,9 +464,8 @@ public class AlwaysRunHandlerTests
 
     private static AlwaysRunHandler CreateHandler(
         IModuleRunner moduleRunner,
-        TimeSpan? schedulerProgressTimeout = null,
-        TimeProvider? timeProvider = null,
-        TimeSpan? defaultModuleTimeout = null)
+        PipelineOptions? pipelineOptions = null,
+        TimeProvider? timeProvider = null)
     {
         var parallelLimitProvider = new Mock<IParallelLimitProvider>();
         parallelLimitProvider
@@ -472,11 +475,7 @@ public class AlwaysRunHandlerTests
         return new AlwaysRunHandler(
             moduleRunner,
             parallelLimitProvider.Object,
-            Microsoft.Extensions.Options.Options.Create(new PipelineOptions
-            {
-                AlwaysRunProgressTimeout = schedulerProgressTimeout ?? new PipelineOptions().AlwaysRunProgressTimeout,
-                DefaultModuleTimeout = defaultModuleTimeout ?? TimeSpan.FromMinutes(30),
-            }),
+            Microsoft.Extensions.Options.Options.Create(pipelineOptions ?? new PipelineOptions()),
             NullLogger<AlwaysRunHandler>.Instance,
             timeProvider ?? TimeProvider.System);
     }

--- a/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/AlwaysRunHandlerTests.cs
@@ -332,7 +332,7 @@ public class AlwaysRunHandlerTests
     }
 
     [Test]
-    public async Task WaitForAlwaysRunModulesAsync_TimesOutWhenSchedulerCannotMakeProgress()
+    public async Task WaitForAlwaysRunModulesAsync_TimesOutWhenModuleTimeoutsAreDisabled()
     {
         var timeProvider = TestPipelineBuilder.CreateFakeTimeProvider();
         var module = new FirstAlwaysRunModule();
@@ -360,12 +360,12 @@ public class AlwaysRunHandlerTests
 
         var handler = CreateHandler(
             moduleRunner.Object,
-            TimeSpan.FromMilliseconds(50),
-            timeProvider);
+            timeProvider: timeProvider,
+            defaultModuleTimeout: TimeSpan.Zero);
         var handlerTask = handler.WaitForAlwaysRunModulesAsync(scheduler.Object, [module, blocker]);
 
         await progressWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        timeProvider.Advance(TimeSpan.FromMilliseconds(50));
+        timeProvider.Advance(TimeSpan.FromSeconds(30));
         var exception = await Assert.ThrowsAsync<AggregateException>(() => handlerTask);
 
         await Assert.That(exception!.InnerExceptions).Contains(x => x is TimeoutException);
@@ -461,7 +461,8 @@ public class AlwaysRunHandlerTests
     private static AlwaysRunHandler CreateHandler(
         IModuleRunner moduleRunner,
         TimeSpan? schedulerProgressTimeout = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        TimeSpan? defaultModuleTimeout = null)
     {
         var parallelLimitProvider = new Mock<IParallelLimitProvider>();
         parallelLimitProvider
@@ -473,7 +474,8 @@ public class AlwaysRunHandlerTests
             parallelLimitProvider.Object,
             Microsoft.Extensions.Options.Options.Create(new PipelineOptions
             {
-                DefaultModuleTimeout = schedulerProgressTimeout ?? TimeSpan.FromSeconds(2),
+                AlwaysRunProgressTimeout = schedulerProgressTimeout ?? new PipelineOptions().AlwaysRunProgressTimeout,
+                DefaultModuleTimeout = defaultModuleTimeout ?? TimeSpan.FromMinutes(30),
             }),
             NullLogger<AlwaysRunHandler>.Instance,
             timeProvider ?? TimeProvider.System);

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -82,6 +82,14 @@ public class ModuleTimeoutTests : TestBase
     }
 
     [Test]
+    public async Task Default_AlwaysRun_Progress_Timeout_Is_Thirty_Seconds()
+    {
+        var options = new PipelineOptions();
+
+        await Assert.That(options.AlwaysRunProgressTimeout).IsEqualTo(TimeSpan.FromSeconds(30));
+    }
+
+    [Test]
     public async Task Pipeline_Default_Module_Timeout_Is_Applied()
     {
         var exception = await Assert.ThrowsAsync<ModuleFailedException>(async () => await TestPipelineBuilder.Create()

--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -519,6 +519,24 @@ public class ValidationTests
     }
 
     [Test]
+    public async Task ValidateAsync_WithNegativeAlwaysRunProgressTimeout_ReturnsError()
+    {
+        var builder = Pipeline.CreateBuilder();
+        builder.AddModule<SimpleModule>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            AlwaysRunProgressTimeout = TimeSpan.FromSeconds(-1),
+        });
+
+        var result = await builder.ValidateAsync();
+
+        await Assert.That(result.HasErrors).IsTrue();
+        await Assert.That(result.Errors.Any(e =>
+            e.Category == ValidationErrorCategory.Options &&
+            e.Message.Contains("AlwaysRunProgressTimeout"))).IsTrue();
+    }
+
+    [Test]
     public async Task ValidateAsync_WithNegativeModuleOutputFlushInterval_ReturnsError()
     {
         var builder = Pipeline.CreateBuilder();


### PR DESCRIPTION
Closes #3794

## Summary
- add a dedicated AlwaysRunProgressTimeout with a 30-second default
- keep AlwaysRun teardown bounded when DefaultModuleTimeout is disabled
- validate negative values and document independent configuration

## Validation
- AlwaysRunHandlerTests: 8/8 passed
- new option validation/default tests: 2/2 passed
- lightweight core Release build: 0 warnings, 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated timeout for monitoring progress while deferred `AlwaysRun` modules are retried.
  - The timeout defaults to 30 seconds, applies cumulatively across retries, and can be disabled with `TimeSpan.Zero`.
- **Bug Fixes**
  - Prevented `AlwaysRun` progress monitoring from relying on the general module timeout setting.
- **Documentation**
  - Documented configuration, disabling behavior, and cumulative timeout handling.
- **Validation**
  - Negative timeout values now produce a clear configuration error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->