### PR TITLE
Cancel parallel limiter waits

### DIFF
--- a/docs/docs/architecture/module-execution-lifecycle.md
+++ b/docs/docs/architecture/module-execution-lifecycle.md
@@ -13,8 +13,8 @@ For a module that runs successfully, the phases are:
 
 1. Dependencies become ready.
 2. Global `IModuleEventReceiver.OnModuleReadyAsync` receivers run concurrently.
-3. Global `IModuleEventReceiver.OnModuleStartAsync` receivers run concurrently.
-4. Attribute `IModuleReadyHandler` handlers run sequentially by priority.
+3. Attribute `IModuleReadyHandler` handlers run sequentially by priority.
+4. Global `IModuleEventReceiver.OnModuleStartAsync` receivers run concurrently.
 5. Attribute `IModuleStartHandler` handlers run sequentially by priority.
 6. The module skip condition is evaluated.
 7. `Module<T>.OnBeforeExecuteAsync` runs once.

--- a/docs/docs/how-to/hooks.md
+++ b/docs/docs/how-to/hooks.md
@@ -135,8 +135,8 @@ run sequentially in priority order.
 The order for a successful module is:
 
 1. Global `OnModuleReadyAsync`
-2. Global `OnModuleStartAsync`
-3. Attribute `IModuleReadyHandler`
+2. Attribute `IModuleReadyHandler`
+3. Global `OnModuleStartAsync`
 4. Attribute `IModuleStartHandler`
 5. Module `OnBeforeExecuteAsync`
 6. Module `ExecuteAsync` with its retry policy

--- a/src/ModularPipelines/Engine/Execution/IParallelLimitHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/IParallelLimitHandler.cs
@@ -11,13 +11,15 @@ internal interface IParallelLimitHandler
     /// Acquires a parallel limit semaphore for the specified module type.
     /// </summary>
     /// <param name="moduleType">The type of the module.</param>
+    /// <param name="cancellationToken">The token that cancels waiting for a slot.</param>
     /// <returns>A disposable that releases the semaphore when disposed.</returns>
-    Task<IDisposable> AcquireParallelLimitAsync(Type moduleType);
+    Task<IDisposable> AcquireParallelLimitAsync(Type moduleType, CancellationToken cancellationToken);
 
     /// <summary>
     /// Acquires an execution type limit semaphore for the specified module state.
     /// </summary>
     /// <param name="moduleState">The module state containing execution type information.</param>
+    /// <param name="cancellationToken">The token that cancels waiting for a slot.</param>
     /// <returns>A disposable that releases the semaphore when disposed.</returns>
-    Task<IDisposable> AcquireExecutionTypeLimitAsync(ModuleState moduleState);
+    Task<IDisposable> AcquireExecutionTypeLimitAsync(ModuleState moduleState, CancellationToken cancellationToken);
 }

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -230,7 +230,7 @@ internal class ModuleRunner : IModuleRunner
     {
         if (!alwaysRun
             && (workerCancellationToken.IsCancellationRequested
-                || _engineCancellationToken.OriginalException is not null)
+                || _engineCancellationToken.IsCancelled)
             && exception is OperationCanceledException operationCanceledException
             && operationCanceledException.CancellationToken == limiterCancellationToken
             && limiterCancellationToken != workerCancellationToken)
@@ -282,11 +282,10 @@ internal class ModuleRunner : IModuleRunner
         var isPipelineCancellation = exception is OperationCanceledException
                                      && _engineCancellationToken.IsCancelled;
         var registeredResult = _resultRegistry.GetResult(moduleType);
-        var completionException = isPipelineCancellation
-            ? registeredResult?.ExceptionOrDefault
-              ?? _engineCancellationToken.OriginalException
-              ?? exception
-            : exception;
+        var completionException = GetCompletionException(
+            exception,
+            isPipelineCancellation,
+            registeredResult?.ExceptionOrDefault);
         if (isPipelineCancellation)
         {
             _logger.LogInformation(
@@ -298,11 +297,10 @@ internal class ModuleRunner : IModuleRunner
             _logger.LogError(exception, "Module {ModuleName} failed", moduleType.Name);
         }
 
-        Enums.Status? statusOverride = isDependencyFailure
-            ? Enums.Status.DependencyFailed
-            : isPipelineCancellation
-                ? registeredResult?.ModuleStatus ?? Enums.Status.PipelineTerminated
-                : null;
+        var statusOverride = GetStatusOverride(
+            isDependencyFailure,
+            isPipelineCancellation,
+            registeredResult?.ModuleStatus);
         scheduler.MarkModuleCompleted(
             moduleType,
             false,
@@ -322,6 +320,29 @@ internal class ModuleRunner : IModuleRunner
         {
             _resultRegistrar.RegisterTerminatedResult(module, moduleType, completionException);
         }
+    }
+
+    private Exception GetCompletionException(
+        Exception exception,
+        bool isPipelineCancellation,
+        Exception? registeredException) =>
+        isPipelineCancellation
+            ? registeredException ?? _engineCancellationToken.OriginalException ?? exception
+            : exception;
+
+    private static Enums.Status? GetStatusOverride(
+        bool isDependencyFailure,
+        bool isPipelineCancellation,
+        Enums.Status? registeredStatus)
+    {
+        if (isDependencyFailure)
+        {
+            return Enums.Status.DependencyFailed;
+        }
+
+        return isPipelineCancellation
+            ? registeredStatus ?? Enums.Status.PipelineTerminated
+            : null;
     }
 
     private async Task UploadProducedArtifactsAsync(

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -159,7 +159,7 @@ internal class ModuleRunner : IModuleRunner
                         scope.ServiceProvider.GetRequiredService<IPipelineContext>(),
                         scope.ServiceProvider,
                         cancellationToken);
-                    await _lifecycleEventInvoker.InvokeReadyEventAsync(readyLifecycleContext).ConfigureAwait(false);
+                    await InvokeReadyEventAsync(moduleState, readyLifecycleContext).ConfigureAwait(false);
                 }
 
                 using var limiterCancellationTokenSource = module.Configuration.AlwaysRun
@@ -222,14 +222,15 @@ internal class ModuleRunner : IModuleRunner
         }
     }
 
-    private static Exception NormalizeLimiterCancellation(
+    private Exception NormalizeLimiterCancellation(
         Exception exception,
         bool alwaysRun,
         CancellationToken workerCancellationToken,
         CancellationToken limiterCancellationToken)
     {
         if (!alwaysRun
-            && workerCancellationToken.IsCancellationRequested
+            && (workerCancellationToken.IsCancellationRequested
+                || _engineCancellationToken.OriginalException is not null)
             && exception is OperationCanceledException operationCanceledException
             && operationCanceledException.CancellationToken == limiterCancellationToken
             && limiterCancellationToken != workerCancellationToken)
@@ -241,6 +242,33 @@ internal class ModuleRunner : IModuleRunner
         }
 
         return exception;
+    }
+
+    private async Task InvokeReadyEventAsync(
+        ModuleState moduleState,
+        ModuleLifecycleContext lifecycleContext)
+    {
+        try
+        {
+            await _lifecycleEventInvoker.InvokeReadyEventAsync(lifecycleContext).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            var executionContext = CreateExecutionContext(moduleState.Module, moduleState.ModuleType);
+            ApplyDependencySkip(moduleState, executionContext);
+
+            try
+            {
+                await HandleModuleFailureAsync(moduleState, executionContext, lifecycleContext, exception)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                await CompleteModuleLifecycleAsync(moduleState, executionContext).ConfigureAwait(false);
+            }
+
+            throw;
+        }
     }
 
     private void HandleExecutionFailure(
@@ -841,13 +869,18 @@ internal class ModuleRunner : IModuleRunner
         }
         finally
         {
-            // Store execution context results in module state
-            moduleState.TrySetSkipResult(executionContext.SkipResult);
+            await CompleteModuleLifecycleAsync(moduleState, executionContext).ConfigureAwait(false);
+        }
+    }
 
