### PR TITLE
[Automated] Update podman CLI Options

### DIFF
--- a/src/ModularPipelines.Podman/Options/PodmanBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanBuildOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Podman.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Podman.Options;
 
@@ -408,7 +409,7 @@ public record PodmanBuildOptions : PodmanOptions
     /// Pull image policy ("always/true"|"missing"|"never/false"|"newer") (default "missing")
     /// </summary>
     [CliOption("--pull", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Pull { get; set; }
+    public CliOptionValue? Pull { get; set; }
 
     /// <summary>
     /// refrain from announcing build instructions and image read/write progress

--- a/src/ModularPipelines.Podman/Options/PodmanFarmBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanFarmBuildOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Podman.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Podman.Options;
 
@@ -372,7 +373,7 @@ public record PodmanFarmBuildOptions : PodmanOptions
     /// Pull image policy ("always/true"|"missing"|"never/false"|"newer") (default "missing")
     /// </summary>
     [CliOption("--pull", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Pull { get; set; }
+    public CliOptionValue? Pull { get; set; }
 
     /// <summary>
     /// refrain from announcing build instructions and image read/write progress

--- a/src/ModularPipelines.Podman/Options/PodmanImageBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanImageBuildOptions.Generated.cs
@@ -9,6 +9,7 @@ using System.CodeDom.Compiler;
 using System.Diagnostics.CodeAnalysis;
 using ModularPipelines.Attributes;
 using ModularPipelines.Podman.Options;
+using ModularPipelines.Models;
 
 namespace ModularPipelines.Podman.Options;
 
@@ -408,7 +409,7 @@ public record PodmanImageBuildOptions : PodmanOptions
     /// Pull image policy ("always/true"|"missing"|"never/false"|"newer") (default "missing")
     /// </summary>
     [CliOption("--pull", Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]
-    public string? Pull { get; set; }
+    public CliOptionValue? Pull { get; set; }
 
     /// <summary>
     /// refrain from announcing build instructions and image read/write progress

--- a/src/ModularPipelines.Podman/Options/PodmanImageListOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanImageListOptions.Generated.cs
@@ -69,7 +69,7 @@ public record PodmanImageListOptions : PodmanOptions
     public bool? Quiet { get; set; }
 
     /// <summary>
-    /// Sort by created, id, repository, size, tag (default "created")
+    /// Sort by size, tag, created, id, repository (default "created")
     /// </summary>
     [CliOption("--sort", Format = OptionFormat.EqualsSeparated)]
     public string? Sort { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanImagePushOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanImagePushOptions.Generated.cs
@@ -129,7 +129,6 @@ public record PodmanImagePushOptions(
     /// <summary>
     /// Read a passphrase for signing an image from PATH
     /// </summary>
-    [SecretValue]
     [CliOption("--sign-passphrase-file", Format = OptionFormat.EqualsSeparated)]
     public string? SignPassphraseFile { get; set; }
 

--- a/src/ModularPipelines.Podman/Options/PodmanImagesOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanImagesOptions.Generated.cs
@@ -69,7 +69,7 @@ public record PodmanImagesOptions : PodmanOptions
     public bool? Quiet { get; set; }
 
     /// <summary>
-    /// Sort by created, id, repository, size, tag (default "created")
+    /// Sort by repository, size, tag, created, id (default "created")
     /// </summary>
     [CliOption("--sort", Format = OptionFormat.EqualsSeparated)]
     public string? Sort { get; set; }

--- a/src/ModularPipelines.Podman/Options/PodmanManifestPushOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanManifestPushOptions.Generated.cs
@@ -123,7 +123,6 @@ public record PodmanManifestPushOptions(
     /// <summary>
     /// Read a passphrase for signing an image from PATH
     /// </summary>
-    [SecretValue]
     [CliOption("--sign-passphrase-file", Format = OptionFormat.EqualsSeparated)]
     public string? SignPassphraseFile { get; set; }
 

--- a/src/ModularPipelines.Podman/Options/PodmanPushOptions.Generated.cs
+++ b/src/ModularPipelines.Podman/Options/PodmanPushOptions.Generated.cs
@@ -129,7 +129,6 @@ public record PodmanPushOptions(
     /// <summary>
     /// Read a passphrase for signing an image from PATH
     /// </summary>
-    [SecretValue]
     [CliOption("--sign-passphrase-file", Format = OptionFormat.EqualsSeparated)]
     public string? SignPassphraseFile { get; set; }
 


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **podman** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- podman (podman version 4.9.3): 224 commands, tree 3498384ddb9819ffcda1e4726408cbd804661370adc49a5a9561ed08b75b28cb

## Verification
- [x] Solution builds successfully
- API compatibility gate: **failure**

---
🤖 Generated with ModularPipelines.OptionsGenerator