### PR TITLE
Fix pipeline module status counts

### DIFF
--- a/src/ModularPipelines/Engine/IMetricsCollector.cs
+++ b/src/ModularPipelines/Engine/IMetricsCollector.cs
@@ -19,6 +19,11 @@ internal interface IMetricsCollector
     DateTimeOffset? GetPipelineStartTime();
 
     /// <summary>
+    /// Registers a module before dependency scheduling begins.
+    /// </summary>
+    void RecordModuleInitialized(Type moduleType, ModulePriority priority, ExecutionType executionType);
+
+    /// <summary>
     /// Records when a module becomes ready (all dependencies satisfied).
     /// </summary>
     void RecordModuleReady(Type moduleType, DateTimeOffset time, ModulePriority priority, ExecutionType executionType);

--- a/src/ModularPipelines/Engine/MetricsCollector.cs
+++ b/src/ModularPipelines/Engine/MetricsCollector.cs
@@ -20,6 +20,13 @@ internal class MetricsCollector : IMetricsCollector
 
     public DateTimeOffset? GetPipelineStartTime() => _pipelineStartTime;
 
+    public void RecordModuleInitialized(Type moduleType, ModulePriority priority, ExecutionType executionType)
+    {
+        var data = _moduleMetrics.GetOrAdd(moduleType, _ => new ModuleMetricsData { ModuleType = moduleType });
+        data.Priority = priority;
+        data.ExecutionType = executionType;
+    }
+
     public void RecordModuleReady(Type moduleType, DateTimeOffset time, ModulePriority priority, ExecutionType executionType)
     {
         var data = _moduleMetrics.GetOrAdd(moduleType, _ => new ModuleMetricsData { ModuleType = moduleType });
@@ -38,6 +45,7 @@ internal class MetricsCollector : IMetricsCollector
     {
         var data = _moduleMetrics.GetOrAdd(moduleType, _ => new ModuleMetricsData { ModuleType = moduleType });
         data.StartTime = time;
+        data.Status = Status.Processing;
     }
 
     public void RecordModuleCompleted(Type moduleType, DateTimeOffset time, bool success, bool skipped, Status status)

--- a/src/ModularPipelines/Engine/MetricsCollector.cs
+++ b/src/ModularPipelines/Engine/MetricsCollector.cs
@@ -64,6 +64,10 @@ internal class MetricsCollector : IMetricsCollector
         var successfulCount = 0;
         var failedCount = 0;
         var skippedCount = 0;
+        var ignoredFailureCount = 0;
+        var pendingCount = 0;
+        var processingCount = 0;
+        var unknownCount = 0;
 
         foreach (var data in moduleData)
         {
@@ -72,21 +76,36 @@ internal class MetricsCollector : IMetricsCollector
                 totalModuleExecutionTime += data.EndTime.Value - data.StartTime.Value;
             }
 
-            if (data.WasSkipped)
+            switch (data.Status)
             {
-                skippedCount++;
-            }
-            else if (data.Status == Status.IgnoredFailure)
-            {
-                // Ignored failures don't count as passed or failed
-            }
-            else if (data.WasSuccessful)
-            {
-                successfulCount++;
-            }
-            else
-            {
-                failedCount++;
+                case Status.Successful:
+                case Status.UsedHistory:
+                case Status.CachedResult:
+                    successfulCount++;
+                    break;
+                case Status.Failed:
+                case Status.PipelineTerminated:
+                case Status.TimedOut:
+                case Status.DependencyFailed:
+                    failedCount++;
+                    break;
+                case Status.IgnoredFailure:
+                    ignoredFailureCount++;
+                    break;
+                case Status.Skipped:
+                    skippedCount++;
+                    break;
+                case Status.NotYetStarted:
+                    pendingCount++;
+                    break;
+                case Status.Processing:
+                    processingCount++;
+                    break;
+                case Status.Unknown:
+                    unknownCount++;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(data.Status), data.Status, "Unsupported module status");
             }
         }
 
@@ -120,6 +139,10 @@ internal class MetricsCollector : IMetricsCollector
             SuccessfulModules = successfulCount,
             FailedModules = failedCount,
             SkippedModules = skippedCount,
