### PR TITLE
[Automated] Update docker CLI Options

### DIFF
--- a/src/ModularPipelines.Docker/Enums/DockerBuilderBakeProgress.Generated.cs
+++ b/src/ModularPipelines.Docker/Enums/DockerBuilderBakeProgress.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Docker.Enums;
 
-/// <summary>
-/// Allowed values for the --progress option.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum DockerBuilderBakeProgress
 {

--- a/src/ModularPipelines.Docker/Enums/DockerBuilderBuildProgress.Generated.cs
+++ b/src/ModularPipelines.Docker/Enums/DockerBuilderBuildProgress.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Docker.Enums;
 
-/// <summary>
-/// Allowed values for the --progress option.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum DockerBuilderBuildProgress
 {

--- a/src/ModularPipelines.Docker/Enums/DockerBuilderDapBuildProgress.Generated.cs
+++ b/src/ModularPipelines.Docker/Enums/DockerBuilderDapBuildProgress.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Docker.Enums;
 
-/// <summary>
-/// Allowed values for the --progress option.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum DockerBuilderDapBuildProgress
 {

--- a/src/ModularPipelines.Docker/Enums/DockerBuilderDialStdioProgress.Generated.cs
+++ b/src/ModularPipelines.Docker/Enums/DockerBuilderDialStdioProgress.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Docker.Enums;
 
-/// <summary>
-/// Allowed values for the --progress option.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum DockerBuilderDialStdioProgress
 {

--- a/src/ModularPipelines.Docker/Enums/DockerBuilderHistoryLogsProgress.Generated.cs
+++ b/src/ModularPipelines.Docker/Enums/DockerBuilderHistoryLogsProgress.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Docker.Enums;
 
-/// <summary>
-/// Allowed values for the --progress option.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum DockerBuilderHistoryLogsProgress
 {

--- a/src/ModularPipelines.Docker/Enums/DockerBuilderImageToolsCreateProgress.Generated.cs
+++ b/src/ModularPipelines.Docker/Enums/DockerBuilderImageToolsCreateProgress.Generated.cs
@@ -10,9 +10,6 @@ using ModularPipelines.Attributes;
 
 namespace ModularPipelines.Docker.Enums;
 
-/// <summary>
-/// Allowed values for the --progress option.
-/// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 public enum DockerBuilderImageToolsCreateProgress
 {

--- a/src/ModularPipelines.Docker/Options/DockerBuilderBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerBuilderBuildOptions.Generated.cs
@@ -33,4 +33,10 @@ public record DockerBuilderBuildOptions : DockerBuildxBuildOptions
             ? null
             : (DockerBuildxBuildProgress)(int)value.Value;
     }
+    [Obsolete("Path is retained for compatibility.")]
+    public new string Path
+    {
+        get => base.Path;
+        init => base.Path = value;
+    }
 }

--- a/src/ModularPipelines.Docker/Options/DockerBuilderDapBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerBuilderDapBuildOptions.Generated.cs
@@ -33,4 +33,10 @@ public record DockerBuilderDapBuildOptions : DockerBuildxDapBuildOptions
             ? null
             : (DockerBuildxDapBuildProgress)(int)value.Value;
     }
+    [Obsolete("Path is retained for compatibility.")]
+    public new string Path
+    {
+        get => base.Path;
+        init => base.Path = value;
+    }
 }

--- a/src/ModularPipelines.Docker/Options/DockerBuilderImageToolsInspectOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerBuilderImageToolsInspectOptions.Generated.cs
@@ -21,4 +21,10 @@ public record DockerBuilderImageToolsInspectOptions : DockerBuildxImageToolsInsp
     {
     }
 
+    [Obsolete("Name is retained for compatibility.")]
+    public new string Name
+    {
+        get => base.Name;
+        init => base.Name = value;
+    }
 }

--- a/src/ModularPipelines.Docker/Options/DockerBuilderPolicyEvalOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerBuilderPolicyEvalOptions.Generated.cs
@@ -21,4 +21,10 @@ public record DockerBuilderPolicyEvalOptions : DockerBuildxPolicyEvalOptions
     {
     }
 
+    [Obsolete("Source is retained for compatibility.")]
+    public new string Source
+    {
+        get => base.Source;
+        init => base.Source = value;
+    }
 }

--- a/src/ModularPipelines.Docker/Options/DockerBuilderPolicyTestOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerBuilderPolicyTestOptions.Generated.cs
@@ -21,4 +21,10 @@ public record DockerBuilderPolicyTestOptions : DockerBuildxPolicyTestOptions
     {
     }
 
+    [Obsolete("Path is retained for compatibility.")]
+    public new string Path
+    {
+        get => base.Path;
+        init => base.Path = value;
+    }
 }

--- a/src/ModularPipelines.Docker/Options/DockerBuilderUseOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerBuilderUseOptions.Generated.cs
@@ -21,4 +21,10 @@ public record DockerBuilderUseOptions : DockerBuildxUseOptions
     {
     }
 
+    [Obsolete("Name is retained for compatibility.")]
+    public new string Name
+    {
+        get => base.Name;
+        init => base.Name = value;
+    }
 }

--- a/src/ModularPipelines.Docker/Options/DockerComposeBuildOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeBuildOptions.Generated.cs
@@ -65,12 +65,6 @@ public record DockerComposeBuildOptions : DockerOptions
     public bool? Print { get; set; }
 
     /// <summary>
-    /// Add a provenance attestation
-    /// </summary>
-    [CliOption("--provenance", Format = OptionFormat.EqualsSeparated)]
-    public string? Provenance { get; set; }
-
-    /// <summary>
     /// Always attempt to pull a newer version of the image
     /// </summary>
     [CliFlag("--pull")]
@@ -83,16 +77,10 @@ public record DockerComposeBuildOptions : DockerOptions
     public bool? Push { get; set; }
 
     /// <summary>
-    /// Suppress the build output
+    /// Don't print anything to STDOUT
     /// </summary>
     [CliFlag("--quiet", ShortForm = "-q")]
     public bool? Quiet { get; set; }
-
-    /// <summary>
-    /// Add a SBOM attestation
-    /// </summary>
-    [CliOption("--sbom", Format = OptionFormat.EqualsSeparated)]
-    public string? Sbom { get; set; }
 
     /// <summary>
     /// Set SSH authentications used when building service images. (use 'default' for using your default SSH Agent)
@@ -111,5 +99,11 @@ public record DockerComposeBuildOptions : DockerOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Service { get; set; }
+
+    [Obsolete("Provenance is no longer supported by the installed CLI and has no effect.")]
+    public string? Provenance { get; set; }
+
+    [Obsolete("Sbom is no longer supported by the installed CLI and has no effect.")]
+    public string? Sbom { get; set; }
 
 }

--- a/src/ModularPipelines.Docker/Options/DockerComposeConfigOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeConfigOptions.Generated.cs
@@ -57,12 +57,6 @@ public record DockerComposeConfigOptions : DockerOptions
     public bool? LockImageDigests { get; set; }
 
     /// <summary>
-    /// Print the model names, one per line.
-    /// </summary>
-    [CliFlag("--models")]
-    public bool? Models { get; set; }
-
-    /// <summary>
     /// Print the network names, one per line.
     /// </summary>
     [CliFlag("--networks")]
@@ -145,5 +139,8 @@ public record DockerComposeConfigOptions : DockerOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Service { get; set; }
+
+    [Obsolete("Models is no longer supported by the installed CLI and has no effect.")]
+    public bool? Models { get; set; }
 
 }

--- a/src/ModularPipelines.Docker/Options/DockerComposeEventsOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeEventsOptions.Generated.cs
@@ -33,21 +33,15 @@ public record DockerComposeEventsOptions : DockerOptions
     public bool? Json { get; set; }
 
     /// <summary>
-    /// Show all events created since timestamp
-    /// </summary>
-    [CliOption("--since", Format = OptionFormat.EqualsSeparated)]
-    public string? Since { get; set; }
-
-    /// <summary>
-    /// Stream events until this timestamp
-    /// </summary>
-    [CliOption("--until", Format = OptionFormat.EqualsSeparated)]
-    public string? Until { get; set; }
-
-    /// <summary>
     /// The SERVICE operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Service { get; set; }
+
+    [Obsolete("Since is no longer supported by the installed CLI and has no effect.")]
+    public string? Since { get; set; }
+
+    [Obsolete("Until is no longer supported by the installed CLI and has no effect.")]
+    public string? Until { get; set; }
 
 }

--- a/src/ModularPipelines.Docker/Options/DockerComposeExecOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeExecOptions.Generated.cs
@@ -48,12 +48,6 @@ public record DockerComposeExecOptions(
     public int? Index { get; set; }
 
     /// <summary>
-    /// Disable pseudo-TTY allocation. By default 'docker compose exec' allocates a TTY. (default true)
-    /// </summary>
-    [CliOption("--no-TTY", ShortForm = "-T", Format = OptionFormat.EqualsSeparated)]
-    public bool? NoTty { get; set; }
-
-    /// <summary>
     /// Give extended privileges to the process
     /// </summary>
     [CliFlag("--privileged")]
@@ -76,5 +70,8 @@ public record DockerComposeExecOptions(
     /// </summary>
     [CliArgument(2, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Args { get; set; }
+
+    [Obsolete("NoTty is no longer supported by the installed CLI and has no effect.")]
+    public bool? NoTty { get; set; }
 
 }

--- a/src/ModularPipelines.Docker/Options/DockerComposePublishOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposePublishOptions.Generated.cs
@@ -23,12 +23,6 @@ public record DockerComposePublishOptions(
 ) : DockerOptions
 {
     /// <summary>
-    /// Published compose application (includes referenced images)
-    /// </summary>
-    [CliFlag("--app")]
-    public bool? App { get; set; }
-
-    /// <summary>
     /// Execute command in dry run mode
     /// </summary>
     [CliFlag("--dry-run")]
@@ -57,5 +51,8 @@ public record DockerComposePublishOptions(
     /// </summary>
     [CliFlag("--yes", ShortForm = "-y")]
     public bool? Yes { get; set; }
+
+    [Obsolete("App is no longer supported by the installed CLI and has no effect.")]
+    public bool? App { get; set; }
 
 }

--- a/src/ModularPipelines.Docker/Options/DockerComposeStartOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeStartOptions.Generated.cs
@@ -27,21 +27,15 @@ public record DockerComposeStartOptions : DockerOptions
     public bool? DryRun { get; set; }
 
     /// <summary>
-    /// Wait for services to be running|healthy. Implies detached mode.
-    /// </summary>
-    [CliFlag("--wait")]
-    public bool? Wait { get; set; }
-
-    /// <summary>
-    /// Maximum duration in seconds to wait for the project to be running|healthy
-    /// </summary>
-    [CliOption("--wait-timeout", Format = OptionFormat.EqualsSeparated)]
-    public int? WaitTimeout { get; set; }
-
-    /// <summary>
     /// The SERVICE operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public IEnumerable<string>? Service { get; set; }
+
+    [Obsolete("Wait is no longer supported by the installed CLI and has no effect.")]
+    public bool? Wait { get; set; }
+
+    [Obsolete("WaitTimeout is no longer supported by the installed CLI and has no effect.")]
+    public int? WaitTimeout { get; set; }
 
 }

--- a/src/ModularPipelines.Docker/Options/DockerComposeUpOptions.Generated.cs
+++ b/src/ModularPipelines.Docker/Options/DockerComposeUpOptions.Generated.cs
@@ -135,12 +135,6 @@ public record DockerComposeUpOptions : DockerOptions
     public string? Pull { get; set; }
 
     /// <summary>
-    /// Suppress the build output
-    /// </summary>
-    [CliFlag("--quiet-build")]
-    public bool? QuietBuild { get; set; }
-
-    /// <summary>
     /// Pull without printing progress information
     /// </summary>
     [CliFlag("--quiet-pull")]
@@ -205,5 +199,8 @@ public record DockerComposeUpOptions : DockerOptions
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
     public IEnumerable<string>? Service { get; set; }
+
+    [Obsolete("QuietBuild is no longer supported by the installed CLI and has no effect.")]
+    public bool? QuietBuild { get; set; }
 
 }

--- a/src/ModularPipelines.Docker/Services/IDocker.Generated.cs
+++ b/src/ModularPipelines.Docker/Services/IDocker.Generated.cs
@@ -23,7 +23,7 @@ public partial interface IDocker
     /// <summary>
     /// Gets the buildx sub-domain service.
     /// </summary>
-    IDockerBuildx Buildx { get; }
+    IDockerBuildx Buildx => throw new System.NotSupportedException();
 
     [Obsolete("docker builder is an alias of docker buildx. Use Buildx instead.")]
     IDockerBuilder Builder { get; }
@@ -31,57 +31,57 @@ public partial interface IDocker
     /// <summary>
     /// Gets the compose sub-domain service.
     /// </summary>
-    IDockerCompose Compose { get; }
+    IDockerCompose Compose => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the container sub-domain service.
     /// </summary>
-    IDockerContainer Container { get; }
+    IDockerContainer Container => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the context sub-domain service.
     /// </summary>
-    IDockerContext Context { get; }
+    IDockerContext Context => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the image sub-domain service.
     /// </summary>
-    IDockerImage Image { get; }
+    IDockerImage Image => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the manifest sub-domain service.
     /// </summary>
-    IDockerManifest Manifest { get; }
+    IDockerManifest Manifest => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the network sub-domain service.
     /// </summary>
-    IDockerNetwork Network { get; }
+    IDockerNetwork Network => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the plugin sub-domain service.
     /// </summary>
-    IDockerPlugin Plugin { get; }
+    IDockerPlugin Plugin => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the swarm sub-domain service.
     /// </summary>
-    IDockerSwarm Swarm { get; }
+    IDockerSwarm Swarm => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the system sub-domain service.
     /// </summary>
-    IDockerSystem System { get; }
+    IDockerSystem System => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the trust sub-domain service.
     /// </summary>
-    IDockerTrust Trust { get; }
+    IDockerTrust Trust => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the volume sub-domain service.
     /// </summary>
-    IDockerVolume Volume { get; }
+    IDockerVolume Volume => throw new System.NotSupportedException();
 
     #endregion
 


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **docker** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- docker (Docker version 28.0.4, build b8034c0): 235 commands, tree 579289c22c807351975b3a09486be77beae5ff4ca69c15374eaa0413b47345a2

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator