### PR TITLE
Stabilize child timeout fixture startup

### DIFF
--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -818,7 +818,7 @@ internal sealed class Command : ICommandContext
             forcefulCancellationReady);
     }
 
-    private static async Task ScheduleForcefulCancellationAsync(
+    internal static async Task ScheduleForcefulCancellationAsync(
         CancellationTokenSource forcefulCancellationToken,
         TimeSpan gracefulShutdownTimeout,
         Task? forcefulCancellationReady)
@@ -827,7 +827,16 @@ internal sealed class Command : ICommandContext
         {
             if (forcefulCancellationReady is not null)
             {
-                await forcefulCancellationReady.ConfigureAwait(false);
+                try
+                {
+                    await forcefulCancellationReady.ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    Trace.TraceError(
+                        "Forceful cancellation readiness failed; arming the timer anyway: {0}",
+                        exception);
+                }
             }
 
             if (forcefulCancellationToken.Token.CanBeCanceled)

--- a/src/ModularPipelines/Context/Command.cs
+++ b/src/ModularPipelines/Context/Command.cs
@@ -450,7 +450,10 @@ internal sealed class Command : ICommandContext
             forcefulCancellationToken.Token.Register(processTreeTerminator.Kill);
 
         var registration = executionCancellationToken.Register(
-            () => ScheduleForcefulCancellation(forcefulCancellationToken, execOpts.GracefulShutdownTimeout));
+            () => ScheduleForcefulCancellation(
+                forcefulCancellationToken,
+                execOpts.GracefulShutdownTimeout,
+                execOpts.InternalForcefulCancellationReady));
         loggingFailures.Capture(
             () => _commandLogger.LogCommandStart(
                 options,
@@ -806,10 +809,27 @@ internal sealed class Command : ICommandContext
 
     private static void ScheduleForcefulCancellation(
         CancellationTokenSource forcefulCancellationToken,
-        TimeSpan gracefulShutdownTimeout)
+        TimeSpan gracefulShutdownTimeout,
+        Task? forcefulCancellationReady)
+    {
+        _ = ScheduleForcefulCancellationAsync(
+            forcefulCancellationToken,
+            gracefulShutdownTimeout,
+            forcefulCancellationReady);
+    }
+
+    private static async Task ScheduleForcefulCancellationAsync(
+        CancellationTokenSource forcefulCancellationToken,
+        TimeSpan gracefulShutdownTimeout,
+        Task? forcefulCancellationReady)
     {
         try
         {
+            if (forcefulCancellationReady is not null)
+            {
+                await forcefulCancellationReady.ConfigureAwait(false);
+            }
+
             if (forcefulCancellationToken.Token.CanBeCanceled)
             {
                 forcefulCancellationToken.CancelAfter(gracefulShutdownTimeout);

--- a/src/ModularPipelines/Options/CommandExecutionOptions.cs
+++ b/src/ModularPipelines/Options/CommandExecutionOptions.cs
@@ -70,4 +70,6 @@ public record CommandExecutionOptions
     public int MaxCapturedOutputLength { get; init; } = DefaultMaxCapturedOutputLength;
 
     internal bool InternalDryRun { get; set; }
+
+    internal Task? InternalForcefulCancellationReady { get; init; }
 }

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -889,6 +889,9 @@ public class CommandTests : TestBase
         var grandchildPidFile = Path.Combine(Path.GetTempPath(), $"modular-pipelines-grandchild-{fileSuffix}.pid");
         Process? intermediateProcess = null;
         Process? grandchildProcess = null;
+        Task<CommandResult>? executionTask = null;
+        var forcefulCancellationReady = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
 
         try
         {
@@ -909,7 +912,7 @@ public class CommandTests : TestBase
                 $"Set-Content -LiteralPath '{EscapePowerShellLiteral(intermediatePidFile)}' -Value $intermediate.Id",
                 "Wait-Process -Id $intermediate.Id");
 
-            var executionTask = command.ExecuteCommandLineToolAsync(
+            executionTask = command.ExecuteCommandLineToolAsync(
                 new GenericCommandLineToolOptions("pwsh")
                 {
                     Arguments = ["-NoProfile", "-Command", parentScript],
@@ -917,6 +920,7 @@ public class CommandTests : TestBase
                 new CommandExecutionOptions
                 {
                     GracefulShutdownTimeout = TimeSpan.FromSeconds(1),
+                    InternalForcefulCancellationReady = forcefulCancellationReady.Task,
                 },
                 cancellationTokenSource.Token);
 
@@ -934,6 +938,7 @@ public class CommandTests : TestBase
                 grandchildPidFile,
                 grandchildPidFileTimeout.Token);
             grandchildProcess = Process.GetProcessById(grandchildProcessId);
+            forcefulCancellationReady.SetResult();
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await executionTask);
 
             var grandchildExited = await WaitForExitAsync(grandchildProcess, TimeSpan.FromSeconds(2));
@@ -941,6 +946,25 @@ public class CommandTests : TestBase
         }
         finally
         {
+            forcefulCancellationReady.TrySetResult();
+            if (executionTask is not null)
+            {
+                try
+                {
+                    await executionTask.WaitAsync(TimeSpan.FromSeconds(5));
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected after the fixture requests command cancellation.
+                }
+                catch (TimeoutException)
+                {
+                    // Process handles below provide the final cleanup fallback.
+                }
+            }
+
+            grandchildProcess ??= TryGetPublishedProcess(grandchildPidFile);
+
             foreach (var process in new[] { intermediateProcess, grandchildProcess })
             {
                 if (process is { HasExited: false })
@@ -960,6 +984,20 @@ public class CommandTests : TestBase
     }
 
     private static string EscapePowerShellLiteral(string value) => value.Replace("'", "''");
+
+    private static Process? TryGetPublishedProcess(string pidFile)
+    {
+        try
+        {
+            return int.TryParse(File.ReadAllText(pidFile), out var processId)
+                ? Process.GetProcessById(processId)
+                : null;
+        }
+        catch (Exception exception) when (exception is IOException or ArgumentException)
+        {
+            return null;
+        }
+    }
 
     private static async Task<int> WaitForProcessIdAsync(string pidFile, CancellationToken cancellationToken)
     {

--- a/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
+++ b/test/ModularPipelines.UnitTests/Helpers/CommandTests.cs
@@ -879,6 +879,22 @@ public class CommandTests : TestBase
     }
 
     [Test]
+    public async Task ScheduleForcefulCancellationAsync_ArmsTimerWhenReadinessFaults()
+    {
+        using var forcefulCancellationToken = new CancellationTokenSource();
+        var readinessFailure = Task.FromException(
+            new InvalidOperationException("readiness failed"));
+
+        await Command.ScheduleForcefulCancellationAsync(
+            forcefulCancellationToken,
+            TimeSpan.Zero,
+            readinessFailure);
+
+        await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            await Task.Delay(TimeSpan.FromSeconds(1), forcefulCancellationToken.Token));
+    }
+
+    [Test]
     [RequiresTool("pwsh")]
     public async Task ExecuteCommandLineToolAsync_ForcefulCancellation_CapturesDescendantSpawnedDuringGrace()
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ProcessCliCommandExecutorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ProcessCliCommandExecutorTests.cs
@@ -214,32 +214,25 @@ public class ProcessCliCommandExecutorTests
         {
             var command = await CreateLongRunningChildCommandAsync(
                 childPidPath,
-                parentExits: false);
+                parentExits: false,
+                delayChildStartup: true);
             scriptPath = command.ScriptPath;
-            var executor = new ProcessCliCommandExecutor(
-                NullLogger<ProcessCliCommandExecutor>.Instance,
-                OperatingSystem.IsWindows()
-                    ? TimeSpan.FromMilliseconds(1500)
-                    : TimeSpan.FromSeconds(2));
-
-            var execution = executor.ExecuteAsync(command.Command, command.Arguments);
-            var result = await execution.WaitAsync(TimeSpan.FromSeconds(5));
-            childPid = int.Parse(await File.ReadAllTextAsync(childPidPath));
+            var execution = await ExecuteAfterChildStartsAsync(
+                command.Command,
+                command.Arguments,
+                childPidPath);
+            childPid = execution.ChildPid;
 
             using (Assert.Multiple())
             {
-                await Assert.That(result.ExitCode).IsEqualTo(-1);
-                await Assert.That(result.StandardError).Contains("timed out");
-                await Assert.That(await WaitForProcessExitAsync(childPid.Value)).IsTrue();
+                await Assert.That(execution.Result.ExitCode).IsEqualTo(-1);
+                await Assert.That(execution.Result.StandardError).Contains("timed out");
+                await Assert.That(await WaitForProcessExitAsync(execution.ChildPid)).IsTrue();
             }
         }
         finally
         {
-            if (childPid.HasValue && IsProcessRunning(childPid.Value))
-            {
-                using var childProcess = Process.GetProcessById(childPid.Value);
-                childProcess.Kill();
-            }
+            KillPublishedChildIfRunning(childPidPath, childPid);
 
             File.Delete(childPidPath);
             if (scriptPath is not null)
@@ -263,30 +256,22 @@ public class ProcessCliCommandExecutorTests
                 childPidPath,
                 parentExits: true);
             scriptPath = command.ScriptPath;
-            var executor = new ProcessCliCommandExecutor(
-                NullLogger<ProcessCliCommandExecutor>.Instance,
-                OperatingSystem.IsWindows()
-                    ? TimeSpan.FromMilliseconds(1500)
-                    : TimeSpan.FromSeconds(2));
-
-            var result = await executor.ExecuteAsync(command.Command, command.Arguments)
-                .WaitAsync(TimeSpan.FromSeconds(5));
-            childPid = int.Parse(await File.ReadAllTextAsync(childPidPath));
+            var execution = await ExecuteAfterChildStartsAsync(
+                command.Command,
+                command.Arguments,
+                childPidPath);
+            childPid = execution.ChildPid;
 
             using (Assert.Multiple())
             {
-                await Assert.That(result.ExitCode).IsEqualTo(-1);
-                await Assert.That(result.StandardError).Contains("timed out");
-                await Assert.That(await WaitForProcessExitAsync(childPid.Value)).IsTrue();
+                await Assert.That(execution.Result.ExitCode).IsEqualTo(-1);
+                await Assert.That(execution.Result.StandardError).Contains("timed out");
+                await Assert.That(await WaitForProcessExitAsync(execution.ChildPid)).IsTrue();
             }
         }
         finally
         {
-            if (childPid.HasValue && IsProcessRunning(childPid.Value))
-            {
-                using var childProcess = Process.GetProcessById(childPid.Value);
-                childProcess.Kill();
-            }
+            KillPublishedChildIfRunning(childPidPath, childPid);
 
             File.Delete(childPidPath);
             if (scriptPath is not null)
@@ -432,26 +417,103 @@ public class ProcessCliCommandExecutorTests
         return !IsProcessRunning(processId);
     }
 
+    private static async Task<int> WaitForPublishedProcessIdAsync(
+        string childPidPath,
+        CancellationToken cancellationToken)
+    {
+        using var startupCancellationTokenSource =
+            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        startupCancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(10));
+
+        while (true)
+        {
+            if (TryReadProcessId(childPidPath) is { } processId)
+            {
+                return processId;
+            }
+
+            await Task.Delay(
+                TimeSpan.FromMilliseconds(25),
+                startupCancellationTokenSource.Token);
+        }
+    }
+
+    private static async Task<(CliCommandResult Result, int ChildPid)> ExecuteAfterChildStartsAsync(
+        string command,
+        string arguments,
+        string childPidPath)
+    {
+        int? childPid = null;
+        var executor = new ProcessCliCommandExecutor(
+            NullLogger<ProcessCliCommandExecutor>.Instance,
+            TimeSpan.FromMilliseconds(250),
+            async cancellationToken =>
+            {
+                childPid = await WaitForPublishedProcessIdAsync(
+                    childPidPath,
+                    cancellationToken);
+            });
+
+        var result = await executor.ExecuteAsync(command, arguments)
+            .WaitAsync(TimeSpan.FromSeconds(15));
+        return (
+            result,
+            childPid ?? throw new InvalidOperationException("Child PID was not published before timeout."));
+    }
+
+    private static int? TryReadProcessId(string childPidPath)
+    {
+        try
+        {
+            return int.TryParse(File.ReadAllText(childPidPath), out var processId)
+                ? processId
+                : null;
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+    }
+
+    private static void KillPublishedChildIfRunning(string childPidPath, int? childPid)
+    {
+        childPid ??= TryReadProcessId(childPidPath);
+        if (!childPid.HasValue || !IsProcessRunning(childPid.Value))
+        {
+            return;
+        }
+
+        using var childProcess = Process.GetProcessById(childPid.Value);
+        childProcess.Kill();
+    }
+
     private static async Task<(string Command, string Arguments, string? ScriptPath)>
-        CreateLongRunningChildCommandAsync(string childPidPath, bool parentExits)
+        CreateLongRunningChildCommandAsync(
+            string childPidPath,
+            bool parentExits,
+            bool delayChildStartup = false)
     {
         if (!OperatingSystem.IsWindows())
         {
             var parentCommand = parentExits ? "sleep 0.05" : "wait";
+            var startupDelay = delayChildStartup ? "sleep 2; " : string.Empty;
             return (
                 "/bin/sh",
-                $"-c \"sleep 30 & child=$!; echo $child > '{childPidPath}'; {parentCommand}\"",
+                $"-c \"{startupDelay}sleep 30 & child=$!; echo $child > '{childPidPath}'; {parentCommand}\"",
                 null);
         }
 
         var scriptPath = Path.ChangeExtension(childPidPath, ".cmd");
         var escapedPidPath = childPidPath.Replace("'", "''", StringComparison.Ordinal);
         var parentDelayMilliseconds = parentExits ? 0 : 3000;
+        var startupDelayCommand = delayChildStartup
+            ? "powershell.exe -NoProfile -Command \"Start-Sleep -Seconds 2\"\r\n"
+            : string.Empty;
         await File.WriteAllTextAsync(
             scriptPath,
             $"""
             @echo off
-            start "" /b powershell.exe -NoProfile -Command "$PID | Set-Content -LiteralPath '{escapedPidPath}'; Start-Sleep -Seconds 30"
+            {startupDelayCommand}start "" /b powershell.exe -NoProfile -Command "$PID | Set-Content -LiteralPath '{escapedPidPath}'; Start-Sleep -Seconds 30"
             powershell.exe -NoProfile -Command "Start-Sleep -Milliseconds {parentDelayMilliseconds}"
             """);
         return (scriptPath, string.Empty, scriptPath);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ProcessCliCommandExecutorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ProcessCliCommandExecutorTests.cs
@@ -483,8 +483,15 @@ public class ProcessCliCommandExecutorTests
             return;
         }
 
-        using var childProcess = Process.GetProcessById(childPid.Value);
-        childProcess.Kill();
+        try
+        {
+            using var childProcess = Process.GetProcessById(childPid.Value);
+            childProcess.Kill();
+        }
+        catch (Exception exception) when (exception is ArgumentException or InvalidOperationException)
+        {
+            // The child exited between the running check and cleanup.
+        }
     }
 
     private static async Task<(string Command, string Arguments, string? ScriptPath)>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ProcessCliCommandExecutorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ProcessCliCommandExecutorTests.cs
@@ -282,6 +282,53 @@ public class ProcessCliCommandExecutorTests
     }
 
     [Test]
+    public async Task Readiness_Failure_Kills_Started_Child_Process()
+    {
+        var childPidPath = Path.Combine(
+            Path.GetTempPath(),
+            $"mp-cli-readiness-failure-{Guid.NewGuid():N}.pid");
+        string? scriptPath = null;
+        int? childPid = null;
+
+        try
+        {
+            var command = await CreateLongRunningChildCommandAsync(
+                childPidPath,
+                parentExits: false);
+            scriptPath = command.ScriptPath;
+            var executor = new ProcessCliCommandExecutor(
+                NullLogger<ProcessCliCommandExecutor>.Instance,
+                TimeSpan.FromSeconds(10),
+                async cancellationToken =>
+                {
+                    childPid = await WaitForPublishedProcessIdAsync(
+                        childPidPath,
+                        cancellationToken);
+                    throw new InvalidOperationException("readiness failed");
+                });
+
+            var result = await executor.ExecuteAsync(command.Command, command.Arguments);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(result.ExitCode).IsEqualTo(-1);
+                await Assert.That(result.StandardError).Contains("readiness failed");
+                await Assert.That(childPid).IsNotNull();
+                await Assert.That(await WaitForProcessExitAsync(childPid!.Value)).IsTrue();
+            }
+        }
+        finally
+        {
+            KillPublishedChildIfRunning(childPidPath, childPid);
+            File.Delete(childPidPath);
+            if (scriptPath is not null)
+            {
+                File.Delete(scriptPath);
+            }
+        }
+    }
+
+    [Test]
     public async Task Executes_Windows_Batch_Files_With_Redirected_Output()
     {
         if (!OperatingSystem.IsWindows())

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
@@ -14,13 +14,23 @@ public class ProcessCliCommandExecutor : ICliCommandExecutor
 
     private readonly ILogger<ProcessCliCommandExecutor> _logger;
     private readonly TimeSpan _timeout;
+    private readonly Func<CancellationToken, Task>? _waitForProcessReady;
 
     public ProcessCliCommandExecutor(ILogger<ProcessCliCommandExecutor> logger, TimeSpan? timeout = null)
+        : this(logger, timeout, waitForProcessReady: null)
+    {
+    }
+
+    internal ProcessCliCommandExecutor(
+        ILogger<ProcessCliCommandExecutor> logger,
+        TimeSpan? timeout,
+        Func<CancellationToken, Task>? waitForProcessReady)
     {
         ArgumentNullException.ThrowIfNull(logger);
 
         _logger = logger;
         _timeout = timeout ?? TimeSpan.FromSeconds(30);
+        _waitForProcessReady = waitForProcessReady;
     }
 
     public async Task<CliCommandResult> ExecuteAsync(
@@ -58,7 +68,10 @@ public class ProcessCliCommandExecutor : ICliCommandExecutor
         {
             using var process = new Process { StartInfo = processLaunch.StartInfo };
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(_timeout);
+            if (_waitForProcessReady is null)
+            {
+                cts.CancelAfter(_timeout);
+            }
 
             process.Start();
             process.StandardInput.Close();
@@ -75,6 +88,12 @@ public class ProcessCliCommandExecutor : ICliCommandExecutor
 
                 try
                 {
+                    if (_waitForProcessReady is not null)
+                    {
+                        await _waitForProcessReady(cts.Token).ConfigureAwait(false);
+                        cts.CancelAfter(_timeout);
+                    }
+
                     await process.WaitForExitAsync(cts.Token);
                     await Task.WhenAll(stdoutTask, stderrTask).WaitAsync(cts.Token);
                 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
@@ -66,76 +66,12 @@ public class ProcessCliCommandExecutor : ICliCommandExecutor
 
         try
         {
-            using var process = new Process { StartInfo = processLaunch.StartInfo };
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            if (_waitForProcessReady is null)
-            {
-                cts.CancelAfter(_timeout);
-            }
-
-            process.Start();
-            process.StandardInput.Close();
-            var descendantTracker = new DescendantProcessTracker(
-                process.Id,
-                processLaunch.UsesUnixProcessGroup,
-                processLaunch.UsesWindowsJobLauncher);
-            var disposeDescendantTracker = true;
-
-            try
-            {
-                var stdoutTask = process.StandardOutput.ReadToEndAsync(cts.Token);
-                var stderrTask = process.StandardError.ReadToEndAsync(cts.Token);
-
-                try
-                {
-                    if (_waitForProcessReady is not null)
-                    {
-                        await _waitForProcessReady(cts.Token).ConfigureAwait(false);
-                        cts.CancelAfter(_timeout);
-                    }
-
-                    await process.WaitForExitAsync(cts.Token);
-                    await Task.WhenAll(stdoutTask, stderrTask).WaitAsync(cts.Token);
-                }
-                catch (OperationCanceledException)
-                {
-                    disposeDescendantTracker = !await TryKillProcessAsync(
-                            process,
-                            descendantTracker,
-                            command,
-                            arguments)
-                        .ConfigureAwait(false);
-                    throw;
-                }
-
-                var stdout = await stdoutTask;
-                var stderr = await stderrTask;
-
-                _logger.LogDebug("Command completed with exit code {ExitCode}", process.ExitCode);
-                if (process.ExitCode != 0)
-                {
-                    _logger.LogWarning(
-                        "Command failed: {Command} {Arguments} (exit code {ExitCode}). stderr: {StandardError}",
-                        command,
-                        arguments,
-                        process.ExitCode,
-                        stderr);
-                }
-
-                return new CliCommandResult
-                {
-                    StandardOutput = stdout,
-                    StandardError = stderr,
-                    ExitCode = process.ExitCode
-                };
-            }
-            finally
-            {
-                if (disposeDescendantTracker)
-                {
-                    descendantTracker.Dispose();
-                }
-            }
+            return await RunProcessAsync(
+                    processLaunch,
+                    command,
+                    arguments,
+                    cancellationToken)
+                .ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -156,6 +92,84 @@ public class ProcessCliCommandExecutor : ICliCommandExecutor
                 StandardError = ex.Message,
                 ExitCode = -1
             };
+        }
+    }
+
+    private async Task<CliCommandResult> RunProcessAsync(
+        ProcessLaunch processLaunch,
+        string command,
+        string arguments,
+        CancellationToken cancellationToken)
+    {
+        using var process = new Process { StartInfo = processLaunch.StartInfo };
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (_waitForProcessReady is null)
+        {
+            cts.CancelAfter(_timeout);
+        }
+
+        process.Start();
+        process.StandardInput.Close();
+        var descendantTracker = new DescendantProcessTracker(
+            process.Id,
+            processLaunch.UsesUnixProcessGroup,
+            processLaunch.UsesWindowsJobLauncher);
+        var disposeDescendantTracker = true;
+
+        try
+        {
+            var stdoutTask = process.StandardOutput.ReadToEndAsync(cts.Token);
+            var stderrTask = process.StandardError.ReadToEndAsync(cts.Token);
+
+            try
+            {
+                if (_waitForProcessReady is not null)
+                {
+                    await _waitForProcessReady(cts.Token).ConfigureAwait(false);
+                    cts.CancelAfter(_timeout);
+                }
+
+                await process.WaitForExitAsync(cts.Token);
+                await Task.WhenAll(stdoutTask, stderrTask).WaitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                disposeDescendantTracker = !await TryKillProcessAsync(
+                        process,
+                        descendantTracker,
+                        command,
+                        arguments)
+                    .ConfigureAwait(false);
+                throw;
+            }
+
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
+
+            _logger.LogDebug("Command completed with exit code {ExitCode}", process.ExitCode);
+            if (process.ExitCode != 0)
+            {
+                _logger.LogWarning(
+                    "Command failed: {Command} {Arguments} (exit code {ExitCode}). stderr: {StandardError}",
+                    command,
+                    arguments,
+                    process.ExitCode,
+                    stderr);
+            }
+
+            return new CliCommandResult
+            {
+                StandardOutput = stdout,
+                StandardError = stderr,
+                ExitCode = process.ExitCode
+            };
+        }
+        finally
+        {
+            if (disposeDescendantTracker)
+            {
+                descendantTracker.Dispose();
+            }
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
@@ -132,7 +132,7 @@ public class ProcessCliCommandExecutor : ICliCommandExecutor
                 await process.WaitForExitAsync(cts.Token);
                 await Task.WhenAll(stdoutTask, stderrTask).WaitAsync(cts.Token);
             }
-            catch (OperationCanceledException)
+            catch (Exception)
             {
                 disposeDescendantTracker = !await TryKillProcessAsync(
                         process,


### PR DESCRIPTION
Closes #3995.

## Summary
- gate timeout measurement on deterministic child PID publication in OptionsGenerator timeout fixtures
- preserve the public executor's existing timeout start point
- gate the core forceful-cancellation fixture until its during-grace descendant is published
- recover late-published PIDs during cleanup so raced children are still terminated

## Validation
- OptionsGenerator tests: 816 passed
- ProcessCliCommandExecutorTests: 17 passed; both race tests repeated 5/5
- CommandTests: 28 passed
- forceful descendant race: repeated 5/5 on Windows
- `ModularPipelines.Tests.slnf` Release build: 0 errors (79 existing nullability warnings)
- OptionsGenerator Release build: 0 warnings, 0 errors
- scoped whitespace format verification passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command cancellation and timeout handling by waiting until the child process is ready before starting shutdown or timeout periods.
  * Increased reliability when terminating descendant processes, including cases where process details become available late.
  * Prevented invalid command options from being counted as executed commands.

* **Tests**
  * Expanded coverage for delayed process startup, cancellation readiness, timeout behavior, validation, and cleanup across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->