### PR TITLE
[Automated] Update docker CLI Options

### DIFF
--- a/src/ModularPipelines.Docker/Options/DockerComposeBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeBuildOptions.Generated.cs
@@ -65,12 +65,6 @@ public record DockerComposeBuildOptions : DockerOptions
     public bool? Print { get; set; }
 
     /// <summary>
-    /// Add a provenance attestation
-    /// </summary>
-    [CliOption("--provenance", Format = OptionFormat.EqualsSeparated)]
-    public string? Provenance { get; set; }
-
-    /// <summary>
     /// Always attempt to pull a newer version of the image
     /// </summary>
     [CliFlag("--pull")]
@@ -83,16 +77,10 @@ public record DockerComposeBuildOptions : DockerOptions
     public bool? Push { get; set; }
 
     /// <summary>
-    /// Suppress the build output
+    /// Don't print anything to STDOUT
     /// </summary>
     [CliFlag("--quiet", ShortForm = "-q")]
     public bool? Quiet { get; set; }
-
-    /// <summary>
-    /// Add a SBOM attestation
-    /// </summary>
-    [CliOption("--sbom", Format = OptionFormat.EqualsSeparated)]
-    public string? Sbom { get; set; }
 
     /// <summary>
     /// Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent)

--- a/src/ModularPipelines.Docker/Options/DockerComposeConfigOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeConfigOptions.Generated.cs
@@ -57,12 +57,6 @@ public record DockerComposeConfigOptions : DockerOptions
     public bool? LockImageDigests { get; set; }
 
     /// <summary>
-    /// Print the model names, one per line.
-    /// </summary>
-    [CliFlag("--models")]
-    public bool? Models { get; set; }
-
-    /// <summary>
     /// Print the network names, one per line.
     /// </summary>
     [CliFlag("--networks")]

--- a/src/ModularPipelines.Docker/Options/DockerComposeEventsOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeEventsOptions.Generated.cs
@@ -33,18 +33,6 @@ public record DockerComposeEventsOptions : DockerOptions
     public bool? Json { get; set; }
 
     /// <summary>
-    /// Show all events created since timestamp
-    /// </summary>
-    [CliOption("--since", Format = OptionFormat.EqualsSeparated)]
-    public string? Since { get; set; }
-
-    /// <summary>
-    /// Stream events until this timestamp
-    /// </summary>
-    [CliOption("--until", Format = OptionFormat.EqualsSeparated)]
-    public string? Until { get; set; }
-
-    /// <summary>
     /// The SERVICE operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]

--- a/src/ModularPipelines.Docker/Options/DockerComposeExecOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeExecOptions.Generated.cs
@@ -48,12 +48,6 @@ public record DockerComposeExecOptions(
     public int? Index { get; set; }
 
     /// <summary>
-    /// Disable pseudo-TTY allocation. By default 'docker compose exec' allocates a TTY. (default true)
-    /// </summary>
-    [CliOption("--no-tty", ShortForm = "-T", Format = OptionFormat.EqualsSeparated)]
-    public bool? NoTty { get; set; }
-
-    /// <summary>
     /// Give extended privileges to the process
     /// </summary>
     [CliFlag("--privileged")]

--- a/src/ModularPipelines.Docker/Options/DockerComposePublishOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposePublishOptions.Generated.cs
@@ -23,12 +23,6 @@ public record DockerComposePublishOptions(
 ) : DockerOptions
 {
     /// <summary>
-    /// Published compose application (includes referenced images)
-    /// </summary>
-    [CliFlag("--app")]
-    public bool? App { get; set; }
-
-    /// <summary>
     /// Execute command in dry run mode
     /// </summary>
     [CliFlag("--dry-run")]

--- a/src/ModularPipelines.Docker/Options/DockerComposeStartOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeStartOptions.Generated.cs
@@ -27,18 +27,6 @@ public record DockerComposeStartOptions : DockerOptions
     public bool? DryRun { get; set; }
 
     /// <summary>
-    /// Wait for services to be running|healthy. Implies detached mode.
-    /// </summary>
-    [CliFlag("--wait")]
-    public bool? Wait { get; set; }
-
-    /// <summary>
-    /// Maximum duration in seconds to wait for the project to be running|healthy
-    /// </summary>
-    [CliOption("--wait-timeout", Format = OptionFormat.EqualsSeparated)]
-    public int? WaitTimeout { get; set; }
-
-    /// <summary>
     /// The SERVICE operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]

--- a/src/ModularPipelines.Docker/Options/DockerComposeUpOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeUpOptions.Generated.cs
@@ -135,12 +135,6 @@ public record DockerComposeUpOptions : DockerOptions
     public string? Pull { get; set; }
 
     /// <summary>
-    /// Suppress the build output
-    /// </summary>
-    [CliFlag("--quiet-build")]
-    public bool? QuietBuild { get; set; }
-
-    /// <summary>
     /// Pull without printing progress information
     /// </summary>
     [CliFlag("--quiet-pull")]


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **docker** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- docker (Docker version 28.0.4, build b8034c0): 235 commands, tree 579289c22c807351975b3a09486be77beae5ff4ca69c15374eaa0413b47345a2

## Verification
- [x] Solution builds successfully
- API compatibility gate: **failure**

---
🤖 Generated with ModularPipelines.OptionsGenerator