### PR TITLE
Match run report deltas by module type

### DIFF
--- a/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
+++ b/src/ModularPipelines/Engine/PipelineRunReportFactory.cs
@@ -1,4 +1,5 @@
 using ModularPipelines.Enums;
+using ModularPipelines.Extensions;
 using ModularPipelines.Models;
 
 namespace ModularPipelines.Engine;
@@ -43,20 +44,13 @@ internal sealed class PipelineRunReportFactory(
             .Where(static group => group.Count() == 1)
             .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
         var timelinesByType = summary.ModuleTimelines?
-            .GroupBy(
+            .ToFirstByKeyDictionary(
                 static timeline => string.IsNullOrWhiteSpace(timeline.RuntimeModuleTypeName)
                     ? timeline.ModuleTypeName
-                    : timeline.RuntimeModuleTypeName,
-                StringComparer.Ordinal)
-            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal)
+                    : timeline.RuntimeModuleTypeName)
             ?? new Dictionary<string, ModuleTimeline>(StringComparer.Ordinal);
         var previousByType = previousReport?.Modules
-            .GroupBy(static module => module.ModuleTypeName, StringComparer.Ordinal)
-            .Where(static group => group.Count() == 1)
-            .ToDictionary(
-                static group => group.Key,
-                static group => group.First(),
-                StringComparer.Ordinal)
+            .ToUniqueByKeyDictionary(static module => module.ModuleTypeName)
             ?? new Dictionary<string, ModuleRunReport>(StringComparer.Ordinal);
 
         var modules = summary.Modules

--- a/src/ModularPipelines/Extensions/EnumerableExtensions.cs
+++ b/src/ModularPipelines/Extensions/EnumerableExtensions.cs
@@ -58,4 +58,23 @@ public static class EnumerableExtensions
 
         return results;
     }
+
+    internal static Dictionary<string, T> ToFirstByKeyDictionary<T>(
+        this IEnumerable<T> source,
+        Func<T, string> keySelector)
+    {
+        return source
+            .GroupBy(keySelector, StringComparer.Ordinal)
+            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
+    }
+
+    internal static Dictionary<string, T> ToUniqueByKeyDictionary<T>(
+        this IEnumerable<T> source,
+        Func<T, string> keySelector)
+    {
+        return source
+            .GroupBy(keySelector, StringComparer.Ordinal)
+            .Where(static group => group.Count() == 1)
+            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
+    }
 }

--- a/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
+++ b/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
@@ -143,8 +143,7 @@ internal class SpectreResultsPrinter : IResultsPrinter
         var reportLookup = pipelineSummary.RunReport is null
             ? new Dictionary<string, ModuleRunReport>(StringComparer.Ordinal)
             : pipelineSummary.RunReport.Modules
-                .GroupBy(static report => report.ModuleTypeName, StringComparer.Ordinal)
-                .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
+                .ToUniqueByKeyDictionary(static report => report.ModuleTypeName);
         var showDeltas = pipelineSummary.RunReport?.TotalDurationDelta.HasValue == true
             || reportLookup.Values.Any(static module => module.DurationDelta.HasValue);
         if (showDeltas)
@@ -157,12 +156,10 @@ internal class SpectreResultsPrinter : IResultsPrinter
 
         // Create a lookup for module timelines by assembly-qualified module type
         var timelineLookup = pipelineSummary.ModuleTimelines?
-            .GroupBy(
+            .ToFirstByKeyDictionary(
                 static timeline => string.IsNullOrWhiteSpace(timeline.RuntimeModuleTypeName)
                     ? timeline.ModuleTypeName
-                    : timeline.RuntimeModuleTypeName,
-                StringComparer.Ordinal)
-            .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal)
+                    : timeline.RuntimeModuleTypeName)
             ?? new Dictionary<string, ModuleTimeline>(StringComparer.Ordinal);
 
         // Sort modules: Failed first, then Skipped, then by start time

--- a/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
+++ b/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
@@ -141,11 +141,10 @@ internal class SpectreResultsPrinter : IResultsPrinter
         table.AddColumn(new TableColumn("[bold]Status[/]").Centered());
         table.AddColumn(new TableColumn("[bold]Duration[/]").RightAligned());
         var reportLookup = pipelineSummary.RunReport is null
-            ? new Dictionary<Type, ModuleRunReport>()
-            : pipelineSummary.Modules
-                .Zip(pipelineSummary.RunReport.Modules)
-                .GroupBy(static pair => pair.First.GetType())
-                .ToDictionary(static group => group.Key, static group => group.First().Second);
+            ? new Dictionary<string, ModuleRunReport>(StringComparer.Ordinal)
+            : pipelineSummary.RunReport.Modules
+                .GroupBy(static report => report.ModuleTypeName, StringComparer.Ordinal)
+                .ToDictionary(static group => group.Key, static group => group.First(), StringComparer.Ordinal);
         var showDeltas = pipelineSummary.RunReport?.TotalDurationDelta.HasValue == true
             || reportLookup.Values.Any(static module => module.DurationDelta.HasValue);
         if (showDeltas)
@@ -208,7 +207,7 @@ internal class SpectreResultsPrinter : IResultsPrinter
         Table table,
         object module,
         Dictionary<string, ModuleTimeline> timelineLookup,
-        IReadOnlyDictionary<Type, ModuleRunReport> reportLookup,
+        IReadOnlyDictionary<string, ModuleRunReport> reportLookup,
         bool showDeltas)
     {
         var moduleName = module.GetType().Name;
@@ -249,7 +248,7 @@ internal class SpectreResultsPrinter : IResultsPrinter
         };
         if (showDeltas)
         {
-            cells.Add(reportLookup.TryGetValue(module.GetType(), out var report)
+            cells.Add(reportLookup.TryGetValue(ModuleTypeIdentifier.Get(module.GetType()), out var report)
                 ? FormatDelta(report.DurationDelta)
                 : "[dim]-[/]");
         }

--- a/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
@@ -19,6 +19,14 @@ public class SpectreResultsPrinterTests
             CancellationToken cancellationToken) => Task.FromResult(true);
     }
 
+    private sealed class FirstModule : SkippedModule
+    {
+    }
+
+    private sealed class SecondModule : SkippedModule
+    {
+    }
+
     [Test]
     public async Task ModulesTable_IsCompactWithoutBlankSeparator_AndLabelsSkippedModules()
     {
@@ -142,6 +150,51 @@ public class SpectreResultsPrinterTests
         {
             await Assert.That(output).Contains("Δ previous");
             await Assert.That(output).Contains("+2s");
+        }
+    }
+
+    [Test]
+    public async Task ModulesTable_MatchesDurationDeltasByModuleType()
+    {
+        var start = new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero);
+        var firstModule = new FirstModule();
+        var secondModule = new SecondModule();
+        var summary = new PipelineSummary(
+            [firstModule, secondModule],
+            [],
+            TimeSpan.FromSeconds(5),
+            start,
+            start.AddSeconds(5)) with
+        {
+            RunReport = new PipelineRunReport
+            {
+                Modules =
+                [
+                    new ModuleRunReport
+                    {
+                        ModuleName = nameof(SecondModule),
+                        ModuleTypeName = ModuleTypeIdentifier.Get(typeof(SecondModule)),
+                        DurationDelta = TimeSpan.FromSeconds(2),
+                    },
+                    new ModuleRunReport
+                    {
+                        ModuleName = nameof(FirstModule),
+                        ModuleTypeName = ModuleTypeIdentifier.Get(typeof(FirstModule)),
+                        DurationDelta = TimeSpan.FromSeconds(1),
+                    },
+                ],
+            },
+        };
+
+        var output = RenderToString(SpectreResultsPrinter.CreateModulesTable(summary));
+        var lines = output.Split(Environment.NewLine);
+        var firstModuleLine = lines.Single(line => line.Contains(nameof(FirstModule), StringComparison.Ordinal));
+        var secondModuleLine = lines.Single(line => line.Contains(nameof(SecondModule), StringComparison.Ordinal));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(firstModuleLine).Contains("+1s");
+            await Assert.That(secondModuleLine).Contains("+2s");
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
@@ -198,6 +198,48 @@ public class SpectreResultsPrinterTests
         }
     }
 
+    [Test]
+    public async Task ModulesTable_DoesNotApplyAmbiguousTypeDeltas()
+    {
+        var start = new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero);
+        var summary = new PipelineSummary(
+            [new FirstModule(), new FirstModule()],
+            [],
+            TimeSpan.FromSeconds(5),
+            start,
+            start.AddSeconds(5)) with
+        {
+            RunReport = new PipelineRunReport
+            {
+                TotalDurationDelta = TimeSpan.FromSeconds(3),
+                Modules =
+                [
+                    new ModuleRunReport
+                    {
+                        ModuleName = nameof(FirstModule),
+                        ModuleTypeName = ModuleTypeIdentifier.Get(typeof(FirstModule)),
+                        DurationDelta = TimeSpan.FromSeconds(1),
+                    },
+                    new ModuleRunReport
+                    {
+                        ModuleName = nameof(FirstModule),
+                        ModuleTypeName = ModuleTypeIdentifier.Get(typeof(FirstModule)),
+                        DurationDelta = TimeSpan.FromSeconds(2),
+                    },
+                ],
+            },
+        };
+
+        var output = RenderToString(SpectreResultsPrinter.CreateModulesTable(summary));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).Contains("Δ previous");
+            await Assert.That(output).DoesNotContain("+1s");
+            await Assert.That(output).DoesNotContain("+2s");
+        }
+    }
+
     private static string RenderToString(IRenderable renderable)
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary
- build the results-printer delta lookup from stable module type identifiers
- remove positional Zip coupling between pipeline modules and report entries
- verify reversed report ordering preserves each module's delta

## Validation
- SpectreResultsPrinterTests: 5/5
- core Release build: 0 warnings, 0 errors

Closes #3749