### PR TITLE
[Automated] Update pulumi CLI Options

### DIFF
--- a/src/ModularPipelines.Pulumi/Generated/Pulumi.CommandCoverage.json
+++ b/src/ModularPipelines.Pulumi/Generated/Pulumi.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "pulumi",
-  "toolVersion": "v3.255.0",
+  "toolVersion": "v3.256.0",
   "commandCount": 226,
   "commandTreeSha256": "c23fbb83a37eb69c9cf574d6e85ffad67be77a27cab19c1f4a05c22b31237a9e",
   "commands": [

--- a/src/ModularPipelines.Pulumi/Options/PulumiDeploymentRunOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiDeploymentRunOptions.Generated.cs
@@ -71,7 +71,6 @@ public record PulumiDeploymentRunOptions(
     /// <summary>
     /// Git SSH private key path; use --git-auth-password for the password, if needed
     /// </summary>
-    [SecretValue]
     [CliOption("--git-auth-ssh-private-key-path", Format = OptionFormat.EqualsSeparated)]
     public string? GitAuthSshPrivateKeyPath { get; set; }
 

--- a/src/ModularPipelines.Pulumi/Options/PulumiDestroyOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiDestroyOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -75,6 +76,12 @@ public record PulumiDestroyOptions : PulumiOptions
     public bool? Help { get; set; }
 
     /// <summary>
+    /// Ignore the protect resource option for this operation, allowing protected resources to be destroyed. Use with caution: deleted resources cannot be recovered
+    /// </summary>
+    [CliFlag("--ignore-protect")]
+    public bool? IgnoreProtect { get; set; }
+
+    /// <summary>
     /// Serialize the destroy diffs, operations, and overall output as JSON
     /// </summary>
     [CliFlag("--json", ShortForm = "-j")]
@@ -114,7 +121,7 @@ public record PulumiDestroyOptions : PulumiOptions
     /// Refresh the state of the stack's resources before this update
     /// </summary>
     [CliOption("--refresh", ShortForm = "-r", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Refresh { get; set; }
+    public CliOptionValue? Refresh { get; set; }
 
     /// <summary>
     /// Remove the stack and its config file after all resources in the stack have been deleted
@@ -186,7 +193,7 @@ public record PulumiDestroyOptions : PulumiOptions
     /// Suppress display of the state permalink
     /// </summary>
     [CliOption("--suppress-permalink", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? SuppressPermalink { get; set; }
+    public CliOptionValue? SuppressPermalink { get; set; }
 
     /// <summary>
     /// Suppress display of periodic progress dots

--- a/src/ModularPipelines.Pulumi/Options/PulumiEnvDiffOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiEnvDiffOptions.Generated.cs
@@ -19,7 +19,8 @@ namespace ModularPipelines.Pulumi.Options;
 [ExcludeFromCodeCoverage]
 [CliSubCommand("env", "diff")]
 public record PulumiEnvDiffOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string EnvironmentName
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string EnvironmentName,
+    [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string OrgNameOrProjectNameOrEnvironmentNameVersion
 ) : PulumiOptions
 {
     /// <summary>
@@ -129,11 +130,5 @@ public record PulumiEnvDiffOptions(
     /// </summary>
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
-
-    /// <summary>
-    /// The [[org-name Or ][&lt;project-name&gt; Or ]&lt;environment-name&gt;]@&lt;version&gt; operand.
-    /// </summary>
-    [CliArgument(1, Phase = CommandLinePhase.EarlyOperand)]
-    public string? OrgNameOrProjectNameOrEnvironmentNameVersion { get; set; }
 
 }

--- a/src/ModularPipelines.Pulumi/Options/PulumiEnvEditOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiEnvEditOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -26,7 +27,7 @@ public record PulumiEnvEditOptions(
     /// set flag without a value (--draft) to create a draft rather than saving changes directly. --draft=&lt;change-request-id&gt; to update an existing change request.
     /// </summary>
     [CliOption("--draft", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Draft { get; set; }
+    public CliOptionValue? Draft { get; set; }
 
     /// <summary>
     /// the command to use to edit the environment definition

--- a/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderAwsLoginOidcOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderAwsLoginOidcOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -34,13 +35,19 @@ public record PulumiEnvProviderAwsLoginOidcOptions(
     /// set flag without a value (--draft) to create a draft rather than saving changes directly. --draft=&lt;change-request-id&gt; to update an existing change request.
     /// </summary>
     [CliOption("--draft", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Draft { get; set; }
+    public CliOptionValue? Draft { get; set; }
 
     /// <summary>
     /// optional session duration, e.g. 1h
     /// </summary>
     [CliOption("--duration", Format = OptionFormat.EqualsSeparated)]
     public string? Duration { get; set; }
+
+    /// <summary>
+    /// also set the AWS SDK environment variables (AWS_ACCESS_KEY_ID, etc.) referencing the login outputs
+    /// </summary>
+    [CliFlag("--export-env-vars")]
+    public bool? ExportEnvVars { get; set; }
 
     /// <summary>
     /// help for oidc

--- a/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderAwsLoginStaticOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderAwsLoginStaticOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -34,7 +35,13 @@ public record PulumiEnvProviderAwsLoginStaticOptions(
     /// set flag without a value (--draft) to create a draft rather than saving changes directly. --draft=&lt;change-request-id&gt; to update an existing change request.
     /// </summary>
     [CliOption("--draft", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Draft { get; set; }
+    public CliOptionValue? Draft { get; set; }
+
+    /// <summary>
+    /// also set the AWS SDK environment variables (AWS_ACCESS_KEY_ID, etc.) referencing the login outputs
+    /// </summary>
+    [CliFlag("--export-env-vars")]
+    public bool? ExportEnvVars { get; set; }
 
     /// <summary>
     /// help for static

--- a/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderAzureLoginOidcOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderAzureLoginOidcOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -35,7 +36,13 @@ public record PulumiEnvProviderAzureLoginOidcOptions(
     /// set flag without a value (--draft) to create a draft rather than saving changes directly. --draft=&lt;change-request-id&gt; to update an existing change request.
     /// </summary>
     [CliOption("--draft", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Draft { get; set; }
+    public CliOptionValue? Draft { get; set; }
+
+    /// <summary>
+    /// also set the Azure environment variables (ARM_CLIENT_ID, etc.) referencing the login outputs
+    /// </summary>
+    [CliFlag("--export-env-vars")]
+    public bool? ExportEnvVars { get; set; }
 
     /// <summary>
     /// help for oidc

--- a/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderAzureLoginStaticOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderAzureLoginStaticOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -36,7 +37,13 @@ public record PulumiEnvProviderAzureLoginStaticOptions(
     /// set flag without a value (--draft) to create a draft rather than saving changes directly. --draft=&lt;change-request-id&gt; to update an existing change request.
     /// </summary>
     [CliOption("--draft", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Draft { get; set; }
+    public CliOptionValue? Draft { get; set; }
+
+    /// <summary>
+    /// also set the Azure environment variables (ARM_CLIENT_ID, etc.) referencing the login outputs
+    /// </summary>
+    [CliFlag("--export-env-vars")]
+    public bool? ExportEnvVars { get; set; }
 
     /// <summary>
     /// help for static

--- a/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderGcpLoginOidcOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderGcpLoginOidcOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -33,7 +34,13 @@ public record PulumiEnvProviderGcpLoginOidcOptions(
     /// set flag without a value (--draft) to create a draft rather than saving changes directly. --draft=&lt;change-request-id&gt; to update an existing change request.
     /// </summary>
     [CliOption("--draft", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Draft { get; set; }
+    public CliOptionValue? Draft { get; set; }
+
+    /// <summary>
+    /// also set the Google SDK environment variables (GOOGLE_PROJECT, etc.) referencing the login outputs
+    /// </summary>
+    [CliFlag("--export-env-vars")]
+    public bool? ExportEnvVars { get; set; }
 
     /// <summary>
     /// help for oidc

--- a/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderGcpLoginStaticOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiEnvProviderGcpLoginStaticOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -34,7 +35,13 @@ public record PulumiEnvProviderGcpLoginStaticOptions(
     /// set flag without a value (--draft) to create a draft rather than saving changes directly. --draft=&lt;change-request-id&gt; to update an existing change request.
     /// </summary>
     [CliOption("--draft", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Draft { get; set; }
+    public CliOptionValue? Draft { get; set; }
+
+    /// <summary>
+    /// also set the Google SDK environment variables (GOOGLE_PROJECT, etc.) referencing the login outputs
+    /// </summary>
+    [CliFlag("--export-env-vars")]
+    public bool? ExportEnvVars { get; set; }
 
     /// <summary>
     /// help for static

--- a/src/ModularPipelines.Pulumi/Options/PulumiEnvSetOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiEnvSetOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -28,7 +29,7 @@ public record PulumiEnvSetOptions(
     /// set flag without a value (--draft) to create a draft rather than saving changes directly. --draft=&lt;change-request-id&gt; to update an existing change request.
     /// </summary>
     [CliOption("--draft", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Draft { get; set; }
+    public CliOptionValue? Draft { get; set; }
 
     /// <summary>
     /// If set, the value is read from the specified file. Pass - to read from standard input.

--- a/src/ModularPipelines.Pulumi/Options/PulumiImportOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiImportOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -150,7 +151,7 @@ public record PulumiImportOptions : PulumiOptions
     /// Suppress display of the state permalink
     /// </summary>
     [CliOption("--suppress-permalink", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? SuppressPermalink { get; set; }
+    public CliOptionValue? SuppressPermalink { get; set; }
 
     /// <summary>
     /// Suppress display of periodic progress dots

--- a/src/ModularPipelines.Pulumi/Options/PulumiNewOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiNewOptions.Generated.cs
@@ -21,12 +21,6 @@ namespace ModularPipelines.Pulumi.Options;
 public record PulumiNewOptions : PulumiOptions
 {
     /// <summary>
-    /// Prompt to use for Pulumi AI
-    /// </summary>
-    [CliOption("--ai", Format = OptionFormat.EqualsSeparated)]
-    public string? Ai { get; set; }
-
-    /// <summary>
     /// Config to save
     /// </summary>
     [CliOption("--config", ShortForm = "-c", Format = OptionFormat.EqualsSeparated)]
@@ -69,12 +63,6 @@ public record PulumiNewOptions : PulumiOptions
     public bool? Help { get; set; }
 
     /// <summary>
-    /// Language to use for Pulumi AI (must be one of TypeScript, JavaScript, Python, Go, C#, Java, or YAML)
-    /// </summary>
-    [CliOption("--language", Format = OptionFormat.EqualsSeparated)]
-    public string? Language { get; set; }
-
-    /// <summary>
     /// List locally installed templates and exit
     /// </summary>
     [CliFlag("--list-templates", ShortForm = "-l")]
@@ -109,12 +97,6 @@ public record PulumiNewOptions : PulumiOptions
     /// </summary>
     [CliOption("--stack", ShortForm = "-s", Format = OptionFormat.EqualsSeparated)]
     public string? Stack { get; set; }
-
-    /// <summary>
-    /// Run in template mode, which will skip prompting for AI or Template functionality
-    /// </summary>
-    [CliFlag("--template-mode", ShortForm = "-t")]
-    public bool? TemplateMode { get; set; }
 
     /// <summary>
     /// Skip prompts and proceed with default values

--- a/src/ModularPipelines.Pulumi/Options/PulumiPackageAddOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiPackageAddOptions.Generated.cs
@@ -41,6 +41,12 @@ public record PulumiPackageAddOptions(
     public string? Language { get; set; }
 
     /// <summary>
+    /// A URL to download the plugin from. When set, the provider argument is used as the plugin name directly and no package resolution is performed.
+    /// </summary>
+    [CliOption("--server", Format = OptionFormat.EqualsSeparated)]
+    public string? Server { get; set; }
+
+    /// <summary>
     /// Colorize output. Choices are: always, never, raw, auto (default "auto")
     /// </summary>
     [CliOption("--color", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Pulumi/Options/PulumiPackageGenSdkOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiPackageGenSdkOptions.Generated.cs
@@ -53,6 +53,12 @@ public record PulumiPackageGenSdkOptions(
     public string? Out { get; set; }
 
     /// <summary>
+    /// A URL to download the plugin from. When set, the provider argument is used as the plugin name directly and no package resolution is performed.
+    /// </summary>
+    [CliOption("--server", Format = OptionFormat.EqualsSeparated)]
+    public string? Server { get; set; }
+
+    /// <summary>
     /// The provider plugin version to generate the SDK for
     /// </summary>
     [CliOption("--version", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Pulumi/Options/PulumiPackageGetMappingOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiPackageGetMappingOptions.Generated.cs
@@ -36,6 +36,12 @@ public record PulumiPackageGetMappingOptions(
     public string? Out { get; set; }
 
     /// <summary>
+    /// A URL to download the plugin from. When set, the provider argument is used as the plugin name directly and no package resolution is performed.
+    /// </summary>
+    [CliOption("--server", Format = OptionFormat.EqualsSeparated)]
+    public string? Server { get; set; }
+
+    /// <summary>
     /// Colorize output. Choices are: always, never, raw, auto (default "auto")
     /// </summary>
     [CliOption("--color", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Pulumi/Options/PulumiPackageGetSchemaOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiPackageGetSchemaOptions.Generated.cs
@@ -35,6 +35,12 @@ public record PulumiPackageGetSchemaOptions(
     public bool? Help { get; set; }
 
     /// <summary>
+    /// A URL to download the plugin from. When set, the provider argument is used as the plugin name directly and no package resolution is performed.
+    /// </summary>
+    [CliOption("--server", Format = OptionFormat.EqualsSeparated)]
+    public string? Server { get; set; }
+
+    /// <summary>
     /// Colorize output. Choices are: always, never, raw, auto (default "auto")
     /// </summary>
     [CliOption("--color", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Pulumi/Options/PulumiPackageInfoOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiPackageInfoOptions.Generated.cs
@@ -53,6 +53,12 @@ public record PulumiPackageInfoOptions(
     public string? Resource { get; set; }
 
     /// <summary>
+    /// A URL to download the plugin from. When set, the provider argument is used as the plugin name directly and no package resolution is performed.
+    /// </summary>
+    [CliOption("--server", Format = OptionFormat.EqualsSeparated)]
+    public string? Server { get; set; }
+
+    /// <summary>
     /// Colorize output. Choices are: always, never, raw, auto (default "auto")
     /// </summary>
     [CliOption("--color", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Pulumi/Options/PulumiPackagePublishOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiPackagePublishOptions.Generated.cs
@@ -47,6 +47,12 @@ public record PulumiPackagePublishOptions(
     public string? Readme { get; set; }
 
     /// <summary>
+    /// A URL to download the plugin from. When set, the provider argument is used as the plugin name directly and no package resolution is performed.
+    /// </summary>
+    [CliOption("--server", Format = OptionFormat.EqualsSeparated)]
+    public string? Server { get; set; }
+
+    /// <summary>
     /// Colorize output. Choices are: always, never, raw, auto (default "auto")
     /// </summary>
     [CliOption("--color", Format = OptionFormat.EqualsSeparated)]

--- a/src/ModularPipelines.Pulumi/Options/PulumiPluginInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiPluginInstallOptions.Generated.cs
@@ -135,9 +135,21 @@ public record PulumiPluginInstallOptions : PulumiOptions
     public int? Verbose { get; set; }
 
     /// <summary>
-    /// The kind name [version] operand.
+    /// The kind operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? KindNameVersion { get; set; }
+    public string? Kind { get; set; }
+
+    /// <summary>
+    /// The name operand.
+    /// </summary>
+    [CliArgument(1, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The version operand.
+    /// </summary>
+    [CliArgument(2, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Version { get; set; }
 
 }

--- a/src/ModularPipelines.Pulumi/Options/PulumiPreviewOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiPreviewOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -24,7 +25,7 @@ public record PulumiPreviewOptions : PulumiOptions
     /// Enable the ability to attach a debugger to the program and source based plugins being executed. Can limit debug type to 'program', 'plugins', 'plugin:&lt;name&gt;' or 'all'.
     /// </summary>
     [CliOption("--attach-debugger", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public IEnumerable<string>? AttachDebugger { get; set; }
+    public IEnumerable<CliOptionValue>? AttachDebugger { get; set; }
 
     /// <summary>
     /// Config to use during the preview and save to the stack config file
@@ -81,6 +82,12 @@ public record PulumiPreviewOptions : PulumiOptions
     public bool? Help { get; set; }
 
     /// <summary>
+    /// Ignore the protect resource option for this operation, previewing the deletion or replacement of protected resources instead of failing
+    /// </summary>
+    [CliFlag("--ignore-protect")]
+    public bool? IgnoreProtect { get; set; }
+
+    /// <summary>
     /// Save any creates seen during the preview into an import file to use with 'pulumi import'
     /// </summary>
     [CliOption("--import-file", Format = OptionFormat.EqualsSeparated)]
@@ -132,7 +139,7 @@ public record PulumiPreviewOptions : PulumiOptions
     /// Refresh the state of the stack's resources before this update
     /// </summary>
     [CliOption("--refresh", ShortForm = "-r", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Refresh { get; set; }
+    public CliOptionValue? Refresh { get; set; }
 
     /// <summary>
     /// Specify resources to replace. Multiple resources can be specified using --replace urn1 --replace urn2
@@ -223,7 +230,7 @@ public record PulumiPreviewOptions : PulumiOptions
     /// Suppress display of the state permalink
     /// </summary>
     [CliOption("--suppress-permalink", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? SuppressPermalink { get; set; }
+    public CliOptionValue? SuppressPermalink { get; set; }
 
     /// <summary>
     /// Suppress display of periodic progress dots

--- a/src/ModularPipelines.Pulumi/Options/PulumiProjectNewOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiProjectNewOptions.Generated.cs
@@ -21,12 +21,6 @@ namespace ModularPipelines.Pulumi.Options;
 public record PulumiProjectNewOptions : PulumiOptions
 {
     /// <summary>
-    /// Prompt to use for Pulumi AI
-    /// </summary>
-    [CliOption("--ai", Format = OptionFormat.EqualsSeparated)]
-    public string? Ai { get; set; }
-
-    /// <summary>
     /// Config to save
     /// </summary>
     [CliOption("--config", ShortForm = "-c", Format = OptionFormat.EqualsSeparated)]
@@ -69,12 +63,6 @@ public record PulumiProjectNewOptions : PulumiOptions
     public bool? Help { get; set; }
 
     /// <summary>
-    /// Language to use for Pulumi AI (must be one of TypeScript, JavaScript, Python, Go, C#, Java, or YAML)
-    /// </summary>
-    [CliOption("--language", Format = OptionFormat.EqualsSeparated)]
-    public string? Language { get; set; }
-
-    /// <summary>
     /// List locally installed templates and exit
     /// </summary>
     [CliFlag("--list-templates", ShortForm = "-l")]
@@ -109,12 +97,6 @@ public record PulumiProjectNewOptions : PulumiOptions
     /// </summary>
     [CliOption("--stack", ShortForm = "-s", Format = OptionFormat.EqualsSeparated)]
     public string? Stack { get; set; }
-
-    /// <summary>
-    /// Run in template mode, which will skip prompting for AI or Template functionality
-    /// </summary>
-    [CliFlag("--template-mode", ShortForm = "-t")]
-    public bool? TemplateMode { get; set; }
 
     /// <summary>
     /// Skip prompts and proceed with default values

--- a/src/ModularPipelines.Pulumi/Options/PulumiRefreshOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiRefreshOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -180,7 +181,7 @@ public record PulumiRefreshOptions : PulumiOptions
     /// Suppress display of the state permalink
     /// </summary>
     [CliOption("--suppress-permalink", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? SuppressPermalink { get; set; }
+    public CliOptionValue? SuppressPermalink { get; set; }
 
     /// <summary>
     /// Suppress display of periodic progress dots

--- a/src/ModularPipelines.Pulumi/Options/PulumiStackNewOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiStackNewOptions.Generated.cs
@@ -18,7 +18,9 @@ namespace ModularPipelines.Pulumi.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("stack", "new")]
-public record PulumiStackNewOptions : PulumiOptions
+public record PulumiStackNewOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string OrgNameOrStackName
+) : PulumiOptions
 {
     /// <summary>
     /// The name of the stack to copy existing config from
@@ -139,11 +141,5 @@ public record PulumiStackNewOptions : PulumiOptions
     /// </summary>
     [CliOption("--verbose", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbose { get; set; }
-
-    /// <summary>
-    /// The [org-name Or ]&lt;stack-name&gt; operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? OrgNameOrStackName { get; set; }
 
 }

--- a/src/ModularPipelines.Pulumi/Options/PulumiUpOptions.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Options/PulumiUpOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Pulumi.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Pulumi.Options;
 
@@ -24,7 +25,7 @@ public record PulumiUpOptions : PulumiOptions
     /// Enable the ability to attach a debugger to the program and source based plugins being executed. Can limit debug type to 'program', 'plugins', 'plugin:&lt;name&gt;' or 'all'.
     /// </summary>
     [CliOption("--attach-debugger", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public IEnumerable<string>? AttachDebugger { get; set; }
+    public IEnumerable<CliOptionValue>? AttachDebugger { get; set; }
 
     /// <summary>
     /// Config to use during the update and save to the stack config file
@@ -87,6 +88,12 @@ public record PulumiUpOptions : PulumiOptions
     public bool? Help { get; set; }
 
     /// <summary>
+    /// Ignore the protect resource option for this operation, allowing protected resources to be deleted or replaced. Use with caution: deleted resources cannot be recovered
+    /// </summary>
+    [CliFlag("--ignore-protect")]
+    public bool? IgnoreProtect { get; set; }
+
+    /// <summary>
     /// Serialize the update diffs, operations, and overall output as JSON
     /// </summary>
     [CliFlag("--json", ShortForm = "-j")]
@@ -132,7 +139,7 @@ public record PulumiUpOptions : PulumiOptions
     /// Refresh the state of the stack's resources before this update
     /// </summary>
     [CliOption("--refresh", ShortForm = "-r", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Refresh { get; set; }
+    public CliOptionValue? Refresh { get; set; }
 
     /// <summary>
     /// Specify a single resource URN to replace. Multiple resources can be specified using --replace urn1 --replace urn2. Wildcards (*, **) are also supported
@@ -234,7 +241,7 @@ public record PulumiUpOptions : PulumiOptions
     /// Suppress display of the state permalink
     /// </summary>
     [CliOption("--suppress-permalink", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? SuppressPermalink { get; set; }
+    public CliOptionValue? SuppressPermalink { get; set; }
 
     /// <summary>
     /// Suppress display of periodic progress dots

--- a/src/ModularPipelines.Pulumi/Services/IPulumiStack.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Services/IPulumiStack.Generated.cs
@@ -125,7 +125,7 @@ public interface IPulumiStack
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> NewAsync(PulumiStackNewOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> NewAsync(PulumiStackNewOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Show a stack's output properties.

--- a/src/ModularPipelines.Pulumi/Services/PulumiStack.Generated.cs
+++ b/src/ModularPipelines.Pulumi/Services/PulumiStack.Generated.cs
@@ -193,11 +193,11 @@ public class PulumiStack : IPulumiStack
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
     public virtual async Task<CommandResult> NewAsync(
-        PulumiStackNewOptions? options = null,
+        PulumiStackNewOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PulumiStackNewOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pulumi** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- pulumi (v3.256.0): 226 commands, tree c23fbb83a37eb69c9cf574d6e85ffad67be77a27cab19c1f4a05c22b31237a9e

## Verification
- [x] Solution builds successfully
- API compatibility gate: **failure**

---
🤖 Generated with ModularPipelines.OptionsGenerator