### PR TITLE
[Automated] Update jq CLI Options

### DIFF
--- a/src/ModularPipelines.Jq/Options/JqExecuteOptions.Generated.cs
+++ b/src/ModularPipelines.Jq/Options/JqExecuteOptions.Generated.cs
@@ -178,12 +178,6 @@ public record JqExecuteOptions : JqOptions
     public bool? ExitStatus { get; set; }
 
     /// <summary>
-    /// Open input/output streams in binary mode
-    /// </summary>
-    [CliFlag("--binary", ShortForm = "-b", PreferShortForm = true)]
-    public bool? Binary { get; set; }
-
-    /// <summary>
     /// show the version
     /// </summary>
     [CliFlag("--version", ShortForm = "-V")]
@@ -206,6 +200,12 @@ public record JqExecuteOptions : JqOptions
     /// </summary>
     [CliOption("--run-tests", ValueArity = CliOptionValueArity.Optional, Phase = CommandLinePhase.Terminal)]
     public CliOptionValue? RunTests { get; set; }
+
+    /// <summary>
+    /// Open input/output streams in binary mode
+    /// </summary>
+    [CliFlag("--binary", ShortForm = "-b", PreferShortForm = true)]
+    public bool? Binary { get; set; }
 
     /// <summary>
     /// The jq filter expression to apply


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **jq** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- jq (jq-1.8.2): 1 commands, tree c84d384f2a25cca2a8fde5eb61b0f81f728e5f778a232211b176ea80143877bc

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator