### PR TITLE
Reject Bare values in grouped optional CLI options

### DIFF
--- a/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandArgumentBuilder.cs
@@ -412,10 +412,15 @@ internal sealed class CommandArgumentBuilder : ICommandArgumentBuilder
                 $"Grouped option '{GetEffectiveName(optionPart.Attribute)}' must use a space separator.");
         }
 
+        if (optionValues.Any(static value => value.IsBare))
+        {
+            throw new InvalidOperationException(
+                $"Grouped optional-value CLI option property '{optionsType.FullName}.{optionPart.PropertyName}' "
+                + $"cannot contain {nameof(CliOptionValue)}.{nameof(CliOptionValue.Bare)}.");
+        }
+
         args.Add(GetEffectiveName(optionPart.Attribute));
-        args.AddRange(optionValues
-            .Where(static value => !value.IsBare)
-            .Select(static value => value.Value!));
+        args.AddRange(optionValues.Select(static value => value.Value!));
     }
 
     private static IEnumerable<CliOptionValue> GetOptionalValues(

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -453,6 +453,24 @@ public class CliAttributeTests
     }
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Parser_Rejects_Bare_Grouped_Optional_Values(bool includeExplicitValue)
+    {
+        var options = new TestCliOptionsWithGroupedOptionalValues
+        {
+            Output = includeExplicitValue
+                ? [CliOptionValue.Bare, "json"]
+                : [CliOptionValue.Bare],
+        };
+
+        await Assert.That(() => BuildArguments(options))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining(
+                $"{typeof(TestCliOptionsWithGroupedOptionalValues).FullName}.Output");
+    }
+
+    [Test]
     public async Task Parser_Rejects_Null_Value_Pair_Operands()
     {
         var repeated = new TestCliOptionsWithValuePairs

--- a/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/SpectreResultsPrinterTests.cs
@@ -12,7 +12,7 @@ using ModuleStatus = ModularPipelines.Enums.Status;
 
 namespace ModularPipelines.UnitTests.Helpers;
 
-[TUnit.Core.NotInParallel(nameof(SpectreResultsPrinterTests))]
+[TUnit.Core.NotInParallel]
 public class SpectreResultsPrinterTests
 {
     private class SkippedModule : Module<bool>


### PR DESCRIPTION
## Summary
- reject CliOptionValue.Bare in grouped optional-value collections instead of silently dropping it
- name the offending options type and property in the exception
- cover Bare-only and mixed Bare/explicit collections

## Test plan
- [x] CliAttributeTests (81/81)
- [x] ModularPipelines.slnx Release build (0 warnings, 0 errors)
- [x] whitespace verification

Closes #3783