-            if (!_pipelineOptions.Value.Console.ShowProgress)
-            {
-                await _moduleDisposer.DisposeAsync(moduleState).ConfigureAwait(false);
-            }
+    private async Task CompleteModuleLifecycleAsync(
+        ModuleState moduleState,
+        ModuleExecutionContext executionContext)
+    {
+        moduleState.TrySetSkipResult(executionContext.SkipResult);
+        if (!_pipelineOptions.Value.Console.ShowProgress)
+        {
+            await _moduleDisposer.DisposeAsync(moduleState).ConfigureAwait(false);
         }
     }
 

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -282,6 +282,11 @@ internal class ModuleRunner : IModuleRunner
         var isPipelineCancellation = exception is OperationCanceledException
                                      && _engineCancellationToken.IsCancelled;
         var registeredResult = _resultRegistry.GetResult(moduleType);
+        var completionException = isPipelineCancellation
+            ? registeredResult?.ExceptionOrDefault
+              ?? _engineCancellationToken.OriginalException
+              ?? exception
+            : exception;
         if (isPipelineCancellation)
         {
             _logger.LogInformation(
@@ -301,7 +306,7 @@ internal class ModuleRunner : IModuleRunner
         scheduler.MarkModuleCompleted(
             moduleType,
             false,
-            exception,
+            completionException,
             statusOverride);
 
         if (moduleState.Result is not null || registeredResult is not null)
@@ -315,7 +320,7 @@ internal class ModuleRunner : IModuleRunner
         }
         else
         {
-            _resultRegistrar.RegisterTerminatedResult(module, moduleType, exception);
+            _resultRegistrar.RegisterTerminatedResult(module, moduleType, completionException);
         }
     }
 

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -150,11 +150,14 @@ internal class ModuleRunner : IModuleRunner
                             cancellationToken)
                         .ConfigureAwait(false);
 
+                var limiterCancellationToken = module.Configuration.AlwaysRun
+                    ? executionContext.ModuleCancellationTokenSource.Token
+                    : cancellationToken;
                 using var semaphoreHandle = await _parallelLimitHandler
-                    .AcquireParallelLimitAsync(moduleType, cancellationToken)
+                    .AcquireParallelLimitAsync(moduleType, limiterCancellationToken)
                     .ConfigureAwait(false);
                 using var executionTypeHandle = await _parallelLimitHandler
-                    .AcquireExecutionTypeLimitAsync(moduleState, cancellationToken)
+                    .AcquireExecutionTypeLimitAsync(moduleState, limiterCancellationToken)
                     .ConfigureAwait(false);
 
                 // Check constraints again after acquiring execution slots. Keeping the module queued

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -128,6 +128,7 @@ internal class ModuleRunner : IModuleRunner
         var module = moduleState.Module;
         var moduleType = moduleState.ModuleType;
         var moduleName = moduleType.Name;
+        var limiterCancellationToken = default(CancellationToken);
 
         // Create a scope to resolve scoped services like IModuleContext and ModuleLogger<T>
         var scope = _serviceProvider.CreateAsyncScope();
@@ -166,7 +167,7 @@ internal class ModuleRunner : IModuleRunner
                     : CancellationTokenSource.CreateLinkedTokenSource(
                         cancellationToken,
                         _engineCancellationToken.Token);
-                var limiterCancellationToken = module.Configuration.AlwaysRun
+                limiterCancellationToken = module.Configuration.AlwaysRun
                     ? _engineCancellationToken.NonFailureCancellationToken
                     : limiterCancellationTokenSource!.Token;
                 using var semaphoreHandle = await _parallelLimitHandler
@@ -201,14 +202,45 @@ internal class ModuleRunner : IModuleRunner
             }
             catch (Exception ex)
             {
-                HandleExecutionFailure(moduleState, scheduler, ex);
+                var handledException = NormalizeLimiterCancellation(
+                    ex,
+                    module.Configuration.AlwaysRun,
+                    cancellationToken,
+                    limiterCancellationToken);
+                HandleExecutionFailure(moduleState, scheduler, handledException);
 
                 if (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                 {
-                    throw;
+                    if (ReferenceEquals(handledException, ex))
+                    {
+                        throw;
+                    }
+
+                    throw handledException;
                 }
             }
         }
+    }
+
+    private static Exception NormalizeLimiterCancellation(
+        Exception exception,
+        bool alwaysRun,
+        CancellationToken workerCancellationToken,
+        CancellationToken limiterCancellationToken)
+    {
+        if (!alwaysRun
+            && workerCancellationToken.IsCancellationRequested
+            && exception is OperationCanceledException operationCanceledException
+            && operationCanceledException.CancellationToken == limiterCancellationToken
+            && limiterCancellationToken != workerCancellationToken)
+        {
+            return new OperationCanceledException(
+                operationCanceledException.Message,
+                operationCanceledException,
+                workerCancellationToken);
+        }
+
+        return exception;
     }
 
     private void HandleExecutionFailure(

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -132,16 +132,6 @@ internal class ModuleRunner : IModuleRunner
         {
             try
             {
-                // Check if the module can proceed with execution
-                // Returns false if constraints (e.g., NotInParallel) prevent execution
-                if (!scheduler.MarkModuleStarted(moduleType))
-                {
-                    _logger.LogDebug("Module {ModuleName} deferred due to constraint check failure", moduleName);
-                    return; // Module will be rescheduled by the scheduler
-                }
-
-                _logger.LogDebug("Starting module {ModuleName}", moduleName);
-
                 if (!skipDependencyWait)
                 {
                     await _dependencyWaiter.WaitForDependenciesAsync(moduleState, scheduler, scope.ServiceProvider).ConfigureAwait(false);
@@ -159,6 +149,23 @@ internal class ModuleRunner : IModuleRunner
                             scheduler,
                             cancellationToken)
                         .ConfigureAwait(false);
+
+                using var semaphoreHandle = await _parallelLimitHandler
+                    .AcquireParallelLimitAsync(moduleType, cancellationToken)
+                    .ConfigureAwait(false);
+                using var executionTypeHandle = await _parallelLimitHandler
+                    .AcquireExecutionTypeLimitAsync(moduleState, cancellationToken)
+                    .ConfigureAwait(false);
+
+                // Check constraints again after acquiring execution slots. Keeping the module queued
+                // until this point prevents limiter wait time from being reported as execution time.
+                if (!scheduler.MarkModuleStarted(moduleType))
+                {
+                    _logger.LogDebug("Module {ModuleName} deferred due to constraint check failure", moduleName);
+                    return; // Module will be rescheduled by the scheduler
+                }
+
+                _logger.LogDebug("Starting module {ModuleName}", moduleName);
 
                 await ExecuteModuleWithPipeline(
                         moduleState,
@@ -726,9 +733,6 @@ internal class ModuleRunner : IModuleRunner
                 new ModuleStartedNotification(moduleState, estimatedDuration),
                 CancellationToken.None)
             .ConfigureAwait(false);
-
-        using var semaphoreHandle = await _parallelLimitHandler.AcquireParallelLimitAsync(moduleType).ConfigureAwait(false);
-        using var executionTypeHandle = await _parallelLimitHandler.AcquireExecutionTypeLimitAsync(moduleState).ConfigureAwait(false);
 
         // Track start time for lifecycle events
         var startTime = DateTimeOffset.UtcNow;

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -201,49 +201,61 @@ internal class ModuleRunner : IModuleRunner
             }
             catch (Exception ex)
             {
-                var isDependencyFailure = ex is DependencyFailedException;
-                var isPipelineCancellation = ex is OperationCanceledException
-                                             && _engineCancellationToken.IsCancelled;
-                var registeredResult = _resultRegistry.GetResult(moduleType);
-                if (isPipelineCancellation)
-                {
-                    _logger.LogInformation(
-                        "Pipeline cancellation stopped module {ModuleName} before execution",
-                        moduleName);
-                }
-                else
-                {
-                    _logger.LogError(ex, "Module {ModuleName} failed", moduleName);
-                }
-
-                Enums.Status? statusOverride = isDependencyFailure
-                    ? Enums.Status.DependencyFailed
-                    : isPipelineCancellation
-                        ? registeredResult?.ModuleStatus ?? Enums.Status.PipelineTerminated
-                        : null;
-                scheduler.MarkModuleCompleted(
-                    moduleType,
-                    false,
-                    ex,
-                    statusOverride);
-
-                if (moduleState.Result == null && registeredResult == null)
-                {
-                    if (isDependencyFailure)
-                    {
-                        _resultRegistrar.RegisterDependencyFailedResult(module, moduleType, ex);
-                    }
-                    else
-                    {
-                        _resultRegistrar.RegisterTerminatedResult(module, moduleType, ex);
-                    }
-                }
+                HandleExecutionFailure(moduleState, scheduler, ex);
 
                 if (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                 {
                     throw;
                 }
             }
+        }
+    }
+
+    private void HandleExecutionFailure(
+        ModuleState moduleState,
+        IModuleScheduler scheduler,
+        Exception exception)
+    {
+        var module = moduleState.Module;
+        var moduleType = moduleState.ModuleType;
+        var isDependencyFailure = exception is DependencyFailedException;
+        var isPipelineCancellation = exception is OperationCanceledException
+                                     && _engineCancellationToken.IsCancelled;
+        var registeredResult = _resultRegistry.GetResult(moduleType);
+        if (isPipelineCancellation)
+        {
+            _logger.LogInformation(
+                "Pipeline cancellation stopped module {ModuleName} before execution",
+                moduleType.Name);
+        }
+        else
+        {
+            _logger.LogError(exception, "Module {ModuleName} failed", moduleType.Name);
+        }
+
+        Enums.Status? statusOverride = isDependencyFailure
+            ? Enums.Status.DependencyFailed
+            : isPipelineCancellation
+                ? registeredResult?.ModuleStatus ?? Enums.Status.PipelineTerminated
+                : null;
+        scheduler.MarkModuleCompleted(
+            moduleType,
+            false,
+            exception,
+            statusOverride);
+
+        if (moduleState.Result is not null || registeredResult is not null)
+        {
+            return;
+        }
+
+        if (isDependencyFailure)
+        {
+            _resultRegistrar.RegisterDependencyFailedResult(module, moduleType, exception);
+        }
+        else
+        {
+            _resultRegistrar.RegisterTerminatedResult(module, moduleType, exception);
         }
     }
 

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -34,6 +34,7 @@ internal class ModuleRunner : IModuleRunner
     private readonly ISafeModuleEstimatedTimeProvider _moduleEstimatedTimeProvider;
     private readonly ModuleDisposer _moduleDisposer;
     private readonly IModuleResultRegistry _resultRegistry;
+    private readonly EngineCancellationToken _engineCancellationToken;
     private readonly IOptions<PipelineOptions> _pipelineOptions;
     private readonly ILogger<ModuleRunner> _logger;
     private readonly IDependencyWaiter _dependencyWaiter;
@@ -63,6 +64,7 @@ internal class ModuleRunner : IModuleRunner
         ISafeModuleEstimatedTimeProvider moduleEstimatedTimeProvider,
         ModuleDisposer moduleDisposer,
         IModuleResultRegistry resultRegistry,
+        EngineCancellationToken engineCancellationToken,
         IOptions<PipelineOptions> pipelineOptions,
         ILogger<ModuleRunner> logger,
         IDependencyWaiter dependencyWaiter,
@@ -85,6 +87,7 @@ internal class ModuleRunner : IModuleRunner
         _moduleEstimatedTimeProvider = moduleEstimatedTimeProvider;
         _moduleDisposer = moduleDisposer;
         _resultRegistry = resultRegistry;
+        _engineCancellationToken = engineCancellationToken;
         _pipelineOptions = pipelineOptions;
         _logger = logger;
         _dependencyWaiter = dependencyWaiter;
@@ -141,14 +144,11 @@ internal class ModuleRunner : IModuleRunner
                     _logger.LogDebug("Skipping dependency wait for late-started AlwaysRun module: {ModuleName}", moduleName);
                 }
 
-                var executionContext = CreateExecutionContext(module, moduleType);
-                ApplyDependencySkip(moduleState, executionContext);
-                executionContext.AllowHistoricalResultWhenSkipped =
-                    !await HasRunnableArtifactConsumerAsync(
-                            moduleType,
-                            scheduler,
-                            cancellationToken)
-                        .ConfigureAwait(false);
+                var allowHistoricalResultWhenSkipped = !await HasRunnableArtifactConsumerAsync(
+                        moduleType,
+                        scheduler,
+                        cancellationToken)
+                    .ConfigureAwait(false);
 
                 if (moduleState.TryStartReadyEvents())
                 {
@@ -161,9 +161,14 @@ internal class ModuleRunner : IModuleRunner
                     await _lifecycleEventInvoker.InvokeReadyEventAsync(readyLifecycleContext).ConfigureAwait(false);
                 }
 
+                using var limiterCancellationTokenSource = module.Configuration.AlwaysRun
+                    ? null
+                    : CancellationTokenSource.CreateLinkedTokenSource(
+                        cancellationToken,
+                        _engineCancellationToken.Token);
                 var limiterCancellationToken = module.Configuration.AlwaysRun
-                    ? executionContext.ModuleCancellationTokenSource.Token
-                    : cancellationToken;
+                    ? _engineCancellationToken.NonFailureCancellationToken
+                    : limiterCancellationTokenSource!.Token;
                 using var semaphoreHandle = await _parallelLimitHandler
                     .AcquireParallelLimitAsync(moduleType, limiterCancellationToken)
                     .ConfigureAwait(false);
@@ -180,6 +185,9 @@ internal class ModuleRunner : IModuleRunner
                 }
 
                 _logger.LogDebug("Starting module {ModuleName}", moduleName);
+                var executionContext = CreateExecutionContext(module, moduleType);
+                ApplyDependencySkip(moduleState, executionContext);
+                executionContext.AllowHistoricalResultWhenSkipped = allowHistoricalResultWhenSkipped;
 
                 await ExecuteModuleWithPipeline(
                         moduleState,
@@ -193,15 +201,33 @@ internal class ModuleRunner : IModuleRunner
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Module {ModuleName} failed", moduleName);
                 var isDependencyFailure = ex is DependencyFailedException;
+                var isPipelineCancellation = ex is OperationCanceledException
+                                             && _engineCancellationToken.IsCancelled;
+                var registeredResult = _resultRegistry.GetResult(moduleType);
+                if (isPipelineCancellation)
+                {
+                    _logger.LogInformation(
+                        "Pipeline cancellation stopped module {ModuleName} before execution",
+                        moduleName);
+                }
+                else
+                {
+                    _logger.LogError(ex, "Module {ModuleName} failed", moduleName);
+                }
+
+                Enums.Status? statusOverride = isDependencyFailure
+                    ? Enums.Status.DependencyFailed
+                    : isPipelineCancellation
+                        ? registeredResult?.ModuleStatus ?? Enums.Status.PipelineTerminated
+                        : null;
                 scheduler.MarkModuleCompleted(
                     moduleType,
                     false,
                     ex,
-                    isDependencyFailure ? Enums.Status.DependencyFailed : null);
+                    statusOverride);
 
