### PR TITLE
[Automated] Update ansible CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/ansible.md
+++ b/docs/docs/mp-packages/cli/ansible.md
@@ -7,7 +7,13 @@ title: ansible CLI reference
 
 `ModularPipelines.Ansible` provides strongly typed access to the `ansible` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `ansible` executable. Install it separately and ensure `ansible` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Ansible
@@ -30,7 +36,10 @@ public class RunCommandModule : Module<CommandResult>
         CancellationToken cancellationToken)
     {
         return await context.Tools.Ansible.ExecuteAsync(
-            new AnsibleExecuteOptions("value"),
+            new AnsibleExecuteOptions("localhost")
+            {
+                ListHosts = true,
+            },
             cancellationToken: cancellationToken);
     }
 }

--- a/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
+++ b/src/ModularPipelines.Ansible/Extensions/AnsibleExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class AnsibleExtensions
     }
 
     /// <summary>
-    /// Gets the ansible service from the pipeline context.
+    /// Gets the ansible service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IAnsible"/> service for executing ansible commands.</returns>

--- a/src/ModularPipelines.Ansible/Generated/Ansible.CommandCoverage.json
+++ b/src/ModularPipelines.Ansible/Generated/Ansible.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "ansible",
+  "toolVersion": "ansible [core 2.21.3]   config file = None   configured module search path = [\u0027/home/runner/.ansible/plugins/modules\u0027, \u0027/usr/share/ansible/plugins/modules\u0027]   ansible python module location = /opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible   ansible collection location = /home/runner/.ansible/collections:/usr/share/ansible/collections   executable location = /opt/pipx_bin/ansible   python version = 3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0] (/opt/pipx/venvs/ansible-core/",
   "commandCount": 1,
   "commandTreeSha256": "0cb87f727f31e5f5a59cca8a10c8f9b55622be05305d4e7e92c334f5911e1034",
   "commands": [

--- a/src/ModularPipelines.Ansible/Options/AnsibleExecuteOptions.Generated.cs
+++ b/src/ModularPipelines.Ansible/Options/AnsibleExecuteOptions.Generated.cs
@@ -26,14 +26,12 @@ public record AnsibleExecuteOptions(
     /// <summary>
     /// Become password file
     /// </summary>
-    [SecretValue]
     [CliOption("--become-password-file")]
     public string? BecomePasswordFile { get; set; }
 
     /// <summary>
     /// Connection password file
     /// </summary>
-    [SecretValue]
     [CliOption("--connection-password-file")]
     public string? ConnectionPasswordFile { get; set; }
 
@@ -70,7 +68,6 @@ public record AnsibleExecuteOptions(
     /// <summary>
     /// vault password file
     /// </summary>
-    [SecretValue]
     [CliOption("--vault-password-file")]
     public string? VaultPasswordFile { get; set; }
 

--- a/src/ModularPipelines.Ansible/Options/AnsibleExecuteOptions.Generated.cs
+++ b/src/ModularPipelines.Ansible/Options/AnsibleExecuteOptions.Generated.cs
@@ -26,12 +26,14 @@ public record AnsibleExecuteOptions(
     /// <summary>
     /// Become password file
     /// </summary>
+    [SecretValue]
     [CliOption("--become-password-file")]
     public string? BecomePasswordFile { get; set; }
 
     /// <summary>
     /// Connection password file
     /// </summary>
+    [SecretValue]
     [CliOption("--connection-password-file")]
     public string? ConnectionPasswordFile { get; set; }
 
@@ -68,6 +70,7 @@ public record AnsibleExecuteOptions(
     /// <summary>
     /// vault password file
     /// </summary>
+    [SecretValue]
     [CliOption("--vault-password-file")]
     public string? VaultPasswordFile { get; set; }
 

--- a/src/ModularPipelines.Ansible/Services/IAnsible.Generated.cs
+++ b/src/ModularPipelines.Ansible/Services/IAnsible.Generated.cs
@@ -27,7 +27,8 @@ public partial interface IAnsible
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(AnsibleExecuteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(AnsibleExecuteOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     #endregion
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ManualOverrideDetectorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ManualOverrideDetectorTests.cs
@@ -7,6 +7,25 @@ namespace ModularPipelines.OptionsGenerator.Tests.TypeDetection;
 public class ManualOverrideDetectorTests
 {
     [Test]
+    [Arguments("--become-password-file")]
+    [Arguments("--connection-password-file")]
+    [Arguments("--vault-password-file")]
+    public async Task Ansible_Credential_File_Overrides_Are_Secret(string optionName)
+    {
+        var detector = new ManualOverrideDetector(NullLogger<ManualOverrideDetector>.Instance);
+        var result = await detector.DetectTypeAsync(new OptionDetectionContext
+        {
+            ToolName = "ansible",
+            CommandPath = ["ansible"],
+            OptionName = optionName,
+            AllNames = [optionName],
+        });
+
+        await Assert.That(result.Type).IsEqualTo(CliOptionType.String);
+        await Assert.That(result.IsSecret).IsTrue();
+    }
+
+    [Test]
     [Arguments("managed-cassandra", "cluster", "invoke-command")]
     [Arguments("synapse", "spark", "job", "submit")]
     public async Task Azure_Arguments_Overrides_Are_String_Lists(params string[] commandParts)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeOverrides/ansible.json
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeOverrides/ansible.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "./schema.json",
+  "global": {
+    "--become-password-file": {
+      "type": "string",
+      "isSecret": true,
+      "reason": "Ansible credential file values are masked from command logs"
+    },
+    "--connection-password-file": {
+      "type": "string",
+      "isSecret": true,
+      "reason": "Ansible credential file values are masked from command logs"
+    },
+    "--vault-password-file": {
+      "type": "string",
+      "isSecret": true,
+      "reason": "Ansible credential file values are masked from command logs"
+    }
+  },
+  "commands": {}
+}


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **ansible** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- ansible (ansible [core 2.21.3]   config file = None   configured module search path = ['/home/runner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']   ansible python module location = /opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible   ansible collection location = /home/runner/.ansible/collections:/usr/share/ansible/collections   executable location = /opt/pipx_bin/ansible   python version = 3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0] (/opt/pipx/venvs/ansible-core/): 1 commands, tree 0cb87f727f31e5f5a59cca8a10c8f9b55622be05305d4e7e92c334f5911e1034

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `ansible` executable must be installed separately and available on the system `PATH`.
  * Updated the module example to demonstrate listing hosts with the appropriate execution option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->