### PR TITLE
Explain missing tool integration registration

### DIFF
--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -27,6 +27,9 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
     private const string ToolPropertyMetadataPrefix =
         "ModularPipelines.ToolProperty:";
 
+    private const string ToolTypeIdentityMetadataPrefix =
+        "ModularPipelines.ToolTypeIdentity:";
+
     private static readonly ImmutableHashSet<string> ShadowedToolPropertyNames =
     [
         "Equals",
@@ -102,13 +105,15 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
             new IntegrationRegistration(
                 method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
                 method.Name),
-            GetToolProperties(method.ContainingType),
+            GetToolProperties(method.ContainingType, context.SemanticModel.Compilation),
             GetGeneratedTypeName(context.SemanticModel.Compilation.AssemblyName),
             method.ToDisplayString(),
             location);
     }
 
-    private static EquatableArray<ToolProperty> GetToolProperties(INamedTypeSymbol type)
+    private static EquatableArray<ToolProperty> GetToolProperties(
+        INamedTypeSymbol type,
+        Compilation compilation)
     {
         return type.GetMembers()
             .OfType<IMethodSymbol>()
@@ -122,13 +127,67 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
                 && method.Parameters[0].Type.ToDisplayString() == PipelineContextFullName
                 && method.ReturnType.IsReferenceType
                 && IsPubliclyAccessible(method.ReturnType))
-            .Select(static method => new ToolProperty(
+            .Select(method => new ToolProperty(
                 method.Name,
                 method.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
+                GetTypeIdentity(method.ReturnType, compilation),
                 method.ToDisplayString(),
                 method.Locations.FirstOrDefault(),
                 method.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)))
             .ToImmutableArray();
+    }
+
+    private static string GetTypeIdentity(ITypeSymbol type, Compilation compilation)
+    {
+        if (type.TypeKind == TypeKind.Dynamic)
+        {
+            return GetTypeIdentity(
+                compilation.GetSpecialType(SpecialType.System_Object),
+                compilation);
+        }
+
+        if (type is IArrayTypeSymbol arrayType)
+        {
+            return $"{GetTypeIdentity(arrayType.ElementType, compilation)}[{new string(',', arrayType.Rank - 1)}]";
+        }
+
+        if (type is not INamedTypeSymbol namedType)
+        {
+            return type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+        }
+
+        var definition = namedType.OriginalDefinition;
+        var typeNames = new Stack<string>();
+        for (var current = definition; current is not null; current = current.ContainingType)
+        {
+            typeNames.Push(current.MetadataName);
+        }
+
+        var namespaceName = definition.ContainingNamespace.IsGlobalNamespace
+            ? string.Empty
+            : $"{definition.ContainingNamespace.ToDisplayString()}.";
+        var identity =
+            $"{definition.ContainingAssembly.Identity.Name}:{namespaceName}{string.Join("+", typeNames)}";
+        var typeArguments = GetAllTypeArguments(namedType).ToArray();
+        return typeArguments.Length == 0
+            ? identity
+            : $"{identity}[{string.Join(",", typeArguments.Select(argument => GetTypeIdentity(argument, compilation)))}]";
+    }
+
+    private static IEnumerable<ITypeSymbol> GetAllTypeArguments(INamedTypeSymbol type)
+    {
+        if (type.ContainingType is { } containingType)
+        {
+            foreach (var typeArgument in GetAllTypeArguments(containingType))
+            {
+                yield return typeArgument;
+            }
+        }
+
+        foreach (var typeArgument in type.TypeArguments)
+        {
+            yield return typeArgument;
+        }
     }
 
     private static EquatableArray<ReferencedToolProperty> GetReferencedToolProperties(
@@ -251,6 +310,10 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
                 "[assembly: global::System.Reflection.AssemblyMetadataAttribute("
                 + $"{Literal(ToolPropertyMetadataPrefix + property.Name)}, "
                 + $"{Literal(property.TypeName)})]");
+            builder.AppendLine(
+                "[assembly: global::System.Reflection.AssemblyMetadataAttribute("
+                + $"{Literal(ToolTypeIdentityMetadataPrefix + property.Name)}, "
+                + $"{Literal(property.TypeIdentity)})]");
         }
 
         builder.AppendLine();
@@ -359,6 +422,7 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
             .Concat(referencedToolProperties.Select(static property => new ToolProperty(
                 property.Name,
                 property.TypeName,
+                TypeIdentity: property.TypeName,
                 MethodName: property.Name,
                 Location: null,
                 property.SourceId)))
@@ -498,6 +562,7 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
     private sealed record ToolProperty(
         string Name,
         string TypeName,
+        string TypeIdentity,
         string MethodName,
         Location? Location,
         string SourceId);

--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -166,13 +166,19 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         var namespaceName = definition.ContainingNamespace.IsGlobalNamespace
             ? string.Empty
             : $"{definition.ContainingNamespace.ToDisplayString()}.";
-        var identity =
-            $"{definition.ContainingAssembly.Identity.Name}:{namespaceName}{string.Join("+", typeNames)}";
+        var assemblyName = NormalizeAssemblyName(definition.ContainingAssembly.Identity.Name);
+        var identity = $"{assemblyName}:{namespaceName}{string.Join("+", typeNames)}";
         var typeArguments = GetAllTypeArguments(namedType).ToArray();
         return typeArguments.Length == 0
             ? identity
             : $"{identity}[{string.Join(",", typeArguments.Select(argument => GetTypeIdentity(argument, compilation)))}]";
     }
+
+    private static string NormalizeAssemblyName(string assemblyName) =>
+        assemblyName is "System" or "mscorlib" or "netstandard"
+        || assemblyName.StartsWith("System.", StringComparison.Ordinal)
+            ? "framework"
+            : assemblyName;
 
     private static IEnumerable<ITypeSymbol> GetAllTypeArguments(INamedTypeSymbol type)
     {

--- a/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/ModularPipelinesIntegrationGenerator.cs
@@ -245,15 +245,12 @@ public sealed class ModularPipelinesIntegrationGenerator : IIncrementalGenerator
         builder.AppendLine(
             "[assembly: global::ModularPipelines.Attributes.ModularPipelinesContextAttribute("
             + "typeof(global::ModularPipelines.Generated.ModularPipelinesContextRegistration))]");
-        if (generatesExtensionMembers)
+        foreach (var property in uniqueToolProperties)
         {
-            foreach (var property in uniqueToolProperties)
-            {
-                builder.AppendLine(
-                    "[assembly: global::System.Reflection.AssemblyMetadataAttribute("
-                    + $"{Literal(ToolPropertyMetadataPrefix + property.Name)}, "
-                    + $"{Literal(property.TypeName)})]");
-            }
+            builder.AppendLine(
+                "[assembly: global::System.Reflection.AssemblyMetadataAttribute("
+                + $"{Literal(ToolPropertyMetadataPrefix + property.Name)}, "
+                + $"{Literal(property.TypeName)})]");
         }
 
         builder.AppendLine();

--- a/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
+++ b/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
@@ -39,8 +39,9 @@ internal class ServicesContext : IServicesContext
         }
 
         var serviceType = typeof(T);
-        throw ToolRegistrationExceptionFactory.IsToolIntegration(serviceType)
-            ? ToolRegistrationExceptionFactory.Create(serviceType)
+        var integrationPackage = ToolRegistrationExceptionFactory.FindIntegrationPackage(serviceType);
+        throw integrationPackage is not null
+            ? ToolRegistrationExceptionFactory.Create(serviceType, integrationPackage)
             : new InvalidOperationException(
                 $"Service '{serviceType.FullName}' is not registered. " +
                 "Register it with the pipeline service collection before building the pipeline.");

--- a/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
+++ b/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
@@ -30,10 +30,21 @@ internal class ServicesContext : IServicesContext
     }
 
     /// <inheritdoc />
-    public T Get<T>() where T : class =>
-        _serviceProvider.GetService<T>() ?? throw new InvalidOperationException(
-            $"Service '{typeof(T).FullName}' is not registered. " +
-            "Register it with the pipeline service collection before building the pipeline.");
+    public T Get<T>() where T : class
+    {
+        var service = _serviceProvider.GetService<T>();
+        if (service is not null)
+        {
+            return service;
+        }
+
+        var serviceType = typeof(T);
+        throw ToolRegistrationExceptionFactory.IsToolIntegration(serviceType)
+            ? ToolRegistrationExceptionFactory.Create(serviceType)
+            : new InvalidOperationException(
+                $"Service '{serviceType.FullName}' is not registered. " +
+                "Register it with the pipeline service collection before building the pipeline.");
+    }
 
     /// <inheritdoc />
     public T? TryGet<T>() where T : class => _serviceProvider.GetService<T>();

--- a/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
+++ b/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
@@ -50,10 +50,9 @@ internal class ServicesContext : IServicesContext
 
         if (assemblyName?.StartsWith(packagePrefix, StringComparison.Ordinal) == true)
         {
-            var integrationName = assemblyName[packagePrefix.Length..];
             return new InvalidOperationException(
                 $"Tool integration service '{serviceType.FullName}' is not registered. " +
-                $"Reference the {assemblyName} package and ensure Register{integrationName}Context() runs. " +
+                $"Reference the {assemblyName} package and call its Register*Context() service collection extension. " +
                 "When using Native AOT, register tool integrations explicitly.");
         }
 

--- a/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
+++ b/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
@@ -30,7 +30,8 @@ internal class ServicesContext : IServicesContext
     }
 
     /// <inheritdoc />
-    public T Get<T>() where T : class => _serviceProvider.GetRequiredService<T>();
+    public T Get<T>() where T : class =>
+        _serviceProvider.GetService<T>() ?? throw CreateMissingServiceException<T>();
 
     /// <inheritdoc />
     public T? TryGet<T>() where T : class => _serviceProvider.GetService<T>();
@@ -40,4 +41,24 @@ internal class ServicesContext : IServicesContext
 
     /// <inheritdoc />
     public PipelineOptions Options => _options.Value;
+
+    private static InvalidOperationException CreateMissingServiceException<T>()
+    {
+        var serviceType = typeof(T);
+        var assemblyName = serviceType.Assembly.GetName().Name;
+        const string packagePrefix = "ModularPipelines.";
+
+        if (assemblyName?.StartsWith(packagePrefix, StringComparison.Ordinal) == true)
+        {
+            var integrationName = assemblyName[packagePrefix.Length..];
+            return new InvalidOperationException(
+                $"Tool integration service '{serviceType.FullName}' is not registered. " +
+                $"Reference the {assemblyName} package and ensure Register{integrationName}Context() runs. " +
+                "When using Native AOT, register tool integrations explicitly.");
+        }
+
+        return new InvalidOperationException(
+            $"Service '{serviceType.FullName}' is not registered. " +
+            "Register it with the pipeline service collection before building the pipeline.");
+    }
 }

--- a/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
+++ b/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
@@ -31,7 +31,9 @@ internal class ServicesContext : IServicesContext
 
     /// <inheritdoc />
     public T Get<T>() where T : class =>
-        _serviceProvider.GetService<T>() ?? throw CreateMissingServiceException<T>();
+        _serviceProvider.GetService<T>() ?? throw new InvalidOperationException(
+            $"Service '{typeof(T).FullName}' is not registered. " +
+            "Register it with the pipeline service collection before building the pipeline.");
 
     /// <inheritdoc />
     public T? TryGet<T>() where T : class => _serviceProvider.GetService<T>();
@@ -41,23 +43,4 @@ internal class ServicesContext : IServicesContext
 
     /// <inheritdoc />
     public PipelineOptions Options => _options.Value;
-
-    private static InvalidOperationException CreateMissingServiceException<T>()
-    {
-        var serviceType = typeof(T);
-        var assemblyName = serviceType.Assembly.GetName().Name;
-        const string packagePrefix = "ModularPipelines.";
-
-        if (assemblyName?.StartsWith(packagePrefix, StringComparison.Ordinal) == true)
-        {
-            return new InvalidOperationException(
-                $"Tool integration service '{serviceType.FullName}' is not registered. " +
-                $"Reference the {assemblyName} package and call its Register*Context() service collection extension. " +
-                "When using Native AOT, register tool integrations explicitly.");
-        }
-
-        return new InvalidOperationException(
-            $"Service '{serviceType.FullName}' is not registered. " +
-            "Register it with the pipeline service collection before building the pipeline.");
-    }
 }

--- a/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
+++ b/src/ModularPipelines/Context/Domains/Implementations/ServicesContext.cs
@@ -39,9 +39,10 @@ internal class ServicesContext : IServicesContext
         }
 
         var serviceType = typeof(T);
-        var integrationPackage = ToolRegistrationExceptionFactory.FindIntegrationPackage(serviceType);
-        throw integrationPackage is not null
-            ? ToolRegistrationExceptionFactory.Create(serviceType, integrationPackage)
+        var integrationAssemblyName =
+            ToolRegistrationExceptionFactory.FindIntegrationAssemblyName(serviceType);
+        throw integrationAssemblyName is not null
+            ? ToolRegistrationExceptionFactory.Create(serviceType, integrationAssemblyName)
             : new InvalidOperationException(
                 $"Service '{serviceType.FullName}' is not registered. " +
                 "Register it with the pipeline service collection before building the pipeline.");

--- a/src/ModularPipelines/Context/IToolsContext.cs
+++ b/src/ModularPipelines/Context/IToolsContext.cs
@@ -13,7 +13,8 @@ public interface IToolsContext
     /// <typeparam name="T">The tool integration type.</typeparam>
     /// <returns>The registered tool integration.</returns>
     /// <exception cref="InvalidOperationException">
-    /// Thrown with package and registration guidance when the integration is not registered.
+    /// Thrown with integration-assembly and registration guidance when the integration
+    /// is not registered.
     /// </exception>
     [EditorBrowsable(EditorBrowsableState.Never)]
     T Get<T>()

--- a/src/ModularPipelines/Context/IToolsContext.cs
+++ b/src/ModularPipelines/Context/IToolsContext.cs
@@ -12,6 +12,9 @@ public interface IToolsContext
     /// </summary>
     /// <typeparam name="T">The tool integration type.</typeparam>
     /// <returns>The registered tool integration.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown with package and registration guidance when the integration is not registered.
+    /// </exception>
     [EditorBrowsable(EditorBrowsableState.Never)]
     T Get<T>()
         where T : class;

--- a/src/ModularPipelines/Context/ToolsContext.cs
+++ b/src/ModularPipelines/Context/ToolsContext.cs
@@ -11,7 +11,7 @@ internal sealed class ToolsContext(IServicesContext services) : IToolsContext
         var toolType = typeof(T);
         return services.TryGet<T>() ?? throw ToolRegistrationExceptionFactory.Create(
             toolType,
-            ToolRegistrationExceptionFactory.FindIntegrationPackage(toolType));
+            ToolRegistrationExceptionFactory.FindIntegrationAssemblyName(toolType));
     }
 }
 
@@ -19,7 +19,7 @@ internal static class ToolRegistrationExceptionFactory
 {
     private const string ToolTypeIdentityMetadataPrefix = "ModularPipelines.ToolTypeIdentity:";
 
-    public static string? FindIntegrationPackage(Type serviceType)
+    public static string? FindIntegrationAssemblyName(Type serviceType)
     {
         var typeIdentity = GetTypeIdentity(serviceType);
         foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
@@ -35,11 +35,12 @@ internal static class ToolRegistrationExceptionFactory
         return null;
     }
 
-    public static InvalidOperationException Create(Type toolType, string? integrationPackage)
+    public static InvalidOperationException Create(Type toolType, string? integrationAssemblyName)
     {
-        var registrationGuidance = integrationPackage is null
+        var registrationGuidance = integrationAssemblyName is null
             ? "Call the service collection extension marked with [ModularPipelinesIntegration]. "
-            : $"Reference the {integrationPackage} package and call its service collection extension marked " +
+            : $"Ensure the integration assembly '{integrationAssemblyName}' is referenced and call its " +
+              "service collection extension marked " +
               "with [ModularPipelinesIntegration]. ";
         return new InvalidOperationException(
             $"Tool integration service '{toolType.FullName}' is not registered. " +
@@ -55,7 +56,8 @@ internal static class ToolRegistrationExceptionFactory
         }
 
         var definition = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
-        var identity = $"{definition.Assembly.GetName().Name}:{definition.FullName}";
+        var assemblyName = NormalizeAssemblyName(definition.Assembly.GetName().Name!);
+        var identity = $"{assemblyName}:{definition.FullName}";
         var typeArguments = type.IsGenericType
             ? type.GetGenericArguments()
             : Type.EmptyTypes;
@@ -63,4 +65,10 @@ internal static class ToolRegistrationExceptionFactory
             ? identity
             : $"{identity}[{string.Join(",", typeArguments.Select(GetTypeIdentity))}]";
     }
+
+    private static string NormalizeAssemblyName(string assemblyName) =>
+        assemblyName is "System" or "mscorlib" or "netstandard"
+        || assemblyName.StartsWith("System.", StringComparison.Ordinal)
+            ? "framework"
+            : assemblyName;
 }

--- a/src/ModularPipelines/Context/ToolsContext.cs
+++ b/src/ModularPipelines/Context/ToolsContext.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using ModularPipelines.Context.Domains;
 
 namespace ModularPipelines.Context;
@@ -5,15 +6,35 @@ namespace ModularPipelines.Context;
 internal sealed class ToolsContext(IServicesContext services) : IToolsContext
 {
     public T Get<T>()
-        where T : class => services.TryGet<T>() ?? throw CreateMissingToolException<T>();
+        where T : class => services.TryGet<T>() ?? throw ToolRegistrationExceptionFactory.Create(typeof(T));
+}
 
-    private static InvalidOperationException CreateMissingToolException<T>()
+internal static class ToolRegistrationExceptionFactory
+{
+    private const string ToolPropertyMetadataPrefix = "ModularPipelines.ToolProperty:";
+
+    public static bool IsToolIntegration(Type serviceType)
     {
-        var toolType = typeof(T);
+        if (serviceType.FullName is not { } fullName)
+        {
+            return false;
+        }
+
+        var metadataTypeName = $"global::{fullName.Replace('+', '.')}";
+        return serviceType.Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .Any(attribute =>
+                attribute.Key.StartsWith(ToolPropertyMetadataPrefix, StringComparison.Ordinal)
+                && string.Equals(attribute.Value, metadataTypeName, StringComparison.Ordinal));
+    }
+
+    public static InvalidOperationException Create(Type toolType)
+    {
         var assemblyName = toolType.Assembly.GetName().Name;
         return new InvalidOperationException(
             $"Tool integration service '{toolType.FullName}' is not registered. " +
-            $"Reference the {assemblyName} package and call its Register*Context() service collection extension. " +
+            $"Reference the {assemblyName} package and call its service collection extension marked " +
+            "with [ModularPipelinesIntegration]. " +
             "When using Native AOT, register tool integrations explicitly.");
     }
 }

--- a/src/ModularPipelines/Context/ToolsContext.cs
+++ b/src/ModularPipelines/Context/ToolsContext.cs
@@ -5,5 +5,15 @@ namespace ModularPipelines.Context;
 internal sealed class ToolsContext(IServicesContext services) : IToolsContext
 {
     public T Get<T>()
-        where T : class => services.Get<T>();
+        where T : class => services.TryGet<T>() ?? throw CreateMissingToolException<T>();
+
+    private static InvalidOperationException CreateMissingToolException<T>()
+    {
+        var toolType = typeof(T);
+        var assemblyName = toolType.Assembly.GetName().Name;
+        return new InvalidOperationException(
+            $"Tool integration service '{toolType.FullName}' is not registered. " +
+            $"Reference the {assemblyName} package and call its Register*Context() service collection extension. " +
+            "When using Native AOT, register tool integrations explicitly.");
+    }
 }

--- a/src/ModularPipelines/Context/ToolsContext.cs
+++ b/src/ModularPipelines/Context/ToolsContext.cs
@@ -6,35 +6,61 @@ namespace ModularPipelines.Context;
 internal sealed class ToolsContext(IServicesContext services) : IToolsContext
 {
     public T Get<T>()
-        where T : class => services.TryGet<T>() ?? throw ToolRegistrationExceptionFactory.Create(typeof(T));
+        where T : class
+    {
+        var toolType = typeof(T);
+        return services.TryGet<T>() ?? throw ToolRegistrationExceptionFactory.Create(
+            toolType,
+            ToolRegistrationExceptionFactory.FindIntegrationPackage(toolType));
+    }
 }
 
 internal static class ToolRegistrationExceptionFactory
 {
-    private const string ToolPropertyMetadataPrefix = "ModularPipelines.ToolProperty:";
+    private const string ToolTypeIdentityMetadataPrefix = "ModularPipelines.ToolTypeIdentity:";
 
-    public static bool IsToolIntegration(Type serviceType)
+    public static string? FindIntegrationPackage(Type serviceType)
     {
-        if (serviceType.FullName is not { } fullName)
+        var typeIdentity = GetTypeIdentity(serviceType);
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
         {
-            return false;
+            if (assembly.GetCustomAttributes<AssemblyMetadataAttribute>().Any(attribute =>
+                    attribute.Key.StartsWith(ToolTypeIdentityMetadataPrefix, StringComparison.Ordinal)
+                    && string.Equals(attribute.Value, typeIdentity, StringComparison.Ordinal)))
+            {
+                return assembly.GetName().Name;
+            }
         }
 
-        var metadataTypeName = $"global::{fullName.Replace('+', '.')}";
-        return serviceType.Assembly
-            .GetCustomAttributes<AssemblyMetadataAttribute>()
-            .Any(attribute =>
-                attribute.Key.StartsWith(ToolPropertyMetadataPrefix, StringComparison.Ordinal)
-                && string.Equals(attribute.Value, metadataTypeName, StringComparison.Ordinal));
+        return null;
     }
 
-    public static InvalidOperationException Create(Type toolType)
+    public static InvalidOperationException Create(Type toolType, string? integrationPackage)
     {
-        var assemblyName = toolType.Assembly.GetName().Name;
+        var registrationGuidance = integrationPackage is null
+            ? "Call the service collection extension marked with [ModularPipelinesIntegration]. "
+            : $"Reference the {integrationPackage} package and call its service collection extension marked " +
+              "with [ModularPipelinesIntegration]. ";
         return new InvalidOperationException(
             $"Tool integration service '{toolType.FullName}' is not registered. " +
-            $"Reference the {assemblyName} package and call its service collection extension marked " +
-            "with [ModularPipelinesIntegration]. " +
+            registrationGuidance +
             "When using Native AOT, register tool integrations explicitly.");
+    }
+
+    private static string GetTypeIdentity(Type type)
+    {
+        if (type.IsArray)
+        {
+            return $"{GetTypeIdentity(type.GetElementType()!)}[{new string(',', type.GetArrayRank() - 1)}]";
+        }
+
+        var definition = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+        var identity = $"{definition.Assembly.GetName().Name}:{definition.FullName}";
+        var typeArguments = type.IsGenericType
+            ? type.GetGenericArguments()
+            : Type.EmptyTypes;
+        return typeArguments.Length == 0
+            ? identity
+            : $"{identity}[{string.Join(",", typeArguments.Select(GetTypeIdentity))}]";
     }
 }

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
@@ -183,6 +183,8 @@ public class ModularPipelinesIntegrationGeneratorTests
             await Assert.That(generatedSource).DoesNotContain("extension(");
             await Assert.That(generatedSource)
                 .Contains("global::GitIntegration.Register(services);");
+            await Assert.That(generatedSource)
+                .Contains("\"ModularPipelines.ToolProperty:Git\", \"global::IGit\"");
         }
     }
 

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
@@ -116,6 +116,42 @@ public class ModularPipelinesIntegrationGeneratorTests
                 .Contains("public global::IGit Git => tools.Get<global::IGit>();");
             await Assert.That(generatedSource)
                 .Contains("\"ModularPipelines.ToolProperty:Git\", \"global::IGit\"");
+            await Assert.That(generatedSource)
+                .Contains("\"ModularPipelines.ToolTypeIdentity:Git\", \"GeneratorTests:IGit\"");
+        }
+    }
+
+    [Test]
+    public async Task Generic_Tool_Accessor_Generates_Runtime_Stable_Type_Identity()
+    {
+        var result = RunGenerator("""
+            using ModularPipelines.Attributes;
+            using ModularPipelines.Context;
+            using Microsoft.Extensions.DependencyInjection;
+
+            public interface IFoo<T>
+            {
+            }
+
+            public static class FooIntegration
+            {
+                [ModularPipelinesIntegration]
+                public static void AddFoo(IServiceCollection services)
+                {
+                }
+
+                public static IFoo<string> Foo(this IPipelineContext context) => throw null!;
+            }
+            """);
+
+        var generatedSource = result.GeneratedTrees.Single().GetText().ToString();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics).IsEmpty();
+            await Assert.That(generatedSource)
+                .Contains("\"ModularPipelines.ToolTypeIdentity:Foo\", " +
+                          "\"GeneratorTests:IFoo`1[System.Private.CoreLib:System.String]\"");
         }
     }
 

--- a/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/ModularPipelinesIntegrationGeneratorTests.cs
@@ -151,7 +151,7 @@ public class ModularPipelinesIntegrationGeneratorTests
             await Assert.That(result.Diagnostics).IsEmpty();
             await Assert.That(generatedSource)
                 .Contains("\"ModularPipelines.ToolTypeIdentity:Foo\", " +
-                          "\"GeneratorTests:IFoo`1[System.Private.CoreLib:System.String]\"");
+                          "\"GeneratorTests:IFoo`1[framework:System.String]\"");
         }
     }
 

--- a/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
@@ -45,7 +45,7 @@ public class ContextExtensionsTests
         mockContext.Setup(c => c.Services).Returns(servicesContext);
 
         // Act & Assert
-        var exception = await Assert.That(() => mockContext.Object.GetService<string>())
+        var exception = await Assert.That(() => mockContext.Object.GetService<TestService>())
             .ThrowsExactly<InvalidOperationException>();
 
         using (Assert.Multiple())

--- a/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Cmd;
+using ModularPipelines.Cmd.Extensions;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains;
 using ModularPipelines.Context.Domains.Environment;
@@ -51,8 +52,28 @@ public class ContextExtensionsTests
         using (Assert.Multiple())
         {
             await Assert.That(exception!.Message).Contains("Register it with the pipeline service collection");
-            await Assert.That(exception.Message).DoesNotContain("Register*Context()");
+            await Assert.That(exception.Message).DoesNotContain("ModularPipelinesIntegration");
             await Assert.That(exception.Message).DoesNotContain("Native AOT");
+        }
+    }
+
+    [Test]
+    public async Task Cmd_WhenIntegrationNotRegistered_ShouldSuggestAttributedRegistration()
+    {
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var servicesContext = CreateServicesContext(serviceProvider);
+        var mockContext = new Mock<IPipelineContext>();
+        mockContext.Setup(c => c.Services).Returns(servicesContext);
+
+        var exception = await Assert.That(() => mockContext.Object.Cmd())
+            .ThrowsExactly<InvalidOperationException>();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("ModularPipelines.Cmd");
+            await Assert.That(exception.Message).Contains("[ModularPipelinesIntegration]");
+            await Assert.That(exception.Message).Contains("Native AOT");
+            await Assert.That(exception.Message).DoesNotContain("Register*Context()");
         }
     }
 
@@ -68,8 +89,9 @@ public class ContextExtensionsTests
         using (Assert.Multiple())
         {
             await Assert.That(exception!.Message).Contains("ModularPipelines.Cmd");
-            await Assert.That(exception.Message).Contains("Register*Context()");
+            await Assert.That(exception.Message).Contains("[ModularPipelinesIntegration]");
             await Assert.That(exception.Message).Contains("Native AOT");
+            await Assert.That(exception.Message).DoesNotContain("Register*Context()");
             await Assert.That(exception.Message).DoesNotContain("No service for type");
         }
     }

--- a/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
@@ -45,8 +45,15 @@ public class ContextExtensionsTests
         mockContext.Setup(c => c.Services).Returns(servicesContext);
 
         // Act & Assert
-        await Assert.That(() => mockContext.Object.GetService<TestService>())
+        var exception = await Assert.That(() => mockContext.Object.GetService<string>())
             .ThrowsExactly<InvalidOperationException>();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("Register it with the pipeline service collection");
+            await Assert.That(exception.Message).DoesNotContain("Register*Context()");
+            await Assert.That(exception.Message).DoesNotContain("Native AOT");
+        }
     }
 
     [Test]
@@ -61,7 +68,7 @@ public class ContextExtensionsTests
         using (Assert.Multiple())
         {
             await Assert.That(exception!.Message).Contains("ModularPipelines.Cmd");
-            await Assert.That(exception.Message).Contains("RegisterCmdContext()");
+            await Assert.That(exception.Message).Contains("Register*Context()");
             await Assert.That(exception.Message).Contains("Native AOT");
             await Assert.That(exception.Message).DoesNotContain("No service for type");
         }

--- a/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Reflection.Emit;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using ModularPipelines.Cmd;
@@ -93,6 +95,39 @@ public class ContextExtensionsTests
             await Assert.That(exception.Message).Contains("Native AOT");
             await Assert.That(exception.Message).DoesNotContain("Register*Context()");
             await Assert.That(exception.Message).DoesNotContain("No service for type");
+        }
+    }
+
+    [Test]
+    public async Task GenericTool_FromContractsAssembly_UsesOwningIntegrationPackage()
+    {
+        const string integrationAssemblyName = "Test.Tool.Integration";
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName(integrationAssemblyName),
+            AssemblyBuilderAccess.Run);
+        var metadataConstructor = typeof(AssemblyMetadataAttribute).GetConstructor(
+            [typeof(string), typeof(string)])!;
+        var genericDefinition = typeof(IGenericTool<>);
+        var stringType = typeof(string);
+        var typeIdentity =
+            $"{genericDefinition.Assembly.GetName().Name}:{genericDefinition.FullName}" +
+            $"[{stringType.Assembly.GetName().Name}:{stringType.FullName}]";
+        assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(
+            metadataConstructor,
+            ["ModularPipelines.ToolTypeIdentity:GenericTool", typeIdentity]));
+
+        var package = ToolRegistrationExceptionFactory.FindIntegrationPackage(
+            typeof(IGenericTool<string>));
+        var exception = ToolRegistrationExceptionFactory.Create(
+            typeof(IGenericTool<string>),
+            package);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(package).IsEqualTo(integrationAssemblyName);
+            await Assert.That(exception.Message).Contains(integrationAssemblyName);
+            await Assert.That(exception.Message)
+                .DoesNotContain($"Reference the {genericDefinition.Assembly.GetName().Name} package");
         }
     }
 
@@ -224,6 +259,10 @@ public class ContextExtensionsTests
     }
 
     private class TestService
+    {
+    }
+
+    private interface IGenericTool<T>
     {
     }
 }

--- a/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using ModularPipelines.Cmd;
 using ModularPipelines.Context;
 using ModularPipelines.Context.Domains;
 using ModularPipelines.Context.Domains.Environment;
@@ -46,6 +47,24 @@ public class ContextExtensionsTests
         // Act & Assert
         await Assert.That(() => mockContext.Object.GetService<TestService>())
             .ThrowsExactly<InvalidOperationException>();
+    }
+
+    [Test]
+    public async Task GetTool_WhenIntegrationNotRegistered_ShouldSuggestExplicitRegistration()
+    {
+        using var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var toolsContext = new ToolsContext(CreateServicesContext(serviceProvider));
+
+        var exception = await Assert.That(() => toolsContext.Get<ICmd>())
+            .ThrowsExactly<InvalidOperationException>();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(exception!.Message).Contains("ModularPipelines.Cmd");
+            await Assert.That(exception.Message).Contains("RegisterCmdContext()");
+            await Assert.That(exception.Message).Contains("Native AOT");
+            await Assert.That(exception.Message).DoesNotContain("No service for type");
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/ContextExtensionsTests.cs
@@ -99,7 +99,7 @@ public class ContextExtensionsTests
     }
 
     [Test]
-    public async Task GenericTool_FromContractsAssembly_UsesOwningIntegrationPackage()
+    public async Task GenericTool_FromContractsAssembly_UsesOwningIntegrationAssembly()
     {
         const string integrationAssemblyName = "Test.Tool.Integration";
         var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
@@ -111,23 +111,24 @@ public class ContextExtensionsTests
         var stringType = typeof(string);
         var typeIdentity =
             $"{genericDefinition.Assembly.GetName().Name}:{genericDefinition.FullName}" +
-            $"[{stringType.Assembly.GetName().Name}:{stringType.FullName}]";
+            $"[framework:{stringType.FullName}]";
         assemblyBuilder.SetCustomAttribute(new CustomAttributeBuilder(
             metadataConstructor,
             ["ModularPipelines.ToolTypeIdentity:GenericTool", typeIdentity]));
 
-        var package = ToolRegistrationExceptionFactory.FindIntegrationPackage(
+        var integrationAssembly = ToolRegistrationExceptionFactory.FindIntegrationAssemblyName(
             typeof(IGenericTool<string>));
         var exception = ToolRegistrationExceptionFactory.Create(
             typeof(IGenericTool<string>),
-            package);
+            integrationAssembly);
 
         using (Assert.Multiple())
         {
-            await Assert.That(package).IsEqualTo(integrationAssemblyName);
-            await Assert.That(exception.Message).Contains(integrationAssemblyName);
+            await Assert.That(integrationAssembly).IsEqualTo(integrationAssemblyName);
             await Assert.That(exception.Message)
-                .DoesNotContain($"Reference the {genericDefinition.Assembly.GetName().Name} package");
+                .Contains($"integration assembly '{integrationAssemblyName}'");
+            await Assert.That(exception.Message)
+                .DoesNotContain(" package");
         }
     }
 


### PR DESCRIPTION
## Summary
- replace raw DI missing-service errors with actionable registration guidance
- infer ModularPipelines integration package and `Register*Context()` method from the service assembly
- call out explicit integration registration for Native AOT
- retain generic guidance for non-integration services

## Validation
- `ContextExtensionsTests`: 17/17 passed
- `ModularPipelines.slnx` Release build: 0 warnings, 0 errors
- the current base has an unrelated `ValidationTests.ThrowingPipelineExceptionValidator` interface compile mismatch; it was corrected only temporarily to run the focused tests and is not part of this diff

Closes #3772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of optional services when requested integrations are unavailable.
  - Missing service errors now distinguish tool integrations from general services.
  - Error messages provide actionable registration guidance, including Native AOT considerations and required package information.

- **Documentation**
  - Documented the expected error behavior and guidance shown when an integration has not been registered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->