### PR TITLE
Switch NuGet publishing to trusted publishing

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -330,6 +330,9 @@ jobs:
             check_name: pipeline (ubuntu-latest)
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+      id-token: write
     # Most healthy runs finish in 20-25 minutes, but a known successful run took 55 minutes.
     # Keep margin above that variance while bounding starvation well below GitHub's six-hour
     # default; hang diagnostics still upload from the always-run artifact step.
@@ -358,13 +361,11 @@ jobs:
         shell: bash
         env:
           DOTNET_FORMAT_PUSH_TOKEN: ${{ secrets.DOTNET_FORMAT_PUSH_TOKEN }}
-          NUGET_API_KEY: ${{ secrets.NuGet__ApiKey }}
           ADMIN_TOKEN: ${{ secrets.ADMIN_TOKEN }}
           CODACY_API_KEY: ${{ secrets.CODACY_APIKEY }}
         run: |
           for secret in \
             "$DOTNET_FORMAT_PUSH_TOKEN" \
-            "$NUGET_API_KEY" \
             "$ADMIN_TOKEN" \
             "$CODACY_API_KEY"
           do
@@ -434,6 +435,13 @@ jobs:
             echo "::endgroup::"
           done < <(sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' BuildSolutions.txt)
 
+      - name: NuGet login
+        if: ${{ github.ref == 'refs/heads/main' && github.event.inputs.publish-packages == 'true' && matrix.os == 'ubuntu-latest' }}
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Run Pipeline
         shell: bash
         run: |
@@ -448,7 +456,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           DOTNET_ENVIRONMENT: ${{ github.ref == 'refs/heads/main' && 'Production' || 'Development' }}
-          NuGet__ApiKey: ${{ github.ref == 'refs/heads/main' && secrets.NuGet__ApiKey || null }}
+          NuGet__ApiKey: ${{ steps.login.outputs.NUGET_API_KEY }}
           GitHub__Actor: ${{ github.actor }}
           GitHub__Repository__Id: ${{ github.repository_id }}
           GitHub__StandardToken: ${{ secrets.DOTNET_FORMAT_PUSH_TOKEN }}


### PR DESCRIPTION
## Summary
- request GitHub OIDC tokens for NuGet trusted publishing
- use NuGet/login@v1 with ${{ secrets.NUGET_USER }} to exchange for a short-lived NuGet API key
- pass steps.login.outputs.NUGET_API_KEY into the existing publish step or pipeline input

## Validation
- parsed the modified workflow YAML files locally
- ran git diff --check

## Follow-up
A matching trusted publishing policy must be configured on nuget.org for this repository and workflow file before the next publish run.