### PR TITLE
Reject conflicting CLI property attributes

### DIFF
--- a/docs/docs/how-to/source-generator-diagnostics.md
+++ b/docs/docs/how-to/source-generator-diagnostics.md
@@ -30,9 +30,11 @@ stripping the `Module` suffix produces a unique name.
 
 ## MPG0003
 
-An inaccessible property with a CLI attribute prevents complete command metadata
-generation. Make the property and getter accessible to generated code. The build
-fails until every attributed property can be generated.
+An inaccessible property, an invalid attribute argument, or conflicting command
+attributes prevent complete command metadata generation. Make the property and
+getter accessible, and apply only one of `[CliArgument]`, `[CliFlag]`, or
+`[CliOption]` to each property. The build fails until every attributed property can
+be generated unambiguously.
 
 **Severity:** Error
 

--- a/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
+++ b/src/ModularPipelines.SourceGenerator/CommandOptionsGenerator.cs
@@ -748,7 +748,13 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             return false;
         }
 
-        var attribute = FindAttribute(property, IsCommandAttribute);
+        var attribute = FindCommandAttribute(property, out var hasConflictingAttributes);
+        if (hasConflictingAttributes)
+        {
+            isIncomplete = true;
+            return true;
+        }
+
         if (attribute is null)
         {
             return false;
@@ -850,6 +856,33 @@ public sealed class CommandOptionsGenerator : IIncrementalGenerator
             }
         }
 
+        return null;
+    }
+
+    private static AttributeData? FindCommandAttribute(
+        IPropertySymbol property,
+        out bool hasConflictingAttributes)
+    {
+        for (var current = property; current is not null; current = current.OverriddenProperty)
+        {
+            var attributes = current.GetAttributes()
+                .Where(IsCommandAttribute)
+                .Take(2)
+                .ToArray();
+            if (attributes.Length > 1)
+            {
+                hasConflictingAttributes = true;
+                return null;
+            }
+
+            if (attributes.Length == 1)
+            {
+                hasConflictingAttributes = false;
+                return attributes[0];
+            }
+        }
+
+        hasConflictingAttributes = false;
         return null;
     }
 

--- a/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
+++ b/src/ModularPipelines.SourceGenerator/GeneratorDiagnostics.cs
@@ -26,7 +26,8 @@ internal static class GeneratorDiagnostics
         "MPG0003",
         "Incomplete command metadata",
         "Command metadata for '{0}' is incomplete because these attributed properties are "
-        + "inaccessible or have invalid attribute arguments: {1}; make every attributed property accessible",
+        + "inaccessible or have invalid or conflicting command attributes: {1}; make every "
+        + "attributed property accessible and declare only one command attribute per property",
         DiagnosticSeverity.Error);
 
     public static DiagnosticDescriptor IncompleteSecretMetadata { get; } = Create(

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -46,7 +46,8 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         var parts = new List<PropertyCommandLinePart>();
         foreach (var property in GetCommandProperties(type))
         {
-            if (property.GetCustomAttribute<CliArgumentAttribute>() is { } argument)
+            var commandAttribute = GetCommandAttribute(type, property);
+            if (commandAttribute is CliArgumentAttribute argument)
             {
                 parts.Add(new ArgumentPart(property.Name, property.GetValue, argument)
                 {
@@ -54,7 +55,7 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                     HasExplicitPosition = HasExplicitArgumentPosition(property),
                 });
             }
-            else if (property.GetCustomAttribute<CliFlagAttribute>() is { } flag)
+            else if (commandAttribute is CliFlagAttribute flag)
             {
                 parts.Add(new FlagPart(property.Name, property.GetValue, flag)
                 {
@@ -62,7 +63,7 @@ internal sealed class CommandModelProvider : ICommandModelProvider
                     IsSupportedPropertyType = IsSupportedFlagType(property.PropertyType),
                 });
             }
-            else if (property.GetCustomAttribute<CliOptionAttribute>() is { } option)
+            else if (commandAttribute is CliOptionAttribute option)
             {
                 var allowsLegacyOptionalValues = IsLegacyGeneratedOption(property);
                 parts.Add(new OptionPart(property.Name, property.GetValue, option)
@@ -78,6 +79,45 @@ internal sealed class CommandModelProvider : ICommandModelProvider
         }
 
         return parts;
+    }
+
+    [RequiresUnreferencedCode("Reflection fallback requires CLI attribute metadata.")]
+    private static Attribute? GetCommandAttribute(Type optionsType, PropertyInfo property)
+    {
+        var baseAccessor = property.GetMethod?.GetBaseDefinition();
+        for (var currentType = property.DeclaringType; currentType is not null; currentType = currentType.BaseType)
+        {
+            var declaredProperty = currentType == property.DeclaringType
+                ? property
+                : currentType.GetProperty(
+                    property.Name,
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            if (declaredProperty?.GetMethod?.GetBaseDefinition().Equals(baseAccessor) != true)
+            {
+                continue;
+            }
+
+            var commandAttributes = declaredProperty
+                .GetCustomAttributes(inherit: false)
+                .OfType<Attribute>()
+                .Where(static attribute => attribute is
+                    CliArgumentAttribute or CliFlagAttribute or CliOptionAttribute)
+                .Take(2)
+                .ToArray();
+            if (commandAttributes.Length > 1)
+            {
+                throw new InvalidOperationException(
+                    $"CLI property '{optionsType.FullName}.{property.Name}' cannot declare more than one of "
+                    + $"{nameof(CliArgumentAttribute)}, {nameof(CliFlagAttribute)}, or {nameof(CliOptionAttribute)}.");
+            }
+
+            if (commandAttributes.Length == 1)
+            {
+                return commandAttributes[0];
+            }
+        }
+
+        return null;
     }
 
     [RequiresUnreferencedCode("Reflection fallback requires option value type metadata.")]

--- a/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
+++ b/src/ModularPipelines/Helpers/Internal/CommandModelProvider.cs
@@ -98,10 +98,10 @@ internal sealed class CommandModelProvider : ICommandModelProvider
             }
 
             var commandAttributes = declaredProperty
-                .GetCustomAttributes(inherit: false)
-                .OfType<Attribute>()
-                .Where(static attribute => attribute is
-                    CliArgumentAttribute or CliFlagAttribute or CliOptionAttribute)
+                .GetCustomAttributes<CliArgumentAttribute>(inherit: false)
+                .Cast<Attribute>()
+                .Concat(declaredProperty.GetCustomAttributes<CliFlagAttribute>(inherit: false))
+                .Concat(declaredProperty.GetCustomAttributes<CliOptionAttribute>(inherit: false))
                 .Take(2)
                 .ToArray();
             if (commandAttributes.Length > 1)

--- a/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
+++ b/test/ModularPipelines.SourceGenerator.UnitTests/IncompleteMetadataDiagnosticTests.cs
@@ -19,6 +19,9 @@ public class IncompleteMetadataDiagnosticTests
             public sealed class CliFlagAttribute(string name) : System.Attribute;
 
             [System.AttributeUsage(System.AttributeTargets.Property)]
+            public sealed class CliArgumentAttribute(int position) : System.Attribute;
+
+            [System.AttributeUsage(System.AttributeTargets.Property)]
             public sealed class SecretValueAttribute(params string[] keys) : System.Attribute;
         }
         """;
@@ -178,6 +181,31 @@ public class IncompleteMetadataDiagnosticTests
             "MPG0003",
             "global::TestOptions");
         await Assert.That(result.Diagnostics.Single().GetMessage()).Contains("Value");
+    }
+
+    [Test]
+    public async Task Conflicting_Command_Attributes_Report_Diagnostic()
+    {
+        var result = GeneratorTestRunner.Run(
+            new CommandOptionsGenerator(),
+            CommandInfrastructure,
+            """
+            public sealed class TestOptions : ModularPipelines.Options.CommandLineToolOptions
+            {
+                [ModularPipelines.Attributes.CliOption("--value")]
+                [ModularPipelines.Attributes.CliArgument(0)]
+                public string Value { get; } = "";
+            }
+            """);
+
+        await AssertIncompleteDiagnostic(result, "MPG0003", "global::TestOptions");
+        using (Assert.Multiple())
+        {
+            await Assert.That(result.Diagnostics.Single().GetMessage()).Contains("conflicting");
+            await Assert.That(result.Diagnostics.Single().GetMessage()).Contains("Value");
+            await Assert.That(result.GeneratedTrees.Single().ToString())
+                .DoesNotContain("(instance).@Value");
+        }
     }
 
     [Test]

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -702,6 +702,16 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task Reflection_CommandModel_Ignores_Unrelated_Throwing_Attribute()
+    {
+        var model = new CommandModelProvider()
+            .GetCommandModel(typeof(ReflectionThrowingUnrelatedAttributeOptions<string>));
+
+        await Assert.That(model).HasSingleItem();
+        await Assert.That(model[0]).IsTypeOf<OptionPart>();
+    }
+
+    [Test]
     public async Task Reflection_CommandModel_Rejects_Inherited_Duplicate_Argument_Position()
     {
         var optionsType = typeof(ReflectionDuplicateOverrideArgumentOptions<string>);
@@ -1091,6 +1101,22 @@ public class CliAttributeTests
         [CliOption("--value")]
         [CliArgument(0)]
         public T? Value { get; init; }
+    }
+
+    private sealed record ReflectionThrowingUnrelatedAttributeOptions<T> : CommandLineToolOptions
+    {
+        [CliOption("--value")]
+        [Throwing]
+        public T? Value { get; init; }
+    }
+
+    [AttributeUsage(AttributeTargets.Property)]
+    private sealed class ThrowingAttribute : Attribute
+    {
+        public ThrowingAttribute()
+        {
+            throw new InvalidOperationException("This unrelated attribute must not be constructed.");
+        }
     }
 
     private record ReflectionExplicitArgumentBase<T> : CommandLineToolOptions

--- a/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
+++ b/test/ModularPipelines.UnitTests/Attributes/CliAttributeTests.cs
@@ -692,6 +692,16 @@ public class CliAttributeTests
     }
 
     [Test]
+    public async Task Reflection_CommandModel_Rejects_Conflicting_Command_Attributes()
+    {
+        var optionsType = typeof(ReflectionConflictingCommandAttributesOptions<string>);
+
+        await Assert.That(() => new CommandModelProvider().GetCommandModel(optionsType))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining($"{optionsType.FullName}.Value");
+    }
+
+    [Test]
     public async Task Reflection_CommandModel_Rejects_Inherited_Duplicate_Argument_Position()
     {
         var optionsType = typeof(ReflectionDuplicateOverrideArgumentOptions<string>);
@@ -1074,6 +1084,13 @@ public class CliAttributeTests
     {
         [CliFlag("--force")]
         public T? Force { get; init; }
+    }
+
+    private sealed record ReflectionConflictingCommandAttributesOptions<T> : CommandLineToolOptions
+    {
+        [CliOption("--value")]
+        [CliArgument(0)]
+        public T? Value { get; init; }
     }
 
     private record ReflectionExplicitArgumentBase<T> : CommandLineToolOptions


### PR DESCRIPTION
## Summary
- reject multiple CLI command attributes on one property in both reflection and source-generated models
- report MPG0003 and omit ambiguous generated metadata
- document the one-command-attribute rule and add regression coverage

## Validation
- conflicting source-generator regression: 1/1 passed
- CliAttributeTests: 80/80 passed
- core Release build: 0 warnings, 0 errors
- targeted whitespace formatter: passed
- broader IncompleteMetadataDiagnosticTests exceeded the mandated 2 GB agent guard; not retried, per repository policy
- docs analyzer precheck verified 24 pages; Docusaurus build unavailable because local dependency is not installed

Closes #3782