+            IgnoredFailureModules = ignoredFailureCount,
+            PendingModules = pendingCount,
+            ProcessingModules = processingCount,
+            UnknownModules = unknownCount,
         };
     }
 

--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -116,6 +116,14 @@ internal class ModuleScheduler : IModuleScheduler
         foreach (var state in _moduleStates.Values)
         {
             ConfigureScheduling(state);
+            _metricsCollector.RecordModuleInitialized(
+                state.ModuleType,
+                state.Priority,
+                state.ExecutionType);
+        }
+
+        foreach (var state in _moduleStates.Values)
+        {
             ConfigureDependencies(state, availableModuleTypes);
         }
 

--- a/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
+++ b/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
@@ -124,12 +124,7 @@ internal class SpectreResultsPrinter : IResultsPrinter
 
     private static int CountModules(PipelineSummary pipelineSummary, Func<ModuleTimeline, bool> predicate)
     {
-        return pipelineSummary.Modules.Count(module =>
-        {
-            var timeline = pipelineSummary.ModuleTimelines?
-                .FirstOrDefault(candidate => candidate.ModuleName == module.GetType().Name);
-            return timeline is not null && predicate(timeline);
-        });
+        return pipelineSummary.ModuleTimelines?.Count(predicate) ?? 0;
     }
 
     private static Table CreateModulesTableCore(PipelineSummary pipelineSummary)

--- a/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
+++ b/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
@@ -60,63 +60,47 @@ internal class SpectreResultsPrinter : IResultsPrinter
     internal static Panel CreateMetricsPanel(PipelineMetrics metrics) =>
         CreateMetricsPanelCore(metrics);
 
-    private static void PrintHeader(PipelineSummary pipelineSummary)
+    internal static string CreateSummaryLine(PipelineSummary pipelineSummary)
     {
         var metrics = pipelineSummary.Metrics;
 
-        // Build summary counts
-        var successCount = metrics?.SuccessfulModules ?? pipelineSummary.Modules.Count(m =>
-        {
-            var timeline = pipelineSummary.ModuleTimelines?.FirstOrDefault(t => t.ModuleName == m.GetType().Name);
-            return timeline?.WasSuccessful == true;
-        });
+        var successCount = metrics?.SuccessfulModules
+            ?? CountModules(pipelineSummary, static timeline => timeline.WasSuccessful);
+        var failedCount = metrics?.FailedModules
+            ?? CountModules(pipelineSummary, static timeline => timeline.Status is ModuleStatus.Failed
+                or ModuleStatus.TimedOut
+                or ModuleStatus.PipelineTerminated
+                or ModuleStatus.DependencyFailed);
+        var skippedCount = metrics?.SkippedModules
+            ?? CountModules(pipelineSummary, static timeline => timeline.WasSkipped);
+        var ignoredCount = metrics?.IgnoredFailureModules
+            ?? CountModules(pipelineSummary, static timeline => timeline.Status == ModuleStatus.IgnoredFailure);
+        var pendingCount = metrics?.PendingModules
+            ?? CountModules(pipelineSummary, static timeline => timeline.Status == ModuleStatus.NotYetStarted);
+        var processingCount = metrics?.ProcessingModules
+            ?? CountModules(pipelineSummary, static timeline => timeline.Status == ModuleStatus.Processing);
+        var unknownCount = metrics?.UnknownModules
+            ?? CountModules(pipelineSummary, static timeline => timeline.Status == ModuleStatus.Unknown);
 
-        var failedCount = metrics?.FailedModules ?? pipelineSummary.Modules.Count(m =>
-        {
-            var timeline = pipelineSummary.ModuleTimelines?.FirstOrDefault(t => t.ModuleName == m.GetType().Name);
-            return timeline?.Status == ModuleStatus.Failed || timeline?.Status == ModuleStatus.TimedOut;
-        });
-
-        var skippedCount = metrics?.SkippedModules ?? pipelineSummary.Modules.Count(m =>
-        {
-            var timeline = pipelineSummary.ModuleTimelines?.FirstOrDefault(t => t.ModuleName == m.GetType().Name);
-            return timeline?.WasSkipped == true;
-        });
-
-        var ignoredCount = pipelineSummary.Modules.Count(m =>
-        {
-            var timeline = pipelineSummary.ModuleTimelines?.FirstOrDefault(t => t.ModuleName == m.GetType().Name);
-            return timeline?.Status == ModuleStatus.IgnoredFailure;
-        });
-
-        var totalCount = metrics?.TotalModules ?? pipelineSummary.Modules.Count;
-
-        // Build the summary line
         var parts = new List<string>();
 
-        if (successCount > 0)
-        {
-            parts.Add($"[green]{successCount} passed[/]");
-        }
+        AddSummaryCount(parts, successCount, "green", "passed");
+        AddSummaryCount(parts, failedCount, "red", "failed");
+        AddSummaryCount(parts, ignoredCount, "yellow", "ignored");
+        AddSummaryCount(parts, skippedCount, "yellow", "skipped");
+        AddSummaryCount(parts, pendingCount, "grey", "pending");
+        AddSummaryCount(parts, processingCount, "blue", "running");
+        AddSummaryCount(parts, unknownCount, "grey", "unknown");
 
-        if (failedCount > 0)
-        {
-            parts.Add($"[red]{failedCount} failed[/]");
-        }
-
-        if (ignoredCount > 0)
-        {
-            parts.Add($"[yellow]{ignoredCount} ignored[/]");
-        }
-
-        if (skippedCount > 0)
-        {
-            parts.Add($"[yellow]{skippedCount} skipped[/]");
-        }
-
-        var summaryLine = parts.Count > 0
+        var totalCount = metrics?.TotalModules ?? pipelineSummary.Modules.Count;
+        return parts.Count > 0
             ? string.Join("[dim] | [/]", parts)
             : $"[dim]{totalCount} modules[/]";
+    }
+
+    private static void PrintHeader(PipelineSummary pipelineSummary)
+    {
+        var summaryLine = CreateSummaryLine(pipelineSummary);
 
         // Create the header rule
         var headerText = pipelineSummary.Status == ModuleStatus.Successful
@@ -128,6 +112,24 @@ internal class SpectreResultsPrinter : IResultsPrinter
         AnsiConsole.MarkupLine(headerText);
         AnsiConsole.MarkupLine($"[dim]Duration:[/] [bold]{pipelineSummary.TotalDuration.ToDisplayString()}[/]  {summaryLine}");
         System.Console.WriteLine();
+    }
+
+    private static void AddSummaryCount(List<string> parts, int count, string color, string label)
+    {
+        if (count > 0)
+        {
+            parts.Add($"[{color}]{count} {label}[/]");
+        }
+    }
+
+    private static int CountModules(PipelineSummary pipelineSummary, Func<ModuleTimeline, bool> predicate)
+    {
+        return pipelineSummary.Modules.Count(module =>
+        {
+            var timeline = pipelineSummary.ModuleTimelines?
+                .FirstOrDefault(candidate => candidate.ModuleName == module.GetType().Name);
+            return timeline is not null && predicate(timeline);
+        });
     }
 
     private static Table CreateModulesTableCore(PipelineSummary pipelineSummary)

--- a/src/ModularPipelines/Models/PipelineMetrics.cs
+++ b/src/ModularPipelines/Models/PipelineMetrics.cs
@@ -72,4 +72,28 @@ public record PipelineMetrics
     /// </summary>
     [JsonInclude]
     public int SkippedModules { get; init; }
+
+    /// <summary>
+    /// Gets the number of modules whose failures were ignored.
+    /// </summary>
+    [JsonInclude]
+    public int IgnoredFailureModules { get; init; }
+
+    /// <summary>
+    /// Gets the number of modules that had not started when the pipeline ended.
+    /// </summary>
+    [JsonInclude]
+    public int PendingModules { get; init; }
+
+    /// <summary>
+    /// Gets the number of modules that were still processing when the pipeline ended.
+    /// </summary>
+    [JsonInclude]
+    public int ProcessingModules { get; init; }
+
+    /// <summary>
+    /// Gets the number of modules whose final status was unknown.
+    /// </summary>
+    [JsonInclude]
+    public int UnknownModules { get; init; }
 }

