### PR TITLE
[Automated] Update go CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/go.md
+++ b/docs/docs/mp-packages/cli/go.md
@@ -7,7 +7,13 @@ title: go CLI reference
 
 `ModularPipelines.Go` provides strongly typed access to the `go` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `go` executable. Install it separately and ensure `go` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Go
@@ -41,7 +47,23 @@ public class RunCommandModule : Module<CommandResult>
 | CLI command | Options record |
 | --- | --- |
 | `go build` | `GoBuildOptions` |
+| `go clean` | `GoCleanOptions` |
+| `go env` | `GoEnvOptions` |
 | `go fix` | `GoFixOptions` |
+| `go fmt` | `GoFmtOptions` |
 | `go generate` | `GoGenerateOptions` |
+| `go get` | `GoGetOptions` |
+| `go install` | `GoInstallOptions` |
+| `go list` | `GoListOptions` |
+| `go mod download` | `GoModDownloadOptions` |
+| `go mod edit` | `GoModEditOptions` |
+| `go mod init` | `GoModInitOptions` |
+| `go mod why` | `GoModWhyOptions` |
+| `go run` | `GoRunOptions` |
+| `go telemetry` | `GoTelemetryOptions` |
 | `go test` | `GoTestOptions` |
+| `go tool` | `GoToolOptions` |
 | `go vet` | `GoVetOptions` |
+| `go work edit` | `GoWorkEditOptions` |
+| `go work init` | `GoWorkInitOptions` |
+| `go work use` | `GoWorkUseOptions` |

--- a/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
+++ b/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class GoExtensions
     }
 
     /// <summary>
-    /// Gets the go service from the pipeline context.
+    /// Gets the go service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGo"/> service for executing go commands.</returns>

--- a/src/ModularPipelines.Go/Generated/Go.CommandCoverage.json
+++ b/src/ModularPipelines.Go/Generated/Go.CommandCoverage.json
@@ -1,15 +1,35 @@
 {
   "formatVersion": 1,
   "toolName": "go",
-  "commandCount": 5,
-  "commandTreeSha256": "d91b6c355f88c3e297ae0e96351ad5c316d2d369a2330c61a3a3c715e9996129",
+  "toolVersion": "go version go1.27.0 linux/amd64",
+  "commandCount": 21,
+  "commandTreeSha256": "9abd262be1f8c72d9607d1042c60088084edfffb0c74a4c8ecd5b60cf61e68ff",
   "commands": [
     "go build",
+    "go clean",
+    "go env",
     "go fix",
+    "go fmt",
     "go generate",
+    "go get",
+    "go install",
+    "go list",
+    "go mod download",
+    "go mod edit",
+    "go mod init",
+    "go mod why",
+    "go run",
+    "go telemetry",
     "go test",
-    "go vet"
+    "go tool",
+    "go vet",
+    "go work edit",
+    "go work init",
+    "go work use"
   ],
-  "commandGroups": [],
+  "commandGroups": [
+    "go mod",
+    "go work"
+  ],
   "exclusions": []
 }

--- a/src/ModularPipelines.Go/Options/GoBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoBuildOptions.Generated.cs
@@ -20,4 +20,10 @@ namespace ModularPipelines.Go.Options;
 [CliSubCommand("build")]
 public record GoBuildOptions : GoOptions
 {
+    /// <summary>
+    /// The packages operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public string? Packages { get; set; }
+
 }

--- a/src/ModularPipelines.Go/Options/GoCleanOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoCleanOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Clean removes object files from package source directories.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("clean")]
+public record GoCleanOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The packages operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    public string? Packages { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoEnvOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoEnvOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Env prints Go environment information.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("env")]
+public record GoEnvOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The var operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    public IEnumerable<string>? Var { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoFixOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoFixOptions.Generated.cs
@@ -20,4 +20,10 @@ namespace ModularPipelines.Go.Options;
 [CliSubCommand("fix")]
 public record GoFixOptions : GoOptions
 {
+    /// <summary>
+    /// The packages operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public string? Packages { get; set; }
+
 }

--- a/src/ModularPipelines.Go/Options/GoFmtOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoFmtOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Fmt runs the command 'gofmt -l -w' on the packages named
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("fmt")]
+public record GoFmtOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The packages operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    public string? Packages { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoGetOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoGetOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Get resolves its command-line arguments to packages at specific module versions,
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("get")]
+public record GoGetOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The packages operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    public string? Packages { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoInstallOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Install compiles and installs the packages named by the import paths.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("install")]
+public record GoInstallOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The packages operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Packages { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoListOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoListOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// List lists the named packages, one per line.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("list")]
+public record GoListOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The packages operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    public string? Packages { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoModDownloadOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoModDownloadOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Download downloads the named modules, which can be module patterns selecting
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("mod", "download")]
+public record GoModDownloadOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The modules operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    public string? Modules { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoModEditOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoModEditOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Edit provides a command-line interface for editing go.mod,
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("mod", "edit")]
+public record GoModEditOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The go.mod operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    public string? GoMod { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoModInitOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoModInitOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Init initializes and writes a new go.mod file in the current directory, in
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("mod", "init")]
+public record GoModInitOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The module-path operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? ModulePath { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoModWhyOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoModWhyOptions.Generated.cs
@@ -13,17 +13,13 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Why shows a shortest path in the import graph from the main module to
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("mod", "why")]
+public record GoModWhyOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Packages
+) : GoOptions
 {
-    /// <summary>
-    /// The file.go operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
-
 }

--- a/src/ModularPipelines.Go/Options/GoRunOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoRunOptions.Generated.cs
@@ -13,17 +13,19 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Run compiles and runs the named main Go package.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("run")]
+public record GoRunOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Package
+) : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The arguments operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? CliArguments { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoTelemetryOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoTelemetryOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Telemetry is used to manage Go telemetry data and settings.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("telemetry")]
+public record GoTelemetryOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The off operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Off { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoTestOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoTestOptions.Generated.cs
@@ -20,4 +20,10 @@ namespace ModularPipelines.Go.Options;
 [CliSubCommand("test")]
 public record GoTestOptions : GoOptions
 {
+    /// <summary>
+    /// The packages operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Packages { get; set; }
+
 }

--- a/src/ModularPipelines.Go/Options/GoToolOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoToolOptions.Generated.cs
@@ -13,17 +13,19 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Tool runs the go tool command identified by the arguments.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("tool")]
+public record GoToolOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Command
+) : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The args operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? Args { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoVetOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoVetOptions.Generated.cs
@@ -20,4 +20,10 @@ namespace ModularPipelines.Go.Options;
 [CliSubCommand("vet")]
 public record GoVetOptions : GoOptions
 {
+    /// <summary>
+    /// The packages operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public string? Packages { get; set; }
+
 }

--- a/src/ModularPipelines.Go/Options/GoWorkEditOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoWorkEditOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Edit provides a command-line interface for editing go.work,
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("work", "edit")]
+public record GoWorkEditOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The go.work operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? GoWork { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoWorkInitOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoWorkInitOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Init initializes and writes a new go.work file in the
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("work", "init")]
+public record GoWorkInitOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The moddirs operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Moddirs { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoWorkUseOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoWorkUseOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Generate runs commands described by directives within existing
+/// Use provides a command-line interface for adding
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("generate")]
-public record GoGenerateOptions : GoOptions
+[CliSubCommand("work", "use")]
+public record GoWorkUseOptions : GoOptions
 {
     /// <summary>
-    /// The file.go operand.
+    /// The moddirs operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? FileGo { get; set; }
+    public string? Moddirs { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Services/Go.Generated.cs
+++ b/src/ModularPipelines.Go/Services/Go.Generated.cs
@@ -41,12 +41,39 @@ internal partial class Go : IGo
     }
 
     /// <inheritdoc />
+    public virtual async Task<CommandResult> CleanAsync(
+        GoCleanOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoCleanOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> EnvAsync(
+        GoEnvOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoEnvOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<CommandResult> FixAsync(
         GoFixOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
         return await _command.ExecuteCommandLineToolAsync(options ?? new GoFixOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> FmtAsync(
+        GoFmtOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoFmtOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -59,6 +86,87 @@ internal partial class Go : IGo
     }
 
     /// <inheritdoc />
+    public virtual async Task<CommandResult> GetAsync(
+        GoGetOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoGetOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> InstallAsync(
+        GoInstallOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoInstallOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> ListAsync(
+        GoListOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoListOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> ModDownloadAsync(
+        GoModDownloadOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoModDownloadOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> ModEditAsync(
+        GoModEditOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoModEditOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> ModInitAsync(
+        GoModInitOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoModInitOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> ModWhyAsync(
+        GoModWhyOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> RunAsync(
+        GoRunOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> TelemetryAsync(
+        GoTelemetryOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoTelemetryOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<CommandResult> TestAsync(
         GoTestOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
@@ -68,12 +176,48 @@ internal partial class Go : IGo
     }
 
     /// <inheritdoc />
+    public virtual async Task<CommandResult> ToolAsync(
+        GoToolOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<CommandResult> VetAsync(
         GoVetOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
         return await _command.ExecuteCommandLineToolAsync(options ?? new GoVetOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> WorkEditAsync(
+        GoWorkEditOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoWorkEditOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> WorkInitAsync(
+        GoWorkInitOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoWorkInitOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> WorkUseAsync(
+        GoWorkUseOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoWorkUseOptions(), executionOptions, cancellationToken);
     }
 
     #endregion

--- a/src/ModularPipelines.Go/Services/IGo.Generated.cs
+++ b/src/ModularPipelines.Go/Services/IGo.Generated.cs
@@ -27,7 +27,28 @@ public partial interface IGo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> BuildAsync(GoBuildOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> BuildAsync(GoBuildOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Clean removes object files from package source directories.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> CleanAsync(GoCleanOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Env prints Go environment information.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> EnvAsync(GoEnvOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Fix runs the Go fix tool (cmd/fix) on the named packages
@@ -36,7 +57,18 @@ public partial interface IGo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FixAsync(GoFixOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> FixAsync(GoFixOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Fmt runs the command 'gofmt -l -w' on the packages named
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> FmtAsync(GoFmtOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate runs commands described by directives within existing
@@ -45,7 +77,98 @@ public partial interface IGo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> GenerateAsync(GoGenerateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> GenerateAsync(GoGenerateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Get resolves its command-line arguments to packages at specific module versions,
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> GetAsync(GoGetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Install compiles and installs the packages named by the import paths.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> InstallAsync(GoInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// List lists the named packages, one per line.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> ListAsync(GoListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Download downloads the named modules, which can be module patterns selecting
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> ModDownloadAsync(GoModDownloadOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Edit provides a command-line interface for editing go.mod,
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> ModEditAsync(GoModEditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Init initializes and writes a new go.mod file in the current directory, in
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> ModInitAsync(GoModInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Why shows a shortest path in the import graph from the main module to
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> ModWhyAsync(GoModWhyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Run compiles and runs the named main Go package.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> RunAsync(GoRunOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Telemetry is used to manage Go telemetry data and settings.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> TelemetryAsync(GoTelemetryOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// 'Go test' automates testing the packages named by the import paths.
@@ -54,7 +177,18 @@ public partial interface IGo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> TestAsync(GoTestOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> TestAsync(GoTestOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Tool runs the go tool command identified by the arguments.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> ToolAsync(GoToolOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Vet runs the Go vet tool (cmd/vet) on the named packages
@@ -63,7 +197,38 @@ public partial interface IGo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> VetAsync(GoVetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> VetAsync(GoVetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Edit provides a command-line interface for editing go.work,
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> WorkEditAsync(GoWorkEditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Init initializes and writes a new go.work file in the
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> WorkInitAsync(GoWorkInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Use provides a command-line interface for adding
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    Task<CommandResult> WorkUseAsync(GoWorkUseOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     #endregion
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **go** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- go (go version go1.27.0 linux/amd64): 21 commands, tree 9abd262be1f8c72d9607d1042c60088084edfffb0c74a4c8ecd5b60cf61e68ff
  - Added: go clean, go env, go fmt, go get, go install, go list, go mod download, go mod edit, go mod init, go mod why, go run, go telemetry, go tool, go work edit, go work init, go work use

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator