### PR TITLE
Announce run report path and delta baseline

### DIFF
--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -38,9 +38,10 @@ The current schema version is available as `PipelineRunReport.CurrentSchemaVersi
 report is also exposed through `PipelineSummary.RunReport`.
 After a successful write, an information log records the report's resolved path.
 
-Each schema-v2 report has a unique `RunId` plus `RunCorrelation` metadata for the machine and
-detected build system. Registering the Git or GitHub integration also adds the available commit,
-branch, and CI run URL. Correlation strings pass through secret obfuscation before persistence.
+Each schema-v3 report has a unique `RunId`, `RunCorrelation` metadata for the machine and detected
+build system, and the previous run's finish time when it supplies a duration-delta baseline.
+Registering the Git or GitHub integration also adds the available commit, branch, and CI run URL.
+Correlation strings pass through secret obfuscation before persistence.
 
 When report writing is enabled, add application-specific metadata through a bounded
 `IRunReportEnricher`:

--- a/docs/docs/how-to/run-reports.md
+++ b/docs/docs/how-to/run-reports.md
@@ -36,6 +36,7 @@ storage location when a pipeline is launched from different working directories.
 
 The current schema version is available as `PipelineRunReport.CurrentSchemaVersion`. The completed
 report is also exposed through `PipelineSummary.RunReport`.
+After a successful write, an information log records the report's resolved path.
 
 Each schema-v2 report has a unique `RunId` plus `RunCorrelation` metadata for the machine and
 detected build system. Registering the Git or GitHub integration also adds the available commit,
@@ -71,7 +72,8 @@ CI runs, even when JSON report writing is disabled. It retains the latest 20 rep
 newest compatible report to calculate module and total-duration deltas. When a previous duration
 exists, the final results table includes a `Δ previous` column. Deltas compare only successful
 runs and successful module executions, so failed or timed-out durations do not create false
-regressions on a later run.
+regressions on a later run. A footer below the table identifies the baseline run by its UTC finish
+time.
 
 Add the default history directory to `.gitignore` if you do not want to commit local run data:
 

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -70,12 +70,7 @@ internal sealed class PipelineRunReportFactory(
                 previousByType))
             .ToArray();
         var status = pipelineException is null ? summary.Status : Status.Failed;
-        TimeSpan? previousTotalDuration = status == Status.Successful
-                                          && previousReport?.Status == Status.Successful
-            ? previousReport.TotalDuration
-            : null;
-        var hasDeltaBaseline = previousTotalDuration.HasValue
-                               || modules.Any(static module => module.DurationDelta.HasValue);
+        var previousTotalDuration = GetPreviousTotalDuration(status, previousReport);
 
         return new PipelineRunReport
         {
@@ -85,7 +80,7 @@ internal sealed class PipelineRunReportFactory(
             Start = summary.Start,
             End = summary.End,
             TotalDuration = summary.TotalDuration,
-            PreviousEnd = hasDeltaBaseline ? previousReport!.End : null,
+            PreviousEnd = GetPreviousEnd(previousReport, previousTotalDuration, modules),
             PreviousTotalDuration = previousTotalDuration,
             TotalDurationDelta = previousTotalDuration is null
                 ? null
@@ -97,6 +92,19 @@ internal sealed class PipelineRunReportFactory(
             UnattributedCommandCount = commandExecutionCounter.UnattributedCount,
         };
     }
+
+    private static TimeSpan? GetPreviousTotalDuration(Status status, PipelineRunReport? previousReport) =>
+        status == Status.Successful && previousReport?.Status == Status.Successful
+            ? previousReport.TotalDuration
+            : null;
+
+    private static DateTimeOffset? GetPreviousEnd(
+        PipelineRunReport? previousReport,
+        TimeSpan? previousTotalDuration,
+        IReadOnlyCollection<ModuleRunReport> modules) =>
+        previousTotalDuration.HasValue || modules.Any(static module => module.DurationDelta.HasValue)
+            ? previousReport?.End
+            : null;
 
     public PipelineRunReport WithCorrelation(
         PipelineRunReport report,

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -74,6 +74,8 @@ internal sealed class PipelineRunReportFactory(
                                           && previousReport?.Status == Status.Successful
             ? previousReport.TotalDuration
             : null;
+        var hasDeltaBaseline = previousTotalDuration.HasValue
+                               || modules.Any(static module => module.DurationDelta.HasValue);
 
         return new PipelineRunReport
         {
@@ -83,7 +85,7 @@ internal sealed class PipelineRunReportFactory(
             Start = summary.Start,
             End = summary.End,
             TotalDuration = summary.TotalDuration,
-            PreviousEnd = previousTotalDuration is null ? null : previousReport!.End,
+            PreviousEnd = hasDeltaBaseline ? previousReport!.End : null,
             PreviousTotalDuration = previousTotalDuration,
             TotalDurationDelta = previousTotalDuration is null
                 ? null

--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -83,6 +83,7 @@ internal sealed class PipelineRunReportFactory(
             Start = summary.Start,
             End = summary.End,
             TotalDuration = summary.TotalDuration,
+            PreviousEnd = previousTotalDuration is null ? null : previousReport!.End,
             PreviousTotalDuration = previousTotalDuration,
             TotalDurationDelta = previousTotalDuration is null
                 ? null

--- a/src/ModularPipelines/Engine/RunReportService.cs
+++ b/src/ModularPipelines/Engine/RunReportService.cs
@@ -252,6 +252,9 @@ internal sealed class RunReportService(
                             RunReportJsonSerializer.Serialize(report),
                             token)
                         .ConfigureAwait(false);
+                    logger.LogInformation(
+                        "Run report written to {RunReportPath}",
+                        fullPath);
                 },
                 ReportWriteTimeout,
                 cancellationToken,

--- a/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
+++ b/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using Microsoft.Extensions.Options;
 using ModularPipelines.Engine;
 using ModularPipelines.Extensions;
@@ -200,6 +201,13 @@ internal class SpectreResultsPrinter : IResultsPrinter
         }
 
         AddTotalRow(table, pipelineSummary, showDeltas);
+
+        if (showDeltas && pipelineSummary.RunReport?.PreviousEnd is { } previousEnd)
+        {
+            var baseline = previousEnd.ToUniversalTime()
+                .ToString("yyyy-MM-dd HH:mm 'UTC'", CultureInfo.InvariantCulture);
+            table.Caption($"[dim]Δ vs run finished {baseline}[/]");
+        }
 
         return table;
     }

--- a/src/ModularPipelines/Models/PipelineRunReport.cs
+++ b/src/ModularPipelines/Models/PipelineRunReport.cs
@@ -10,7 +10,7 @@ public sealed record PipelineRunReport
     /// <summary>
     /// Gets the current run report schema version.
     /// </summary>
-    public const int CurrentSchemaVersion = 2;
+    public const int CurrentSchemaVersion = 3;
 
     /// <summary>
     /// Gets the schema version used by this report.

--- a/src/ModularPipelines/Models/PipelineRunReport.cs
+++ b/src/ModularPipelines/Models/PipelineRunReport.cs
@@ -53,6 +53,11 @@ public sealed record PipelineRunReport
     public TimeSpan TotalDuration { get; init; }
 
     /// <summary>
+    /// Gets when the previous retained run used as the delta baseline finished.
+    /// </summary>
+    public DateTimeOffset? PreviousEnd { get; init; }
+
+    /// <summary>
     /// Gets the previous retained run's total duration, when available.
     /// </summary>
     public TimeSpan? PreviousTotalDuration { get; init; }

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -1171,12 +1171,16 @@ public class RunReportTests
     [Test]
     public async Task FileSystemHistoryStoreAcceptsAdditiveOlderSchemas()
     {
+        const int expectedCurrentSchemaVersion = 3;
+
         using (Assert.Multiple())
         {
-            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(1, 2)).IsTrue();
-            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(2, 2)).IsTrue();
-            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(0, 2)).IsFalse();
-            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(3, 2)).IsFalse();
+            await Assert.That(new PipelineRunReport().SchemaVersion).IsEqualTo(expectedCurrentSchemaVersion);
+            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(1, expectedCurrentSchemaVersion)).IsTrue();
+            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(2, expectedCurrentSchemaVersion)).IsTrue();
+            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(3, expectedCurrentSchemaVersion)).IsTrue();
+            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(0, expectedCurrentSchemaVersion)).IsFalse();
+            await Assert.That(FileSystemRunHistoryStore.IsSchemaVersionCompatible(4, expectedCurrentSchemaVersion)).IsFalse();
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -272,6 +272,7 @@ public class RunReportTests
             {
                 await Assert.That(secondSummary.RunReport!.PreviousTotalDuration).IsNull();
                 await Assert.That(secondReport!.TotalDurationDelta).IsNull();
+                await Assert.That(secondReport.PreviousEnd).IsEqualTo(firstReport!.End);
                 await Assert.That(secondReport.Modules
                         .Single(module => module.Status == Status.Successful)
                         .PreviousDuration)

--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -303,6 +303,8 @@ public class RunReportTests
             {
                 await Assert.That(firstSummary.RunReport!.PreviousTotalDuration).IsNull();
                 await Assert.That(secondSummary.RunReport!.PreviousTotalDuration).IsNotNull();
+                await Assert.That(secondSummary.RunReport.PreviousEnd)
+                    .IsEqualTo(firstSummary.RunReport.End);
                 await Assert.That(Directory.GetFiles(historyPath, "*.json")).Count().IsEqualTo(2);
             }
         }
@@ -1359,6 +1361,40 @@ public class RunReportTests
                 HistoryRetention = 0,
             },
         };
+
+    [Test]
+    public async Task SuccessfulReportWriteLogsFullPath()
+    {
+        var directory = CreateTemporaryDirectory();
+        var reportPath = Path.Combine(directory, "artifacts", "run-report.json");
+        var log = new StringBuilder();
+        var distributedOptions = OptionsFactory.Create(new DistributedOptions());
+        var commandExecutionCounter = new CommandExecutionCounter();
+        var service = new RunReportService(
+            Mock.Of<IRunHistoryStore>(),
+            new PipelineRunReportFactory(
+                commandExecutionCounter,
+                new PassthroughSecretObfuscator()),
+            Mock.Of<IBuildSystemDetector>(),
+            OptionsFactory.Create(CreateReportingOptions(reportPath)),
+            distributedOptions,
+            new RoleDetector(distributedOptions),
+            Mock.Of<IDistributedCoordinator>(),
+            commandExecutionCounter,
+            new StringLogger<RunReportService>(log));
+
+        try
+        {
+            await service.CompleteAsync(CreateEmptySummary());
+
+            await Assert.That(log.ToString())
+                .Contains($"Run report written to {Path.GetFullPath(reportPath)}");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
 
     [Test]
     public async Task RunReportEnrichersPopulateObfuscatedCorrelation()

--- a/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
@@ -98,6 +98,7 @@ public class SpectreResultsPrinterTests
         {
             RunReport = new PipelineRunReport
             {
+                PreviousEnd = new DateTimeOffset(2026, 7, 27, 11, 58, 0, TimeSpan.Zero),
                 TotalDurationDelta = TimeSpan.FromSeconds(2),
                 Modules =
                 [
@@ -115,6 +116,7 @@ public class SpectreResultsPrinterTests
 
         await Assert.That(output).Contains("Δ previous");
         await Assert.That(output).Contains("+2s");
+        await Assert.That(output).Contains("Δ vs run finished 2026-07-27 11:58 UTC");
     }
 
     [Test]


### PR DESCRIPTION
Closes #3750.

Logs the resolved run-report path after a successful atomic write. Carries the previous successful run's finish time into the report and displays it as a dim UTC footer whenever duration deltas are shown.

Validation:
- `RunReportTests`: 69/69 passed
- `SpectreResultsPrinterTests`: 4/4 passed
- core Release build: 0 warnings, 0 errors
- scoped whitespace and diff checks clean