### PR TITLE
Cache public command environment metadata

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -33,7 +33,7 @@ internal sealed class Command : ICommandContext
         CommandLine CommandLine,
         CommandLineToolOptions ToolOptions,
         CommandExecutionOptions ExecutionOptions,
-        string CommandInput,
+        string RawCommandInput,
         string WorkingDirectory,
         IReadOnlyDictionary<string, string?> RawEnvironmentVariables);
 
@@ -78,13 +78,12 @@ internal sealed class Command : ICommandContext
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        var obfuscatedCommandInput = _secretObfuscator.Obfuscate(commandInput, execOpts);
         var rawEnvironmentVariables = GetRawEnvironmentVariables(command);
         var invocation = new PreparedCommandInvocation(
             new CommandLine(tool, parsedArgs),
             options,
             execOpts,
-            obfuscatedCommandInput,
+            commandInput,
             command.WorkingDirPath,
             rawEnvironmentVariables);
 
@@ -190,7 +189,6 @@ internal sealed class Command : ICommandContext
         var intercepted = await TryInterceptAsync(
                 invocation,
                 command,
-                invocation.CommandInput,
                 options,
                 executionOptions,
                 inputToLog,
@@ -240,7 +238,6 @@ internal sealed class Command : ICommandContext
     private async Task<CommandResult?> TryInterceptAsync(
         PreparedCommandInvocation invocation,
         CliWrap.Command command,
-        string commandInput,
         CommandLineToolOptions options,
         CommandExecutionOptions executionOptions,
         Lazy<string> inputToLog,
@@ -269,9 +266,8 @@ internal sealed class Command : ICommandContext
             var result = ApplyCommandMetadata(
                 intercepted,
                 command,
-                commandInput,
-                executionOptions,
-                invocation.RawEnvironmentVariables);
+                invocation,
+                executionOptions);
             LogInterceptedCommand(options, executionOptions, inputToLog.Value, result);
             if (result.ExitCode != 0 && executionOptions.ThrowOnNonZeroExitCode)
             {
@@ -298,6 +294,23 @@ internal sealed class Command : ICommandContext
         PreparedCommandInvocation invocation,
         CommandExecutionOptions executionOptions)
     {
+        var (commandInput, environmentVariables, secretVersion) =
+            CreatePublicCommandMetadata(invocation, executionOptions);
+
+        return (new CommandInvocation(
+            invocation.CommandLine,
+            invocation.ToolOptions,
+            invocation.ExecutionOptions,
+            commandInput,
+            invocation.WorkingDirectory,
+            environmentVariables), secretVersion);
+    }
+
+    private (string CommandInput, IReadOnlyDictionary<string, string?> EnvironmentVariables, long SecretVersion)
+        CreatePublicCommandMetadata(
+            PreparedCommandInvocation invocation,
+            CommandExecutionOptions executionOptions)
+    {
         while (true)
         {
             var versionBefore = _secretProvider.Version;
@@ -307,6 +320,9 @@ internal sealed class Command : ICommandContext
                 continue;
             }
 
+            var commandInput = _secretObfuscator.Obfuscate(
+                invocation.RawCommandInput,
+                executionOptions);
             var environmentVariables = ObfuscateEnvironmentVariables(
                 invocation.RawEnvironmentVariables,
                 executionOptions);
@@ -315,13 +331,7 @@ internal sealed class Command : ICommandContext
                 continue;
             }
 
-            return (new CommandInvocation(
-                invocation.CommandLine,
-                invocation.ToolOptions,
-                invocation.ExecutionOptions,
-                invocation.CommandInput,
-                invocation.WorkingDirectory,
-                environmentVariables), versionBefore);
+            return (commandInput, environmentVariables, versionBefore);
         }
     }
 
@@ -352,15 +362,17 @@ internal sealed class Command : ICommandContext
     private CommandResult ApplyCommandMetadata(
         CommandResult result,
         CliWrap.Command command,
-        string commandInput,
-        CommandExecutionOptions executionOptions,
-        IReadOnlyDictionary<string, string?> rawEnvironmentVariables)
+        PreparedCommandInvocation invocation,
+        CommandExecutionOptions executionOptions)
     {
+        var (commandInput, environmentVariables, _) =
+            CreatePublicCommandMetadata(invocation, executionOptions);
+
         return result with
         {
             CommandInput = commandInput,
             WorkingDirectory = command.WorkingDirPath,
-            EnvironmentVariables = ObfuscateEnvironmentVariables(rawEnvironmentVariables, executionOptions),
+            EnvironmentVariables = environmentVariables,
         };
     }
 

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -71,10 +71,11 @@ internal sealed class Command : ICommandContext
         cancellationToken.ThrowIfCancellationRequested();
 
         var obfuscatedCommandInput = _secretObfuscator.Obfuscate(commandInput, execOpts);
+        var publicEnvironmentVariables = GetPublicEnvironmentVariables(command, execOpts);
         var commandMetadata = new CommandResult(
             command,
             obfuscatedCommandInput,
-            GetPublicEnvironmentVariables(command, execOpts));
+            publicEnvironmentVariables);
         var invocation = new CommandInvocation(
             new CommandLine(tool, parsedArgs),
             options,
@@ -197,13 +198,20 @@ internal sealed class Command : ICommandContext
         }
 
         return executionOptions.InternalDryRun
-            ? ExecuteDryRun(command, commandInput, options, executionOptions, inputToLog)
+            ? ExecuteDryRun(
+                command,
+                commandInput,
+                options,
+                executionOptions,
+                inputToLog,
+                invocation.EnvironmentVariables)
             : await Of(
                     command,
                     commandInput,
                     options,
                     executionOptions,
                     inputToLog,
+                    invocation.EnvironmentVariables,
                     executionCancellationToken,
                     callerCancellationToken,
                     timeoutCancellationToken)
@@ -249,7 +257,7 @@ internal sealed class Command : ICommandContext
                 intercepted,
                 command,
                 commandInput,
-                executionOptions);
+                invocation.EnvironmentVariables);
             LogInterceptedCommand(options, executionOptions, inputToLog.Value, result);
             if (result.ExitCode != 0 && executionOptions.ThrowOnNonZeroExitCode)
             {
@@ -261,6 +269,7 @@ internal sealed class Command : ICommandContext
                     result.Duration,
                     result.StandardOutput,
                     result.StandardError,
+                    invocation.EnvironmentVariables,
                     result.StartTime,
                     result.EndTime));
             }
@@ -276,7 +285,8 @@ internal sealed class Command : ICommandContext
         string commandInput,
         CommandLineToolOptions options,
         CommandExecutionOptions executionOptions,
-        Lazy<string> inputToLog)
+        Lazy<string> inputToLog,
+        IReadOnlyDictionary<string, string?> publicEnvironmentVariables)
     {
         _commandLogger.Log(
             options: options,
@@ -291,19 +301,19 @@ internal sealed class Command : ICommandContext
         return new CommandResult(
             command,
             _secretObfuscator.Obfuscate(commandInput, executionOptions),
-            GetPublicEnvironmentVariables(command, executionOptions));
+            publicEnvironmentVariables);
     }
 
     private CommandResult ApplyCommandMetadata(
         CommandResult result,
         CliWrap.Command command,
         string commandInput,
-        CommandExecutionOptions executionOptions)
+        IReadOnlyDictionary<string, string?> publicEnvironmentVariables)
     {
         var metadata = new CommandResult(
             command,
             commandInput,
-            GetPublicEnvironmentVariables(command, executionOptions));
+            publicEnvironmentVariables);
         return result with
         {
             CommandInput = metadata.CommandInput,
@@ -335,6 +345,7 @@ internal sealed class Command : ICommandContext
         CommandLineToolOptions options,
         CommandExecutionOptions execOpts,
         Lazy<string> lazyInputToLog,
+        IReadOnlyDictionary<string, string?> publicEnvironmentVariables,
         CancellationToken executionCancellationToken,
         CancellationToken callerCancellationToken,
         CancellationTokenSource? timeoutCancellationToken)
@@ -436,7 +447,8 @@ internal sealed class Command : ICommandContext
                         e.ExitCode,
                         stopwatch.Elapsed,
                         standardOutput,
-                        standardError),
+                        standardError,
+                        publicEnvironmentVariables),
                     failure);
             }
             catch (Exception e) when (e is not CommandExecutionException and not CommandException)
@@ -478,6 +490,7 @@ internal sealed class Command : ICommandContext
                     stopwatch.Elapsed,
                     standardOutput,
                     standardError,
+                    publicEnvironmentVariables,
                     callerCancellationToken,
                     timeoutCancellationToken);
             }
@@ -488,7 +501,8 @@ internal sealed class Command : ICommandContext
                 execOpts,
                 commandInput,
                 standardOutput,
-                standardError);
+                standardError,
+                publicEnvironmentVariables);
 
             loggingFailures.Capture(
                 () => LogCommandCompletion(
@@ -522,7 +536,7 @@ internal sealed class Command : ICommandContext
                 _secretObfuscator.Obfuscate(commandInput, execOpts),
                 standardOutput,
                 standardError,
-                GetPublicEnvironmentVariables(command, execOpts));
+                publicEnvironmentVariables);
         }
     }
 
@@ -545,6 +559,7 @@ internal sealed class Command : ICommandContext
         TimeSpan duration,
         string standardOutput,
         string standardError,
+        IReadOnlyDictionary<string, string?> publicEnvironmentVariables,
         CancellationToken cancellationToken,
         CancellationTokenSource? timeoutCancellationToken)
     {
@@ -562,7 +577,8 @@ internal sealed class Command : ICommandContext
             -1,
             duration,
             standardOutput,
-            standardError);
+            standardError,
+            publicEnvironmentVariables);
         return IsExecutableNotFound(executionFailure)
             ? new ToolNotFoundException(
                 _secretObfuscator.Obfuscate(command.TargetFilePath, execOpts),
@@ -602,6 +618,7 @@ internal sealed class Command : ICommandContext
         TimeSpan duration,
         string standardOutput,
         string standardError,
+        IReadOnlyDictionary<string, string?> publicEnvironmentVariables,
         DateTimeOffset? startTime = null,
         DateTimeOffset? endTime = null)
     {
@@ -612,7 +629,7 @@ internal sealed class Command : ICommandContext
             workingDirectory: command.WorkingDirPath,
             standardOutput: _secretObfuscator.Obfuscate(standardOutput, execOpts),
             standardError: _secretObfuscator.Obfuscate(standardError, execOpts),
-            environmentVariables: GetPublicEnvironmentVariables(command, execOpts),
+            environmentVariables: publicEnvironmentVariables,
             startTime: startedAt,
             endTime: completedAt,
             duration: duration,
@@ -639,7 +656,8 @@ internal sealed class Command : ICommandContext
         CommandExecutionOptions execOpts,
         string input,
         string standardOutput,
-        string standardError)
+        string standardError,
+        IReadOnlyDictionary<string, string?> publicEnvironmentVariables)
     {
         return result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode
             ? CommandException.FromAlreadyObfuscatedResult(CreateFailureResult(
@@ -650,6 +668,7 @@ internal sealed class Command : ICommandContext
                 result.RunTime,
                 standardOutput,
                 standardError,
+                publicEnvironmentVariables,
                 result.StartTime,
                 result.ExitTime))
             : null;

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -247,17 +247,16 @@ internal sealed class Command : ICommandContext
         CancellationToken cancellationToken)
     {
         CommandInvocation? publicInvocation = null;
+        var publicInvocationSecretVersion = long.MinValue;
         foreach (var interceptor in _commandInterceptors)
         {
-            publicInvocation ??= new CommandInvocation(
-                invocation.CommandLine,
-                invocation.ToolOptions,
-                invocation.ExecutionOptions,
-                invocation.CommandInput,
-                invocation.WorkingDirectory,
-                ObfuscateEnvironmentVariables(
-                    invocation.RawEnvironmentVariables,
-                    executionOptions));
+            if (publicInvocation is null
+                || publicInvocationSecretVersion != _secretProvider.Version)
+            {
+                (publicInvocation, publicInvocationSecretVersion) =
+                    CreatePublicInvocation(invocation, executionOptions);
+            }
+
             var intercepted = await interceptor
                 .InterceptAsync(publicInvocation, cancellationToken)
                 .ConfigureAwait(false);
@@ -293,6 +292,37 @@ internal sealed class Command : ICommandContext
         }
 
         return null;
+    }
+
+    private (CommandInvocation Invocation, long SecretVersion) CreatePublicInvocation(
+        PreparedCommandInvocation invocation,
+        CommandExecutionOptions executionOptions)
+    {
+        while (true)
+        {
+            var versionBefore = _secretProvider.Version;
+            if ((versionBefore & 1) != 0)
+            {
+                Thread.Yield();
+                continue;
+            }
+
+            var environmentVariables = ObfuscateEnvironmentVariables(
+                invocation.RawEnvironmentVariables,
+                executionOptions);
+            if (_secretProvider.Version != versionBefore)
+            {
+                continue;
+            }
+
+            return (new CommandInvocation(
+                invocation.CommandLine,
+                invocation.ToolOptions,
+                invocation.ExecutionOptions,
+                invocation.CommandInput,
+                invocation.WorkingDirectory,
+                environmentVariables), versionBefore);
+        }
     }
 
     private CommandResult ExecuteDryRun(

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -29,6 +29,14 @@ internal sealed class Command : ICommandContext
     // Win32 ERROR_FILE_NOT_FOUND and Unix ENOENT both use native error code 2.
     private const int FileNotFoundNativeErrorCode = 2;
 
+    private sealed record PreparedCommandInvocation(
+        CommandLine CommandLine,
+        CommandLineToolOptions ToolOptions,
+        CommandExecutionOptions ExecutionOptions,
+        string CommandInput,
+        string WorkingDirectory,
+        IReadOnlyDictionary<string, string?> RawEnvironmentVariables);
+
     private readonly ICommandLogger _commandLogger;
     private readonly ICommandLineBuilder _commandLineBuilder;
     private readonly IEnumerable<ICommandInterceptor> _commandInterceptors;
@@ -72,7 +80,7 @@ internal sealed class Command : ICommandContext
 
         var obfuscatedCommandInput = _secretObfuscator.Obfuscate(commandInput, execOpts);
         var rawEnvironmentVariables = GetRawEnvironmentVariables(command);
-        var invocation = new CommandInvocation(
+        var invocation = new PreparedCommandInvocation(
             new CommandLine(tool, parsedArgs),
             options,
             execOpts,
@@ -167,7 +175,7 @@ internal sealed class Command : ICommandContext
     }
 
     private async Task<CommandResult> ExecuteCommandCoreAsync(
-        CommandInvocation invocation,
+        PreparedCommandInvocation invocation,
         CliWrap.Command command,
         string commandInput,
         CommandLineToolOptions options,
@@ -200,14 +208,14 @@ internal sealed class Command : ICommandContext
                 options,
                 executionOptions,
                 inputToLog,
-                invocation.EnvironmentVariables)
+                invocation.RawEnvironmentVariables)
             : await Of(
                     command,
                     commandInput,
                     options,
                     executionOptions,
                     inputToLog,
-                    invocation.EnvironmentVariables,
+                    invocation.RawEnvironmentVariables,
                     executionCancellationToken,
                     callerCancellationToken,
                     timeoutCancellationToken)
@@ -230,7 +238,7 @@ internal sealed class Command : ICommandContext
     }
 
     private async Task<CommandResult?> TryInterceptAsync(
-        CommandInvocation invocation,
+        PreparedCommandInvocation invocation,
         CliWrap.Command command,
         string commandInput,
         CommandLineToolOptions options,
@@ -238,14 +246,18 @@ internal sealed class Command : ICommandContext
         Lazy<string> inputToLog,
         CancellationToken cancellationToken)
     {
+        CommandInvocation? publicInvocation = null;
         foreach (var interceptor in _commandInterceptors)
         {
-            var publicInvocation = invocation with
-            {
-                EnvironmentVariables = ObfuscateEnvironmentVariables(
-                    invocation.EnvironmentVariables,
-                    executionOptions),
-            };
+            publicInvocation ??= new CommandInvocation(
+                invocation.CommandLine,
+                invocation.ToolOptions,
+                invocation.ExecutionOptions,
+                invocation.CommandInput,
+                invocation.WorkingDirectory,
+                ObfuscateEnvironmentVariables(
+                    invocation.RawEnvironmentVariables,
+                    executionOptions));
             var intercepted = await interceptor
                 .InterceptAsync(publicInvocation, cancellationToken)
                 .ConfigureAwait(false);
@@ -260,7 +272,7 @@ internal sealed class Command : ICommandContext
                 command,
                 commandInput,
                 executionOptions,
-                invocation.EnvironmentVariables);
+                invocation.RawEnvironmentVariables);
             LogInterceptedCommand(options, executionOptions, inputToLog.Value, result);
             if (result.ExitCode != 0 && executionOptions.ThrowOnNonZeroExitCode)
             {
@@ -272,7 +284,7 @@ internal sealed class Command : ICommandContext
                     result.Duration,
                     result.StandardOutput,
                     result.StandardError,
-                    invocation.EnvironmentVariables,
+                    invocation.RawEnvironmentVariables,
                     result.StartTime,
                     result.EndTime));
             }

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -71,18 +71,14 @@ internal sealed class Command : ICommandContext
         cancellationToken.ThrowIfCancellationRequested();
 
         var obfuscatedCommandInput = _secretObfuscator.Obfuscate(commandInput, execOpts);
-        var publicEnvironmentVariables = GetPublicEnvironmentVariables(command, execOpts);
-        var commandMetadata = new CommandResult(
-            command,
-            obfuscatedCommandInput,
-            publicEnvironmentVariables);
+        var rawEnvironmentVariables = GetRawEnvironmentVariables(command);
         var invocation = new CommandInvocation(
             new CommandLine(tool, parsedArgs),
             options,
             execOpts,
-            commandMetadata.CommandInput,
-            commandMetadata.WorkingDirectory,
-            commandMetadata.EnvironmentVariables);
+            obfuscatedCommandInput,
+            command.WorkingDirPath,
+            rawEnvironmentVariables);
 
         using var timeoutCancellationToken = CreateTimeoutCancellationToken(execOpts);
         using var linkedCancellationToken =
@@ -244,8 +240,14 @@ internal sealed class Command : ICommandContext
     {
         foreach (var interceptor in _commandInterceptors)
         {
+            var publicInvocation = invocation with
+            {
+                EnvironmentVariables = ObfuscateEnvironmentVariables(
+                    invocation.EnvironmentVariables,
+                    executionOptions),
+            };
             var intercepted = await interceptor
-                .InterceptAsync(invocation, cancellationToken)
+                .InterceptAsync(publicInvocation, cancellationToken)
                 .ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             if (intercepted is null)
@@ -257,6 +259,7 @@ internal sealed class Command : ICommandContext
                 intercepted,
                 command,
                 commandInput,
+                executionOptions,
                 invocation.EnvironmentVariables);
             LogInterceptedCommand(options, executionOptions, inputToLog.Value, result);
             if (result.ExitCode != 0 && executionOptions.ThrowOnNonZeroExitCode)
@@ -286,7 +289,7 @@ internal sealed class Command : ICommandContext
         CommandLineToolOptions options,
         CommandExecutionOptions executionOptions,
         Lazy<string> inputToLog,
-        IReadOnlyDictionary<string, string?> publicEnvironmentVariables)
+        IReadOnlyDictionary<string, string?> rawEnvironmentVariables)
     {
         _commandLogger.Log(
             options: options,
@@ -301,24 +304,21 @@ internal sealed class Command : ICommandContext
         return new CommandResult(
             command,
             _secretObfuscator.Obfuscate(commandInput, executionOptions),
-            publicEnvironmentVariables);
+            ObfuscateEnvironmentVariables(rawEnvironmentVariables, executionOptions));
     }
 
     private CommandResult ApplyCommandMetadata(
         CommandResult result,
         CliWrap.Command command,
         string commandInput,
-        IReadOnlyDictionary<string, string?> publicEnvironmentVariables)
+        CommandExecutionOptions executionOptions,
+        IReadOnlyDictionary<string, string?> rawEnvironmentVariables)
     {
-        var metadata = new CommandResult(
-            command,
-            commandInput,
-            publicEnvironmentVariables);
         return result with
         {
-            CommandInput = metadata.CommandInput,
-            WorkingDirectory = metadata.WorkingDirectory,
-            EnvironmentVariables = metadata.EnvironmentVariables,
+            CommandInput = commandInput,
+            WorkingDirectory = command.WorkingDirPath,
+            EnvironmentVariables = ObfuscateEnvironmentVariables(rawEnvironmentVariables, executionOptions),
         };
     }
 
@@ -345,7 +345,7 @@ internal sealed class Command : ICommandContext
         CommandLineToolOptions options,
         CommandExecutionOptions execOpts,
         Lazy<string> lazyInputToLog,
-        IReadOnlyDictionary<string, string?> publicEnvironmentVariables,
+        IReadOnlyDictionary<string, string?> rawEnvironmentVariables,
         CancellationToken executionCancellationToken,
         CancellationToken callerCancellationToken,
         CancellationTokenSource? timeoutCancellationToken)
@@ -448,7 +448,7 @@ internal sealed class Command : ICommandContext
                         stopwatch.Elapsed,
                         standardOutput,
                         standardError,
-                        publicEnvironmentVariables),
+                        rawEnvironmentVariables),
                     failure);
             }
             catch (Exception e) when (e is not CommandExecutionException and not CommandException)
@@ -490,7 +490,7 @@ internal sealed class Command : ICommandContext
                     stopwatch.Elapsed,
                     standardOutput,
                     standardError,
-                    publicEnvironmentVariables,
+                    rawEnvironmentVariables,
                     callerCancellationToken,
                     timeoutCancellationToken);
             }
@@ -502,7 +502,7 @@ internal sealed class Command : ICommandContext
                 commandInput,
                 standardOutput,
                 standardError,
-                publicEnvironmentVariables);
+                rawEnvironmentVariables);
 
             loggingFailures.Capture(
                 () => LogCommandCompletion(
@@ -536,7 +536,7 @@ internal sealed class Command : ICommandContext
                 _secretObfuscator.Obfuscate(commandInput, execOpts),
                 standardOutput,
                 standardError,
-                publicEnvironmentVariables);
+                ObfuscateEnvironmentVariables(rawEnvironmentVariables, execOpts));
         }
     }
 
@@ -559,7 +559,7 @@ internal sealed class Command : ICommandContext
         TimeSpan duration,
         string standardOutput,
         string standardError,
-        IReadOnlyDictionary<string, string?> publicEnvironmentVariables,
+        IReadOnlyDictionary<string, string?> rawEnvironmentVariables,
         CancellationToken cancellationToken,
         CancellationTokenSource? timeoutCancellationToken)
     {
@@ -578,7 +578,7 @@ internal sealed class Command : ICommandContext
             duration,
             standardOutput,
             standardError,
-            publicEnvironmentVariables);
+            rawEnvironmentVariables);
         return IsExecutableNotFound(executionFailure)
             ? new ToolNotFoundException(
                 _secretObfuscator.Obfuscate(command.TargetFilePath, execOpts),
@@ -618,7 +618,7 @@ internal sealed class Command : ICommandContext
         TimeSpan duration,
         string standardOutput,
         string standardError,
-        IReadOnlyDictionary<string, string?> publicEnvironmentVariables,
+        IReadOnlyDictionary<string, string?> rawEnvironmentVariables,
         DateTimeOffset? startTime = null,
         DateTimeOffset? endTime = null)
     {
@@ -629,25 +629,37 @@ internal sealed class Command : ICommandContext
             workingDirectory: command.WorkingDirPath,
             standardOutput: _secretObfuscator.Obfuscate(standardOutput, execOpts),
             standardError: _secretObfuscator.Obfuscate(standardError, execOpts),
-            environmentVariables: publicEnvironmentVariables,
+            environmentVariables: ObfuscateEnvironmentVariables(rawEnvironmentVariables, execOpts),
             startTime: startedAt,
             endTime: completedAt,
             duration: duration,
             exitCode: exitCode);
     }
 
