### PR TITLE
Harden Kevlar shield boundaries

### DIFF
--- a/docs/docs/architecture/module-execution-lifecycle.md
+++ b/docs/docs/architecture/module-execution-lifecycle.md
@@ -18,7 +18,7 @@ For a module that runs successfully, the phases are:
 5. Attribute `IModuleStartHandler` handlers run sequentially by priority.
 6. The module skip condition is evaluated.
 7. `Module<T>.OnBeforeExecuteAsync` runs once.
-8. `Module<T>.ExecuteAsync` runs through timeout and retry policies.
+8. `Module<T>.ExecuteAsync` runs through timeout handling and the configured resilience shield, which may compose retries with other resilience strategies.
 9. `Module<T>.OnAfterExecuteAsync` runs once.
 10. Global `IModuleEventReceiver.OnModuleEndAsync` receivers run concurrently.
 11. Attribute `IModuleEndHandler` handlers run sequentially by priority.

--- a/docs/docs/migrating-to-v3.md
+++ b/docs/docs/migrating-to-v3.md
@@ -867,7 +867,7 @@ The following have been removed in V3:
 | `ShouldIgnoreFailures()` method | `Configure().WithIgnoreFailures()` |
 | `ModuleRunType` property | `Configure().WithAlwaysRun()` |
 | `Timeout` property | `Configure().WithTimeout()` |
-| `RetryPolicy` property | `Configure().WithRetry()` or `.Advanced.WithShield()` |
+| `RetryPolicy` property | `Configure().WithRetry(count, ...)` or `.Advanced.WithShield(shield)` |
 | `GetModule<T>()` on module | `context.GetModule<TModule>()` |
 
 ## New Features in V3
@@ -1192,7 +1192,7 @@ public class DeployModule : Module<bool>
 | `ShouldSkip()` override | `Configure().WithSkipWhen()` | Fluent builder |
 | `ShouldIgnoreFailures()` override | `Configure().WithIgnoreFailures()` | Fluent builder |
 | `Timeout` property override | `Configure().WithTimeout()` | Fluent builder |
-| `RetryPolicy` property override | `Configure().WithRetry()` | Fluent builder |
+| `RetryPolicy` property override | `Configure().WithRetry(count, ...)` | Fluent builder |
 | `ModuleRunType` override | `Configure().WithAlwaysRun()` | Fluent builder |
 | `OnBeforeExecute()` override | `OnBeforeExecuteAsync()` | Override the module virtual |
 | `OnAfterExecute()` override | `OnAfterExecuteAsync()` | Override the module virtual |

--- a/src/ModularPipelines/Configuration/ModuleRetryShieldFactory.cs
+++ b/src/ModularPipelines/Configuration/ModuleRetryShieldFactory.cs
@@ -32,10 +32,20 @@ internal static class ModuleRetryShieldFactory
             throw new ArgumentOutOfRangeException(nameof(jitterFactor));
         }
 
+        if (baseDelay == TimeSpan.Zero)
+        {
+            return TimeSpan.Zero;
+        }
+
         var exponentialTicks = baseDelay.Ticks * Math.Pow(2, retryAttempt - 1);
         var maximumTicks = Math.Min(exponentialTicks, TimeSpan.MaxValue.Ticks);
         var minimumTicks = maximumTicks / 2;
         var jitteredTicks = minimumTicks + ((maximumTicks - minimumTicks) * jitterFactor);
+
+        if (jitteredTicks >= TimeSpan.MaxValue.Ticks)
+        {
+            return TimeSpan.MaxValue;
+        }
 
         return TimeSpan.FromTicks((long) jitteredTicks);
     }

--- a/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
+++ b/test/ModularPipelines.UnitTests/Configuration/ModuleConfigurationTests.cs
@@ -446,6 +446,28 @@ public class ModuleConfigurationTests
         await Assert.That(delay).IsEqualTo(TimeSpan.FromMilliseconds(expectedMilliseconds));
     }
 
+    [Test]
+    public async Task RetryDelayCalculator_ZeroDelay_RemainsZeroAtMaximumAttempt()
+    {
+        var delay = ModuleRetryShieldFactory.CalculateDelay(
+            retryAttempt: int.MaxValue,
+            baseDelay: TimeSpan.Zero,
+            jitterFactor: 0.5);
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.Zero);
+    }
+
+    [Test]
+    public async Task RetryDelayCalculator_MaximumDelay_RemainsInTimeSpanRange()
+    {
+        var delay = ModuleRetryShieldFactory.CalculateDelay(
+            retryAttempt: 2,
+            baseDelay: TimeSpan.MaxValue,
+            jitterFactor: 1);
+
+        await Assert.That(delay).IsEqualTo(TimeSpan.MaxValue);
+    }
+
     #endregion
 
     #region WithIgnoreFailures Tests

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ResilientCliCommandExecutorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ResilientCliCommandExecutorTests.cs
@@ -52,11 +52,25 @@ public class ResilientCliCommandExecutorTests
         await Assert.That(inner.ExecutionCount).IsEqualTo(5);
     }
 
-    private static ResilientCliCommandExecutor CreateExecutor(ICliCommandExecutor inner)
+    [Test]
+    public async Task CircuitBreaker_CountsFailedCommands_NotIndividualRetryAttempts()
+    {
+        var inner = new SequenceExecutor([.. Enumerable.Repeat(Failure(), 20)]);
+        var executor = CreateExecutor(inner, maxRetries: 3);
+
+        var results = await ExecuteAsync(executor, 6);
+
+        await Assert.That(results.Take(5).Select(result => result.ExitCode))
+            .IsEquivalentTo(Enumerable.Repeat(-1, 5));
+        await Assert.That(results[5].ExitCode).IsEqualTo(-2);
+        await Assert.That(inner.ExecutionCount).IsEqualTo(20);
+    }
+
+    private static ResilientCliCommandExecutor CreateExecutor(ICliCommandExecutor inner, int maxRetries = 0)
         => new(
             inner,
             NullLogger<ResilientCliCommandExecutor>.Instance,
-            maxRetries: 0,
+            maxRetries,
             baseDelay: TimeSpan.Zero,
             circuitBreakerThreshold: 5,
             circuitBreakerDuration: TimeSpan.FromMinutes(1));

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ResilientCliCommandExecutorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ResilientCliCommandExecutorTests.cs
@@ -20,6 +20,94 @@ public class ResilientCliCommandExecutorTests
         await Assert.That(inner.ExecutionCount).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task CircuitBreaker_StaysClosed_WhenFailuresAreInterleavedWithSuccesses()
+    {
+        var inner = new SequenceExecutor(
+            Failure(), Success(),
+            Failure(), Success(),
+            Failure(), Success(),
+            Failure(), Success(),
+            Failure(), Success());
+        var executor = CreateExecutor(inner);
+
+        var results = await ExecuteAsync(executor, 10);
+
+        await Assert.That(results.Select(result => result.ExitCode)).DoesNotContain(-2);
+        await Assert.That(inner.ExecutionCount).IsEqualTo(10);
+    }
+
+    [Test]
+    public async Task CircuitBreaker_Opens_AfterFiveConsecutiveFailures()
+    {
+        var inner = new SequenceExecutor(
+            Failure(), Failure(), Failure(), Failure(), Failure(), Success());
+        var executor = CreateExecutor(inner);
+
+        var results = await ExecuteAsync(executor, 6);
+
+        await Assert.That(results.Take(5).Select(result => result.ExitCode))
+            .IsEquivalentTo(Enumerable.Repeat(-1, 5));
+        await Assert.That(results[5].ExitCode).IsEqualTo(-2);
+        await Assert.That(inner.ExecutionCount).IsEqualTo(5);
+    }
+
+    private static ResilientCliCommandExecutor CreateExecutor(ICliCommandExecutor inner)
+        => new(
+            inner,
+            NullLogger<ResilientCliCommandExecutor>.Instance,
+            maxRetries: 0,
+            baseDelay: TimeSpan.Zero,
+            circuitBreakerThreshold: 5,
+            circuitBreakerDuration: TimeSpan.FromMinutes(1));
+
+    private static async Task<IReadOnlyList<CliCommandResult>> ExecuteAsync(
+        ResilientCliCommandExecutor executor,
+        int count)
+    {
+        var results = new List<CliCommandResult>(count);
+        for (var i = 0; i < count; i++)
+        {
+            results.Add(await executor.ExecuteAsync("test", string.Empty));
+        }
+
+        return results;
+    }
+
+    private static CliCommandResult Failure() => new()
+    {
+        ExitCode = -1,
+        StandardOutput = string.Empty,
+        StandardError = "timeout",
+    };
+
+    private static CliCommandResult Success() => new()
+    {
+        ExitCode = 0,
+        StandardOutput = string.Empty,
+        StandardError = string.Empty,
+    };
+
+    private sealed class SequenceExecutor(params CliCommandResult[] results) : ICliCommandExecutor
+    {
+        private readonly Queue<CliCommandResult> _results = new(results);
+
+        public int ExecutionCount { get; private set; }
+
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            ExecutionCount++;
+            return Task.FromResult(_results.Dequeue());
+        }
+
+        public Task<bool> IsAvailableAsync(string command, CancellationToken cancellationToken = default)
+            => Task.FromResult(true);
+    }
+
     private sealed class RecordingExecutor : ICliCommandExecutor
     {
         public List<(string Command, string Arguments)> AvailabilityProbes { get; } = [];

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ResilientCliCommandExecutor.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ResilientCliCommandExecutor.cs
@@ -58,19 +58,6 @@ public sealed class ResilientCliCommandExecutor : ICliCommandExecutor
 
         _shield = Shield.For<CliCommandResult>()
             .WhenResult(IsTransientFailure)
-            .Retry(options =>
-            {
-                options.MaxRetries = maxRetries;
-                options.Backoff = Backoff.Exponential(baseDelay, jitter: false);
-                options.OnRetry = retryEvent =>
-                {
-                    _logger.LogWarning(
-                        "CLI command failed (attempt {Attempt}/{MaxAttempts}), retrying in {Delay}ms...",
-                        retryEvent.Attempt,
-                        maxRetries,
-                        retryEvent.Delay.TotalMilliseconds);
-                };
-            })
             .CircuitBreaker(options =>
             {
                 options.ConsecutiveFailures = circuitBreakerThreshold;
@@ -91,6 +78,19 @@ public sealed class ResilientCliCommandExecutor : ICliCommandExecutor
                             _logger.LogInformation("Circuit breaker HALF-OPEN - Testing if CLI commands are healthy...");
                             break;
                     }
+                };
+            })
+            .Retry(options =>
+            {
+                options.MaxRetries = maxRetries;
+                options.Backoff = Backoff.Exponential(baseDelay, jitter: false);
+                options.OnRetry = retryEvent =>
+                {
+                    _logger.LogWarning(
+                        "CLI command failed (attempt {Attempt}/{MaxAttempts}), retrying in {Delay}ms...",
+                        retryEvent.Attempt,
+                        maxRetries,
+                        retryEvent.Delay.TotalMilliseconds);
                 };
             });
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ResilientCliCommandExecutor.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ResilientCliCommandExecutor.cs
@@ -73,9 +73,7 @@ public sealed class ResilientCliCommandExecutor : ICliCommandExecutor
             })
             .CircuitBreaker(options =>
             {
-                options.FailureRatio = 0.5;
-                options.MinimumThroughput = circuitBreakerThreshold;
-                options.SamplingWindow = TimeSpan.FromSeconds(30);
+                options.ConsecutiveFailures = circuitBreakerThreshold;
                 options.BreakDuration = circuitBreakerDuration;
                 options.OnStateChanged = stateChangedEvent =>
                 {
@@ -106,8 +104,9 @@ public sealed class ResilientCliCommandExecutor : ICliCommandExecutor
         try
         {
             return await _shield.ExecuteAsync(
-                async token => await _inner.ExecuteAsync(command, arguments, token, workingDirectory),
-                cancellationToken);
+                    async token => await _inner.ExecuteAsync(command, arguments, token, workingDirectory).ConfigureAwait(false),
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
         catch (CircuitOpenException ex)
         {
@@ -124,7 +123,7 @@ public sealed class ResilientCliCommandExecutor : ICliCommandExecutor
     public async Task<bool> IsAvailableAsync(string command, CancellationToken cancellationToken = default)
     {
         // Availability check doesn't use resilience patterns - we want immediate feedback
-        return await _inner.IsAvailableAsync(command, cancellationToken);
+        return await _inner.IsAvailableAsync(command, cancellationToken).ConfigureAwait(false);
     }
 
     public Task<bool> IsAvailableAsync(


### PR DESCRIPTION
## Summary

- translate the migrated CLI circuit breaker to five consecutive failures, so successes reset the streak
- saturate extreme module retry delays at `TimeSpan.MaxValue` and preserve zero delay
- correct Kevlar migration/lifecycle docs and add focused regressions

## Validation

- `ResilientCliCommandExecutorTests`: 2 passed
- `ModuleConfigurationTests`: 35 passed
- OptionsGenerator suite: 817 passed; one unrelated PID-fixture failure tracked in #3995
- `ModularPipelines.slnx` Release build: 0 warnings/errors
- OptionsGenerator Release build: 0 warnings/errors
- targeted format verification: clean
- Docusaurus production build: 326 documents

Fixes #4001
Refs #3980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retry-delay handling for zero and maximum-duration values, preventing invalid timing results.
  - Refined resilience behavior so circuit breakers correctly track consecutive command failures while retries operate as expected.
  - Improved asynchronous command execution reliability.

- **Documentation**
  - Clarified that module execution uses timeout handling and the configured resilience strategy, including retries and other safeguards.
  - Updated migration guidance with the required retry-count parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->