### PR TITLE
Stop marking failed pipeline output as successful

### DIFF
--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -94,7 +94,9 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
             RequestThresholdFlush,
             isSpectreEnabled: logLevel => _loggerControl.WouldRender(
                 OutputLoggerCategories.Pipeline,
-                logLevel));
+                logLevel),
+            // Unattributed logs do not represent pipeline completion status.
+            showSuccessMarker: false);
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/ConsoleCoordinator.cs
+++ b/src/ModularPipelines/Console/ConsoleCoordinator.cs
@@ -303,7 +303,8 @@ internal class ConsoleCoordinator : IConsoleCoordinator, IProgressDisplay
                 RequestThresholdFlush,
                 isSpectreEnabled: logLevel => _loggerControl.WouldRender(
                     OutputLoggerCategories.ForModule(t),
-                    logLevel)));
+                    logLevel),
+                showFailureHeaderWithoutOutput: !_options.Value.Console.PrintResults));
     }
 
     /// <inheritdoc />

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -36,6 +36,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly TimeSpan _renderGateTimeout;
     private readonly Func<LogLevel, bool> _isSpectreEnabled;
     private readonly Action<IModuleOutputBuffer>? _requestIncrementalFlush;
+    private readonly bool _showFailureHeaderWithoutOutput;
     private readonly bool _showSuccessMarker;
     private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = [];
     private Exception? _exception;
@@ -57,19 +58,22 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="requestIncrementalFlush">Callback that requests an incremental flush.</param>
     /// <param name="renderGateTimeout">Maximum time to wait for the Spectre logger render gate.</param>
     /// <param name="isSpectreEnabled">Determines whether Spectre would render a structured event level.</param>
+    /// <param name="showFailureHeaderWithoutOutput">Whether a failed empty buffer renders a failure header.</param>
     public ModuleOutputBuffer(
         Type moduleType,
         int outputFlushThreshold = 0,
         Action<IModuleOutputBuffer>? requestIncrementalFlush = null,
         TimeSpan? renderGateTimeout = null,
-        Func<LogLevel, bool>? isSpectreEnabled = null)
+        Func<LogLevel, bool>? isSpectreEnabled = null,
+        bool showFailureHeaderWithoutOutput = false)
         : this(
             moduleType.Name,
             moduleType,
             outputFlushThreshold,
             requestIncrementalFlush,
             renderGateTimeout,
-            isSpectreEnabled)
+            isSpectreEnabled,
+            showFailureHeaderWithoutOutput)
     {
     }
 
@@ -83,6 +87,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="requestIncrementalFlush">Callback that requests an incremental flush.</param>
     /// <param name="renderGateTimeout">Maximum time to wait for the Spectre logger render gate.</param>
     /// <param name="isSpectreEnabled">Determines whether Spectre would render a structured event level.</param>
+    /// <param name="showFailureHeaderWithoutOutput">Whether a failed empty buffer renders a failure header.</param>
     /// <param name="showSuccessMarker">Whether successful output groups include a success marker.</param>
     internal ModuleOutputBuffer(
         string name,
@@ -91,6 +96,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         Action<IModuleOutputBuffer>? requestIncrementalFlush = null,
         TimeSpan? renderGateTimeout = null,
         Func<LogLevel, bool>? isSpectreEnabled = null,
+        bool showFailureHeaderWithoutOutput = false,
         bool showSuccessMarker = true)
     {
         ModuleType = moduleType;
@@ -100,6 +106,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         _requestIncrementalFlush = requestIncrementalFlush;
         _renderGateTimeout = renderGateTimeout ?? DefaultRenderGateTimeout;
         _isSpectreEnabled = isSpectreEnabled ?? (static _ => true);
+        _showFailureHeaderWithoutOutput = showFailureHeaderWithoutOutput;
         _showSuccessMarker = showSuccessMarker;
     }
 
@@ -183,7 +190,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                        || _structuredDeliveryRetries.Count > 0
                        || _isIncrementalFlushInProgress
                        || (_exception is not null
-                           && _hasRenderedIncrementalOutput
+                           && (_hasRenderedIncrementalOutput || _showFailureHeaderWithoutOutput)
                            && !_hasRenderedCompletionHeader);
             }
         }
@@ -324,7 +331,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
             var needsExceptionHeader = flushKind is OutputFlushKind.Complete
                                        && _exception is not null
-                                       && _hasRenderedIncrementalOutput
+                                       && (_hasRenderedIncrementalOutput || _showFailureHeaderWithoutOutput)
                                        && !_hasRenderedCompletionHeader;
             if (_outputs.Count == 0
                 && _structuredDeliveryRetries.Count == 0

--- a/src/ModularPipelines/Console/ModuleOutputBuffer.cs
+++ b/src/ModularPipelines/Console/ModuleOutputBuffer.cs
@@ -36,6 +36,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     private readonly TimeSpan _renderGateTimeout;
     private readonly Func<LogLevel, bool> _isSpectreEnabled;
     private readonly Action<IModuleOutputBuffer>? _requestIncrementalFlush;
+    private readonly bool _showSuccessMarker;
     private readonly ConditionalWeakTable<TextWriter, IAnsiConsole> _directConsoles = [];
     private Exception? _exception;
     private bool _isComplete;
@@ -82,13 +83,15 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
     /// <param name="requestIncrementalFlush">Callback that requests an incremental flush.</param>
     /// <param name="renderGateTimeout">Maximum time to wait for the Spectre logger render gate.</param>
     /// <param name="isSpectreEnabled">Determines whether Spectre would render a structured event level.</param>
+    /// <param name="showSuccessMarker">Whether successful output groups include a success marker.</param>
     internal ModuleOutputBuffer(
         string name,
         Type moduleType,
         int outputFlushThreshold = 0,
         Action<IModuleOutputBuffer>? requestIncrementalFlush = null,
         TimeSpan? renderGateTimeout = null,
-        Func<LogLevel, bool>? isSpectreEnabled = null)
+        Func<LogLevel, bool>? isSpectreEnabled = null,
+        bool showSuccessMarker = true)
     {
         ModuleType = moduleType;
         _moduleName = name;
@@ -97,6 +100,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
         _requestIncrementalFlush = requestIncrementalFlush;
         _renderGateTimeout = renderGateTimeout ?? DefaultRenderGateTimeout;
         _isSpectreEnabled = isSpectreEnabled ?? (static _ => true);
+        _showSuccessMarker = showSuccessMarker;
     }
 
     /// <inheritdoc />
@@ -178,7 +182,9 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
                 return _outputs.Count > 0
                        || _structuredDeliveryRetries.Count > 0
                        || _isIncrementalFlushInProgress
-                       || (_exception is not null && !_hasRenderedCompletionHeader);
+                       || (_exception is not null
+                           && _hasRenderedIncrementalOutput
+                           && !_hasRenderedCompletionHeader);
             }
         }
     }
@@ -318,6 +324,7 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
 
             var needsExceptionHeader = flushKind is OutputFlushKind.Complete
                                        && _exception is not null
+                                       && _hasRenderedIncrementalOutput
                                        && !_hasRenderedCompletionHeader;
             if (_outputs.Count == 0
                 && _structuredDeliveryRetries.Count == 0
@@ -645,9 +652,14 @@ internal class ModuleOutputBuffer : IModuleOutputBuffer
             return $"{_moduleName} \u2717{continuationText} ({durationText}) - {exception.GetType().Name}";
         }
 
-        return flushKind is OutputFlushKind.Complete
+        if (flushKind is OutputFlushKind.Incremental)
+        {
+            return $"{_moduleName} \u2026{continuationText} ({durationText})";
+        }
+
+        return _showSuccessMarker
             ? $"{_moduleName} \u2713{continuationText} ({durationText})"
-            : $"{_moduleName} \u2026{continuationText} ({durationText})";
+            : $"{_moduleName}{continuationText} ({durationText})";
     }
 
     private static IAnsiConsole CreateDirectConsole(TextWriter writer)

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -509,6 +509,31 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task CompleteFlush_RendersSilentFailureWhenResultsAreHidden()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            nameof(ModuleOutputBufferTests),
+            typeof(ModuleOutputBufferTests),
+            showFailureHeaderWithoutOutput: true);
+        buffer.SetException(new InvalidOperationException("module failure"));
+        buffer.MarkComplete();
+
+        await Assert.That(buffer.NeedsCompletionFlush).IsTrue();
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("ModuleOutputBufferTests ✗");
+        await Assert.That(output).Contains(nameof(InvalidOperationException));
+    }
+
+    [Test]
     public async Task LaterFlushes_AreLabelledAsContinued()
     {
         var writer = new StringWriter();

--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -353,6 +353,47 @@ public class ModuleOutputBufferTests
     }
 
     [Test]
+    public async Task CompleteFlush_RendersSuccessMarkerForModuleOutput()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        buffer.WriteLine("completed output");
+
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        await Assert.That(writer.ToString()).Contains("ModuleOutputBufferTests ✓");
+    }
+
+    [Test]
+    public async Task FailedPipelineOutput_DoesNotRenderSuccessMarker()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(
+            "Pipeline",
+            typeof(void),
+            showSuccessMarker: false);
+        buffer.WriteLine("Pipeline Failed");
+
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        var output = writer.ToString();
+        await Assert.That(output).Contains("Pipeline Failed");
+        await Assert.That(output).DoesNotContain("Pipeline ✓");
+    }
+
+    [Test]
     public async Task IncrementalFlush_DoesNotDrainCompletedModule()
     {
         var writer = new StringWriter();
@@ -445,6 +486,26 @@ public class ModuleOutputBufferTests
         await Assert.That(output).Contains("ModuleOutputBufferTests ✗ (continued)");
         await Assert.That(output).Contains(nameof(InvalidOperationException));
         await Assert.That(buffer.NeedsCompletionFlush).IsFalse();
+    }
+
+    [Test]
+    public async Task CompleteFlush_SuppressesFailureGroupWithoutOutput()
+    {
+        var writer = new StringWriter();
+        var loggerControl = new SynchronousLoggerControl(writer);
+        var buffer = new ModuleOutputBuffer(typeof(ModuleOutputBufferTests));
+        buffer.SetException(new InvalidOperationException("module failure"));
+        buffer.MarkComplete();
+
+        await Assert.That(buffer.NeedsCompletionFlush).IsFalse();
+        await buffer.FlushToAsync(
+            writer,
+            new GitHubActionsFormatter(),
+            loggerControl,
+            loggerControl,
+            OutputFlushKind.Complete);
+
+        await Assert.That(writer.ToString()).IsEmpty();
     }
 
     [Test]


### PR DESCRIPTION
## What changed

- Stop the unattributed Pipeline log group from inferring a successful completion marker.
- Keep success markers for completed module output.
- Suppress failure groups when a failed module never emitted output.
- Preserve a failed completion header when earlier module output was already flushed incrementally.
- Add focused coverage for failed pipeline text, successful module output, and silent module failures.

## Why

The motivating run printed Pipeline Failed inside a group whose header said Pipeline ✓. That contradictory status made the final CI output misleading and created empty groups for modules that failed without producing output.

Motivating run: https://github.com/thomhurst/ModularPipelines/actions/runs/30972375285/job/92199614528

## Impact

Pipeline-level logs remain grouped but no longer claim success before the final summary exists. Normal module success/failure headers remain intact. Silent failures rely on the results summary instead of adding empty CI groups.

## Root cause

ConsoleCoordinator uses an unattributed ModuleOutputBuffer named Pipeline. PipelineOutputCoordinator flushes that buffer during output-scope teardown, before ExecutionOrchestrator computes and prints the final PipelineSummary. ModuleOutputBuffer treated every exception-free complete flush as success, so pipeline-level log output received a ✓ regardless of the eventual pipeline status. Exception state also forced a completion group even when a module had no buffered or previously rendered output.

## Checks

- Guarded Release build of ModularPipelines.slnx: succeeded with 0 warnings and 0 errors
- Guarded focused ModuleOutputBufferTests run: 33 passed
- git diff --check