### PR TITLE
Mask generated registry credentials

### DIFF
--- a/src/ModularPipelines.Buildah/Options/BuildahBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahBuildOptions.Generated.cs
@@ -162,6 +162,7 @@ public record BuildahBuildOptions : BuildahOptions
     /// <summary>
     /// use [username[:password]] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Buildah/Options/BuildahCommitOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahCommitOptions.Generated.cs
@@ -47,6 +47,7 @@ public record BuildahCommitOptions : BuildahOptions
     /// <summary>
     /// use [username[:password]] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Buildah/Options/BuildahFromOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahFromOptions.Generated.cs
@@ -108,6 +108,7 @@ public record BuildahFromOptions : BuildahOptions
     /// <summary>
     /// use [username[:password]] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Buildah/Options/BuildahManifestAddOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahManifestAddOptions.Generated.cs
@@ -53,6 +53,7 @@ public record BuildahManifestAddOptions : BuildahOptions
     /// <summary>
     /// use [username[:password]] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Buildah/Options/BuildahManifestPushOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahManifestPushOptions.Generated.cs
@@ -59,6 +59,7 @@ public record BuildahManifestPushOptions : BuildahOptions
     /// <summary>
     /// use [username[:password]] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Buildah/Options/BuildahPullOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahPullOptions.Generated.cs
@@ -47,6 +47,7 @@ public record BuildahPullOptions : BuildahOptions
     /// <summary>
     /// use [username[:password]] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Buildah/Options/BuildahPushOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahPushOptions.Generated.cs
@@ -54,6 +54,7 @@ public record BuildahPushOptions : BuildahOptions
     /// <summary>
     /// use [username[:password]] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Buildah/Options/BuildahSourcePullOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahSourcePullOptions.Generated.cs
@@ -23,6 +23,7 @@ public record BuildahSourcePullOptions : BuildahOptions
     /// <summary>
     /// use [username[:password]] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Buildah/Options/BuildahSourcePushOptions.Generated.cs
+++ b/src/ModularPipelines.Buildah/Options/BuildahSourcePushOptions.Generated.cs
@@ -23,6 +23,7 @@ public record BuildahSourcePushOptions : BuildahOptions
     /// <summary>
     /// use [username[:password]] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxBootstrapBitbucketServerOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapBitbucketServerOptions.Generated.cs
@@ -308,6 +308,7 @@ public record FluxBootstrapBitbucketServerOptions : FluxOptions
     /// <summary>
     /// container registry credentials in the format 'user:password', requires --image-pull-secret to be set
     /// </summary>
+    [SecretValue]
     [CliOption("--registry-creds", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryCreds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxBootstrapGitOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapGitOptions.Generated.cs
@@ -291,6 +291,7 @@ public record FluxBootstrapGitOptions : FluxOptions
     /// <summary>
     /// container registry credentials in the format 'user:password', requires --image-pull-secret to be set
     /// </summary>
+    [SecretValue]
     [CliOption("--registry-creds", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryCreds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxBootstrapGiteaOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapGiteaOptions.Generated.cs
@@ -302,6 +302,7 @@ public record FluxBootstrapGiteaOptions : FluxOptions
     /// <summary>
     /// container registry credentials in the format 'user:password', requires --image-pull-secret to be set
     /// </summary>
+    [SecretValue]
     [CliOption("--registry-creds", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryCreds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxBootstrapGithubOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapGithubOptions.Generated.cs
@@ -302,6 +302,7 @@ public record FluxBootstrapGithubOptions : FluxOptions
     /// <summary>
     /// container registry credentials in the format 'user:password', requires --image-pull-secret to be set
     /// </summary>
+    [SecretValue]
     [CliOption("--registry-creds", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryCreds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxBootstrapGitlabOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapGitlabOptions.Generated.cs
@@ -308,6 +308,7 @@ public record FluxBootstrapGitlabOptions : FluxOptions
     /// <summary>
     /// container registry credentials in the format 'user:password', requires --image-pull-secret to be set
     /// </summary>
+    [SecretValue]
     [CliOption("--registry-creds", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryCreds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxBootstrapOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxBootstrapOptions.Generated.cs
@@ -140,6 +140,7 @@ public record FluxBootstrapOptions : FluxOptions
     /// <summary>
     /// container registry credentials in the format 'user:password', requires --image-pull-secret to be set
     /// </summary>
+    [SecretValue]
     [CliOption("--registry-creds", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryCreds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxDiffArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxDiffArtifactOptions.Generated.cs
@@ -24,6 +24,7 @@ public record FluxDiffArtifactOptions : FluxOptions
     /// <summary>
     /// credentials for OCI registry in the format &lt;username&gt;[:&lt;password&gt;] if --provider is generic
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxInstallOptions.Generated.cs
@@ -85,6 +85,7 @@ public record FluxInstallOptions : FluxOptions
     /// <summary>
     /// container registry credentials in the format 'user:password', requires --image-pull-secret to be set
     /// </summary>
+    [SecretValue]
     [CliOption("--registry-creds", Format = OptionFormat.EqualsSeparated)]
     public string? RegistryCreds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxListArtifactsOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxListArtifactsOptions.Generated.cs
@@ -24,6 +24,7 @@ public record FluxListArtifactsOptions : FluxOptions
     /// <summary>
     /// credentials for OCI registry in the format &lt;username&gt;[:&lt;password&gt;] if --provider is generic
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxPullArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPullArtifactOptions.Generated.cs
@@ -24,6 +24,7 @@ public record FluxPullArtifactOptions : FluxOptions
     /// <summary>
     /// credentials for OCI registry in the format &lt;username&gt;[:&lt;password&gt;] if --provider is generic
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxPushArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxPushArtifactOptions.Generated.cs
@@ -30,6 +30,7 @@ public record FluxPushArtifactOptions : FluxOptions
     /// <summary>
     /// credentials for OCI registry in the format &lt;username&gt;[:&lt;password&gt;] if --provider is generic
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Flux/Options/FluxTagArtifactOptions.Generated.cs
+++ b/src/ModularPipelines.Flux/Options/FluxTagArtifactOptions.Generated.cs
@@ -24,6 +24,7 @@ public record FluxTagArtifactOptions : FluxOptions
     /// <summary>
     /// credentials for OCI registry in the format &lt;username&gt;[:&lt;password&gt;] if --provider is generic
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Skopeo/Options/SkopeoCopyOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoCopyOptions.Generated.cs
@@ -81,6 +81,7 @@ public record SkopeoCopyOptions(
     /// <summary>
     /// Use USERNAME[:PASSWORD] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--dest-creds", Format = OptionFormat.EqualsSeparated)]
     public string? DestCreds { get; set; }
 
@@ -252,6 +253,7 @@ public record SkopeoCopyOptions(
     /// <summary>
     /// Use USERNAME[:PASSWORD] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--src-creds", Format = OptionFormat.EqualsSeparated)]
     public string? SrcCreds { get; set; }
 

--- a/src/ModularPipelines.Skopeo/Options/SkopeoDeleteOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoDeleteOptions.Generated.cs
@@ -37,6 +37,7 @@ public record SkopeoDeleteOptions(
     /// <summary>
     /// Use USERNAME[:PASSWORD] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Skopeo/Options/SkopeoInspectOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoInspectOptions.Generated.cs
@@ -43,6 +43,7 @@ public record SkopeoInspectOptions(
     /// <summary>
     /// Use USERNAME[:PASSWORD] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Skopeo/Options/SkopeoListTagsOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoListTagsOptions.Generated.cs
@@ -37,6 +37,7 @@ public record SkopeoListTagsOptions(
     /// <summary>
     /// Use USERNAME[:PASSWORD] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--creds", Format = OptionFormat.EqualsSeparated)]
     public string? Creds { get; set; }
 

--- a/src/ModularPipelines.Skopeo/Options/SkopeoSyncOptions.Generated.cs
+++ b/src/ModularPipelines.Skopeo/Options/SkopeoSyncOptions.Generated.cs
@@ -64,6 +64,7 @@ public record SkopeoSyncOptions(
     /// <summary>
     /// Use USERNAME[:PASSWORD] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--dest-creds", Format = OptionFormat.EqualsSeparated)]
     public string? DestCreds { get; set; }
 
@@ -193,6 +194,7 @@ public record SkopeoSyncOptions(
     /// <summary>
     /// Use USERNAME[:PASSWORD] for accessing the registry
     /// </summary>
+    [SecretValue]
     [CliOption("--src-creds", Format = OptionFormat.EqualsSeparated)]
     public string? SrcCreds { get; set; }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorUtilsTests.cs
@@ -680,6 +680,10 @@ public class GeneratorUtilsTests
     [Test]
     [Arguments("Credential")]
     [Arguments("UserCredential")]
+    [Arguments("Creds")]
+    [Arguments("RegistryCreds")]
+    [Arguments("DestCreds")]
+    [Arguments("SrcCreds")]
     public async Task IsSecretOption_Returns_True_For_Credential_Variants(string propertyName)
     {
         var result = GeneratorUtils.IsSecretOption(propertyName, isFlag: false);
@@ -758,6 +762,7 @@ public class GeneratorUtilsTests
     [Arguments("GrpcWebRootPath")]
     [Arguments("RdbSnapshotPeriod")]
     [Arguments("AutopilotPrivilegedAdmission")]
+    [Arguments("CredsHelper")]
     public async Task IsSecretOption_Returns_False_For_Non_Secret_Names(string propertyName)
     {
         var result = GeneratorUtils.IsSecretOption(propertyName, isFlag: false);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/RegistryCredentialScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/RegistryCredentialScraperTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class RegistryCredentialScraperTests
+{
+    [Test]
+    public async Task Buildah_Masks_Creds()
+    {
+        var command = await new TestBuildahCliScraper().Parse(
+            ["buildah", "build"],
+            "Usage: buildah build [flags]\n\nFlags:\n  --creds string   Registry credentials");
+
+        await AssertSecretOptions(command, "Creds");
+    }
+
+    [Test]
+    public async Task Flux_Masks_Registry_Creds_But_Not_Helper_Name()
+    {
+        var command = await new TestFluxCliScraper().Parse(
+            ["flux", "bootstrap", "git"],
+            "Usage: flux bootstrap git [flags]\n\nFlags:\n  --registry-creds string   Registry credentials\n  --creds-helper string   Credential helper name");
+
+        await AssertSecretOptions(command, "RegistryCreds");
+    }
+
+    [Test]
+    public async Task Skopeo_Masks_Source_And_Destination_Creds()
+    {
+        var command = await new TestSkopeoCliScraper().Parse(
+            ["skopeo", "copy"],
+            "Usage: skopeo copy [flags]\n\nFlags:\n  --dest-creds string   Destination credentials\n  --src-creds string   Source credentials");
+
+        await AssertSecretOptions(command, "DestCreds", "SrcCreds");
+    }
+
+    private static async Task AssertSecretOptions(
+        CliCommandDefinition? command,
+        params string[] expectedSecretProperties)
+    {
+        await Assert.That(command!.Options.Where(option => option.IsSecret).Select(option => option.PropertyName))
+            .IsEquivalentTo(expectedSecretProperties);
+    }
+
+    private sealed class TestBuildahCliScraper()
+        : BuildahCliScraper(
+            RegistryCredentialScraperTests.Executor,
+            RegistryCredentialScraperTests.Cache,
+            NullLogger<BuildahCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] path, string helpText) =>
+            ParseCommandAsync(path, helpText, ParseUsageSynopsis(path, helpText), CancellationToken.None);
+    }
+
+    private sealed class TestFluxCliScraper()
+        : FluxCliScraper(
+            RegistryCredentialScraperTests.Executor,
+            RegistryCredentialScraperTests.Cache,
+            NullLogger<FluxCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] path, string helpText) =>
+            ParseCommandAsync(path, helpText, ParseUsageSynopsis(path, helpText), CancellationToken.None);
+    }
+
+    private sealed class TestSkopeoCliScraper()
+        : SkopeoCliScraper(
+            RegistryCredentialScraperTests.Executor,
+            RegistryCredentialScraperTests.Cache,
+            NullLogger<SkopeoCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] path, string helpText) =>
+            ParseCommandAsync(path, helpText, ParseUsageSynopsis(path, helpText), CancellationToken.None);
+    }
+
+    private static ICliCommandExecutor Executor { get; } =
+        new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance);
+
+    private static IHelpTextCache Cache { get; } =
+        new HelpTextCache(NullLogger<HelpTextCache>.Instance);
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -855,7 +855,8 @@ public static partial class GeneratorUtils
 
         var hasSecretKeyword = SecretKeywords.Any(keyword =>
                                    propertyName.Contains(keyword, StringComparison.OrdinalIgnoreCase))
-                               || ContainsIdentifierSegment(propertyName, "Otp");
+                               || ContainsIdentifierSegment(propertyName, "Otp")
+                               || propertyName.EndsWith("Creds", StringComparison.OrdinalIgnoreCase);
         if (!hasSecretKeyword || IsFilePathOption(propertyName, description))
         {
             return false;


### PR DESCRIPTION
## Summary
- classify value options whose generated property names end in `Creds` as secrets
- keep helper names and boolean credential flags unmasked
- regenerate Buildah, Flux, and Skopeo credential options
- add shared-rule and real-scraper regression tests

## Validation
- OptionsGenerator tests: 824 passed
- OptionsGenerator solution: build passed, 0 warnings/errors
- Buildah solution: build passed, 0 warnings/errors
- Skopeo solution: build passed, 0 warnings/errors
- Flux solution: local agent guard stopped process tree at 2552 MB (2 GB limit); not retried
- generated credential audit: 28 value properties masked; 7 boolean flags unmasked

Closes #4007