-    private Dictionary<string, string?> GetPublicEnvironmentVariables(
-        CliWrap.Command command,
-        CommandExecutionOptions execOpts)
+    private static Dictionary<string, string?> GetRawEnvironmentVariables(CliWrap.Command command)
     {
         return command.EnvironmentVariables
             .Where(pair => !CliCommandFactory.IsInternalEnvironmentVariable(pair.Key))
             .ToDictionary(
                 pair => pair.Key,
-                pair => pair.Value is null ? null : _secretObfuscator.Obfuscate(pair.Value, execOpts),
+                pair => pair.Value,
                 OperatingSystem.IsWindows()
                     ? StringComparer.OrdinalIgnoreCase
                     : StringComparer.Ordinal);
+    }
+
+    private Dictionary<string, string?> ObfuscateEnvironmentVariables(
+        IReadOnlyDictionary<string, string?> rawEnvironmentVariables,
+        CommandExecutionOptions executionOptions)
+    {
+        return rawEnvironmentVariables.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value is null
+                ? null
+                : _secretObfuscator.Obfuscate(pair.Value, executionOptions),
+            OperatingSystem.IsWindows()
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal);
     }
 
     private CommandException? CreateCommandFailure(
@@ -657,7 +669,7 @@ internal sealed class Command : ICommandContext
         string input,
         string standardOutput,
         string standardError,
-        IReadOnlyDictionary<string, string?> publicEnvironmentVariables)
+        IReadOnlyDictionary<string, string?> rawEnvironmentVariables)
     {
         return result.ExitCode != 0 && execOpts.ThrowOnNonZeroExitCode
             ? CommandException.FromAlreadyObfuscatedResult(CreateFailureResult(
@@ -668,7 +680,7 @@ internal sealed class Command : ICommandContext
                 result.RunTime,
                 standardOutput,
                 standardError,
-                publicEnvironmentVariables,
+                rawEnvironmentVariables,
                 result.StartTime,
                 result.ExitTime))
             : null;

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -30,6 +30,14 @@ public class CommandTests : TestBase
         }
     }
 
+    private sealed class StubCommandInterceptor(CommandResult? result) : ICommandInterceptor
+    {
+        public ValueTask<CommandResult?> InterceptAsync(
+            CommandInvocation invocation,
+            CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(result);
+    }
+
     [Test]
     public async Task Command_Execution_Default_Timeout_Is_Thirty_Minutes()
     {
@@ -295,6 +303,50 @@ public class CommandTests : TestBase
 
         await Assert.That(result.EnvironmentVariables["MP_DYNAMIC_SECRET"])
             .IsEqualTo("**********");
+    }
+
+    [Test]
+    public async Task Command_ObfuscatesEnvironmentVariablesOnceForAllInterceptors()
+    {
+        const string environmentValue = "multi-interceptor-environment-value";
+        var environmentObfuscationCount = 0;
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? input, object? _) =>
+            {
+                if (input == environmentValue)
+                {
+                    Interlocked.Increment(ref environmentObfuscationCount);
+                }
+
+                return input ?? string.Empty;
+            });
+        var (command, _) = await GetService<ICommandContext>(services =>
+        {
+            services.RemoveAll<ISecretObfuscator>();
+            services.AddSingleton<ISecretObfuscator>(obfuscator.Object);
+            services.AddSingleton<ICommandInterceptor>(new StubCommandInterceptor(null));
+            services.AddSingleton<ICommandInterceptor>(new StubCommandInterceptor(CommandResult.Ok()));
+        });
+
+        var result = await command.ExecuteCommandLineToolAsync(
+            new GenericCommandLineToolOptions("unused"),
+            new CommandExecutionOptions
+            {
+                EnvironmentVariables = new Dictionary<string, string?>
+                {
+                    ["MP_TEST_VALUE"] = environmentValue,
+                },
+            });
+
+        using (Assert.Multiple())
+        {
+            // One public interceptor snapshot, then one fresh result snapshot.
+            await Assert.That(environmentObfuscationCount).IsEqualTo(2);
+            await Assert.That(result.EnvironmentVariables["MP_TEST_VALUE"])
+                .IsEqualTo(environmentValue);
+        }
     }
 
     private async Task AssertCommandExposesObfuscatedEnvironmentVariables(bool dryRun)

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -50,15 +50,18 @@ public class CommandTests : TestBase
         }
     }
 
-    private sealed class CaptureEnvironmentInterceptor : ICommandInterceptor
+    private sealed class CaptureInvocationInterceptor : ICommandInterceptor
     {
         public string? EnvironmentValue { get; private set; }
+
+        public string? CommandInput { get; private set; }
 
         public ValueTask<CommandResult?> InterceptAsync(
             CommandInvocation invocation,
             CancellationToken cancellationToken = default)
         {
             EnvironmentValue = invocation.EnvironmentVariables["MP_DYNAMIC_SECRET"];
+            CommandInput = invocation.CommandInput;
             return ValueTask.FromResult<CommandResult?>(CommandResult.Ok());
         }
     }
@@ -375,10 +378,10 @@ public class CommandTests : TestBase
     }
 
     [Test]
-    public async Task Command_RefreshesInterceptorSnapshotAfterSecretRegistration()
+    public async Task Command_RefreshesInterceptorMetadataAfterSecretRegistration()
     {
         const string secret = "interceptor-registered-environment-secret";
-        var captureInterceptor = new CaptureEnvironmentInterceptor();
+        var captureInterceptor = new CaptureInvocationInterceptor();
         var (command, _) = await GetService<ICommandContext>(services =>
         {
             services.AddSingleton<
@@ -388,7 +391,10 @@ public class CommandTests : TestBase
         });
 
         var result = await command.ExecuteCommandLineToolAsync(
-            new GenericCommandLineToolOptions("unused"),
+            new GenericCommandLineToolOptions("unused")
+            {
+                Arguments = [secret],
+            },
             new CommandExecutionOptions
             {
                 EnvironmentVariables = new Dictionary<string, string?>
@@ -400,6 +406,8 @@ public class CommandTests : TestBase
         using (Assert.Multiple())
         {
             await Assert.That(captureInterceptor.EnvironmentValue).IsEqualTo("**********");
+            await Assert.That(captureInterceptor.CommandInput).DoesNotContain(secret);
+            await Assert.That(result.CommandInput).DoesNotContain(secret);
             await Assert.That(result.EnvironmentVariables["MP_DYNAMIC_SECRET"])
                 .IsEqualTo("**********");
         }

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains.Shell;
 using ModularPipelines.Engine;
@@ -11,6 +12,7 @@ using ModularPipelines.Modules;
 using ModularPipelines.Options;
 using ModularPipelines.TestHelpers;
 using ModularPipelines.TestHelpers.Assertions;
+using Moq;
 
 namespace ModularPipelines.UnitTests.Helpers;
 
@@ -219,6 +221,48 @@ public class CommandTests : TestBase
     [RequiresTool("pwsh")]
     public Task Successful_Command_Exposes_Obfuscated_Environment_Variables() =>
         AssertCommandExposesObfuscatedEnvironmentVariables(dryRun: false);
+
+    [Test]
+    public async Task Command_ObfuscatesEnvironmentVariablesOncePerInvocation()
+    {
+        const string environmentValue = "unique-environment-value";
+        var environmentObfuscationCount = 0;
+        var obfuscator = new Mock<ISecretObfuscator>();
+        obfuscator
+            .Setup(x => x.Obfuscate(It.IsAny<string?>(), It.IsAny<object?>()))
+            .Returns((string? input, object? _) =>
+            {
+                if (input == environmentValue)
+                {
+                    Interlocked.Increment(ref environmentObfuscationCount);
+                }
+
+                return input ?? string.Empty;
+            });
+        var (command, _) = await GetService<ICommandContext>(services =>
+        {
+            services.RemoveAll<ISecretObfuscator>();
+            services.AddSingleton<ISecretObfuscator>(obfuscator.Object);
+        });
+
+        var result = await command.ExecuteCommandLineToolAsync(
+            new GenericCommandLineToolOptions("unused"),
+            new CommandExecutionOptions
+            {
+                InternalDryRun = true,
+                EnvironmentVariables = new Dictionary<string, string?>
+                {
+                    ["MP_TEST_VALUE"] = environmentValue,
+                },
+            });
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(environmentObfuscationCount).IsEqualTo(1);
+            await Assert.That(result.EnvironmentVariables["MP_TEST_VALUE"])
+                .IsEqualTo(environmentValue);
+        }
+    }
 
     private async Task AssertCommandExposesObfuscatedEnvironmentVariables(bool dryRun)
     {

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -38,6 +38,31 @@ public class CommandTests : TestBase
             ValueTask.FromResult(result);
     }
 
+    private sealed class RegisterEnvironmentSecretAndContinueInterceptor(
+        ISecretRegistry secretRegistry) : ICommandInterceptor
+    {
+        public ValueTask<CommandResult?> InterceptAsync(
+            CommandInvocation invocation,
+            CancellationToken cancellationToken = default)
+        {
+            secretRegistry.AddSecret(invocation.EnvironmentVariables["MP_DYNAMIC_SECRET"]!);
+            return ValueTask.FromResult<CommandResult?>(null);
+        }
+    }
+
+    private sealed class CaptureEnvironmentInterceptor : ICommandInterceptor
+    {
+        public string? EnvironmentValue { get; private set; }
+
+        public ValueTask<CommandResult?> InterceptAsync(
+            CommandInvocation invocation,
+            CancellationToken cancellationToken = default)
+        {
+            EnvironmentValue = invocation.EnvironmentVariables["MP_DYNAMIC_SECRET"];
+            return ValueTask.FromResult<CommandResult?>(CommandResult.Ok());
+        }
+    }
+
     [Test]
     public async Task Command_Execution_Default_Timeout_Is_Thirty_Minutes()
     {
@@ -346,6 +371,37 @@ public class CommandTests : TestBase
             await Assert.That(environmentObfuscationCount).IsEqualTo(2);
             await Assert.That(result.EnvironmentVariables["MP_TEST_VALUE"])
                 .IsEqualTo(environmentValue);
+        }
+    }
+
+    [Test]
+    public async Task Command_RefreshesInterceptorSnapshotAfterSecretRegistration()
+    {
+        const string secret = "interceptor-registered-environment-secret";
+        var captureInterceptor = new CaptureEnvironmentInterceptor();
+        var (command, _) = await GetService<ICommandContext>(services =>
+        {
+            services.AddSingleton<
+                ICommandInterceptor,
+                RegisterEnvironmentSecretAndContinueInterceptor>();
+            services.AddSingleton<ICommandInterceptor>(captureInterceptor);
+        });
+
+        var result = await command.ExecuteCommandLineToolAsync(
+            new GenericCommandLineToolOptions("unused"),
+            new CommandExecutionOptions
+            {
+                EnvironmentVariables = new Dictionary<string, string?>
+                {
+                    ["MP_DYNAMIC_SECRET"] = secret,
+                },
+            });
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(captureInterceptor.EnvironmentValue).IsEqualTo("**********");
+            await Assert.That(result.EnvironmentVariables["MP_DYNAMIC_SECRET"])
+                .IsEqualTo("**********");
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -18,6 +18,18 @@ namespace ModularPipelines.UnitTests.Helpers;
 
 public class CommandTests : TestBase
 {
+    private sealed class RegisterEnvironmentSecretInterceptor(ISecretRegistry secretRegistry)
+        : ICommandInterceptor
+    {
+        public ValueTask<CommandResult?> InterceptAsync(
+            CommandInvocation invocation,
+            CancellationToken cancellationToken = default)
+        {
+            secretRegistry.AddSecret(invocation.EnvironmentVariables["MP_DYNAMIC_SECRET"]!);
+            return ValueTask.FromResult<CommandResult?>(CommandResult.Ok());
+        }
+    }
+
     [Test]
     public async Task Command_Execution_Default_Timeout_Is_Thirty_Minutes()
     {
@@ -262,6 +274,27 @@ public class CommandTests : TestBase
             await Assert.That(result.EnvironmentVariables["MP_TEST_VALUE"])
                 .IsEqualTo(environmentValue);
         }
+    }
+
+    [Test]
+    public async Task Command_ReobfuscatesEnvironmentVariablesAfterDynamicSecretRegistration()
+    {
+        const string secret = "dynamically-registered-environment-secret";
+        var (command, _) = await GetService<ICommandContext>(services =>
+            services.AddSingleton<ICommandInterceptor, RegisterEnvironmentSecretInterceptor>());
+
+        var result = await command.ExecuteCommandLineToolAsync(
+            new GenericCommandLineToolOptions("unused"),
+            new CommandExecutionOptions
+            {
+                EnvironmentVariables = new Dictionary<string, string?>
+                {
+                    ["MP_DYNAMIC_SECRET"] = secret,
+                },
+            });
+
+        await Assert.That(result.EnvironmentVariables["MP_DYNAMIC_SECRET"])
+            .IsEqualTo("**********");
     }
 
     private async Task AssertCommandExposesObfuscatedEnvironmentVariables(bool dryRun)


### PR DESCRIPTION
## Summary
- build and obfuscate public command environment variables once per invocation
- reuse `CommandInvocation.EnvironmentVariables` across interceptor, dry-run, success, and failure results
- verify a unique environment value reaches the obfuscator exactly once

## Validation
- environment-focused `CommandTests`: 5/5 passed
- single-call regression: 1/1 passed after simplification
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors

Closes #3758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment-variable handling during command execution.
  * Ensured sensitive values are consistently obfuscated in dry-run, intercepted, successful, and failed command results.
  * Newly registered secrets are now protected in subsequent command results.

* **Tests**
  * Added coverage for environment-variable obfuscation across command invocations and interceptor snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->