### PR TITLE
Fix AWS CLI man-page help parsing

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Fixtures/AwsCli/aws-2.36.29-root-help.json
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Fixtures/AwsCli/aws-2.36.29-root-help.json
@@ -1,0 +1,4 @@
+{
+  "version": "aws-cli/2.36.29 Python/3.14.6 Linux/6.17.0-1022-azure exe/x86_64.ubuntu.24",
+  "help": "AWS()                                                                    AWS()\n\nNAME\n       aws -\n\nDESCRIPTION\n       The  AWS  Command  Line  Interface is a unified tool to manage your AWS\n       services.\n\nSYNOPSIS\n          aws [options] <command> <subcommand> [parameters]\n\nGLOBAL OPTIONS\n       --debug (boolean)\n\n       Turn on debug logging.\n\nAVAILABLE SERVICES\n       +\bo accessanalyzer\n\n       +\bo cloudformation\n\n       +\bo ec2\n\nSEE ALSO\n       aws help topics\n"
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ModularPipelines.OptionsGenerator.Tests.csproj
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ModularPipelines.OptionsGenerator.Tests.csproj
@@ -23,4 +23,8 @@
     <ProjectReference Include="..\ModularPipelines.OptionsGenerator\ModularPipelines.OptionsGenerator.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="Fixtures\**\*" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
@@ -2,11 +2,38 @@ using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;
+using System.Text.Json;
 
 namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
 
 public class AwsCliScraperTests
 {
+    [Test]
+    public async Task Extracts_Services_From_Aws_2_36_29_Help_Fixture()
+    {
+        var fixturePath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Fixtures",
+            "AwsCli",
+            "aws-2.36.29-root-help.json");
+        using var fixture = JsonDocument.Parse(await File.ReadAllTextAsync(fixturePath));
+        var helpText = fixture.RootElement.GetProperty("help").GetString()!;
+
+        var scraper = new AwsCliScraper(
+            new AwsFixtureExecutor(helpText),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<AwsCliScraper>.Instance);
+        var commands = new List<CliCommandDefinition>();
+
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        await Assert.That(commands.Select(command => command.FullCommand))
+            .IsEquivalentTo(["aws accessanalyzer", "aws cloudformation", "aws ec2"]);
+    }
+
     [Test]
     public async Task Scrape_Normalizes_Ansi_Formatted_Section_Headers()
     {
@@ -55,6 +82,28 @@ public class AwsCliScraperTests
                 ExitCode = string.IsNullOrEmpty(output) ? 1 : 0,
             });
         }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+
+    private sealed class AwsFixtureExecutor(string rootHelp) : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null) =>
+            Task.FromResult(new CliCommandResult
+            {
+                StandardOutput = arguments == "help"
+                    ? rootHelp
+                    : "OPTIONS\n       --enabled (boolean)\n\n       Enable the command.\n",
+                StandardError = string.Empty,
+                ExitCode = 0,
+            });
 
         public Task<bool> IsAvailableAsync(
             string command,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -658,8 +658,11 @@ public abstract partial class CliScraperBase : ICliScraper
     /// Removes terminal formatting that changes the text shape consumed by scraper parsers.
     /// Some CLIs emit ANSI sequences even when output is redirected and <c>NO_COLOR</c> is set.
     /// </summary>
-    protected static string NormalizeHelpText(string helpText) =>
-        AnsiEscapeSequencePattern().Replace(helpText, string.Empty);
+    protected static string NormalizeHelpText(string helpText)
+    {
+        var withoutAnsi = AnsiEscapeSequencePattern().Replace(helpText, string.Empty);
+        return ManPageOverstrikePattern().Replace(withoutAnsi, string.Empty);
+    }
 
     /// <summary>
     /// Parses a command from its help text into a CliCommandDefinition.
@@ -1016,6 +1019,9 @@ public abstract partial class CliScraperBase : ICliScraper
 
     [GeneratedRegex(@"\x1B(?:\][^\x07\x1B]*(?:\x07|\x1B\\)|\[[0-?]*[ -/]*[@-~])")]
     private static partial Regex AnsiEscapeSequencePattern();
+
+    [GeneratedRegex(@".\x08")]
+    private static partial Regex ManPageOverstrikePattern();
 
     #endregion
 }


### PR DESCRIPTION
## Summary
- normalize groff/man-page backspace overstrikes before CLI help parsing
- add an AWS CLI 2.36.29 root-help fixture reproducing the current `+\bo` service bullets
- verify the fixture through the full AWS `ScrapeAsync` traversal

## Test plan
- [x] AWS scraper tests (4 passed)
- [x] OptionsGenerator tests (817 passed)
- [x] OptionsGenerator Release build (0 warnings, 0 errors)
- [x] Changed-file formatting

Full solution `dotnet format --verify-no-changes --severity info` also reports pre-existing findings outside this change, including `IHelpTextCache.cs` whitespace and `AzureCliHelpTypeDetector.cs` style errors.

Closes #3986


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line help parsing by removing formatting artifacts commonly found in man-page output.
  - Increased reliability when extracting available AWS CLI services from help text.

- **Tests**
  - Added coverage for AWS CLI version 2.36.29 help output.
  - Added test fixture handling to ensure CLI help data is available during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->