### PR TITLE
Prioritize pipeline cancellation classification

### DIFF
--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -693,7 +693,10 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         }
 
         // Check if we should ignore failures
-        if (config.IgnoreFailuresCondition != null)
+        if (config.IgnoreFailuresCondition != null
+            && (executionContext.Status != Status.PipelineTerminated
+                || exception is ModuleTimeoutException
+                || IsTimeout(config, executionContext, exception)))
         {
             if (await config.IgnoreFailuresCondition(moduleContext, exception).ConfigureAwait(false))
             {

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -680,16 +680,6 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         executionContext.Status = ClassifyException(config, executionContext, exception);
 
-        if (executionContext.Status == Status.PipelineTerminated)
-        {
-            logger.LogInformation("Pipeline has been canceled");
-
-            var cancelledResult = ModuleResult<T>.CreateFailure(exception, executionContext);
-            preserveResult(cancelledResult);
-            executionContext.SetTypedResult(cancelledResult);
-            return cancelledResult;
-        }
-
         // Use the enhanced exception type for detailed timeout logging.
         if (exception is ModuleTimeoutException timeoutException)
         {
@@ -722,6 +712,16 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
                     .ConfigureAwait(false);
                 return ignoredResult;
             }
+        }
+
+        if (executionContext.Status == Status.PipelineTerminated)
+        {
+            logger.LogInformation("Pipeline has been canceled");
+
+            var cancelledResult = ModuleResult<T>.CreateFailure(exception, executionContext);
+            preserveResult(cancelledResult);
+            executionContext.SetTypedResult(cancelledResult);
+            return cancelledResult;
         }
 
         // Create a failed result before cancelling and throwing

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -678,29 +678,10 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
 
         executionContext.Exception = exception;
 
-        // Check for timeout - use the enhanced exception type for detailed logging
-        if (exception is ModuleTimeoutException timeoutException)
-        {
-            executionContext.Status = Status.TimedOut;
+        executionContext.Status = ClassifyException(config, executionContext, exception);
 
-            // Log additional timeout details
-            if (!timeoutException.WasCancellationTokenRespected)
-            {
-                logger.LogWarning(
-                    "Module {ModuleName} did not complete within the cancellation grace period; timeout enforcement stopped waiting after {ElapsedTime}",
-                    executionContext.ModuleType.Name,
-                    timeoutException.ElapsedTime.ToDisplayString());
-            }
-        }
-        else if (IsTimeout(config, executionContext, exception))
+        if (executionContext.Status == Status.PipelineTerminated)
         {
-            executionContext.Status = Status.TimedOut;
-        }
-
-        // Check for pipeline cancellation
-        else if (IsPipelineCancelled(exception))
-        {
-            executionContext.Status = Status.PipelineTerminated;
             logger.LogInformation("Pipeline has been canceled");
 
             var cancelledResult = ModuleResult<T>.CreateFailure(exception, executionContext);
@@ -708,9 +689,17 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             executionContext.SetTypedResult(cancelledResult);
             return cancelledResult;
         }
-        else
+
+        // Use the enhanced exception type for detailed timeout logging.
+        if (exception is ModuleTimeoutException timeoutException)
         {
-            executionContext.Status = Status.Failed;
+            if (!timeoutException.WasCancellationTokenRespected)
+            {
+                logger.LogWarning(
+                    "Module {ModuleName} did not complete within the cancellation grace period; timeout enforcement stopped waiting after {ElapsedTime}",
+                    executionContext.ModuleType.Name,
+                    timeoutException.ElapsedTime.ToDisplayString());
+            }
         }
 
         // Check if we should ignore failures
@@ -751,6 +740,22 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         throw exception;
     }
 
+    private Status ClassifyException(
+        ModuleConfiguration config,
+        ModuleExecutionContext executionContext,
+        Exception exception)
+    {
+        if (_engineCancellationToken.IsCancelled
+            && exception is OperationCanceledException or ModuleTimeoutException)
+        {
+            return Status.PipelineTerminated;
+        }
+
+        return exception is ModuleTimeoutException || IsTimeout(config, executionContext, exception)
+            ? Status.TimedOut
+            : Status.Failed;
+    }
+
     private bool IsTimeout(ModuleConfiguration config, ModuleExecutionContext executionContext, Exception exception)
     {
         var timeout = GetTimeout(config);
@@ -760,13 +765,7 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         }
 
         var isTimeoutExceeded = executionContext.Stopwatch.Elapsed >= timeout;
-        return isTimeoutExceeded && exception is ModuleTimeoutException or TaskCanceledException or OperationCanceledException;
-    }
-
-    private bool IsPipelineCancelled(Exception exception)
-    {
-        return exception is TaskCanceledException or OperationCanceledException or ModuleTimeoutException
-               && _engineCancellationToken.IsCancelled;
+        return isTimeoutExceeded && exception is OperationCanceledException;
     }
 
     private void CancelPipelineAndThrow(

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -745,7 +745,8 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
         ModuleExecutionContext executionContext,
         Exception exception)
     {
-        if (_engineCancellationToken.IsCancelled
+        if (!config.AlwaysRun
+            && _engineCancellationToken.IsCancelled
             && exception is OperationCanceledException or ModuleTimeoutException)
         {
             return Status.PipelineTerminated;

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -63,27 +63,25 @@ public class ModuleExecutionPipelineTests
         }
     }
 
-    private sealed class TimeoutExceptionModule : Module<int>
+    private class TimeoutExceptionModule : Module<int>
     {
-        private readonly TaskCompletionSource _executionStarted =
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
-        private readonly TaskCompletionSource _throwTimeout =
-            new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public Task ExecutionStarted => _executionStarted.Task;
-
-        public void ThrowTimeout() => _throwTimeout.TrySetResult();
-
-        protected internal override async Task<int> ExecuteAsync(
+        protected internal override Task<int> ExecuteAsync(
             IModuleContext context,
             CancellationToken cancellationToken)
         {
-            _executionStarted.TrySetResult();
-            await _throwTimeout.Task.ConfigureAwait(false);
-            throw new ModuleTimeoutException(
+            return Task.FromException<int>(new ModuleTimeoutException(
                 GetType(),
-                TimeSpan.FromSeconds(1));
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                wasCancellationTokenRespected: false));
         }
+    }
+
+    private sealed class IgnoredTimeoutExceptionModule : TimeoutExceptionModule
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithIgnoreFailures()
+            .Build();
     }
 
     private sealed class ElapsedCancellationModule : Module<int>
@@ -135,26 +133,43 @@ public class ModuleExecutionPipelineTests
     public async Task ExecuteAsync_ClassifiesLateTimeoutAsPipelineTerminated()
     {
         var module = new TimeoutExceptionModule();
+        var logger = new Mock<IInternalModuleLogger>();
         var result = await ExecuteAfterPipelineCancellation(
             module,
-            executionStarted: module.ExecutionStarted,
-            releaseExecution: module.ThrowTimeout);
+            cancelPipelineInFailureHook: true,
+            logger: logger);
+
+        await Assert.That(result.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+        logger.Verify(x => x.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((state, _) => state.ToString()!
+                .Contains("did not complete within the cancellation grace period", StringComparison.Ordinal)),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ClassifiesPipelineCancellationAsPipelineTerminated()
+    {
+        var module = new ElapsedCancellationModule();
+        var executionContext = new ModuleExecutionContext<int>(module, module.GetType());
+
+        var result = await ExecuteAfterPipelineCancellation(module, executionContext);
 
         await Assert.That(result.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
     }
 
     [Test]
-    public async Task ExecuteAsync_ClassifiesElapsedCancellationAsPipelineTerminated()
+    public async Task ExecuteAsync_HonorsIgnoredTimeoutAfterPipelineCancellation()
     {
-        var module = new ElapsedCancellationModule();
-        var executionContext = new ModuleExecutionContext<int>(module, module.GetType());
-        executionContext.Stopwatch.Start();
-        await Task.Delay(TimeSpan.FromMilliseconds(25));
-        executionContext.Stopwatch.Stop();
+        var module = new IgnoredTimeoutExceptionModule();
 
-        var result = await ExecuteAfterPipelineCancellation(module, executionContext);
+        var result = await ExecuteAfterPipelineCancellation(
+            module,
+            cancelPipelineInFailureHook: true);
 
-        await Assert.That(result.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+        await Assert.That(result.ModuleStatus).IsEqualTo(Status.IgnoredFailure);
     }
 
     [Test]
@@ -422,12 +437,12 @@ public class ModuleExecutionPipelineTests
     private static async Task<ModuleResult<int>> ExecuteAfterPipelineCancellation(
         Module<int> module,
         ModuleExecutionContext<int>? executionContext = null,
-        Task? executionStarted = null,
-        Action? releaseExecution = null)
+        bool cancelPipelineInFailureHook = false,
+        Mock<IInternalModuleLogger>? logger = null)
     {
         executionContext ??= new ModuleExecutionContext<int>(module, module.GetType());
 
-        var logger = new Mock<IInternalModuleLogger>();
+        logger ??= new Mock<IInternalModuleLogger>();
         var services = new Mock<IServicesContext>();
         services.SetupGet(x => x.Options).Returns(new PipelineOptions());
         var moduleContext = new Mock<IModuleContext>();
@@ -436,6 +451,8 @@ public class ModuleExecutionPipelineTests
 
         var resultRepository = new Mock<IModuleResultRepository>();
         resultRepository.SetupGet(x => x.IsEnabled).Returns(false);
+        using var engineCancellationToken =
+            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
         var directHookInvoker = new Mock<IDirectHookInvoker>();
         directHookInvoker
             .Setup(x => x.InvokeBeforeExecuteAsync(
@@ -449,7 +466,16 @@ public class ModuleExecutionPipelineTests
                 moduleContext.Object,
                 It.IsAny<Exception>(),
                 It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask);
+            .Returns(() =>
+            {
+                if (cancelPipelineInFailureHook)
+                {
+                    engineCancellationToken.CancelWithException(
+                        new InvalidOperationException("Prior module failure"));
+                }
+
+                return Task.CompletedTask;
+            });
         directHookInvoker
             .Setup(x => x.InvokeAfterExecuteAsync(
                 module,
@@ -457,9 +483,6 @@ public class ModuleExecutionPipelineTests
                 It.IsAny<ModuleResult<int>>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync((ModuleResult<int>?) null);
-
-        using var engineCancellationToken =
-            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
 
         var moduleConditionHandler = new Mock<IModuleConditionHandler>();
         moduleConditionHandler
@@ -472,7 +495,7 @@ public class ModuleExecutionPipelineTests
             moduleConditionHandler.Object,
             OptionsFactory.Create(new PipelineOptions()));
 
-        if (executionStarted is null)
+        if (!cancelPipelineInFailureHook)
         {
             engineCancellationToken.CancelWithException(new InvalidOperationException("Prior module failure"));
         }
@@ -482,19 +505,6 @@ public class ModuleExecutionPipelineTests
             executionContext,
             moduleContext.Object,
             CancellationToken.None);
-
-        if (executionStarted is not null)
-        {
-            try
-            {
-                await executionStarted.WaitAsync(TimeSpan.FromSeconds(5));
-                engineCancellationToken.CancelWithException(new InvalidOperationException("Prior module failure"));
-            }
-            finally
-            {
-                releaseExecution?.Invoke();
-            }
-        }
 
         return await executionTask;
     }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -98,6 +98,20 @@ public class ModuleExecutionPipelineTests
         }
     }
 
+    private sealed class IgnoredCancellationModule : Module<int>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithIgnoreFailures()
+            .Build();
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromException<int>(new OperationCanceledException());
+        }
+    }
+
     private sealed class AlwaysRunTimeoutExceptionModule : Module<int>
     {
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
@@ -156,6 +170,16 @@ public class ModuleExecutionPipelineTests
         var executionContext = new ModuleExecutionContext<int>(module, module.GetType());
 
         var result = await ExecuteAfterPipelineCancellation(module, executionContext);
+
+        await Assert.That(result.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_DoesNotIgnorePipelineCancellationWithoutTimeout()
+    {
+        var module = new IgnoredCancellationModule();
+
+        var result = await ExecuteAfterPipelineCancellation(module);
 
         await Assert.That(result.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
     }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -89,6 +89,37 @@ public class ModuleExecutionPipelineTests
         }
     }
 
+    private sealed class AlwaysRunTimeoutExceptionModule : Module<int>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithAlwaysRun()
+            .Build();
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromException<int>(new ModuleTimeoutException(
+                GetType(),
+                TimeSpan.FromSeconds(1)));
+        }
+    }
+
+    private sealed class AlwaysRunElapsedCancellationModule : Module<int>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithAlwaysRun()
+            .WithTimeout(TimeSpan.FromMilliseconds(5))
+            .Build();
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromException<int>(new OperationCanceledException());
+        }
+    }
+
     [Test]
     public async Task ExecuteAsync_ClassifiesLateTimeoutAsPipelineTerminated()
     {
@@ -109,6 +140,33 @@ public class ModuleExecutionPipelineTests
         var result = await ExecuteAfterPipelineCancellation(module, executionContext);
 
         await Assert.That(result.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ClassifiesAlwaysRunTimeoutIndependentlyOfPipelineCancellation()
+    {
+        var module = new AlwaysRunTimeoutExceptionModule();
+        var executionContext = new ModuleExecutionContext<int>(module, module.GetType());
+
+        await Assert.That(async () => await ExecuteAfterPipelineCancellation(module, executionContext))
+            .Throws<ModuleFailedException>();
+
+        await Assert.That(executionContext.Status).IsEqualTo(Status.TimedOut);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ClassifiesAlwaysRunElapsedCancellationAsTimeout()
+    {
+        var module = new AlwaysRunElapsedCancellationModule();
+        var executionContext = new ModuleExecutionContext<int>(module, module.GetType());
+        executionContext.Stopwatch.Start();
+        await Task.Delay(TimeSpan.FromMilliseconds(25));
+        executionContext.Stopwatch.Stop();
+
+        await Assert.That(async () => await ExecuteAfterPipelineCancellation(module, executionContext))
+            .Throws<ModuleFailedException>();
+
+        await Assert.That(executionContext.Status).IsEqualTo(Status.TimedOut);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -65,13 +65,24 @@ public class ModuleExecutionPipelineTests
 
     private sealed class TimeoutExceptionModule : Module<int>
     {
-        protected internal override Task<int> ExecuteAsync(
+        private readonly TaskCompletionSource _executionStarted =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _throwTimeout =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ExecutionStarted => _executionStarted.Task;
+
+        public void ThrowTimeout() => _throwTimeout.TrySetResult();
+
+        protected internal override async Task<int> ExecuteAsync(
             IModuleContext context,
             CancellationToken cancellationToken)
         {
-            return Task.FromException<int>(new ModuleTimeoutException(
+            _executionStarted.TrySetResult();
+            await _throwTimeout.Task.ConfigureAwait(false);
+            throw new ModuleTimeoutException(
                 GetType(),
-                TimeSpan.FromSeconds(1)));
+                TimeSpan.FromSeconds(1));
         }
     }
 
@@ -123,7 +134,11 @@ public class ModuleExecutionPipelineTests
     [Test]
     public async Task ExecuteAsync_ClassifiesLateTimeoutAsPipelineTerminated()
     {
-        var result = await ExecuteAfterPipelineCancellation(new TimeoutExceptionModule());
+        var module = new TimeoutExceptionModule();
+        var result = await ExecuteAfterPipelineCancellation(
+            module,
+            executionStarted: module.ExecutionStarted,
+            releaseExecution: module.ThrowTimeout);
 
         await Assert.That(result.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
     }
@@ -406,7 +421,9 @@ public class ModuleExecutionPipelineTests
 
     private static async Task<ModuleResult<int>> ExecuteAfterPipelineCancellation(
         Module<int> module,
-        ModuleExecutionContext<int>? executionContext = null)
+        ModuleExecutionContext<int>? executionContext = null,
+        Task? executionStarted = null,
+        Action? releaseExecution = null)
     {
         executionContext ??= new ModuleExecutionContext<int>(module, module.GetType());
 
@@ -443,7 +460,6 @@ public class ModuleExecutionPipelineTests
 
         using var engineCancellationToken =
             new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
-        engineCancellationToken.CancelWithException(new InvalidOperationException("Prior module failure"));
 
         var moduleConditionHandler = new Mock<IModuleConditionHandler>();
         moduleConditionHandler
@@ -456,10 +472,30 @@ public class ModuleExecutionPipelineTests
             moduleConditionHandler.Object,
             OptionsFactory.Create(new PipelineOptions()));
 
-        return await pipeline.ExecuteAsync(
+        if (executionStarted is null)
+        {
+            engineCancellationToken.CancelWithException(new InvalidOperationException("Prior module failure"));
+        }
+
+        var executionTask = pipeline.ExecuteAsync(
             module,
             executionContext,
             moduleContext.Object,
             CancellationToken.None);
+
+        if (executionStarted is not null)
+        {
+            try
+            {
+                await executionStarted.WaitAsync(TimeSpan.FromSeconds(5));
+                engineCancellationToken.CancelWithException(new InvalidOperationException("Prior module failure"));
+            }
+            finally
+            {
+                releaseExecution?.Invoke();
+            }
+        }
+
+        return await executionTask;
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutionPipelineTests.cs
@@ -2,9 +2,11 @@ using Microsoft.Extensions.Logging;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains;
 using ModularPipelines.Caching;
+using ModularPipelines.Configuration;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.Execution;
 using ModularPipelines.Enums;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
@@ -59,6 +61,54 @@ public class ModuleExecutionPipelineTests
         {
             return Task.FromResult(42);
         }
+    }
+
+    private sealed class TimeoutExceptionModule : Module<int>
+    {
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromException<int>(new ModuleTimeoutException(
+                GetType(),
+                TimeSpan.FromSeconds(1)));
+        }
+    }
+
+    private sealed class ElapsedCancellationModule : Module<int>
+    {
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithTimeout(TimeSpan.FromMilliseconds(5))
+            .Build();
+
+        protected internal override Task<int> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromException<int>(new OperationCanceledException());
+        }
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ClassifiesLateTimeoutAsPipelineTerminated()
+    {
+        var result = await ExecuteAfterPipelineCancellation(new TimeoutExceptionModule());
+
+        await Assert.That(result.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+    }
+
+    [Test]
+    public async Task ExecuteAsync_ClassifiesElapsedCancellationAsPipelineTerminated()
+    {
+        var module = new ElapsedCancellationModule();
+        var executionContext = new ModuleExecutionContext<int>(module, module.GetType());
+        executionContext.Stopwatch.Start();
+        await Task.Delay(TimeSpan.FromMilliseconds(25));
+        executionContext.Stopwatch.Stop();
+
+        var result = await ExecuteAfterPipelineCancellation(module, executionContext);
+
+        await Assert.That(result.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
     }
 
     [Test]
@@ -294,5 +344,64 @@ public class ModuleExecutionPipelineTests
             await Assert.That(cacheRepository.WriteCancellationToken)
                 .IsEqualTo(cacheRepository.ReadCancellationToken);
         }
+    }
+
+    private static async Task<ModuleResult<int>> ExecuteAfterPipelineCancellation(
+        Module<int> module,
+        ModuleExecutionContext<int>? executionContext = null)
+    {
+        executionContext ??= new ModuleExecutionContext<int>(module, module.GetType());
+
+        var logger = new Mock<IInternalModuleLogger>();
+        var services = new Mock<IServicesContext>();
+        services.SetupGet(x => x.Options).Returns(new PipelineOptions());
+        var moduleContext = new Mock<IModuleContext>();
+        moduleContext.SetupGet(x => x.Logger).Returns(logger.Object);
+        moduleContext.SetupGet(x => x.Services).Returns(services.Object);
+
+        var resultRepository = new Mock<IModuleResultRepository>();
+        resultRepository.SetupGet(x => x.IsEnabled).Returns(false);
+        var directHookInvoker = new Mock<IDirectHookInvoker>();
+        directHookInvoker
+            .Setup(x => x.InvokeBeforeExecuteAsync(
+                module,
+                moduleContext.Object,
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        directHookInvoker
+            .Setup(x => x.InvokeFailedAsync(
+                module,
+                moduleContext.Object,
+                It.IsAny<Exception>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        directHookInvoker
+            .Setup(x => x.InvokeAfterExecuteAsync(
+                module,
+                moduleContext.Object,
+                It.IsAny<ModuleResult<int>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ModuleResult<int>?) null);
+
+        using var engineCancellationToken =
+            new PipelineEngineCancellationToken(new PrimaryExceptionContainer());
+        engineCancellationToken.CancelWithException(new InvalidOperationException("Prior module failure"));
+
+        var moduleConditionHandler = new Mock<IModuleConditionHandler>();
+        moduleConditionHandler
+            .Setup(x => x.ShouldIgnore(module, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((false, null));
+        var pipeline = new ModuleExecutionPipeline(
+            resultRepository.Object,
+            engineCancellationToken,
+            directHookInvoker.Object,
+            moduleConditionHandler.Object,
+            OptionsFactory.Create(new PipelineOptions()));
+
+        return await pipeline.ExecuteAsync(
+            module,
+            executionContext,
+            moduleContext.Object,
+            CancellationToken.None);
     }
 }


### PR DESCRIPTION
## Summary
- classify cancellation-shaped exceptions against pipeline cancellation before timeout inference
- preserve independent failures while removing redundant timeout exception tests
- cover late module timeouts and elapsed cancellation races deterministically

## Validation
- ModuleExecutionPipelineTests: 6/6
- ModuleTimeoutTests: 12/12
- EngineCancellationTokenTests: 15/15
- core Release build: 0 warnings, 0 errors

Closes #3791