### PR TITLE
Deduplicate propagated module failures

### DIFF
--- a/src/ModularPipelines/Console/IModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/IModuleOutputBuffer.cs
@@ -57,6 +57,22 @@ internal interface IModuleOutputBuffer
     void SetException(Exception exception);
 
     /// <summary>
+    /// Registers a one-shot fallback for a deferred completion flush failure.
+    /// </summary>
+    /// <param name="handler">Receives the output flush exception.</param>
+    void SetDeferredFlushFailureHandler(Action<Exception> handler)
+    {
+    }
+
+    /// <summary>
+    /// Reports that deferred completion output could not be flushed.
+    /// </summary>
+    /// <param name="exception">The output flush exception.</param>
+    void ReportDeferredFlushFailure(Exception exception)
+    {
+    }
+
+    /// <summary>
     /// Gets a value indicating whether there is any output to flush.
     /// </summary>
     bool HasOutput { get; }

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -40,6 +40,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly bool _showSuccessMarker;
     private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = [];
     private Exception? _exception;
+    private Action<Exception>? _deferredFlushFailureHandler;
     private bool _isComplete;
     private bool _hasRenderedCompletionHeader;
     private bool _isIncrementalFlushInProgress;
@@ -140,6 +141,35 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         {
             _exception = exception;
             _hasRenderedCompletionHeader = false;
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetDeferredFlushFailureHandler(Action<Exception> handler)
+    {
+        lock (_lock)
+        {
+            _deferredFlushFailureHandler = handler;
+        }
+    }
+
+    /// <inheritdoc />
+    public void ReportDeferredFlushFailure(Exception exception)
+    {
+        Action<Exception>? handler;
+        lock (_lock)
+        {
+            handler = _deferredFlushFailureHandler;
+            _deferredFlushFailureHandler = null;
+        }
+
+        try
+        {
+            handler?.Invoke(exception);
+        }
+        catch
+        {
+            // A diagnostic fallback must not replace the output failure.
         }
     }
 
@@ -550,6 +580,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             {
                 _hasRenderedIncrementalOutput = false;
                 _hasRenderedCompletionHeader = true;
+                _deferredFlushFailureHandler = null;
             }
             else
             {

--- a/src/ModularPipelines/Console/OutputCoordinator.cs
+++ b/src/ModularPipelines/Console/OutputCoordinator.cs
@@ -157,17 +157,21 @@ internal sealed class OutputCoordinator : IOutputCoordinator
                     .ConfigureAwait(false);
             }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException exception) when (cancellationToken.IsCancellationRequested)
         {
-            RequeueDeferredOutputs(toFlush.Skip(nextOutputIndex));
+            var unflushedOutputs = toFlush.Skip(nextOutputIndex).ToArray();
+            ReportDeferredFlushFailure(unflushedOutputs, exception);
+            RequeueDeferredOutputs(unflushedOutputs);
 
             throw;
         }
-        catch
+        catch (Exception exception)
         {
             // Preserve the current buffer too. Its own render cursor retains the
             // failed item, preferring a possible duplicate over lost diagnostics.
-            RequeueDeferredOutputs(toFlush.Skip(nextOutputIndex));
+            var unflushedOutputs = toFlush.Skip(nextOutputIndex).ToArray();
+            ReportDeferredFlushFailure(unflushedOutputs, exception);
+            RequeueDeferredOutputs(unflushedOutputs);
 
             throw;
         }
@@ -345,6 +349,16 @@ internal sealed class OutputCoordinator : IOutputCoordinator
         lock (_deferredLock)
         {
             _deferredOutputs.InsertRange(0, outputs);
+        }
+    }
+
+    private static void ReportDeferredFlushFailure(
+        IEnumerable<DeferredModuleOutput> outputs,
+        Exception exception)
+    {
+        foreach (var output in outputs)
+        {
+            output.Buffer.ReportDeferredFlushFailure(exception);
         }
     }
 

--- a/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
@@ -38,7 +38,7 @@ internal class DependencyWaiter : IDependencyWaiter
                             ? runtime.GetLogger(scopedServiceProvider)
                             : (IModuleLogger) scopedServiceProvider.GetRequiredService(
                                 typeof(ModuleLogger<>).MakeGenericType(moduleState.ModuleType));
-                    depLogger.LogError(e, "Ignoring Exception due to 'AlwaysRun' set");
+                    depLogger.LogIgnoredDependencyFailure(e);
                 }
                 catch (Exception e) when (
                     e is not OperationCanceledException)

--- a/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
@@ -46,7 +46,7 @@ internal class DependencyWaiter : IDependencyWaiter
                 }
                 catch (Exception e) when (
                     e is not OperationCanceledException operationCanceledException
-                    || !workerCancellationToken.CanBeCanceled
+                    || !workerCancellationToken.IsCancellationRequested
                     || operationCanceledException.CancellationToken != workerCancellationToken)
                 {
                     var dependency = scheduler.GetModuleState(dependencyType)?.Module;

--- a/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
@@ -1,12 +1,10 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Logging;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
-using ModularPipelines.Options;
 
 namespace ModularPipelines.Engine.Execution;
 
@@ -15,13 +13,6 @@ namespace ModularPipelines.Engine.Execution;
 /// </summary>
 internal class DependencyWaiter : IDependencyWaiter
 {
-    private readonly IOptions<PipelineOptions> _pipelineOptions;
-
-    public DependencyWaiter(IOptions<PipelineOptions> pipelineOptions)
-    {
-        _pipelineOptions = pipelineOptions;
-    }
-
     /// <inheritdoc />
     [UnconditionalSuppressMessage(
         "AOT",
@@ -50,8 +41,7 @@ internal class DependencyWaiter : IDependencyWaiter
                     depLogger.LogError(e, "Ignoring Exception due to 'AlwaysRun' set");
                 }
                 catch (Exception e) when (
-                    e is not OperationCanceledException
-                    && _pipelineOptions.Value.ExecutionMode == ExecutionMode.WaitForAllModules)
+                    e is not OperationCanceledException)
                 {
                     var dependency = scheduler.GetModuleState(dependencyType)?.Module;
                     if (dependency is null)

--- a/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
@@ -45,9 +45,7 @@ internal class DependencyWaiter : IDependencyWaiter
                     depLogger.LogIgnoredDependencyFailure(e);
                 }
                 catch (Exception e) when (
-                    e is not OperationCanceledException operationCanceledException
-                    || !workerCancellationToken.IsCancellationRequested
-                    || operationCanceledException.CancellationToken != workerCancellationToken)
+                    !WorkerCancellationClassifier.IsExpected(e, workerCancellationToken))
                 {
                     var dependency = scheduler.GetModuleState(dependencyType)?.Module;
                     if (dependency is null)

--- a/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/DependencyWaiter.cs
@@ -18,7 +18,11 @@ internal class DependencyWaiter : IDependencyWaiter
         "AOT",
         "IL3050",
         Justification = "Generated runtime metadata handles statically known modules; MakeGenericType is the documented fallback for dynamic modules.")]
-    public async Task WaitForDependenciesAsync(ModuleState moduleState, IModuleScheduler scheduler, IServiceProvider scopedServiceProvider)
+    public async Task WaitForDependenciesAsync(
+        ModuleState moduleState,
+        IModuleScheduler scheduler,
+        IServiceProvider scopedServiceProvider,
+        CancellationToken workerCancellationToken)
     {
         foreach (var (dependencyType, optional) in moduleState.Dependencies)
         {
@@ -41,7 +45,9 @@ internal class DependencyWaiter : IDependencyWaiter
                     depLogger.LogIgnoredDependencyFailure(e);
                 }
                 catch (Exception e) when (
-                    e is not OperationCanceledException)
+                    e is not OperationCanceledException operationCanceledException
+                    || !workerCancellationToken.CanBeCanceled
+                    || operationCanceledException.CancellationToken != workerCancellationToken)
                 {
                     var dependency = scheduler.GetModuleState(dependencyType)?.Module;
                     if (dependency is null)

--- a/src/ModularPipelines/Engine/Execution/IDependencyWaiter.cs
+++ b/src/ModularPipelines/Engine/Execution/IDependencyWaiter.cs
@@ -12,5 +12,10 @@ internal interface IDependencyWaiter
     /// <param name="moduleState">The state of the module waiting for dependencies.</param>
     /// <param name="scheduler">The scheduler to get dependency completion tasks from.</param>
     /// <param name="scopedServiceProvider">The scoped service provider for logging.</param>
-    Task WaitForDependenciesAsync(ModuleState moduleState, IModuleScheduler scheduler, IServiceProvider scopedServiceProvider);
+    /// <param name="workerCancellationToken">The token used to cancel the current worker.</param>
+    Task WaitForDependenciesAsync(
+        ModuleState moduleState,
+        IModuleScheduler scheduler,
+        IServiceProvider scopedServiceProvider,
+        CancellationToken workerCancellationToken);
 }

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -226,7 +226,7 @@ internal class ModuleRunner : IModuleRunner
         }
     }
 
-    private Exception NormalizeLimiterCancellation(
+    internal static Exception NormalizeLimiterCancellation(
         Exception exception,
         CancellationToken workerCancellationToken,
         CancellationToken limiterCancellationToken)
@@ -236,7 +236,7 @@ internal class ModuleRunner : IModuleRunner
             && operationCanceledException.CancellationToken == limiterCancellationToken
             && limiterCancellationToken != workerCancellationToken)
         {
-            return new OperationCanceledException(
+            return new NormalizedWorkerCancellationException(
                 operationCanceledException.Message,
                 operationCanceledException,
                 workerCancellationToken);
@@ -1207,3 +1207,9 @@ internal class ModuleRunner : IModuleRunner
         return (IModuleLogger) serviceProvider.GetRequiredService(loggerType);
     }
 }
+
+internal sealed class NormalizedWorkerCancellationException(
+    string? message,
+    OperationCanceledException innerException,
+    CancellationToken workerCancellationToken)
+    : OperationCanceledException(message, innerException, workerCancellationToken);

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -211,7 +211,11 @@ internal class ModuleRunner : IModuleRunner
                     ex,
                     cancellationToken,
                     limiterCancellationToken);
-                HandleExecutionFailure(moduleState, scheduler, handledException);
+                HandleExecutionFailure(
+                    moduleState,
+                    scheduler,
+                    handledException,
+                    cancellationToken);
 
                 if (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                 {
@@ -275,13 +279,16 @@ internal class ModuleRunner : IModuleRunner
     private void HandleExecutionFailure(
         ModuleState moduleState,
         IModuleScheduler scheduler,
-        Exception exception)
+        Exception exception,
+        CancellationToken workerCancellationToken)
     {
         var module = moduleState.Module;
         var moduleType = moduleState.ModuleType;
         var isDependencyFailure = exception is DependencyFailedException;
-        var isPipelineCancellation = exception is OperationCanceledException
-                                     && _engineCancellationToken.IsCancelled;
+        var isPipelineCancellation = IsPipelineCancellation(
+            exception,
+            workerCancellationToken,
+            _engineCancellationToken.IsCancelled);
         var registeredResult = _resultRegistry.GetResult(moduleType);
         var completionException = GetCompletionException(
             exception,
@@ -322,6 +329,14 @@ internal class ModuleRunner : IModuleRunner
             _resultRegistrar.RegisterTerminatedResult(module, moduleType, completionException);
         }
     }
+
+    internal static bool IsPipelineCancellation(
+        Exception exception,
+        CancellationToken workerCancellationToken,
+        bool isEngineCancelled) =>
+        exception is OperationCanceledException
+        && (isEngineCancelled
+            || WorkerCancellationClassifier.IsExpected(exception, workerCancellationToken));
 
     private Exception GetCompletionException(
         Exception exception,

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -290,7 +290,7 @@ internal class ModuleRunner : IModuleRunner
         }
         else
         {
-            LogModuleFailure(moduleType.Name, exception);
+            LogModuleFailure(_logger, moduleType.Name, exception);
         }
 
         var statusOverride = GetStatusOverride(
@@ -341,23 +341,26 @@ internal class ModuleRunner : IModuleRunner
             : null;
     }
 
-    private void LogModuleFailure(string moduleName, Exception exception)
+    internal static void LogModuleFailure(
+        ILogger logger,
+        string moduleName,
+        Exception exception)
     {
         switch (exception)
         {
             case DependencyFailedException dependencyFailedException:
-                _logger.LogInformation(
+                logger.LogInformation(
                     "Module {ModuleName} did not run because dependency {FailingModuleName} failed",
                     moduleName,
                     dependencyFailedException.FailingModuleName);
                 break;
-            case ModuleFailedException:
-                _logger.LogDebug(
+            case ModuleFailedException { WasLogged: true }:
+                logger.LogDebug(
                     "Module {ModuleName} failure was recorded in its module output",
                     moduleName);
                 break;
             default:
-                _logger.LogError(exception, "Module {ModuleName} failed", moduleName);
+                logger.LogError(exception, "Module {ModuleName} failed", moduleName);
                 break;
         }
     }

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -138,7 +138,12 @@ internal class ModuleRunner : IModuleRunner
             {
                 if (!skipDependencyWait)
                 {
-                    await _dependencyWaiter.WaitForDependenciesAsync(moduleState, scheduler, scope.ServiceProvider).ConfigureAwait(false);
+                    await _dependencyWaiter.WaitForDependenciesAsync(
+                            moduleState,
+                            scheduler,
+                            scope.ServiceProvider,
+                            cancellationToken)
+                        .ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
+++ b/src/ModularPipelines/Engine/Execution/ModuleRunner.cs
@@ -290,7 +290,7 @@ internal class ModuleRunner : IModuleRunner
         }
         else
         {
-            _logger.LogError(exception, "Module {ModuleName} failed", moduleType.Name);
+            LogModuleFailure(moduleType.Name, exception);
         }
 
         var statusOverride = GetStatusOverride(
@@ -339,6 +339,27 @@ internal class ModuleRunner : IModuleRunner
         return isPipelineCancellation
             ? registeredStatus ?? Enums.Status.PipelineTerminated
             : null;
+    }
+
+    private void LogModuleFailure(string moduleName, Exception exception)
+    {
+        switch (exception)
+        {
+            case DependencyFailedException dependencyFailedException:
+                _logger.LogInformation(
+                    "Module {ModuleName} did not run because dependency {FailingModuleName} failed",
+                    moduleName,
+                    dependencyFailedException.FailingModuleName);
+                break;
+            case ModuleFailedException:
+                _logger.LogDebug(
+                    "Module {ModuleName} failure was recorded in its module output",
+                    moduleName);
+                break;
+            default:
+                _logger.LogError(exception, "Module {ModuleName} failed", moduleName);
+                break;
+        }
     }
 
     private async Task UploadProducedArtifactsAsync(

--- a/src/ModularPipelines/Engine/Execution/WorkerCancellationClassifier.cs
+++ b/src/ModularPipelines/Engine/Execution/WorkerCancellationClassifier.cs
@@ -1,0 +1,14 @@
+namespace ModularPipelines.Engine.Execution;
+
+internal static class WorkerCancellationClassifier
+{
+    public static bool IsExpected(
+        Exception exception,
+        CancellationToken workerCancellationToken)
+    {
+        return exception is OperationCanceledException operationCanceledException
+               && operationCanceledException.CancellationToken == workerCancellationToken
+               && (workerCancellationToken.IsCancellationRequested
+                   || exception is NormalizedWorkerCancellationException);
+    }
+}

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -861,6 +861,6 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             _ => LogLevel.Error,
         };
 
-        logger.Log(logLevel, ModuleLogEvents.Status, message);
+        logger.LogStatus(logLevel, message);
     }
 }

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -780,7 +780,10 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
     {
         ((IInternalModuleLogger) logger).SetException(exception);
 
-        var moduleFailedException = new ModuleFailedException(executionContext.ModuleType, exception);
+        var moduleFailedException = new ModuleFailedException(
+            executionContext.ModuleType,
+            exception,
+            wasLogged: true);
 
         if (moduleContext.Services.Options.ExecutionMode == ExecutionMode.StopOnFirstException)
         {

--- a/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutionPipeline.cs
@@ -861,6 +861,6 @@ internal class ModuleExecutionPipeline : IModuleExecutionPipeline
             _ => LogLevel.Error,
         };
 
-        logger.Log(logLevel, message);
+        logger.Log(logLevel, ModuleLogEvents.Status, message);
     }
 }

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -275,7 +275,7 @@ internal class ModuleExecutor : IModuleExecutor
                         var pipelineException = GetPipelineException(ex);
                         var isFirstFailure = false;
 
-                        if (!IsExpectedWorkerCancellation(ex, ct)
+                        if (!WorkerCancellationClassifier.IsExpected(ex, ct)
                             && recordedWorkerExceptions.TryAdd(pipelineException, 0))
                         {
                             _secondaryExceptionContainer.RegisterException(pipelineException);
@@ -313,18 +313,6 @@ internal class ModuleExecutor : IModuleExecutor
         }
 
         return firstFailure;
-    }
-
-    // Engine-linked module cancellation is converted to a PipelineTerminated result
-    // by ModuleExecutionPipeline. Only worker-token cancellation can reach this layer.
-    internal static bool IsExpectedWorkerCancellation(
-        Exception exception,
-        CancellationToken workerCancellationToken)
-    {
-        return exception is OperationCanceledException operationCanceledException
-               && operationCanceledException.CancellationToken == workerCancellationToken
-               && (workerCancellationToken.IsCancellationRequested
-                   || exception is NormalizedWorkerCancellationException);
     }
 
     private static Exception GetPipelineException(Exception exception)

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -389,6 +389,11 @@ internal class ModuleExecutor : IModuleExecutor
                 return false;
             }
 
+            if (moduleState.Module.Configuration.AlwaysRun)
+            {
+                return false;
+            }
+
             return moduleState.Dependencies.Keys.Any(dependencyType =>
                 dependencyType == failedModuleType
                 || HasDependencyPath(dependencyType));

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -271,6 +271,7 @@ internal class ModuleExecutor : IModuleExecutor
                     }
                     catch (Exception ex) when (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                     {
+                        var failedModuleType = FindFailedModuleType(ex) ?? moduleState.ModuleType;
                         var pipelineException = GetPipelineException(ex);
                         var isFirstFailure = false;
 
@@ -280,7 +281,7 @@ internal class ModuleExecutor : IModuleExecutor
                             _secondaryExceptionContainer.RegisterException(pipelineException);
                             var workerFailure = new WorkerFailure(
                                 pipelineException,
-                                FindModuleFailure(pipelineException)?.ModuleType ?? moduleState.ModuleType);
+                                failedModuleType);
                             isFirstFailure = Interlocked.CompareExchange(
                                 ref firstFailure,
                                 workerFailure,
@@ -340,7 +341,7 @@ internal class ModuleExecutor : IModuleExecutor
         Exception exception,
         Type? failedModuleType = null)
     {
-        failedModuleType = FindModuleFailure(exception)?.ModuleType ?? failedModuleType;
+        failedModuleType = FindFailedModuleType(exception) ?? failedModuleType;
         if (failedModuleType is null
             || scheduler.GetModuleState(failedModuleType)?.Module is not { } failedModule)
         {
@@ -371,14 +372,15 @@ internal class ModuleExecutor : IModuleExecutor
         }
     }
 
-    private static ModuleFailedException? FindModuleFailure(Exception exception) =>
+    private static Type? FindFailedModuleType(Exception exception) =>
         exception switch
         {
-            ModuleFailedException moduleFailure => moduleFailure,
+            ModuleFailedException moduleFailure => moduleFailure.ModuleType,
+            DependencyFailedException dependencyFailure => dependencyFailure.FailingModuleType,
             AggregateException aggregateException => aggregateException.InnerExceptions
-                .Select(FindModuleFailure)
-                .FirstOrDefault(moduleFailure => moduleFailure is not null),
-            { InnerException: { } innerException } => FindModuleFailure(innerException),
+                .Select(FindFailedModuleType)
+                .FirstOrDefault(moduleType => moduleType is not null),
+            { InnerException: { } innerException } => FindFailedModuleType(innerException),
             _ => null,
         };
 

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -181,11 +181,11 @@ internal class ModuleExecutor : IModuleExecutor
 
         var schedulerTask = scheduler.RunSchedulerAsync(cancellationTokenSource.Token);
 
-        Exception? firstException;
+        WorkerFailure? firstFailure;
 
         try
         {
-            firstException = await ExecuteWorkerPoolAsync(scheduler, cancellationTokenSource).ConfigureAwait(false);
+            firstFailure = await ExecuteWorkerPoolAsync(scheduler, cancellationTokenSource).ConfigureAwait(false);
         }
         catch (Exception exception)
         {
@@ -207,7 +207,7 @@ internal class ModuleExecutor : IModuleExecutor
         {
             await schedulerTask.ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (firstException != null)
+        catch (OperationCanceledException) when (firstFailure != null)
         {
             // Expected when cancellation was triggered due to module failure.
             // The scheduler throws OperationCanceledException from WaitForNextSchedulingOpportunity
@@ -218,12 +218,16 @@ internal class ModuleExecutor : IModuleExecutor
         _logger.LogDebug("All modules completed");
 
         // Register PipelineTerminated results for modules that were cancelled before they started
-        if (firstException != null)
+        if (firstFailure != null)
         {
-            RegisterCancelledModuleResults(scheduler, modules, firstException);
+            RegisterCancelledModuleResults(
+                scheduler,
+                modules,
+                firstFailure.Exception,
+                firstFailure.ModuleType);
         }
 
-        ThrowWorkerExceptionsIfPresent(firstException);
+        ThrowWorkerExceptionsIfPresent(firstFailure?.Exception);
 
         _logger.LogDebug("ExecuteAsync returning normally with {Count} modules", modules.Count);
         return modules;
@@ -235,7 +239,7 @@ internal class ModuleExecutor : IModuleExecutor
             () => scheduler.CancelPendingModules());
     }
 
-    private async Task<Exception?> ExecuteWorkerPoolAsync(
+    private async Task<WorkerFailure?> ExecuteWorkerPoolAsync(
         IModuleScheduler scheduler,
         CancellationTokenSource cancellationTokenSource)
     {
@@ -250,7 +254,7 @@ internal class ModuleExecutor : IModuleExecutor
             CancellationToken = cancellationTokenSource.Token,
         };
 
-        Exception? firstException = null;
+        WorkerFailure? firstFailure = null;
         var recordedWorkerExceptions =
             new ConcurrentDictionary<Exception, byte>(ReferenceEqualityComparer.Instance);
 
@@ -274,9 +278,12 @@ internal class ModuleExecutor : IModuleExecutor
                             && recordedWorkerExceptions.TryAdd(pipelineException, 0))
                         {
                             _secondaryExceptionContainer.RegisterException(pipelineException);
-                            isFirstFailure = Interlocked.CompareExchange(
-                                ref firstException,
+                            var workerFailure = new WorkerFailure(
                                 pipelineException,
+                                FindModuleFailure(pipelineException)?.ModuleType ?? moduleState.ModuleType);
+                            isFirstFailure = Interlocked.CompareExchange(
+                                ref firstFailure,
+                                workerFailure,
                                 null) == null;
                         }
 
@@ -287,7 +294,8 @@ internal class ModuleExecutor : IModuleExecutor
                             RegisterCancelledModuleResults(
                                 scheduler,
                                 cancelledModules,
-                                pipelineException);
+                                pipelineException,
+                                firstFailure!.ModuleType);
                         }
 
                         EnsureCancellation(cancellationTokenSource);
@@ -298,12 +306,12 @@ internal class ModuleExecutor : IModuleExecutor
                     }
                 }).ConfigureAwait(false);
         }
-        catch (OperationCanceledException) when (firstException != null)
+        catch (OperationCanceledException) when (firstFailure != null)
         {
             // Expected when we cancelled due to StopOnFirstException
         }
 
-        return firstException;
+        return firstFailure;
     }
 
     // Engine-linked module cancellation is converted to a PipelineTerminated result
@@ -329,11 +337,12 @@ internal class ModuleExecutor : IModuleExecutor
     private void RegisterCancelledModuleResults(
         IModuleScheduler scheduler,
         IReadOnlyList<IModule> modules,
-        Exception exception)
+        Exception exception,
+        Type? failedModuleType = null)
     {
-        var moduleFailure = FindModuleFailure(exception);
-        if (moduleFailure is null
-            || scheduler.GetModuleState(moduleFailure.ModuleType)?.Module is not { } failedModule)
+        failedModuleType = FindModuleFailure(exception)?.ModuleType ?? failedModuleType;
+        if (failedModuleType is null
+            || scheduler.GetModuleState(failedModuleType)?.Module is not { } failedModule)
         {
             _resultRegistrar.RegisterTerminatedResultsForCancelledModules(modules, exception);
             return;
@@ -348,7 +357,7 @@ internal class ModuleExecutor : IModuleExecutor
             }
 
             var moduleType = module.GetType();
-            if (DependsOnFailedModule(scheduler, moduleType, moduleFailure.ModuleType))
+            if (DependsOnFailedModule(scheduler, moduleType, failedModuleType))
             {
                 _resultRegistrar.RegisterDependencyFailedResult(
                     module,
@@ -474,4 +483,6 @@ internal class ModuleExecutor : IModuleExecutor
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(firstException).Throw();
         }
     }
+
+    private sealed record WorkerFailure(Exception Exception, Type ModuleType);
 }

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -322,8 +322,9 @@ internal class ModuleExecutor : IModuleExecutor
         CancellationToken workerCancellationToken)
     {
         return exception is OperationCanceledException operationCanceledException
-               && workerCancellationToken.IsCancellationRequested
-               && operationCanceledException.CancellationToken == workerCancellationToken;
+               && operationCanceledException.CancellationToken == workerCancellationToken
+               && (workerCancellationToken.IsCancellationRequested
+                   || exception is NormalizedWorkerCancellationException);
     }
 
     private static Exception GetPipelineException(Exception exception)

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -317,11 +317,12 @@ internal class ModuleExecutor : IModuleExecutor
 
     // Engine-linked module cancellation is converted to a PipelineTerminated result
     // by ModuleExecutionPipeline. Only worker-token cancellation can reach this layer.
-    private static bool IsExpectedWorkerCancellation(
+    internal static bool IsExpectedWorkerCancellation(
         Exception exception,
         CancellationToken workerCancellationToken)
     {
         return exception is OperationCanceledException operationCanceledException
+               && workerCancellationToken.IsCancellationRequested
                && operationCanceledException.CancellationToken == workerCancellationToken;
     }
 

--- a/src/ModularPipelines/Engine/ModuleExecutor.cs
+++ b/src/ModularPipelines/Engine/ModuleExecutor.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using ModularPipelines.Engine.Attributes;
 using ModularPipelines.Engine.Dependencies;
 using ModularPipelines.Engine.Execution;
+using ModularPipelines.Exceptions;
 using ModularPipelines.Helpers;
 using ModularPipelines.Interfaces;
 using ModularPipelines.Modules;
@@ -190,7 +191,8 @@ internal class ModuleExecutor : IModuleExecutor
         {
             var cancelledModules =
                 scheduler.CancelPendingModules();
-            _resultRegistrar.RegisterTerminatedResultsForCancelledModules(
+            RegisterCancelledModuleResults(
+                scheduler,
                 cancelledModules,
                 exception);
             throw;
@@ -218,7 +220,7 @@ internal class ModuleExecutor : IModuleExecutor
         // Register PipelineTerminated results for modules that were cancelled before they started
         if (firstException != null)
         {
-            _resultRegistrar.RegisterTerminatedResultsForCancelledModules(modules, firstException);
+            RegisterCancelledModuleResults(scheduler, modules, firstException);
         }
 
         ThrowWorkerExceptionsIfPresent(firstException);
@@ -265,22 +267,27 @@ internal class ModuleExecutor : IModuleExecutor
                     }
                     catch (Exception ex) when (_pipelineOptions.Value.ExecutionMode == ExecutionMode.StopOnFirstException)
                     {
+                        var pipelineException = GetPipelineException(ex);
                         var isFirstFailure = false;
 
                         if (!IsExpectedWorkerCancellation(ex, ct)
-                            && recordedWorkerExceptions.TryAdd(ex, 0))
+                            && recordedWorkerExceptions.TryAdd(pipelineException, 0))
                         {
-                            _secondaryExceptionContainer.RegisterException(ex);
-                            isFirstFailure = Interlocked.CompareExchange(ref firstException, ex, null) == null;
+                            _secondaryExceptionContainer.RegisterException(pipelineException);
+                            isFirstFailure = Interlocked.CompareExchange(
+                                ref firstException,
+                                pipelineException,
+                                null) == null;
                         }
 
                         if (isFirstFailure)
                         {
                             var cancelledModules =
                                 scheduler.CancelPendingModules();
-                            _resultRegistrar.RegisterTerminatedResultsForCancelledModules(
+                            RegisterCancelledModuleResults(
+                                scheduler,
                                 cancelledModules,
-                                ex);
+                                pipelineException);
                         }
 
                         EnsureCancellation(cancellationTokenSource);
@@ -307,6 +314,85 @@ internal class ModuleExecutor : IModuleExecutor
     {
         return exception is OperationCanceledException operationCanceledException
                && operationCanceledException.CancellationToken == workerCancellationToken;
+    }
+
+    private static Exception GetPipelineException(Exception exception)
+    {
+        while (exception is DependencyFailedException { InnerException: { } innerException })
+        {
+            exception = innerException;
+        }
+
+        return exception;
+    }
+
+    private void RegisterCancelledModuleResults(
+        IModuleScheduler scheduler,
+        IReadOnlyList<IModule> modules,
+        Exception exception)
+    {
+        var moduleFailure = FindModuleFailure(exception);
+        if (moduleFailure is null
+            || scheduler.GetModuleState(moduleFailure.ModuleType)?.Module is not { } failedModule)
+        {
+            _resultRegistrar.RegisterTerminatedResultsForCancelledModules(modules, exception);
+            return;
+        }
+
+        foreach (var module in modules)
+        {
+            if (module.Configuration.AlwaysRun
+                || _resultRegistry.GetResult(module.GetType()) is not null)
+            {
+                continue;
+            }
+
+            var moduleType = module.GetType();
+            if (DependsOnFailedModule(scheduler, moduleType, moduleFailure.ModuleType))
+            {
+                _resultRegistrar.RegisterDependencyFailedResult(
+                    module,
+                    moduleType,
+                    new DependencyFailedException(exception, failedModule));
+            }
+            else
+            {
+                _resultRegistrar.RegisterTerminatedResult(module, moduleType, exception);
+            }
+        }
+    }
+
+    private static ModuleFailedException? FindModuleFailure(Exception exception) =>
+        exception switch
+        {
+            ModuleFailedException moduleFailure => moduleFailure,
+            AggregateException aggregateException => aggregateException.InnerExceptions
+                .Select(FindModuleFailure)
+                .FirstOrDefault(moduleFailure => moduleFailure is not null),
+            { InnerException: { } innerException } => FindModuleFailure(innerException),
+            _ => null,
+        };
+
+    private static bool DependsOnFailedModule(
+        IModuleScheduler scheduler,
+        Type moduleType,
+        Type failedModuleType)
+    {
+        var visitedModules = new HashSet<Type>();
+        return HasDependencyPath(moduleType);
+
+        bool HasDependencyPath(Type candidateType)
+        {
+            if (!visitedModules.Add(candidateType)
+                || scheduler.GetModuleState(candidateType) is not { } moduleState)
+            {
+                return false;
+            }
+
+            return moduleState.Dependencies.Keys.Any(dependencyType =>
+                dependencyType == failedModuleType
+                || HasDependencyPath(dependencyType));
+        }
     }
 
     private void HandleWaitForAllWorkerFailure(

--- a/src/ModularPipelines/Exceptions/DependencyFailedException.cs
+++ b/src/ModularPipelines/Exceptions/DependencyFailedException.cs
@@ -39,6 +39,8 @@ namespace ModularPipelines.Exceptions;
 /// <seealso cref="ModuleNotRegisteredException"/>
 public class DependencyFailedException : PipelineException
 {
+    internal Type FailingModuleType { get; }
+
     /// <summary>
     /// Gets the name of the module that failed, causing this dependency failure.
     /// </summary>
@@ -50,27 +52,37 @@ public class DependencyFailedException : PipelineException
     /// </summary>
     /// <param name="exception">The exception that caused the dependency to fail.</param>
     /// <param name="module">The module that failed.</param>
-    public DependencyFailedException(Exception exception, IModule module) : base($"The dependency {GetInnerMostFailingModule(module, exception)} has failed.", exception)
+    public DependencyFailedException(Exception exception, IModule module)
+        : this(exception, GetInnerMostFailingModule(module, exception))
     {
-        FailingModuleName = GetInnerMostFailingModule(module, exception);
     }
 
-    private static string GetInnerMostFailingModule(IModule rootModule, Exception rootException)
+    private DependencyFailedException(Exception exception, (string Name, Type Type) failingModule)
+        : base($"The dependency {failingModule.Name} has failed.", exception)
     {
-        var module = rootModule.GetType().Name;
+        FailingModuleName = failingModule.Name;
+        FailingModuleType = failingModule.Type;
+    }
 
+    private static (string Name, Type Type) GetInnerMostFailingModule(
+        IModule rootModule,
+        Exception rootException)
+    {
+        var moduleType = rootModule.GetType();
+        var moduleName = moduleType.Name;
         var exception = rootException;
 
         while (exception != null)
         {
             if (exception is DependencyFailedException dependencyFailedException)
             {
-                module = dependencyFailedException.FailingModuleName;
+                moduleName = dependencyFailedException.FailingModuleName;
+                moduleType = dependencyFailedException.FailingModuleType;
             }
 
             exception = exception.InnerException;
         }
 
-        return module;
+        return (moduleName, moduleType);
     }
 }

--- a/src/ModularPipelines/Exceptions/ModuleFailedException.cs
+++ b/src/ModularPipelines/Exceptions/ModuleFailedException.cs
@@ -44,15 +44,22 @@ internal class ModuleFailedException : PipelineException
     public Type ModuleType { get; }
 
     /// <summary>
+    /// Gets a value indicating whether the failure was already written to the module log.
+    /// </summary>
+    public bool WasLogged { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ModuleFailedException"/> class.
     /// </summary>
     /// <param name="module">The module that failed to execute.</param>
     /// <param name="exception">The exception that caused the module to fail.</param>
-    public ModuleFailedException(IModule module, Exception exception)
+    /// <param name="wasLogged">Whether the failure was already written to the module log.</param>
+    public ModuleFailedException(IModule module, Exception exception, bool wasLogged = false)
         : base($"The module {module.GetType().Name} has failed.{GetInnerMessage(exception)}", exception)
     {
         Module = module;
         ModuleType = module.GetType();
+        WasLogged = wasLogged;
     }
 
     /// <summary>
@@ -60,10 +67,12 @@ internal class ModuleFailedException : PipelineException
     /// </summary>
     /// <param name="moduleType">The type of module that failed to execute.</param>
     /// <param name="exception">The exception that caused the module to fail.</param>
-    public ModuleFailedException(Type moduleType, Exception exception)
+    /// <param name="wasLogged">Whether the failure was already written to the module log.</param>
+    public ModuleFailedException(Type moduleType, Exception exception, bool wasLogged = false)
         : base($"The module {moduleType.Name} has failed.{GetInnerMessage(exception)}", exception)
     {
         ModuleType = moduleType;
+        WasLogged = wasLogged;
     }
 
     private static string GetInnerMessage(Exception exception)

--- a/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 
@@ -13,6 +14,8 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
 
     private readonly IBuildSystemFormatter _formatter;
     private readonly IBuildSystemCommandWriter _commandWriter;
+    private readonly ConcurrentDictionary<string, byte> _reportedErrors =
+        new(StringComparer.Ordinal);
 
     public BuildSystemLogIssueLoggerProvider(
         IBuildSystemFormatterProvider formatterProvider,
@@ -33,6 +36,7 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
         new BuildSystemLogIssueLogger(
             _formatter,
             _commandWriter,
+            _reportedErrors,
             IsIssueCategory(categoryName));
 
     public void Dispose()
@@ -47,6 +51,7 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
     private sealed class BuildSystemLogIssueLogger(
         IBuildSystemFormatter formatter,
         IBuildSystemCommandWriter commandWriter,
+        ConcurrentDictionary<string, byte> reportedErrors,
         bool isIssueCategory) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state)
@@ -71,7 +76,16 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
             var message = messageFormatter(state, exception);
             if (exception is not null)
             {
-                message = $"{message}{Environment.NewLine}{exception}";
+                var rootException = GetRootException(exception);
+                if (logLevel is LogLevel.Error or LogLevel.Critical
+                    && !reportedErrors.TryAdd(rootException.ToString(), 0))
+                {
+                    return;
+                }
+
+                message = string.IsNullOrWhiteSpace(message)
+                    ? rootException.Message
+                    : $"{message}: {rootException.Message}";
             }
 
             var command = formatter.GetLogIssueCommand(logLevel, message);
@@ -79,6 +93,16 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
             {
                 commandWriter.WriteLine(command);
             }
+        }
+
+        private static Exception GetRootException(Exception exception)
+        {
+            while (exception.InnerException is not null)
+            {
+                exception = exception.InnerException;
+            }
+
+            return exception;
         }
     }
 }

--- a/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
@@ -75,12 +75,20 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
                 return;
             }
 
+            if (ModuleLogEvents.IsStatus(eventId))
+            {
+                return;
+            }
+
             var message = messageFormatter(state, exception);
             if (exception is not null)
             {
                 var rootException = exception.GetBaseException();
+                var errorIdentity = rootException is IOriginalExceptionIdentity identity
+                    ? identity.OriginalException.GetBaseException()
+                    : rootException;
                 if (logLevel is LogLevel.Error or LogLevel.Critical
-                    && !reportedErrors.TryAdd(rootException, ReportedErrorMarker))
+                    && !reportedErrors.TryAdd(errorIdentity, ReportedErrorMarker))
                 {
                     return;
                 }

--- a/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
@@ -70,7 +70,7 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
             Exception? exception,
             Func<TState, Exception?, string> messageFormatter)
         {
-            if (!IsEnabled(logLevel) || ModuleLogEvents.IsStatus(eventId))
+            if (!IsEnabled(logLevel) || ModuleLogEvents.IsBuildIssueSuppressed(eventId))
             {
                 return;
             }

--- a/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
@@ -70,32 +70,15 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
             Exception? exception,
             Func<TState, Exception?, string> messageFormatter)
         {
-            if (!IsEnabled(logLevel))
+            if (!IsEnabled(logLevel) || ModuleLogEvents.IsStatus(eventId))
             {
                 return;
             }
 
-            if (ModuleLogEvents.IsStatus(eventId))
+            var message = FormatIssueMessage(logLevel, messageFormatter(state, exception), exception);
+            if (message is null)
             {
                 return;
-            }
-
-            var message = messageFormatter(state, exception);
-            if (exception is not null)
-            {
-                var rootException = exception.GetBaseException();
-                var errorIdentity = rootException is IOriginalExceptionIdentity identity
-                    ? identity.OriginalException.GetBaseException()
-                    : rootException;
-                if (logLevel is LogLevel.Error or LogLevel.Critical
-                    && !reportedErrors.TryAdd(errorIdentity, ReportedErrorMarker))
-                {
-                    return;
-                }
-
-                message = string.IsNullOrWhiteSpace(message)
-                    ? rootException.Message
-                    : $"{message}: {rootException.Message}";
             }
 
             var command = formatter.GetLogIssueCommand(logLevel, message);
@@ -103,6 +86,31 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
             {
                 commandWriter.WriteLine(command);
             }
+        }
+
+        private string? FormatIssueMessage(
+            LogLevel logLevel,
+            string message,
+            Exception? exception)
+        {
+            if (exception is null)
+            {
+                return message;
+            }
+
+            var rootException = exception.GetBaseException();
+            var errorIdentity = rootException is IOriginalExceptionIdentity identity
+                ? identity.OriginalException.GetBaseException()
+                : rootException;
+            if (logLevel is LogLevel.Error or LogLevel.Critical
+                && !reportedErrors.TryAdd(errorIdentity, ReportedErrorMarker))
+            {
+                return null;
+            }
+
+            return string.IsNullOrWhiteSpace(message)
+                ? rootException.Message
+                : $"{message}: {rootException.Message}";
         }
     }
 }

--- a/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.Engine;
 
@@ -11,11 +11,13 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
         "Microsoft",
         "System",
     ];
+    private static readonly object ReportedErrorMarker = new();
 
     private readonly IBuildSystemFormatter _formatter;
     private readonly IBuildSystemCommandWriter _commandWriter;
-    private readonly ConcurrentDictionary<string, byte> _reportedErrors =
-        new(StringComparer.Ordinal);
+    // Identity deduplicates propagated wrappers without merging independent failures that
+    // share diagnostics. Weak keys let completed failures leave with their exception graph.
+    private readonly ConditionalWeakTable<Exception, object> _reportedErrors = new();
 
     public BuildSystemLogIssueLoggerProvider(
         IBuildSystemFormatterProvider formatterProvider,
@@ -51,7 +53,7 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
     private sealed class BuildSystemLogIssueLogger(
         IBuildSystemFormatter formatter,
         IBuildSystemCommandWriter commandWriter,
-        ConcurrentDictionary<string, byte> reportedErrors,
+        ConditionalWeakTable<Exception, object> reportedErrors,
         bool isIssueCategory) : ILogger
     {
         public IDisposable? BeginScope<TState>(TState state)
@@ -76,9 +78,9 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
             var message = messageFormatter(state, exception);
             if (exception is not null)
             {
-                var rootException = GetRootException(exception);
+                var rootException = exception.GetBaseException();
                 if (logLevel is LogLevel.Error or LogLevel.Critical
-                    && !reportedErrors.TryAdd(rootException.ToString(), 0))
+                    && !reportedErrors.TryAdd(rootException, ReportedErrorMarker))
                 {
                     return;
                 }
@@ -93,16 +95,6 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
             {
                 commandWriter.WriteLine(command);
             }
-        }
-
-        private static Exception GetRootException(Exception exception)
-        {
-            while (exception.InnerException is not null)
-            {
-                exception = exception.InnerException;
-            }
-
-            return exception;
         }
     }
 }

--- a/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
+++ b/src/ModularPipelines/Logging/BuildSystemLogIssueLoggerProvider.cs
@@ -100,7 +100,7 @@ internal sealed class BuildSystemLogIssueLoggerProvider : ILoggerProvider
 
             var rootException = exception.GetBaseException();
             var errorIdentity = rootException is IOriginalExceptionIdentity identity
-                ? identity.OriginalException.GetBaseException()
+                ? identity.OriginalException
                 : rootException;
             if (logLevel is LogLevel.Error or LogLevel.Critical
                 && !reportedErrors.TryAdd(errorIdentity, ReportedErrorMarker))

--- a/src/ModularPipelines/Logging/ModuleLogEvents.cs
+++ b/src/ModularPipelines/Logging/ModuleLogEvents.cs
@@ -6,6 +6,12 @@ internal static class ModuleLogEvents
 {
     public static EventId Status { get; } = new(int.MinValue, "ModularPipelines.ModuleStatus");
 
+    public static void LogStatus(
+        this ILogger logger,
+        LogLevel logLevel,
+        string message) =>
+        logger.Log(logLevel, Status, message);
+
     public static bool IsStatus(EventId eventId) =>
         eventId.Id == Status.Id
         && string.Equals(eventId.Name, Status.Name, StringComparison.Ordinal);

--- a/src/ModularPipelines/Logging/ModuleLogEvents.cs
+++ b/src/ModularPipelines/Logging/ModuleLogEvents.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Logging;
+
+namespace ModularPipelines.Logging;
+
+internal static class ModuleLogEvents
+{
+    public static EventId Status { get; } = new(int.MinValue, "ModularPipelines.ModuleStatus");
+
+    public static bool IsStatus(EventId eventId) =>
+        eventId.Id == Status.Id
+        && string.Equals(eventId.Name, Status.Name, StringComparison.Ordinal);
+}

--- a/src/ModularPipelines/Logging/ModuleLogEvents.cs
+++ b/src/ModularPipelines/Logging/ModuleLogEvents.cs
@@ -6,6 +6,9 @@ internal static class ModuleLogEvents
 {
     public static EventId Status { get; } = new(int.MinValue, "ModularPipelines.ModuleStatus");
 
+    public static EventId IgnoredDependencyFailure { get; } =
+        new(int.MinValue + 1, "ModularPipelines.IgnoredDependencyFailure");
+
     public static void LogStatus(
         this ILogger logger,
         LogLevel logLevel,
@@ -15,4 +18,18 @@ internal static class ModuleLogEvents
     public static bool IsStatus(EventId eventId) =>
         eventId.Id == Status.Id
         && string.Equals(eventId.Name, Status.Name, StringComparison.Ordinal);
+
+    public static void LogIgnoredDependencyFailure(this ILogger logger, Exception exception) =>
+        logger.LogError(
+            IgnoredDependencyFailure,
+            exception,
+            "Ignoring Exception due to 'AlwaysRun' set");
+
+    public static bool IsBuildIssueSuppressed(EventId eventId) =>
+        IsStatus(eventId)
+        || (eventId.Id == IgnoredDependencyFailure.Id
+            && string.Equals(
+                eventId.Name,
+                IgnoredDependencyFailure.Name,
+                StringComparison.Ordinal));
 }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -190,6 +190,11 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
 
         if (shouldFlush)
         {
+            if (_exception is not null)
+            {
+                _buffer.SetDeferredFlushFailureHandler(LogFlushFailure);
+            }
+
             // Flush output asynchronously without blocking
             try
             {

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -198,19 +198,48 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
             }
             catch (OperationCanceledException)
             {
-                // Timeout occurred - log warning, output may be lost
-                _defaultLogger.LogWarning(
-                    "Module output handling timed out after 30 seconds for {ModuleType}. Some output may be lost.",
-                    typeof(T).Name);
+                LogFlushTimeout();
             }
             catch (Exception ex)
             {
-                // Best effort - don't fail disposal, but log the issue
-                _defaultLogger.LogWarning(ex, "Failed to flush module output during disposal for {ModuleType}", typeof(T).Name);
+                LogFlushFailure(ex);
             }
         }
 
         GC.SuppressFinalize(this);
+    }
+
+    private void LogFlushTimeout()
+    {
+        if (_exception is not null)
+        {
+            _defaultLogger.LogError(
+                _exception,
+                "Module {ModuleType} failed and its buffered output timed out after 30 seconds",
+                typeof(T).Name);
+            return;
+        }
+
+        _defaultLogger.LogWarning(
+            "Module output handling timed out after 30 seconds for {ModuleType}. Some output may be lost.",
+            typeof(T).Name);
+    }
+
+    private void LogFlushFailure(Exception flushException)
+    {
+        if (_exception is not null)
+        {
+            _defaultLogger.LogError(
+                _exception,
+                "Module {ModuleType} failed and its buffered output could not be flushed",
+                typeof(T).Name);
+            return;
+        }
+
+        _defaultLogger.LogWarning(
+            flushException,
+            "Failed to flush module output during disposal for {ModuleType}",
+            typeof(T).Name);
     }
 
     public override void LogToConsole(string value)

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -196,12 +196,12 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
             }
 
             // Flush output asynchronously without blocking
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
             try
             {
-                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
                 await _outputCoordinator.OnModuleCompletedAsync(_buffer, typeof(T), cts.Token).ConfigureAwait(false);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cts.IsCancellationRequested)
             {
                 LogFlushTimeout();
             }

--- a/src/ModularPipelines/Logging/ModuleLogger.cs
+++ b/src/ModularPipelines/Logging/ModuleLogger.cs
@@ -214,7 +214,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
         if (_exception is not null)
         {
             _defaultLogger.LogError(
-                _exception,
+                ObfuscatedLogException.Create(_exception, _secretObfuscator),
                 "Module {ModuleType} failed and its buffered output timed out after 30 seconds",
                 typeof(T).Name);
             return;
@@ -230,7 +230,7 @@ internal class ModuleLogger<T> : ModuleLogger, IInternalModuleLogger, IConsoleWr
         if (_exception is not null)
         {
             _defaultLogger.LogError(
-                _exception,
+                ObfuscatedLogException.Create(_exception, _secretObfuscator),
                 "Module {ModuleType} failed and its buffered output could not be flushed",
                 typeof(T).Name);
             return;

--- a/src/ModularPipelines/Logging/ObfuscatedLogException.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedLogException.cs
@@ -13,7 +13,12 @@ namespace ModularPipelines.Logging;
 /// <remarks>
 /// Wrapping intentionally replaces the original exception type identity.
 /// </remarks>
-internal sealed class ObfuscatedLogException : Exception
+internal interface IOriginalExceptionIdentity
+{
+    Exception OriginalException { get; }
+}
+
+internal sealed class ObfuscatedLogException : Exception, IOriginalExceptionIdentity
 {
     private readonly string? _obfuscatedStackTrace;
     private readonly string _obfuscatedText;
@@ -23,6 +28,7 @@ internal sealed class ObfuscatedLogException : Exception
             GetObfuscatedMessage(exception, secretObfuscator),
             Create(exception.InnerException, secretObfuscator))
     {
+        OriginalException = exception;
         _obfuscatedStackTrace = GetObfuscatedDiagnostic(
             () => exception.StackTrace,
             secretObfuscator);
@@ -38,6 +44,8 @@ internal sealed class ObfuscatedLogException : Exception
                 new ObfuscatedAggregateLogException(aggregateException, secretObfuscator),
             _ => new ObfuscatedLogException(exception, secretObfuscator),
         };
+
+    public Exception OriginalException { get; }
 
     public override string? StackTrace => _obfuscatedStackTrace;
 
@@ -218,7 +226,7 @@ internal sealed class ObfuscatedLogException : Exception
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_idxFirstFreeStackTraceEntry")]
     private static extern ref int GetNativeAotStackTraceCount(Exception exception);
 
-    private sealed class ObfuscatedAggregateLogException : AggregateException
+    private sealed class ObfuscatedAggregateLogException : AggregateException, IOriginalExceptionIdentity
     {
         private readonly string? _obfuscatedStackTrace;
         private readonly string _obfuscatedText;
@@ -230,12 +238,15 @@ internal sealed class ObfuscatedLogException : Exception
                 GetObfuscatedMessage(exception, secretObfuscator),
                 exception.InnerExceptions.Select(inner => Create(inner, secretObfuscator)!))
         {
+            OriginalException = exception;
             _obfuscatedStackTrace = GetObfuscatedDiagnostic(
                 () => exception.StackTrace,
                 secretObfuscator);
             _obfuscatedText = GetObfuscatedText(exception, secretObfuscator);
             CopyDiagnostics(this, exception, secretObfuscator);
         }
+
+        public Exception OriginalException { get; }
 
         public override string? StackTrace => _obfuscatedStackTrace;
 

--- a/src/ModularPipelines/Logging/ObfuscatedLogException.cs
+++ b/src/ModularPipelines/Logging/ObfuscatedLogException.cs
@@ -20,6 +20,7 @@ internal interface IOriginalExceptionIdentity
 
 internal sealed class ObfuscatedLogException : Exception, IOriginalExceptionIdentity
 {
+    private readonly Exception _originalException;
     private readonly string? _obfuscatedStackTrace;
     private readonly string _obfuscatedText;
 
@@ -28,7 +29,7 @@ internal sealed class ObfuscatedLogException : Exception, IOriginalExceptionIden
             GetObfuscatedMessage(exception, secretObfuscator),
             Create(exception.InnerException, secretObfuscator))
     {
-        OriginalException = exception;
+        _originalException = exception;
         _obfuscatedStackTrace = GetObfuscatedDiagnostic(
             () => exception.StackTrace,
             secretObfuscator);
@@ -45,7 +46,7 @@ internal sealed class ObfuscatedLogException : Exception, IOriginalExceptionIden
             _ => new ObfuscatedLogException(exception, secretObfuscator),
         };
 
-    public Exception OriginalException { get; }
+    Exception IOriginalExceptionIdentity.OriginalException => _originalException;
 
     public override string? StackTrace => _obfuscatedStackTrace;
 
@@ -228,6 +229,7 @@ internal sealed class ObfuscatedLogException : Exception, IOriginalExceptionIden
 
     private sealed class ObfuscatedAggregateLogException : AggregateException, IOriginalExceptionIdentity
     {
+        private readonly Exception _originalException;
         private readonly string? _obfuscatedStackTrace;
         private readonly string _obfuscatedText;
 
@@ -238,7 +240,7 @@ internal sealed class ObfuscatedLogException : Exception, IOriginalExceptionIden
                 GetObfuscatedMessage(exception, secretObfuscator),
                 exception.InnerExceptions.Select(inner => Create(inner, secretObfuscator)!))
         {
-            OriginalException = exception;
+            _originalException = exception;
             _obfuscatedStackTrace = GetObfuscatedDiagnostic(
                 () => exception.StackTrace,
                 secretObfuscator);
@@ -246,7 +248,7 @@ internal sealed class ObfuscatedLogException : Exception, IOriginalExceptionIden
             CopyDiagnostics(this, exception, secretObfuscator);
         }
 
-        public Exception OriginalException { get; }
+        Exception IOriginalExceptionIdentity.OriginalException => _originalException;
 
         public override string? StackTrace => _obfuscatedStackTrace;
 

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -86,6 +86,8 @@ public class OutputCoordinatorTests
         await coordinator.FlushDeferredAsync();
 
         await Assert.That(firstBuffer.FlushCount).IsEqualTo(2);
+        await Assert.That(firstBuffer.DeferredFlushFailure?.Message)
+            .IsEqualTo("simulated deferred flush failure");
         await Assert.That(secondBuffer.FlushCount).IsEqualTo(1);
     }
 
@@ -617,6 +619,8 @@ public class OutputCoordinatorTests
 
         public int FlushCount { get; private set; }
 
+        public Exception? DeferredFlushFailure { get; private set; }
+
         public bool HasOutput => true;
 
         public bool IsComplete { get; private set; }
@@ -643,6 +647,11 @@ public class OutputCoordinatorTests
 
         public void SetException(Exception exception)
         {
+        }
+
+        public void ReportDeferredFlushFailure(Exception deferredFlushFailure)
+        {
+            DeferredFlushFailure = deferredFlushFailure;
         }
 
         public Task FlushToAsync(

--- a/test/ModularPipelines.UnitTests/Engine/Execution/DependencyWaiterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/DependencyWaiterTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Context;
+using ModularPipelines.Engine;
+using ModularPipelines.Engine.Execution;
+using ModularPipelines.Modules;
+using Moq;
+
+namespace ModularPipelines.UnitTests.Engine.Execution;
+
+public class DependencyWaiterTests
+{
+    private sealed class DependencyModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+
+    private sealed class DependentModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(true);
+    }
+
+    [Test]
+    public async Task NormalizedWorkerCancellation_Is_NotWrappedAsDependencyFailure()
+    {
+        using var workerCancellationTokenSource = new CancellationTokenSource();
+        using var limiterCancellationTokenSource = new CancellationTokenSource();
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        limiterCancellationTokenSource.Cancel();
+
+        var normalizedCancellation = ModuleRunner.NormalizeLimiterCancellation(
+            new OperationCanceledException(limiterCancellationTokenSource.Token),
+            workerCancellationTokenSource.Token,
+            limiterCancellationTokenSource.Token);
+        var dependency = new DependencyModule();
+        var dependentState = new ModuleState(new DependentModule(), typeof(DependentModule));
+        dependentState.RecordDependency(typeof(DependencyModule), optional: false);
+        var scheduler = new Mock<IModuleScheduler>();
+        scheduler
+            .Setup(x => x.GetModuleCompletionTask(typeof(DependencyModule)))
+            .Returns(Task.FromException<IModule>(normalizedCancellation));
+        scheduler
+            .Setup(x => x.GetModuleState(typeof(DependencyModule)))
+            .Returns(new ModuleState(dependency, typeof(DependencyModule)));
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await new DependencyWaiter().WaitForDependenciesAsync(
+                dependentState,
+                scheduler.Object,
+                serviceProvider,
+                workerCancellationTokenSource.Token));
+
+        await Assert.That(exception).IsSameReferenceAs(normalizedCancellation);
+    }
+}

--- a/test/ModularPipelines.UnitTests/Engine/Execution/ModuleRunnerLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Execution/ModuleRunnerLoggingTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Logging;
+using ModularPipelines.Engine.Execution;
+using ModularPipelines.Exceptions;
+
+namespace ModularPipelines.UnitTests.Engine.Execution;
+
+public class ModuleRunnerLoggingTests
+{
+    [Test]
+    public async Task ArtifactUploadFailureWrapper_IsLoggedAsError()
+    {
+        var logger = new RecordingLogger();
+        var exception = new ModuleFailedException(
+            typeof(ExampleModule),
+            new InvalidOperationException("Artifact upload failed"));
+
+        ModuleRunner.LogModuleFailure(logger, nameof(ExampleModule), exception);
+
+        await Assert.That(logger.Entries).HasSingleItem();
+        var entry = logger.Entries.Single();
+        await Assert.That(entry.Level).IsEqualTo(LogLevel.Error);
+        await Assert.That(entry.Exception).IsSameReferenceAs(exception);
+    }
+
+    [Test]
+    public async Task PreviouslyLoggedModuleFailure_IsLoggedAsDebugWithoutException()
+    {
+        var logger = new RecordingLogger();
+        var exception = new ModuleFailedException(
+            typeof(ExampleModule),
+            new InvalidOperationException("Module failed"),
+            wasLogged: true);
+
+        ModuleRunner.LogModuleFailure(logger, nameof(ExampleModule), exception);
+
+        await Assert.That(logger.Entries).HasSingleItem();
+        var entry = logger.Entries.Single();
+        await Assert.That(entry.Level).IsEqualTo(LogLevel.Debug);
+        await Assert.That(entry.Exception).IsNull();
+    }
+
+    private sealed class ExampleModule;
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+        }
+    }
+
+    private sealed record LogEntry(
+        LogLevel Level,
+        string Message,
+        Exception? Exception);
+}

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -277,6 +277,7 @@ public class ModuleExecutorLoggingTests
         scheduler.SetupGet(x => x.ReadyModules).Returns(readyModules.Reader);
         scheduler.Setup(x => x.RunSchedulerAsync(It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
+        scheduler.Setup(x => x.CancelPendingModules()).Returns([]);
         scheduler
             .Setup(x => x.GetModuleState(It.IsAny<Type>()))
             .Returns((Type moduleType) => moduleStates[moduleType]);

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -1,10 +1,12 @@
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Attributes;
 using ModularPipelines.Configuration;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.Engine;
+using ModularPipelines.Engine.Execution;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
 using ModularPipelines.Interfaces;
@@ -249,6 +251,69 @@ public class EngineCancellationTokenTests : TestBase
         protected override bool Result => true;
     }
 
+    [ModularPipelines.Attributes.DependsOn<ReadyHookFailingModule>]
+    private class ReadyHookSiblingDependentModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    private sealed class CoordinatedModuleResultRegistrar : IModuleResultRegistrar
+    {
+        private readonly ModuleResultRegistrar _inner;
+        private readonly HashSet<Type> _registeredDependentTypes = [];
+        private readonly ManualResetEventSlim _allDependentsRegistered = new();
+
+        public CoordinatedModuleResultRegistrar(
+            IModuleResultRegistry resultRegistry,
+            Microsoft.Extensions.Logging.ILogger<ModuleResultRegistrar> logger)
+        {
+            _inner = new ModuleResultRegistrar(resultRegistry, logger);
+        }
+
+        public void RegisterTerminatedResult(IModule module, Type moduleType, Exception exception)
+        {
+            _inner.RegisterTerminatedResult(module, moduleType, exception);
+            RecordDependent(moduleType);
+
+            if (moduleType == typeof(ReadyHookFailingModule)
+                && !_allDependentsRegistered.Wait(TestHostSettings.DefaultTestTimeout))
+            {
+                throw new TimeoutException("Dependent failure workers did not win the coordinated race.");
+            }
+        }
+
+        public void RegisterDependencyFailedResult(IModule module, Type moduleType, Exception exception)
+        {
+            _inner.RegisterDependencyFailedResult(module, moduleType, exception);
+            RecordDependent(moduleType);
+        }
+
+        public void RegisterTerminatedResultsForCancelledModules(
+            IReadOnlyList<IModule> modules,
+            Exception exception)
+        {
+            _inner.RegisterTerminatedResultsForCancelledModules(modules, exception);
+        }
+
+        private void RecordDependent(Type moduleType)
+        {
+            if (moduleType != typeof(ReadyHookDependentModule)
+                && moduleType != typeof(ReadyHookSiblingDependentModule))
+            {
+                return;
+            }
+
+            lock (_registeredDependentTypes)
+            {
+                _registeredDependentTypes.Add(moduleType);
+                if (_registeredDependentTypes.Count == 2)
+                {
+                    _allDependentsRegistered.Set();
+                }
+            }
+        }
+    }
+
     private sealed class ThrowingReadyHookReceiver : IModuleEventReceiver
     {
         public Task OnModuleReadyAsync(IModuleHookContext context)
@@ -406,6 +471,45 @@ public class EngineCancellationTokenTests : TestBase
         await Assert.That(dependentResult.ExceptionOrDefault).IsTypeOf<DependencyFailedException>();
         await Assert.That(((DependencyFailedException) dependentResult.ExceptionOrDefault!).FailingModuleName)
             .IsEqualTo(nameof(ReadyHookFailingModule));
+    }
+
+    [Test]
+    public async Task StopOnFirstException_Preserves_Raw_ReadyHook_Failure_When_Dependent_Reports_First()
+    {
+        var builder = TestPipelineBuilder.Create()
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IModuleResultRegistrar>();
+                services.AddSingleton<IModuleResultRegistrar, CoordinatedModuleResultRegistrar>();
+            })
+            .AddModule<ReadyHookFailingModule>()
+            .AddModule<ReadyHookDependentModule>()
+            .AddModule<ReadyHookSiblingDependentModule>()
+            .AddModuleEventReceiver<ThrowingReadyHookReceiver>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            ThrowOnPipelineFailure = true,
+            Concurrency = options.Concurrency with { MaxParallelism = 2 },
+        });
+
+        var host = await builder.BuildAsync();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+
+        await Assert.That(async () => await host.RunAsync()).Throws<InvalidOperationException>();
+
+        foreach (var dependentType in new[]
+                 {
+                     typeof(ReadyHookDependentModule),
+                     typeof(ReadyHookSiblingDependentModule),
+                 })
+        {
+            var dependentResult = resultRegistry.GetResult(dependentType);
+            await Assert.That(dependentResult).IsNotNull();
+            await Assert.That(dependentResult!.ModuleStatus).IsEqualTo(Status.DependencyFailed);
+            await Assert.That(dependentResult.ExceptionOrDefault).IsTypeOf<DependencyFailedException>();
+            await Assert.That(((DependencyFailedException) dependentResult.ExceptionOrDefault!).FailingModuleName)
+                .IsEqualTo(nameof(ReadyHookFailingModule));
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -7,6 +7,7 @@ using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.Engine;
 using ModularPipelines.Exceptions;
 using ModularPipelines.Extensions;
+using ModularPipelines.Interfaces;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
 using ModularPipelines.Options;
@@ -237,6 +238,30 @@ public class EngineCancellationTokenTests : TestBase
         }
     }
 
+    private class ReadyHookFailingModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    [ModularPipelines.Attributes.DependsOn<ReadyHookFailingModule>]
+    private class ReadyHookDependentModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    private sealed class ThrowingReadyHookReceiver : IModuleEventReceiver
+    {
+        public Task OnModuleReadyAsync(IModuleHookContext context)
+        {
+            if (context.ModuleType == typeof(ReadyHookFailingModule))
+            {
+                throw new InvalidOperationException("Ready hook failure");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
     private class StopOnFirstQueuedDependencyModule : Module<bool>
     {
         protected internal override Task<bool> ExecuteAsync(
@@ -355,6 +380,32 @@ public class EngineCancellationTokenTests : TestBase
         await Assert.That(module1Result.ExceptionOrDefault).IsTypeOf<DependencyFailedException>();
         await Assert.That(((DependencyFailedException) module1Result.ExceptionOrDefault!).FailingModuleName)
             .IsEqualTo(nameof(BadModule));
+    }
+
+    [Test]
+    public async Task StopOnFirstException_Reports_DependencyFailed_When_ReadyHookThrows()
+    {
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<ReadyHookFailingModule>()
+            .AddModule<ReadyHookDependentModule>()
+            .AddModuleEventReceiver<ThrowingReadyHookReceiver>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            ThrowOnPipelineFailure = true,
+            Concurrency = options.Concurrency with { MaxParallelism = 1 },
+        });
+
+        var host = await builder.BuildAsync();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+
+        await Assert.That(async () => await host.RunAsync()).Throws<InvalidOperationException>();
+
+        var dependentResult = resultRegistry.GetResult(typeof(ReadyHookDependentModule));
+        await Assert.That(dependentResult).IsNotNull();
+        await Assert.That(dependentResult!.ModuleStatus).IsEqualTo(Status.DependencyFailed);
+        await Assert.That(dependentResult.ExceptionOrDefault).IsTypeOf<DependencyFailedException>();
+        await Assert.That(((DependencyFailedException) dependentResult.ExceptionOrDefault!).FailingModuleName)
+            .IsEqualTo(nameof(ReadyHookFailingModule));
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -185,7 +185,7 @@ public class EngineCancellationTokenTests : TestBase
         {
             AwaitingTerminatedModuleStarted.TrySetResult();
             var result = await context.GetModule<TerminatedBeforeExecutionModule>();
-            return result.ModuleStatus == Status.PipelineTerminated;
+            return result.ModuleStatus == Status.DependencyFailed;
         }
     }
 
@@ -323,13 +323,14 @@ public class EngineCancellationTokenTests : TestBase
         builder.ConfigurePipelineOptions(options => options with
         {
             ThrowOnPipelineFailure = true,
+            Concurrency = options.Concurrency with { MaxParallelism = 1 },
         });
 
         var host = await builder.BuildAsync();
 
         var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
 
-        await Assert.That(async () => await host.RunAsync()).ThrowsException();
+        await Assert.That(async () => await host.RunAsync()).Throws<ModuleFailedException>();
 
         // Results should be registered before the exception is thrown, no delay needed
         var module1Result = resultRegistry.GetResult(typeof(Module1));

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -538,7 +538,7 @@ public class EngineCancellationTokenTests : TestBase
         using var cancellationTokenSource = new CancellationTokenSource();
         var exception = new OperationCanceledException(cancellationTokenSource.Token);
 
-        await Assert.That(ModuleExecutor.IsExpectedWorkerCancellation(
+        await Assert.That(WorkerCancellationClassifier.IsExpected(
                 exception,
                 cancellationTokenSource.Token))
             .IsFalse();
@@ -558,7 +558,7 @@ public class EngineCancellationTokenTests : TestBase
             workerCancellationTokenSource.Token,
             limiterCancellationTokenSource.Token);
 
-        await Assert.That(ModuleExecutor.IsExpectedWorkerCancellation(
+        await Assert.That(WorkerCancellationClassifier.IsExpected(
                 normalizedCancellation,
                 workerCancellationTokenSource.Token))
             .IsTrue();

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -295,6 +295,11 @@ public class EngineCancellationTokenTests : TestBase
             Exception exception)
         {
             _inner.RegisterTerminatedResultsForCancelledModules(modules, exception);
+
+            foreach (var module in modules)
+            {
+                RecordDependent(module.GetType());
+            }
         }
 
         private void RecordDependent(Type moduleType)
@@ -537,6 +542,26 @@ public class EngineCancellationTokenTests : TestBase
                 exception,
                 cancellationTokenSource.Token))
             .IsFalse();
+    }
+
+    [Test]
+    public async Task EngineLinked_Limiter_Cancellation_Is_Expected_Before_Worker_Cancellation()
+    {
+        using var workerCancellationTokenSource = new CancellationTokenSource();
+        using var limiterCancellationTokenSource = new CancellationTokenSource();
+        limiterCancellationTokenSource.Cancel();
+        var limiterCancellation = new OperationCanceledException(
+            limiterCancellationTokenSource.Token);
+
+        var normalizedCancellation = ModuleRunner.NormalizeLimiterCancellation(
+            limiterCancellation,
+            workerCancellationTokenSource.Token,
+            limiterCancellationTokenSource.Token);
+
+        await Assert.That(ModuleExecutor.IsExpectedWorkerCancellation(
+                normalizedCancellation,
+                workerCancellationTokenSource.Token))
+            .IsTrue();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -257,11 +257,13 @@ public class EngineCancellationTokenTests : TestBase
         protected override bool Result => true;
     }
 
-    private sealed class CoordinatedModuleResultRegistrar : IModuleResultRegistrar
+    private sealed class CoordinatedModuleResultRegistrar : IModuleResultRegistrar, IDisposable
     {
         private readonly ModuleResultRegistrar _inner;
         private readonly HashSet<Type> _registeredDependentTypes = [];
         private readonly ManualResetEventSlim _allDependentsRegistered = new();
+
+        public void Dispose() => _allDependentsRegistered.Dispose();
 
         public CoordinatedModuleResultRegistrar(
             IModuleResultRegistry resultRegistry,

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -528,6 +528,18 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
+    public async Task Uncancelled_Worker_Token_Is_Not_Expected_Cancellation()
+    {
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var exception = new OperationCanceledException(cancellationTokenSource.Token);
+
+        await Assert.That(ModuleExecutor.IsExpectedWorkerCancellation(
+                exception,
+                cancellationTokenSource.Token))
+            .IsFalse();
+    }
+
+    [Test]
     public async Task StopOnFirstException_Wraps_Independent_ReadyHook_Cancellation_For_Dependents()
     {
         var builder = TestPipelineBuilder.Create()

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -313,7 +313,7 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
-    public async Task When_Cancel_Engine_Token_With_DependsOn_Then_Modules_Cancel()
+    public async Task StopOnFirstException_Reports_DependencyFailed_For_Dependent_Module()
     {
         var builder = TestPipelineBuilder.Create()
             .AddModule<BadModule>()
@@ -333,9 +333,11 @@ public class EngineCancellationTokenTests : TestBase
 
         // Results should be registered before the exception is thrown, no delay needed
         var module1Result = resultRegistry.GetResult(typeof(Module1));
-        // Module1 depends on BadModule which failed, so Module1 should be marked as PipelineTerminated
         await Assert.That(module1Result).IsNotNull();
-        await Assert.That(module1Result!.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+        await Assert.That(module1Result!.ModuleStatus).IsEqualTo(Status.DependencyFailed);
+        await Assert.That(module1Result.ExceptionOrDefault).IsTypeOf<DependencyFailedException>();
+        await Assert.That(((DependencyFailedException) module1Result.ExceptionOrDefault!).FailingModuleName)
+            .IsEqualTo(nameof(BadModule));
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -329,6 +329,19 @@ public class EngineCancellationTokenTests : TestBase
         }
     }
 
+    private sealed class IndependentlyCancellingReadyHookReceiver : IModuleEventReceiver
+    {
+        public Task OnModuleReadyAsync(IModuleHookContext context)
+        {
+            if (context.ModuleType == typeof(ReadyHookFailingModule))
+            {
+                throw new OperationCanceledException("Independent ready hook cancellation");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
     private class StopOnFirstQueuedDependencyModule : Module<bool>
     {
         protected internal override Task<bool> ExecuteAsync(
@@ -498,6 +511,45 @@ public class EngineCancellationTokenTests : TestBase
         var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
 
         await Assert.That(async () => await host.RunAsync()).Throws<InvalidOperationException>();
+
+        foreach (var dependentType in new[]
+                 {
+                     typeof(ReadyHookDependentModule),
+                     typeof(ReadyHookSiblingDependentModule),
+                 })
+        {
+            var dependentResult = resultRegistry.GetResult(dependentType);
+            await Assert.That(dependentResult).IsNotNull();
+            await Assert.That(dependentResult!.ModuleStatus).IsEqualTo(Status.DependencyFailed);
+            await Assert.That(dependentResult.ExceptionOrDefault).IsTypeOf<DependencyFailedException>();
+            await Assert.That(((DependencyFailedException) dependentResult.ExceptionOrDefault!).FailingModuleName)
+                .IsEqualTo(nameof(ReadyHookFailingModule));
+        }
+    }
+
+    [Test]
+    public async Task StopOnFirstException_Wraps_Independent_ReadyHook_Cancellation_For_Dependents()
+    {
+        var builder = TestPipelineBuilder.Create()
+            .ConfigureServices(services =>
+            {
+                services.RemoveAll<IModuleResultRegistrar>();
+                services.AddSingleton<IModuleResultRegistrar, CoordinatedModuleResultRegistrar>();
+            })
+            .AddModule<ReadyHookFailingModule>()
+            .AddModule<ReadyHookDependentModule>()
+            .AddModule<ReadyHookSiblingDependentModule>()
+            .AddModuleEventReceiver<IndependentlyCancellingReadyHookReceiver>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            ThrowOnPipelineFailure = true,
+            Concurrency = options.Concurrency with { MaxParallelism = 2 },
+        });
+
+        var host = await builder.BuildAsync();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+
+        await Assert.That(async () => await host.RunAsync()).Throws<OperationCanceledException>();
 
         foreach (var dependentType in new[]
                  {

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -35,6 +35,22 @@ public class EngineCancellationTokenTests : TestBase
         protected override bool Result => true;
     }
 
+    [ModularPipelines.Attributes.DependsOn<BadModule>]
+    private class AlwaysRunBarrierModule : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+
+        protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
+            .WithAlwaysRun()
+            .Build();
+    }
+
+    [ModularPipelines.Attributes.DependsOn<AlwaysRunBarrierModule>]
+    private class ModuleBehindAlwaysRunBarrier : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
     private class LongRunningModule : Module<bool>
     {
         private readonly TaskCompletionSource<bool> _taskCompletionSource = new();
@@ -339,6 +355,35 @@ public class EngineCancellationTokenTests : TestBase
         await Assert.That(module1Result.ExceptionOrDefault).IsTypeOf<DependencyFailedException>();
         await Assert.That(((DependencyFailedException) module1Result.ExceptionOrDefault!).FailingModuleName)
             .IsEqualTo(nameof(BadModule));
+    }
+
+    [Test]
+    public async Task StopOnFirstException_DoesNotPropagateDependencyFailureAcrossAlwaysRunModule()
+    {
+        var builder = TestPipelineBuilder.Create()
+            .AddModule<BadModule>()
+            .AddModule<AlwaysRunBarrierModule>()
+            .AddModule<ModuleBehindAlwaysRunBarrier>();
+        builder.ConfigurePipelineOptions(options => options with
+        {
+            ThrowOnPipelineFailure = true,
+            Concurrency = options.Concurrency with { MaxParallelism = 1 },
+        });
+
+        var host = await builder.BuildAsync();
+        var resultRegistry = host.Services.GetRequiredService<IModuleResultRegistry>();
+
+        await Assert.That(async () => await host.RunAsync()).Throws<ModuleFailedException>();
+
+        var alwaysRunResult = resultRegistry.GetResult(typeof(AlwaysRunBarrierModule));
+        var downstreamResult = resultRegistry.GetResult(typeof(ModuleBehindAlwaysRunBarrier));
+        using (Assert.Multiple())
+        {
+            await Assert.That(alwaysRunResult).IsNotNull();
+            await Assert.That(alwaysRunResult!.ModuleStatus).IsEqualTo(Status.Successful);
+            await Assert.That(downstreamResult).IsNotNull();
+            await Assert.That(downstreamResult!.ModuleStatus).IsEqualTo(Status.PipelineTerminated);
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -565,6 +565,26 @@ public class EngineCancellationTokenTests : TestBase
     }
 
     [Test]
+    public async Task Normalized_Limiter_Cancellation_Is_Treated_As_Pipeline_Cancellation()
+    {
+        using var workerCancellationTokenSource = new CancellationTokenSource();
+        using var limiterCancellationTokenSource = new CancellationTokenSource();
+        limiterCancellationTokenSource.Cancel();
+        var limiterCancellation = new OperationCanceledException(
+            limiterCancellationTokenSource.Token);
+        var normalizedCancellation = ModuleRunner.NormalizeLimiterCancellation(
+            limiterCancellation,
+            workerCancellationTokenSource.Token,
+            limiterCancellationTokenSource.Token);
+
+        await Assert.That(ModuleRunner.IsPipelineCancellation(
+                normalizedCancellation,
+                workerCancellationTokenSource.Token,
+                isEngineCancelled: false))
+            .IsTrue();
+    }
+
+    [Test]
     public async Task StopOnFirstException_Wraps_Independent_ReadyHook_Cancellation_For_Dependents()
     {
         var builder = TestPipelineBuilder.Create()

--- a/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Console;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.BuildSystemFormatters;
 using ModularPipelines.Logging;
+using Moq;
 
 namespace ModularPipelines.UnitTests.Logging;
 
@@ -65,6 +67,50 @@ public class BuildSystemLogIssueLoggerProviderTests
         await Assert.That(writer.ToString())
             .IsEqualTo(
                 $"##vso[task.logissue type=error;]first message: failure{Environment.NewLine}");
+    }
+
+    [Test]
+    public async Task Logger_WritesOnlyOneErrorAfterBufferedExceptionObfuscation()
+    {
+        using var writer = new StringWriter();
+        using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
+        var logger = provider.CreateLogger("Example.Module");
+        var exception = new InvalidOperationException("failure");
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string>(), null))
+            .Returns((string input, object? _) => input);
+        var firstEvent = CreateBufferedEvent("first message");
+        var secondEvent = CreateBufferedEvent("second message");
+
+        firstEvent.WriteTo(logger);
+        secondEvent.WriteTo(logger);
+
+        await Assert.That(writer.ToString())
+            .IsEqualTo(
+                $"##vso[task.logissue type=error;]first message: failure{Environment.NewLine}");
+
+        BufferedLogEvent<string> CreateBufferedEvent(string message) =>
+            new(
+                LogLevel.Error,
+                default,
+                message,
+                message,
+                exception,
+                static (state, _) => state,
+                obfuscator.Object);
+    }
+
+    [Test]
+    public async Task Logger_DoesNotWriteIssueForModuleStatusEvent()
+    {
+        using var writer = new StringWriter();
+        using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
+        var logger = provider.CreateLogger("Example.Module");
+
+        logger.Log(LogLevel.Error, ModuleLogEvents.Status, "Module failed");
+
+        await Assert.That(writer.ToString()).IsEmpty();
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
@@ -68,6 +68,22 @@ public class BuildSystemLogIssueLoggerProviderTests
     }
 
     [Test]
+    public async Task Logger_WritesIndependentErrorsWithIdenticalDiagnostics()
+    {
+        using var writer = new StringWriter();
+        using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
+        var logger = provider.CreateLogger("Example.Pipeline");
+
+        logger.LogError(new InvalidOperationException("failure"), "first message");
+        logger.LogError(new InvalidOperationException("failure"), "second message");
+
+        await Assert.That(writer.ToString())
+            .IsEqualTo(
+                $"##vso[task.logissue type=error;]first message: failure{Environment.NewLine}"
+                + $"##vso[task.logissue type=error;]second message: failure{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task Logger_WritesNothingWhenBuildSystemHasNoIssueCommand()
     {
         using var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
@@ -114,6 +114,22 @@ public class BuildSystemLogIssueLoggerProviderTests
     }
 
     [Test]
+    public async Task Logger_OriginatingFailureWinsAfterIgnoredDependencyFailure()
+    {
+        using var writer = new StringWriter();
+        using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
+        var logger = provider.CreateLogger("Example.Module");
+        var exception = new InvalidOperationException("failure");
+
+        logger.LogIgnoredDependencyFailure(exception);
+        logger.LogError(exception, "originating failure");
+
+        await Assert.That(writer.ToString())
+            .IsEqualTo(
+                $"##vso[task.logissue type=error;]originating failure: failure{Environment.NewLine}");
+    }
+
+    [Test]
     public async Task Logger_WritesIndependentErrorsWithIdenticalDiagnostics()
     {
         using var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/BuildSystemLogIssueLoggerProviderTests.cs
@@ -36,7 +36,7 @@ public class BuildSystemLogIssueLoggerProviderTests
     }
 
     [Test]
-    public async Task Logger_IncludesExceptionDetailsInIssueCommand()
+    public async Task Logger_IncludesConciseExceptionMessageInIssueCommand()
     {
         using var writer = new StringWriter();
         using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
@@ -45,12 +45,26 @@ public class BuildSystemLogIssueLoggerProviderTests
 
         logger.LogError(exception, "message");
 
-        var escapedNewLine = Environment.NewLine
-            .Replace("\r", "%0D", StringComparison.Ordinal)
-            .Replace("\n", "%0A", StringComparison.Ordinal);
         await Assert.That(writer.ToString())
             .IsEqualTo(
-                $"##vso[task.logissue type=error;]message{escapedNewLine}{exception}{Environment.NewLine}");
+                $"##vso[task.logissue type=error;]message: failure{Environment.NewLine}");
+    }
+
+    [Test]
+    public async Task Logger_WritesOnlyOneErrorForRepeatedRootException()
+    {
+        using var writer = new StringWriter();
+        using var provider = CreateProvider(new AzurePipelinesFormatter(), writer);
+        var moduleLogger = provider.CreateLogger("Example.Module");
+        var runnerLogger = provider.CreateLogger("Example.Runner");
+        var rootException = new InvalidOperationException("failure");
+
+        moduleLogger.LogError(new Exception("first wrapper", rootException), "first message");
+        runnerLogger.LogError(new Exception("second wrapper", rootException), "second message");
+
+        await Assert.That(writer.ToString())
+            .IsEqualTo(
+                $"##vso[task.logissue type=error;]first message: failure{Environment.NewLine}");
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -264,7 +264,7 @@ public class ModuleLoggerTests
     }
 
     [Test]
-    public async Task DisposeAsync_LogsModuleFailureWhenBufferedOutputFlushFails()
+    public async Task DisposeAsync_LogsObfuscatedModuleFailureWhenBufferedOutputFlushFails()
     {
         var moduleOutputBuffer = Mock.Of<IModuleOutputBuffer>();
         var consoleCoordinator = CreateConsoleCoordinator(moduleOutputBuffer);
@@ -276,10 +276,14 @@ public class ModuleLoggerTests
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new IOException("flush failed"));
         var defaultLogger = new Mock<ILogger<ModuleLoggerTests>>();
-        var moduleException = new InvalidOperationException("module failed");
+        var moduleException = new InvalidOperationException("module secret-value");
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? value, object? _) => value?.Replace("secret-value", "**********") ?? string.Empty);
         var logger = new ModuleLogger<ModuleLoggerTests>(
             defaultLogger.Object,
-            Mock.Of<ISecretObfuscator>(),
+            secretObfuscator.Object,
             Mock.Of<IFormattedLogValuesObfuscator>(),
             consoleCoordinator.Object,
             outputCoordinator.Object);
@@ -292,8 +296,16 @@ public class ModuleLoggerTests
             It.IsAny<EventId>(),
             It.Is<It.IsAnyType>((state, _) =>
                 state.ToString()!.Contains("buffered output could not be flushed", StringComparison.Ordinal)),
-            moduleException,
+            It.Is<Exception?>(exception => IsObfuscatedCopyOf(exception, moduleException)),
             It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+    }
+
+    private static bool IsObfuscatedCopyOf(Exception? exception, Exception originalException)
+    {
+        return exception is IOriginalExceptionIdentity identity
+               && ReferenceEquals(identity.OriginalException, originalException)
+               && exception.ToString().Contains("**********", StringComparison.Ordinal)
+               && !exception.ToString().Contains("secret-value", StringComparison.Ordinal);
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -300,6 +300,45 @@ public class ModuleLoggerTests
             It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
     }
 
+    [Test]
+    public async Task DeferredFlushFailure_LogsObfuscatedModuleFailureAfterDisposal()
+    {
+        var moduleOutputBuffer = new ModuleOutputBuffer(typeof(ModuleLoggerTests));
+        var consoleCoordinator = CreateConsoleCoordinator(moduleOutputBuffer);
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(x => x.OnModuleCompletedAsync(
+                moduleOutputBuffer,
+                typeof(ModuleLoggerTests),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var defaultLogger = new Mock<ILogger<ModuleLoggerTests>>();
+        var moduleException = new InvalidOperationException("module secret-value");
+        var secretObfuscator = new Mock<ISecretObfuscator>();
+        secretObfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? value, object? _) =>
+                value?.Replace("secret-value", "**********") ?? string.Empty);
+        var logger = new ModuleLogger<ModuleLoggerTests>(
+            defaultLogger.Object,
+            secretObfuscator.Object,
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            outputCoordinator.Object);
+        logger.SetException(moduleException);
+
+        await logger.DisposeAsync();
+        moduleOutputBuffer.ReportDeferredFlushFailure(new IOException("deferred flush failed"));
+
+        defaultLogger.Verify(x => x.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((state, _) =>
+                state.ToString()!.Contains("buffered output could not be flushed", StringComparison.Ordinal)),
+            It.Is<Exception?>(exception => IsObfuscatedCopyOf(exception, moduleException)),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+    }
+
     private static bool IsObfuscatedCopyOf(Exception? exception, Exception originalException)
     {
         return exception is IOriginalExceptionIdentity identity

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -301,6 +301,38 @@ public class ModuleLoggerTests
     }
 
     [Test]
+    public async Task DisposeAsync_LogsIndependentCancellationAsFlushFailure()
+    {
+        var moduleOutputBuffer = Mock.Of<IModuleOutputBuffer>();
+        var consoleCoordinator = CreateConsoleCoordinator(moduleOutputBuffer);
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        var providerCancellation = new OperationCanceledException("provider cancelled");
+        outputCoordinator
+            .Setup(x => x.OnModuleCompletedAsync(
+                moduleOutputBuffer,
+                typeof(ModuleLoggerTests),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(providerCancellation);
+        var defaultLogger = new Mock<ILogger<ModuleLoggerTests>>();
+        var logger = new ModuleLogger<ModuleLoggerTests>(
+            defaultLogger.Object,
+            Mock.Of<ISecretObfuscator>(),
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            outputCoordinator.Object);
+
+        await logger.DisposeAsync();
+
+        defaultLogger.Verify(x => x.Log(
+            LogLevel.Warning,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((state, _) =>
+                state.ToString()!.Contains("Failed to flush module output", StringComparison.Ordinal)),
+            providerCancellation,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+    }
+
+    [Test]
     public async Task DeferredFlushFailure_LogsObfuscatedModuleFailureAfterDisposal()
     {
         var moduleOutputBuffer = new ModuleOutputBuffer(typeof(ModuleLoggerTests));

--- a/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
+++ b/test/ModularPipelines.UnitTests/Logging/ModuleLoggerTests.cs
@@ -264,6 +264,39 @@ public class ModuleLoggerTests
     }
 
     [Test]
+    public async Task DisposeAsync_LogsModuleFailureWhenBufferedOutputFlushFails()
+    {
+        var moduleOutputBuffer = Mock.Of<IModuleOutputBuffer>();
+        var consoleCoordinator = CreateConsoleCoordinator(moduleOutputBuffer);
+        var outputCoordinator = new Mock<IOutputCoordinator>();
+        outputCoordinator
+            .Setup(x => x.OnModuleCompletedAsync(
+                moduleOutputBuffer,
+                typeof(ModuleLoggerTests),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("flush failed"));
+        var defaultLogger = new Mock<ILogger<ModuleLoggerTests>>();
+        var moduleException = new InvalidOperationException("module failed");
+        var logger = new ModuleLogger<ModuleLoggerTests>(
+            defaultLogger.Object,
+            Mock.Of<ISecretObfuscator>(),
+            Mock.Of<IFormattedLogValuesObfuscator>(),
+            consoleCoordinator.Object,
+            outputCoordinator.Object);
+        logger.SetException(moduleException);
+
+        await logger.DisposeAsync();
+
+        defaultLogger.Verify(x => x.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((state, _) =>
+                state.ToString()!.Contains("buffered output could not be flushed", StringComparison.Ordinal)),
+            moduleException,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+    }
+
+    [Test]
     public async Task Write_ReusesClearedRenderer()
     {
         var renderedLines = new List<string>();


### PR DESCRIPTION
## What changed

- Build-system issue annotations now include the concise root exception message instead of the full exception stack.
- Repeated error logs for the same root exception produce one build-system issue annotation across logger categories.
- Dependency failures are classified as `DependencyFailed` in both `StopOnFirstException` and `WaitForAllModules`.
- Propagated dependency failures are logged as short informational messages.
- `ModuleRunner` no longer repeats a root failure already captured by the module's buffered failure output.

## Why

In the motivating run, one failed command was rendered 15 times. Its exception was wrapped and logged again by `ModuleRunner`, then propagated to Kubernetes, Helm, Python, Yarn, and Homebrew modules. Two behaviors amplified the noise:

1. `BuildSystemLogIssueLoggerProvider` appended `Exception.ToString()` to every warning/error annotation.
2. `DependencyWaiter` only created `DependencyFailedException` in `WaitForAllModules`; fail-fast runs let the original `ModuleFailedException` escape into each dependent, making cascades look like independent failures.

https://github.com/thomhurst/ModularPipelines/actions/runs/30972375285/job/92199614528

## Impact

A root module failure now creates one concise, actionable build-system annotation. Build-system annotations and dependency-cascade messages no longer embed exception stacks. The full exception remains available in the buffered module failure details.

Exception propagation is intentionally unchanged: callers that leave the exception from `RunAsync` unhandled may still receive the runtime's terminal exception stack. This PR does not swallow or alter that failure signal.

## Checks

All .NET commands ran through `scripts/Invoke-AgentDotNet.ps1`.

- `BuildSystemLogIssueLoggerProviderTests`: 11 passed.
- `EngineCancellationTokenTests`: 15 passed.
- `git diff --check`.
- Code-simplifier review completed with no broader refactor needed.

The test project emitted pre-existing nullability warnings in `ArtifactContractTests`, `PipelineLifecycleTests`, `RunReportTests`, and `TelemetryIntegrationTests`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure propagation for dependent modules, including clearer dependency-failed results during cancellation.
  * Improved handling and reporting of deferred output-flush failures.
  * Prevented duplicate error and critical log entries.
  * Preserved exception details while redacting sensitive information in module-failure logs.
  * Refined logging levels and messages for dependency, module, and output failures.
* **Tests**
  * Added coverage for cancellation, dependency propagation, deferred flush failures, logging behavior, deduplication, and secret redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->