### PR TITLE
Normalize SonarScanner version metadata

### DIFF
--- a/src/ModularPipelines.SonarScanner/Generated/SonarScanner.CommandCoverage.json
+++ b/src/ModularPipelines.SonarScanner/Generated/SonarScanner.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "sonar-scanner",
-  "toolVersion": "02:49:45.708 INFO  Scanner configuration file: /home/runner/work/_temp/cli-tools/sonar-scanner-8.0.1.6346-linux-x64/conf/sonar-scanner.properties 02:49:45.711 INFO  Project root configuration file: NONE 02:49:45.731 INFO  SonarScanner CLI 8.0.1.6346 02:49:45.737 INFO  Linux 6.17.0-1020-azure amd64",
+  "toolVersion": "SonarScanner CLI 8.0.1.6346",
   "commandCount": 1,
   "commandTreeSha256": "944baa3accf9323dfebdf2c80745c343a30dd6bbb1b9ea867489959c12c680be",
   "commands": [

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SonarScannerCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SonarScannerCliScraperTests.cs
@@ -74,6 +74,18 @@ public class SonarScannerCliScraperTests
         await Assert.That(version).IsNull();
     }
 
+    [Test]
+    public async Task Version_Finds_Stable_Identity_After_Generic_Truncation_Limit()
+    {
+        var output = new string('x', 600) + Environment.NewLine
+                     + "02:49:45.731 INFO SonarScanner CLI 8.0.1.6346";
+        var scraper = new TestSonarScannerCliScraper(new VersionExecutor(output));
+
+        var version = await scraper.GetVersionAsync();
+
+        await Assert.That(version).IsEqualTo("SonarScanner CLI 8.0.1.6346");
+    }
+
     private sealed class TestSonarScannerCliScraper : SonarScannerCliScraper
     {
         public TestSonarScannerCliScraper()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SonarScannerCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SonarScannerCliScraperTests.cs
@@ -47,11 +47,43 @@ public class SonarScannerCliScraperTests
         await Assert.That(token.IsSecret).IsTrue();
     }
 
+    [Test]
+    public async Task Version_Strips_Startup_Logs_And_Runner_Paths()
+    {
+        const string capturedOutput = """
+            02:49:45.708 INFO  Scanner configuration file: /home/runner/work/_temp/cli-tools/sonar-scanner-8.0.1.6346-linux-x64/conf/sonar-scanner.properties
+            02:49:45.711 INFO  Project root configuration file: NONE
+            02:49:45.731 INFO  SonarScanner CLI 8.0.1.6346
+            02:49:45.737 INFO  Linux 6.17.0-1020-azure amd64
+            """;
+        var scraper = new TestSonarScannerCliScraper(new VersionExecutor(capturedOutput));
+
+        var version = await scraper.GetVersionAsync();
+
+        await Assert.That(version).IsEqualTo("SonarScanner CLI 8.0.1.6346");
+    }
+
+    [Test]
+    public async Task Version_Returns_Null_When_No_Stable_Identity_Is_Present()
+    {
+        var scraper = new TestSonarScannerCliScraper(new VersionExecutor(
+            "02:49:45.708 INFO Scanner configuration file: /home/runner/work/_temp/scanner.properties"));
+
+        var version = await scraper.GetVersionAsync();
+
+        await Assert.That(version).IsNull();
+    }
+
     private sealed class TestSonarScannerCliScraper : SonarScannerCliScraper
     {
         public TestSonarScannerCliScraper()
+            : this(new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance))
+        {
+        }
+
+        public TestSonarScannerCliScraper(ICliCommandExecutor executor)
             : base(
-                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                executor,
                 new HelpTextCache(NullLogger<HelpTextCache>.Instance),
                 NullLogger<SonarScannerCliScraper>.Instance)
         {
@@ -59,5 +91,25 @@ public class SonarScannerCliScraperTests
 
         public Task<CliCommandDefinition?> Parse(string helpText) =>
             ParseCommandAsync(["sonar-scanner"], helpText, CancellationToken.None);
+    }
+
+    private sealed class VersionExecutor(string output) : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null) =>
+            Task.FromResult(new CliCommandResult
+            {
+                StandardOutput = output,
+                StandardError = string.Empty,
+                ExitCode = 0,
+            });
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -172,19 +172,27 @@ public abstract partial class CliScraperBase : ICliScraper
                 return null;
             }
 
-            var version = result.CombinedOutput.ReplaceLineEndings(" ").Trim();
-            return version.Length switch
-            {
-                0 => null,
-                > 500 => version[..500],
-                _ => version,
-            };
+            return ParseVersionOutput(result);
         }
         catch (Exception ex) when (ex is not (OutOfMemoryException or StackOverflowException))
         {
             Logger.LogWarning(ex, "Could not determine installed {Tool} version", ToolName);
             return null;
         }
+    }
+
+    /// <summary>
+    /// Parses successful version-command output into stable coverage metadata.
+    /// </summary>
+    protected virtual string? ParseVersionOutput(CliCommandResult result)
+    {
+        var version = result.CombinedOutput.ReplaceLineEndings(" ").Trim();
+        return version.Length switch
+        {
+            0 => null,
+            > 500 => version[..500],
+            _ => version,
+        };
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SonarScannerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SonarScannerCliScraper.cs
@@ -37,6 +37,24 @@ public partial class SonarScannerCliScraper : CliScraperBase
 
     protected override string ExecutablePath { get; }
 
+    public override async Task<string?> GetVersionAsync(CancellationToken cancellationToken = default)
+    {
+        var output = await base.GetVersionAsync(cancellationToken).ConfigureAwait(false);
+        if (output is null)
+        {
+            return null;
+        }
+
+        var match = SonarScannerVersionPattern().Match(output);
+        if (match.Success)
+        {
+            return match.Value;
+        }
+
+        Logger.LogWarning("Could not extract stable {Tool} version identity", ToolName);
+        return null;
+    }
+
     /// <summary>
     /// SonarScanner doesn't have subcommands.
     /// </summary>
@@ -239,6 +257,9 @@ public partial class SonarScannerCliScraper : CliScraperBase
     /// </summary>
     [GeneratedRegex(@"^\s*(?:(?<short>-\w),)?(?<long>--[\w-]+)(?:\s+(?<value><[^>]+>))?\s+(?<desc>.*)$", RegexOptions.Multiline)]
     private static partial Regex SonarOptionPattern();
+
+    [GeneratedRegex(@"\bSonarScanner CLI \d+(?:\.\d+)+(?:[-+][0-9A-Za-z.-]+)?\b")]
+    private static partial Regex SonarScannerVersionPattern();
 
     #endregion
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SonarScannerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SonarScannerCliScraper.cs
@@ -37,15 +37,9 @@ public partial class SonarScannerCliScraper : CliScraperBase
 
     protected override string ExecutablePath { get; }
 
-    public override async Task<string?> GetVersionAsync(CancellationToken cancellationToken = default)
+    protected override string? ParseVersionOutput(CliCommandResult result)
     {
-        var output = await base.GetVersionAsync(cancellationToken).ConfigureAwait(false);
-        if (output is null)
-        {
-            return null;
-        }
-
-        var match = SonarScannerVersionPattern().Match(output);
+        var match = SonarScannerVersionPattern().Match(result.CombinedOutput);
         if (match.Success)
         {
             return match.Value;


### PR DESCRIPTION
## Summary
- extract only the stable SonarScanner CLI <version> identity from verbose startup output
- discard unmatched volatile version output instead of committing timestamps and runner paths
- regenerate the SonarScanner command-coverage manifest

## Validation
- SonarScannerCliScraperTests: 4/4 passed
- OptionsGenerator Release build: 0 warnings, 0 errors
- SonarScanner solution Release build: 0 warnings, 0 errors
- narrow whitespace verification passed

Closes #3915