--- a/test/ModularPipelines.UnitTests/Engine/MetricsCollectorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/MetricsCollectorTests.cs
@@ -1,4 +1,5 @@
 using ModularPipelines.Context;
+using ModularPipelines.Engine;
 using ModularPipelines.Enums;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
@@ -8,6 +9,10 @@ namespace ModularPipelines.UnitTests.Engine;
 [TUnit.Core.NotInParallel(nameof(MetricsCollectorTests))]
 public class MetricsCollectorTests : TestBase
 {
+    private class MetricsModule<T>
+    {
+    }
+
     public class QuickModule1 : Module<string>
     {
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
@@ -113,6 +118,55 @@ public class MetricsCollectorTests : TestBase
     }
 
     [Test]
+    public async Task PipelineMetrics_PreservesStatusCounts()
+    {
+        var collector = new MetricsCollector();
+        var moduleTypes = CreateModuleTypes(68).GetEnumerator();
+        var now = DateTimeOffset.UtcNow;
+
+        RecordCompletedModules(collector, moduleTypes, now, 34, Status.Successful);
+        RecordCompletedModules(collector, moduleTypes, now, 6, Status.Failed);
+        RecordCompletedModules(collector, moduleTypes, now, 5, Status.Skipped);
+        RecordPendingModules(collector, moduleTypes, now, 23);
+
+        var metrics = collector.ComputeMetrics(now, now.AddMinutes(1), maxParallelism: 4);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(metrics.TotalModules).IsEqualTo(68);
+            await Assert.That(metrics.SuccessfulModules).IsEqualTo(34);
+            await Assert.That(metrics.FailedModules).IsEqualTo(6);
+            await Assert.That(metrics.SkippedModules).IsEqualTo(5);
+            await Assert.That(metrics.PendingModules).IsEqualTo(23);
+        }
+    }
+
+    [Test]
+    public async Task PipelineMetrics_DoesNotTreatNonFailureStatusesAsFailed()
+    {
+        var collector = new MetricsCollector();
+        var moduleTypes = CreateModuleTypes(5).GetEnumerator();
+        var now = DateTimeOffset.UtcNow;
+
+        RecordCompletedModules(collector, moduleTypes, now, 1, Status.UsedHistory);
+        RecordCompletedModules(collector, moduleTypes, now, 1, Status.CachedResult);
+        RecordCompletedModules(collector, moduleTypes, now, 1, Status.IgnoredFailure);
+        RecordCompletedModules(collector, moduleTypes, now, 1, Status.Processing);
+        RecordCompletedModules(collector, moduleTypes, now, 1, Status.Unknown);
+
+        var metrics = collector.ComputeMetrics(now, now.AddMinutes(1), maxParallelism: 4);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(metrics.SuccessfulModules).IsEqualTo(2);
+            await Assert.That(metrics.FailedModules).IsEqualTo(0);
+            await Assert.That(metrics.IgnoredFailureModules).IsEqualTo(1);
+            await Assert.That(metrics.ProcessingModules).IsEqualTo(1);
+            await Assert.That(metrics.UnknownModules).IsEqualTo(1);
+        }
+    }
+
+    [Test]
     public async Task PipelineMetrics_HasTimingData()
     {
         var result = await TestPipelineBuilder.Create()
@@ -161,5 +215,52 @@ public class MetricsCollectorTests : TestBase
         await Assert.That(timeline.StartTime).IsNotNull();
         await Assert.That(timeline.EndTime).IsNotNull();
         await Assert.That(timeline.ExecutionDuration).IsNotNull();
+    }
+
+    private static IEnumerable<Type> CreateModuleTypes(int count)
+    {
+        var typeArgument = typeof(int);
+        for (var index = 0; index < count; index++)
+        {
+            typeArgument = typeof(MetricsModule<>).MakeGenericType(typeArgument);
+            yield return typeArgument;
+        }
+    }
+
+    private static void RecordCompletedModules(
+        MetricsCollector collector,
+        IEnumerator<Type> moduleTypes,
+        DateTimeOffset now,
+        int count,
+        Status status)
+    {
+        for (var index = 0; index < count; index++)
+        {
+            var moduleType = GetNextModuleType(moduleTypes);
+            collector.RecordModuleReady(moduleType, now, default, default);
+            collector.RecordModuleCompleted(moduleType, now, status == Status.Successful, status == Status.Skipped, status);
+        }
+    }
+
+    private static void RecordPendingModules(
+        MetricsCollector collector,
+        IEnumerator<Type> moduleTypes,
+        DateTimeOffset now,
+        int count)
+    {
+        for (var index = 0; index < count; index++)
+        {
+            collector.RecordModuleReady(GetNextModuleType(moduleTypes), now, default, default);
+        }
+    }
+
+    private static Type GetNextModuleType(IEnumerator<Type> moduleTypes)
+    {
+        if (!moduleTypes.MoveNext())
+        {
+            throw new InvalidOperationException("Expected another module type");
+        }
+
+        return moduleTypes.Current;
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/MetricsCollectorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/MetricsCollectorTests.cs
@@ -167,6 +167,39 @@ public class MetricsCollectorTests : TestBase
     }
 
     [Test]
+    public async Task PipelineMetrics_CountsInitializedModulesAsPending()
+    {
+        var collector = new MetricsCollector();
+        var now = DateTimeOffset.UtcNow;
+        collector.RecordModuleInitialized(typeof(QuickModule1), default, default);
+
+        var metrics = collector.ComputeMetrics(now, now.AddMinutes(1), maxParallelism: 1);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(metrics.TotalModules).IsEqualTo(1);
+            await Assert.That(metrics.PendingModules).IsEqualTo(1);
+        }
+    }
+
+    [Test]
+    public async Task PipelineMetrics_CountsStartedModulesAsProcessing()
+    {
+        var collector = new MetricsCollector();
+        var now = DateTimeOffset.UtcNow;
+        collector.RecordModuleInitialized(typeof(QuickModule1), default, default);
+        collector.RecordModuleStarted(typeof(QuickModule1), now);
+
+        var metrics = collector.ComputeMetrics(now, now.AddMinutes(1), maxParallelism: 1);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(metrics.PendingModules).IsEqualTo(0);
+            await Assert.That(metrics.ProcessingModules).IsEqualTo(1);
+        }
+    }
+
+    [Test]
     public async Task PipelineMetrics_HasTimingData()
     {
         var result = await TestPipelineBuilder.Create()

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerConfigurationTests.cs
@@ -28,7 +28,8 @@ public class ModuleSchedulerConfigurationTests
     [Test]
     public async Task InitializeModules_PreservesDirectModuleSchedulingAttributes()
     {
-        var scheduler = CreateScheduler();
+        var metricsCollector = new Mock<IMetricsCollector>();
+        var scheduler = CreateScheduler(metricsCollector.Object);
 
         scheduler.InitializeModules([new DirectAttributedModule()]);
 
@@ -37,9 +38,13 @@ public class ModuleSchedulerConfigurationTests
         await Assert.That(state!.RequiredLockKeys).IsEquivalentTo(["direct-lock"]);
         await Assert.That(state.Priority).IsEqualTo(ModulePriority.Critical);
         await Assert.That(state.ExecutionType).IsEqualTo(ExecutionType.IoIntensive);
+        metricsCollector.Verify(x => x.RecordModuleInitialized(
+            typeof(DirectAttributedModule),
+            ModulePriority.Critical,
+            ExecutionType.IoIntensive), Times.Once);
     }
 
-    private static ModuleScheduler CreateScheduler()
+    private static ModuleScheduler CreateScheduler(IMetricsCollector metricsCollector)
     {
         return new ModuleScheduler(
             NullLogger.Instance,
@@ -47,7 +52,7 @@ public class ModuleSchedulerConfigurationTests
             Microsoft.Extensions.Options.Options.Create(new SchedulerOptions()),
             new ModuleDependencyRegistry(),
             new ModuleMetadataRegistry(new ModuleAttributeEventService()),
-            Mock.Of<IMetricsCollector>(),
+            metricsCollector,
             Mock.Of<IModuleConstraintEvaluator>(),
             Mock.Of<ISchedulerStatusReporter>());
     }

--- a/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
@@ -114,6 +114,40 @@ public class SpectreResultsPrinterTests
     }
 
     [Test]
+    public async Task SummaryLine_CountsDuplicateModuleTimelinesOnceEach()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var summary = new PipelineSummary(
+            [new SkippedModule(), new SkippedModule()],
+            [],
+            TimeSpan.Zero,
+            now,
+            now,
+            moduleTimelines:
+            [
+                new ModuleTimeline
+                {
+                    ModuleName = nameof(SkippedModule),
+                    Status = ModuleStatus.Failed,
+                },
+                new ModuleTimeline
+                {
+                    ModuleName = nameof(SkippedModule),
+                    Status = ModuleStatus.Skipped,
+                    WasSkipped = true,
+                },
+            ]);
+
+        var summaryLine = SpectreResultsPrinter.CreateSummaryLine(summary);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(summaryLine).Contains("1 failed");
+            await Assert.That(summaryLine).Contains("1 skipped");
+        }
+    }
+
+    [Test]
     public async Task ModulesTable_ShowsPreviousRunDurationDelta()
     {
         var start = new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero);

--- a/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
@@ -83,6 +83,37 @@ public class SpectreResultsPrinterTests
     }
 
     [Test]
+    public async Task SummaryLine_SeparatesPendingModulesFromFailures()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var summary = new PipelineSummary(
+            [],
+            [],
+            TimeSpan.FromMinutes(18),
+            now,
+            now.AddMinutes(18),
+            new PipelineMetrics
+            {
+                TotalModules = 68,
+                SuccessfulModules = 34,
+                FailedModules = 6,
+                SkippedModules = 5,
+                PendingModules = 23,
+            });
+
+        var summaryLine = SpectreResultsPrinter.CreateSummaryLine(summary);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(summaryLine).Contains("34 passed");
+            await Assert.That(summaryLine).Contains("6 failed");
+            await Assert.That(summaryLine).Contains("5 skipped");
+            await Assert.That(summaryLine).Contains("23 pending");
+            await Assert.That(summaryLine).DoesNotContain("29 failed");
+        }
+    }
+
+    [Test]
     public async Task ModulesTable_ShowsPreviousRunDurationDelta()
     {
         var start = new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero);


### PR DESCRIPTION
## What

- Classify every module `Status` explicitly in pipeline metrics.
- Preserve ignored, pending, processing, and unknown counts instead of folding them into failures.
- Show nonzero pending/running/unknown categories in the human-readable results header.
- Add regression coverage matching the motivating run: 34 passed, 6 failed, 5 skipped, 23 pending.

## Why

The pipeline summary reported 29 failed modules while the result table showed 6 failure statuses and 23 pending modules. That contradiction made the real outcome harder to scan.

Motivating run: https://github.com/thomhurst/ModularPipelines/actions/runs/30972375285/job/92199614528

## Root cause

`MetricsCollector.ComputeMetrics` treated every status that was not skipped, ignored, or successful as failed. `Status.NotYetStarted` therefore increased `FailedModules`, and the header consumed that incorrect aggregate.

## Impact

Failed counts now represent failure statuses only. Pending and other unfinished/non-failure statuses remain visible as separate summary categories, so totals are accurate and easier to understand.

## Checks

- `MetricsCollectorTests`: 12 passed
- `SpectreResultsPrinterTests`: 5 passed
- `dotnet format ModularPipelines.Tests.slnf` for changed files (formatter emitted expected unsupported F# fixture notice)
- All `dotnet` commands ran through `scripts/Invoke-AgentDotNet.ps1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pipeline metrics now report ignored failures, pending modules, processing modules, and unknown statuses.
  - Pipeline result summaries now display separate counts for successful, failed, ignored, skipped, pending, processing, and unknown modules.
  - Pending and processing modules are no longer included in failure totals.

- **Bug Fixes**
  - Improved status classification to ensure failures and non-failure states are counted accurately.
  - Summary counts remain reliable when detailed metrics are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->