### PR TITLE
[Automated] Update buildah CLI Options

### DIFF
--- a/src/ModularPipelines.Buildah/Options/BuildahBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahBuildOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Buildah.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Buildah.Options;
 
@@ -413,8 +414,8 @@ public record BuildahBuildOptions : BuildahOptions
     /// <summary>
     /// pull the image from the registry if newer or not present in store, if false, only pull the image if not present, if always, pull the image even if the named image is present in store, if never, only use the image present in store if available (default "true")
     /// </summary>
-    [CliOption("--pull", Format = OptionFormat.EqualsSeparated)]
-    public string? Pull { get; set; }
+    [CliOption("--pull", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
+    public CliOptionValue? Pull { get; set; }
 
     /// <summary>
     /// refrain from announcing build instructions and image read/write progress

--- a/src/ModularPipelines.Buildah/Options/BuildahFromOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahFromOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Buildah.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Buildah.Options;
 
@@ -221,8 +222,8 @@ public record BuildahFromOptions : BuildahOptions
     /// <summary>
     /// pull the image from the registry if newer or not present in store, if false, only pull the image if not present, if always, pull the image even if the named image is present in store, if never, only use the image present in store if available (default "true")
     /// </summary>
-    [CliOption("--pull", Format = OptionFormat.EqualsSeparated)]
-    public string? Pull { get; set; }
+    [CliOption("--pull", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
+    public CliOptionValue? Pull { get; set; }
 
     /// <summary>
     /// don't output progress information when pulling images

--- a/src/ModularPipelines.Buildah/Options/BuildahManifestOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahManifestOptions.Generated.cs
@@ -26,10 +26,4 @@ public record BuildahManifestOptions : BuildahOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? Command { get; set; }
-
 }

--- a/src/ModularPipelines.Buildah/Options/BuildahSourceOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahSourceOptions.Generated.cs
@@ -26,10 +26,4 @@ public record BuildahSourceOptions : BuildahOptions
     [CliFlag("--help", ShortForm = "-h")]
     public bool? Help { get; set; }
 
-    /// <summary>
-    /// The command operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? Command { get; set; }
-
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **buildah** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- buildah (buildah version 1.33.7 (image-spec 1.1.0-rc.5, runtime-spec 1.1.0)): 37 commands, tree 40421c40371cc91f2731cecc414602c829d251cb603067ac9cbef046a69eeb90

## Verification
- [x] Solution builds successfully
- API compatibility gate: **failure**

---
🤖 Generated with ModularPipelines.OptionsGenerator