### PR TITLE
[Automated] Update mvn CLI Options

### DIFF
--- a/src/ModularPipelines.Java/Generated/Maven.CommandCoverage.json
+++ b/src/ModularPipelines.Java/Generated/Maven.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "mvn",
-  "toolVersion": "Apache Maven 3.9.16 (2bdd9fddda4b155ebf8000e807eb73fd829a51d5) Maven home: /home/runner/work/_temp/cli-tools/apache-maven-3.9.16 Java version: 17.0.19, vendor: Eclipse Adoptium, runtime: /usr/lib/jvm/temurin-17-jdk-amd64 Default locale: en, platform encoding: UTF-8 OS name: \u0022linux\u0022, version: \u00226.17.0-1020-azure\u0022, arch: \u0022amd64\u0022, family: \u0022unix\u0022",
+  "toolVersion": "Apache Maven 3.9.16 (2bdd9fddda4b155ebf8000e807eb73fd829a51d5) Maven home: /home/runner/work/_temp/cli-tools/apache-maven-3.9.16 Java version: 17.0.20, vendor: Eclipse Adoptium, runtime: /usr/lib/jvm/temurin-17-jdk-amd64 Default locale: en, platform encoding: UTF-8 OS name: \u0022linux\u0022, version: \u00226.17.0-1022-azure\u0022, arch: \u0022amd64\u0022, family: \u0022unix\u0022",
   "commandCount": 1,
   "commandTreeSha256": "77b009e6e3fcca705290e093300672ab0c85c6661417cced8369040f3290be3f",
   "commands": [

--- a/src/ModularPipelines.Java/Services/IMaven.Generated.cs
+++ b/src/ModularPipelines.Java/Services/IMaven.Generated.cs
@@ -27,7 +27,8 @@ public partial interface IMaven
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(MavenExecuteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(MavenExecuteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     #endregion
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **mvn** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- mvn (Apache Maven 3.9.16 (2bdd9fddda4b155ebf8000e807eb73fd829a51d5) Maven home: /home/runner/work/_temp/cli-tools/apache-maven-3.9.16 Java version: 17.0.20, vendor: Eclipse Adoptium, runtime: /usr/lib/jvm/temurin-17-jdk-amd64 Default locale: en, platform encoding: UTF-8 OS name: "linux", version: "6.17.0-1022-azure", arch: "amd64", family: "unix"): 1 commands, tree 77b009e6e3fcca705290e093300672ab0c85c6661417cced8369040f3290be3f

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator