### PR TITLE
Preserve generated positional operands

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/CodeGeneratorOrchestratorTests.cs
@@ -317,6 +317,45 @@ public class CodeGeneratorOrchestratorTests
     }
 
     [Test]
+    public async Task Operand_Coverage_Failure_Leaves_Existing_Output_Untouched()
+    {
+        var (outputRoot, existingFile) = await CreateOutputRootWithExistingFileAsync();
+        var generatorCalled = false;
+
+        try
+        {
+            var invalidCommand = FakeCommand() with
+            {
+                HasOperandTakingUsage = true,
+                UsageSynopsis = "fake run <target>",
+            };
+            var scraper = new FakeCliScraper { Commands = [invalidCommand] };
+            var generator = new FakeGenerator
+            {
+                OnGenerate = _ =>
+                {
+                    generatorCalled = true;
+                    return [];
+                },
+            };
+
+            var result = await Orchestrator(scraper, generator).GenerateAsync("fake", outputRoot);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result.HasErrors).IsTrue();
+                await Assert.That(result.Errors[0].Message).Contains("no CliPositionalArgument values");
+                await Assert.That(generatorCalled).IsFalse();
+                await Assert.That(File.Exists(existingFile)).IsTrue();
+            }
+        }
+        finally
+        {
+            Directory.Delete(outputRoot, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task Duplicate_Output_Paths_Fail_Without_Mutating_Existing_Output()
     {
         var (outputRoot, existingFile) = await CreateOutputRootWithExistingFileAsync();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -41,7 +41,7 @@ public class PositionalOperandAdapterTests
 
         await AssertArgument(command, "Packages", isRequired: false, isVariadic: false);
         await Assert.That(command!.PositionalArguments.Select(argument => argument.PropertyName))
-            .DoesNotContain("Prog");
+            .IsEquivalentTo(["Packages"]);
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -1,0 +1,165 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class PositionalOperandAdapterTests
+{
+    private static ICliCommandExecutor Executor { get; } =
+        new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance);
+
+    private static IHelpTextCache Cache { get; } =
+        new HelpTextCache(NullLogger<HelpTextCache>.Instance);
+
+    [Test]
+    public async Task Winget_Hash_Preserves_File_Operand()
+    {
+        var command = await new TestWinGetCliScraper().Parse(
+            ["winget", "hash"],
+            "usage: winget hash [-f] <file> [<options>]");
+
+        await AssertArgument(command, "File", isRequired: true, isVariadic: false);
+    }
+
+    [Test]
+    public async Task DotNet_Store_Preserves_Variadic_Argument_Operand()
+    {
+        var command = await new TestDotNetCliScraper().Parse(
+            ["dotnet", "store"],
+            "Usage: dotnet store [<argument>...] [options]");
+
+        await AssertArgument(command, "Argument", isRequired: false, isVariadic: true);
+    }
+
+    [Test]
+    public async Task Go_Fix_Preserves_Packages_But_Not_Option_Value()
+    {
+        const string helpText = "usage: go fix [build flags] [-fixtool prog] [fix flags] [packages]";
+        var command = await new TestGoCliScraper().Parse(["go", "fix"], helpText);
+
+        await AssertArgument(command, "Packages", isRequired: false, isVariadic: false);
+        await Assert.That(command!.PositionalArguments.Select(argument => argument.PropertyName))
+            .DoesNotContain("Prog");
+    }
+
+    [Test]
+    public async Task Liquibase_Help_Option_Description_Is_Not_An_Operand()
+    {
+        const string helpText = "Usage: liquibase init [OPTIONS] [COMMAND]\n  -h, --help   Show this help message and exit";
+
+        var usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(
+            UsageSynopsisParser.Parse(helpText, ["liquibase", "init"]));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(usage.HasOperandTokens).IsFalse();
+            await Assert.That(usage.PositionalArguments).IsEmpty();
+        }
+    }
+
+    [Test]
+    public async Task Pip_Show_Preserves_Variadic_Package_Operand()
+    {
+        var command = await new TestPipCliScraper().Parse(
+            ["pip", "show"],
+            "Usage: pip show [options] <package> ...");
+
+        await AssertArgument(command, "Package", isRequired: true, isVariadic: true);
+    }
+
+    [Test]
+    public async Task Pnpm_Add_Preserves_Name_Operand()
+    {
+        var command = await new TestPnpmCliScraper().Parse(
+            ["pnpm", "add"],
+            "Usage: pnpm add <name>");
+
+        await AssertArgument(command, "Name", isRequired: true, isVariadic: false);
+    }
+
+    private static async Task AssertArgument(
+        CliCommandDefinition? command,
+        string propertyName,
+        bool isRequired,
+        bool isVariadic)
+    {
+        var argument = command!.PositionalArguments.Single(item => item.PropertyName == propertyName);
+        using (Assert.Multiple())
+        {
+            await Assert.That(argument.IsRequired).IsEqualTo(isRequired);
+            await Assert.That(argument.IsVariadic).IsEqualTo(isVariadic);
+        }
+    }
+
+    private sealed class TestWinGetCliScraper()
+        : WinGetCliScraper(
+            PositionalOperandAdapterTests.Executor,
+            PositionalOperandAdapterTests.Cache,
+            NullLogger<WinGetCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
+    }
+
+    private sealed class TestDotNetCliScraper()
+        : DotNetCliScraper(
+            PositionalOperandAdapterTests.Executor,
+            PositionalOperandAdapterTests.Cache,
+            NullLogger<DotNetCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
+    }
+
+    private sealed class TestGoCliScraper()
+        : GoCliScraper(
+            PositionalOperandAdapterTests.Executor,
+            PositionalOperandAdapterTests.Cache,
+            NullLogger<GoCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
+    }
+
+    private sealed class TestPipCliScraper()
+        : PipCliScraper(
+            PositionalOperandAdapterTests.Executor,
+            PositionalOperandAdapterTests.Cache,
+            NullLogger<PipCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
+    }
+
+    private sealed class TestPnpmCliScraper()
+        : PnpmCliScraper(
+            PositionalOperandAdapterTests.Executor,
+            PositionalOperandAdapterTests.Cache,
+            NullLogger<PnpmCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -142,11 +142,7 @@ public class PositionalOperandAdapterTests
             NullLogger<PipCliScraper>.Instance)
     {
         public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(
-                commandPath,
-                helpText,
-                ParseUsageSynopsis(commandPath, helpText),
-                CancellationToken.None);
+            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
     }
 
     private sealed class TestPnpmCliScraper()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -142,7 +142,11 @@ public class PositionalOperandAdapterTests
             NullLogger<PipCliScraper>.Instance)
     {
         public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
     }
 
     private sealed class TestPnpmCliScraper()

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
@@ -415,10 +415,6 @@ public class SnykCliScraperTests
         public bool CanGenerate(string helpText) => HasOptions(helpText);
 
         public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
-        {
-            var usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(
-                ParseUsageSynopsis(commandPath, helpText));
-            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
-        }
+            => ParseCommandAsync(commandPath, helpText, CancellationToken.None);
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
@@ -340,6 +340,22 @@ public class SnykCliScraperTests
     }
 
     [Test]
+    public async Task Iac_Group_Models_Optional_Path_From_Usage()
+    {
+        var command = await new TestSnykCliScraper().Parse(
+            ["snyk", "iac"],
+            "Usage: snyk iac <COMMAND> [<OPTIONS>] [<PATH>]");
+
+        var path = command!.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(path.PropertyName).IsEqualTo("Path");
+            await Assert.That(path.IsRequired).IsFalse();
+            await Assert.That(path.CSharpType).IsEqualTo("string?");
+        }
+    }
+
+    [Test]
     public async Task Windows_Resolver_Finds_Standalone_Executable()
     {
         var root = Path.Combine(Path.GetTempPath(), "mp-snyk-resolver-tests", Guid.NewGuid().ToString("N"));
@@ -398,7 +414,11 @@ public class SnykCliScraperTests
 
         public bool CanGenerate(string helpText) => HasOptions(helpText);
 
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
-            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        {
+            var usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(
+                ParseUsageSynopsis(commandPath, helpText));
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
@@ -415,6 +415,10 @@ public class SnykCliScraperTests
         public bool CanGenerate(string helpText) => HasOptions(helpText);
 
         public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
-            => ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+            => ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
@@ -124,15 +124,13 @@ public class WinGetCliScraperTests
         var command = await scraper.Parse(["winget", "search"], helpText);
         var usage = scraper.ParseUsage(["winget", "search"], helpText);
 
-        command!.ValidateOperandCoverage(
-            usage.HasOperandTokens,
-            usage.Synopsis,
-            usage.PositionalArguments);
+        command!.ValidateOperandCoverage();
 
         using (Assert.Multiple())
         {
             await Assert.That(command.Options.Single().PropertyName).IsEqualTo("Query");
             await Assert.That(command.PositionalArguments).IsEmpty();
+            await Assert.That(command.UsagePositionalArguments).HasSingleItem();
             await Assert.That(usage.PositionalArguments.Single().AssociatedOptionSwitch)
                 .IsEqualTo("-q");
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
@@ -109,6 +109,35 @@ public class WinGetCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Search_Query_Usage_Is_Covered_By_Named_Option()
+    {
+        const string helpText = """
+            Searches for packages from configured sources.
+
+            usage: winget search [[-q] <query>] [<options>]
+
+            The following arguments are available:
+              -q,--query   The query used to search for a package
+            """;
+        var scraper = new TestWinGetCliScraper();
+        var command = await scraper.Parse(["winget", "search"], helpText);
+        var usage = scraper.ParseUsage(["winget", "search"], helpText);
+
+        command!.ValidateOperandCoverage(
+            usage.HasOperandTokens,
+            usage.Synopsis,
+            usage.PositionalArguments);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command.Options.Single().PropertyName).IsEqualTo("Query");
+            await Assert.That(command.PositionalArguments).IsEmpty();
+            await Assert.That(usage.PositionalArguments.Single().AssociatedOptionSwitch)
+                .IsEqualTo("-q");
+        }
+    }
+
     private sealed class TestWinGetCliScraper : WinGetCliScraper
     {
         public TestWinGetCliScraper(ICliCommandExecutor? executor = null)
@@ -130,6 +159,9 @@ public class WinGetCliScraperTests
             var usage = ParseUsageSynopsis(commandPath, helpText);
             return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
         }
+
+        public UsageSynopsisParseResult ParseUsage(string[] commandPath, string helpText) =>
+            ParseUsageSynopsis(commandPath, helpText);
     }
 
     private sealed class StubExecutor(string rootHelp, string listHelp) : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
@@ -152,10 +152,13 @@ public class WinGetCliScraperTests
         public IReadOnlyList<string> Extract(string helpText) =>
             ExtractSubcommands(helpText).ToList();
 
-        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
+        public async Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText)
         {
             var usage = ParseUsageSynopsis(commandPath, helpText);
-            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+            var command = await ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+            return command is null
+                ? null
+                : command with { UsagePositionalArguments = usage.PositionalArguments };
         }
 
         public UsageSynopsisParseResult ParseUsage(string[] commandPath, string helpText) =>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/CodeGeneratorOrchestrator.cs
@@ -764,6 +764,8 @@ public class CodeGeneratorOrchestrator
 
         await foreach (var command in cliScraper.ScrapeAsync(cancellationToken))
         {
+            // Fail the tool before any generators run. Skipping an invalid command here
+            // could silently delete an existing generated API during stale-file cleanup.
             command.ValidateOperandCoverage();
             allCommands.Add(command);
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -66,6 +66,11 @@ public record CliCommandDefinition
     public bool HasOperandTakingUsage { get; init; }
 
     /// <summary>
+    /// Operands parsed from the usage synopsis, including placeholders owned by named options.
+    /// </summary>
+    public IReadOnlyList<CliPositionalArgument> UsagePositionalArguments { get; init; } = [];
+
+    /// <summary>
     /// Required options that should be constructor parameters.
     /// </summary>
     public IReadOnlyList<CliOptionDefinition> RequiredOptions =>
@@ -123,7 +128,10 @@ public record CliCommandDefinition
     /// Verifies that operand-taking usage cannot silently generate an unusable API.
     /// </summary>
     public void ValidateOperandCoverage() =>
-        ValidateOperandCoverage(HasOperandTakingUsage, UsageSynopsis);
+        ValidateOperandCoverage(
+            HasOperandTakingUsage,
+            UsageSynopsis,
+            UsagePositionalArguments);
 
     /// <summary>
     /// Verifies operand coverage against usage parsed by the shared traversal.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -471,6 +471,10 @@ public abstract partial class CliScraperBase : ICliScraper
             return;
         }
 
+        command = command with
+        {
+            UsagePositionalArguments = usage.PositionalArguments,
+        };
         command.ValidateOperandCoverage(
             usage.HasOperandTokens,
             usage.Synopsis,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -721,6 +721,15 @@ public abstract partial class CliScraperBase : ICliScraper
             GetAdditionalUsageSynopses(commandPath, helpText));
 
     /// <summary>
+    /// Returns true positional operands, excluding values syntactically owned by an option switch.
+    /// </summary>
+    protected static IReadOnlyList<CliPositionalArgument> GetPositionalArguments(
+        UsageSynopsisParseResult usage) =>
+        usage.PositionalArguments
+            .Where(argument => argument.AssociatedOptionSwitch is null)
+            .ToArray();
+
+    /// <summary>
     /// Checks if help text indicates the command has options/flags.
     /// Override if the CLI has a different pattern for leaf commands.
     /// </summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
@@ -124,6 +124,18 @@ public partial class DotNetCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    /// <inheritdoc />
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray(); // Skip tool name
@@ -146,6 +158,10 @@ public partial class DotNetCliScraper : CliScraperBase
 
         // Parse positional arguments
         var positionalArgs = ParsePositionalArguments(helpText);
+        if (positionalArgs.Count == 0)
+        {
+            positionalArgs.AddRange(GetPositionalArguments(usage));
+        }
 
         // Apply command-specific positional argument fixes
         positionalArgs = ApplyPositionalArgumentFixes(commandParts, positionalArgs);
@@ -169,6 +185,8 @@ public partial class DotNetCliScraper : CliScraperBase
             DocumentationUrl = null,
             Options = options,
             PositionalArguments = positionalArgs,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = positionalArgs.Count > 0,
             SubDomainGroup = subDomain,
             Enums = enums,
             CompatibilityProperties = DotNetCliCompatibility.GetProperties(commandParts),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
@@ -125,11 +125,7 @@ public partial class DotNetCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     /// <inheritdoc />
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
@@ -186,7 +182,7 @@ public partial class DotNetCliScraper : CliScraperBase
             Options = options,
             PositionalArguments = positionalArgs,
             UsageSynopsis = usage.Synopsis,
-            HasOperandTakingUsage = positionalArgs.Count > 0,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = subDomain,
             Enums = enums,
             CompatibilityProperties = DotNetCliCompatibility.GetProperties(commandParts),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -151,6 +151,18 @@ public partial class GoCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    /// <inheritdoc />
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray();
@@ -166,6 +178,7 @@ public partial class GoCliScraper : CliScraperBase
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)
             .ToList();
+        var positionalArguments = GetPositionalArguments(usage);
 
         var className = GenerateClassName(commandPath);
 
@@ -179,7 +192,9 @@ public partial class GoCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = null,
             Options = options,
-            PositionalArguments = [],
+            PositionalArguments = positionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = positionalArguments.Count > 0,
             SubDomainGroup = null,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -152,11 +152,7 @@ public partial class GoCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     /// <inheritdoc />
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
@@ -194,7 +190,7 @@ public partial class GoCliScraper : CliScraperBase
             Options = options,
             PositionalArguments = positionalArguments,
             UsageSynopsis = usage.Synopsis,
-            HasOperandTakingUsage = positionalArguments.Count > 0,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = null,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
@@ -123,6 +123,18 @@ public partial class PipCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    /// <inheritdoc />
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray();
@@ -138,6 +150,7 @@ public partial class PipCliScraper : CliScraperBase
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)
             .ToList();
+        var positionalArguments = GetPositionalArguments(usage);
 
         var className = GenerateClassName(commandPath);
 
@@ -151,7 +164,9 @@ public partial class PipCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = null,
             Options = options,
-            PositionalArguments = [],
+            PositionalArguments = positionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = positionalArguments.Count > 0,
             SubDomainGroup = null,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
@@ -124,11 +124,7 @@ public partial class PipCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     /// <inheritdoc />
     protected override Task<CliCommandDefinition?> ParseCommandAsync(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
@@ -124,7 +124,11 @@ public partial class PipCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
 
     /// <inheritdoc />
     protected override Task<CliCommandDefinition?> ParseCommandAsync(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
@@ -124,11 +124,7 @@ public partial class PipCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     /// <inheritdoc />
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
@@ -166,7 +162,7 @@ public partial class PipCliScraper : CliScraperBase
             Options = options,
             PositionalArguments = positionalArguments,
             UsageSynopsis = usage.Synopsis,
-            HasOperandTakingUsage = positionalArguments.Count > 0,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = null,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
@@ -144,11 +144,7 @@ public partial class PnpmCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     /// <inheritdoc />
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
@@ -191,7 +187,7 @@ public partial class PnpmCliScraper : CliScraperBase
             Options = options,
             PositionalArguments = positionalArguments,
             UsageSynopsis = usage.Synopsis,
-            HasOperandTakingUsage = positionalArguments.Count > 0,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = null,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
@@ -143,6 +143,18 @@ public partial class PnpmCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    /// <inheritdoc />
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray(); // Skip tool name
@@ -163,6 +175,7 @@ public partial class PnpmCliScraper : CliScraperBase
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)
             .ToList();
+        var positionalArguments = GetPositionalArguments(usage);
 
         var className = GenerateClassName(commandPath);
 
@@ -176,7 +189,9 @@ public partial class PnpmCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = null,
             Options = options,
-            PositionalArguments = [],
+            PositionalArguments = positionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = positionalArguments.Count > 0,
             SubDomainGroup = null,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
@@ -145,6 +145,18 @@ public partial class SnykCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    /// <inheritdoc />
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray();
@@ -157,7 +169,9 @@ public partial class SnykCliScraper : CliScraperBase
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
         AddDocumentedOptions(commandParts, options);
-        var positionalArguments = GetPositionalArguments(commandParts);
+        var positionalArguments = CliPositionalArgument.MergeDuplicates(
+            GetPositionalArguments(commandParts)
+                .Concat(GetPositionalArguments(usage)));
         var enums = options
             .Where(x => x.EnumDefinition is not null)
             .Select(x => x.EnumDefinition!)
@@ -178,6 +192,8 @@ public partial class SnykCliScraper : CliScraperBase
             DocumentationUrl = "https://docs.snyk.io/snyk-cli/commands",
             Options = options,
             PositionalArguments = positionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = null,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
@@ -146,11 +146,7 @@ public partial class SnykCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     /// <inheritdoc />
     protected override Task<CliCommandDefinition?> ParseCommandAsync(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
@@ -159,6 +159,8 @@ public partial class SnykCliScraper : CliScraperBase
         UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
+        usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage);
+
         var commandParts = commandPath.Skip(1).ToArray();
 
         if (commandParts.Length == 0)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -726,17 +726,29 @@ public static class UsageSynopsisParser
     private static IReadOnlyList<string> TrimTrailingUsageExplanation(IEnumerable<string> sourceTokens)
     {
         var tokens = sourceTokens.ToList();
-        var boundaryIndex = tokens.FindIndex(static token =>
+        var punctuationBoundaryIndex = tokens.FindIndex(static token =>
             token.Length > 1
             && token[^1] == '.'
             && token[^2] is ']' or '>' or '}' or ')');
+        var optionDescriptionBoundaryIndex = tokens.FindIndex(static token =>
+            token.StartsWith('-')
+            && token.EndsWith(','));
+        var boundaryIndex = new[] { punctuationBoundaryIndex, optionDescriptionBoundaryIndex }
+            .Where(index => index >= 0)
+            .DefaultIfEmpty(-1)
+            .Min();
         if (boundaryIndex < 0)
         {
             return tokens;
         }
 
-        tokens[boundaryIndex] = tokens[boundaryIndex][..^1];
-        return tokens.Take(boundaryIndex + 1).ToList();
+        if (boundaryIndex == punctuationBoundaryIndex)
+        {
+            tokens[boundaryIndex] = tokens[boundaryIndex][..^1];
+            boundaryIndex++;
+        }
+
+        return tokens.Take(boundaryIndex).ToList();
     }
 
     private static string? NormalizeOperandName(string content)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -813,9 +813,13 @@ public static class UsageSynopsisParser
         var content = TrimControlWrappers(token);
         return string.IsNullOrWhiteSpace(content)
                || content.StartsWith('-')
-               || OptionControlTokens.Contains(content)
+               || IsOptionControlLabel(content)
                || content.All(character => !char.IsLetterOrDigit(character));
     }
+
+    private static bool IsOptionControlLabel(string content) =>
+        OptionControlTokens.Contains(content)
+        || content.EndsWith(" flags", StringComparison.OrdinalIgnoreCase);
 
     private static bool IsOptionControlToken(string token)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
@@ -143,6 +143,18 @@ public partial class WinGetCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    /// <inheritdoc />
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray(); // Skip tool name
@@ -171,6 +183,7 @@ public partial class WinGetCliScraper : CliScraperBase
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)
             .ToList();
+        var positionalArguments = GetPositionalArguments(usage);
 
         var className = GenerateClassName(commandPath);
 
@@ -184,7 +197,9 @@ public partial class WinGetCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = null,
             Options = options,
-            PositionalArguments = [],
+            PositionalArguments = positionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = positionalArguments.Count > 0,
             SubDomainGroup = null,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
@@ -144,11 +144,7 @@ public partial class WinGetCliScraper : CliScraperBase
         string[] commandPath,
         string helpText,
         CancellationToken cancellationToken) =>
-        ParseCommandAsync(
-            commandPath,
-            helpText,
-            ParseUsageSynopsis(commandPath, helpText),
-            cancellationToken);
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
 
     /// <inheritdoc />
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
@@ -199,7 +195,7 @@ public partial class WinGetCliScraper : CliScraperBase
             Options = options,
             PositionalArguments = positionalArguments,
             UsageSynopsis = usage.Synopsis,
-            HasOperandTakingUsage = positionalArguments.Count > 0,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = null,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
@@ -196,7 +196,6 @@ public partial class WinGetCliScraper : CliScraperBase
             PositionalArguments = positionalArguments,
             UsageSynopsis = usage.Synopsis,
             HasOperandTakingUsage = usage.HasOperandTokens,
-            UsagePositionalArguments = usage.PositionalArguments,
             SubDomainGroup = null,
             Enums = enums
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
@@ -196,6 +196,7 @@ public partial class WinGetCliScraper : CliScraperBase
             PositionalArguments = positionalArguments,
             UsageSynopsis = usage.Synopsis,
             HasOperandTakingUsage = usage.HasOperandTokens,
+            UsagePositionalArguments = usage.PositionalArguments,
             SubDomainGroup = null,
             Enums = enums
         };


### PR DESCRIPTION
## Summary

- thread shared usage-synopsis operands through the WinGet, .NET, Go, pip, and pnpm adapters
- exclude option-owned placeholders from generated positional properties
- stop Liquibase's indented `-h, --help` description from bleeding into a usage synopsis
- cover all six failing workflow shapes with adapter/parser regressions

## Validation

- positional regression fixtures: 6 passed
- usage parser tests: 35 passed
- affected existing adapter tests: 21 passed
- full OptionsGenerator suite: 822 passed
- OptionsGenerator Release build: 0 warnings/errors
- formatter and `git diff --check`: clean

Fixes #3987
Part of #3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command definitions now capture positional arguments and usage syntax across WinGet, .NET, Go, pip, pnpm, and Snyk commands.
  * Commands accurately indicate whether they accept operands.
* **Bug Fixes**
  * Improved parsing to exclude option values and descriptions from positional arguments.
  * Corrected usage synopsis boundary handling.
  * Prevented invalid operand coverage from overwriting existing generated output.
* **Tests**
  * Added coverage for required, optional, and variadic operands across supported command-line tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->