### PR TITLE
Preserve explicit Azure CLI Boolean values

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -62,6 +62,53 @@ public class AzCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Comma_Separated_Boolean_Values_Are_Recognized()
+    {
+        const string helpText = """
+            Command
+                az service update : Update a service.
+
+            Optional Arguments
+                --enabled : Allowed values: false, true.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(
+            ["az", "service", "update"],
+            helpText);
+        var option = command!.Options.Single(item => item.SwitchName == "--enabled");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.CSharpType).IsEqualTo("bool?");
+        }
+    }
+
+    [Test]
+    public async Task Unrelated_Multiple_Wording_Does_Not_Make_Boolean_A_Collection()
+    {
+        const string helpText = """
+            Command
+                az service update : Update a service.
+
+            Optional Arguments
+                --enabled : Applies to multiple resources. Allowed values: true, false.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(
+            ["az", "service", "update"],
+            helpText);
+        var option = command!.Options.Single(item => item.SwitchName == "--enabled");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.CSharpType).IsEqualTo("bool?");
+            await Assert.That(option.AcceptsMultipleValues).IsFalse();
+        }
+    }
+
     private sealed class TestAzCliScraper()
         : AzCliScraper(
             new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -36,6 +36,32 @@ public class AzCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Boolean_Lists_Remain_Collections()
+    {
+        const string helpText = """
+            Command
+                az vm application set : Set applications for a VM.
+
+            Optional Arguments
+                --treat-deployment-as-failure : Space-separated list of true or false corresponding
+                                                to the application version ids.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(
+            ["az", "vm", "application", "set"],
+            helpText);
+        var option = command!.Options.Single(
+            item => item.SwitchName == "--treat-deployment-as-failure");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.CSharpType).IsEqualTo("IEnumerable<string>?");
+            await Assert.That(option.AcceptsMultipleValues).IsTrue();
+        }
+    }
+
     private sealed class TestAzCliScraper()
         : AzCliScraper(
             new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -109,6 +109,53 @@ public class AzCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Tri_State_Allowed_Values_Are_Not_Collapsed_To_Boolean()
+    {
+        const string helpText = """
+            Command
+                az service update : Update a service.
+
+            Optional Arguments
+                --mode MODE : Allowed values: true, false, auto.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(
+            ["az", "service", "update"],
+            helpText);
+        var option = command!.Options.Single(item => item.SwitchName == "--mode");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.CSharpType).IsEqualTo("string?");
+        }
+    }
+
+    [Test]
+    public async Task Repeatable_Explicit_Boolean_Values_Remain_A_Collection()
+    {
+        const string helpText = """
+            Command
+                az service update : Update a service.
+
+            Optional Arguments
+                --enabled : One or more values: true or false.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(
+            ["az", "service", "update"],
+            helpText);
+        var option = command!.Options.Single(item => item.SwitchName == "--enabled");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.CSharpType).IsEqualTo("IEnumerable<string>?");
+            await Assert.That(option.AcceptsMultipleValues).IsTrue();
+        }
+    }
+
     private sealed class TestAzCliScraper()
         : AzCliScraper(
             new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class AzCliScraperTests
+{
+    [Test]
+    public async Task Boolean_Accepted_Values_Require_An_Explicit_Value()
+    {
+        const string helpText = """
+            Command
+                az eventhubs namespace create : Create an Event Hubs namespace.
+
+            Optional Arguments
+                --disable-local-auth : A boolean value that indicates whether SAS
+                                       authentication is enabled/disabled for the
+                                       Event Hubs. Allowed values: false, true.
+                --force              : Force the operation without confirmation.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(
+            ["az", "eventhubs", "namespace", "create"],
+            helpText);
+        var option = command!.Options.Single(item => item.SwitchName == "--disable-local-auth");
+        var force = command.Options.Single(item => item.SwitchName == "--force");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.CSharpType).IsEqualTo("bool?");
+            await Assert.That(option.ValueSeparator).IsEqualTo(" ");
+            await Assert.That(force.IsFlag).IsTrue();
+        }
+    }
+
+    private sealed class TestAzCliScraper()
+        : AzCliScraper(
+            new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<AzCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/WinGetCliScraperTests.cs
@@ -75,6 +75,31 @@ public class WinGetCliScraperTests
     }
 
     [Test]
+    public async Task Authentication_Mode_With_Explicit_Choices_Is_A_Value_Option()
+    {
+        const string helpText = """
+            Add a package pin.
+
+            usage: winget pin add [<options>]
+
+            The following options are available:
+              --authentication-mode   Specify authentication window preference (silent, silentPreferred, or interactive)
+            """;
+
+        var command = await new TestWinGetCliScraper().Parse(
+            ["winget", "pin", "add"],
+            helpText);
+        var authenticationMode = command!.Options.Single(option =>
+            option.SwitchName == "--authentication-mode");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(authenticationMode.IsFlag).IsFalse();
+            await Assert.That(authenticationMode.CSharpType).IsEqualTo("string?");
+        }
+    }
+
+    [Test]
     public async Task Traversal_Keeps_Boolean_Flags_With_Repeatability_Wording()
     {
         const string rootHelp = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/DescriptionEnumValueParserTests.cs
@@ -26,6 +26,7 @@ public class DescriptionEnumValueParserTests
     [Test]
     [Arguments("Output format (table, json, yaml)", "table,json,yaml")]
     [Arguments("Log types to enable (all, none, api, audit)", "all,none,api,audit")]
+    [Arguments("Specify authentication window preference (silent, silentPreferred, or interactive)", "silent,silentPreferred,interactive")]
     [Arguments("""Set the logging level ("debug", "info", "warn", "error", "fatal")""", "debug,info,warn,error,fatal")]
     public async Task TryParse_Accepts_Contextual_Parenthesized_Values(string description, string expectedValues)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -349,7 +349,7 @@ public partial class AzCliScraper : CliScraperBase
         bool isFlag,
         bool explicitBooleanValue)
     {
-        if (isFlag || explicitBooleanValue)
+        if (isFlag)
         {
             return "bool?";
         }
@@ -370,6 +370,11 @@ public partial class AzCliScraper : CliScraperBase
             lowerDesc.Contains("multiple"))
         {
             return "IEnumerable<string>?";
+        }
+
+        if (explicitBooleanValue)
+        {
+            return "bool?";
         }
 
         return "string?";

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -365,6 +365,16 @@ public partial class AzCliScraper : CliScraperBase
             return "int?";
         }
 
+        // Explicit Boolean values stay scalar unless the help specifically describes
+        // the Boolean values themselves as a collection. Words such as "multiple"
+        // may instead describe the resources affected by one Boolean value.
+        if (explicitBooleanValue)
+        {
+            return HelpDeclaresBooleanList(lowerDesc)
+                ? "IEnumerable<string>?"
+                : "bool?";
+        }
+
         // Check for list types (space-separated or multiple values)
         if (lowerDesc.Contains("space-separated") || lowerDesc.Contains("list of") ||
             lowerDesc.Contains("multiple"))
@@ -372,13 +382,13 @@ public partial class AzCliScraper : CliScraperBase
             return "IEnumerable<string>?";
         }
 
-        if (explicitBooleanValue)
-        {
-            return "bool?";
-        }
-
         return "string?";
     }
+
+    private static bool HelpDeclaresBooleanList(string description) =>
+        description.Contains("space-separated") ||
+        description.Contains("list of true") ||
+        description.Contains("list of false");
 
     /// <summary>
     /// Checks if an option is a global option that should be on the base class.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -296,13 +296,12 @@ public partial class AzCliScraper : CliScraperBase
                 }
 
                 // Determine type based on value hint
-                var isFlag = string.IsNullOrEmpty(valueHint) ||
-                             valueHint.Equals("true", StringComparison.OrdinalIgnoreCase) ||
-                             valueHint.Equals("false", StringComparison.OrdinalIgnoreCase);
+                var explicitBooleanValue = HelpDeclaresExplicitBooleanValue(description);
+                var isFlag = IsPresenceOnlyFlag(valueHint, explicitBooleanValue);
 
                 var isRequired = sectionName.Equals("Required Arguments", StringComparison.OrdinalIgnoreCase);
 
-                var csharpType = DetermineType(valueHint, description, isFlag);
+                var csharpType = DetermineType(valueHint, description, isFlag, explicitBooleanValue);
 
                 options.Add(new CliOptionDefinition
                 {
@@ -327,11 +326,30 @@ public partial class AzCliScraper : CliScraperBase
     }
 
     /// <summary>
+    /// Determines whether an option is rendered without a value.
+    /// </summary>
+    private static bool IsPresenceOnlyFlag(string valueHint, bool explicitBooleanValue)
+    {
+        if (explicitBooleanValue)
+        {
+            return false;
+        }
+
+        return string.IsNullOrEmpty(valueHint) ||
+               valueHint.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+               valueHint.Equals("false", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Determines the C# type based on value hint and description.
     /// </summary>
-    private static string DetermineType(string valueHint, string description, bool isFlag)
+    private static string DetermineType(
+        string valueHint,
+        string description,
+        bool isFlag,
+        bool explicitBooleanValue)
     {
-        if (isFlag)
+        if (isFlag || explicitBooleanValue)
         {
             return "bool?";
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -376,7 +376,7 @@ public partial class AzCliScraper : CliScraperBase
         }
 
         // Check for list types (space-separated or multiple values)
-        if (lowerDesc.Contains("space-separated") || lowerDesc.Contains("list of") ||
+        if (HelpDeclaresSpaceSeparatedList(lowerDesc) || lowerDesc.Contains("list of") ||
             lowerDesc.Contains("multiple"))
         {
             return "IEnumerable<string>?";
@@ -386,9 +386,12 @@ public partial class AzCliScraper : CliScraperBase
     }
 
     private static bool HelpDeclaresBooleanList(string description) =>
-        description.Contains("space-separated") ||
+        HelpDeclaresSpaceSeparatedList(description) ||
         description.Contains("list of true") ||
         description.Contains("list of false");
+
+    private static bool HelpDeclaresSpaceSeparatedList(string description) =>
+        description.Contains("space-separated");
 
     /// <summary>
     /// Checks if an option is a global option that should be on the base class.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -387,6 +387,7 @@ public partial class AzCliScraper : CliScraperBase
 
     private static bool HelpDeclaresBooleanList(string description) =>
         HelpDeclaresSpaceSeparatedList(description) ||
+        DescriptionDeclaresRepeatableOption(description) ||
         description.Contains("list of true") ||
         description.Contains("list of false");
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -1005,7 +1005,7 @@ public abstract partial class CliScraperBase : ICliScraper
     private static partial Regex CommandSectionHeadingPattern();
 
     [GeneratedRegex(
-        @"(?:[\[{(<]\s*true\s*(?:\||/|or)\s*false\s*[\]})>]|(?:boolean|bool)\s+value|true\s+or\s+false|allowed\s+values?\s*:\s*(?:true\s*,\s*false|false\s*,\s*true))",
+        @"(?:[\[{(<]\s*true\s*(?:\||/|or)\s*false\s*[\]})>]|(?:boolean|bool)\s+value|true\s+or\s+false|allowed\s+values?\s*:\s*(?:true\s*,\s*false|false\s*,\s*true)(?=\s*(?:[.)]|$)))",
         RegexOptions.IgnoreCase)]
     private static partial Regex ExplicitBooleanValuePattern();
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -1005,7 +1005,7 @@ public abstract partial class CliScraperBase : ICliScraper
     private static partial Regex CommandSectionHeadingPattern();
 
     [GeneratedRegex(
-        @"(?:[\[{(<]\s*true\s*(?:\||/|or)\s*false\s*[\]})>]|(?:boolean|bool)\s+value|true\s+or\s+false)",
+        @"(?:[\[{(<]\s*true\s*(?:\||/|or)\s*false\s*[\]})>]|(?:boolean|bool)\s+value|true\s+or\s+false|allowed\s+values?\s*:\s*(?:true\s*,\s*false|false\s*,\s*true))",
         RegexOptions.IgnoreCase)]
     private static partial Regex ExplicitBooleanValuePattern();
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/WinGetCliScraper.cs
@@ -397,6 +397,11 @@ public partial class WinGetCliScraper : CliScraperBase
             return false;
         }
 
+        if (DescriptionEnumValueParser.TryParse(description) is not null)
+        {
+            return false;
+        }
+
         var lowerDesc = description.ToLowerInvariant();
         return lowerDesc.Contains("enable") ||
                lowerDesc.Contains("disable") ||

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/DescriptionEnumValueParser.cs
@@ -81,7 +81,7 @@ internal static partial class DescriptionEnumValueParser
     [GeneratedRegex("""\b(?:must be(?:\s+one of)?|one of)\b\s+(?<values>["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`](?:(?:\s*,\s*(?:(?:or|and)\s+)?|\s+(?:or|and)\s+)["'`][A-Za-z0-9][A-Za-z0-9_-]{0,28}["'`])+)""", RegexOptions.IgnoreCase)]
     private static partial Regex QuotedOneOfValuesPattern();
 
-    [GeneratedRegex("""\b(?:formats?|types?|modes?|levels?)\b[^()\r\n]{0,40}\((?<values>[^\s,|)]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|)]+)+)\)""", RegexOptions.IgnoreCase)]
+    [GeneratedRegex("""\b(?:formats?|types?|modes?|levels?|preferences?)\b[^()\r\n]{0,40}\((?<values>[^\s,|)]+(?:\s*(?:\||,)\s*(?:or\s+|and\s+)?[^\s,|)]+)+)\)""", RegexOptions.IgnoreCase)]
     private static partial Regex ContextualParenthesizedValuesPattern();
 
     [GeneratedRegex(@"(?:\s*(?:\||,)\s*(?:(?:or|and)\s+)?|\s+(?:or|and)\s+)", RegexOptions.IgnoreCase)]


### PR DESCRIPTION
## Summary
- detect Azure CLI descriptions that require explicit Boolean values before classifying presence-only flags
- emit affected options as value-taking `bool?` while preserving ordinary flags
- add a regression fixture from `az eventhubs namespace create`

## Validation
- Az scraper regression: 1/1 passed
- full OptionsGenerator tests: 817/817 passed
- OptionsGenerator Release build: 0 warnings, 0 errors
- touched-file whitespace formatting: clean

Fixes #3989
Part of #3996