### PR TITLE
[Automated] Update eksctl CLI Options

### DIFF
--- a/src/ModularPipelines.Eksctl/Generated/Eksctl.CommandCoverage.json
+++ b/src/ModularPipelines.Eksctl/Generated/Eksctl.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "eksctl",
+  "toolVersion": "0.230.0",
   "commandCount": 85,
   "commandTreeSha256": "84fec058d6a4a16c205233e11b13a4ffb48fce85b9cb074d731bba5dc937d7a5",
   "commands": [

--- a/src/ModularPipelines.Eksctl/Services/IEksctl.Generated.cs
+++ b/src/ModularPipelines.Eksctl/Services/IEksctl.Generated.cs
@@ -23,77 +23,77 @@ public partial interface IEksctl
     /// <summary>
     /// Gets the associate sub-domain service.
     /// </summary>
-    IEksctlAssociate Associate { get; }
+    IEksctlAssociate Associate => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the create sub-domain service.
     /// </summary>
-    IEksctlCreate Create { get; }
+    IEksctlCreate Create => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the delete sub-domain service.
     /// </summary>
-    IEksctlDelete Delete { get; }
+    IEksctlDelete Delete => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the deregister sub-domain service.
     /// </summary>
-    IEksctlDeregister Deregister { get; }
+    IEksctlDeregister Deregister => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the disassociate sub-domain service.
     /// </summary>
-    IEksctlDisassociate Disassociate { get; }
+    IEksctlDisassociate Disassociate => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the drain sub-domain service.
     /// </summary>
-    IEksctlDrain Drain { get; }
+    IEksctlDrain Drain => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the enable sub-domain service.
     /// </summary>
-    IEksctlEnable Enable { get; }
+    IEksctlEnable Enable => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the get sub-domain service.
     /// </summary>
-    IEksctlGet Get { get; }
+    IEksctlGet Get => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the register sub-domain service.
     /// </summary>
-    IEksctlRegister Register { get; }
+    IEksctlRegister Register => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the scale sub-domain service.
     /// </summary>
-    IEksctlScale Scale { get; }
+    IEksctlScale Scale => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the set sub-domain service.
     /// </summary>
-    IEksctlSet Set { get; }
+    IEksctlSet Set => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the unset sub-domain service.
     /// </summary>
-    IEksctlUnset Unset { get; }
+    IEksctlUnset Unset => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the update sub-domain service.
     /// </summary>
-    IEksctlUpdate Update { get; }
+    IEksctlUpdate Update => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the upgrade sub-domain service.
     /// </summary>
-    IEksctlUpgrade Upgrade { get; }
+    IEksctlUpgrade Upgrade => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the utils sub-domain service.
     /// </summary>
-    IEksctlUtils Utils { get; }
+    IEksctlUtils Utils => throw new System.NotSupportedException();
 
     #endregion
 


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **eksctl** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- eksctl (0.230.0): 85 commands, tree 84fec058d6a4a16c205233e11b13a4ffb48fce85b9cb074d731bba5dc937d7a5

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator