### PR TITLE
Harden gcloud option generation

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -205,16 +205,39 @@ public class MarkdownDocumentationGeneratorTests
             PreferredDocumentationExampleCommand = nestedCommand.FullCommand,
         };
 
+        var executeCommand = Command(
+            "fake app execute",
+            "FakeAppExecuteOptions",
+            ["app", "execute"],
+            "app") with
+        {
+            IsSafeForDocumentation = true,
+        };
+        var executeCollisionTool = Tool(
+            "fake",
+            Command("fake app", "FakeAppOptions", ["app"]),
+            executeCommand) with
+        {
+            PreferredDocumentationExampleCommand = executeCommand.FullCommand,
+        };
+
         var testCases = new[]
         {
             (Tool: rootCollisionTool,
                 Invocation: "context.Tools.Fake.App.ExecuteAsync(",
+                Method: "ExecuteAsync(",
                 ServiceFile: "FakeApp.Generated.cs",
                 OptionsType: "FakeAppOptions"),
             (Tool: nestedCollisionTool,
                 Invocation: "context.Tools.Fake.App.Get.ExecuteAsync(",
+                Method: "ExecuteAsync(",
                 ServiceFile: "FakeAppGet.Generated.cs",
                 OptionsType: "FakeAppGetOptions"),
+            (Tool: executeCollisionTool,
+                Invocation: "context.Tools.Fake.App.ExecuteCommandAsync(",
+                Method: "ExecuteCommandAsync(",
+                ServiceFile: "FakeApp.Generated.cs",
+                OptionsType: "FakeAppExecuteOptions"),
         };
 
         foreach (var testCase in testCases)
@@ -226,7 +249,7 @@ public class MarkdownDocumentationGeneratorTests
 
             await Assert.That(documentation).Contains(testCase.Invocation);
             await Assert.That(collisionService.Content)
-                .Contains("Task<CommandResult> ExecuteAsync(");
+                .Contains($"Task<CommandResult> {testCase.Method}");
             await Assert.That(collisionService.Content).Contains(testCase.OptionsType);
             await AssertDocumentationExampleCompiles(testCase.Tool);
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -256,6 +256,40 @@ public class MarkdownDocumentationGeneratorTests
     }
 
     [Test]
+    public async Task GenerateAsync_MatchesPascalizedParentCollisions()
+    {
+        var executeCommand = Command(
+            "fake app service_accounts execute",
+            "FakeAppServiceAccountsExecuteOptions",
+            ["app", "service_accounts", "execute"],
+            "app") with
+        {
+            IsSafeForDocumentation = true,
+        };
+        var tool = Tool(
+            "fake",
+            Command(
+                "fake app service-accounts",
+                "FakeAppServiceAccountsOptions",
+                ["app", "service-accounts"],
+                "app"),
+            executeCommand) with
+        {
+            PreferredDocumentationExampleCommand = executeCommand.FullCommand,
+        };
+
+        var documentation = await GenerateDocumentation(tool);
+        var serviceFiles = await new SubDomainClassGenerator().GenerateAsync(tool);
+        var service = serviceFiles.Single(file =>
+            Path.GetFileName(file.RelativePath) == "FakeAppServiceAccounts.Generated.cs");
+
+        await Assert.That(documentation)
+            .Contains("context.Tools.Fake.App.ServiceAccounts.ExecuteCommandAsync(");
+        await Assert.That(service.Content)
+            .Contains("Task<CommandResult> ExecuteCommandAsync(");
+    }
+
+    [Test]
     public async Task GenerateAsync_UsesTheGeneratedConstructorParameterList()
     {
         var command = Command("fake run", "FakeRunOptions", ["run"]) with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
@@ -121,6 +121,33 @@ public partial class NestedArgumentGroupParsingTests
     }
 
     [Test]
+    public async Task Gcloud_Models_Repeatable_Options_As_Collections()
+    {
+        const string helpText = """
+            NAME
+                gcloud asset search-all-resources - search all resources
+
+            SYNOPSIS
+                gcloud asset search-all-resources
+
+            FLAGS
+                 --order-by=FIELD
+                    This flag can be repeated to provide a list of fields.
+
+            GCLOUD WIDE FLAGS
+                 --project=PROJECT_ID
+            """;
+
+        var command = await CreateGcloudScraper().Parse(
+            ["gcloud", "asset", "search-all-resources"],
+            helpText);
+        var orderBy = command!.Options.Single(option => option.SwitchName == "--order-by");
+
+        await Assert.That(orderBy.AcceptsMultipleValues).IsTrue();
+        await Assert.That(orderBy.CSharpType).IsEqualTo("IEnumerable<string>?");
+    }
+
+    [Test]
     public async Task GcloudAgentIdentityUpdate_Emits_Nested_Scope_Credential_And_Negatable_Flags()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
@@ -148,6 +148,33 @@ public partial class NestedArgumentGroupParsingTests
     }
 
     [Test]
+    public async Task Gcloud_Prioritizes_Enum_Types_Over_Key_Value_Hints()
+    {
+        const string helpText = """
+            NAME
+                gcloud example update - update an example
+
+            SYNOPSIS
+                gcloud example update
+
+            FLAGS
+                 --labels=KEY=VALUE,...
+                    Value must be one of: alpha, beta.
+
+            GCLOUD WIDE FLAGS
+                 --project=PROJECT_ID
+            """;
+
+        var command = await CreateGcloudScraper().Parse(
+            ["gcloud", "example", "update"],
+            helpText);
+        var labels = command!.Options.Single(option => option.SwitchName == "--labels");
+
+        await Assert.That(labels.CSharpType).IsEqualTo("GcloudLabels?");
+        await Assert.That(labels.EnumDefinition).IsNotNull();
+    }
+
+    [Test]
     public async Task Gcloud_Does_Not_Mask_Secret_Named_File_Path_Options()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/NestedArgumentGroupParsingTests.cs
@@ -148,6 +148,32 @@ public partial class NestedArgumentGroupParsingTests
     }
 
     [Test]
+    public async Task Gcloud_Does_Not_Mask_Secret_Named_File_Path_Options()
+    {
+        const string helpText = """
+            NAME
+                gcloud example create - create an example
+
+            SYNOPSIS
+                gcloud example create
+
+            FLAGS
+                 --credential=CREDENTIAL
+                    Path to the credential file.
+
+            GCLOUD WIDE FLAGS
+                 --project=PROJECT_ID
+            """;
+
+        var command = await CreateGcloudScraper().Parse(
+            ["gcloud", "example", "create"],
+            helpText);
+        var credential = command!.Options.Single(option => option.SwitchName == "--credential");
+
+        await Assert.That(credential.IsSecret).IsFalse();
+    }
+
+    [Test]
     public async Task GcloudAgentIdentityUpdate_Emits_Nested_Scope_Credential_And_Negatable_Flags()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -544,6 +544,21 @@ public static partial class GeneratorUtils
     }
 
     /// <summary>
+    /// Generates a method name for a command emitted on a sub-domain service.
+    /// A literal <c>execute</c> child is disambiguated from the parent command's
+    /// reserved <c>ExecuteAsync</c> method.
+    /// </summary>
+    public static string GenerateSubDomainMethodName(
+        CliCommandDefinition command,
+        bool hasParentCommand)
+    {
+        var methodName = GenerateMethodNameFromLastCommandPart(command);
+        return hasParentCommand && methodName.Equals("Execute", StringComparison.OrdinalIgnoreCase)
+            ? "ExecuteCommand"
+            : methodName;
+    }
+
+    /// <summary>
     /// The executionOptions parameter as emitted in every generated command method.
     /// </summary>
     public const string ExecutionOptionsParameter = "CommandExecutionOptions? executionOptions = null";

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -308,9 +308,20 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
             return $"context.Tools.{tool.NamespacePrefix}.{string.Join('.', navigationSegments)}.ExecuteAsync";
         }
 
-        var methodName = GeneratorUtils.GenerateMethodNameFromLastCommandPart(command);
+        var methodName = GeneratorUtils.GenerateSubDomainMethodName(
+            command,
+            HasExecutableParentCommand(tool, command));
         return $"context.Tools.{tool.NamespacePrefix}.{string.Join('.', navigationSegments)}.{GeneratorUtils.EnsureAsyncSuffix(methodName)}";
     }
+
+    private static bool HasExecutableParentCommand(
+        CliToolDefinition tool,
+        CliCommandDefinition command) =>
+        tool.Commands.Any(candidate =>
+            candidate.CommandParts.Length == command.CommandParts.Length - 1
+            && candidate.CommandParts.SequenceEqual(
+                command.CommandParts.Take(candidate.CommandParts.Length),
+                StringComparer.OrdinalIgnoreCase));
 
     private static bool IsCommandPrefix(
         CliCommandDefinition command,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -316,12 +316,43 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
 
     private static bool HasExecutableParentCommand(
         CliToolDefinition tool,
-        CliCommandDefinition command) =>
-        tool.Commands.Any(candidate =>
-            candidate.CommandParts.Length == command.CommandParts.Length - 1
-            && candidate.CommandParts.SequenceEqual(
-                command.CommandParts.Take(candidate.CommandParts.Length),
-                StringComparer.OrdinalIgnoreCase));
+        CliCommandDefinition command)
+    {
+        if (command.CommandParts.Length < 2)
+        {
+            return false;
+        }
+
+        if (command.CommandParts.Length == 2)
+        {
+            var subDomainIdentifier = GeneratorUtils.GetSubDomainIdentifier(
+                tool,
+                command.SubDomainGroup!);
+            return GeneratorUtils.GetSubDomainParentCommands(tool)
+                .Any(candidate => string.Equals(
+                    GeneratorUtils.GetCommandGroupIdentifier(candidate),
+                    subDomainIdentifier,
+                    StringComparison.OrdinalIgnoreCase));
+        }
+
+        var parentPathLength = command.CommandParts.Length - 2;
+        var nodeIdentifier = GeneratorUtils.ToPascalCase(command.CommandParts[^2]);
+        return tool.Commands.Any(candidate =>
+            string.Equals(
+                candidate.SubDomainGroup,
+                command.SubDomainGroup,
+                StringComparison.OrdinalIgnoreCase)
+            && candidate.CommandParts.Length == command.CommandParts.Length - 1
+            && candidate.CommandParts
+                .Take(parentPathLength)
+                .SequenceEqual(
+                    command.CommandParts.Take(parentPathLength),
+                    StringComparer.OrdinalIgnoreCase)
+            && string.Equals(
+                GeneratorUtils.GenerateMethodNameFromLastCommandPart(candidate),
+                nodeIdentifier,
+                StringComparison.OrdinalIgnoreCase));
+    }
 
     private static bool IsCommandPrefix(
         CliCommandDefinition command,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
@@ -214,13 +214,11 @@ public class SubDomainClassGenerator : ICodeGenerator
             sb.AppendLine();
         }
 
-        foreach (var command in node.Commands
-                     .Where(command => !excludedCommands.Contains(command))
-                     .OrderBy(command => command.ClassName))
+        foreach (var (command, methodName) in GetCompatibilityCommands(
+                     node,
+                     parentCommand,
+                     excludedCommands))
         {
-            var methodName = GeneratorUtils.GenerateSubDomainMethodName(
-                command,
-                parentCommand is not null);
             GenerateCompatibilityMethodSignature(sb, tool, alias, methodName, command);
             sb.AppendLine();
         }
@@ -305,13 +303,11 @@ public class SubDomainClassGenerator : ICodeGenerator
                 parentCommand);
         }
 
-        foreach (var command in node.Commands
-                     .Where(command => !excludedCommands.Contains(command))
-                     .OrderBy(command => command.ClassName))
+        foreach (var (command, methodName) in GetCompatibilityCommands(
+                     node,
+                     parentCommand,
+                     excludedCommands))
         {
-            var methodName = GeneratorUtils.GenerateSubDomainMethodName(
-                command,
-                parentCommand is not null);
             sb.AppendLine();
             GenerateCompatibilityForwardingMethod(
                 sb,
@@ -332,6 +328,19 @@ public class SubDomainClassGenerator : ICodeGenerator
             Content = sb.ToString(),
         };
     }
+
+    private static IEnumerable<(CliCommandDefinition Command, string MethodName)> GetCompatibilityCommands(
+        CommandTreeNode node,
+        CliCommandDefinition? parentCommand,
+        HashSet<CliCommandDefinition> excludedCommands) =>
+        node.Commands
+            .Where(command => !excludedCommands.Contains(command))
+            .OrderBy(command => command.ClassName)
+            .Select(command => (
+                command,
+                GeneratorUtils.GenerateSubDomainMethodName(
+                    command,
+                    parentCommand is not null)));
 
     private static void GenerateCompatibilityMethodSignature(
         StringBuilder sb,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
@@ -518,85 +518,94 @@ public class SubDomainClassGenerator : ICodeGenerator
         sb.AppendLine($"public class {node.ClassName}{interfaceClause}");
         sb.AppendLine("{");
 
-        // Private field for ICommandContext
-        sb.AppendLine("    private readonly ICommandContext _command;");
-
-        // Private fields for child instances (lazy). Nullable: the fields are only
-        // populated on first property access, and generated files declare #nullable enable.
-        foreach (var child in node.Children.Values.OrderBy(c => c.PascalSegment))
-        {
-            var fieldName = GetSafeFieldName(child.PascalSegment);
-            sb.AppendLine($"    private {child.ClassName}? {fieldName};");
-        }
-
-        sb.AppendLine();
-
-        // Constructor
-        sb.AppendLine($"    /// <summary>");
-        sb.AppendLine($"    /// Initializes a new instance of the <see cref=\"{node.ClassName}\"/> class.");
-        sb.AppendLine($"    /// </summary>");
-        sb.AppendLine($"    public {node.ClassName}(ICommandContext command)");
-        sb.AppendLine("    {");
-        sb.AppendLine("        _command = command;");
-        sb.AppendLine("    }");
-
-        // Properties for child sub-command groups
-        if (node.Children.Count > 0)
-        {
-            sb.AppendLine();
-            sb.AppendLine("    #region Sub-command Groups");
-            sb.AppendLine();
-
-            foreach (var child in node.Children.Values.OrderBy(c => c.PascalSegment))
-            {
-                var fieldName = GetSafeFieldName(child.PascalSegment);
-
-                sb.AppendLine($"    /// <summary>");
-                sb.AppendLine($"    /// {tool.ToolName} {child.Segment.ToLowerInvariant()} sub-commands.");
-                sb.AppendLine($"    /// </summary>");
-                sb.AppendLine($"    public {child.ClassName} {child.PascalSegment} => {fieldName} ??= new {child.ClassName}(_command);");
-                sb.AppendLine();
-            }
-
-            sb.AppendLine("    #endregion");
-        }
-
-        // Methods for direct commands at this level
-        // Filter out commands that collide with child property names
-        var filteredCommands = excludedCommands != null
-            ? node.Commands.Where(c => !excludedCommands.Contains(c)).ToList()
-            : node.Commands;
-        EnsureUniquePublicMemberNames(tool, node, filteredCommands, parentCommand);
-
-        var hasCommands = filteredCommands.Count > 0 || parentCommand is not null;
-        if (hasCommands)
-        {
-            sb.AppendLine();
-            sb.AppendLine("    #region Commands");
-            sb.AppendLine();
-
-            // Add ExecuteAsync method for the parent command if it exists
-            if (parentCommand is not null)
-            {
-                GenerateExecuteMethod(sb, parentCommand);
-                sb.AppendLine();
-            }
-
-            foreach (var command in filteredCommands.OrderBy(c => c.ClassName))
-            {
-                var methodName = GeneratorUtils.GenerateSubDomainMethodName(
-                    command,
-                    parentCommand is not null);
-                GeneratorUtils.GenerateServiceMethod(sb, methodName, command);
-                sb.AppendLine();
-            }
-
-            sb.AppendLine("    #endregion");
-        }
+        AppendStateAndConstructor(sb, node);
+        AppendChildProperties(sb, node, tool);
+        AppendCommandMethods(sb, node, tool, parentCommand, excludedCommands);
 
         sb.AppendLine("}");
 
         return sb.ToString();
+    }
+
+    private static void AppendStateAndConstructor(StringBuilder sb, CommandTreeNode node)
+    {
+        sb.AppendLine("    private readonly ICommandContext _command;");
+
+        // Child fields are populated on first property access. Generated files enable nullable analysis.
+        foreach (var child in node.Children.Values.OrderBy(c => c.PascalSegment))
+        {
+            sb.AppendLine($"    private {child.ClassName}? {GetSafeFieldName(child.PascalSegment)};");
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>");
+        sb.AppendLine($"    /// Initializes a new instance of the <see cref=\"{node.ClassName}\"/> class.");
+        sb.AppendLine("    /// </summary>");
+        sb.AppendLine($"    public {node.ClassName}(ICommandContext command)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        _command = command;");
+        sb.AppendLine("    }");
+    }
+
+    private static void AppendChildProperties(StringBuilder sb, CommandTreeNode node, CliToolDefinition tool)
+    {
+        if (node.Children.Count == 0)
+        {
+            return;
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("    #region Sub-command Groups");
+        sb.AppendLine();
+
+        foreach (var child in node.Children.Values.OrderBy(c => c.PascalSegment))
+        {
+            var fieldName = GetSafeFieldName(child.PascalSegment);
+            sb.AppendLine("    /// <summary>");
+            sb.AppendLine($"    /// {tool.ToolName} {child.Segment.ToLowerInvariant()} sub-commands.");
+            sb.AppendLine("    /// </summary>");
+            sb.AppendLine($"    public {child.ClassName} {child.PascalSegment} => {fieldName} ??= new {child.ClassName}(_command);");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("    #endregion");
+    }
+
+    private static void AppendCommandMethods(
+        StringBuilder sb,
+        CommandTreeNode node,
+        CliToolDefinition tool,
+        CliCommandDefinition? parentCommand,
+        HashSet<CliCommandDefinition>? excludedCommands)
+    {
+        var commands = excludedCommands is null
+            ? node.Commands
+            : node.Commands.Where(command => !excludedCommands.Contains(command)).ToList();
+        EnsureUniquePublicMemberNames(tool, node, commands, parentCommand);
+
+        if (commands.Count == 0 && parentCommand is null)
+        {
+            return;
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("    #region Commands");
+        sb.AppendLine();
+
+        if (parentCommand is not null)
+        {
+            GenerateExecuteMethod(sb, parentCommand);
+            sb.AppendLine();
+        }
+
+        foreach (var command in commands.OrderBy(c => c.ClassName))
+        {
+            var methodName = GeneratorUtils.GenerateSubDomainMethodName(command, parentCommand is not null);
+            GeneratorUtils.GenerateServiceMethod(sb, methodName, command);
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("    #endregion");
     }
 
     private static void EnsureUniquePublicMemberNames(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
@@ -218,7 +218,9 @@ public class SubDomainClassGenerator : ICodeGenerator
                      .Where(command => !excludedCommands.Contains(command))
                      .OrderBy(command => command.ClassName))
         {
-            var methodName = GeneratorUtils.GenerateMethodNameFromLastCommandPart(command);
+            var methodName = GeneratorUtils.GenerateSubDomainMethodName(
+                command,
+                parentCommand is not null);
             GenerateCompatibilityMethodSignature(sb, tool, alias, methodName, command);
             sb.AppendLine();
         }
@@ -307,7 +309,9 @@ public class SubDomainClassGenerator : ICodeGenerator
                      .Where(command => !excludedCommands.Contains(command))
                      .OrderBy(command => command.ClassName))
         {
-            var methodName = GeneratorUtils.GenerateMethodNameFromLastCommandPart(command);
+            var methodName = GeneratorUtils.GenerateSubDomainMethodName(
+                command,
+                parentCommand is not null);
             sb.AppendLine();
             GenerateCompatibilityForwardingMethod(
                 sb,
@@ -463,7 +467,9 @@ public class SubDomainClassGenerator : ICodeGenerator
 
         foreach (var command in commands.OrderBy(command => command.ClassName))
         {
-            var methodName = GeneratorUtils.GenerateMethodNameFromLastCommandPart(command);
+            var methodName = GeneratorUtils.GenerateSubDomainMethodName(
+                command,
+                parentCommand is not null);
             GeneratorUtils.GenerateServiceMethodSignature(sb, methodName, command);
             sb.AppendLine();
         }
@@ -569,7 +575,9 @@ public class SubDomainClassGenerator : ICodeGenerator
 
             foreach (var command in filteredCommands.OrderBy(c => c.ClassName))
             {
-                var methodName = GeneratorUtils.GenerateMethodNameFromLastCommandPart(command);
+                var methodName = GeneratorUtils.GenerateSubDomainMethodName(
+                    command,
+                    parentCommand is not null);
                 GeneratorUtils.GenerateServiceMethod(sb, methodName, command);
                 sb.AppendLine();
             }
@@ -591,7 +599,9 @@ public class SubDomainClassGenerator : ICodeGenerator
         var publicMembers = node.Children.Values
             .Select(child => child.PascalSegment)
             .Concat(commands
-                .Select(GeneratorUtils.GenerateMethodNameFromLastCommandPart)
+                .Select(command => GeneratorUtils.GenerateSubDomainMethodName(
+                    command,
+                    parentCommand is not null))
                 .Select(GeneratorUtils.EnsureAsyncSuffix));
         if (parentCommand is not null)
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -226,58 +226,62 @@ public partial class GcloudCliScraper : CliScraperBase
 
         foreach (var argument in argumentGroup.FlattenArguments())
         {
-            var negatable = argument.IsNegatable;
-            var longForm = argument.SwitchName;
-            var valueHint = argument.ValueHint ?? string.Empty;
-
-            if (string.IsNullOrEmpty(longForm) || seenOptions.Contains(longForm))
+            var option = CreateOption(argument);
+            if (option is null || !seenOptions.Add(option.SwitchName))
             {
                 continue;
             }
 
-            seenOptions.Add(longForm);
+            options.Add(option);
+        }
 
-            var propertyName = NormalizePropertyName(longForm);
-            if (propertyName is null)
-            {
-                continue;
-            }
+        return (options, [argumentGroup]);
+    }
 
-            var description = argument.Documentation;
+    private static CliOptionDefinition? CreateOption(CliArgumentDefinition argument)
+    {
+        var longForm = argument.SwitchName;
+        if (string.IsNullOrEmpty(longForm))
+        {
+            return null;
+        }
 
-            var isFlag = string.IsNullOrEmpty(valueHint) || negatable;
-            var acceptsMultipleValues = !isFlag
-                && (valueHint.Contains("...")
-                    || DescriptionDeclaresRepeatableOption(description ?? string.Empty));
-            var isNumeric = IsNumericHint(valueHint);
-            var isKeyValue = valueHint.Contains("KEY=VALUE") || valueHint.Contains("=VALUE,");
+        var propertyName = NormalizePropertyName(longForm);
+        if (propertyName is null)
+        {
+            return null;
+        }
 
-            var enumDef = TryDetectEnum(propertyName, description);
-            var csharpType = DetermineCSharpType(
+        var valueHint = argument.ValueHint ?? string.Empty;
+        var description = argument.Documentation;
+        var isFlag = string.IsNullOrEmpty(valueHint) || argument.IsNegatable;
+        var acceptsMultipleValues = !isFlag
+            && (valueHint.Contains("...")
+                || DescriptionDeclaresRepeatableOption(description ?? string.Empty));
+        var isNumeric = IsNumericHint(valueHint);
+        var isKeyValue = valueHint.Contains("KEY=VALUE") || valueHint.Contains("=VALUE,");
+        var enumDefinition = TryDetectEnum(propertyName, description);
+
+        return new CliOptionDefinition
+        {
+            SwitchName = longForm,
+            PropertyName = propertyName,
+            CSharpType = DetermineCSharpType(
                 isFlag,
                 acceptsMultipleValues,
                 isKeyValue,
                 isNumeric,
-                enumDef);
-
-            options.Add(new CliOptionDefinition
-            {
-                SwitchName = longForm,
-                PropertyName = propertyName,
-                CSharpType = csharpType,
-                Description = description,
-                IsFlag = isFlag,
-                IsRequired = false,
-                AcceptsMultipleValues = acceptsMultipleValues,
-                IsKeyValue = isKeyValue,
-                IsNumeric = isNumeric,
-                ValueSeparator = isFlag ? " " : "=",
-                EnumDefinition = enumDef,
-                IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
-            });
-        }
-
-        return (options, [argumentGroup]);
+                enumDefinition),
+            Description = description,
+            IsFlag = isFlag,
+            IsRequired = false,
+            AcceptsMultipleValues = acceptsMultipleValues,
+            IsKeyValue = isKeyValue,
+            IsNumeric = isNumeric,
+            ValueSeparator = isFlag ? " " : "=",
+            EnumDefinition = enumDefinition,
+            IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
+        };
     }
 
     private static CliArgumentDefinition? ParseGcloudArgument(string line)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -280,7 +280,7 @@ public partial class GcloudCliScraper : CliScraperBase
             IsNumeric = isNumeric,
             ValueSeparator = isFlag ? " " : "=",
             EnumDefinition = enumDefinition,
-            IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
+            IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag, description)
         };
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -99,7 +99,7 @@ public partial class GcloudCliScraper : CliScraperBase
 
         var subDomain = commandParts.Length > 1 ? ToPascalCase(commandParts[0]) : null;
         var description = ExtractDescription(helpText);
-        var parsedOptions = ParseOptions(helpText, commandParts);
+        var parsedOptions = ParseOptions(helpText);
         var options = parsedOptions.Options;
         var positionalArgs = ParsePositionalArguments(helpText);
 
@@ -202,13 +202,11 @@ public partial class GcloudCliScraper : CliScraperBase
         return null;
     }
 
-    private (List<CliOptionDefinition> Options, IReadOnlyList<CliArgumentGroup> ArgumentGroups) ParseOptions(
-        string helpText,
-        string[] commandParts)
+    private static (List<CliOptionDefinition> Options, IReadOnlyList<CliArgumentGroup> ArgumentGroups) ParseOptions(
+        string helpText)
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var className = GenerateClassName([ToolName, .. commandParts]);
 
         // Find FLAGS section
         var flagsMatch = Regex.Match(helpText, @"^FLAGS\s*$", RegexOptions.Multiline);
@@ -254,7 +252,7 @@ public partial class GcloudCliScraper : CliScraperBase
             var isNumeric = IsNumericHint(valueHint);
             var isKeyValue = valueHint.Contains("KEY=VALUE") || valueHint.Contains("=VALUE,");
 
-            var enumDef = TryDetectEnum(propertyName, className, description);
+            var enumDef = TryDetectEnum(propertyName, description);
             var csharpType = DetermineCSharpType(
                 isFlag,
                 acceptsMultipleValues,
@@ -351,7 +349,7 @@ public partial class GcloudCliScraper : CliScraperBase
                lower.Contains("timeout") || lower.Contains("seconds") || lower.Contains("iops");
     }
 
-    private static CliEnumDefinition? TryDetectEnum(string propertyName, string className, string? description)
+    private static CliEnumDefinition? TryDetectEnum(string propertyName, string? description)
     {
         if (string.IsNullOrEmpty(description))
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -248,12 +248,19 @@ public partial class GcloudCliScraper : CliScraperBase
             var description = argument.Documentation;
 
             var isFlag = string.IsNullOrEmpty(valueHint) || negatable;
-            var isArray = valueHint.Contains("...") || (description?.Contains("may be repeated") ?? false);
+            var acceptsMultipleValues = !isFlag
+                && (valueHint.Contains("...")
+                    || DescriptionDeclaresRepeatableOption(description ?? string.Empty));
             var isNumeric = IsNumericHint(valueHint);
             var isKeyValue = valueHint.Contains("KEY=VALUE") || valueHint.Contains("=VALUE,");
 
             var enumDef = TryDetectEnum(propertyName, className, description);
-            var csharpType = DetermineCSharpType(isFlag, isArray, isKeyValue, isNumeric, enumDef);
+            var csharpType = DetermineCSharpType(
+                isFlag,
+                acceptsMultipleValues,
+                isKeyValue,
+                isNumeric,
+                enumDef);
 
             options.Add(new CliOptionDefinition
             {
@@ -263,7 +270,7 @@ public partial class GcloudCliScraper : CliScraperBase
                 Description = description,
                 IsFlag = isFlag,
                 IsRequired = false,
-                AcceptsMultipleValues = isArray,
+                AcceptsMultipleValues = acceptsMultipleValues,
                 IsKeyValue = isKeyValue,
                 IsNumeric = isNumeric,
                 ValueSeparator = isFlag ? " " : "=",
@@ -405,14 +412,25 @@ public partial class GcloudCliScraper : CliScraperBase
         };
     }
 
-    private static string DetermineCSharpType(bool isFlag, bool isArray, bool isKeyValue, bool isNumeric, CliEnumDefinition? enumDef)
+    private static string DetermineCSharpType(
+        bool isFlag,
+        bool acceptsMultipleValues,
+        bool isKeyValue,
+        bool isNumeric,
+        CliEnumDefinition? enumDef)
     {
-        if (isFlag) return "bool?";
-        if (enumDef is not null) return $"{enumDef.EnumName}?";
-        if (isKeyValue) return "IReadOnlyList<KeyValue>?";
-        if (isArray) return "IEnumerable<string>?";
-        if (isNumeric) return "int?";
-        return "string?";
+        if (isFlag)
+        {
+            return "bool?";
+        }
+
+        if (isKeyValue)
+        {
+            return "IReadOnlyList<KeyValue>?";
+        }
+
+        var scalarType = enumDef?.EnumName ?? (isNumeric ? "int" : "string");
+        return acceptsMultipleValues ? $"IEnumerable<{scalarType}>?" : $"{scalarType}?";
     }
 
     #endregion

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GcloudCliScraper.cs
@@ -426,12 +426,17 @@ public partial class GcloudCliScraper : CliScraperBase
             return "bool?";
         }
 
+        if (enumDef is not null)
+        {
+            return $"{enumDef.EnumName}?";
+        }
+
         if (isKeyValue)
         {
             return "IReadOnlyList<KeyValue>?";
         }
 
-        var scalarType = enumDef?.EnumName ?? (isNumeric ? "int" : "string");
+        var scalarType = isNumeric ? "int" : "string";
         return acceptsMultipleValues ? $"IEnumerable<{scalarType}>?" : $"{scalarType}?";
     }
 


### PR DESCRIPTION
## Summary
- model gcloud repeatable options with the shared marker parser and collection element types
- disambiguate a literal `execute` child as `ExecuteCommandAsync` when its executable parent owns `ExecuteAsync`
- keep generated service interfaces, implementations, compatibility facades, and documentation invocations aligned

## Triage
- Aug 23 gcloud did not reach installation or generation: GitHub terminated `dotnet pack` after 3m23s with runner shutdown/exit 143; this was runner preemption, not the 60-minute job timeout
- Aug 2/9/16 gcloud completed the full ~7.7k-command scrape, then failed on repeatable option shapes and duplicate `patch-jobs.ExecuteAsync`; these fixes address those deterministic failures
- podman generation, build, API validation, and PR creation succeeded; its final red step intentionally reports the detected breaking API and correctly left auto-merge disabled on #3970

## Validation
- Markdown documentation tests: 23/23 passed
- nested/gcloud parser tests: 7/7 passed
- full OptionsGenerator tests: 817/817 passed
- OptionsGenerator Release build: 0 warnings, 0 errors
- touched-file formatting: 0 errors

Fixes #3994
Part of #3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated command naming to prevent collisions between root, nested, and `execute` commands.
  * Enhanced Google Cloud CLI parsing for repeatable options, including multi-value collection support.
  * Preserved enum types when generating repeatable option collections.
* **Tests**
  * Added coverage for command-name collision scenarios and repeatable Google Cloud CLI options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->