### PR TITLE
Preserve handwritten Git API during generation cleanup

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -81,7 +81,8 @@ jobs:
                 tool: .toolName,
                 package: .packageName,
                 prefix: .namespacePrefix,
-                outputDirectory: .outputDirectory
+                outputDirectory: .outputDirectory,
+                generateCommandFacade: .generateCommandFacade
               }]}' \
               "$RUNNER_TEMP/tool-catalog.json"
           }
@@ -189,9 +190,8 @@ jobs:
             fi
           }
 
-          # Git's service API is handwritten and generation only validates coverage.
-          # Never remove it before the coverage-only generator run.
-          if [ "${{ matrix.tool }}" != "git" ]; then
+          # Preserve handwritten service APIs during coverage-only generator runs.
+          if [ "${{ matrix.generateCommandFacade }}" = "true" ]; then
             # Only delete specific service interface/implementation files (not all I*.cs files)
             # These are the exact files the generator will create in Services/
             remove_legacy_file "$PKG_DIR/I${PREFIX}.cs"
@@ -800,9 +800,8 @@ jobs:
             }
           }
 
-          # Git's service API is handwritten and generation only validates coverage.
-          # Never remove it before the coverage-only generator run.
-          if ('${{ matrix.tool }}' -ne 'git') {
+          # Preserve handwritten service APIs during coverage-only generator runs.
+          if ('${{ matrix.generateCommandFacade }}' -eq 'true') {
             # Only delete specific service interface/implementation files (not all I*.cs files)
             # These are the exact files the generator will create in Services/
             $interfaceFile = Join-Path $pkgDir "I$prefix.cs"

--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -189,15 +189,19 @@ jobs:
             fi
           }
 
-          # Only delete specific service interface/implementation files (not all I*.cs files)
-          # These are the exact files the generator will create in Services/
-          remove_legacy_file "$PKG_DIR/I${PREFIX}.cs"
-          remove_legacy_file "$PKG_DIR/${PREFIX}.cs"
+          # Git's service API is handwritten and generation only validates coverage.
+          # Never remove it before the coverage-only generator run.
+          if [ "${{ matrix.tool }}" != "git" ]; then
+            # Only delete specific service interface/implementation files (not all I*.cs files)
+            # These are the exact files the generator will create in Services/
+            remove_legacy_file "$PKG_DIR/I${PREFIX}.cs"
+            remove_legacy_file "$PKG_DIR/${PREFIX}.cs"
 
-          # Delete only this tool's generated service files. Packages such as
-          # ModularPipelines.Java contain services for multiple CLI tools.
-          remove_legacy_file "$PKG_DIR/Services/I${PREFIX}.Generated.cs"
-          remove_legacy_file "$PKG_DIR/Services/${PREFIX}.Generated.cs"
+            # Delete only this tool's generated service files. Packages such as
+            # ModularPipelines.Java contain services for multiple CLI tools.
+            remove_legacy_file "$PKG_DIR/Services/I${PREFIX}.Generated.cs"
+            remove_legacy_file "$PKG_DIR/Services/${PREFIX}.Generated.cs"
+          fi
 
           echo "Cleanup complete for $PACKAGE"
 
@@ -796,20 +800,24 @@ jobs:
             }
           }
 
-          # Only delete specific service interface/implementation files (not all I*.cs files)
-          # These are the exact files the generator will create in Services/
-          $interfaceFile = Join-Path $pkgDir "I$prefix.cs"
-          $implFile = Join-Path $pkgDir "$prefix.cs"
+          # Git's service API is handwritten and generation only validates coverage.
+          # Never remove it before the coverage-only generator run.
+          if ('${{ matrix.tool }}' -ne 'git') {
+            # Only delete specific service interface/implementation files (not all I*.cs files)
+            # These are the exact files the generator will create in Services/
+            $interfaceFile = Join-Path $pkgDir "I$prefix.cs"
+            $implFile = Join-Path $pkgDir "$prefix.cs"
 
-          Remove-LegacyFile $interfaceFile
-          Remove-LegacyFile $implFile
+            Remove-LegacyFile $interfaceFile
+            Remove-LegacyFile $implFile
 
-          # Delete only this tool's generated service files. A package may
-          # contain services for multiple CLI tools.
-          $servicesDir = Join-Path $pkgDir "Services"
-          if (Test-Path $servicesDir) {
-            Remove-LegacyFile (Join-Path $servicesDir "I$prefix.Generated.cs")
-            Remove-LegacyFile (Join-Path $servicesDir "$prefix.Generated.cs")
+            # Delete only this tool's generated service files. A package may
+            # contain services for multiple CLI tools.
+            $servicesDir = Join-Path $pkgDir "Services"
+            if (Test-Path $servicesDir) {
+              Remove-LegacyFile (Join-Path $servicesDir "I$prefix.Generated.cs")
+              Remove-LegacyFile (Join-Path $servicesDir "$prefix.Generated.cs")
+            }
           }
 
           Write-Host "Cleanup complete for $package"

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ToolCatalogTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/ToolCatalogTests.cs
@@ -19,6 +19,12 @@ public class ToolCatalogTests
             .IsEquivalentTo(["choco", "winget"]);
         await Assert.That(entries.Single(entry => entry.ToolName == "npm").IncludeInGenerationMatrix)
             .IsFalse();
+        await Assert.That(entries.Single(entry => entry.ToolName == "git").GenerateCommandFacade)
+            .IsFalse();
+        await Assert.That(entries
+                .Where(entry => entry.ToolName != "git")
+                .All(entry => entry.GenerateCommandFacade))
+            .IsTrue();
         await Assert.That(entries
                 .Where(entry => entry.ToolName != "npm")
                 .All(entry => entry.IncludeInGenerationMatrix))
@@ -67,6 +73,7 @@ public class ToolCatalogTests
             .IsEqualTo("src/ModularPipelines.Fake");
         await Assert.That(tool.GetProperty("generationPlatform").GetString()).IsEqualTo("linux");
         await Assert.That(tool.GetProperty("includeInGenerationMatrix").GetBoolean()).IsTrue();
+        await Assert.That(tool.GetProperty("generateCommandFacade").GetBoolean()).IsTrue();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -22,6 +22,7 @@ public partial class GitCliScraper : ICliScraper
     public string NamespacePrefix => "Git";
     public string TargetNamespace => "ModularPipelines.Git";
     public string OutputDirectory => "src/ModularPipelines.Git";
+    public bool GenerateCommandFacade => false;
 
     public GitCliScraper(ICliCommandExecutor executor, ILogger<GitCliScraper> logger)
     {
@@ -43,7 +44,7 @@ public partial class GitCliScraper : ICliScraper
             TargetNamespace = "ModularPipelines.Git",
             OutputDirectory = "src/ModularPipelines.Git",
             DocumentationOutputDirectory = null,
-            GenerateCommandFacade = false,
+            GenerateCommandFacade = GenerateCommandFacade,
             Commands = [],
             Errors = [],
         };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ICliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/ICliScraper.cs
@@ -39,6 +39,11 @@ public interface ICliScraper
     bool IncludeInGenerationMatrix => true;
 
     /// <summary>
+    /// Whether generation owns the tool's command facade and service files.
+    /// </summary>
+    bool GenerateCommandFacade => true;
+
+    /// <summary>
     /// Whether the CLI tool is available on the system.
     /// </summary>
     Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ToolCatalog.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/ToolCatalog.cs
@@ -36,10 +36,11 @@ internal static class ToolCatalog
 
     public static string ToText(IReadOnlyList<ToolCatalogEntry> entries)
     {
-        var lines = new[] { "Tool\tPackage\tNamespace prefix\tPlatform\tAutomation" }
+        var lines = new[] { "Tool\tPackage\tNamespace prefix\tPlatform\tAutomation\tCommand facade" }
             .Concat(entries.Select(entry =>
                 $"{entry.ToolName}\t{entry.PackageName}\t{entry.NamespacePrefix}\t"
-                + $"{entry.GenerationPlatform}\t{entry.IncludeInGenerationMatrix}"));
+                + $"{entry.GenerationPlatform}\t{entry.IncludeInGenerationMatrix}\t"
+                + $"{entry.GenerateCommandFacade}"));
         return string.Join(Environment.NewLine, lines);
     }
 
@@ -74,7 +75,8 @@ internal static class ToolCatalog
             NamespacePrefix: namespacePrefix,
             OutputDirectory: outputDirectory,
             GenerationPlatform: scraper.GenerationPlatform,
-            IncludeInGenerationMatrix: scraper.IncludeInGenerationMatrix);
+            IncludeInGenerationMatrix: scraper.IncludeInGenerationMatrix,
+            GenerateCommandFacade: scraper.GenerateCommandFacade);
     }
 
     private static string RequireValue(string value, string description) =>
@@ -89,4 +91,5 @@ internal sealed record ToolCatalogEntry(
     string NamespacePrefix,
     string OutputDirectory,
     CliGenerationPlatform GenerationPlatform,
-    bool IncludeInGenerationMatrix);
+    bool IncludeInGenerationMatrix,
+    bool GenerateCommandFacade);


### PR DESCRIPTION
## Summary
- skip legacy service cleanup for the handwritten Git integration
- keep Linux and Windows generation paths consistent
- allow Git's coverage-only generator mode to validate without deleting IGit.cs/Git.cs before the package build

## Validation
- workflow diff check clean
- reproduced failure: Git build lost IGit after pre-generation cleanup

Part of #3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI option generation cleanup to preserve handwritten service integrations for tools that do not generate command facades.
  * Replaced tool-specific cleanup handling with catalog-driven behavior for more consistent Linux and Windows results.

* **Documentation**
  * Added command-facade status to the tool catalog, making cleanup and generation behavior clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->