### PR TITLE
Make timeout tests deterministic under load

### DIFF
--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -581,13 +581,20 @@ public class HttpTests : TestBase
             Timeout = timeout,
         });
 
-        await Task.Delay(timeout + TimeSpan.FromMilliseconds(50));
-
+        var stream = await response.Content.ReadAsStreamAsync();
         await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await ReadUntilTimeout(stream).WaitAsync(TestHostSettings.DefaultTestTimeout));
+
+        static async Task ReadUntilTimeout(Stream responseStream)
         {
-            var stream = await response.Content.ReadAsStreamAsync();
-            await stream.ReadExactlyAsync(new byte[1]);
-        });
+            while (true)
+            {
+#pragma warning disable CA2022 // Zero-byte read probes timeout cancellation without consuming replay content.
+                responseStream.Read(Span<byte>.Empty);
+#pragma warning restore CA2022
+                await Task.Yield();
+            }
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -59,6 +59,15 @@ public class ModuleTimeoutTests : TestBase
     {
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return TestConstants.TestString;
+        }
+    }
+
+    private class ZeroDefaultTimeoutModule : Module<string>
+    {
+        protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
+        {
             await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
             return TestConstants.TestString;
         }
@@ -81,7 +90,8 @@ public class ModuleTimeoutTests : TestBase
                 DefaultModuleTimeout = TimeSpan.FromMilliseconds(10),
             })
             .AddModule<PipelineDefaultTimeoutModule>()
-            .ExecutePipelineAsync());
+            .ExecutePipelineAsync()
+            .WaitAsync(TestHostSettings.DefaultTestTimeout));
 
         var timeoutException = exception!.InnerException as ModuleTimeoutException;
         await Assert.That(timeoutException).IsNotNull();
@@ -96,7 +106,7 @@ public class ModuleTimeoutTests : TestBase
             {
                 DefaultModuleTimeout = TimeSpan.Zero,
             })
-            .AddModule<PipelineDefaultTimeoutModule>()
+            .AddModule<ZeroDefaultTimeoutModule>()
             .ExecutePipelineAsync()).ThrowsNothing();
     }
 


### PR DESCRIPTION
## What changed

- Make the logged HTTP replay timeout test poll the wrapped stream's cancellation state without consuming its content.
- Make the default module-timeout test block until its cancellation token fires instead of racing a 10 ms timer against a 100 ms timer.
- Keep the zero-timeout behavior covered by a separate completing module.
- Bound both cancellation assertions with the shared test timeout.

## Why

Under the full 1,956-test CI load, ThreadPool timer callbacks can be delayed and run out of deadline order. Two tests assumed a longer delay always completed after a shorter cancellation timer, producing intermittent false failures.

Observed failures:

- `SendAsync_CustomClientKeepsTimeoutOutsideLoggedReplayContent`
- `Pipeline_Default_Module_Timeout_Is_Applied`

Motivating run: https://github.com/thomhurst/ModularPipelines/actions/runs/31266462563/job/93126923852

## Impact

The tests still verify production timeout semantics, but completion now depends on the cancellation being tested rather than scheduler timing. No production behavior or timeout value changes.

## Checks

- Guarded focused `HttpTests` and `ModuleTimeoutTests`: 51 passed, run twice
- Guarded Release build of `ModularPipelines.UnitTests.csproj`
- Focused whitespace-format verification
- `git diff --check`