### PR TITLE
[Automated] Update skopeo CLI Options

### DIFF
--- a/src/ModularPipelines.Skopeo/Options/SkopeoCopyOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoCopyOptions.Generated.cs
@@ -234,7 +234,6 @@ public record SkopeoCopyOptions(
     /// <summary>
     /// Read a passphrase for signing an image from PATH
     /// </summary>
-    [SecretValue]
     [CliOption("--sign-passphrase-file", Format = OptionFormat.EqualsSeparated)]
     public string? SignPassphraseFile { get; set; }
 
@@ -304,6 +303,6 @@ public record SkopeoCopyOptions(
     /// The command options operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? CommandOptions { get; set; }
+    public IEnumerable<string>? CommandOptions { get; set; }
 
 }

--- a/src/ModularPipelines.Skopeo/Options/SkopeoDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoDeleteOptions.Generated.cs
@@ -100,6 +100,6 @@ public record SkopeoDeleteOptions(
     /// The command options operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? CommandOptions { get; set; }
+    public IEnumerable<string>? CommandOptions { get; set; }
 
 }

--- a/src/ModularPipelines.Skopeo/Options/SkopeoGenerateSigstoreKeyOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoGenerateSigstoreKeyOptions.Generated.cs
@@ -37,7 +37,6 @@ public record SkopeoGenerateSigstoreKeyOptions(
     /// <summary>
     /// Read a passphrase for the private key from PATH
     /// </summary>
-    [SecretValue]
     [CliOption("--passphrase-file", Format = OptionFormat.EqualsSeparated)]
     public string? PassphraseFile { get; set; }
 
@@ -45,6 +44,6 @@ public record SkopeoGenerateSigstoreKeyOptions(
     /// The command options operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? CommandOptions { get; set; }
+    public IEnumerable<string>? CommandOptions { get; set; }
 
 }

--- a/src/ModularPipelines.Skopeo/Options/SkopeoInspectOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoInspectOptions.Generated.cs
@@ -124,6 +124,6 @@ public record SkopeoInspectOptions(
     /// The command options operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? CommandOptions { get; set; }
+    public IEnumerable<string>? CommandOptions { get; set; }
 
 }

--- a/src/ModularPipelines.Skopeo/Options/SkopeoListTagsOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoListTagsOptions.Generated.cs
@@ -88,6 +88,6 @@ public record SkopeoListTagsOptions(
     /// The command options operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? CommandOptions { get; set; }
+    public IEnumerable<string>? CommandOptions { get; set; }
 
 }

--- a/src/ModularPipelines.Skopeo/Options/SkopeoLoginOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoLoginOptions.Generated.cs
@@ -87,6 +87,6 @@ public record SkopeoLoginOptions(
     /// The command options operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? CommandOptions { get; set; }
+    public IEnumerable<string>? CommandOptions { get; set; }
 
 }

--- a/src/ModularPipelines.Skopeo/Options/SkopeoLogoutOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoLogoutOptions.Generated.cs
@@ -56,6 +56,6 @@ public record SkopeoLogoutOptions(
     /// The command options operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? CommandOptions { get; set; }
+    public IEnumerable<string>? CommandOptions { get; set; }
 
 }

--- a/src/ModularPipelines.Skopeo/Options/SkopeoStandaloneSignOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoStandaloneSignOptions.Generated.cs
@@ -40,7 +40,6 @@ public record SkopeoStandaloneSignOptions(
     /// <summary>
     /// file that contains a passphrase for the --sign-by key
     /// </summary>
-    [SecretValue]
     [CliOption("--passphrase-file", Format = OptionFormat.EqualsSeparated)]
     public string? PassphraseFile { get; set; }
 
@@ -48,6 +47,6 @@ public record SkopeoStandaloneSignOptions(
     /// The command options operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? CommandOptions { get; set; }
+    public IEnumerable<string>? CommandOptions { get; set; }
 
 }

--- a/src/ModularPipelines.Skopeo/Options/SkopeoSyncOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoSyncOptions.Generated.cs
@@ -169,7 +169,6 @@ public record SkopeoSyncOptions(
     /// <summary>
     /// File that contains a passphrase for the --sign-by key
     /// </summary>
-    [SecretValue]
     [CliOption("--sign-passphrase-file", Format = OptionFormat.EqualsSeparated)]
     public string? SignPassphraseFile { get; set; }
 
@@ -233,6 +232,6 @@ public record SkopeoSyncOptions(
     /// The command options operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
-    public string? CommandOptions { get; set; }
+    public IEnumerable<string>? CommandOptions { get; set; }
 
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **skopeo** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- skopeo (skopeo version 1.13.3): 11 commands, tree 71df545926b8f3395c60d1ed9e037569395c16b401bff0417eacdfb16d3d7908

## Verification
- [x] Solution builds successfully
- API compatibility gate: **failure**

---
🤖 Generated with ModularPipelines.OptionsGenerator