### PR TITLE
Exclude boolean CLI options from secret inference

### DIFF
--- a/src/ModularPipelines.Yq/Options/YqEvalAllOptions.Generated.cs
+++ b/src/ModularPipelines.Yq/Options/YqEvalAllOptions.Generated.cs
@@ -269,7 +269,6 @@ public record YqEvalAllOptions : YqOptions
     /// <summary>
     /// enables using RawToken method instead Token. Commonly disables namespace translations. See https://pkg.go.dev/encoding/xml#Decoder.RawToken for details. (default true)
     /// </summary>
-    [SecretValue]
     [CliOption("--xml-raw-token", Format = OptionFormat.EqualsSeparated)]
     public bool? XmlRawToken { get; set; }
 

--- a/src/ModularPipelines.Yq/Options/YqEvalOptions.Generated.cs
+++ b/src/ModularPipelines.Yq/Options/YqEvalOptions.Generated.cs
@@ -269,7 +269,6 @@ public record YqEvalOptions : YqOptions
     /// <summary>
     /// enables using RawToken method instead Token. Commonly disables namespace translations. See https://pkg.go.dev/encoding/xml#Decoder.RawToken for details. (default true)
     /// </summary>
-    [SecretValue]
     [CliOption("--xml-raw-token", Format = OptionFormat.EqualsSeparated)]
     public bool? XmlRawToken { get; set; }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/OptionTypeEnhancerTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/OptionTypeEnhancerTests.cs
@@ -163,7 +163,7 @@ public class OptionTypeEnhancerTests
     }
 
     [Test]
-    public async Task EnhanceAsync_Warns_When_Secret_Looking_Option_Is_A_Flag()
+    public async Task EnhanceAsync_Warns_When_Secret_Looking_Option_Is_Boolean()
     {
         var pipeline = new OptionTypeDetectorPipeline(
             [],
@@ -184,7 +184,34 @@ public class OptionTypeEnhancerTests
         {
             await Assert.That(enhanced.Commands.Single().Options.Single().IsSecret).IsFalse();
             await Assert.That(logger.Messages).Contains(message =>
-                message.Contains("was detected as a flag", StringComparison.Ordinal));
+                message.Contains("was detected as boolean", StringComparison.Ordinal));
+        }
+    }
+
+    [Test]
+    public async Task EnhanceAsync_Removes_Inferred_Secret_From_Boolean_Value_Option()
+    {
+        var pipeline = new OptionTypeDetectorPipeline(
+            [],
+            NullLogger<OptionTypeDetectorPipeline>.Instance);
+        var enhancer = new OptionTypeEnhancer(pipeline, NullLogger<OptionTypeEnhancer>.Instance);
+        var tool = CreateTool(new CliOptionDefinition
+        {
+            SwitchName = "--xml-raw-token",
+            PropertyName = "XmlRawToken",
+            CSharpType = "bool?",
+            Description = "Enables using RawToken instead of Token.",
+            IsSecret = true,
+        });
+
+        var enhanced = await enhancer.EnhanceAsync(tool);
+        var option = enhanced.Commands.Single().Options.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.IsSecret).IsFalse();
+            await Assert.That(option.SecretValueKeys).IsEmpty();
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/OptionTypeEnhancer.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/OptionTypeEnhancer.cs
@@ -226,19 +226,24 @@ public class OptionTypeEnhancer
                              || hasSecretKeyword;
         var requestsSecret = secretValueKeys.Count > 0
                              || (explicitlySecret ?? inferredSecret);
+        var isBoolean = option.IsFlag
+                        || string.Equals(
+                            option.CSharpType.TrimEnd('?'),
+                            "bool",
+                            StringComparison.Ordinal);
 
-        if (option.IsFlag && requestsSecret)
+        if (isBoolean && requestsSecret)
         {
             _logger.LogWarning(
-                "Secret-looking option {Command} {Option} was detected as a flag and cannot be masked",
+                "Secret-looking option {Command} {Option} was detected as boolean and cannot be masked",
                 command.FullCommand,
                 option.SwitchName);
         }
 
         return option with
         {
-            IsSecret = !option.IsFlag && requestsSecret,
-            SecretValueKeys = secretValueKeys,
+            IsSecret = !isBoolean && requestsSecret,
+            SecretValueKeys = isBoolean ? [] : secretValueKeys,
         };
     }
 


### PR DESCRIPTION
Closes #3916

Boolean-valued options are now excluded from generated secret metadata by their C# type, even when the CLI requires an explicit boolean value and emits CliOption rather than CliFlag. Scoped Yq regeneration removes [SecretValue] from both XmlRawToken properties.

Validation:
- OptionTypeEnhancerTests: 7/7
- OptionsGenerator Release build: 0 warnings/errors
- Yq solution Release build: 0 warnings/errors
- scoped regeneration with official yq v4.53.3: only the two expected generated removals