### PR TITLE
Fix obsolete test pipeline validator contract

### DIFF
--- a/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
+++ b/test/ModularPipelines.UnitTests/Validation/ValidationTests.cs
@@ -197,8 +197,8 @@ public class ValidationTests
     {
         public int Order => int.MaxValue;
 
-        public ValidationResult Validate(IServiceProvider services) =>
-            throw new PipelineException("No modules can be serialized.");
+        public Task<ValidationResult> ValidateAsync(IServiceProvider services) =>
+            Task.FromException<ValidationResult>(new PipelineException("No modules can be serialized."));
     }
 
     [Test]


### PR DESCRIPTION
Closes #3924.

Updates the test-only ThrowingPipelineExceptionValidator to implement the current asynchronous IPipelineValidator.ValidateAsync contract. This restores compilation for the shared unit-test project and unblocks unrelated PR platform jobs.

Validation:
- Validation contract/exception tests: 2/2
- ModularPipelines.Tests.slnf Release build: 0 errors (79 pre-existing nullable warnings)