-                if (moduleState.Result == null && _resultRegistry.GetResult(moduleType) == null)
+                if (moduleState.Result == null && registeredResult == null)
                 {
                     if (isDependencyFailure)
                     {

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -204,7 +204,6 @@ internal class ModuleRunner : IModuleRunner
             {
                 var handledException = NormalizeLimiterCancellation(
                     ex,
-                    module.Configuration.AlwaysRun,
                     cancellationToken,
                     limiterCancellationToken);
                 HandleExecutionFailure(moduleState, scheduler, handledException);
@@ -224,13 +223,10 @@ internal class ModuleRunner : IModuleRunner
 
     private Exception NormalizeLimiterCancellation(
         Exception exception,
-        bool alwaysRun,
         CancellationToken workerCancellationToken,
         CancellationToken limiterCancellationToken)
     {
-        if (!alwaysRun
-            && (workerCancellationToken.IsCancellationRequested
-                || _engineCancellationToken.IsCancelled)
+        if (limiterCancellationToken.IsCancellationRequested
             && exception is OperationCanceledException operationCanceledException
             && operationCanceledException.CancellationToken == limiterCancellationToken
             && limiterCancellationToken != workerCancellationToken)

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -150,6 +150,11 @@ internal class ModuleRunner : IModuleRunner
                             cancellationToken)
                         .ConfigureAwait(false);
 
+                if (moduleState.TryStartGlobalReadyEvent())
+                {
+                    await _pipelineSetupExecutor.OnModuleReadyAsync(moduleState).ConfigureAwait(false);
+                }
+
                 var limiterCancellationToken = module.Configuration.AlwaysRun
                     ? executionContext.ModuleCancellationTokenSource.Token
                     : cancellationToken;
@@ -727,8 +732,7 @@ internal class ModuleRunner : IModuleRunner
         var module = moduleState.Module;
         var moduleType = moduleState.ModuleType;
 
-        // Before module hooks - module is ready (dependencies satisfied)
-        await _pipelineSetupExecutor.OnModuleReadyAsync(moduleState).ConfigureAwait(false);
+        // Before module hooks - module is starting execution.
         await _pipelineSetupExecutor.OnModuleStartAsync(moduleState).ConfigureAwait(false);
 
         var estimatedDuration = await _moduleEstimatedTimeProvider.GetModuleEstimatedTimeAsync(moduleType).ConfigureAwait(false);

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -195,7 +195,7 @@ internal class ModuleRunner : IModuleRunner
                     ex,
                     isDependencyFailure ? Enums.Status.DependencyFailed : null);
 
-                if (moduleState.Result == null)
+                if (moduleState.Result == null && _resultRegistry.GetResult(moduleType) == null)
                 {
                     if (isDependencyFailure)
                     {

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -150,9 +150,15 @@ internal class ModuleRunner : IModuleRunner
                             cancellationToken)
                         .ConfigureAwait(false);
 
-                if (moduleState.TryStartGlobalReadyEvent())
+                if (moduleState.TryStartReadyEvents())
                 {
                     await _pipelineSetupExecutor.OnModuleReadyAsync(moduleState).ConfigureAwait(false);
+                    var readyLifecycleContext = CreateLifecycleContext(
+                        moduleState,
+                        scope.ServiceProvider.GetRequiredService<IPipelineContext>(),
+                        scope.ServiceProvider,
+                        cancellationToken);
+                    await _lifecycleEventInvoker.InvokeReadyEventAsync(readyLifecycleContext).ConfigureAwait(false);
                 }
 
                 var limiterCancellationToken = module.Configuration.AlwaysRun
@@ -741,20 +747,11 @@ internal class ModuleRunner : IModuleRunner
                 CancellationToken.None)
             .ConfigureAwait(false);
 
-        // Track start time for lifecycle events
-        var startTime = DateTimeOffset.UtcNow;
-        var moduleAttributes = _moduleAttributeEventService.GetAttributes(moduleType);
-        var lifecycleContext = new ModuleLifecycleContext(
-            module,
-            moduleType,
-            moduleAttributes,
-            startTime,
+        var lifecycleContext = CreateLifecycleContext(
+            moduleState,
             pipelineContext,
             scopedServiceProvider,
-            cancellationToken)
-        {
-            ReadyTime = moduleState.ReadyTime ?? startTime,
-        };
+            cancellationToken);
 
         try
         {
@@ -792,9 +789,6 @@ internal class ModuleRunner : IModuleRunner
         ModuleLifecycleContext lifecycleContext,
         CancellationToken cancellationToken)
     {
-        // Invoke OnModuleReady lifecycle event (dependencies satisfied, about to execute)
-        await _lifecycleEventInvoker.InvokeReadyEventAsync(lifecycleContext).ConfigureAwait(false);
-
         // Invoke OnModuleStart lifecycle event
         await _lifecycleEventInvoker.InvokeStartEventAsync(lifecycleContext).ConfigureAwait(false);
 
@@ -831,6 +825,26 @@ internal class ModuleRunner : IModuleRunner
                 new ModuleCompletedNotification(moduleState, isSuccessful),
                 CancellationToken.None)
             .ConfigureAwait(false);
+    }
+
+    private ModuleLifecycleContext CreateLifecycleContext(
+        ModuleState moduleState,
+        IPipelineContext pipelineContext,
+        IServiceProvider scopedServiceProvider,
+        CancellationToken cancellationToken)
+    {
+        var startTime = DateTimeOffset.UtcNow;
+        return new ModuleLifecycleContext(
+            moduleState.Module,
+            moduleState.ModuleType,
+            _moduleAttributeEventService.GetAttributes(moduleState.ModuleType),
+            startTime,
+            pipelineContext,
+            scopedServiceProvider,
+            cancellationToken)
+        {
+            ReadyTime = moduleState.ReadyTime ?? startTime,
+        };
     }
 
     private async Task HandleModuleFailureAsync(

--- a/src/ModularPipelines/Engine/Execution/ParallelLimitHandler.cs
+++ b/src/ModularPipelines/Engine/Execution/ParallelLimitHandler.cs
@@ -23,7 +23,9 @@ internal class ParallelLimitHandler : IParallelLimitHandler
     }
 
     /// <inheritdoc />
-    public async Task<IDisposable> AcquireParallelLimitAsync(Type moduleType)
+    public async Task<IDisposable> AcquireParallelLimitAsync(
+        Type moduleType,
+        CancellationToken cancellationToken)
     {
         var parallelLimiterAttribute =
             moduleType.GetCustomAttributes<ParallelLimiterAttribute>().FirstOrDefault();
@@ -36,14 +38,19 @@ internal class ParallelLimitHandler : IParallelLimitHandler
                 parallelLimiterAttribute.Type.Name);
 
             // Use the attribute's GetLock method to avoid reflection on IParallelLimit
-            return await parallelLimiterAttribute.GetLock(_parallelLimitProvider).WaitAsync().ConfigureAwait(false);
+            return await parallelLimiterAttribute
+                .GetLock(_parallelLimitProvider)
+                .WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
         }
 
         return NoOpDisposable.Instance;
     }
 
     /// <inheritdoc />
-    public async Task<IDisposable> AcquireExecutionTypeLimitAsync(ModuleState moduleState)
+    public async Task<IDisposable> AcquireExecutionTypeLimitAsync(
+        ModuleState moduleState,
+        CancellationToken cancellationToken)
     {
         var executionTypeLock = _parallelLimitProvider.GetExecutionTypeLock(moduleState.ExecutionType);
 
@@ -54,7 +61,7 @@ internal class ParallelLimitHandler : IParallelLimitHandler
                 moduleState.ModuleType.Name,
                 moduleState.ExecutionType);
 
-            return await executionTypeLock.WaitAsync().ConfigureAwait(false);
+            return await executionTypeLock.WaitAsync(cancellationToken).ConfigureAwait(false);
         }
 
         return NoOpDisposable.Instance;

--- a/src/ModularPipelines/Engine/ModuleState.cs
+++ b/src/ModularPipelines/Engine/ModuleState.cs
@@ -47,6 +47,7 @@ internal enum ModuleExecutionState
 internal class ModuleState
 {
     private ImmutableDictionary<Type, bool> _dependencies = ImmutableDictionary<Type, bool>.Empty;
+    private int _globalReadyEventStarted;
     private SkipDecision _skipResult = SkipDecision.DoNotSkip;
 
     public ModuleState(IModule module, Type moduleType)
@@ -146,6 +147,12 @@ internal class ModuleState
     /// Gets or sets when all dependencies were satisfied and the module became ready.
     /// </summary>
     public DateTimeOffset? ReadyTime { get; set; }
+
+    /// <summary>
+    /// Atomically records that the global ready event has started.
+    /// </summary>
+    /// <returns><see langword="true"/> only for the first caller.</returns>
+    public bool TryStartGlobalReadyEvent() => Interlocked.Exchange(ref _globalReadyEventStarted, 1) == 0;
 
     /// <summary>
     /// Gets a value indicating whether checks if this module is ready to execute (all dependencies resolved and constraints satisfied)

--- a/src/ModularPipelines/Engine/ModuleState.cs
+++ b/src/ModularPipelines/Engine/ModuleState.cs
@@ -47,7 +47,7 @@ internal enum ModuleExecutionState
 internal class ModuleState
 {
     private ImmutableDictionary<Type, bool> _dependencies = ImmutableDictionary<Type, bool>.Empty;
-    private int _globalReadyEventStarted;
+    private int _readyEventsStarted;
     private SkipDecision _skipResult = SkipDecision.DoNotSkip;
 
     public ModuleState(IModule module, Type moduleType)
@@ -149,10 +149,10 @@ internal class ModuleState
     public DateTimeOffset? ReadyTime { get; set; }
 
     /// <summary>
-    /// Atomically records that the global ready event has started.
+    /// Atomically records that the ready events have started.
     /// </summary>
     /// <returns><see langword="true"/> only for the first caller.</returns>
-    public bool TryStartGlobalReadyEvent() => Interlocked.Exchange(ref _globalReadyEventStarted, 1) == 0;
+    public bool TryStartReadyEvents() => Interlocked.Exchange(ref _readyEventsStarted, 1) == 0;
 
     /// <summary>
     /// Gets a value indicating whether checks if this module is ready to execute (all dependencies resolved and constraints satisfied)

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -259,6 +259,47 @@ public class ParallelLimitHandlerTests
     }
 
     [Test]
+    public async Task ModuleRunner_AlwaysRunEngineCancellationNormalizesLimiterWaitToWorkerToken()
+    {
+        var limiterWaitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var parallelLimitHandler = new Mock<IParallelLimitHandler>();
+        parallelLimitHandler
+            .Setup(x => x.AcquireParallelLimitAsync(
+                typeof(AlwaysRunTestModule),
+                It.IsAny<CancellationToken>()))
+            .Returns<Type, CancellationToken>(async (_, token) =>
+            {
+                limiterWaitStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                return Mock.Of<IDisposable>();
+            });
+
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<AlwaysRunTestModule>();
+        builder.Services.AddSingleton(parallelLimitHandler.Object);
+        await using var host = await builder.BuildAsync();
+        var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
+        var engineCancellationToken = host.Services.GetRequiredService<ModularPipelines.Engine.EngineCancellationToken>();
+        var scheduler = new Mock<IModuleScheduler>();
+        var moduleState = new ModuleState(
+            new AlwaysRunTestModule(),
+            typeof(AlwaysRunTestModule));
+        using var workerCancellationTokenSource = new CancellationTokenSource();
+
+        var executionTask = moduleRunner.ExecuteAsync(
+            moduleState,
+            scheduler.Object,
+            workerCancellationTokenSource.Token);
+        await limiterWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        engineCancellationToken.CancelWithReason("User cancellation");
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => executionTask);
+
+        await Assert.That(exception!.CancellationToken)
+            .IsEqualTo(workerCancellationTokenSource.Token);
+    }
+
+    [Test]
     public async Task ModuleRunner_PreservesWorkerTokenForFailureDrivenEngineCancellation()
     {
         var limiterWaitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Execution;
+using ModularPipelines.Enums;
+using ModularPipelines.Helpers;
+using ModularPipelines.Interfaces;
+using ModularPipelines.Modules;
+using ModularPipelines.Options;
+using ModularPipelines.TestHelpers;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine.Execution;
+
+public class ParallelLimitHandlerTests
+{
+    [Test]
+    public async Task AcquireParallelLimitAsync_CancelsWhileWaiting()
+    {
+        var handler = CreateHandler(new PipelineOptions());
+        using var heldSlot = await handler.AcquireParallelLimitAsync(
+            typeof(ParallelLimitedModule),
+            CancellationToken.None);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var waitingTask = handler.AcquireParallelLimitAsync(
+            typeof(ParallelLimitedModule),
+            cancellationTokenSource.Token);
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => waitingTask);
+    }
+
+    [Test]
+    public async Task AcquireExecutionTypeLimitAsync_CancelsWhileWaiting()
+    {
+        var handler = CreateHandler(new PipelineOptions
+        {
+            Concurrency = new ConcurrencyOptions
+            {
+                MaxCpuIntensiveModules = 1,
+            },
+        });
+        var firstState = new ModuleState(new TestModule(), typeof(TestModule))
+        {
+            ExecutionType = ExecutionType.CpuIntensive,
+        };
+        var secondState = new ModuleState(new TestModule(), typeof(TestModule))
+        {
+            ExecutionType = ExecutionType.CpuIntensive,
+        };
+        using var heldSlot = await handler.AcquireExecutionTypeLimitAsync(
+            firstState,
+            CancellationToken.None);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var waitingTask = handler.AcquireExecutionTypeLimitAsync(
+            secondState,
+            cancellationTokenSource.Token);
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => waitingTask);
+    }
+
+    [Test]
+    public async Task ModuleRunner_AcquiresLimitsBeforeMarkingModuleStarted()
+    {
+        var limitWaitObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLimitWait = new TaskCompletionSource<IDisposable>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var parallelLimitHandler = new Mock<IParallelLimitHandler>();
+        parallelLimitHandler
+            .Setup(x => x.AcquireParallelLimitAsync(typeof(TestModule), It.IsAny<CancellationToken>()))
+            .Callback(() => limitWaitObserved.TrySetResult())
+            .Returns(releaseLimitWait.Task);
+        parallelLimitHandler
+            .Setup(x => x.AcquireExecutionTypeLimitAsync(It.IsAny<ModuleState>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Mock.Of<IDisposable>());
+
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<TestModule>();
+        builder.Services.AddSingleton(parallelLimitHandler.Object);
+        await using var host = await builder.BuildAsync();
+        var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler
+            .Setup(x => x.MarkModuleStarted(typeof(TestModule)))
+            .Returns(false);
+        var moduleState = new ModuleState(new TestModule(), typeof(TestModule));
+
+        var executionTask = moduleRunner.ExecuteAsync(
+            moduleState,
+            scheduler.Object,
+            CancellationToken.None);
+        await limitWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        scheduler.Verify(x => x.MarkModuleStarted(typeof(TestModule)), Times.Never);
+
+        releaseLimitWait.TrySetResult(Mock.Of<IDisposable>());
+        await executionTask;
+
+        scheduler.Verify(x => x.MarkModuleStarted(typeof(TestModule)), Times.Once);
+    }
+
+    private static ParallelLimitHandler CreateHandler(PipelineOptions options)
+    {
+        return new ParallelLimitHandler(
+            new ParallelLimitProvider(Microsoft.Extensions.Options.Options.Create(options)),
+            NullLogger<ParallelLimitHandler>.Instance);
+    }
+
+    private sealed record SingleSlotLimit : IParallelLimit
+    {
+        public static int Limit => 1;
+    }
+
+    [ModularPipelines.Attributes.ParallelLimiter<SingleSlotLimit>]
+    private sealed class ParallelLimitedModule : TestModule;
+
+    private class TestModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes.Events;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
@@ -65,13 +66,14 @@ public class ParallelLimitHandlerTests
     }
 
     [Test]
-    public async Task ModuleRunner_FiresReadyOnceBeforeLimitsAndMarksStartedAfter()
+    public async Task ModuleRunner_FiresGlobalAndAttributeReadyOnceBeforeLimitsAndMarksStartedAfter()
     {
+        TrackingReadyAttribute.Reset();
         var limitWaitObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseLimitWait = new TaskCompletionSource<IDisposable>(TaskCreationOptions.RunContinuationsAsynchronously);
         var parallelLimitHandler = new Mock<IParallelLimitHandler>();
         parallelLimitHandler
-            .Setup(x => x.AcquireParallelLimitAsync(typeof(TestModule), It.IsAny<CancellationToken>()))
+            .Setup(x => x.AcquireParallelLimitAsync(typeof(ReadyTestModule), It.IsAny<CancellationToken>()))
             .Callback(() => limitWaitObserved.TrySetResult())
             .Returns(releaseLimitWait.Task);
         parallelLimitHandler
@@ -83,16 +85,16 @@ public class ParallelLimitHandlerTests
             .Returns(Task.CompletedTask);
 
         var builder = TestPipelineBuilder.Create()
-            .AddModule<TestModule>();
+            .AddModule<ReadyTestModule>();
         builder.Services.AddSingleton(parallelLimitHandler.Object);
         builder.Services.AddSingleton(receiver.Object);
         await using var host = await builder.BuildAsync();
         var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
         var scheduler = new Mock<IModuleScheduler>();
         scheduler
-            .Setup(x => x.MarkModuleStarted(typeof(TestModule)))
+            .Setup(x => x.MarkModuleStarted(typeof(ReadyTestModule)))
             .Returns(false);
-        var moduleState = new ModuleState(new TestModule(), typeof(TestModule));
+        var moduleState = new ModuleState(new ReadyTestModule(), typeof(ReadyTestModule));
 
         var executionTask = moduleRunner.ExecuteAsync(
             moduleState,
@@ -101,17 +103,19 @@ public class ParallelLimitHandlerTests
         await limitWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
 
         receiver.Verify(x => x.OnModuleReadyAsync(It.IsAny<IModuleHookContext>()), Times.Once);
-        scheduler.Verify(x => x.MarkModuleStarted(typeof(TestModule)), Times.Never);
+        await Assert.That(TrackingReadyAttribute.InvocationCount).IsEqualTo(1);
+        scheduler.Verify(x => x.MarkModuleStarted(typeof(ReadyTestModule)), Times.Never);
 
         releaseLimitWait.TrySetResult(Mock.Of<IDisposable>());
         await executionTask;
 
-        scheduler.Verify(x => x.MarkModuleStarted(typeof(TestModule)), Times.Once);
+        scheduler.Verify(x => x.MarkModuleStarted(typeof(ReadyTestModule)), Times.Once);
 
         await moduleRunner.ExecuteAsync(moduleState, scheduler.Object, CancellationToken.None);
 
         receiver.Verify(x => x.OnModuleReadyAsync(It.IsAny<IModuleHookContext>()), Times.Once);
-        scheduler.Verify(x => x.MarkModuleStarted(typeof(TestModule)), Times.Exactly(2));
+        await Assert.That(TrackingReadyAttribute.InvocationCount).IsEqualTo(1);
+        scheduler.Verify(x => x.MarkModuleStarted(typeof(ReadyTestModule)), Times.Exactly(2));
     }
 
     [Test]
@@ -219,6 +223,25 @@ public class ParallelLimitHandlerTests
             CancellationToken cancellationToken)
         {
             return Task.FromResult(true);
+        }
+    }
+
+    [TrackingReady]
+    private sealed class ReadyTestModule : TestModule;
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class TrackingReadyAttribute : Attribute, IModuleReadyHandler
+    {
+        private static int _invocationCount;
+
+        public static int InvocationCount => Volatile.Read(ref _invocationCount);
+
+        public static void Reset() => Volatile.Write(ref _invocationCount, 0);
+
+        public Task OnModuleReadyAsync(IModuleHookContext context)
+        {
+            Interlocked.Increment(ref _invocationCount);
+            return Task.CompletedTask;
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -253,6 +253,44 @@ public class ParallelLimitHandlerTests
             It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Never);
     }
 
+    [Test]
+    public async Task ModuleRunner_PreservesWorkerTokenForCancelledLinkedLimiterWait()
+    {
+        var limiterWaitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var parallelLimitHandler = new Mock<IParallelLimitHandler>();
+        parallelLimitHandler
+            .Setup(x => x.AcquireParallelLimitAsync(
+                typeof(TestModule),
+                It.IsAny<CancellationToken>()))
+            .Returns<Type, CancellationToken>(async (_, token) =>
+            {
+                limiterWaitStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                return Mock.Of<IDisposable>();
+            });
+
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<TestModule>();
+        builder.Services.AddSingleton(parallelLimitHandler.Object);
+        await using var host = await builder.BuildAsync();
+        var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
+        var scheduler = new Mock<IModuleScheduler>();
+        var moduleState = new ModuleState(new TestModule(), typeof(TestModule));
+        using var workerCancellationTokenSource = new CancellationTokenSource();
+
+        var executionTask = moduleRunner.ExecuteAsync(
+            moduleState,
+            scheduler.Object,
+            workerCancellationTokenSource.Token);
+        await limiterWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        workerCancellationTokenSource.Cancel();
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => executionTask);
+
+        await Assert.That(exception!.CancellationToken)
+            .IsEqualTo(workerCancellationTokenSource.Token);
+    }
+
     private static ParallelLimitHandler CreateHandler(PipelineOptions options)
     {
         return new ParallelLimitHandler(

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -277,21 +277,37 @@ public class ParallelLimitHandlerTests
         await using var host = await builder.BuildAsync();
         var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
         var engineCancellationToken = host.Services.GetRequiredService<ModularPipelines.Engine.EngineCancellationToken>();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
         var scheduler = new Mock<IModuleScheduler>();
-        var moduleState = new ModuleState(new TestModule(), typeof(TestModule));
+        var module = new TestModule();
+        var moduleState = new ModuleState(module, typeof(TestModule));
         using var workerCancellationTokenSource = new CancellationTokenSource();
+        var originalException = new InvalidOperationException("Primary module failure");
 
         var executionTask = moduleRunner.ExecuteAsync(
             moduleState,
             scheduler.Object,
             workerCancellationTokenSource.Token);
         await limiterWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        engineCancellationToken.CancelWithException(new InvalidOperationException("Primary module failure"));
+        engineCancellationToken.CancelWithException(originalException);
 
         var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => executionTask);
+        var registeredResult = resultRegistry.GetResult(typeof(TestModule));
+        var awaitedResult = await module;
 
-        await Assert.That(exception!.CancellationToken)
-            .IsEqualTo(workerCancellationTokenSource.Token);
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.CancellationToken)
+                .IsEqualTo(workerCancellationTokenSource.Token);
+            await Assert.That(registeredResult).IsSameReferenceAs(awaitedResult);
+            await Assert.That(awaitedResult.ExceptionOrDefault).IsSameReferenceAs(originalException);
+        }
+
+        scheduler.Verify(x => x.MarkModuleCompleted(
+            typeof(TestModule),
+            false,
+            originalException,
+            Status.PipelineTerminated), Times.Once);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -159,6 +159,44 @@ public class ParallelLimitHandlerTests
         }
     }
 
+    [Test]
+    public async Task ModuleRunner_DoesNotReplaceResultRegisteredBeforeLimiterCancellation()
+    {
+        var parallelLimitHandler = new Mock<IParallelLimitHandler>();
+        parallelLimitHandler
+            .Setup(x => x.AcquireParallelLimitAsync(
+                typeof(TestModule),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.FromException<IDisposable>(new OperationCanceledException()));
+
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<TestModule>();
+        builder.Services.AddSingleton(parallelLimitHandler.Object);
+        await using var host = await builder.BuildAsync();
+        var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
+        var resultRegistrar = host.Services.GetRequiredService<IModuleResultRegistrar>();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+        var scheduler = new Mock<IModuleScheduler>();
+        var module = new TestModule();
+        var moduleState = new ModuleState(module, typeof(TestModule));
+        var originalException = new InvalidOperationException("Original pipeline failure");
+        resultRegistrar.RegisterTerminatedResult(module, typeof(TestModule), originalException);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            moduleRunner.ExecuteAsync(
+                moduleState,
+                scheduler.Object,
+                CancellationToken.None));
+
+        var registeredResult = resultRegistry.GetResult(typeof(TestModule));
+        var awaitedResult = await module;
+        using (Assert.Multiple())
+        {
+            await Assert.That(registeredResult).IsSameReferenceAs(awaitedResult);
+            await Assert.That(awaitedResult.ExceptionOrDefault).IsSameReferenceAs(originalException);
+        }
+    }
+
     private static ParallelLimitHandler CreateHandler(PipelineOptions options)
     {
         return new ParallelLimitHandler(

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -1,3 +1,4 @@
+using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -7,6 +8,7 @@ using ModularPipelines.Context;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Enums;
+using ModularPipelines.Events;
 using ModularPipelines.Helpers;
 using ModularPipelines.Interfaces;
 using ModularPipelines.Modules;
@@ -254,6 +256,86 @@ public class ParallelLimitHandlerTests
     }
 
     [Test]
+    public async Task ModuleRunner_PreservesWorkerTokenForFailureDrivenEngineCancellation()
+    {
+        var limiterWaitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var parallelLimitHandler = new Mock<IParallelLimitHandler>();
+        parallelLimitHandler
+            .Setup(x => x.AcquireParallelLimitAsync(
+                typeof(TestModule),
+                It.IsAny<CancellationToken>()))
+            .Returns<Type, CancellationToken>(async (_, token) =>
+            {
+                limiterWaitStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                return Mock.Of<IDisposable>();
+            });
+
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<TestModule>();
+        builder.Services.AddSingleton(parallelLimitHandler.Object);
+        await using var host = await builder.BuildAsync();
+        var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
+        var engineCancellationToken = host.Services.GetRequiredService<ModularPipelines.Engine.EngineCancellationToken>();
+        var scheduler = new Mock<IModuleScheduler>();
+        var moduleState = new ModuleState(new TestModule(), typeof(TestModule));
+        using var workerCancellationTokenSource = new CancellationTokenSource();
+
+        var executionTask = moduleRunner.ExecuteAsync(
+            moduleState,
+            scheduler.Object,
+            workerCancellationTokenSource.Token);
+        await limiterWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        engineCancellationToken.CancelWithException(new InvalidOperationException("Primary module failure"));
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => executionTask);
+
+        await Assert.That(exception!.CancellationToken)
+            .IsEqualTo(workerCancellationTokenSource.Token);
+    }
+
+    [Test]
+    public async Task ModuleRunner_RoutesThrowingReadyHandlerThroughFailureLifecycle()
+    {
+        ThrowingReadyAttribute.Reset();
+        var receiver = new TrackingFailureReceiver();
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(x => x.Publish(
+                It.IsAny<ModuleCompletedNotification>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(ValueTask.CompletedTask);
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<ThrowingReadyTestModule>();
+        builder.Services.AddSingleton<IModuleEventReceiver>(receiver);
+        builder.Services.AddSingleton(mediator.Object);
+        await using var host = await builder.BuildAsync();
+        var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+        var scheduler = new Mock<IModuleScheduler>();
+        var moduleState = new ModuleState(
+            new ThrowingReadyTestModule(),
+            typeof(ThrowingReadyTestModule));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            moduleRunner.ExecuteAsync(moduleState, scheduler.Object, CancellationToken.None));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resultRegistry.GetResult(typeof(ThrowingReadyTestModule))!.ModuleStatus)
+                .IsEqualTo(Status.Failed);
+            await Assert.That(ThrowingReadyAttribute.FailureInvocationCount).IsEqualTo(1);
+            await Assert.That(receiver.FailureInvocationCount).IsEqualTo(1);
+        }
+
+        mediator.Verify(x => x.Publish(
+            It.Is<ModuleCompletedNotification>(notification =>
+                notification.ModuleState.ModuleType == typeof(ThrowingReadyTestModule)
+                && !notification.IsSuccessful),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Test]
     public async Task ModuleRunner_PreservesWorkerTokenForCancelledLinkedLimiterWait()
     {
         var limiterWaitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -319,6 +401,9 @@ public class ParallelLimitHandlerTests
     [TrackingReady]
     private sealed class ReadyTestModule : TestModule;
 
+    [ThrowingReady]
+    private sealed class ThrowingReadyTestModule : TestModule;
+
     [AttributeUsage(AttributeTargets.Class)]
     private sealed class TrackingReadyAttribute : Attribute, IModuleReadyHandler
     {
@@ -331,6 +416,38 @@ public class ParallelLimitHandlerTests
         public Task OnModuleReadyAsync(IModuleHookContext context)
         {
             Interlocked.Increment(ref _invocationCount);
+            return Task.CompletedTask;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class ThrowingReadyAttribute : Attribute, IModuleReadyHandler, IModuleFailureHandler
+    {
+        private static int _failureInvocationCount;
+
+        public static int FailureInvocationCount => Volatile.Read(ref _failureInvocationCount);
+
+        public static void Reset() => Volatile.Write(ref _failureInvocationCount, 0);
+
+        public Task OnModuleReadyAsync(IModuleHookContext context) =>
+            Task.FromException(new InvalidOperationException("Ready handler failure"));
+
+        public Task OnModuleFailureAsync(IModuleHookContext context, Exception exception)
+        {
+            Interlocked.Increment(ref _failureInvocationCount);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TrackingFailureReceiver : IModuleEventReceiver
+    {
+        private int _failureInvocationCount;
+
+        public int FailureInvocationCount => Volatile.Read(ref _failureInvocationCount);
+
+        public Task OnModuleFailureAsync(IModuleHookContext context)
+        {
+            Interlocked.Increment(ref _failureInvocationCount);
             return Task.CompletedTask;
         }
     }

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -65,7 +65,7 @@ public class ParallelLimitHandlerTests
     }
 
     [Test]
-    public async Task ModuleRunner_AcquiresLimitsBeforeMarkingModuleStarted()
+    public async Task ModuleRunner_FiresReadyOnceBeforeLimitsAndMarksStartedAfter()
     {
         var limitWaitObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseLimitWait = new TaskCompletionSource<IDisposable>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -77,10 +77,15 @@ public class ParallelLimitHandlerTests
         parallelLimitHandler
             .Setup(x => x.AcquireExecutionTypeLimitAsync(It.IsAny<ModuleState>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Mock.Of<IDisposable>());
+        var receiver = new Mock<IModuleEventReceiver>();
+        receiver
+            .Setup(x => x.OnModuleReadyAsync(It.IsAny<IModuleHookContext>()))
+            .Returns(Task.CompletedTask);
 
         var builder = TestPipelineBuilder.Create()
             .AddModule<TestModule>();
         builder.Services.AddSingleton(parallelLimitHandler.Object);
+        builder.Services.AddSingleton(receiver.Object);
         await using var host = await builder.BuildAsync();
         var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
         var scheduler = new Mock<IModuleScheduler>();
@@ -95,12 +100,18 @@ public class ParallelLimitHandlerTests
             CancellationToken.None);
         await limitWaitObserved.Task.WaitAsync(TimeSpan.FromSeconds(2));
 
+        receiver.Verify(x => x.OnModuleReadyAsync(It.IsAny<IModuleHookContext>()), Times.Once);
         scheduler.Verify(x => x.MarkModuleStarted(typeof(TestModule)), Times.Never);
 
         releaseLimitWait.TrySetResult(Mock.Of<IDisposable>());
         await executionTask;
 
         scheduler.Verify(x => x.MarkModuleStarted(typeof(TestModule)), Times.Once);
+
+        await moduleRunner.ExecuteAsync(moduleState, scheduler.Object, CancellationToken.None);
+
+        receiver.Verify(x => x.OnModuleReadyAsync(It.IsAny<IModuleHookContext>()), Times.Once);
+        scheduler.Verify(x => x.MarkModuleStarted(typeof(TestModule)), Times.Exactly(2));
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Execution;
@@ -102,6 +103,51 @@ public class ParallelLimitHandlerTests
         scheduler.Verify(x => x.MarkModuleStarted(typeof(TestModule)), Times.Once);
     }
 
+    [Test]
+    public async Task ModuleRunner_PreservesAlwaysRunDuringCancelledLimiterWaits()
+    {
+        var observedTokens = new List<CancellationToken>();
+        var parallelLimitHandler = new Mock<IParallelLimitHandler>();
+        parallelLimitHandler
+            .Setup(x => x.AcquireParallelLimitAsync(
+                typeof(AlwaysRunTestModule),
+                It.IsAny<CancellationToken>()))
+            .Callback<Type, CancellationToken>((_, token) => observedTokens.Add(token))
+            .ReturnsAsync(Mock.Of<IDisposable>());
+        parallelLimitHandler
+            .Setup(x => x.AcquireExecutionTypeLimitAsync(
+                It.IsAny<ModuleState>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<ModuleState, CancellationToken>((_, token) => observedTokens.Add(token))
+            .ReturnsAsync(Mock.Of<IDisposable>());
+
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<AlwaysRunTestModule>();
+        builder.Services.AddSingleton(parallelLimitHandler.Object);
+        await using var host = await builder.BuildAsync();
+        var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler
+            .Setup(x => x.MarkModuleStarted(typeof(AlwaysRunTestModule)))
+            .Returns(false);
+        var moduleState = new ModuleState(
+            new AlwaysRunTestModule(),
+            typeof(AlwaysRunTestModule));
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await moduleRunner.ExecuteWithoutDependencyWaitAsync(
+            moduleState,
+            scheduler.Object,
+            cancellationTokenSource.Token);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(observedTokens).Count().IsEqualTo(2);
+            await Assert.That(observedTokens.All(token => !token.IsCancellationRequested)).IsTrue();
+        }
+    }
+
     private static ParallelLimitHandler CreateHandler(PipelineOptions options)
     {
         return new ParallelLimitHandler(
@@ -125,5 +171,13 @@ public class ParallelLimitHandlerTests
         {
             return Task.FromResult(true);
         }
+    }
+
+    private sealed class AlwaysRunTestModule : TestModule
+    {
+        protected override ModuleConfiguration Configure() =>
+            ModuleConfiguration.Create()
+                .WithAlwaysRun()
+                .Build();
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -231,15 +231,18 @@ public class ParallelLimitHandlerTests
         var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
         var scheduler = new Mock<IModuleScheduler>();
         var moduleState = new ModuleState(new TestModule(), typeof(TestModule));
+        using var workerCancellationTokenSource = new CancellationTokenSource();
 
         var executionTask = moduleRunner.ExecuteAsync(
             moduleState,
             scheduler.Object,
-            CancellationToken.None);
+            workerCancellationTokenSource.Token);
         await limiterWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
         engineCancellationToken.Cancel();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(() => executionTask);
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => executionTask);
+        await Assert.That(exception!.CancellationToken)
+            .IsEqualTo(workerCancellationTokenSource.Token);
         scheduler.Verify(x => x.MarkModuleCompleted(
             typeof(TestModule),
             false,

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ParallelLimitHandlerTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.Attributes.Events;
 using ModularPipelines.Configuration;
@@ -199,6 +200,57 @@ public class ParallelLimitHandlerTests
             await Assert.That(registeredResult).IsSameReferenceAs(awaitedResult);
             await Assert.That(awaitedResult.ExceptionOrDefault).IsSameReferenceAs(originalException);
         }
+    }
+
+    [Test]
+    public async Task ModuleRunner_EngineCancellationStopsLimiterWaitAsPipelineTerminated()
+    {
+        var limiterWaitStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var parallelLimitHandler = new Mock<IParallelLimitHandler>();
+        parallelLimitHandler
+            .Setup(x => x.AcquireParallelLimitAsync(
+                typeof(TestModule),
+                It.IsAny<CancellationToken>()))
+            .Returns<Type, CancellationToken>(async (_, token) =>
+            {
+                limiterWaitStarted.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                return Mock.Of<IDisposable>();
+            });
+
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<TestModule>();
+        var logger = new Mock<ILogger<ModuleRunner>>();
+        builder.Services.AddSingleton(parallelLimitHandler.Object);
+        builder.Services.AddSingleton(logger.Object);
+        await using var host = await builder.BuildAsync();
+        var moduleRunner = host.Services.GetRequiredService<IModuleRunner>();
+        var engineCancellationToken = host.Services.GetRequiredService<ModularPipelines.Engine.EngineCancellationToken>();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+        var scheduler = new Mock<IModuleScheduler>();
+        var moduleState = new ModuleState(new TestModule(), typeof(TestModule));
+
+        var executionTask = moduleRunner.ExecuteAsync(
+            moduleState,
+            scheduler.Object,
+            CancellationToken.None);
+        await limiterWaitStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        engineCancellationToken.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => executionTask);
+        scheduler.Verify(x => x.MarkModuleCompleted(
+            typeof(TestModule),
+            false,
+            It.IsAny<OperationCanceledException>(),
+            Status.PipelineTerminated), Times.Once);
+        await Assert.That(resultRegistry.GetResult(typeof(TestModule))!.ModuleStatus)
+            .IsEqualTo(Status.PipelineTerminated);
+        logger.Verify(x => x.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<Exception?>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Never);
     }
 
     private static ParallelLimitHandler CreateHandler(PipelineOptions options)

--- a/test/ModularPipelines.UnitTests/Hooks/DirectModuleHooksIntegrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Hooks/DirectModuleHooksIntegrationTests.cs
@@ -251,8 +251,8 @@ public class DirectModuleHooksIntegrationTests : TestBase
         var expected = new[]
         {
             "Global:Ready",
-            "Global:Start",
             "Attribute:Ready",
+            "Global:Start",
             "Attribute:Start",
             "Module:Before",
             "Module:Execute",


### PR DESCRIPTION
Closes #3792

## Summary
- pass engine cancellation into custom and execution-type semaphore waits
- acquire slots before MarkModuleStarted so queued wait time is not execution time
- keep dependency readiness work outside scarce limiter slots

## Validation
- ParallelLimitHandlerTests: 3/3 passed
- lightweight core Release build: 0 warnings, 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved cancellation while modules wait for execution capacity.
  - Preserved “always run” modules and existing results during cancellation.
  - Prevented duplicate ready-stage notifications.

- **Bug Fixes**
  - Corrected lifecycle ordering so ready handlers run before global start notifications.
  - Improved handling of cancelled pipelines and execution statuses.
  - Rechecked scheduling constraints before module execution.

- **Documentation**
  - Updated lifecycle and hooks documentation to reflect the corrected execution order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->