### PR TITLE
[Automated] Update jq CLI Options

### DIFF
--- a/src/ModularPipelines.Jq/Services/IJq.Generated.cs
+++ b/src/ModularPipelines.Jq/Services/IJq.Generated.cs
@@ -27,7 +27,8 @@ public partial interface IJq
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(JqExecuteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(JqExecuteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     #endregion
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **jq** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- jq (jq-1.8.2): 1 commands, tree c84d384f2a25cca2a8fde5eb61b0f81f728e5f778a232211b176ea80143877bc

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator