### PR TITLE
Reduce routine pipeline output noise

### DIFF
--- a/src/ModularPipelines.Build/Modules/FindProjectDependenciesModule.cs
+++ b/src/ModularPipelines.Build/Modules/FindProjectDependenciesModule.cs
@@ -52,7 +52,14 @@ public class FindProjectDependenciesModule : Module<FindProjectDependenciesModul
 
         foreach (var project in projectDependencies.Others)
         {
-            context.Logger.LogInformation("Project {Project} is not a dependency of other projects", project);
+            context.Logger.LogDebug("Project {Project} is not a dependency of other projects", project);
+        }
+
+        if (projectDependencies.Others.Count > 0)
+        {
+            context.Logger.LogInformation(
+                "{Count} projects are not dependencies of other projects",
+                projectDependencies.Others.Count);
         }
     }
 

--- a/src/ModularPipelines/Engine/Scheduling/SchedulerStatusReporter.cs
+++ b/src/ModularPipelines/Engine/Scheduling/SchedulerStatusReporter.cs
@@ -16,6 +16,7 @@ namespace ModularPipelines.Engine.Scheduling;
 /// </remarks>
 internal class SchedulerStatusReporter : ISchedulerStatusReporter
 {
+    private const int MaxModuleDetails = 10;
     private static readonly TimeSpan StatusCheckInterval = TimeSpan.FromSeconds(15);
 
     private readonly ILogger<SchedulerStatusReporter> _logger;
@@ -64,15 +65,11 @@ internal class SchedulerStatusReporter : ISchedulerStatusReporter
                 snapshot = new SchedulerStatusSnapshot(
                     stateQueries.GetStatistics(),
                     includeModuleDetails
-                        ? string.Join(", ", stateQueries.GetPendingModules()
-                            .Select(FormatModuleWithDependencyCount)
-                            .Order(StringComparer.Ordinal))
-                        : string.Empty,
+                        ? FormatModuleDetails(stateQueries.GetPendingModules().Select(FormatModuleWithDependencyCount))
+                        : ModuleDetails.Empty,
                     includeModuleDetails
-                        ? string.Join(", ", stateQueries.GetExecutingModules()
-                            .Select(m => FormatModuleType(m.ModuleType))
-                            .Order(StringComparer.Ordinal))
-                        : string.Empty);
+                        ? FormatModuleDetails(stateQueries.GetExecutingModules().Select(m => FormatModuleType(m.ModuleType)))
+                        : ModuleDetails.Empty);
             }
             finally
             {
@@ -96,15 +93,30 @@ internal class SchedulerStatusReporter : ISchedulerStatusReporter
             snapshot.Statistics.Completed,
             snapshot.Statistics.Pending);
 
-        if (snapshot.PendingModules.Length > 0)
+        if (snapshot.PendingModules.Display.Length > 0)
         {
-            _logger.LogTrace("Pending modules: {Modules}", snapshot.PendingModules);
+            _logger.LogTrace("Pending modules: {Modules}", snapshot.PendingModules.Display);
         }
 
-        if (snapshot.ExecutingModules.Length > 0)
+        if (snapshot.ExecutingModules.Display.Length > 0)
         {
-            _logger.LogTrace("Executing modules: {Modules}", snapshot.ExecutingModules);
+            _logger.LogTrace("Executing modules: {Modules}", snapshot.ExecutingModules.Display);
         }
+    }
+
+    private static ModuleDetails FormatModuleDetails(IEnumerable<string> modules)
+    {
+        var orderedModules = modules.Order(StringComparer.Ordinal).ToList();
+        var display = string.Join(", ", orderedModules.Take(MaxModuleDetails));
+        var omittedCount = orderedModules.Count - MaxModuleDetails;
+
+        if (omittedCount > 0)
+        {
+            display = $"{display}, ... (+{omittedCount} more)";
+        }
+
+        // Full fingerprint preserves change detection even when changed modules are outside the displayed subset.
+        return new ModuleDetails(string.Join('\n', orderedModules), display);
     }
 
     private static string FormatModuleWithDependencyCount(ModuleState m)
@@ -116,6 +128,11 @@ internal class SchedulerStatusReporter : ISchedulerStatusReporter
 
     private sealed record SchedulerStatusSnapshot(
         ModuleStateStatistics Statistics,
-        string PendingModules,
-        string ExecutingModules);
+        ModuleDetails PendingModules,
+        ModuleDetails ExecutingModules);
+
+    private sealed record ModuleDetails(string Fingerprint, string Display)
+    {
+        public static ModuleDetails Empty { get; } = new(string.Empty, string.Empty);
+    }
 }

--- a/src/ModularPipelines/Engine/UnusedModuleDetector.cs
+++ b/src/ModularPipelines/Engine/UnusedModuleDetector.cs
@@ -23,19 +23,15 @@ internal class UnusedModuleDetector : IUnusedModuleDetector
 
     public void Log()
     {
-        if (!_logger.IsEnabled(LogLevel.Warning))
+        var debugEnabled = _logger.IsEnabled(LogLevel.Debug);
+        var warningEnabled = _logger.IsEnabled(LogLevel.Warning);
+        if (!debugEnabled && !warningEnabled)
         {
             return;
         }
 
         // Use the centralized helper that works with factory-based registrations
         var registeredServices = ServiceCollectionExtensions.GetRegisteredModuleTypes(_serviceContainerWrapper.ServiceCollection);
-
-        var allDetectedModules = _assemblyLoadedTypesProvider.GetLoadedTypesAssignableTo(typeof(IModule));
-
-        var unregisteredModules = allDetectedModules
-            .Except(registeredServices)
-            .ToList();
 
         var unregisteredDependencies = registeredServices
             .SelectMany(ModuleDependencyResolver.GetDependencies)
@@ -45,14 +41,31 @@ internal class UnusedModuleDetector : IUnusedModuleDetector
             .Where(depType => !registeredServices.Contains(depType))
             .ToList();
 
-        if (unregisteredModules.Count == 0 && unregisteredDependencies.Count == 0)
+        if (warningEnabled && unregisteredDependencies.Count > 0)
+        {
+            _logger.LogWarning("⚠ Missing Required Module Dependencies:\n{Modules}",
+                string.Join("\n", unregisteredDependencies.Select(static module => $"  • {module.Name}")));
+        }
+
+        if (!debugEnabled)
         {
             return;
         }
 
-        var allUnregistered = unregisteredModules.Concat(unregisteredDependencies).Distinct().ToList();
+        var loadedButUnusedModules = _assemblyLoadedTypesProvider
+            .GetLoadedTypesAssignableTo(typeof(IModule))
+            .Except(registeredServices)
+            .Except(unregisteredDependencies)
+            .Select(static module => module.Name)
+            .Order(StringComparer.Ordinal)
+            .ToList();
 
-        _logger.LogWarning("⚠ Unregistered Modules:\n{Modules}",
-            string.Join("\n", allUnregistered.Select(m => $"  • {m?.Name}")));
+        if (loadedButUnusedModules.Count > 0)
+        {
+            _logger.LogDebug(
+                "Loaded module types not registered ({Count}): {Modules}",
+                loadedButUnusedModules.Count,
+                string.Join(", ", loadedButUnusedModules));
+        }
     }
 }

--- a/src/ModularPipelines/Engine/UnusedModuleDetector.cs
+++ b/src/ModularPipelines/Engine/UnusedModuleDetector.cs
@@ -41,10 +41,20 @@ internal class UnusedModuleDetector : IUnusedModuleDetector
             .Where(depType => !registeredServices.Contains(depType))
             .ToList();
 
-        if (warningEnabled && unregisteredDependencies.Count > 0)
+        if (unregisteredDependencies.Count > 0)
         {
-            _logger.LogWarning("⚠ Missing Required Module Dependencies:\n{Modules}",
-                string.Join("\n", unregisteredDependencies.Select(static module => $"  • {module.Name}")));
+            if (warningEnabled)
+            {
+                _logger.LogWarning("⚠ Missing Required Module Dependencies:\n{Modules}",
+                    string.Join("\n", unregisteredDependencies.Select(static module => $"  • {module.Name}")));
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "Missing required module dependencies ({Count}): {Modules}",
+                    unregisteredDependencies.Count,
+                    string.Join(", ", unregisteredDependencies.Select(static module => module.Name)));
+            }
         }
 
         if (!debugEnabled)

