### PR TITLE
Reduce default build pipeline log verbosity

### DIFF
--- a/src/ModularPipelines.Build/Program.cs
+++ b/src/ModularPipelines.Build/Program.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ModularPipelines;
 using ModularPipelines.Build;
@@ -117,8 +116,6 @@ if (!string.IsNullOrEmpty(runOnlyCategories))
 {
     builder.RunOnlyCategories(runOnlyCategories.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
 }
-
-builder.SetLogLevel(LogLevel.Debug); // Temporarily hardcoded for debugging
 
 await using var pipeline = await builder.BuildAsync();
 await pipeline.RunAsync();

--- a/src/ModularPipelines.Build/appsettings.json
+++ b/src/ModularPipelines.Build/appsettings.json
@@ -1,7 +1,7 @@
 ﻿{
   "Logging": {
     "LogLevel": {
-      "Default": "Trace"
+      "Default": "Information"
     }
   },
   "Pipeline": {


### PR DESCRIPTION
## What changed

- Changed the build pipeline's default log level from `Trace` to `Information`.
- Removed the temporary hardcoded `Debug` override from `Program.cs`.

## Why

The build pipeline currently emits high-volume trace and debug diagnostics during normal CI runs, making actionable information harder to find. The motivating run includes 435 `Debug`/`Trace` lines in the pipeline output:

https://github.com/thomhurst/ModularPipelines/actions/runs/30972375285/job/92199614528

## Impact

Normal local and CI runs now show information-level output and above. Detailed diagnostics remain opt-in through standard configuration, including environment overrides such as:

```text
Logging__LogLevel__Default=Debug
Logging__LogLevel__Default=Trace
```

## Checks

- Parsed `src/ModularPipelines.Build/appsettings.json` with PowerShell `ConvertFrom-Json`.
- Ran `git diff --check`.
- Reviewed the focused diff with the code-simplifier workflow.
- Did not build or run `ModularPipelines.Build`; repository guidance reserves the full build pipeline and its broad dependency graph for CI.