### PR TITLE
Use valid CLI version probes

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/LiquibaseCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/LiquibaseCliScraperTests.cs
@@ -227,6 +227,24 @@ public class LiquibaseCliScraperTests
         await Assert.That(resolved).IsEqualTo("liquibase");
     }
 
+    [Test]
+    [Arguments("Liquibase Version: 5.0.3")]
+    [Arguments("Liquibase Community 5.0.3 by Liquibase")]
+    [Arguments("Liquibase 'community' version 5.0.3 by Liquibase")]
+    public async Task Version_Parser_Skips_Banner_And_Returns_Machine_Readable_Version(string versionLine)
+    {
+        var result = new CliCommandResult
+        {
+            StandardOutput = $"{new string('#', 600)}\n{versionLine}",
+            StandardError = string.Empty,
+            ExitCode = 0,
+        };
+
+        var version = _scraper.ParseLiquibaseVersion(result);
+
+        await Assert.That(version).IsEqualTo("5.0.3");
+    }
+
     private sealed class TestLiquibaseCliScraper(ICliCommandExecutor? executor = null)
         : LiquibaseCliScraper(executor ?? new StubExecutor(), new StubHelpTextCache(), NullLogger<LiquibaseCliScraper>.Instance)
     {
@@ -239,6 +257,8 @@ public class LiquibaseCliScraperTests
 
         public Task<CliCommandDefinition?> ParseLiquibaseCommand(string[] commandPath, string helpText) =>
             ParseCommandAsync(commandPath, helpText, CancellationToken.None);
+
+        public string? ParseLiquibaseVersion(CliCommandResult result) => ParseVersionOutput(result);
     }
 
     private sealed class StubExecutor(string? rootHelp = null, string? updateHelp = null) : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/LiquibaseCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/LiquibaseCliScraperTests.cs
@@ -230,6 +230,8 @@ public class LiquibaseCliScraperTests
     [Test]
     [Arguments("Liquibase Version: 5.0.3")]
     [Arguments("Liquibase Community 5.0.3 by Liquibase")]
+    [Arguments("Liquibase Pro 5.0.3 by Liquibase")]
+    [Arguments("Liquibase Secure 5.0.3 by Liquibase")]
     [Arguments("Liquibase 'community' version 5.0.3 by Liquibase")]
     public async Task Version_Parser_Skips_Banner_And_Returns_Machine_Readable_Version(string versionLine)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CliVersionProbeTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CliVersionProbeTests.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class CliVersionProbeTests
+{
+    [Test]
+    public async Task ArgoCd_Uses_Client_Version_Subcommand() =>
+        await AssertVersionProbeAsync(
+            "argocd",
+            "version --client",
+            (executor, cache) => new ArgoCdCliScraper(
+                executor,
+                cache,
+                NullLogger<ArgoCdCliScraper>.Instance));
+
+    [Test]
+    public async Task Eksctl_Uses_Version_Subcommand() =>
+        await AssertVersionProbeAsync(
+            "eksctl",
+            "version",
+            (executor, cache) => new EksctlCliScraper(
+                executor,
+                cache,
+                NullLogger<EksctlCliScraper>.Instance));
+
+    [Test]
+    public async Task Cosign_Uses_Version_Subcommand() =>
+        await AssertVersionProbeAsync(
+            "cosign",
+            "version",
+            (executor, cache) => new CosignCliScraper(
+                executor,
+                cache,
+                NullLogger<CosignCliScraper>.Instance));
+
+    [Test]
+    public async Task Kustomize_Uses_Version_Subcommand() =>
+        await AssertVersionProbeAsync(
+            "kustomize",
+            "version",
+            (executor, cache) => new KustomizeCliScraper(
+                executor,
+                cache,
+                NullLogger<KustomizeCliScraper>.Instance));
+
+    [Test]
+    public async Task Go_Uses_Version_Subcommand() =>
+        await AssertVersionProbeAsync(
+            "go",
+            "version",
+            (executor, cache) => new GoCliScraper(
+                executor,
+                cache,
+                NullLogger<GoCliScraper>.Instance));
+
+    private static async Task AssertVersionProbeAsync(
+        string expectedCommand,
+        string expectedArguments,
+        Func<ICliCommandExecutor, IHelpTextCache, ICliScraper> createScraper)
+    {
+        var executor = new RecordingExecutor(expectedCommand, expectedArguments);
+        var scraper = createScraper(
+            executor,
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance));
+
+        var isAvailable = await scraper.IsAvailableAsync();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(isAvailable).IsTrue();
+            await Assert.That(executor.InvocationCount).IsEqualTo(1);
+        }
+    }
+
+    private sealed class RecordingExecutor(string expectedCommand, string expectedArguments)
+        : ICliCommandExecutor
+    {
+        public int InvocationCount { get; private set; }
+
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            InvocationCount++;
+            var success = command.Equals(expectedCommand, StringComparison.Ordinal)
+                          && arguments.Equals(expectedArguments, StringComparison.Ordinal);
+            return Task.FromResult(new CliCommandResult
+            {
+                StandardOutput = success ? "version" : string.Empty,
+                StandardError = success ? string.Empty : "unexpected probe",
+                ExitCode = success ? 0 : 1,
+            });
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+
+        public async Task<bool> IsAvailableAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default) =>
+            (await ExecuteAsync(command, arguments, cancellationToken)).Success;
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/HelmCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/HelmCliScraperTests.cs
@@ -21,7 +21,8 @@ public class HelmCliScraperTests
 
         await Assert.That(isAvailable).IsTrue();
         await Assert.That(version).IsEqualTo("version.BuildInfo{Version:\"v4.0.0\"}");
-        await Assert.That(executor.Arguments).IsEquivalentTo(["version", "version"]);
+        await Assert.That(executor.AvailabilityArguments).IsEquivalentTo(["version"]);
+        await Assert.That(executor.Arguments).IsEquivalentTo(["version"]);
     }
 
     [Test]
@@ -56,6 +57,8 @@ public class HelmCliScraperTests
     {
         public List<string> Arguments { get; } = [];
 
+        public List<string> AvailabilityArguments { get; } = [];
+
         public Task<CliCommandResult> ExecuteAsync(
             string command,
             string arguments,
@@ -76,6 +79,15 @@ public class HelmCliScraperTests
             string command,
             CancellationToken cancellationToken = default) =>
             Task.FromResult(false);
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default)
+        {
+            AvailabilityArguments.Add(arguments);
+            return Task.FromResult(arguments == "version");
+        }
     }
 
     private sealed class HelmHelpExecutor : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KubectlCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/KubectlCliScraperTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class KubectlCliScraperTests
+{
+    [Test]
+    public async Task Uses_Version_Subcommand_For_Availability_And_Version()
+    {
+        var executor = new RecordingExecutor();
+        var scraper = new KubectlCliScraper(
+            executor,
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<KubectlCliScraper>.Instance);
+
+        var isAvailable = await scraper.IsAvailableAsync();
+        var version = await scraper.GetVersionAsync();
+
+        await Assert.That(isAvailable).IsTrue();
+        await Assert.That(version).IsEqualTo("Client Version: v1.35.0");
+        await Assert.That(executor.AvailabilityArguments).IsEquivalentTo(["version --client"]);
+        await Assert.That(executor.Arguments).IsEquivalentTo(["version --client"]);
+    }
+
+    private sealed class RecordingExecutor : ICliCommandExecutor
+    {
+        public List<string> Arguments { get; } = [];
+
+        public List<string> AvailabilityArguments { get; } = [];
+
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            Arguments.Add(arguments);
+            var success = arguments == "version --client";
+            return Task.FromResult(new CliCommandResult
+            {
+                StandardOutput = success ? "Client Version: v1.35.0" : string.Empty,
+                StandardError = success ? string.Empty : "error: unknown flag: --version",
+                ExitCode = success ? 0 : 1,
+            });
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default)
+        {
+            AvailabilityArguments.Add(arguments);
+            return Task.FromResult(arguments == "version --client");
+        }
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ProcessCliCommandExecutorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ProcessCliCommandExecutorTests.cs
@@ -407,6 +407,46 @@ public class ProcessCliCommandExecutorTests
     }
 
     [Test]
+    public async Task Argument_Aware_IsAvailableAsync_Falls_Back_To_Help()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mp-cli-executor-tests", Guid.NewGuid().ToString("N"));
+        var scriptPath = Path.Combine(root, OperatingSystem.IsWindows() ? "probe.cmd" : "probe.sh");
+
+        try
+        {
+            Directory.CreateDirectory(root);
+            if (OperatingSystem.IsWindows())
+            {
+                await File.WriteAllTextAsync(
+                    scriptPath,
+                    "@echo off\r\nif \"%~1\"==\"--help\" exit /b 0\r\nexit /b 1\r\n");
+            }
+            else
+            {
+                await File.WriteAllTextAsync(
+                    scriptPath,
+                    "#!/bin/sh\n[ \"$1\" = \"--help\" ]\n");
+                File.SetUnixFileMode(
+                    scriptPath,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+
+            var executor = new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance);
+
+            var isAvailable = await executor.IsAvailableAsync(scriptPath, "--version");
+
+            await Assert.That(isAvailable).IsTrue();
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+
+    [Test]
     public async Task IsAvailableAsync_Returns_False_For_Missing_Command()
     {
         var executor = new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ProcessCliCommandExecutorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ProcessCliCommandExecutorTests.cs
@@ -407,7 +407,10 @@ public class ProcessCliCommandExecutorTests
     }
 
     [Test]
-    public async Task Argument_Aware_IsAvailableAsync_Falls_Back_To_Help()
+    [Arguments("version")]
+    [Arguments("version --client")]
+    public async Task Argument_Aware_IsAvailableAsync_Falls_Back_To_Help_For_Real_Version_Arguments(
+        string versionArguments)
     {
         var root = Path.Combine(Path.GetTempPath(), "mp-cli-executor-tests", Guid.NewGuid().ToString("N"));
         var scriptPath = Path.Combine(root, OperatingSystem.IsWindows() ? "probe.cmd" : "probe.sh");
@@ -433,7 +436,7 @@ public class ProcessCliCommandExecutorTests
 
             var executor = new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance);
 
-            var isAvailable = await executor.IsAvailableAsync(scriptPath, "--version");
+            var isAvailable = await executor.IsAvailableAsync(scriptPath, versionArguments);
 
             await Assert.That(isAvailable).IsTrue();
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ResilientCliCommandExecutorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/TypeDetection/ResilientCliCommandExecutorTests.cs
@@ -1,0 +1,58 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.TypeDetection;
+
+public class ResilientCliCommandExecutorTests
+{
+    [Test]
+    public async Task ToolSpecificAvailabilityProbe_BypassesResilienceShield()
+    {
+        var inner = new RecordingExecutor();
+        var executor = new ResilientCliCommandExecutor(
+            inner,
+            NullLogger<ResilientCliCommandExecutor>.Instance);
+
+        var isAvailable = await executor.IsAvailableAsync("kubectl", "version --client");
+
+        await Assert.That(isAvailable).IsTrue();
+        await Assert.That(inner.AvailabilityProbes).IsEquivalentTo([("kubectl", "version --client")]);
+        await Assert.That(inner.ExecutionCount).IsEqualTo(0);
+    }
+
+    private sealed class RecordingExecutor : ICliCommandExecutor
+    {
+        public List<(string Command, string Arguments)> AvailabilityProbes { get; } = [];
+
+        public int ExecutionCount { get; private set; }
+
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            ExecutionCount++;
+            return Task.FromResult(new CliCommandResult
+            {
+                StandardOutput = string.Empty,
+                StandardError = "transient failure",
+                ExitCode = -1
+            });
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default)
+        {
+            AvailabilityProbes.Add((command, arguments));
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ArgoCdCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ArgoCdCliScraper.cs
@@ -37,6 +37,8 @@ public partial class ArgoCdCliScraper : CobraCliScraper
 
     public override string OutputDirectory => "src/ModularPipelines.ArgoCd";
 
+    protected override string VersionArguments => "version --client";
+
     /// <summary>
     /// Argo CD calls the ApplicationSet command "appset". Expanding the compound name
     /// prevents it from colliding with the separate "app set" command in generated code.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -154,7 +154,10 @@ public abstract partial class CliScraperBase : ICliScraper
     /// </summary>
     public virtual async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
     {
-        return await Executor.IsAvailableAsync(ExecutablePath, cancellationToken);
+        return await Executor.IsAvailableAsync(
+            ExecutablePath,
+            VersionArguments,
+            cancellationToken);
     }
 
     /// <inheritdoc />

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CosignCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CosignCliScraper.cs
@@ -60,6 +60,8 @@ public partial class CosignCliScraper : CobraCliScraper
 
     public override string OutputDirectory => "src/ModularPipelines.Cosign";
 
+    protected override string VersionArguments => "version";
+
     /// <summary>
     /// Cosign validates many positional arguments in command code without including them
     /// in the generated usage line. Supply that metadata explicitly from the v3 command

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/EksctlCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/EksctlCliScraper.cs
@@ -45,6 +45,8 @@ public partial class EksctlCliScraper : CobraCliScraper
 
     public override string OutputDirectory => "src/ModularPipelines.Eksctl";
 
+    protected override string VersionArguments => "version";
+
     protected override string NormalizeCommandIdentifier(string commandPart) =>
         commandPart.Equals("kubeconfig", StringComparison.OrdinalIgnoreCase)
             ? "Kubeconfig"

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -47,6 +47,8 @@ public partial class GoCliScraper : CliScraperBase
 
     public override string OutputDirectory => "src/ModularPipelines.Go";
 
+    protected override string VersionArguments => "version";
+
     /// <summary>
     /// Skip utility commands.
     /// </summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/HelmCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/HelmCliScraper.cs
@@ -22,17 +22,6 @@ public class HelmCliScraper : CobraCliScraper
     {
     }
 
-    public override async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
-    {
-        var result = await Executor.ExecuteAsync(
-                ExecutablePath,
-                VersionArguments,
-                cancellationToken)
-            .ConfigureAwait(false);
-
-        return result.Success;
-    }
-
     protected override IReadOnlyList<CliPositionalArgument> ApplyPositionalArgumentFixes(
         string[] commandParts,
         IReadOnlyList<CliPositionalArgument> positionalArguments)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KubectlCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KubectlCliScraper.cs
@@ -14,6 +14,8 @@ public class KubectlCliScraper : CobraCliScraper
     public override string TargetNamespace => "ModularPipelines.Kubernetes";
     public override string OutputDirectory => "src/ModularPipelines.Kubernetes";
 
+    protected override string VersionArguments => "version --client";
+
     public KubectlCliScraper(ICliCommandExecutor executor, IHelpTextCache helpCache, ILogger<KubectlCliScraper> logger)
         : base(executor, helpCache, logger)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/KustomizeCliScraper.cs
@@ -54,6 +54,8 @@ public partial class KustomizeCliScraper : CobraCliScraper
 
     public override string OutputDirectory => "src/ModularPipelines.Kubernetes";
 
+    protected override string VersionArguments => "version";
+
     /// <summary>
     /// Kustomize renders the build directory as required in its Cobra usage line even
     /// though omitting it is documented to use the current directory.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/LiquibaseCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/LiquibaseCliScraper.cs
@@ -89,6 +89,18 @@ public partial class LiquibaseCliScraper : CliScraperBase
     /// </summary>
     protected override int MaxParallelism => 2;
 
+    protected override string? ParseVersionOutput(CliCommandResult result)
+    {
+        var match = LiquibaseVersionPattern().Match(result.CombinedOutput);
+        if (match.Success)
+        {
+            return match.Groups["version"].Value;
+        }
+
+        Logger.LogWarning("Could not extract stable {Tool} version identity", ToolName);
+        return null;
+    }
+
     /// <summary>
     /// Skip utility commands.
     /// </summary>
@@ -558,6 +570,11 @@ public partial class LiquibaseCliScraper : CliScraperBase
 
     [GeneratedRegex(@"\s*\(defaults file:.*$", RegexOptions.IgnoreCase | RegexOptions.Singleline)]
     private static partial Regex DefaultsMetadataPattern();
+
+    [GeneratedRegex(
+        @"(?:Liquibase Version:|Liquibase (?:Community|'community' version))\s*(?<version>\d+(?:\.\d+)+(?:[-+][0-9A-Za-z.-]+)?)",
+        RegexOptions.IgnoreCase)]
+    private static partial Regex LiquibaseVersionPattern();
 
     #endregion
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/LiquibaseCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/LiquibaseCliScraper.cs
@@ -572,7 +572,7 @@ public partial class LiquibaseCliScraper : CliScraperBase
     private static partial Regex DefaultsMetadataPattern();
 
     [GeneratedRegex(
-        @"(?:Liquibase Version:|Liquibase (?:Community|'community' version))\s*(?<version>\d+(?:\.\d+)+(?:[-+][0-9A-Za-z.-]+)?)",
+        @"(?:Liquibase Version:|Liquibase (?:'community' version|\S+))\s*(?<version>\d+(?:\.\d+)+(?:[-+][0-9A-Za-z.-]+)?)",
         RegexOptions.IgnoreCase)]
     private static partial Regex LiquibaseVersionPattern();
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ICliCommandExecutor.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ICliCommandExecutor.cs
@@ -34,7 +34,7 @@ public interface ICliCommandExecutor
     /// <param name="command">The command to check (e.g., "kubectl").</param>
     /// <param name="arguments">Arguments that should complete successfully when the tool is available.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>True if the command executes successfully.</returns>
+    /// <returns>True if the command is available using the requested probe or the help fallback.</returns>
     Task<bool> IsAvailableAsync(
         string command,
         string arguments,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ICliCommandExecutor.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ICliCommandExecutor.cs
@@ -27,6 +27,19 @@ public interface ICliCommandExecutor
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>True if the command is available.</returns>
     Task<bool> IsAvailableAsync(string command, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a CLI tool accepts a tool-specific availability probe.
+    /// </summary>
+    /// <param name="command">The command to check (e.g., "kubectl").</param>
+    /// <param name="arguments">Arguments that should complete successfully when the tool is available.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True if the command executes successfully.</returns>
+    Task<bool> IsAvailableAsync(
+        string command,
+        string arguments,
+        CancellationToken cancellationToken = default) =>
+        IsAvailableAsync(command, cancellationToken);
 }
 
 /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
@@ -277,6 +277,15 @@ public class ProcessCliCommandExecutor : ICliCommandExecutor
         }
     }
 
+    public async Task<bool> IsAvailableAsync(
+        string command,
+        string arguments,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await ExecuteAsync(command, arguments, cancellationToken);
+        return result.Success;
+    }
+
     /// <summary>
     /// Attempts to kill a process gracefully, falling back to force kill.
     /// Logs but swallows exceptions to prevent masking the original error.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ProcessCliCommandExecutor.cs
@@ -256,34 +256,34 @@ public class ProcessCliCommandExecutor : ICliCommandExecutor
         .Select(pathDirectory => pathDirectory.Trim('"'))
         ?? [];
 
-    public async Task<bool> IsAvailableAsync(string command, CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            // Try to get version/help to check if command exists
-            var result = await ExecuteAsync(command, "--version", cancellationToken);
-            if (result.Success)
-            {
-                return true;
-            }
-
-            // Some commands don't support --version, try --help
-            result = await ExecuteAsync(command, "--help", cancellationToken);
-            return result.ExitCode != -1; // -1 indicates execution failure (command not found)
-        }
-        catch
-        {
-            return false;
-        }
-    }
+    public Task<bool> IsAvailableAsync(string command, CancellationToken cancellationToken = default) =>
+        IsAvailableAsync(command, "--version", cancellationToken);
 
     public async Task<bool> IsAvailableAsync(
         string command,
         string arguments,
         CancellationToken cancellationToken = default)
     {
-        var result = await ExecuteAsync(command, arguments, cancellationToken);
-        return result.Success;
+        try
+        {
+            var result = await ExecuteAsync(command, arguments, cancellationToken);
+            if (result.Success)
+            {
+                return true;
+            }
+
+            // Some commands don't support the preferred probe, so preserve the help fallback.
+            if (!arguments.Equals("--help", StringComparison.Ordinal))
+            {
+                result = await ExecuteAsync(command, "--help", cancellationToken);
+            }
+
+            return result.ExitCode != -1; // -1 indicates execution failure (command not found)
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ResilientCliCommandExecutor.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/TypeDetection/ResilientCliCommandExecutor.cs
@@ -127,6 +127,15 @@ public sealed class ResilientCliCommandExecutor : ICliCommandExecutor
         return await _inner.IsAvailableAsync(command, cancellationToken);
     }
 
+    public Task<bool> IsAvailableAsync(
+        string command,
+        string arguments,
+        CancellationToken cancellationToken = default)
+    {
+        // Availability check doesn't use resilience patterns - we want immediate feedback
+        return _inner.IsAvailableAsync(command, arguments, cancellationToken);
+    }
+
     /// <summary>
     /// Determines if a failure is transient and should trigger retry.
     /// Transient failures include:


### PR DESCRIPTION
Part of #3996.

- make availability checks honor each scraper's `VersionArguments`
- use supported version subcommands for ArgoCD, eksctl, Cosign, Go, Kubectl, and Kustomize
- cover all probes with focused regression tests

Validation:
- OptionsGenerator solution Release build: 0 warnings, 0 errors
- OptionsGenerator tests: 831/831 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * CLI availability checks now use each tool’s appropriate version command.
  * Added support for tool-specific probes, including client version checks for Kubernetes-related tools.
  * Improved version detection for Liquibase output containing lengthy banners or varied formats.
  * Availability checks retain a help-command fallback when version commands are unsupported.

* **Tests**
  * Expanded coverage for CLI probing, version parsing, fallback behavior, and command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->