### PR TITLE
Keep Kustomize build path optional

### DIFF
--- a/src/ModularPipelines.Kubernetes/Options/KustomizeBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeBuildOptions.Generated.cs
@@ -18,9 +18,7 @@ namespace ModularPipelines.Kubernetes.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("build")]
-public record KustomizeBuildOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Dir
-) : KustomizeOptions
+public record KustomizeBuildOptions : KustomizeOptions
 {
     /// <summary>
     /// use the uid and gid of the command executor to run the function in the container
@@ -117,5 +115,11 @@ public record KustomizeBuildOptions(
     /// </summary>
     [CliFlag("--stack-trace")]
     public bool? StackTrace { get; set; }
+
+    /// <summary>
+    /// The DIR operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Dir { get; set; }
 
 }

--- a/src/ModularPipelines.Kubernetes/Services/IKustomize.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/IKustomize.Generated.cs
@@ -46,7 +46,7 @@ public partial interface IKustomize
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> BuildAsync(KustomizeBuildOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> BuildAsync(KustomizeBuildOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Create a new kustomization in the current directory

--- a/src/ModularPipelines.Kubernetes/Services/Kustomize.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/Kustomize.Generated.cs
@@ -54,11 +54,11 @@ internal partial class Kustomize : IKustomize
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> BuildAsync(
-        KustomizeBuildOptions options,
+        KustomizeBuildOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options ?? new KustomizeBuildOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KustomizeCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KustomizeCliScraperTests.cs
@@ -55,13 +55,45 @@ public class KustomizeCliScraperTests
             .And.HasMessageContaining("kustomize edit set image set");
     }
 
-    private sealed class TestKustomizeCliScraper(ICliCommandExecutor executor)
+    [Test]
+    [Arguments("DIR")]
+    [Arguments("[path]")]
+    public async Task Build_Path_Is_Optional(string operandSyntax)
+    {
+        var command = await new TestKustomizeCliScraper().Parse(
+            ["kustomize", "build"],
+            $$"""
+              Build a set of KRM resources using a 'kustomization.yaml' file.
+              If DIR is omitted, '.' is assumed.
+
+              Usage:
+                kustomize build {{operandSyntax}} [flags]
+
+              Flags:
+                    --enable-helm   Enable use of the Helm chart inflator generator.
+              """);
+
+        var directory = command!.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(directory.IsRequired).IsFalse();
+            await Assert.That(directory.CSharpType).IsEqualTo("string?");
+        }
+    }
+
+    private sealed class TestKustomizeCliScraper(ICliCommandExecutor? executor = null)
         : KustomizeCliScraper(
-            executor,
+            executor ?? new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
             new HelpTextCache(NullLogger<HelpTextCache>.Instance),
             NullLogger<KustomizeCliScraper>.Instance)
     {
         protected override int MaxParallelism => 1;
+
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = ParseUsageSynopsis(commandPath, helpText);
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
     }
 
     private sealed class KustomizeHelpExecutor(bool includeBogusChild) : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
@@ -55,6 +55,29 @@ public partial class KustomizeCliScraper : CobraCliScraper
     public override string OutputDirectory => "src/ModularPipelines.Kubernetes";
 
     /// <summary>
+    /// Kustomize renders the build directory as required in its Cobra usage line even
+    /// though omitting it is documented to use the current directory.
+    /// </summary>
+    protected override IReadOnlyList<CliPositionalArgument> ApplyPositionalArgumentFixes(
+        string[] commandParts,
+        IReadOnlyList<CliPositionalArgument> positionalArguments)
+    {
+        if (commandParts is not ["build"] || positionalArguments is not [var directory])
+        {
+            return positionalArguments;
+        }
+
+        return
+        [
+            directory with
+            {
+                CSharpType = $"{directory.CSharpType.TrimEnd('?')}?",
+                IsRequired = false,
+            },
+        ];
+    }
+
+    /// <summary>
     /// Kustomize validates buildmetadata operands but omits them from Cobra's Use value.
     /// </summary>
     protected override IEnumerable<string> GetAdditionalUsageSynopses(


### PR DESCRIPTION
## Summary
- normalize Kustomize build directory as optional despite Cobra usage showing `DIR`
- preserve parameterless `KustomizeBuildOptions` construction and `BuildAsync` calls
- add regressions for executable `DIR` and documented `[path]` syntax
- regenerate only Kustomize build options/services

## Validation
- `KustomizeCliScraperTests`: 2/2 passed
- OptionsGenerator Release build: 0 warnings, 0 errors
- Kubernetes solution Release build: 0 warnings, 0 errors
- narrow whitespace verification passed

Closes #3914