### PR TITLE
Make cancellation tests deterministic

### DIFF
--- a/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/ModuleOutputBufferTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.BuildSystemFormatters;
+using ModularPipelines.TestHelpers;
 using Moq;
 
 namespace ModularPipelines.UnitTests.Console;
@@ -803,7 +804,12 @@ public class ModuleOutputBufferTests
     public async Task Flush_CancellationInterruptsRenderGateWait()
     {
         var writer = new StringWriter();
-        var loggerControl = new SynchronousLoggerControl(writer);
+        var renderGateWaitStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var loggerControl = new SynchronousLoggerControl(writer)
+        {
+            RenderGateWaitStarted = renderGateWaitStarted,
+        };
         var buffer = CreateBufferWithStructuredLog();
         var lockAcquired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var releaseLock = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -816,18 +822,23 @@ public class ModuleOutputBufferTests
             }
         });
 
-        await lockAcquired.Task.WaitAsync(TimeSpan.FromSeconds(1));
-        using var cancellationTokenSource = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+        await lockAcquired.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
+        using var cancellationTokenSource = new CancellationTokenSource();
         try
         {
+            var flush = buffer.FlushToAsync(
+                writer,
+                new GitHubActionsFormatter(),
+                loggerControl,
+                loggerControl,
+                OutputFlushKind.Complete,
+                cancellationToken: cancellationTokenSource.Token);
+
+            await renderGateWaitStarted.Task.WaitAsync(TestHostSettings.DefaultTestTimeout);
+            await cancellationTokenSource.CancelAsync();
+
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                await buffer.FlushToAsync(
-                    writer,
-                    new GitHubActionsFormatter(),
-                    loggerControl,
-                    loggerControl,
-                    OutputFlushKind.Complete,
-                    cancellationToken: cancellationTokenSource.Token));
+                await flush.WaitAsync(TestHostSettings.DefaultTestTimeout));
         }
         finally
         {
@@ -1090,6 +1101,8 @@ public class ModuleOutputBufferTests
 
         public Exception? LogExceptionAfterWrite { get; set; }
 
+        public TaskCompletionSource? RenderGateWaitStarted { get; init; }
+
         public int LogCallCount { get; private set; }
 
         public IDisposable? BeginScope<TState>(TState state)
@@ -1168,6 +1181,7 @@ public class ModuleOutputBufferTests
             TimeSpan timeout,
             CancellationToken cancellationToken = default)
         {
+            RenderGateWaitStarted?.TrySetResult();
             var deadline = DateTime.UtcNow + timeout;
             while (DateTime.UtcNow < deadline)
             {

--- a/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
+++ b/test/ModularPipelines.UnitTests/Console/OutputCoordinatorTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using ModularPipelines.Console;
 using ModularPipelines.Engine;
 using ModularPipelines.Engine.BuildSystemFormatters;
+using ModularPipelines.TestHelpers;
 using Moq;
 
 namespace ModularPipelines.UnitTests.Console;
@@ -340,14 +341,19 @@ public class OutputCoordinatorTests
             OutputFlushKind.Complete,
             queuedCancellation.Token);
 
-        await queuedCancellation.CancelAsync();
-        var completedTask = await Task.WhenAny(queuedFlush, Task.Delay(TimeSpan.FromSeconds(1)));
+        try
+        {
+            await queuedCancellation.CancelAsync();
+            await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                await queuedFlush.WaitAsync(TestHostSettings.DefaultTestTimeout));
+            await Assert.That(firstFlush.IsCompleted).IsFalse();
+        }
+        finally
+        {
+            firstBuffer.ReleaseFlush.TrySetResult();
+            await firstFlush;
+        }
 
-        firstBuffer.ReleaseFlush.TrySetResult();
-        await firstFlush;
-
-        await Assert.That(completedTask).IsSameReferenceAs(queuedFlush);
-        await Assert.ThrowsAsync<OperationCanceledException>(async () => await queuedFlush);
         await Assert.That(queuedBuffer.FlushCount).IsEqualTo(0);
     }
 

--- a/test/ModularPipelines.UnitTests/Context/HttpTests.cs
+++ b/test/ModularPipelines.UnitTests/Context/HttpTests.cs
@@ -255,7 +255,7 @@ public class HttpTests : TestBase
     public async Task SendAsync_DoesNotTreatCancellationAsSuccessfulEndOfStream(
         bool useBufferedCopy)
     {
-        var timeout = TimeSpan.FromMilliseconds(100);
+        using var cancellationTokenSource = new CancellationTokenSource();
         var contentStream = new BlockingReadStream(
             ignoreAsyncCancellation: true,
             returnEofWhenDisposed: true);
@@ -271,8 +271,8 @@ public class HttpTests : TestBase
         {
             HttpClient = httpClient,
             LoggingType = HttpLoggingType.None,
-            Timeout = timeout,
-        });
+            Timeout = TimeSpan.FromMinutes(1),
+        }, cancellationTokenSource.Token);
 
         Task readTask;
         if (useBufferedCopy)
@@ -284,6 +284,9 @@ public class HttpTests : TestBase
             var stream = await response.Content.ReadAsStreamAsync();
             readTask = stream.ReadAsync(new byte[1]).AsTask();
         }
+
+        await contentStream.ReadStarted.WaitAsync(TestHostSettings.DefaultTestTimeout);
+        await cancellationTokenSource.CancelAsync();
 
         await Assert.ThrowsAsync<OperationCanceledException>(
             async () => await readTask.WaitAsync(TestHostSettings.DefaultTestTimeout));

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -32,7 +32,7 @@ public class ModuleTimeoutTests : TestBase
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            await Task.Delay(Timeout.InfiniteTimeSpan);
+            await Task.Delay(TimeSpan.FromSeconds(5));
             return TestConstants.TestString;
         }
     }

--- a/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
+++ b/test/ModularPipelines.UnitTests/Execution/ModuleTimeoutTests.cs
@@ -26,22 +26,13 @@ public class ModuleTimeoutTests : TestBase
 
     private class Module_NotUsingCancellationToken : Module<string>
     {
-        private static readonly TaskCompletionSource<bool> _taskCompletionSource = new();
-
         protected override ModuleConfiguration Configure() => ModuleConfiguration.Create()
             .WithTimeout(TimeSpan.FromSeconds(1))
             .Build();
 
         protected internal override async Task<string> ExecuteAsync(IModuleContext context, CancellationToken cancellationToken)
         {
-            try
-            {
-                await _taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(5));
-            }
-            catch (TimeoutException)
-            {
-            }
-
+            await Task.Delay(Timeout.InfiniteTimeSpan);
             return TestConstants.TestString;
         }
     }


### PR DESCRIPTION
Closes #3918

## Summary
- coordinate render-gate cancellation explicitly instead of relying on 100 ms/1 s timers
- make the non-cooperative timeout module wait indefinitely so CI timer starvation cannot invert the timeout race
- cancel streamed HTTP content through an explicit caller token after the blocking read starts
- await queued-output cancellation with the shared test timeout and guaranteed cleanup

## Validation
- four affected regressions: 5 stress rounds / 20 invocations passed
- ModuleOutputBufferTests: 34/34
- OutputCoordinatorTests: 19/19
- ModuleTimeoutTests: 13/13
- HttpTests: 39/39
- ModularPipelines.slnx Release build: 0 warnings, 0 errors
- scoped format and diff checks clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cancellation test reliability across console output, HTTP operations, and module execution.
  * Added deterministic synchronization to prevent timing-related test failures.
  * Strengthened cleanup and timeout handling in queued output cancellation tests.
  * Verified that canceled HTTP reads report cancellation rather than successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->