### PR TITLE
[Automated] Update kind CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/kind.md
+++ b/docs/docs/mp-packages/cli/kind.md
@@ -7,7 +7,13 @@ title: kind CLI reference
 
 `ModularPipelines.Kind` provides strongly typed access to the `kind` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `kind` executable. Install it separately and ensure `kind` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Kind
@@ -17,10 +23,9 @@ Resolve the service with `context.Tools.Kind`. For projects older than C# 14, im
 
 ## Module example
 
-Resolve the service in a module, then select a generated sub-domain and command from the table below:
+Resolve the service in a module, then select a command from the table below. A runnable example is omitted when no command has complete safety metadata:
 
 ```csharp
-
 var kind = context.Tools.Kind;
 ```
 
@@ -28,14 +33,20 @@ var kind = context.Tools.Kind;
 
 | CLI command | Options record |
 | --- | --- |
+| `kind build` | `KindBuildOptions` |
 | `kind build node-image` | `KindBuildNodeImageOptions` |
+| `kind create` | `KindCreateOptions` |
 | `kind create cluster` | `KindCreateClusterOptions` |
+| `kind delete` | `KindDeleteOptions` |
 | `kind delete cluster` | `KindDeleteClusterOptions` |
 | `kind delete clusters` | `KindDeleteClustersOptions` |
+| `kind export` | `KindExportOptions` |
 | `kind export kubeconfig` | `KindExportKubeconfigOptions` |
 | `kind export logs` | `KindExportLogsOptions` |
+| `kind get` | `KindGetOptions` |
 | `kind get clusters` | `KindGetClustersOptions` |
 | `kind get kubeconfig` | `KindGetKubeconfigOptions` |
 | `kind get nodes` | `KindGetNodesOptions` |
+| `kind load` | `KindLoadOptions` |
 | `kind load docker-image` | `KindLoadDockerImageOptions` |
 | `kind load image-archive` | `KindLoadImageArchiveOptions` |

--- a/src/ModularPipelines.Kind/Enums/KindBuildNodeImageType.Generated.cs
+++ b/src/ModularPipelines.Kind/Enums/KindBuildNodeImageType.Generated.cs
@@ -17,17 +17,17 @@ namespace ModularPipelines.Kind.Enums;
 public enum KindBuildNodeImageType
 {
     [EnumValue("url")]
-    Url,
+    Url = 0,
 
     [EnumValue("file")]
-    File,
+    File = 1,
 
     [EnumValue("release")]
-    Release,
+    Release = 2,
 
     [EnumValue("ci")]
-    Ci,
+    Ci = 3,
 
     [EnumValue("source")]
-    Source
+    Source = 4
 }

--- a/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
+++ b/src/ModularPipelines.Kind/Extensions/KindExtensions.Generated.cs
@@ -39,7 +39,7 @@ public static class KindExtensions
     }
 
     /// <summary>
-    /// Gets the kind service from the pipeline context.
+    /// Gets the kind service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKind"/> service for executing kind commands.</returns>

--- a/src/ModularPipelines.Kind/Generated/Kind.CommandCoverage.json
+++ b/src/ModularPipelines.Kind/Generated/Kind.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "kind",
+  "toolVersion": "kind version 0.33.0-alpha\u002Bfed268827e21ca",
   "commandCount": 17,
   "commandTreeSha256": "a31e4891e1c87ea5e6da505fb24f5fd2529e7fd0762e6ecd515001187472577b",
   "commands": [

--- a/src/ModularPipelines.Kind/Options/KindBuildNodeImageOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindBuildNodeImageOptions.Generated.cs
@@ -28,7 +28,7 @@ public record KindBuildNodeImageOptions : KindOptions
     public string? Arch { get; set; }
 
     /// <summary>
-    /// name:tag of the base image to use for the build (default "docker.io/kindest/base:v20260601-995e8fa5")
+    /// name:tag of the base image to use for the build (default "docker.io/kindest/base:v20260820-69b56db7")
     /// </summary>
     [CliOption("--base-image", Format = OptionFormat.EqualsSeparated)]
     public string? BaseImage { get; set; }
@@ -62,5 +62,11 @@ public record KindBuildNodeImageOptions : KindOptions
     /// </summary>
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
+
+    /// <summary>
+    /// The kubernetes-source operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? KubernetesSource { get; set; }
 
 }

--- a/src/ModularPipelines.Kind/Options/KindCreateClusterOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindCreateClusterOptions.Generated.cs
@@ -42,7 +42,7 @@ public record KindCreateClusterOptions : KindOptions
     /// sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config
     /// </summary>
     [CliOption("--kubeconfig", Format = OptionFormat.EqualsSeparated)]
-    public string? Kubeconfig { get; set; }
+    public string? KubeConfig { get; set; }
 
     /// <summary>
     /// cluster name, overrides KIND_CLUSTER_NAME, config (default kind)
@@ -73,5 +73,12 @@ public record KindCreateClusterOptions : KindOptions
     /// </summary>
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
+
+    [Obsolete("Use KubeConfig instead.")]
+    public string? Kubeconfig
+    {
+        get => KubeConfig;
+        set => KubeConfig = value;
+    }
 
 }

--- a/src/ModularPipelines.Kind/Options/KindDeleteClusterOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindDeleteClusterOptions.Generated.cs
@@ -30,7 +30,7 @@ public record KindDeleteClusterOptions : KindOptions
     /// sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config
     /// </summary>
     [CliOption("--kubeconfig", Format = OptionFormat.EqualsSeparated)]
-    public string? Kubeconfig { get; set; }
+    public string? KubeConfig { get; set; }
 
     /// <summary>
     /// the cluster name (default "kind")
@@ -49,5 +49,12 @@ public record KindDeleteClusterOptions : KindOptions
     /// </summary>
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
+
+    [Obsolete("Use KubeConfig instead.")]
+    public string? Kubeconfig
+    {
+        get => KubeConfig;
+        set => KubeConfig = value;
+    }
 
 }

--- a/src/ModularPipelines.Kind/Options/KindDeleteClustersOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindDeleteClustersOptions.Generated.cs
@@ -36,7 +36,7 @@ public record KindDeleteClustersOptions : KindOptions
     /// sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config
     /// </summary>
     [CliOption("--kubeconfig", Format = OptionFormat.EqualsSeparated)]
-    public string? Kubeconfig { get; set; }
+    public string? KubeConfig { get; set; }
 
     /// <summary>
     /// silence all stderr output
@@ -49,5 +49,12 @@ public record KindDeleteClustersOptions : KindOptions
     /// </summary>
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
+
+    [Obsolete("Use KubeConfig instead.")]
+    public string? Kubeconfig
+    {
+        get => KubeConfig;
+        set => KubeConfig = value;
+    }
 
 }

--- a/src/ModularPipelines.Kind/Options/KindExportKubeconfigOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindExportKubeconfigOptions.Generated.cs
@@ -36,7 +36,7 @@ public record KindExportKubeconfigOptions : KindOptions
     /// sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config
     /// </summary>
     [CliOption("--kubeconfig", Format = OptionFormat.EqualsSeparated)]
-    public string? Kubeconfig { get; set; }
+    public string? KubeConfig { get; set; }
 
     /// <summary>
     /// the cluster context name (default "kind")
@@ -55,5 +55,12 @@ public record KindExportKubeconfigOptions : KindOptions
     /// </summary>
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
+
+    [Obsolete("Use KubeConfig instead.")]
+    public string? Kubeconfig
+    {
+        get => KubeConfig;
+        set => KubeConfig = value;
+    }
 
 }

--- a/src/ModularPipelines.Kind/Options/KindExportLogsOptions.Generated.cs
+++ b/src/ModularPipelines.Kind/Options/KindExportLogsOptions.Generated.cs
@@ -44,4 +44,10 @@ public record KindExportLogsOptions : KindOptions
     [CliOption("--verbosity", ShortForm = "-v", Format = OptionFormat.EqualsSeparated)]
     public int? Verbosity { get; set; }
 
+    /// <summary>
+    /// The output-dir operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? OutputDir { get; set; }
+
 }

--- a/src/ModularPipelines.Kind/Services/IKind.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/IKind.Generated.cs
@@ -23,32 +23,32 @@ public partial interface IKind
     /// <summary>
     /// Gets the build sub-domain service.
     /// </summary>
-    IKindBuild Build { get; }
+    IKindBuild Build => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the create sub-domain service.
     /// </summary>
-    IKindCreate Create { get; }
+    IKindCreate Create => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the delete sub-domain service.
     /// </summary>
-    IKindDelete Delete { get; }
+    IKindDelete Delete => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the export sub-domain service.
     /// </summary>
-    IKindExport Export { get; }
+    IKindExport Export => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the get sub-domain service.
     /// </summary>
-    IKindGet Get { get; }
+    IKindGet Get => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the load sub-domain service.
     /// </summary>
-    IKindLoad Load { get; }
+    IKindLoad Load => throw new System.NotSupportedException();
 
     #endregion
 

--- a/src/ModularPipelines.Kind/Services/IKindBuild.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/IKindBuild.Generated.cs
@@ -15,6 +15,9 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind build commands.
 /// </summary>
+/// <remarks>
+/// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
+/// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public interface IKindBuild
 {
@@ -25,10 +28,8 @@ public interface IKindBuild
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(
-        KindBuildOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(KindBuildOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Build the node image which contains Kubernetes build artifacts and other kind requirements.
@@ -37,9 +38,7 @@ public interface IKindBuild
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> NodeImageAsync(
-        KindBuildNodeImageOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> NodeImageAsync(KindBuildNodeImageOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Kind/Services/IKindCreate.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/IKindCreate.Generated.cs
@@ -15,6 +15,9 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind create commands.
 /// </summary>
+/// <remarks>
+/// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
+/// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public interface IKindCreate
 {
@@ -25,10 +28,8 @@ public interface IKindCreate
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(
-        KindCreateOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(KindCreateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Creates a local Kubernetes cluster using Docker container 'nodes'
@@ -37,9 +38,7 @@ public interface IKindCreate
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ClusterAsync(
-        KindCreateClusterOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ClusterAsync(KindCreateClusterOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Kind/Services/IKindDelete.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/IKindDelete.Generated.cs
@@ -15,6 +15,9 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind delete commands.
 /// </summary>
+/// <remarks>
+/// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
+/// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public interface IKindDelete
 {
@@ -25,10 +28,8 @@ public interface IKindDelete
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(
-        KindDeleteOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(KindDeleteOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Deletes a Kind cluster from the system.
@@ -37,10 +38,8 @@ public interface IKindDelete
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ClusterAsync(
-        KindDeleteClusterOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ClusterAsync(KindDeleteClusterOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Deletes one or more Kind clusters from the system.
@@ -49,9 +48,7 @@ public interface IKindDelete
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ClustersAsync(
-        KindDeleteClustersOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ClustersAsync(KindDeleteClustersOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Kind/Services/IKindExport.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/IKindExport.Generated.cs
@@ -15,6 +15,9 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind export commands.
 /// </summary>
+/// <remarks>
+/// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
+/// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public interface IKindExport
 {
@@ -25,10 +28,8 @@ public interface IKindExport
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(
-        KindExportOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(KindExportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Exports cluster kubeconfig
@@ -37,10 +38,14 @@ public interface IKindExport
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> KubeconfigAsync(
-        KindExportKubeconfigOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    #pragma warning disable CS0618
+    Task<CommandResult> KubeConfigAsync(KindExportKubeconfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => KubeconfigAsync(options, executionOptions, cancellationToken);
+    #pragma warning restore CS0618
+
+    [Obsolete("Use KubeConfigAsync instead.")]
+    Task<CommandResult> KubeconfigAsync(KindExportKubeconfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Exports logs to a tempdir or [output-dir] if specified
@@ -49,9 +54,7 @@ public interface IKindExport
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> LogsAsync(
-        KindExportLogsOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> LogsAsync(KindExportLogsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Kind/Services/IKindGet.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/IKindGet.Generated.cs
@@ -15,6 +15,9 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind get commands.
 /// </summary>
+/// <remarks>
+/// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
+/// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public interface IKindGet
 {
@@ -25,10 +28,8 @@ public interface IKindGet
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(
-        KindGetOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(KindGetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Lists existing kind clusters by their name
@@ -37,10 +38,8 @@ public interface IKindGet
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ClustersAsync(
-        KindGetClustersOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ClustersAsync(KindGetClustersOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Prints cluster kubeconfig
@@ -49,10 +48,14 @@ public interface IKindGet
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> KubeconfigAsync(
-        KindGetKubeconfigOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    #pragma warning disable CS0618
+    Task<CommandResult> KubeConfigAsync(KindGetKubeconfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => KubeconfigAsync(options, executionOptions, cancellationToken);
+    #pragma warning restore CS0618
+
+    [Obsolete("Use KubeConfigAsync instead.")]
+    Task<CommandResult> KubeconfigAsync(KindGetKubeconfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Lists existing kind nodes by their name
@@ -61,9 +64,7 @@ public interface IKindGet
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> NodesAsync(
-        KindGetNodesOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> NodesAsync(KindGetNodesOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Kind/Services/IKindLoad.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/IKindLoad.Generated.cs
@@ -15,6 +15,9 @@ namespace ModularPipelines.Kind.Services;
 /// <summary>
 /// kind load commands.
 /// </summary>
+/// <remarks>
+/// Nested sub-command groups are exposed as concrete services; only this top-level facade is interface-backed.
+/// </remarks>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public interface IKindLoad
 {
@@ -25,10 +28,8 @@ public interface IKindLoad
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(
-        KindLoadOptions? options = null,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteAsync(KindLoadOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Loads docker images from host into all or specified nodes by name
@@ -37,10 +38,8 @@ public interface IKindLoad
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DockerImageAsync(
-        KindLoadDockerImageOptions options,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> DockerImageAsync(KindLoadDockerImageOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Loads docker image from archive into all or specified nodes by name
@@ -49,9 +48,7 @@ public interface IKindLoad
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ImageArchiveAsync(
-        KindLoadImageArchiveOptions options,
-        CommandExecutionOptions? executionOptions = null,
-        CancellationToken cancellationToken = default);
+    Task<CommandResult> ImageArchiveAsync(KindLoadImageArchiveOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Kind/Services/KindExport.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/KindExport.Generated.cs
@@ -53,12 +53,21 @@ public class KindExport : IKindExport
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public virtual async Task<CommandResult> KubeconfigAsync(
+    public virtual async Task<CommandResult> KubeConfigAsync(
         KindExportKubeconfigOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
         return await _command.ExecuteCommandLineToolAsync(options ?? new KindExportKubeconfigOptions(), executionOptions, cancellationToken);
+    }
+
+    [Obsolete("Use KubeConfigAsync instead.")]
+    public virtual async Task<CommandResult> KubeconfigAsync(
+        KindExportKubeconfigOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await KubeConfigAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>

--- a/src/ModularPipelines.Kind/Services/KindGet.Generated.cs
+++ b/src/ModularPipelines.Kind/Services/KindGet.Generated.cs
@@ -68,12 +68,21 @@ public class KindGet : IKindGet
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    public virtual async Task<CommandResult> KubeconfigAsync(
+    public virtual async Task<CommandResult> KubeConfigAsync(
         KindGetKubeconfigOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
         return await _command.ExecuteCommandLineToolAsync(options ?? new KindGetKubeconfigOptions(), executionOptions, cancellationToken);
+    }
+
+    [Obsolete("Use KubeConfigAsync instead.")]
+    public virtual async Task<CommandResult> KubeconfigAsync(
+        KindGetKubeconfigOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await KubeConfigAsync(options, executionOptions, cancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **kind** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- kind (kind version 0.33.0-alpha+fed268827e21ca): 17 commands, tree a31e4891e1c87ea5e6da505fb24f5fd2529e7fd0762e6ecd515001187472577b

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator