### PR TITLE
[Automated] Update pip CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/pip.md
+++ b/docs/docs/mp-packages/cli/pip.md
@@ -7,7 +7,13 @@ title: pip CLI reference
 
 `ModularPipelines.Python` provides strongly typed access to the `pip` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `pip` executable. Install it separately and ensure `pip` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Python

--- a/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
+++ b/src/ModularPipelines.Python/Extensions/PipExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class PipExtensions
     }
 
     /// <summary>
-    /// Gets the pip service from the pipeline context.
+    /// Gets the pip service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPip"/> service for executing pip commands.</returns>

--- a/src/ModularPipelines.Python/Generated/Pip.CommandCoverage.json
+++ b/src/ModularPipelines.Python/Generated/Pip.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "pip",
+  "toolVersion": "pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)",
   "commandCount": 14,
   "commandTreeSha256": "a9b92993f96a5cee7b1131d5da44c679e8bd64ee6a736a1d92dc95e915bd18ac",
   "commands": [

--- a/src/ModularPipelines.Python/Options/PipCacheOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipCacheOptions.Generated.cs
@@ -158,4 +158,16 @@ public record PipCacheOptions : PipOptions
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
 
+    /// <summary>
+    /// The list operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? List { get; set; }
+
+    /// <summary>
+    /// The &lt;pattern&gt; operand.
+    /// </summary>
+    [CliArgument(1, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Pattern { get; set; }
+
 }

--- a/src/ModularPipelines.Python/Options/PipConfigOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipConfigOptions.Generated.cs
@@ -176,4 +176,16 @@ public record PipConfigOptions : PipOptions
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
 
+    /// <summary>
+    /// The &lt;file-option&gt; operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? FileOption { get; set; }
+
+    /// <summary>
+    /// The list operand.
+    /// </summary>
+    [CliArgument(1, Phase = CommandLinePhase.EarlyOperand)]
+    public string? List { get; set; }
+
 }

--- a/src/ModularPipelines.Python/Options/PipDownloadOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipDownloadOptions.Generated.cs
@@ -24,13 +24,13 @@ public record PipDownloadOptions : PipOptions
     /// Constrain versions using the given constraints file. This option can be used multiple times.
     /// </summary>
     [CliOption("--constraint", ShortForm = "-c")]
-    public string? Constraint { get; set; }
+    public IEnumerable<string>? ConstraintValues { get; set; }
 
     /// <summary>
     /// Install from the given requirements file. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public string? Requirement { get; set; }
+    public IEnumerable<string>? RequirementValues { get; set; }
 
     /// <summary>
     /// Don't install package dependencies.
@@ -66,7 +66,7 @@ public record PipDownloadOptions : PipOptions
     /// Require a hash to check each requirement against, for repeatable installs. This option is implied when any package in a requirements file has a --hash option.
     /// </summary>
     [CliOption("--require-hashes")]
-    public string? RequireHashes { get; set; }
+    public IEnumerable<string>? RequireHashesValues { get; set; }
 
     /// <summary>
     /// Disable isolation when building a modern source distribution. Build dependencies specified by PEP 518 must be already installed if this option is used.
@@ -102,13 +102,13 @@ public record PipDownloadOptions : PipOptions
     /// Only use wheels compatible with &lt;platform&gt;. Defaults to the platform of the running system. Use this option multiple times to specify multiple platforms supported by the target interpreter.
     /// </summary>
     [CliOption("--platform")]
-    public string? Platform { get; set; }
+    public IEnumerable<string>? PlatformValues { get; set; }
 
     /// <summary>
     /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
     /// </summary>
     [CliOption("--abi")]
-    public string? Abi { get; set; }
+    public IEnumerable<string>? AbiValues { get; set; }
 
     /// <summary>
     /// Don't clean up build directories.
@@ -271,5 +271,52 @@ public record PipDownloadOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    /// <summary>
+    /// The requirement specifier operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public string? RequirementSpecifier { get; set; }
+
+    /// <summary>
+    /// The package-index-options operand.
+    /// </summary>
+    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? PackageIndexOptions { get; set; }
+
+    [Obsolete("Use ConstraintValues instead.")]
+    public string? Constraint
+    {
+        get => ConstraintValues?.FirstOrDefault();
+        set => ConstraintValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use RequirementValues instead.")]
+    public string? Requirement
+    {
+        get => RequirementValues?.FirstOrDefault();
+        set => RequirementValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use RequireHashesValues instead.")]
+    public string? RequireHashes
+    {
+        get => RequireHashesValues?.FirstOrDefault();
+        set => RequireHashesValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use PlatformValues instead.")]
+    public string? Platform
+    {
+        get => PlatformValues?.FirstOrDefault();
+        set => PlatformValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use AbiValues instead.")]
+    public string? Abi
+    {
+        get => AbiValues?.FirstOrDefault();
+        set => AbiValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipFreezeOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipFreezeOptions.Generated.cs
@@ -24,7 +24,7 @@ public record PipFreezeOptions : PipOptions
     /// Use the order in the given requirements file and its comments when generating output. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public string? Requirement { get; set; }
+    public IEnumerable<string>? RequirementValues { get; set; }
 
     /// <summary>
     /// If in a virtualenv that has global access, do not output globally-installed packages.
@@ -42,7 +42,7 @@ public record PipFreezeOptions : PipOptions
     /// Restrict to the specified installation path for listing packages (can be used multiple times).
     /// </summary>
     [CliOption("--path")]
-    public string? Path { get; set; }
+    public IEnumerable<string>? PathValues { get; set; }
 
     /// <summary>
     /// Do not skip these packages in the output: pip
@@ -193,5 +193,19 @@ public record PipFreezeOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    [Obsolete("Use RequirementValues instead.")]
+    public string? Requirement
+    {
+        get => RequirementValues?.FirstOrDefault();
+        set => RequirementValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use PathValues instead.")]
+    public string? Path
+    {
+        get => PathValues?.FirstOrDefault();
+        set => PathValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipHashOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipHashOptions.Generated.cs
@@ -18,8 +18,15 @@ namespace ModularPipelines.Python.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("hash")]
-public record PipHashOptions : PipOptions
+public record PipHashOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> File
+) : PipOptions
 {
+    public PipHashOptions()
+        : this(default(IEnumerable<string>)!)
+    {
+    }
+
     /// <summary>
     /// Show help.
     /// </summary>

--- a/src/ModularPipelines.Python/Options/PipIndexOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipIndexOptions.Generated.cs
@@ -18,19 +18,27 @@ namespace ModularPipelines.Python.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("index")]
-public record PipIndexOptions : PipOptions
+public record PipIndexOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Versions,
+    [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Package
+) : PipOptions
 {
+    public PipIndexOptions()
+        : this(default(string)!, default(string)!)
+    {
+    }
+
     /// <summary>
     /// Only use wheels compatible with &lt;platform&gt;. Defaults to the platform of the running system. Use this option multiple times to specify multiple platforms supported by the target interpreter.
     /// </summary>
     [CliOption("--platform")]
-    public string? Platform { get; set; }
+    public IEnumerable<string>? PlatformValues { get; set; }
 
     /// <summary>
     /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
     /// </summary>
     [CliOption("--abi")]
-    public string? Abi { get; set; }
+    public IEnumerable<string>? AbiValues { get; set; }
 
     /// <summary>
     /// Ignore the Requires-Python information.
@@ -199,5 +207,19 @@ public record PipIndexOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    [Obsolete("Use PlatformValues instead.")]
+    public string? Platform
+    {
+        get => PlatformValues?.FirstOrDefault();
+        set => PlatformValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use AbiValues instead.")]
+    public string? Abi
+    {
+        get => AbiValues?.FirstOrDefault();
+        set => AbiValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipInspectOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipInspectOptions.Generated.cs
@@ -36,7 +36,7 @@ public record PipInspectOptions : PipOptions
     /// Restrict to the specified installation path for listing packages (can be used multiple times).
     /// </summary>
     [CliOption("--path")]
-    public string? Path { get; set; }
+    public IEnumerable<string>? PathValues { get; set; }
 
     /// <summary>
     /// Show help.
@@ -169,5 +169,12 @@ public record PipInspectOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    [Obsolete("Use PathValues instead.")]
+    public string? Path
+    {
+        get => PathValues?.FirstOrDefault();
+        set => PathValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipInstallOptions.Generated.cs
@@ -24,13 +24,13 @@ public record PipInstallOptions : PipOptions
     /// Install from the given requirements file. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public string? Requirement { get; set; }
+    public IEnumerable<string>? RequirementValues { get; set; }
 
     /// <summary>
     /// Constrain versions using the given constraints file. This option can be used multiple times.
     /// </summary>
     [CliOption("--constraint", ShortForm = "-c")]
-    public string? Constraint { get; set; }
+    public IEnumerable<string>? ConstraintValues { get; set; }
 
     /// <summary>
     /// Don't install package dependencies.
@@ -66,13 +66,13 @@ public record PipInstallOptions : PipOptions
     /// Only use wheels compatible with &lt;platform&gt;. Defaults to the platform of the running system. Use this option multiple times to specify multiple platforms supported by the target interpreter.
     /// </summary>
     [CliOption("--platform")]
-    public string? Platform { get; set; }
+    public IEnumerable<string>? PlatformValues { get; set; }
 
     /// <summary>
     /// Only use wheels compatible with Python abi &lt;abi&gt;, e.g. 'pypy_41'. If not specified, then the current interpreter abi tag is used. Use this option multiple times to specify multiple abis supported by the target interpreter. Generally you will need to specify
     /// </summary>
     [CliOption("--abi")]
-    public string? Abi { get; set; }
+    public IEnumerable<string>? AbiValues { get; set; }
 
     /// <summary>
     /// Install to the Python user install directory for your platform. Typically ~/.local/, or %APPDATA%\Python on Windows. (See the Python documentation for site.USER_BASE for full details.)
@@ -186,7 +186,7 @@ public record PipInstallOptions : PipOptions
     /// Require a hash to check each requirement against, for repeatable installs. This option is implied when any package in a requirements file has a --hash option.
     /// </summary>
     [CliOption("--require-hashes")]
-    public string? RequireHashes { get; set; }
+    public IEnumerable<string>? RequireHashesValues { get; set; }
 
     /// <summary>
     /// Generate a JSON file describing what pip did to install the provided requirements. Can be used in combination with --dry-run and --ignore- installed to 'resolve' the requirements. When - is used as file name it writes to stdout. When writing to stdout, please combine with the
@@ -355,5 +355,52 @@ public record PipInstallOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    /// <summary>
+    /// The requirement specifier operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public string? RequirementSpecifier { get; set; }
+
+    /// <summary>
+    /// The package-index-options operand.
+    /// </summary>
+    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? PackageIndexOptions { get; set; }
+
+    [Obsolete("Use RequirementValues instead.")]
+    public string? Requirement
+    {
+        get => RequirementValues?.FirstOrDefault();
+        set => RequirementValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use ConstraintValues instead.")]
+    public string? Constraint
+    {
+        get => ConstraintValues?.FirstOrDefault();
+        set => ConstraintValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use PlatformValues instead.")]
+    public string? Platform
+    {
+        get => PlatformValues?.FirstOrDefault();
+        set => PlatformValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use AbiValues instead.")]
+    public string? Abi
+    {
+        get => AbiValues?.FirstOrDefault();
+        set => AbiValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use RequireHashesValues instead.")]
+    public string? RequireHashes
+    {
+        get => RequireHashesValues?.FirstOrDefault();
+        set => RequireHashesValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipListOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipListOptions.Generated.cs
@@ -54,7 +54,7 @@ public record PipListOptions : PipOptions
     /// Restrict to the specified installation path for listing packages (can be used multiple times).
     /// </summary>
     [CliOption("--path")]
-    public string? Path { get; set; }
+    public IEnumerable<string>? PathValues { get; set; }
 
     /// <summary>
     /// Include pre-release and development versions. By default, pip only finds stable versions.
@@ -247,5 +247,12 @@ public record PipListOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    [Obsolete("Use PathValues instead.")]
+    public string? Path
+    {
+        get => PathValues?.FirstOrDefault();
+        set => PathValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipSearchOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipSearchOptions.Generated.cs
@@ -18,8 +18,15 @@ namespace ModularPipelines.Python.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("search")]
-public record PipSearchOptions : PipOptions
+public record PipSearchOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Query
+) : PipOptions
 {
+    public PipSearchOptions()
+        : this(default(string)!)
+    {
+    }
+
     /// <summary>
     /// Base URL of Python Package Index (default https://pypi.org/pypi)
     /// </summary>

--- a/src/ModularPipelines.Python/Options/PipShowOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipShowOptions.Generated.cs
@@ -18,8 +18,15 @@ namespace ModularPipelines.Python.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("show")]
-public record PipShowOptions : PipOptions
+public record PipShowOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Package
+) : PipOptions
 {
+    public PipShowOptions()
+        : this(default(IEnumerable<string>)!)
+    {
+    }
+
     /// <summary>
     /// Show the full list of installed files for each package.
     /// </summary>

--- a/src/ModularPipelines.Python/Options/PipUninstallOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipUninstallOptions.Generated.cs
@@ -24,7 +24,7 @@ public record PipUninstallOptions : PipOptions
     /// Uninstall all the packages listed in the given requirements file.  This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public string? Requirement { get; set; }
+    public IEnumerable<string>? RequirementValues { get; set; }
 
     /// <summary>
     /// Don't ask for confirmation of uninstall deletions.
@@ -169,5 +169,18 @@ public record PipUninstallOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    /// <summary>
+    /// The package operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? Package { get; set; }
+
+    [Obsolete("Use RequirementValues instead.")]
+    public string? Requirement
+    {
+        get => RequirementValues?.FirstOrDefault();
+        set => RequirementValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Options/PipWheelOptions.Generated.cs
+++ b/src/ModularPipelines.Python/Options/PipWheelOptions.Generated.cs
@@ -54,7 +54,7 @@ public record PipWheelOptions : PipOptions
     /// Constrain versions using the given constraints file. This option can be used multiple times.
     /// </summary>
     [CliOption("--constraint", ShortForm = "-c")]
-    public string? Constraint { get; set; }
+    public IEnumerable<string>? ConstraintValues { get; set; }
 
     /// <summary>
     /// Install a project in editable mode (i.e. setuptools "develop mode") from a local project path or a VCS url.
@@ -66,7 +66,7 @@ public record PipWheelOptions : PipOptions
     /// Install from the given requirements file. This option can be used multiple times.
     /// </summary>
     [CliOption("--requirement", ShortForm = "-r")]
-    public string? Requirement { get; set; }
+    public IEnumerable<string>? RequirementValues { get; set; }
 
     /// <summary>
     /// Directory to check out editable projects into. The default in a virtualenv is "&lt;venv path&gt;/src". The default for global installs is "&lt;current dir&gt;/src".
@@ -114,7 +114,7 @@ public record PipWheelOptions : PipOptions
     /// Require a hash to check each requirement against, for repeatable installs. This option is implied when any package in a requirements file has a --hash option.
     /// </summary>
     [CliOption("--require-hashes")]
-    public string? RequireHashes { get; set; }
+    public IEnumerable<string>? RequireHashesValues { get; set; }
 
     /// <summary>
     /// Don't clean up build directories.
@@ -277,5 +277,32 @@ public record PipWheelOptions : PipOptions
     /// </summary>
     [CliOption("--use-deprecated")]
     public string? UseDeprecated { get; set; }
+
+    /// <summary>
+    /// The requirement specifier operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? RequirementSpecifier { get; set; }
+
+    [Obsolete("Use ConstraintValues instead.")]
+    public string? Constraint
+    {
+        get => ConstraintValues?.FirstOrDefault();
+        set => ConstraintValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use RequirementValues instead.")]
+    public string? Requirement
+    {
+        get => RequirementValues?.FirstOrDefault();
+        set => RequirementValues = value is null ? null : [value];
+    }
+
+    [Obsolete("Use RequireHashesValues instead.")]
+    public string? RequireHashes
+    {
+        get => RequireHashesValues?.FirstOrDefault();
+        set => RequireHashesValues = value is null ? null : [value];
+    }
 
 }

--- a/src/ModularPipelines.Python/Services/IPip.Generated.cs
+++ b/src/ModularPipelines.Python/Services/IPip.Generated.cs
@@ -27,7 +27,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> CacheAsync(PipCacheOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> CacheAsync(PipCacheOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Verify installed packages have compatible dependencies.
@@ -36,7 +37,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> CheckAsync(PipCheckOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> CheckAsync(PipCheckOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Manage local and global configuration.
@@ -45,7 +47,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ConfigAsync(PipConfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ConfigAsync(PipConfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Download packages from:
@@ -54,7 +57,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DownloadAsync(PipDownloadOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> DownloadAsync(PipDownloadOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Output installed packages in requirements format.
@@ -63,7 +67,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FreezeAsync(PipFreezeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> FreezeAsync(PipFreezeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Compute a hash of a local package archive.
@@ -72,7 +77,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> HashAsync(PipHashOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> HashAsync(PipHashOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Inspect information available from package indexes.
@@ -81,7 +87,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> IndexAsync(PipIndexOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> IndexAsync(PipIndexOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Inspect the content of a Python environment and produce a report in JSON format.
@@ -90,7 +97,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InspectAsync(PipInspectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> InspectAsync(PipInspectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Install packages from:
@@ -99,7 +107,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InstallAsync(PipInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> InstallAsync(PipInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// List installed packages, including editables.
@@ -108,7 +117,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ListAsync(PipListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ListAsync(PipListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Search for PyPI packages whose name or summary contains &lt;query&gt;.
@@ -117,7 +127,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SearchAsync(PipSearchOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> SearchAsync(PipSearchOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Show information about one or more installed packages.
@@ -126,7 +137,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ShowAsync(PipShowOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ShowAsync(PipShowOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Uninstall packages.
@@ -135,7 +147,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UninstallAsync(PipUninstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> UninstallAsync(PipUninstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Build Wheel archives for your requirements and dependencies.
@@ -144,7 +157,8 @@ public partial interface IPip
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> WheelAsync(PipWheelOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> WheelAsync(PipWheelOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     #endregion
 }

--- a/src/ModularPipelines.Python/Services/Pip.Generated.cs
+++ b/src/ModularPipelines.Python/Services/Pip.Generated.cs
@@ -78,20 +78,20 @@ internal partial class Pip : IPip
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> HashAsync(
-        PipHashOptions? options = null,
+        PipHashOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PipHashOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> IndexAsync(
-        PipIndexOptions? options = null,
+        PipIndexOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PipIndexOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -123,20 +123,20 @@ internal partial class Pip : IPip
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> SearchAsync(
-        PipSearchOptions? options = null,
+        PipSearchOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PipSearchOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
     public virtual async Task<CommandResult> ShowAsync(
-        PipShowOptions? options = null,
+        PipShowOptions options,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
-        return await _command.ExecuteCommandLineToolAsync(options ?? new PipShowOptions(), executionOptions, cancellationToken);
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pip** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- pip (pip 24.0 from /usr/lib/python3/dist-packages/pip (python 3.12)): 14 commands, tree a9b92993f96a5cee7b1131d5da44c679e8bd64ee6a736a1d92dc95e915bd18ac

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator