### PR TITLE
Collapse module results table in CI logs

### DIFF
--- a/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
+++ b/src/ModularPipelines/Helpers/SpectreResultsPrinter.cs
@@ -20,10 +20,17 @@ internal class SpectreResultsPrinter : IResultsPrinter
     private const int MaxStackFrames = 5;
 
     private readonly IOptions<PipelineOptions> _options;
+    private readonly IBuildSystemCommandWriter _commandWriter;
+    private readonly IBuildSystemFormatter _formatter;
 
-    public SpectreResultsPrinter(IOptions<PipelineOptions> options)
+    public SpectreResultsPrinter(
+        IOptions<PipelineOptions> options,
+        IBuildSystemCommandWriter commandWriter,
+        IBuildSystemFormatterProvider formatterProvider)
     {
         _options = options;
+        _commandWriter = commandWriter;
+        _formatter = formatterProvider.GetFormatter();
     }
 
     public void PrintResults(PipelineSummary pipelineSummary)
@@ -40,7 +47,7 @@ internal class SpectreResultsPrinter : IResultsPrinter
 
         // Create and print the main results table
         var table = CreateModulesTable(pipelineSummary);
-        AnsiConsole.Write(table);
+        PrintModulesTable(table);
 
         // Print failed module details if pipeline failed
         if (pipelineSummary.Status == ModuleStatus.Failed)
@@ -52,6 +59,36 @@ internal class SpectreResultsPrinter : IResultsPrinter
         PrintMetrics(pipelineSummary);
 
         System.Console.WriteLine();
+    }
+
+    private void PrintModulesTable(Table table)
+    {
+        if (!_formatter.UsesRawCommands)
+        {
+            AnsiConsole.Write(table);
+            return;
+        }
+
+        var startCommand = _formatter.GetStartBlockCommand("Module Results");
+        if (startCommand is null)
+        {
+            AnsiConsole.Write(table);
+            return;
+        }
+
+        _commandWriter.WriteLine(startCommand);
+        try
+        {
+            AnsiConsole.Write(table);
+        }
+        finally
+        {
+            var endCommand = _formatter.GetEndBlockCommand("Module Results");
+            if (endCommand is not null)
+            {
+                _commandWriter.WriteLine(endCommand);
+            }
+        }
     }
 
     internal static Table CreateModulesTable(PipelineSummary pipelineSummary) =>

--- a/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
@@ -1,8 +1,10 @@
 using ModularPipelines.Context;
 using ModularPipelines.Engine;
+using ModularPipelines.Engine.BuildSystemFormatters;
 using ModularPipelines.Helpers;
 using ModularPipelines.Models;
 using ModularPipelines.Modules;
+using ModularPipelines.Options;
 using Moq;
 using Spectre.Console;
 using Spectre.Console.Rendering;
@@ -10,6 +12,7 @@ using ModuleStatus = ModularPipelines.Enums.Status;
 
 namespace ModularPipelines.UnitTests.Helpers;
 
+[TUnit.Core.NotInParallel(nameof(SpectreResultsPrinterTests))]
 public class SpectreResultsPrinterTests
 {
     private class SkippedModule : Module<bool>
@@ -25,6 +28,13 @@ public class SpectreResultsPrinterTests
 
     private sealed class SecondModule : SkippedModule
     {
+    }
+
+    private class FailedModule : Module<bool>
+    {
+        protected internal override Task<bool> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult(true);
     }
 
     [Test]
@@ -201,6 +211,32 @@ public class SpectreResultsPrinterTests
     }
 
     [Test]
+    public async Task GitHubOutput_GroupsOnlyModuleResultsTable()
+    {
+        var output = PrintResults(CreateFailedSummary(), new GitHubActionsFormatter());
+
+        var headline = output.IndexOf("Pipeline Failed", StringComparison.Ordinal);
+        var counts = output.IndexOf("1 failed", StringComparison.Ordinal);
+        var groupStart = output.IndexOf("::group::Module Results", StringComparison.Ordinal);
+        var table = output.IndexOf(nameof(FailedModule), groupStart, StringComparison.Ordinal);
+        var groupEnd = output.IndexOf("::endgroup::", groupStart, StringComparison.Ordinal);
+        var failureDetails = output.IndexOf("Failed Modules", StringComparison.Ordinal);
+        var metrics = output.IndexOf("Speedup:", StringComparison.Ordinal);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(headline).IsGreaterThanOrEqualTo(0);
+            await Assert.That(counts).IsGreaterThan(headline);
+            await Assert.That(groupStart).IsGreaterThan(counts);
+            await Assert.That(table).IsGreaterThan(groupStart);
+            await Assert.That(groupEnd).IsGreaterThan(table);
+            await Assert.That(failureDetails).IsGreaterThan(groupEnd);
+            await Assert.That(metrics).IsGreaterThan(failureDetails);
+            await Assert.That(output).Contains("root failure");
+        }
+    }
+
+    [Test]
     public async Task ModulesTable_DoesNotApplyAmbiguousTypeDeltas()
     {
         var start = new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero);
@@ -239,6 +275,96 @@ public class SpectreResultsPrinterTests
             await Assert.That(output).Contains("Δ previous");
             await Assert.That(output).DoesNotContain("+1s");
             await Assert.That(output).DoesNotContain("+2s");
+        }
+    }
+
+    [Test]
+    public async Task LocalOutput_DoesNotAddModuleResultsGroup()
+    {
+        var output = PrintResults(CreateFailedSummary(), new DefaultFormatter());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(output).DoesNotContain("Module Results");
+            await Assert.That(output).Contains("Pipeline Failed");
+            await Assert.That(output).Contains(nameof(FailedModule));
+            await Assert.That(output).Contains("Failed Modules");
+            await Assert.That(output).Contains("Speedup:");
+        }
+    }
+
+    private static PipelineSummary CreateFailedSummary()
+    {
+        var start = new DateTimeOffset(2026, 7, 27, 12, 0, 0, TimeSpan.Zero);
+        var end = start.AddSeconds(5);
+        var module = new FailedModule();
+        var result = new ModuleResult.Failure(new InvalidOperationException("root failure"))
+        {
+            ModuleName = nameof(FailedModule),
+            ModuleTypeName = ModuleTypeIdentifier.Get(typeof(FailedModule)),
+            ModuleDuration = end - start,
+            ModuleStart = start,
+            ModuleEnd = end,
+            ModuleStatus = ModuleStatus.Failed,
+        };
+
+        return new PipelineSummary(
+            [module],
+            [result],
+            end - start,
+            start,
+            end,
+            new PipelineMetrics
+            {
+                ParallelismFactor = 1,
+                PeakConcurrency = 1,
+                TotalModuleExecutionTime = end - start,
+                WallClockDuration = end - start,
+                TotalModules = 1,
+                FailedModules = 1,
+            },
+            [
+                new ModuleTimeline
+                {
+                    ModuleName = nameof(FailedModule),
+                    ModuleTypeName = ModuleTypeIdentifier.Get(typeof(FailedModule)),
+                    StartTime = start,
+                    EndTime = end,
+                    ExecutionDuration = end - start,
+                    Status = ModuleStatus.Failed,
+                },
+            ]);
+    }
+
+    private static string PrintResults(
+        PipelineSummary summary,
+        IBuildSystemFormatter formatter)
+    {
+        using var writer = new StringWriter();
+        var originalAnsiConsole = AnsiConsole.Console;
+
+        try
+        {
+            AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings
+            {
+                Out = new AnsiConsoleOutput(writer),
+                Ansi = AnsiSupport.No,
+                ColorSystem = ColorSystemSupport.NoColors,
+            });
+
+            var formatterProvider = new Mock<IBuildSystemFormatterProvider>();
+            formatterProvider.Setup(x => x.GetFormatter()).Returns(formatter);
+            var printer = new SpectreResultsPrinter(
+                Microsoft.Extensions.Options.Options.Create(new PipelineOptions()),
+                new BuildSystemCommandWriter(writer),
+                formatterProvider.Object);
+
+            printer.PrintResults(summary);
+            return writer.ToString();
+        }
+        finally
+        {
+            AnsiConsole.Console = originalAnsiConsole;
         }
     }
 


### PR DESCRIPTION
## What changed

- Wraps only the full module results table in a raw CI group named `Module Results`.
- Uses the existing build-system formatter and command writer pattern, so workflow commands bypass Spectre rendering.
- Leaves the pipeline headline, summary counts, failed-module details, and metrics outside the collapsed group.
- Leaves local/default terminal rendering unchanged.

## Why

Large pipelines render a long module table inline, pushing the actionable failure details farther down the log. In the motivating run, the table contains 73 rows:

https://github.com/thomhurst/ModularPipelines/actions/runs/30972375285/job/92199614528

Collapsing only that table keeps normal CI output easy to scan without hiding the failure summary or diagnostics users need first.

This is intentionally separate from #3886, which corrects status counts, and complements the group-status work in #3889. It does not change result classification or pipeline status formatting.

## Impact

CI systems using raw group commands, including GitHub Actions, show `Module Results` as a collapsible section. Headline/counts remain visible above it; root failure details and metrics remain visible below it. Local terminals receive the same table output as before, with no additional group heading.

## Checks

All .NET commands ran through `scripts/Invoke-AgentDotNet.ps1`.

- `SpectreResultsPrinterTests`: 6 passed.
- Core Release build (`ModularPipelines.slnx`): succeeded with 0 warnings and 0 errors.
- `git diff --check`.
- Code-simplifier review completed.

An initial guarded build attempt exposed the wrapper's optional `-SingleNode` argument formatting issue before compilation; the same guarded core build passed without that optional switch. Focused test compilation emitted only pre-existing nullability warnings elsewhere in the test project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GitHub Actions output now groups module result tables with formatter-provided start and end commands.
  - Local output continues to display failure details and metrics as before.

- **Bug Fixes**
  - Formatted output blocks are now properly closed even when table rendering encounters an error.
  - Improved reliability and consistency of build output across supported formatting environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->