### PR TITLE
Skip logging obfuscation when no secrets exist

### DIFF
--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -819,9 +819,7 @@ internal sealed class BufferedLogEvent<TState>(
         => Obfuscate(_rawFormattedMessage.Value);
 
     private string Obfuscate(string value)
-        => secretObfuscator.HasSecrets
-            ? secretObfuscator.Obfuscate(value, null)
-            : value;
+        => secretObfuscator.Obfuscate(value, null);
 
     private string FormatTyped(TState state, Exception? logException)
         => Format(state!, logException);

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -813,10 +813,15 @@ internal sealed class BufferedLogEvent<TState>(
     public string? FormatException()
         => _obfuscatedException is null
             ? null
-            : secretObfuscator.Obfuscate(_obfuscatedException.ToString(), null);
+            : Obfuscate(_obfuscatedException.ToString());
 
     private string Format(object? state, Exception? logException)
-        => secretObfuscator.Obfuscate(_rawFormattedMessage.Value, null) ?? string.Empty;
+        => Obfuscate(_rawFormattedMessage.Value);
+
+    private string Obfuscate(string value)
+        => secretObfuscator.HasSecrets
+            ? secretObfuscator.Obfuscate(value, null)
+            : value;
 
     private string FormatTyped(TState state, Exception? logException)
         => Format(state!, logException);

--- a/src/ModularPipelines/Engine/ISecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/ISecretObfuscator.cs
@@ -9,8 +9,8 @@ public interface ISecretObfuscator
     /// Gets whether any secrets are currently registered for global masking.
     /// </summary>
     /// <remarks>
-    /// The conservative default preserves masking for custom implementations that do not
-    /// expose their registration state.
+    /// This is a performance hint only. Callers must not use it to bypass safety or masking
+    /// behavior that custom implementations may provide.
     /// </remarks>
     bool HasSecrets => true;
 

--- a/src/ModularPipelines/Engine/ISecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/ISecretObfuscator.cs
@@ -6,6 +6,15 @@ namespace ModularPipelines.Engine;
 public interface ISecretObfuscator
 {
     /// <summary>
+    /// Gets whether any secrets are currently registered for global masking.
+    /// </summary>
+    /// <remarks>
+    /// The conservative default preserves masking for custom implementations that do not
+    /// expose their registration state.
+    /// </remarks>
+    bool HasSecrets => true;
+
+    /// <summary>
     /// Obfuscates sensitive information in the provided input.
     /// </summary>
     /// <param name="input">The input string that may contain sensitive information.</param>

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -34,6 +34,9 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
 
     public int Order => int.MaxValue;
 
+    public bool HasSecrets =>
+        GetRegisteredSecretCache(_maskingOptions.Value.CaseInsensitive).SearchValues is not null;
+
     public SecretObfuscator(
         ISecretProvider secretProvider,
         IOptions<SecretMaskingOptions> maskingOptions)

--- a/src/ModularPipelines/Engine/SecretObfuscator.cs
+++ b/src/ModularPipelines/Engine/SecretObfuscator.cs
@@ -34,8 +34,7 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
 
     public int Order => int.MaxValue;
 
-    public bool HasSecrets =>
-        GetRegisteredSecretCache(_maskingOptions.Value.CaseInsensitive).SearchValues is not null;
+    public bool HasSecrets => GetRegistrationState().HasSecrets;
 
     public SecretObfuscator(
         ISecretProvider secretProvider,
@@ -79,6 +78,12 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
             secretCache.SearchValues,
             maskValue,
             caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+    }
+
+    internal SecretRegistrationState GetRegistrationState()
+    {
+        var cache = GetRegisteredSecretCache(_maskingOptions.Value.CaseInsensitive);
+        return new SecretRegistrationState(cache.Version, cache.SearchValues is not null);
     }
 
     internal SecretCache GetSecretCache(
@@ -260,4 +265,6 @@ internal class SecretObfuscator : ISecretObfuscator, IInitializer
         string[] Secrets,
         IReadOnlySet<string> ExactSecrets,
         SearchValues<string>? SearchValues);
+
+    internal readonly record struct SecretRegistrationState(long Version, bool HasSecrets);
 }

--- a/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
+++ b/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
@@ -31,11 +31,34 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
 
     public object TryObfuscateValues(object state)
     {
-        var hasSecrets = _secretObfuscator.HasSecrets;
+        // HasSecrets is only a hint; custom obfuscators may still apply policy-based masking.
+        if (_secretObfuscator is not SecretObfuscator builtInObfuscator)
+        {
+            return TryObfuscateValues(state, skipOrdinaryValues: false);
+        }
 
+        var registrationState = builtInObfuscator.GetRegistrationState();
+        var skipOrdinaryValues = !registrationState.HasSecrets;
+        var obfuscatedState = TryObfuscateValues(state, skipOrdinaryValues);
+
+        if (!skipOrdinaryValues)
+        {
+            return obfuscatedState;
+        }
+
+        // A secret may be registered while the zero-secret fast path traverses the state.
+        var currentRegistrationState = builtInObfuscator.GetRegistrationState();
+        return currentRegistrationState.Version != registrationState.Version
+               && currentRegistrationState.HasSecrets
+            ? TryObfuscateValues(state, skipOrdinaryValues: false)
+            : obfuscatedState;
+    }
+
+    private object TryObfuscateValues(object state, bool skipOrdinaryValues)
+    {
         if (state is not IReadOnlyList<KeyValuePair<string, object?>> values)
         {
-            return hasSecrets ? ObfuscateValue(state) : state;
+            return skipOrdinaryValues ? state : ObfuscateValue(state);
         }
 
         KeyValuePair<string, object?>[]? obfuscatedValues = null;
@@ -53,7 +76,7 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
             {
                 obfuscatedValue = preObfuscatedValue.Value;
             }
-            else if (hasSecrets)
+            else if (!skipOrdinaryValues)
             {
                 obfuscatedValue = ObfuscateValue(property.Value);
             }

--- a/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
+++ b/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
@@ -31,6 +31,11 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
 
     public object TryObfuscateValues(object state)
     {
+        if (!_secretObfuscator.HasSecrets)
+        {
+            return state;
+        }
+
         if (state is not IReadOnlyList<KeyValuePair<string, object?>> values)
         {
             return ObfuscateValue(state);
@@ -69,7 +74,7 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
         string originalValue;
         try
         {
-            originalValue = value.ToString() ?? string.Empty;
+            originalValue = value as string ?? value.ToString() ?? string.Empty;
         }
         catch (Exception)
         {
@@ -77,7 +82,8 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
         }
 
         var obfuscatedValue = _secretObfuscator.Obfuscate(originalValue, null);
-        return obfuscatedValue.Equals(originalValue, StringComparison.Ordinal)
+        return ReferenceEquals(obfuscatedValue, originalValue)
+               || obfuscatedValue.Equals(originalValue, StringComparison.Ordinal)
             ? value
             : obfuscatedValue;
     }

--- a/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
+++ b/src/ModularPipelines/Logging/FormattedLogValuesObfuscator.cs
@@ -31,14 +31,11 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
 
     public object TryObfuscateValues(object state)
     {
-        if (!_secretObfuscator.HasSecrets)
-        {
-            return state;
-        }
+        var hasSecrets = _secretObfuscator.HasSecrets;
 
         if (state is not IReadOnlyList<KeyValuePair<string, object?>> values)
         {
-            return ObfuscateValue(state);
+            return hasSecrets ? ObfuscateValue(state) : state;
         }
 
         KeyValuePair<string, object?>[]? obfuscatedValues = null;
@@ -51,7 +48,20 @@ internal class FormattedLogValuesObfuscator : IFormattedLogValuesObfuscator
                 continue;
             }
 
-            var obfuscatedValue = ObfuscateValue(property.Value);
+            object obfuscatedValue;
+            if (property.Value is PreObfuscatedLogValue preObfuscatedValue)
+            {
+                obfuscatedValue = preObfuscatedValue.Value;
+            }
+            else if (hasSecrets)
+            {
+                obfuscatedValue = ObfuscateValue(property.Value);
+            }
+            else
+            {
+                continue;
+            }
+
             if (ReferenceEquals(obfuscatedValue, property.Value))
             {
                 continue;

--- a/src/ModularPipelines/Logging/ObfuscatedLogException.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedLogException.cs
@@ -31,15 +31,13 @@ internal sealed class ObfuscatedLogException : Exception
     }
 
     public static Exception? Create(Exception? exception, ISecretObfuscator secretObfuscator)
-        => exception is null || !secretObfuscator.HasSecrets
-            ? exception
-            : exception switch
-            {
-                null => null,
-                AggregateException aggregateException =>
-                    new ObfuscatedAggregateLogException(aggregateException, secretObfuscator),
-                _ => new ObfuscatedLogException(exception, secretObfuscator),
-            };
+        => exception switch
+        {
+            null => null,
+            AggregateException aggregateException =>
+                new ObfuscatedAggregateLogException(aggregateException, secretObfuscator),
+            _ => new ObfuscatedLogException(exception, secretObfuscator),
+        };
 
     public override string? StackTrace => _obfuscatedStackTrace;
 

--- a/src/ModularPipelines/Logging/ObfuscatedLogException.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedLogException.cs
@@ -31,13 +31,15 @@ internal sealed class ObfuscatedLogException : Exception
     }
 
     public static Exception? Create(Exception? exception, ISecretObfuscator secretObfuscator)
-        => exception switch
-        {
-            null => null,
-            AggregateException aggregateException =>
-                new ObfuscatedAggregateLogException(aggregateException, secretObfuscator),
-            _ => new ObfuscatedLogException(exception, secretObfuscator),
-        };
+        => exception is null || !secretObfuscator.HasSecrets
+            ? exception
+            : exception switch
+            {
+                null => null,
+                AggregateException aggregateException =>
+                    new ObfuscatedAggregateLogException(aggregateException, secretObfuscator),
+                _ => new ObfuscatedLogException(exception, secretObfuscator),
+            };
 
     public override string? StackTrace => _obfuscatedStackTrace;
 

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -203,6 +203,7 @@ public class ModuleOutputBufferTests
     {
         var formatterCalls = 0;
         var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(true);
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns((string? value, object? _) => value?.Replace("secret", "***") ?? string.Empty);
@@ -236,6 +237,7 @@ public class ModuleOutputBufferTests
         const string secret = "late-registered-secret";
         var redactSecret = false;
         var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(() => redactSecret);
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns((string? value, object? _) => redactSecret
@@ -268,6 +270,7 @@ public class ModuleOutputBufferTests
         const string secret = "late-registered-secret";
         var redactSecret = false;
         var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(() => redactSecret);
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns((string? value, object? _) => redactSecret

--- a/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
@@ -168,6 +168,28 @@ public class FormattedLogValuesObfuscatorTests
             Times.Never);
     }
 
+    [Test]
+    public async Task TryObfuscateValues_UnwrapsPreObfuscatedValuesWithoutSecrets()
+    {
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(false);
+        var state = new[]
+        {
+            new KeyValuePair<string, object?>(
+                "CommandOutput",
+                new PreObfuscatedLogValue("already-masked")),
+        };
+
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object)
+            .TryObfuscateValues(state);
+        var value = ((IReadOnlyList<KeyValuePair<string, object?>>) obfuscatedState)[0].Value;
+
+        await Assert.That(value).IsEqualTo("already-masked");
+        secretObfuscator.Verify(
+            x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()),
+            Times.Never);
+    }
+
     private sealed class ThrowingToStringState
     {
         public override string ToString() => throw new InvalidOperationException("Cannot format state.");

--- a/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
@@ -8,6 +8,22 @@ namespace ModularPipelines.UnitTests.Logging;
 public class FormattedLogValuesObfuscatorTests
 {
     [Test]
+    public async Task TryObfuscateValues_DoesNotInspectStateWhenNoSecretsAreRegistered()
+    {
+        var state = new ThrowingToStringState();
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(false);
+
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object)
+            .TryObfuscateValues(state);
+
+        await Assert.That(obfuscatedState).IsSameReferenceAs(state);
+        secretObfuscator.Verify(
+            x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()),
+            Times.Never);
+    }
+
+    [Test]
     public async Task TryObfuscateValues_MasksSecretsInOriginalFormat()
     {
         const string secret = "literal-secret";
@@ -17,6 +33,7 @@ public class FormattedLogValuesObfuscatorTests
 
         var state = logger.Invocations.Single(x => x.Method.Name == nameof(ILogger.Log)).Arguments[2];
         var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(true);
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns((string? value, object? _) => (value ?? string.Empty).Replace(secret, "********", StringComparison.Ordinal));
@@ -43,6 +60,7 @@ public class FormattedLogValuesObfuscatorTests
 
         var state = logger.Invocations.Single(x => x.Method.Name == nameof(ILogger.Log)).Arguments[2];
         var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(true);
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns((string? value, object? _) => value == "secret" ? "********" : value ?? string.Empty);
@@ -66,6 +84,7 @@ public class FormattedLogValuesObfuscatorTests
 
         var state = logger.Invocations.Single(x => x.Method.Name == nameof(ILogger.Log)).Arguments[2];
         var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(true);
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns((string? value, object? _) => value == secret.ToString() ? "********" : value ?? string.Empty);
@@ -82,6 +101,7 @@ public class FormattedLogValuesObfuscatorTests
     {
         var state = new ModuleCompletionLogState("secret", TimeSpan.FromSeconds(1), "(none)", 0, 0);
         var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(true);
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns((string? value, object? _) => value == "secret" ? "********" : value ?? string.Empty);
@@ -98,6 +118,7 @@ public class FormattedLogValuesObfuscatorTests
     {
         const string secret = "plain-state-secret";
         var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(true);
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns((string? value, object? _) =>
@@ -114,6 +135,7 @@ public class FormattedLogValuesObfuscatorTests
     {
         var state = new ThrowingToStringState();
         var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(true);
 
         var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object)
             .TryObfuscateValues(state);
@@ -128,6 +150,7 @@ public class FormattedLogValuesObfuscatorTests
     public async Task TryObfuscateValues_DoesNotRescanPreObfuscatedValues()
     {
         var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(true);
         var state = new[]
         {
             new KeyValuePair<string, object?>(

--- a/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/FormattedLogValuesObfuscatorTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 using ModularPipelines.Logging;
+using ModularPipelines.Options;
 using Moq;
 
 namespace ModularPipelines.UnitTests.Logging;
@@ -10,17 +11,72 @@ public class FormattedLogValuesObfuscatorTests
     [Test]
     public async Task TryObfuscateValues_DoesNotInspectStateWhenNoSecretsAreRegistered()
     {
-        var state = new ThrowingToStringState();
-        var secretObfuscator = new Mock<ISecretObfuscator>();
-        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(false);
+        var state = new CountingToStringState();
+        var secretObfuscator = CreateBuiltInObfuscator();
 
-        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object)
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator)
             .TryObfuscateValues(state);
 
         await Assert.That(obfuscatedState).IsSameReferenceAs(state);
-        secretObfuscator.Verify(
-            x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()),
-            Times.Never);
+        await Assert.That(state.ToStringCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task TryObfuscateValues_PreservesCustomMaskingWhenHintIsFalse()
+    {
+        const string secret = "policy-secret";
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(false);
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) =>
+                (value ?? string.Empty).Replace(secret, "********", StringComparison.Ordinal));
+        var state = new[]
+        {
+            new KeyValuePair<string, object?>("PolicyValue", secret),
+        };
+
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator.Object)
+            .TryObfuscateValues(state);
+        var value = ((IReadOnlyList<KeyValuePair<string, object?>>) obfuscatedState)[0].Value;
+
+        await Assert.That(value).IsEqualTo("********");
+    }
+
+    [Test]
+    public async Task TryObfuscateValues_RetriesWhenSecretIsRegisteredDuringFastPath()
+    {
+        const string secret = "dynamic-secret";
+        var version = 0L;
+        IReadOnlyList<string> secrets = [];
+        var secretProvider = new Mock<ISecretProvider>();
+        secretProvider.SetupGet(x => x.Version).Returns(() => version);
+        secretProvider.Setup(x => x.GetSnapshot())
+            .Returns(() => new SecretSnapshot(version, secrets));
+        var secretObfuscator = CreateBuiltInObfuscator(secretProvider.Object);
+        var values = new[] { new KeyValuePair<string, object?>("Value", secret) };
+        var registered = false;
+        var state = new Mock<IReadOnlyList<KeyValuePair<string, object?>>>();
+        state.SetupGet(x => x.Count).Returns(() =>
+        {
+            if (!registered)
+            {
+                registered = true;
+                secrets = [secret];
+                version += 2;
+            }
+
+            return values.Length;
+        });
+        state.Setup(x => x[0]).Returns(values[0]);
+        state.Setup(x => x.GetEnumerator())
+            .Returns(() => ((IEnumerable<KeyValuePair<string, object?>>) values).GetEnumerator());
+
+        var obfuscatedState = new FormattedLogValuesObfuscator(secretObfuscator)
+            .TryObfuscateValues(state.Object);
+        var value = ((IReadOnlyList<KeyValuePair<string, object?>>) obfuscatedState)[0].Value;
+
+        await Assert.That(value).IsEqualTo("**********");
     }
 
     [Test]
@@ -193,5 +249,27 @@ public class FormattedLogValuesObfuscatorTests
     private sealed class ThrowingToStringState
     {
         public override string ToString() => throw new InvalidOperationException("Cannot format state.");
+    }
+
+    private sealed class CountingToStringState
+    {
+        public int ToStringCalls { get; private set; }
+
+        public override string ToString()
+        {
+            ToStringCalls++;
+            return "state";
+        }
+    }
+
+    private static SecretObfuscator CreateBuiltInObfuscator(ISecretProvider? secretProvider = null)
+    {
+        secretProvider ??= Mock.Of<ISecretProvider>(provider =>
+            provider.Version == 0 &&
+            provider.GetSnapshot() == new SecretSnapshot(0, Array.Empty<string>()));
+
+        return new SecretObfuscator(
+            secretProvider,
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()));
     }
 }

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -145,12 +145,15 @@ public class PipelineLevelLoggerTests
     }
 
     [Test]
-    public async Task Log_PreservesOriginalExceptionWhenNoSecretsAreRegistered()
+    public async Task Log_WrapsExceptionWhenNoSecretsAreRegistered()
     {
         var underlyingLogger = new RecordingLogger();
         var originalException = new InvalidOperationException("Failure");
         var secretObfuscator = new Mock<ISecretObfuscator>();
         secretObfuscator.SetupGet(x => x.HasSecrets).Returns(false);
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
+            .Returns((string? value, object? _) => value ?? string.Empty);
         var pipelineLevelLogger = new PipelineLevelLogger(
             underlyingLogger,
             secretObfuscator.Object,
@@ -158,10 +161,7 @@ public class PipelineLevelLoggerTests
 
         pipelineLevelLogger.LogError(originalException, "Failure");
 
-        await Assert.That(underlyingLogger.Exception).IsSameReferenceAs(originalException);
-        secretObfuscator.Verify(
-            x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()),
-            Times.Never);
+        await Assert.That(underlyingLogger.Exception).IsNotSameReferenceAs(originalException);
     }
 
     [Test]
@@ -220,10 +220,45 @@ public class PipelineLevelLoggerTests
     }
 
     [Test]
+    public async Task Log_GuardsHostileExceptionDiagnosticsWithoutSecrets()
+    {
+        var underlyingLogger = new RecordingLogger();
+        var pipelineLevelLogger = CreateLogger(underlyingLogger, hasSecrets: false);
+
+        await Assert.That(
+                () => pipelineLevelLogger.LogError(new ThrowingDiagnosticException(), "Failure"))
+            .ThrowsNothing();
+
+        await Assert.That(underlyingLogger.Exception?.Message)
+            .IsEqualTo(LoggingConstants.SecretMask);
+    }
+
+    [Test]
     public async Task Log_GuardsHostileStructuredTraversal()
     {
         var underlyingLogger = new RecordingLogger();
         var pipelineLevelLogger = CreateLogger(underlyingLogger);
+
+        await Assert.That(() => pipelineLevelLogger.Log(
+                LogLevel.Information,
+                new EventId(3, "HostileState"),
+                new ThrowingCountStructuredState(),
+                null,
+                static (_, _) => throw new InvalidOperationException("Cannot format state.")))
+            .ThrowsNothing();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(underlyingLogger.State).IsEqualTo(LoggingConstants.SecretMask);
+            await Assert.That(underlyingLogger.Message).IsEqualTo(LoggingConstants.SecretMask);
+        }
+    }
+
+    [Test]
+    public async Task Log_GuardsHostileStructuredTraversalWithoutSecrets()
+    {
+        var underlyingLogger = new RecordingLogger();
+        var pipelineLevelLogger = CreateLogger(underlyingLogger, hasSecrets: false);
 
         await Assert.That(() => pipelineLevelLogger.Log(
                 LogLevel.Information,
@@ -335,10 +370,11 @@ public class PipelineLevelLoggerTests
 
     private static PipelineLevelLogger CreateLogger(
         ILogger logger,
-        Func<string?, string>? obfuscate = null)
+        Func<string?, string>? obfuscate = null,
+        bool hasSecrets = true)
     {
         var secretObfuscator = new Mock<ISecretObfuscator>();
-        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(true);
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(hasSecrets);
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns((string? value, object? _) => obfuscate?.Invoke(value) ?? value ?? string.Empty);

--- a/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/PipelineLevelLoggerTests.cs
@@ -145,6 +145,26 @@ public class PipelineLevelLoggerTests
     }
 
     [Test]
+    public async Task Log_PreservesOriginalExceptionWhenNoSecretsAreRegistered()
+    {
+        var underlyingLogger = new RecordingLogger();
+        var originalException = new InvalidOperationException("Failure");
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(false);
+        var pipelineLevelLogger = new PipelineLevelLogger(
+            underlyingLogger,
+            secretObfuscator.Object,
+            new FormattedLogValuesObfuscator(secretObfuscator.Object));
+
+        pipelineLevelLogger.LogError(originalException, "Failure");
+
+        await Assert.That(underlyingLogger.Exception).IsSameReferenceAs(originalException);
+        secretObfuscator.Verify(
+            x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()),
+            Times.Never);
+    }
+
+    [Test]
     public async Task Log_PreservesSanitizedExceptionDiagnostics()
     {
         const string secret = "pipeline-secret";
@@ -318,6 +338,7 @@ public class PipelineLevelLoggerTests
         Func<string?, string>? obfuscate = null)
     {
         var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator.SetupGet(x => x.HasSecrets).Returns(true);
         secretObfuscator
             .Setup(x => x.Obfuscate(It.IsAny<string?>(), null))
             .Returns((string? value, object? _) => obfuscate?.Invoke(value) ?? value ?? string.Empty);

--- a/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/SecretObfuscatorCachingTests.cs
@@ -9,6 +9,25 @@ namespace ModularPipelines.UnitTests.Logging;
 public class SecretObfuscatorCachingTests
 {
     [Test]
+    public async Task HasSecrets_TracksDynamicSecretRegistration()
+    {
+        var optionsProvider = new Mock<IOptionsProvider>();
+        optionsProvider.Setup(x => x.GetOptions()).Returns([]);
+        var secretProvider = new SecretProvider(
+            optionsProvider.Object,
+            Mock.Of<IBuildSystemSecretMasker>(),
+            Microsoft.Extensions.Options.Options.Create(new SecretMaskingOptions()),
+            Mock.Of<ILogger<SecretProvider>>());
+        var obfuscator = CreateObfuscator(secretProvider);
+
+        await Assert.That(obfuscator.HasSecrets).IsFalse();
+
+        secretProvider.AddSecret("dynamic-secret");
+
+        await Assert.That(obfuscator.HasSecrets).IsTrue();
+    }
+
+    [Test]
     public async Task ReusesSecretSnapshotUntilProviderChanges()
     {
         var secretProvider = new Mock<ISecretProvider>();


### PR DESCRIPTION
## Summary
- expose a conservative `HasSecrets` capability backed by the versioned secret cache
- bypass structured-value, exception, and deferred message scans while the cache is empty
- preserve late secret registration and custom obfuscator behavior

## Validation
- `FormattedLogValuesObfuscatorTests`: 8 passed
- `SecretObfuscatorCachingTests`: 14 passed
- `PipelineLevelLoggerTests`: 16 passed
- `ModuleOutputBufferTests`: 30 passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors
- targeted whitespace verification and `git diff --check`

Closes #3756