### PR TITLE
[Automated] Update yq CLI Options

### DIFF
--- a/src/ModularPipelines.Yq/Options/YqEvalAllOptions.Generated.cs
+++ b/src/ModularPipelines.Yq/Options/YqEvalAllOptions.Generated.cs
@@ -269,6 +269,7 @@ public record YqEvalAllOptions : YqOptions
     /// <summary>
     /// enables using RawToken method instead Token. Commonly disables namespace translations. See https://pkg.go.dev/encoding/xml#Decoder.RawToken for details. (default true)
     /// </summary>
+    [SecretValue]
     [CliOption("--xml-raw-token", Format = OptionFormat.EqualsSeparated)]
     public bool? XmlRawToken { get; set; }
 

--- a/src/ModularPipelines.Yq/Options/YqEvalOptions.Generated.cs
+++ b/src/ModularPipelines.Yq/Options/YqEvalOptions.Generated.cs
@@ -269,6 +269,7 @@ public record YqEvalOptions : YqOptions
     /// <summary>
     /// enables using RawToken method instead Token. Commonly disables namespace translations. See https://pkg.go.dev/encoding/xml#Decoder.RawToken for details. (default true)
     /// </summary>
+    [SecretValue]
     [CliOption("--xml-raw-token", Format = OptionFormat.EqualsSeparated)]
     public bool? XmlRawToken { get; set; }
 


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **yq** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- yq (yq (https://github.com/mikefarah/yq/) version v4.53.3): 2 commands, tree 328b5b077fb40b3d69b15529bbcc453b6d65385140018db3cd2467f0e69454ee

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator