### PR TITLE
Isolate test run report persistence

### DIFF
--- a/test/ModularPipelines.TestHelpers/TestPipelineBuilder.cs
+++ b/test/ModularPipelines.TestHelpers/TestPipelineBuilder.cs
@@ -34,6 +34,11 @@ public static class TestPipelineBuilder
                 PrintLogo = false,
                 PrintDependencyChains = false,
             },
+            RunReport = options.RunReport with
+            {
+                AutoWriteInCi = false,
+                HistoryRetention = 0,
+            },
             ThrowOnPipelineFailure = false, // Tests handle failures explicitly
         });
 

--- a/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
+++ b/test/ModularPipelines.UnitTests/Registration/PipelineBuilderRegistrationTests.cs
@@ -58,6 +58,24 @@ public class PipelineBuilderRegistrationTests
     }
 
     [Test]
+    public async Task TestPipelineBuilder_DisablesPersistentRunReports()
+    {
+        await using var pipeline = await TestPipelineBuilder.Create()
+            .AddModule<TestModuleA>()
+            .BuildAsync();
+        var runReportOptions = pipeline.Services
+            .GetRequiredService<IOptions<PipelineOptions>>()
+            .Value
+            .RunReport;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(runReportOptions.AutoWriteInCi).IsFalse();
+            await Assert.That(runReportOptions.HistoryRetention).IsEqualTo(0);
+        }
+    }
+
+    [Test]
     public async Task RegistrationApi_ReturnsPipelineBuilderForChaining()
     {
         var addMethods = typeof(PipelineBuilderExtensions)


### PR DESCRIPTION
## Summary

- disable automatic CI run-report writes for pipelines created by `TestPipelineBuilder`
- disable test-helper run-history persistence by default
- add a regression covering both defaults

## Root cause

Ordinary test pipelines inherited production `RunReportOptions` defaults. In GitHub Actions, hundreds of parallel tests therefore overwrote the same repository-root `artifacts/run-report.json` and scanned, wrote, and pruned the same `.modularpipelines/run-history` directory.

`host.RunAsync()` awaits run-report completion before rethrowing a module failure. Shared storage contention could therefore make the test watchdog return `TimeoutException` instead of the expected `ModuleFailedException`. Increasing the watchdog from 5 to 30 seconds in #3891 delayed the failure but retained the contention.

In-memory run-report generation remains enabled. Dedicated run-report tests use explicit isolated paths and continue covering persistence.

## Validation

- new `TestPipelineBuilder_DisablesPersistentRunReports` regression: 1/1 passed
- `EngineCancellationTokenTests` with `GITHUB_ACTIONS=true`: 15/15 passed
- confirmed simulated CI run created neither `artifacts/run-report.json` nor `.modularpipelines/run-history`
- `ModularPipelines.Tests.slnf` Release build: succeeded; 79 existing nullability warnings
- touched-file formatting verification: passed
- solution-wide formatting verification remains blocked by the existing unsupported F# project and unrelated whitespace findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test pipelines now disable automatic CI run reports by default.
  * Run-report history retention is set to zero for test pipelines.

* **Tests**
  * Added coverage verifying that persistent run reports are disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->