### PR TITLE
Track scheduler-ready modules incrementally

### DIFF
--- a/src/ModularPipelines/Engine/ModuleScheduler.cs
+++ b/src/ModularPipelines/Engine/ModuleScheduler.cs
@@ -28,6 +28,7 @@ internal class ModuleScheduler : IModuleScheduler
     private readonly IModuleConstraintEvaluator _constraintEvaluator;
     private readonly ISchedulerStatusReporter _statusReporter;
     private readonly ConcurrentDictionary<Type, ModuleState> _moduleStates;
+    private readonly HashSet<ModuleState> _pendingReadyModules;
     private readonly HashSet<ModuleState> _queuedModules;
     private readonly HashSet<ModuleState> _executingModules;
     private readonly ModuleStateQueries _stateQueries;
@@ -63,6 +64,7 @@ internal class ModuleScheduler : IModuleScheduler
         _constraintEvaluator = constraintEvaluator;
         _statusReporter = statusReporter;
         _moduleStates = new ConcurrentDictionary<Type, ModuleState>();
+        _pendingReadyModules = new HashSet<ModuleState>();
         _queuedModules = new HashSet<ModuleState>();
         _executingModules = new HashSet<ModuleState>();
         _stateQueries = new ModuleStateQueries(_moduleStates);
@@ -84,6 +86,7 @@ internal class ModuleScheduler : IModuleScheduler
             _moduleStates,
             _queuedModules,
             _executingModules,
+            _pendingReadyModules,
             _stateQueries,
             _stateLock,
             _schedulerNotification,
@@ -117,6 +120,14 @@ internal class ModuleScheduler : IModuleScheduler
         {
             ConfigureScheduling(state);
             ConfigureDependencies(state, availableModuleTypes);
+            if (state.IsReadyToExecute)
+            {
+                _pendingReadyModules.Add(state);
+            }
+            else
+            {
+                _pendingReadyModules.Remove(state);
+            }
         }
 
         _logger.LogDebug(
@@ -511,18 +522,19 @@ internal class ModuleScheduler : IModuleScheduler
         try
         {
             // Sort by priority descending so higher priority modules are queued first
-            var potentiallyReadyModules = _moduleStates.Values
-                .Where(m => m.IsReadyToExecute)
+            var potentiallyReadyModules = _pendingReadyModules
                 .OrderByDescending(m => (int) m.Priority)
                 .ToArray();
 
             // Constraint-free pipelines need no active-module scan or pairwise evaluation.
             // When constraints exist, keep one list and append modules queued in this cycle.
-            var activeModules = _hasSchedulingConstraints
-                ? _moduleStates.Values
-                    .Where(m => m.State == ModuleExecutionState.Queued || m.State == ModuleExecutionState.Executing)
-                    .ToList()
-                : null;
+            List<ModuleState>? activeModules = null;
+            if (_hasSchedulingConstraints)
+            {
+                activeModules = new List<ModuleState>(_queuedModules.Count + _executingModules.Count);
+                activeModules.AddRange(_queuedModules);
+                activeModules.AddRange(_executingModules);
+            }
 
             modulesToQueue = new List<ModuleState>();
             metricsData = new List<(Type, DateTimeOffset, ModulePriority, ExecutionType, DateTimeOffset)>();
@@ -544,6 +556,7 @@ internal class ModuleScheduler : IModuleScheduler
                 _stateCounters.Transition(moduleState.State, ModuleExecutionState.Queued);
                 moduleState.State = ModuleExecutionState.Queued;
                 moduleState.QueuedTime = now;
+                _pendingReadyModules.Remove(moduleState);
                 _queuedModules.Add(moduleState);
 
                 activeModules?.Add(moduleState);

--- a/src/ModularPipelines/Engine/ModuleStateTracker.cs
+++ b/src/ModularPipelines/Engine/ModuleStateTracker.cs
@@ -25,6 +25,7 @@ internal class ModuleStateTracker : IModuleStateTracker
     private readonly ConcurrentDictionary<Type, ModuleState> _moduleStates;
     private readonly HashSet<ModuleState> _queuedModules;
     private readonly HashSet<ModuleState> _executingModules;
+    private readonly HashSet<ModuleState> _pendingReadyModules;
     private readonly ModuleStateQueries _stateQueries;
     private readonly ModuleStateCounters _stateCounters;
     private readonly ReaderWriterLockSlim _stateLock;
@@ -41,6 +42,7 @@ internal class ModuleStateTracker : IModuleStateTracker
     /// <param name="moduleStates">Shared dictionary of module states.</param>
     /// <param name="queuedModules">Set of modules currently in the queue.</param>
     /// <param name="executingModules">Set of modules currently executing.</param>
+    /// <param name="pendingReadyModules">Set of pending modules whose dependencies are resolved.</param>
     /// <param name="stateQueries">Query helper for module states.</param>
     /// <param name="stateLock">Shared lock for state access synchronization.</param>
     /// <param name="schedulerNotification">Semaphore to notify scheduler of state changes.</param>
@@ -54,6 +56,7 @@ internal class ModuleStateTracker : IModuleStateTracker
         ConcurrentDictionary<Type, ModuleState> moduleStates,
         HashSet<ModuleState> queuedModules,
         HashSet<ModuleState> executingModules,
+        HashSet<ModuleState> pendingReadyModules,
         ModuleStateQueries stateQueries,
         ReaderWriterLockSlim stateLock,
         SemaphoreSlim schedulerNotification,
@@ -67,6 +70,7 @@ internal class ModuleStateTracker : IModuleStateTracker
         _moduleStates = moduleStates;
         _queuedModules = queuedModules;
         _executingModules = executingModules;
+        _pendingReadyModules = pendingReadyModules;
         _stateQueries = stateQueries;
         _stateCounters = stateCounters ?? CreateCounters(moduleStates);
         _stateLock = stateLock;
@@ -117,11 +121,13 @@ internal class ModuleStateTracker : IModuleStateTracker
                 _stateCounters.Transition(state.State, ModuleExecutionState.Pending);
                 state.State = ModuleExecutionState.Pending;
                 state.QueuedTime = null;
+                _pendingReadyModules.Add(state);
                 needsReschedule = true;
             }
             else
             {
                 _queuedModules.Remove(state);
+                _pendingReadyModules.Remove(state);
                 _stateCounters.Transition(state.State, ModuleExecutionState.Executing);
                 state.State = ModuleExecutionState.Executing;
                 _executingModules.Add(state);
@@ -183,6 +189,7 @@ internal class ModuleStateTracker : IModuleStateTracker
 
             _queuedModules.Remove(state);
             _executingModules.Remove(state);
+            _pendingReadyModules.Remove(state);
             _stateCounters.Transition(state.State, ModuleExecutionState.Completed);
             state.State = ModuleExecutionState.Completed;
             state.CompletionTime = _timeProvider.GetUtcNow();
@@ -274,6 +281,7 @@ internal class ModuleStateTracker : IModuleStateTracker
                     var originalState = moduleState.State;
                     _queuedModules.Remove(moduleState);
                     _executingModules.Remove(moduleState);
+                    _pendingReadyModules.Remove(moduleState);
                     _stateCounters.Transition(originalState, ModuleExecutionState.Completed);
                     moduleState.State = ModuleExecutionState.Completed;
                     cancelledModules.Add((moduleState, originalState));
@@ -350,6 +358,7 @@ internal class ModuleStateTracker : IModuleStateTracker
             if (dependent.IsReadyToExecute)
             {
                 dependent.ReadyTime = _timeProvider.GetUtcNow();
+                _pendingReadyModules.Add(dependent);
                 updates.Add((dependent, true));
             }
             else

--- a/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleExecutorLoggingTests.cs
@@ -758,6 +758,7 @@ public class ModuleExecutorLoggingTests
             moduleStates,
             [],
             [],
+            [],
             new ModuleStateQueries(moduleStates),
             new ReaderWriterLockSlim(),
             new SemaphoreSlim(0),

--- a/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/ModuleSchedulerDynamicCycleTests.cs
@@ -36,6 +36,21 @@ public class ModuleSchedulerDynamicCycleTests
             CancellationToken cancellationToken) => Task.FromResult<string>(nameof(CompletedDependencyModule));
     }
 
+    private class ReadyDependencyModule : Module<string>
+    {
+        protected internal override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string>(nameof(ReadyDependencyModule));
+    }
+
+    [ModularPipelines.Attributes.DependsOn<ReadyDependencyModule>]
+    private class NewlyReadyDependentModule : Module<string>
+    {
+        protected internal override Task<string> ExecuteAsync(
+            IModuleContext context,
+            CancellationToken cancellationToken) => Task.FromResult<string>(nameof(NewlyReadyDependentModule));
+    }
+
     [ModularPipelines.Attributes.NotInParallel]
     private class DeferredConstraintModule : Module<string>
     {
@@ -120,6 +135,30 @@ public class ModuleSchedulerDynamicCycleTests
             Times.Never);
 
         scheduler.MarkModuleCompleted(module.ModuleType, success: true);
+        await schedulerTask.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task RunSchedulerAsync_QueuesDependentWhenDependencyCompletes()
+    {
+        var constraintEvaluator = new Mock<IModuleConstraintEvaluator>();
+        constraintEvaluator
+            .Setup(x => x.CanStartExecution(It.IsAny<ModuleState>(), It.IsAny<IEnumerable<ModuleState>>()))
+            .Returns(true);
+        using var scheduler = CreateScheduler(constraintEvaluator.Object);
+        scheduler.InitializeModules([new NewlyReadyDependentModule(), new ReadyDependencyModule()]);
+
+        var schedulerTask = scheduler.RunSchedulerAsync(CancellationToken.None);
+        var dependency = await scheduler.ReadyModules.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(dependency.ModuleType).IsEqualTo(typeof(ReadyDependencyModule));
+        await Assert.That(scheduler.MarkModuleStarted(dependency.ModuleType)).IsTrue();
+        scheduler.MarkModuleCompleted(dependency.ModuleType, success: true);
+
+        var dependent = await scheduler.ReadyModules.ReadAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(dependent.ModuleType).IsEqualTo(typeof(NewlyReadyDependentModule));
+        await Assert.That(scheduler.MarkModuleStarted(dependent.ModuleType)).IsTrue();
+        scheduler.MarkModuleCompleted(dependent.ModuleType, success: true);
+
         await schedulerTask.WaitAsync(TimeSpan.FromSeconds(5));
     }
 

--- a/test/ModularPipelines.UnitTests/Engine/TaskCompletionSourceTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/TaskCompletionSourceTests.cs
@@ -200,6 +200,7 @@ public class TaskCompletionSourceTests
             moduleStates,
             [],
             [],
+            [],
             new ModuleStateQueries(moduleStates),
             new ReaderWriterLockSlim(),
             new SemaphoreSlim(0),


### PR DESCRIPTION
## Summary
- maintain an incremental set of pending modules whose dependencies are resolved
- build constraint-active modules from the existing queued and executing sets
- cover the dependency-completion wakeup path with a scheduler regression test

## Validation
- `ModuleScheduler*` tests: 9 passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors

Closes #3759