### PR TITLE
Stabilize cancellation watchdog under CI load

### DIFF
--- a/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/EngineCancellationTokenTests.cs
@@ -546,7 +546,7 @@ public class EngineCancellationTokenTests : TestBase
             .Single();
 
         var exception = await Assert.ThrowsAsync<ModuleFailedException>(
-            async () => await host.RunAsync().WaitAsync(TimeSpan.FromSeconds(5)));
+            async () => await host.RunAsync().WaitAsync(TestHostSettings.DefaultTestTimeout));
         var awaitedResult = await ((IInternalModule) pendingModule).ResultTask
             .WaitAsync(TimeSpan.FromSeconds(1));
         var registeredResult = resultRegistry.GetResult(typeof(StopOnFirstPendingModule));


### PR DESCRIPTION
## Summary

- reuse the shared 30-second test watchdog for the stop-on-first cancellation scenario
- keep the one-second post-completion assertion that verifies pending module results complete promptly

## Root cause

The common `pipeline (ubuntu-latest)` failures were not external service failures or 20-minute hangs. Microsoft.Testing.Platform returned exit code 2 because `EngineCancellationTokenTests.StopOnFirstException_PendingModuleAwaiterReturnsTerminatedResult` intermittently exceeded its hardcoded five-second `host.RunAsync()` watchdog under full-suite Linux runner load.

The adjacent coordinated cancellation tests already use `TestHostSettings.DefaultTestTimeout` after earlier CI evidence showed loaded runners can exceed five seconds. This test was added separately and retained the shorter timeout.

## Validation

- `ModularPipelines.Tests.slnf` Release build: passed
- exact failing test: 20/20 focused runs passed
- `EngineCancellationTokenTests`: 15/15 passed
- touched-file format verification: passed
- `git diff --check`: passed

The broader solution-filter format command also reports pre-existing whitespace findings and unsupported F# formatting; no files were changed by that diagnostic.