### PR TITLE
[Automated] Update cargo CLI Options

### DIFF
--- a/src/ModularPipelines.Rust/Generated/Cargo.CommandCoverage.json
+++ b/src/ModularPipelines.Rust/Generated/Cargo.CommandCoverage.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "cargo",
-  "toolVersion": "cargo 1.97.1 (c980f4866 2026-06-30)",
+  "toolVersion": "cargo 1.98.0 (797e8a9bc 2026-08-05)",
   "commandCount": 16,
   "commandTreeSha256": "f8b1c0ec09c6f1a8fbc12f34c9e244131aa2869c068c7f752c8da91976b1ec19",
   "commands": [

--- a/src/ModularPipelines.Rust/Options/CargoDocOptions.Generated.cs
+++ b/src/ModularPipelines.Rust/Options/CargoDocOptions.Generated.cs
@@ -40,6 +40,12 @@ public record CargoDocOptions : CargoOptions
     public bool? DocumentPrivateItems { get; set; }
 
     /// <summary>
+    /// The output type to write (unstable) [possible values: html, json]
+    /// </summary>
+    [CliOption("--output-format")]
+    public string? OutputFormat { get; set; }
+
+    /// <summary>
     /// Error format [possible values: human, short, json,
     /// </summary>
     [CliOption("--message-format")]


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **cargo** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- cargo (cargo 1.98.0 (797e8a9bc 2026-08-05)): 16 commands, tree f8b1c0ec09c6f1a8fbc12f34c9e244131aa2869c068c7f752c8da91976b1ec19

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator