### PR TITLE
[Automated] Update hadolint CLI Options

### DIFF
--- a/src/ModularPipelines.Hadolint/Services/IHadolint.Generated.cs
+++ b/src/ModularPipelines.Hadolint/Services/IHadolint.Generated.cs
@@ -27,7 +27,8 @@ public partial interface IHadolint
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(HadolintExecuteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(HadolintExecuteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     #endregion
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **hadolint** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- hadolint (Haskell Dockerfile Linter 2.15.1): 1 commands, tree aeb27eae3024b418e56e8f019f96d51b3a9c807828bc0b65fc1c600d24a325b5

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator