### PR TITLE
Apply Liquibase CLI regeneration to main

### DIFF
--- a/docs/docs/mp-packages/cli/liquibase.md
+++ b/docs/docs/mp-packages/cli/liquibase.md
@@ -7,7 +7,13 @@ title: liquibase CLI reference
 
 `ModularPipelines.Liquibase` provides strongly typed access to the `liquibase` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `liquibase` executable. Install it separately and ensure `liquibase` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Liquibase
@@ -17,23 +23,10 @@ Resolve the service with `context.Tools.Liquibase`. For projects older than C# 1
 
 ## Module example
 
-```csharp
-using ModularPipelines.Context;
-using ModularPipelines.Models;
-using ModularPipelines.Modules;
-using ModularPipelines.Liquibase.Options;
+Resolve the service in a module, then select a command from the table below. A runnable example is omitted when no command has complete safety metadata:
 
-public class RunCommandModule : Module<CommandResult>
-{
-    protected override async Task<CommandResult> ExecuteAsync(
-        IModuleContext context,
-        CancellationToken cancellationToken)
-    {
-        return await context.Tools.Liquibase.CalculateChecksumAsync(
-            new LiquibaseCalculateChecksumOptions(),
-            cancellationToken: cancellationToken);
-    }
-}
+```csharp
+var liquibase = context.Tools.Liquibase;
 ```
 
 ## Global options
@@ -42,7 +35,7 @@ Global options are rendered before the selected subcommand.
 
 | CLI option | Property | Availability | Description |
 | --- | --- | --- | --- |
-| `--allow-duplicated-changeset-identifiers` | `AllowDuplicatedChangesetIdentifiers` | All editions | Allows duplicated changeset identifiers without failing Liquibase execution. DEFAULT: false |
+| `--allow-duplicated-changeset-identifiers` | `AllowDuplicatedChangeSetIdentifiers` | All editions | Allows duplicated changeset identifiers without failing Liquibase execution. DEFAULT: false |
 | `--allow-inherit-logical-file-path` | `AllowInheritLogicalFilePath` | All editions | If true, included changelogs without an explicit logicalFilePath will inherit their parent changelog's logicalFilePath, and explicit logicalFilePath attributes on include statements are honored (Liquibase 4.31.0+ behavior). If false, included changelogs use their physical file paths, ignoring both implicit inheritance and explicit logicalFilePath attributes on include statements. Only logicalFilePath set directly on the changelog itself is respected. Defaults to true for backward compatibility. DEFAULT: true |
 | `--always-drop-instead-of-replace` | `AlwaysDropInsteadOfReplace` | All editions | If true, drop and recreate a view instead of replacing it. DEFAULT: false |
 | `--always-override-stored-logic-schema` | `AlwaysOverrideStoredLogicSchema` | All editions | When generating SQL for createProcedure, should the procedure schema be forced to the default schema if no schemaName attribute is set? DEFAULT: false |
@@ -69,8 +62,8 @@ Global options are rendered before the selected subcommand.
 | `--fail-on-null-snapshot-id` | `FailOnNullSnapshotId` | All editions | If true, referenced objects which do not have a snapshot ID will cause snapshot failure DEFAULT: true |
 | `--file-encoding` | `FileEncoding` | All editions | Encoding to use when reading files. Valid values include: UTF-8, UTF-16, UTF-16BE, UTF-16LE, US-ASCII, or OS to use the system configured encoding. DEFAULT: UTF-8 |
 | `--filter-log-messages` | `FilterLogMessages` | All editions | DEPRECATED: No longer used |
-| `--generate-changeset-created-values` | `GenerateChangesetCreatedValues` | All editions | Should Liquibase include a 'created' attribute in diff/generateChangelog changesets with the current datetime DEFAULT: false |
-| `--generated-changeset-ids-contains-description` | `GeneratedChangesetIdsContainsDescription` | All editions | Should Liquibase include the change description in the id when generating changesets? DEFAULT: false |
+| `--generate-changeset-created-values` | `GenerateChangeSetCreatedValues` | All editions | Should Liquibase include a 'created' attribute in diff/generateChangelog changesets with the current datetime DEFAULT: false |
+| `--generated-changeset-ids-contains-description` | `GeneratedChangeSetIdsContainsDescription` | All editions | Should Liquibase include the change description in the id when generating changesets? DEFAULT: false |
 | `--headless` | `Headless` | All editions | Force Liquibase to think it has no access to a keyboard DEFAULT: false |
 | `--help` | `Help` | All editions | Show this help message and exit |
 | `--include-catalog-in-specification` | `IncludeCatalogInSpecification` | All editions | Should Liquibase include the catalog name when determining equality? DEFAULT: false |

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseChangelogParseMode.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseChangelogParseMode.Generated.cs
@@ -17,8 +17,8 @@ namespace ModularPipelines.Liquibase.Enums;
 public enum LiquibaseChangelogParseMode
 {
     [EnumValue("strict")]
-    Strict,
+    Strict = 0,
 
     [EnumValue("lax")]
-    Lax
+    Lax = 1
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseDuplicateFileMode.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseDuplicateFileMode.Generated.cs
@@ -17,17 +17,17 @@ namespace ModularPipelines.Liquibase.Enums;
 public enum LiquibaseDuplicateFileMode
 {
     [EnumValue("silent")]
-    Silent,
+    Silent = 0,
 
     [EnumValue("debug")]
-    Debug,
+    Debug = 1,
 
     [EnumValue("info")]
-    Info,
+    Info = 2,
 
     [EnumValue("warn")]
-    Warn,
+    Warn = 3,
 
     [EnumValue("error")]
-    Error
+    Error = 4
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseLogFormat.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseLogFormat.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Liquibase.Enums;
 public enum LiquibaseLogFormat
 {
     [EnumValue("text")]
-    Text,
+    Text = 0,
 
     [EnumValue("json")]
-    Json,
+    Json = 1,
 
     [EnumValue("json_pretty")]
-    JsonPretty
+    JsonPretty = 2
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseLogLevel.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseLogLevel.Generated.cs
@@ -17,17 +17,17 @@ namespace ModularPipelines.Liquibase.Enums;
 public enum LiquibaseLogLevel
 {
     [EnumValue("off")]
-    Off,
+    Off = 0,
 
     [EnumValue("severe")]
-    Severe,
+    Severe = 1,
 
     [EnumValue("warning")]
-    Warning,
+    Warning = 2,
 
     [EnumValue("info")]
-    Info,
+    Info = 3,
 
     [EnumValue("fine")]
-    Fine
+    Fine = 4
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseMissingPropertyMode.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseMissingPropertyMode.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Liquibase.Enums;
 public enum LiquibaseMissingPropertyMode
 {
     [EnumValue("preserve")]
-    Preserve,
+    Preserve = 0,
 
     [EnumValue("empty")]
-    Empty,
+    Empty = 1,
 
     [EnumValue("error")]
-    Error
+    Error = 2
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseOnMissingIncludeChangelog.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseOnMissingIncludeChangelog.Generated.cs
@@ -17,8 +17,8 @@ namespace ModularPipelines.Liquibase.Enums;
 public enum LiquibaseOnMissingIncludeChangelog
 {
     [EnumValue("warn")]
-    Warn,
+    Warn = 0,
 
     [EnumValue("fail")]
-    Fail
+    Fail = 1
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseShowSummary.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseShowSummary.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Liquibase.Enums;
 public enum LiquibaseShowSummary
 {
     [EnumValue("off")]
-    Off,
+    Off = 0,
 
     [EnumValue("summary")]
-    Summary,
+    Summary = 1,
 
     [EnumValue("verbose")]
-    Verbose
+    Verbose = 2
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseShowSummaryOutput.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseShowSummaryOutput.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Liquibase.Enums;
 public enum LiquibaseShowSummaryOutput
 {
     [EnumValue("log")]
-    Log,
+    Log = 0,
 
     [EnumValue("console")]
-    Console,
+    Console = 1,
 
     [EnumValue("all")]
-    All
+    All = 2
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseSupportsMethodValidationLevel.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseSupportsMethodValidationLevel.Generated.cs
@@ -17,11 +17,11 @@ namespace ModularPipelines.Liquibase.Enums;
 public enum LiquibaseSupportsMethodValidationLevel
 {
     [EnumValue("off")]
-    Off,
+    Off = 0,
 
     [EnumValue("warn")]
-    Warn,
+    Warn = 1,
 
     [EnumValue("fail")]
-    Fail
+    Fail = 2
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseTagVersion.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseTagVersion.Generated.cs
@@ -17,8 +17,8 @@ namespace ModularPipelines.Liquibase.Enums;
 public enum LiquibaseTagVersion
 {
     [EnumValue("oldest")]
-    Oldest,
+    Oldest = 0,
 
     [EnumValue("newest")]
-    Newest
+    Newest = 1
 }

--- a/src/ModularPipelines.Liquibase/Enums/LiquibaseUiService.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Enums/LiquibaseUiService.Generated.cs
@@ -17,8 +17,8 @@ namespace ModularPipelines.Liquibase.Enums;
 public enum LiquibaseUiService
 {
     [EnumValue("console")]
-    Console,
+    Console = 0,
 
     [EnumValue("logger")]
-    Logger
+    Logger = 1
 }

--- a/src/ModularPipelines.Liquibase/Extensions/LiquibaseExtensions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Extensions/LiquibaseExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class LiquibaseExtensions
     }
 
     /// <summary>
-    /// Gets the liquibase service from the pipeline context.
+    /// Gets the liquibase service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="ILiquibase"/> service for executing liquibase commands.</returns>

--- a/src/ModularPipelines.Liquibase/Generated/Liquibase.CommandCoverage.json
+++ b/src/ModularPipelines.Liquibase/Generated/Liquibase.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "liquibase",
+  "toolVersion": "5.0.3",
   "commandCount": 43,
   "commandTreeSha256": "41e289cc33bbedcb50c94a7ac63a85c7d6ddacbd20208a60c02222e6d2d3c647",
   "commands": [

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseCalculateChecksumOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseCalculateChecksumOptions.Generated.cs
@@ -32,25 +32,25 @@ public record LiquibaseCalculateChecksumOptions : LiquibaseOptions
     /// ChangeSet Author attribute
     /// </summary>
     [CliOption("--changeset-author", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangesetAuthor { get; set; }
+    public string? ChangeSetAuthor { get; set; }
 
     /// <summary>
     /// ChangeSet ID attribute
     /// </summary>
     [CliOption("--changeset-id", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangesetId { get; set; }
+    public string? ChangeSetId { get; set; }
 
     /// <summary>
     /// ChangeSet identifier of form filepath::id::author
     /// </summary>
     [CliOption("--changeset-identifier", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangesetIdentifier { get; set; }
+    public string? ChangeSetIdentifier { get; set; }
 
     /// <summary>
     /// Changelog path in which the changeSet is included
     /// </summary>
     [CliOption("--changeset-path", Format = OptionFormat.EqualsSeparated)]
-    public string? ChangesetPath { get; set; }
+    public string? ChangeSetPath { get; set; }
 
     /// <summary>
     /// Pass a name/value pair for substitution in the changelog(s) Pass as -D&lt;property.name&gt;=&lt;property.value&gt; [deprecated: set changelog properties in defaults file or environment variables]
@@ -88,5 +88,33 @@ public record LiquibaseCalculateChecksumOptions : LiquibaseOptions
     /// </summary>
     [CliOption("--username", Format = OptionFormat.EqualsSeparated)]
     public string? Username { get; set; }
+
+    [Obsolete("Use ChangeSetAuthor instead.")]
+    public string? ChangesetAuthor
+    {
+        get => ChangeSetAuthor;
+        set => ChangeSetAuthor = value;
+    }
+
+    [Obsolete("Use ChangeSetId instead.")]
+    public string? ChangesetId
+    {
+        get => ChangeSetId;
+        set => ChangeSetId = value;
+    }
+
+    [Obsolete("Use ChangeSetIdentifier instead.")]
+    public string? ChangesetIdentifier
+    {
+        get => ChangeSetIdentifier;
+        set => ChangeSetIdentifier = value;
+    }
+
+    [Obsolete("Use ChangeSetPath instead.")]
+    public string? ChangesetPath
+    {
+        get => ChangeSetPath;
+        set => ChangeSetPath = value;
+    }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseOptions.Generated.cs
@@ -27,7 +27,7 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     /// Allows duplicated changeset identifiers without failing Liquibase execution. DEFAULT: false
     /// </summary>
     [CliOption("--allow-duplicated-changeset-identifiers", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? AllowDuplicatedChangesetIdentifiers { get; set; }
+    public virtual bool? AllowDuplicatedChangeSetIdentifiers { get; set; }
 
     /// <summary>
     /// If true, included changelogs without an explicit logicalFilePath will inherit their parent changelog's logicalFilePath, and explicit logicalFilePath attributes on include statements are honored (Liquibase 4.31.0+ behavior). If false, included changelogs use their physical file paths, ignoring both implicit inheritance and explicit logicalFilePath attributes on include statements. Only logicalFilePath set directly on the changelog itself is respected. Defaults to true for backward compatibility. DEFAULT: true
@@ -189,13 +189,13 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     /// Should Liquibase include a 'created' attribute in diff/generateChangelog changesets with the current datetime DEFAULT: false
     /// </summary>
     [CliOption("--generate-changeset-created-values", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? GenerateChangesetCreatedValues { get; set; }
+    public virtual bool? GenerateChangeSetCreatedValues { get; set; }
 
     /// <summary>
     /// Should Liquibase include the change description in the id when generating changesets? DEFAULT: false
     /// </summary>
     [CliOption("--generated-changeset-ids-contains-description", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? GeneratedChangesetIdsContainsDescription { get; set; }
+    public virtual bool? GeneratedChangeSetIdsContainsDescription { get; set; }
 
     /// <summary>
     /// Force Liquibase to think it has no access to a keyboard DEFAULT: false
@@ -446,5 +446,26 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     /// </summary>
     [CliFlag("--version", ShortForm = "-v")]
     public virtual bool? Version { get; set; }
+
+    [Obsolete("Use AllowDuplicatedChangeSetIdentifiers instead.")]
+    public virtual bool? AllowDuplicatedChangesetIdentifiers
+    {
+        get => AllowDuplicatedChangeSetIdentifiers;
+        set => AllowDuplicatedChangeSetIdentifiers = value;
+    }
+
+    [Obsolete("Use GenerateChangeSetCreatedValues instead.")]
+    public virtual bool? GenerateChangesetCreatedValues
+    {
+        get => GenerateChangeSetCreatedValues;
+        set => GenerateChangeSetCreatedValues = value;
+    }
+
+    [Obsolete("Use GeneratedChangeSetIdsContainsDescription instead.")]
+    public virtual bool? GeneratedChangesetIdsContainsDescription
+    {
+        get => GeneratedChangeSetIdsContainsDescription;
+        set => GeneratedChangeSetIdsContainsDescription = value;
+    }
 
 }

--- a/src/ModularPipelines.Liquibase/Options/LiquibaseOptions.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Options/LiquibaseOptions.Generated.cs
@@ -27,7 +27,13 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     /// Allows duplicated changeset identifiers without failing Liquibase execution. DEFAULT: false
     /// </summary>
     [CliOption("--allow-duplicated-changeset-identifiers", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? AllowDuplicatedChangeSetIdentifiers { get; set; }
+#pragma warning disable CS0618
+    public virtual bool? AllowDuplicatedChangeSetIdentifiers
+    {
+        get => AllowDuplicatedChangesetIdentifiers;
+        set => AllowDuplicatedChangesetIdentifiers = value;
+    }
+#pragma warning restore CS0618
 
     /// <summary>
     /// If true, included changelogs without an explicit logicalFilePath will inherit their parent changelog's logicalFilePath, and explicit logicalFilePath attributes on include statements are honored (Liquibase 4.31.0+ behavior). If false, included changelogs use their physical file paths, ignoring both implicit inheritance and explicit logicalFilePath attributes on include statements. Only logicalFilePath set directly on the changelog itself is respected. Defaults to true for backward compatibility. DEFAULT: true
@@ -189,13 +195,25 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     /// Should Liquibase include a 'created' attribute in diff/generateChangelog changesets with the current datetime DEFAULT: false
     /// </summary>
     [CliOption("--generate-changeset-created-values", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? GenerateChangeSetCreatedValues { get; set; }
+#pragma warning disable CS0618
+    public virtual bool? GenerateChangeSetCreatedValues
+    {
+        get => GenerateChangesetCreatedValues;
+        set => GenerateChangesetCreatedValues = value;
+    }
+#pragma warning restore CS0618
 
     /// <summary>
     /// Should Liquibase include the change description in the id when generating changesets? DEFAULT: false
     /// </summary>
     [CliOption("--generated-changeset-ids-contains-description", Format = OptionFormat.EqualsSeparated)]
-    public virtual bool? GeneratedChangeSetIdsContainsDescription { get; set; }
+#pragma warning disable CS0618
+    public virtual bool? GeneratedChangeSetIdsContainsDescription
+    {
+        get => GeneratedChangesetIdsContainsDescription;
+        set => GeneratedChangesetIdsContainsDescription = value;
+    }
+#pragma warning restore CS0618
 
     /// <summary>
     /// Force Liquibase to think it has no access to a keyboard DEFAULT: false
@@ -448,24 +466,12 @@ public abstract record LiquibaseOptions : CommandLineToolOptions
     public virtual bool? Version { get; set; }
 
     [Obsolete("Use AllowDuplicatedChangeSetIdentifiers instead.")]
-    public virtual bool? AllowDuplicatedChangesetIdentifiers
-    {
-        get => AllowDuplicatedChangeSetIdentifiers;
-        set => AllowDuplicatedChangeSetIdentifiers = value;
-    }
+    public virtual bool? AllowDuplicatedChangesetIdentifiers { get; set; }
 
     [Obsolete("Use GenerateChangeSetCreatedValues instead.")]
-    public virtual bool? GenerateChangesetCreatedValues
-    {
-        get => GenerateChangeSetCreatedValues;
-        set => GenerateChangeSetCreatedValues = value;
-    }
+    public virtual bool? GenerateChangesetCreatedValues { get; set; }
 
     [Obsolete("Use GeneratedChangeSetIdsContainsDescription instead.")]
-    public virtual bool? GeneratedChangesetIdsContainsDescription
-    {
-        get => GeneratedChangeSetIdsContainsDescription;
-        set => GeneratedChangeSetIdsContainsDescription = value;
-    }
+    public virtual bool? GeneratedChangesetIdsContainsDescription { get; set; }
 
 }

--- a/src/ModularPipelines.Liquibase/Services/ILiquibase.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Services/ILiquibase.Generated.cs
@@ -27,7 +27,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> CalculateChecksumAsync(LiquibaseCalculateChecksumOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> CalculateChecksumAsync(LiquibaseCalculateChecksumOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Marks all changes as executed in the database
@@ -36,7 +37,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ChangelogSyncAsync(LiquibaseChangelogSyncOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ChangelogSyncAsync(LiquibaseChangelogSyncOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Output the raw SQL used by Liquibase when running changelogSync
@@ -45,7 +47,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ChangelogSyncSqlAsync(LiquibaseChangelogSyncSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ChangelogSyncSqlAsync(LiquibaseChangelogSyncSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Marks all undeployed changesets as executed, up to a tag
@@ -54,7 +57,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ChangelogSyncToTagAsync(LiquibaseChangelogSyncToTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ChangelogSyncToTagAsync(LiquibaseChangelogSyncToTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Output the raw SQL used by Liquibase when running changelogSyncToTag
@@ -63,7 +67,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ChangelogSyncToTagSqlAsync(LiquibaseChangelogSyncToTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ChangelogSyncToTagSqlAsync(LiquibaseChangelogSyncToTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Clears all checksums
@@ -72,7 +77,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ClearChecksumsAsync(LiquibaseClearChecksumsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ClearChecksumsAsync(LiquibaseClearChecksumsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generates JavaDoc documentation for the existing database and changelogs
@@ -81,7 +87,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DbDocAsync(LiquibaseDbDocOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> DbDocAsync(LiquibaseDbDocOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Compare two databases to produce changesets and write them to a changelog file
@@ -90,7 +97,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DiffChangelogAsync(LiquibaseDiffChangelogOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> DiffChangelogAsync(LiquibaseDiffChangelogOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Outputs a description of differences.  If you have a Liquibase License Key, you can output the differences as JSON using the --format=JSON option
@@ -99,7 +107,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DiffAsync(LiquibaseDiffOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> DiffAsync(LiquibaseDiffOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Drop all database objects owned by the user
@@ -108,7 +117,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DropAllAsync(LiquibaseDropAllOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> DropAllAsync(LiquibaseDropAllOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Execute a SQL string or file
@@ -117,7 +127,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteSqlAsync(LiquibaseExecuteSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ExecuteSqlAsync(LiquibaseExecuteSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generates SQL to sequentially revert &lt;count&gt; number of changes
@@ -126,7 +137,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FutureRollbackCountSqlAsync(LiquibaseFutureRollbackCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> FutureRollbackCountSqlAsync(LiquibaseFutureRollbackCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generates SQL to revert future changes up to the specified tag
@@ -135,7 +147,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FutureRollbackFromTagSqlAsync(LiquibaseFutureRollbackFromTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> FutureRollbackFromTagSqlAsync(LiquibaseFutureRollbackFromTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate the raw SQL needed to rollback undeployed changes
@@ -144,7 +157,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FutureRollbackSqlAsync(LiquibaseFutureRollbackSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> FutureRollbackSqlAsync(LiquibaseFutureRollbackSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate a changelog
@@ -153,7 +167,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> GenerateChangelogAsync(LiquibaseGenerateChangelogOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> GenerateChangelogAsync(LiquibaseGenerateChangelogOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// List all deployed changesets and their deployment ID
@@ -162,7 +177,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> HistoryAsync(LiquibaseHistoryOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> HistoryAsync(LiquibaseHistoryOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// &lt; Init commands &gt;
@@ -171,7 +187,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InitAsync(LiquibaseInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> InitAsync(LiquibaseInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Creates the directory and files needed to run Liquibase commands. Run without any flags on the CLI, or set via Environment variable, etc. will launch an interactive guide to walk users through setting up the necessary project's default and changelog files. This guide can be turned off by setting the 'liquibase.command.init.project.projectGuide=off'
@@ -180,7 +197,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InitProjectAsync(LiquibaseInitProjectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> InitProjectAsync(LiquibaseInitProjectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Launches H2, an included open source in-memory database. This Java application is shipped with Liquibase, and is useful in the Getting Started experience and for testing out Liquibase commands.
@@ -189,7 +207,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InitStartH2Async(LiquibaseInitStartH2Options? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> InitStartH2Async(LiquibaseInitStartH2Options? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// List the hostname, IP address, and timestamp of the Liquibase lock record
@@ -198,7 +217,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ListLocksAsync(LiquibaseListLocksOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ListLocksAsync(LiquibaseListLocksOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Marks the next change you apply as executed in your database
@@ -207,7 +227,14 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> MarkNextChangesetRanAsync(LiquibaseMarkNextChangesetRanOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    #pragma warning disable CS0618
+    Task<CommandResult> MarkNextChangeSetRanAsync(LiquibaseMarkNextChangesetRanOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => MarkNextChangesetRanAsync(options, executionOptions, cancellationToken);
+    #pragma warning restore CS0618
+
+    [Obsolete("Use MarkNextChangeSetRanAsync instead.")]
+    Task<CommandResult> MarkNextChangesetRanAsync(LiquibaseMarkNextChangesetRanOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Writes the SQL used to mark the next change you apply as executed in your database
@@ -216,7 +243,14 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> MarkNextChangesetRanSqlAsync(LiquibaseMarkNextChangesetRanSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    #pragma warning disable CS0618
+    Task<CommandResult> MarkNextChangeSetRanSqlAsync(LiquibaseMarkNextChangesetRanSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => MarkNextChangesetRanSqlAsync(options, executionOptions, cancellationToken);
+    #pragma warning restore CS0618
+
+    [Obsolete("Use MarkNextChangeSetRanSqlAsync instead.")]
+    Task<CommandResult> MarkNextChangesetRanSqlAsync(LiquibaseMarkNextChangesetRanSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Remove the Liquibase lock record from the DATABASECHANGELOG table
@@ -225,7 +259,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ReleaseLocksAsync(LiquibaseReleaseLocksOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ReleaseLocksAsync(LiquibaseReleaseLocksOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Rollback the specified number of changes made to the database
@@ -234,7 +269,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackCountAsync(LiquibaseRollbackCountOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> RollbackCountAsync(LiquibaseRollbackCountOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate the SQL to rollback the specified number of changes
@@ -243,7 +279,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackCountSqlAsync(LiquibaseRollbackCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> RollbackCountSqlAsync(LiquibaseRollbackCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Rollback changes made to the database based on the specific tag
@@ -252,7 +289,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackAsync(LiquibaseRollbackOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> RollbackAsync(LiquibaseRollbackOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate the SQL to rollback changes made to the database based on the specific tag
@@ -261,7 +299,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackSqlAsync(LiquibaseRollbackSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> RollbackSqlAsync(LiquibaseRollbackSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Rollback changes made to the database based on the specific date
@@ -270,7 +309,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackToDateAsync(LiquibaseRollbackToDateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> RollbackToDateAsync(LiquibaseRollbackToDateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate the SQL to rollback changes made to the database based on the specific date
@@ -279,7 +319,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RollbackToDateSqlAsync(LiquibaseRollbackToDateSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> RollbackToDateSqlAsync(LiquibaseRollbackToDateSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Capture the current state of the database
@@ -288,7 +329,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SnapshotAsync(LiquibaseSnapshotOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> SnapshotAsync(LiquibaseSnapshotOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Capture the current state of the reference database
@@ -297,7 +339,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> SnapshotReferenceAsync(LiquibaseSnapshotReferenceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> SnapshotReferenceAsync(LiquibaseSnapshotReferenceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate a list of pending changesets
@@ -306,7 +349,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> StatusAsync(LiquibaseStatusOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> StatusAsync(LiquibaseStatusOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Verify the existence of the specified tag
@@ -315,7 +359,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> TagExistsAsync(LiquibaseTagExistsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> TagExistsAsync(LiquibaseTagExistsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Mark the current database state with the specified tag
@@ -324,7 +369,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> TagAsync(LiquibaseTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> TagAsync(LiquibaseTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate a list of changesets that have been executed but are not in the current changelog
@@ -333,7 +379,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UnexpectedChangesetsAsync(LiquibaseUnexpectedChangesetsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> UnexpectedChangesetsAsync(LiquibaseUnexpectedChangesetsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Deploy the specified number of changes from the changelog file
@@ -342,7 +389,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateCountAsync(LiquibaseUpdateCountOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> UpdateCountAsync(LiquibaseUpdateCountOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate the SQL to deploy the specified number of changes
@@ -351,7 +399,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateCountSqlAsync(LiquibaseUpdateCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> UpdateCountSqlAsync(LiquibaseUpdateCountSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Deploy any changes in the changelog file that have not been deployed
@@ -360,7 +409,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateAsync(LiquibaseUpdateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> UpdateAsync(LiquibaseUpdateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate the SQL to deploy changes in the changelog which have not been deployed
@@ -369,7 +419,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateSqlAsync(LiquibaseUpdateSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> UpdateSqlAsync(LiquibaseUpdateSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Updates database, then rolls back changes before updating again. Useful for testing rollback support
@@ -378,7 +429,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateTestingRollbackAsync(LiquibaseUpdateTestingRollbackOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> UpdateTestingRollbackAsync(LiquibaseUpdateTestingRollbackOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Deploy changes from the changelog file to the specified tag
@@ -387,7 +439,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateToTagAsync(LiquibaseUpdateToTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> UpdateToTagAsync(LiquibaseUpdateToTagOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate the SQL to deploy changes up to the tag
@@ -396,7 +449,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UpdateToTagSqlAsync(LiquibaseUpdateToTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> UpdateToTagSqlAsync(LiquibaseUpdateToTagSqlOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Validate the changelog for errors
@@ -405,7 +459,8 @@ public partial interface ILiquibase
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ValidateAsync(LiquibaseValidateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    Task<CommandResult> ValidateAsync(LiquibaseValidateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     #endregion
 }

--- a/src/ModularPipelines.Liquibase/Services/Liquibase.Generated.cs
+++ b/src/ModularPipelines.Liquibase/Services/Liquibase.Generated.cs
@@ -212,7 +212,7 @@ internal partial class Liquibase : ILiquibase
     }
 
     /// <inheritdoc />
-    public virtual async Task<CommandResult> MarkNextChangesetRanAsync(
+    public virtual async Task<CommandResult> MarkNextChangeSetRanAsync(
         LiquibaseMarkNextChangesetRanOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
@@ -220,13 +220,31 @@ internal partial class Liquibase : ILiquibase
         return await _command.ExecuteCommandLineToolAsync(options ?? new LiquibaseMarkNextChangesetRanOptions(), executionOptions, cancellationToken);
     }
 
+    [Obsolete("Use MarkNextChangeSetRanAsync instead.")]
+    public virtual async Task<CommandResult> MarkNextChangesetRanAsync(
+        LiquibaseMarkNextChangesetRanOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await MarkNextChangeSetRanAsync(options, executionOptions, cancellationToken);
+    }
+
     /// <inheritdoc />
-    public virtual async Task<CommandResult> MarkNextChangesetRanSqlAsync(
+    public virtual async Task<CommandResult> MarkNextChangeSetRanSqlAsync(
         LiquibaseMarkNextChangesetRanSqlOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
         return await _command.ExecuteCommandLineToolAsync(options ?? new LiquibaseMarkNextChangesetRanSqlOptions(), executionOptions, cancellationToken);
+    }
+
+    [Obsolete("Use MarkNextChangeSetRanSqlAsync instead.")]
+    public virtual async Task<CommandResult> MarkNextChangesetRanSqlAsync(
+        LiquibaseMarkNextChangesetRanSqlOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await MarkNextChangeSetRanSqlAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />

--- a/test/ModularPipelines.Liquibase.UnitTests/Commands/LiquibaseOptionsTests.cs
+++ b/test/ModularPipelines.Liquibase.UnitTests/Commands/LiquibaseOptionsTests.cs
@@ -124,9 +124,28 @@ public class LiquibaseOptionsTests : TestBase
             "liquibase --defaults-file=liquibase.properties update");
     }
 
+    [Test]
+    public async Task Legacy_Virtual_Override_Still_Renders_Global_Option()
+    {
+        var result = await GetResult(new LegacyLiquibaseUpdateOptions
+        {
+            AllowDuplicatedChangesetIdentifiers = true,
+        });
+
+        await Assert.That(result.CommandInput).IsEqualTo(
+            "liquibase --allow-duplicated-changeset-identifiers=true update");
+    }
+
     private async Task<CommandResult> GetResult(CommandLineToolOptions options)
     {
         var command = await GetService<ICommandContext>();
         return await command.ExecuteCommandLineToolAsync(options, new CommandExecutionOptions { InternalDryRun = true });
     }
+
+#pragma warning disable CS0618
+    private sealed record LegacyLiquibaseUpdateOptions : LiquibaseUpdateOptions
+    {
+        public override bool? AllowDuplicatedChangesetIdentifiers { get; set; }
+    }
+#pragma warning restore CS0618
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2420,7 +2420,7 @@ public class GeneratorHardeningTests
     }
 
     [Test]
-    public async Task Global_Compatibility_Targets_Follow_Inherited_Property_Renames()
+    public async Task Global_Compatibility_Aliases_Follow_Inherited_Renames_And_Preserve_Dispatch()
     {
         var tool = Tool(Command("ToolRunOptions", "ToolOptions", ["run"])) with
         {
@@ -2451,8 +2451,10 @@ public class GeneratorHardeningTests
         using (Assert.Multiple())
         {
             await Assert.That(generated).Contains("public virtual IEnumerable<string>? CliArguments");
-            await Assert.That(generated).Contains("get => CliArguments;");
-            await Assert.That(generated).Contains("set => CliArguments = value;");
+            await Assert.That(generated).Contains("get => LegacyArguments;");
+            await Assert.That(generated).Contains("set => LegacyArguments = value;");
+            await Assert.That(generated)
+                .Contains("public virtual IEnumerable<string>? LegacyArguments { get; set; }");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GlobalOptionsBaseGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GlobalOptionsBaseGeneratorTests.cs
@@ -129,4 +129,47 @@ public class GlobalOptionsBaseGeneratorTests
 
         await Assert.That(generated).Contains("[SecretValue(\"token\", \"password\")]");
     }
+
+    [Test]
+    public async Task Generate_Preserves_Virtual_Dispatch_For_Renamed_Global_Options()
+    {
+        var tool = new CliToolDefinition
+        {
+            ToolName = "liquibase",
+            NamespacePrefix = "Liquibase",
+            TargetNamespace = "ModularPipelines.Liquibase",
+            OutputDirectory = "src/ModularPipelines.Liquibase",
+            Commands = [],
+            GlobalOptions =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--allow-duplicated-changeset-identifiers",
+                    PropertyName = "AllowDuplicatedChangeSetIdentifiers",
+                    CSharpType = "bool?",
+                },
+            ],
+            GlobalCompatibilityProperties =
+            [
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "AllowDuplicatedChangesetIdentifiers",
+                    CSharpType = "bool?",
+                    ForwardToPropertyName = "AllowDuplicatedChangeSetIdentifiers",
+                    ObsoleteMessage = "Use AllowDuplicatedChangeSetIdentifiers instead.",
+                },
+            ],
+        };
+
+        var generated = (await new GlobalOptionsBaseGenerator().GenerateAsync(tool)).Single().Content;
+
+        await Assert.That(generated).Contains(
+            "get => AllowDuplicatedChangesetIdentifiers;");
+        await Assert.That(generated).Contains(
+            "set => AllowDuplicatedChangesetIdentifiers = value;");
+        await Assert.That(generated).Contains(
+            "public virtual bool? AllowDuplicatedChangesetIdentifiers { get; set; }");
+        await Assert.That(generated).DoesNotContain(
+            "get => AllowDuplicatedChangeSetIdentifiers;");
+    }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/LiquibaseCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/LiquibaseCliScraperTests.cs
@@ -148,6 +148,31 @@ public class LiquibaseCliScraperTests
     }
 
     [Test]
+    public async Task ParseCommand_Preserves_Usage_Operands()
+    {
+        const string helpText = "Usage: liquibase init [OPTIONS] [COMMAND]";
+
+        var command = await _scraper.ParseLiquibaseCommand(["liquibase", "init"], helpText);
+
+        await Assert.That(command!.PositionalArguments.Select(argument => argument.PropertyName))
+            .IsEquivalentTo(["Command"]);
+        await Assert.That(command.PositionalArguments.Single().IsRequired).IsFalse();
+    }
+
+    [Test]
+    public async Task ParseVersion_Extracts_Stable_Liquibase_Version()
+    {
+        var version = _scraper.ParseVersion(new CliCommandResult
+        {
+            StandardOutput = "Starting Liquibase\nLiquibase Version: 5.0.3\n",
+            StandardError = string.Empty,
+            ExitCode = 0,
+        });
+
+        await Assert.That(version).IsEqualTo("5.0.3");
+    }
+
+    [Test]
     public async Task Scrape_Separates_Global_Options_From_Command_Options()
     {
         const string rootHelp = """
@@ -242,7 +267,7 @@ public class LiquibaseCliScraperTests
             ExitCode = 0,
         };
 
-        var version = _scraper.ParseLiquibaseVersion(result);
+        var version = _scraper.ParseVersion(result);
 
         await Assert.That(version).IsEqualTo("5.0.3");
     }
@@ -260,7 +285,7 @@ public class LiquibaseCliScraperTests
         public Task<CliCommandDefinition?> ParseLiquibaseCommand(string[] commandPath, string helpText) =>
             ParseCommandAsync(commandPath, helpText, CancellationToken.None);
 
-        public string? ParseLiquibaseVersion(CliCommandResult result) => ParseVersionOutput(result);
+        public string? ParseVersion(CliCommandResult result) => ParseVersionOutput(result);
     }
 
     private sealed class StubExecutor(string? rootHelp = null, string? updateHelp = null) : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GlobalOptionsBaseGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GlobalOptionsBaseGenerator.cs
@@ -33,6 +33,9 @@ public class GlobalOptionsBaseGenerator : ICodeGenerator
     {
         var sb = new StringBuilder();
         var globalOptions = tool.GetGlobalOptions();
+        var virtualDispatchAliases = GetVirtualDispatchAliases(
+            globalOptions,
+            tool.GlobalCompatibilityProperties);
 
         // File header with nullable enable
         GeneratorUtils.GenerateFileHeaderWithNullable(sb);
@@ -86,7 +89,8 @@ public class GlobalOptionsBaseGenerator : ICodeGenerator
         // Properties for global options
         foreach (var option in globalOptions.OrderBy(o => o.PropertyName))
         {
-            GenerateProperty(sb, option);
+            virtualDispatchAliases.TryGetValue(option.PropertyName, out var virtualDispatchAlias);
+            GenerateProperty(sb, option, virtualDispatchAlias?.PropertyName);
             sb.AppendLine();
         }
 
@@ -98,7 +102,7 @@ public class GlobalOptionsBaseGenerator : ICodeGenerator
                 : string.Empty;
             GeneratorUtils.GenerateCompatibilityProperty(
                 sb,
-                compatibilityProperty,
+                GetEmittedCompatibilityProperty(compatibilityProperty, virtualDispatchAliases),
                 $"{newModifier}virtual ");
             sb.AppendLine();
         }
@@ -108,7 +112,45 @@ public class GlobalOptionsBaseGenerator : ICodeGenerator
         return sb.ToString();
     }
 
-    private static void GenerateProperty(StringBuilder sb, CliOptionDefinition option)
+    private static IReadOnlyDictionary<string, CliCompatibilityProperty> GetVirtualDispatchAliases(
+        IReadOnlyList<CliOptionDefinition> globalOptions,
+        IReadOnlyList<CliCompatibilityProperty> compatibilityProperties)
+    {
+        return compatibilityProperties
+            .Where(property => property is
+            {
+                ForwardToPropertyName: not null,
+                ForwardingKind: CliCompatibilityForwardingKind.Direct,
+                UseInitAccessor: false,
+            })
+            .Where(property => globalOptions.Any(option =>
+                option.PropertyName.Equals(property.ForwardToPropertyName, StringComparison.Ordinal)
+                && option.PropertyType.Equals(property.CSharpType, StringComparison.Ordinal)))
+            .GroupBy(property => property.ForwardToPropertyName!, StringComparer.Ordinal)
+            .Where(group => group.Count() == 1)
+            .ToDictionary(group => group.Key, group => group.Single(), StringComparer.Ordinal);
+    }
+
+    private static CliCompatibilityProperty GetEmittedCompatibilityProperty(
+        CliCompatibilityProperty compatibilityProperty,
+        IReadOnlyDictionary<string, CliCompatibilityProperty> virtualDispatchAliases)
+    {
+        if (compatibilityProperty.ForwardToPropertyName is not { } target
+            || !virtualDispatchAliases.TryGetValue(target, out var virtualDispatchAlias)
+            || !virtualDispatchAlias.PropertyName.Equals(
+                compatibilityProperty.PropertyName,
+                StringComparison.Ordinal))
+        {
+            return compatibilityProperty;
+        }
+
+        return compatibilityProperty with { ForwardToPropertyName = null };
+    }
+
+    private static void GenerateProperty(
+        StringBuilder sb,
+        CliOptionDefinition option,
+        string? virtualDispatchAlias)
     {
         // XML documentation
         GeneratorUtils.GenerateXmlDocumentation(sb, GetDescription(option));
@@ -133,7 +175,19 @@ public class GlobalOptionsBaseGenerator : ICodeGenerator
         sb.AppendLine($"    [{attribute}]");
 
         // Property
-        sb.AppendLine($"    public virtual {option.PropertyType} {option.PropertyName} {{ get; set; }}");
+        if (virtualDispatchAlias is null)
+        {
+            sb.AppendLine($"    public virtual {option.PropertyType} {option.PropertyName} {{ get; set; }}");
+            return;
+        }
+
+        sb.AppendLine("#pragma warning disable CS0618");
+        sb.AppendLine($"    public virtual {option.PropertyType} {option.PropertyName}");
+        sb.AppendLine("    {");
+        sb.AppendLine($"        get => {virtualDispatchAlias};");
+        sb.AppendLine($"        set => {virtualDispatchAlias} = value;");
+        sb.AppendLine("    }");
+        sb.AppendLine("#pragma warning restore CS0618");
     }
 
     private static string? GetDescription(CliOptionDefinition option)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/LiquibaseCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/LiquibaseCliScraper.cs
@@ -196,6 +196,17 @@ public partial class LiquibaseCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        ParseCommandAsync(
+            commandPath,
+            helpText,
+            ParseUsageSynopsis(commandPath, helpText),
+            cancellationToken);
+
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray();
@@ -230,7 +241,7 @@ public partial class LiquibaseCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = "https://docs.liquibase.com/commands/home.html",
             Options = options,
-            PositionalArguments = [],
+            PositionalArguments = GetPositionalArguments(usage),
             SubDomainGroup = null,
             Enums = enums
         };


### PR DESCRIPTION
Carries the reviewed Liquibase regeneration from #4026 onto the actual default branch. #4026 was merged into the obsolete stacked base after that base PR had already landed, so its squash commit never reached main.

This cherry-picks only the #4026 squash diff onto current main. The sole integration conflict was two names for the same Liquibase version-parser test helper; both regressions now share one helper. No generated file was hand-edited.

Validation:
- LiquibaseCliScraperTests: 17/17
- OptionsGenerator tests: 929/929
- OptionsGenerator Release build: 0 warnings/errors
- diff check: clean

The prior full Liquibase solution build reached the fixed 2 GB agent guard, so it was not retried or raised; CI owns that expensive validation.

Refs #4026
Refs #3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Liquibase command parsing now preserves positional arguments from usage descriptions.
  - Generated compatibility options better support legacy overrides and virtual dispatch.
  - Liquibase version detection more reliably identifies stable releases.

- **Bug Fixes**
  - Corrected Liquibase option names and generated changeset properties.
  - Preserved legacy global option behavior.

- **Documentation**
  - Clarified executable prerequisites, package installation, module usage, and supported option names.

- **Tests**
  - Added coverage for command operands, version detection, compatibility aliases, and legacy option rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->