--- a/test/ModularPipelines.UnitTests/Engine/Scheduling/SchedulerStatusReporterTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/Scheduling/SchedulerStatusReporterTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using ModularPipelines.Engine;
@@ -118,6 +119,31 @@ public class SchedulerStatusReporterTests
         await Assert.That(logger.Messages[0]).DoesNotContain("ExecutingModule");
     }
 
+    [Test]
+    public async Task Trace_Module_Details_Are_Truncated()
+    {
+        var states = new ConcurrentDictionary<Type, ModuleState>();
+        var moduleType = typeof(PendingModule);
+        for (var index = 0; index < 12; index++)
+        {
+            moduleType = typeof(ModuleSlot<>).MakeGenericType(moduleType);
+            var state = CreateModuleState(moduleType, ModuleExecutionState.Pending);
+            state.UnresolvedDependencies.Add(typeof(DependencyModule));
+            states[moduleType] = state;
+        }
+
+        var logger = new RecordingLogger<SchedulerStatusReporter>();
+        var reporter = new SchedulerStatusReporter(logger, new FakeTimeProvider(StartTime));
+        var stateQueries = new ModuleStateQueries(states);
+        using var stateLock = new ReaderWriterLockSlim();
+
+        reporter.LogStatusIfIntervalElapsed(stateQueries, stateLock);
+
+        var details = logger.Messages.Single(message => message.StartsWith("Pending modules:", StringComparison.Ordinal));
+        await Assert.That(Regex.Matches(details, "deps:").Count).IsEqualTo(10);
+        await Assert.That(details).Contains("... (+2 more)");
+    }
+
     private static ModuleState CreateModuleState(Type moduleType, ModuleExecutionState executionState)
     {
         return new ModuleState(new Mock<IModule>().Object, moduleType)
@@ -131,6 +157,8 @@ public class SchedulerStatusReporterTests
     private sealed class PendingModule;
 
     private sealed class DependencyModule;
+
+    private sealed class ModuleSlot<T>;
 
     private sealed class FirstContainer
     {

--- a/test/ModularPipelines.UnitTests/Engine/UnusedModuleDetectorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/UnusedModuleDetectorTests.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ModularPipelines.DependencyInjection;
@@ -7,34 +6,16 @@ using ModularPipelines.Extensions;
 using ModularPipelines.Modules;
 using ModularPipelines.TestHelpers;
 using Moq;
-using ModularPipelines.UnitTests.Logging;
 
 namespace ModularPipelines.UnitTests.Engine;
 
 public class UnusedModuleDetectorTests
 {
-    private readonly UnusedModuleDetector _unusedModuleDetector;
-    private readonly Mock<IPipelineServiceContainerWrapper> _serviceContainerWrapper;
-    private readonly Mock<IAssemblyLoadedTypesProvider> _assemblyLoadedTypesProvider;
-    private readonly StringBuilder _sb;
-
-    public UnusedModuleDetectorTests()
-    {
-        _sb = new StringBuilder();
-
-        _serviceContainerWrapper = new Mock<IPipelineServiceContainerWrapper>();
-
-        _assemblyLoadedTypesProvider = new Mock<IAssemblyLoadedTypesProvider>();
-
-        _unusedModuleDetector = new UnusedModuleDetector(
-            _assemblyLoadedTypesProvider.Object,
-            _serviceContainerWrapper.Object,
-            new StringLogger<UnusedModuleDetector>(_sb)
-            );
-    }
+    private readonly Mock<IPipelineServiceContainerWrapper> _serviceContainerWrapper = new();
+    private readonly Mock<IAssemblyLoadedTypesProvider> _assemblyLoadedTypesProvider = new();
 
     [Test]
-    public async Task Logs_Unregisted_Modules_Correctly()
+    public async Task Loaded_But_Unused_Modules_Are_Debug_Only()
     {
         _assemblyLoadedTypesProvider.Setup(x => x.GetLoadedTypesAssignableTo(typeof(IModule)))
             .Returns([
@@ -52,21 +33,47 @@ public class UnusedModuleDetectorTests
 
         _serviceContainerWrapper.Setup(x => x.ServiceCollection)
             .Returns(serviceCollection);
+        var logger = new RecordingLogger<UnusedModuleDetector>();
+        var detector = new UnusedModuleDetector(
+            _assemblyLoadedTypesProvider.Object,
+            _serviceContainerWrapper.Object,
+            logger);
 
-        _unusedModuleDetector.Log();
-        await Assert.That(_sb.ToString()).IsNotEmpty();
+        detector.Log();
 
-        // Normalize line endings for cross-platform compatibility
-        var actual = _sb.ToString().Trim().Replace("\r\n", "\n");
-        var expected = "⚠ Unregistered Modules:\n  • Module2\n  • Module5";
-
-        await Assert.That(actual).IsEqualTo(expected);
+        var entry = logger.Entries.Single();
+        await Assert.That(entry.Level).IsEqualTo(LogLevel.Debug);
+        await Assert.That(entry.Message).IsEqualTo("Loaded module types not registered (2): Module2, Module5");
     }
 
     [Test]
-    public async Task Log_WhenWarningDisabled_DoesNotScanAssembliesOrServices()
+    public async Task Missing_Required_Dependencies_Are_Warnings()
+    {
+        var logger = new RecordingLogger<UnusedModuleDetector>();
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddModule<ModuleWithMissingDependency>();
+        _serviceContainerWrapper.Setup(x => x.ServiceCollection).Returns(serviceCollection);
+        _assemblyLoadedTypesProvider.Setup(x => x.GetLoadedTypesAssignableTo(typeof(IModule)))
+            .Returns([typeof(ModuleWithMissingDependency), typeof(Module2)]);
+        var detector = new UnusedModuleDetector(
+            _assemblyLoadedTypesProvider.Object,
+            _serviceContainerWrapper.Object,
+            logger);
+
+        detector.Log();
+
+        var warning = logger.Entries.Single(entry => entry.Level == LogLevel.Warning);
+        await Assert.That(warning.Message).Contains("Missing Required Module Dependencies");
+        await Assert.That(warning.Message).Contains(nameof(Module2));
+        await Assert.That(logger.Entries.Where(entry => entry.Level == LogLevel.Debug))
+            .IsEmpty();
+    }
+
+    [Test]
+    public async Task Log_WhenDiagnosticsDisabled_DoesNotScanAssembliesOrServices()
     {
         var logger = new Mock<ILogger<UnusedModuleDetector>>();
+        logger.Setup(x => x.IsEnabled(LogLevel.Debug)).Returns(false);
         logger.Setup(x => x.IsEnabled(LogLevel.Warning)).Returns(false);
         var detector = new UnusedModuleDetector(
             _assemblyLoadedTypesProvider.Object,
@@ -79,7 +86,8 @@ public class UnusedModuleDetectorTests
             x => x.GetLoadedTypesAssignableTo(It.IsAny<Type>()),
             Times.Never);
         _serviceContainerWrapper.VerifyGet(x => x.ServiceCollection, Times.Never);
-        await Assert.That(_sb.ToString()).IsEmpty();
+        await Assert.That(logger.Invocations.Where(invocation => invocation.Method.Name == nameof(ILogger.Log)))
+            .IsEmpty();
     }
 
     private class Module1 : SimpleTestModule<bool>
@@ -105,5 +113,31 @@ public class UnusedModuleDetectorTests
     private class Module5 : SimpleTestModule<bool>
     {
         protected override bool Result => true;
+    }
+
+    [ModularPipelines.Attributes.DependsOn<Module2>]
+    private class ModuleWithMissingDependency : SimpleTestModule<bool>
+    {
+        protected override bool Result => true;
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state)
+            where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Entries.Add((logLevel, formatter(state, exception)));
+        }
     }
 }

--- a/test/ModularPipelines.UnitTests/Engine/UnusedModuleDetectorTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/UnusedModuleDetectorTests.cs
@@ -70,6 +70,28 @@ public class UnusedModuleDetectorTests
     }
 
     [Test]
+    public async Task Missing_Required_Dependencies_Fall_Back_To_Debug_When_Warnings_Are_Disabled()
+    {
+        var logger = new RecordingLogger<UnusedModuleDetector>(level => level == LogLevel.Debug);
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddModule<ModuleWithMissingDependency>();
+        _serviceContainerWrapper.Setup(x => x.ServiceCollection).Returns(serviceCollection);
+        _assemblyLoadedTypesProvider.Setup(x => x.GetLoadedTypesAssignableTo(typeof(IModule)))
+            .Returns([typeof(ModuleWithMissingDependency)]);
+        var detector = new UnusedModuleDetector(
+            _assemblyLoadedTypesProvider.Object,
+            _serviceContainerWrapper.Object,
+            logger);
+
+        detector.Log();
+
+        var entry = logger.Entries.Single();
+        await Assert.That(entry.Level).IsEqualTo(LogLevel.Debug);
+        await Assert.That(entry.Message).Contains("Missing required module dependencies (1)");
+        await Assert.That(entry.Message).Contains(nameof(Module2));
+    }
+
+    [Test]
     public async Task Log_WhenDiagnosticsDisabled_DoesNotScanAssembliesOrServices()
     {
         var logger = new Mock<ILogger<UnusedModuleDetector>>();
@@ -123,12 +145,19 @@ public class UnusedModuleDetectorTests
 
     private sealed class RecordingLogger<T> : ILogger<T>
     {
+        private readonly Func<LogLevel, bool> _isEnabled;
+
+        public RecordingLogger(Func<LogLevel, bool>? isEnabled = null)
+        {
+            _isEnabled = isEnabled ?? (static level => level != LogLevel.None);
+        }
+
         public List<(LogLevel Level, string Message)> Entries { get; } = [];
 
         public IDisposable? BeginScope<TState>(TState state)
             where TState : notnull => null;
 
-        public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+        public bool IsEnabled(LogLevel logLevel) => _isEnabled(logLevel);
 
         public void Log<TState>(
             LogLevel logLevel,


### PR DESCRIPTION
## What

- Limit Trace scheduler detail to 10 pending and 10 executing modules, with an omitted-count suffix.
- Keep a full internal scheduler fingerprint so changes outside the displayed subset still trigger diagnostics.
- Log loaded-but-unused module types at Debug instead of Warning.
- Reserve Warning for genuinely missing required module dependencies.
- Replace per-project negative dependency messages at Information with one count; retain names at Debug.

## Why

The motivating run emitted 14 large scheduler snapshots, 40 routine `is not a dependency` lines, and a warning annotation for intentionally loaded local-only modules. These entries obscured actionable failures.

Motivating run: https://github.com/thomhurst/ModularPipelines/actions/runs/30972375285/job/92199614528

## Root cause

Diagnostic lists were unbounded, project dependency classification logged every negative result at Information, and the unused-module detector combined harmless loaded-but-unused types with missing required dependencies under one Warning.

## Impact

Normal CI output becomes shorter and warning annotations remain actionable. Trace/Debug diagnostics retain bounded module/project details and scheduler change detection remains complete.

The dependency graph already uses the build-system `Module Dependencies` group, so this PR preserves its collapsed GitHub presentation. Results-table grouping is intentionally excluded: it would overlap PR #3886's `SpectreResultsPrinter` changes and grouping the current monolithic renderer would hide the failure headline and root details with the table.

## Checks

- `SchedulerStatusReporterTests`: 6 passed
- `UnusedModuleDetectorTests`: 3 passed
- `ModularPipelines.Build.csproj` Release build succeeded (8 unrelated existing warnings)
- Changed files formatted; formatter emitted only the expected unsupported F# fixture notice
- All `dotnet` commands ran through `scripts/Invoke-AgentDotNet.ps1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Scheduler status logs now present pending and active modules in a clearer, more concise format, showing up to 10 entries with an omitted-count indicator.
  - Module dependency diagnostics are now easier to interpret, with missing required dependencies highlighted as warnings.
  - Additional unused or unregistered module details are available through debug logging.
  - Non-dependent projects are reported individually in debug logs, with an informational count when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->