### PR TITLE
Retry transient Claude review failures

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,6 +32,22 @@ jobs:
       pull-requests: write   # Allows posting review comments
       issues: write          # Allows creating/updating issues
       id-token: write        # Required for OIDC authentication
+    env:
+      CLAUDE_REVIEW_PROMPT: |
+        Instructions:
+        - ALWAYS post a review comment, even if no issues are found. If the code is good, acknowledge it.
+        - Compare the current state of the PR against any previous PR comments to make sure they have been addressed.
+        - You MUST post your review as a PR comment using `gh pr review` or `gh pr comment` before finishing. Do not just output the review - actually post it to the PR.
+        - When you find issues, ALWAYS suggest better approaches or architectural improvements, not just minor optimizations.
+        - Focus on:
+          * Design patterns that could be improved
+          * Alternative approaches that are more maintainable or scalable
+          * Architectural concerns or anti-patterns
+          * Better abstractions or simplifications
+        - Skip minor style/formatting issues unless they impact readability significantly.
+        - Always explain WHY the suggested approach is better, not just WHAT to change.
+
+        Use the code review skill to run this review: /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number || inputs.pr_number }}
 
     steps:
       - name: Checkout repository
@@ -40,31 +56,69 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Run Claude Code Review
+      - name: Run Claude Code Review (attempt 1)
         if: github.event_name == 'workflow_dispatch' || github.event.pull_request.user.login != 'dependabot[bot]'
-        id: claude-review
+        id: claude_review_1
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: 'dependabot[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: |
-            Instructions:
-            - ALWAYS post a review comment, even if no issues are found. If the code is good, acknowledge it.
-            - Compare the current state of the PR against any previous PR comments to make sure they have been addressed.
-            - You MUST post your review as a PR comment using `gh pr review` or `gh pr comment` before finishing. Do not just output the review - actually post it to the PR.
-            - When you find issues, ALWAYS suggest better approaches or architectural improvements, not just minor optimizations.
-            - Focus on:
-              * Design patterns that could be improved
-              * Alternative approaches that are more maintainable or scalable
-              * Architectural concerns or anti-patterns
-              * Better abstractions or simplifications
-            - Skip minor style/formatting issues unless they impact readability significantly.
-            - Always explain WHY the suggested approach is better, not just WHAT to change.
-
-            Use the code review skill to run this review: /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number || inputs.pr_number }}
+          prompt: ${{ env.CLAUDE_REVIEW_PROMPT }}
           claude_args: "--allowedTools Bash,Read,Glob,Grep,WebFetch,WebSearch"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+
+      - name: Diagnose Claude failure (attempt 1)
+        if: steps.claude_review_1.outcome == 'failure'
+        id: diagnose_1
+        shell: pwsh
+        env:
+          CLAUDE_EXECUTION_FILE: ${{ steps.claude_review_1.outputs.execution_file }}
+          CLAUDE_SESSION_ID: ${{ steps.claude_review_1.outputs.session_id }}
+        run: |
+          ./scripts/Summarize-ClaudeExecution.ps1 `
+            -Attempt 1 `
+            -ExecutionFile $env:CLAUDE_EXECUTION_FILE `
+            -SessionId $env:CLAUDE_SESSION_ID
+
+      - name: Back off before retry
+        if: steps.diagnose_1.outputs.retryable == 'true'
+        shell: bash
+        run: |
+          delay=$((15 + RANDOM % 16))
+          echo "Claude infrastructure failure; retrying in ${delay}s."
+          sleep "$delay"
+
+      - name: Run Claude Code Review (attempt 2)
+        if: steps.diagnose_1.outputs.retryable == 'true'
+        id: claude_review_2
+        continue-on-error: true
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'dependabot[bot]'
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: ${{ env.CLAUDE_REVIEW_PROMPT }}
+          claude_args: "--allowedTools Bash,Read,Glob,Grep,WebFetch,WebSearch"
+
+      - name: Diagnose Claude failure (attempt 2)
+        if: steps.claude_review_2.outcome == 'failure'
+        shell: pwsh
+        env:
+          CLAUDE_EXECUTION_FILE: ${{ steps.claude_review_2.outputs.execution_file }}
+          CLAUDE_SESSION_ID: ${{ steps.claude_review_2.outputs.session_id }}
+        run: |
+          ./scripts/Summarize-ClaudeExecution.ps1 `
+            -Attempt 2 `
+            -ExecutionFile $env:CLAUDE_EXECUTION_FILE `
+            -SessionId $env:CLAUDE_SESSION_ID
+
+      - name: Fail after exhausted Claude attempts
+        if: steps.claude_review_1.outcome == 'failure' && steps.claude_review_2.outcome != 'success'
+        shell: pwsh
+        run: throw 'Claude Code Review failed. See the safe execution summaries above.'
 

--- a/scripts/Summarize-ClaudeExecution.ps1
+++ b/scripts/Summarize-ClaudeExecution.ps1
@@ -1,0 +1,139 @@
+param(
+    [Parameter(Mandatory)]
+    [ValidateRange(1, 10)]
+    [int] $Attempt,
+
+    [string] $ExecutionFile,
+
+    [string] $SessionId
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Get-PropertyValue {
+    param(
+        [AllowNull()]
+        [object] $InputObject,
+
+        [Parameter(Mandatory)]
+        [string] $Name
+    )
+
+    if ($null -eq $InputObject) {
+        return $null
+    }
+
+    $property = $InputObject.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+
+function Write-ClaudeSummary {
+    param(
+        [Parameter(Mandatory)]
+        [hashtable] $Summary
+    )
+
+    $retryableCategories = @('transient-provider', 'action-or-bootstrap', 'unreadable-execution')
+    $detail = if ($Summary.ContainsKey('error_detail')) { [string] $Summary.error_detail } else { [string] $Summary.detail }
+    $retryable = $Summary.category -in $retryableCategories -or
+        ($Summary.category -eq 'claude-execution' -and $detail -match '(?i)rate.?limit|overload|timed?.?out|unavailable|capacity|connection|network')
+    $Summary.retryable = $retryable
+
+    $json = $Summary | ConvertTo-Json -Compress -Depth 10
+    Write-Host "Claude attempt $Attempt execution summary: $json"
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {
+        Add-Content -LiteralPath $env:GITHUB_OUTPUT -Value "retryable=$($retryable.ToString().ToLowerInvariant())"
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_STEP_SUMMARY)) {
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value "### Claude review attempt $Attempt"
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value '```json'
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $json
+        Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value '```'
+    }
+}
+
+$summary = @{
+    attempt = $Attempt
+    session_id = $SessionId
+}
+
+if ([string]::IsNullOrWhiteSpace($ExecutionFile) -or -not (Test-Path -LiteralPath $ExecutionFile -PathType Leaf)) {
+    $summary.category = 'action-or-bootstrap'
+    $summary.detail = 'The action did not provide a readable Claude execution file.'
+    Write-ClaudeSummary -Summary $summary
+    exit 0
+}
+
+try {
+    $rawExecution = Get-Content -LiteralPath $ExecutionFile -Raw
+    try {
+        $events = @($rawExecution | ConvertFrom-Json -Depth 100)
+    }
+    catch {
+        $events = @(
+            $rawExecution -split "`r?`n" |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+                ForEach-Object { $_ | ConvertFrom-Json -Depth 100 }
+        )
+    }
+}
+catch {
+    $summary.category = 'unreadable-execution'
+    $summary.detail = $_.Exception.Message
+    Write-ClaudeSummary -Summary $summary
+    exit 0
+}
+
+$result = $events |
+    Where-Object { (Get-PropertyValue -InputObject $_ -Name 'type') -eq 'result' } |
+    Select-Object -Last 1
+
+if ($null -eq $result) {
+    $summary.category = 'action-or-bootstrap'
+    $summary.detail = 'Claude produced no result event.'
+    Write-ClaudeSummary -Summary $summary
+    exit 0
+}
+
+$isError = Get-PropertyValue -InputObject $result -Name 'is_error'
+$turns = Get-PropertyValue -InputObject $result -Name 'num_turns'
+$cost = Get-PropertyValue -InputObject $result -Name 'total_cost_usd'
+
+$summary.category = if ($isError -eq $true -and $cost -eq 0 -and $turns -le 1) {
+    'transient-provider'
+}
+elseif ($isError -eq $true) {
+    'claude-execution'
+}
+else {
+    'action-failure'
+}
+
+foreach ($name in @('subtype', 'is_error', 'duration_ms', 'duration_api_ms', 'num_turns', 'total_cost_usd', 'permission_denials_count')) {
+    $value = Get-PropertyValue -InputObject $result -Name $name
+    if ($null -ne $value) {
+        $summary[$name] = $value
+    }
+}
+
+foreach ($name in @('error', 'errors', 'message', 'result')) {
+    $value = Get-PropertyValue -InputObject $result -Name $name
+    if ($null -ne $value -and -not [string]::IsNullOrWhiteSpace([string] $value)) {
+        $detail = $value | ConvertTo-Json -Compress -Depth 10
+        $summary.error_detail = if ($detail.Length -le 1000) { $detail } else { $detail.Substring(0, 1000) + '…' }
+        break
+    }
+}
+
+if (-not $summary.ContainsKey('error_detail') -and $isError -eq $true) {
+    $summary.error_detail = 'Provider returned is_error:true without an error field.'
+}
+
+Write-ClaudeSummary -Summary $summary

--- a/scripts/Test-SummarizeClaudeExecution.ps1
+++ b/scripts/Test-SummarizeClaudeExecution.ps1
@@ -1,0 +1,73 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$scriptPath = Join-Path $PSScriptRoot 'Summarize-ClaudeExecution.ps1'
+$testDirectory = Join-Path ([System.IO.Path]::GetTempPath()) "claude-execution-summary-$([guid]::NewGuid())"
+
+function Assert-Contains {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Actual,
+
+        [Parameter(Mandatory)]
+        [string] $Expected
+    )
+
+    if (-not $Actual.Contains($Expected, [System.StringComparison]::Ordinal)) {
+        throw "Expected output to contain '$Expected'. Actual output: $Actual"
+    }
+}
+
+New-Item -ItemType Directory -Path $testDirectory | Out-Null
+
+try {
+    $transientPath = Join-Path $testDirectory 'transient.jsonl'
+    @'
+{"type":"system","subtype":"init","model":"claude-sonnet-5"}
+{"type":"result","subtype":"success","is_error":true,"duration_ms":740,"num_turns":1,"total_cost_usd":0}
+'@ | Set-Content -LiteralPath $transientPath
+
+    $output = & $scriptPath -Attempt 1 -ExecutionFile $transientPath -SessionId 'session-1' *>&1 | Out-String
+    Assert-Contains -Actual $output -Expected '"category":"transient-provider"'
+    Assert-Contains -Actual $output -Expected '"retryable":true'
+    Assert-Contains -Actual $output -Expected '"session_id":"session-1"'
+    Assert-Contains -Actual $output -Expected 'Provider returned is_error:true without an error field.'
+
+    $errorPath = Join-Path $testDirectory 'error.json'
+    @(
+        [ordered]@{
+            type = 'result'
+            subtype = 'error_during_execution'
+            is_error = $true
+            num_turns = 2
+            total_cost_usd = 0.01
+            error = 'Rate limit exceeded'
+        }
+    ) | ConvertTo-Json | Set-Content -LiteralPath $errorPath
+
+    $output = & $scriptPath -Attempt 2 -ExecutionFile $errorPath -SessionId 'session-2' *>&1 | Out-String
+    Assert-Contains -Actual $output -Expected '"category":"claude-execution"'
+    Assert-Contains -Actual $output -Expected '"retryable":true'
+    Assert-Contains -Actual $output -Expected 'Rate limit exceeded'
+
+    $nonRetryablePath = Join-Path $testDirectory 'non-retryable.json'
+    [ordered]@{
+        type = 'result'
+        subtype = 'error_during_execution'
+        is_error = $true
+        num_turns = 2
+        total_cost_usd = 0.01
+        error = 'Invalid authentication credentials'
+    } | ConvertTo-Json | Set-Content -LiteralPath $nonRetryablePath
+
+    $output = & $scriptPath -Attempt 1 -ExecutionFile $nonRetryablePath *>&1 | Out-String
+    Assert-Contains -Actual $output -Expected '"retryable":false'
+
+    $output = & $scriptPath -Attempt 1 -ExecutionFile (Join-Path $testDirectory 'missing.json') *>&1 | Out-String
+    Assert-Contains -Actual $output -Expected '"category":"action-or-bootstrap"'
+
+    Write-Host 'All Claude execution summary tests passed.'
+}
+finally {
+    Remove-Item -LiteralPath $testDirectory -Recurse -Force
+}


### PR DESCRIPTION
Closes #3917

## What changed
- retry one classified transient Claude/action failure after a 15-30 second jittered backoff
- emit safe execution metadata, session ID, retry classification, and available provider error details without dumping full tool output
- preserve failure after non-retryable errors or an exhausted retry
- add focused PowerShell coverage for transient, retryable provider, deterministic credential, and missing-output cases

## Investigation
The failed batch initialized Claude successfully, then returned is_error:true after one turn, roughly 740 ms, and $0 cost. The result contained no error field. Two reviews in the same batch succeeded, supporting transient provider/concurrency pressure rather than a prompt or credential defect.

## Validation
- pwsh -NoProfile -File scripts/Test-SummarizeClaudeExecution.ps1
- workflow parsed by Prettier 3.6.2