### PR TITLE
Preserve restored Terraform root identifiers

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1955,6 +1955,46 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Preserves_Live_Group_Casing_For_Restored_Sibling()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolCloudShellScpOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"cloud-shell\", \"scp\")] "
+                + "public record ToolCloudShellScpOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolCloudshell.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolCloudshell { "
+                + "public Task ScpAsync(ToolCloudShellScpOptions? options = null) => Task.CompletedTask; }");
+            var tool = Tool(Command(
+                "ToolCloudShellListOptions",
+                "ToolOptions",
+                ["cloud-shell", "list"],
+                subDomainGroup: "Cloudshell"));
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(tool, root);
+
+            var restored = preserved.Commands.Single(command => command.ClassName == "ToolCloudShellScpOptions");
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored.SubDomainGroup).IsEqualTo("Cloudshell");
+                await Assert.That(restored.CommandGroupIdentifierOverride).IsEqualTo("Cloudshell");
+                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["Cloudshell"]);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Distinguishes_Literal_Execute_From_Parent_Facade()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1992,6 +1992,91 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Distinguishes_Execute_When_Parent_Name_Ends_In_Execute()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolRemoteExecuteExecuteOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"remote-execute\", \"execute\")] "
+                + "public record ToolRemoteExecuteExecuteOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolRemoteExecute.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolRemoteExecute { "
+                + "public Task ExecuteAsync(ToolRemoteExecuteExecuteOptions? options = null) => Task.CompletedTask; }");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+                Tool(Command("ToolCurrentOptions", "ToolOptions", ["current"])),
+                root);
+
+            var restored = preserved.Commands.Single(command => command.ClassName == "ToolRemoteExecuteExecuteOptions");
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored.SubDomainGroup).IsEqualTo("RemoteExecute");
+                await Assert.That(restored.CommandGroupIdentifierOverride).IsEqualTo("RemoteExecute");
+                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["RemoteExecute"]);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Maps_Restored_Identifier_To_Live_Group_Key()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolAlphaOldOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"foo\", \"old\")] "
+                + "public record ToolAlphaOldOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolAlpha.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolAlpha { "
+                + "public Task OldAsync(ToolAlphaOldOptions? options = null) => Task.CompletedTask; }");
+            var tool = Tool(
+                Command(
+                    "ToolAlphaCurrentOptions",
+                    "ToolOptions",
+                    ["foo", "current"],
+                    subDomainGroup: "foo",
+                    commandGroupIdentifierOverride: "Alpha"),
+                Command(
+                    "ToolBetaCurrentOptions",
+                    "ToolOptions",
+                    ["foo", "beta"],
+                    subDomainGroup: "beta-key",
+                    commandGroupIdentifierOverride: "Beta"));
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(tool, root);
+
+            var restored = preserved.Commands.Single(command => command.ClassName == "ToolAlphaOldOptions");
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored.SubDomainGroup).IsEqualTo("foo");
+                await Assert.That(restored.CommandGroupIdentifierOverride).IsEqualTo("Alpha");
+                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["foo", "beta-key"]);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Uses_One_Root_For_Removed_Parent_And_Child()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1917,6 +1917,43 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Preserves_Historical_Facade_Casing()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolCloudShellScpOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"cloud-shell\", \"scp\")] "
+                + "public record ToolCloudShellScpOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolCloudshell.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolCloudshell { "
+                + "public Task ScpAsync(ToolCloudShellScpOptions? options = null) => Task.CompletedTask; }");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+                Tool(Command("ToolCurrentOptions", "ToolOptions", ["current"])),
+                root);
+
+            var restored = preserved.Commands.Single(command => command.ClassName == "ToolCloudShellScpOptions");
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored.SubDomainGroup).IsEqualTo("Cloudshell");
+                await Assert.That(restored.CommandGroupIdentifierOverride).IsEqualTo("Cloudshell");
+                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["Cloudshell"]);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Retains_Optional_Facade_When_Required_Member_Is_Added()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1874,6 +1874,38 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Preserves_Custom_Root_Identifier_For_Restored_Facades()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolApplicationSetCreateOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"appset\", \"create\")] "
+                + "public record ToolApplicationSetCreateOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolApplicationSet.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolApplicationSet { "
+                + "public Task CreateAsync(ToolApplicationSetCreateOptions? options = null) => Task.CompletedTask; }");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+                Tool(Command("ToolCurrentOptions", "ToolOptions", ["current"])),
+                root);
+
+            var restored = preserved.Commands.Single(command => command.SubDomainGroup == "appset");
+            await Assert.That(restored.CommandGroupIdentifierOverride).IsEqualTo("ApplicationSet");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Retains_Optional_Facade_When_Required_Member_Is_Added()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2002,6 +2002,69 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Applies_Restored_Casing_To_Live_Siblings()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolGroupCloudShellOldOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"group\", \"cloud-shell\", \"old\")] "
+                + "public record ToolGroupCloudShellOldOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolGroupCloudshell.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolGroupCloudshell { "
+                + "public Task OldAsync(ToolGroupCloudShellOldOptions? options = null) => Task.CompletedTask; }");
+            var tool = Tool(Command(
+                "ToolGroupCloudShellCurrentOptions",
+                "ToolOptions",
+                ["group", "cloud-shell", "current"],
+                subDomainGroup: "Group",
+                commandGroupIdentifierOverride: "Group"));
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(tool, root);
+            var generated = (await new SubDomainClassGenerator().GenerateAsync(preserved))
+                .Single(file => file.RelativePath.EndsWith("ToolGroupCloudshell.Generated.cs", StringComparison.Ordinal));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(generated.Content).Contains("OldAsync(");
+                await Assert.That(generated.Content).Contains("ToolGroupCloudShellOldOptions? options = null");
+                await Assert.That(generated.Content).Contains("CurrentAsync(");
+                await Assert.That(generated.Content).Contains("ToolGroupCloudShellCurrentOptions? options = null");
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task CommandTreeNode_Rejects_Conflicting_Explicit_Identifiers()
+    {
+        var commands = new[]
+        {
+            Command("ToolGroupFirstOptions", "ToolOptions", ["group", "cloud-shell", "first"]) with
+            {
+                CommandPartIdentifierOverrides = new Dictionary<int, string> { [1] = "Cloudshell" },
+            },
+            Command("ToolGroupSecondOptions", "ToolOptions", ["group", "cloud-shell", "second"]) with
+            {
+                CommandPartIdentifierOverrides = new Dictionary<int, string> { [1] = "CloudShell" },
+            },
+        };
+
+        await Assert.That(() => CommandTreeNode.BuildTree("Tool", "Group", commands))
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("Cloudshell, CloudShell");
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Preserves_Live_Group_Casing_For_Restored_Sibling()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1824,6 +1824,56 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Uses_Root_Identifier_For_Restored_Nested_Facades()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolGroupChildOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"group\", \"child\")] "
+                + "public record ToolGroupChildOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolGroupNestedChildOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"group\", \"nested\", \"child\")] "
+                + "public record ToolGroupNestedChildOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolGroup.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolGroup { "
+                + "public Task ChildAsync(ToolGroupChildOptions? options = null) => Task.CompletedTask; }");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolGroupNested.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolGroupNested { "
+                + "public Task ChildAsync(ToolGroupNestedChildOptions? options = null) => Task.CompletedTask; }");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+                Tool(Command("ToolCurrentOptions", "ToolOptions", ["current"])),
+                root);
+
+            var restored = preserved.Commands
+                .Where(command => command.SubDomainGroup == "group")
+                .ToArray();
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored).Count().IsEqualTo(2);
+                await Assert.That(restored.Select(command => command.CommandGroupIdentifierOverride!))
+                    .IsEquivalentTo(["Group", "Group"]);
+                await Assert.That(GeneratorUtils.GetSubDomainIdentifier(preserved, "group"))
+                    .IsEqualTo("Group");
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Retains_Optional_Facade_When_Required_Member_Is_Added()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1955,6 +1955,53 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Merges_Compatible_Facade_Casing()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolGroupCloudShellNestedOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"group\", \"cloud-shell\", \"nested\")] "
+                + "public record ToolGroupCloudShellNestedOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolGroupCloudShellNestedChildOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"group\", \"cloud-shell\", \"nested\", \"child\")] "
+                + "public record ToolGroupCloudShellNestedChildOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolGroupCloudshell.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolGroupCloudshell { "
+                + "public Task NestedAsync(ToolGroupCloudShellNestedOptions? options = null) => Task.CompletedTask; }");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolGroupCloudshellNested.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolGroupCloudshellNested { "
+                + "public Task ExecuteAsync(ToolGroupCloudShellNestedOptions? options = null) => Task.CompletedTask; "
+                + "public Task ChildAsync(ToolGroupCloudShellNestedChildOptions? options = null) => Task.CompletedTask; }");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+                Tool(Command("ToolCurrentOptions", "ToolOptions", ["current"])),
+                root);
+
+            var restored = preserved.Commands.Single(command =>
+                command.ClassName == "ToolGroupCloudShellNestedOptions");
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored.CommandPartIdentifierOverrides[1]).IsEqualTo("Cloudshell");
+                await Assert.That(restored.CommandPartIdentifierOverrides[2]).IsEqualTo("Nested");
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Preserves_Live_Group_Casing_For_Restored_Sibling()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2045,6 +2045,81 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Applies_Restored_Parent_Casing_To_Live_Child()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolGroupCloudShellOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"group\", \"cloud-shell\")] "
+                + "public record ToolGroupCloudShellOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolGroupCloudshell.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolGroupCloudshell { "
+                + "public Task ExecuteAsync(ToolGroupCloudShellOptions? options = null) => Task.CompletedTask; }");
+            var tool = Tool(Command(
+                "ToolGroupCloudShellCurrentOptions",
+                "ToolOptions",
+                ["group", "cloud-shell", "current"],
+                subDomainGroup: "Group",
+                commandGroupIdentifierOverride: "Group"));
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(tool, root);
+            var generated = (await new SubDomainClassGenerator().GenerateAsync(preserved))
+                .Single(file => file.RelativePath.EndsWith("ToolGroupCloudshell.Generated.cs", StringComparison.Ordinal));
+
+            await Assert.That(generated.Content).Contains("ExecuteAsync(");
+            await Assert.That(generated.Content).Contains("ToolGroupCloudShellOptions? options = null");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Recovers_Length_Changing_Nested_Identifier()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolAdminUsersApplicationSetOldOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"admin\", \"users\", \"appset\", \"old\")] "
+                + "public record ToolAdminUsersApplicationSetOldOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolAdminUsersApplicationSet.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolAdminUsersApplicationSet { "
+                + "public Task OldAsync(ToolAdminUsersApplicationSetOldOptions? options = null) => Task.CompletedTask; }");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+                Tool(Command("ToolCurrentOptions", "ToolOptions", ["current"])),
+                root);
+
+            var restored = preserved.Commands.Single(command =>
+                command.ClassName == "ToolAdminUsersApplicationSetOldOptions");
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored.CommandPartIdentifierOverrides[1]).IsEqualTo("Users");
+                await Assert.That(restored.CommandPartIdentifierOverrides[2]).IsEqualTo("ApplicationSet");
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task CommandTreeNode_Rejects_Conflicting_Explicit_Identifiers()
     {
         var commands = new[]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1955,6 +1955,54 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Uses_One_Root_For_Removed_Parent_And_Child()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolGroupNestedOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"group\", \"nested\")] "
+                + "public record ToolGroupNestedOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolGroupNestedChildOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"group\", \"nested\", \"child\")] "
+                + "public record ToolGroupNestedChildOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolGroupNested.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolGroupNested { "
+                + "public Task ExecuteAsync(ToolGroupNestedOptions? options = null) => Task.CompletedTask; "
+                + "public Task ChildAsync(ToolGroupNestedChildOptions? options = null) => Task.CompletedTask; }");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+                Tool(Command("ToolCurrentOptions", "ToolOptions", ["current"])),
+                root);
+
+            var restored = preserved.Commands
+                .Where(command => command.ClassName != "ToolCurrentOptions")
+                .ToArray();
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored).Count().IsEqualTo(2);
+                await Assert.That(restored.Select(command => command.SubDomainGroup!))
+                    .IsEquivalentTo(["Group", "Group"]);
+                await Assert.That(restored.Select(command => command.CommandGroupIdentifierOverride!))
+                    .IsEquivalentTo(["Group", "Group"]);
+                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["Group"]);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Retains_Optional_Facade_When_Required_Member_Is_Added()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2158,6 +2158,47 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Infers_Root_Through_Historical_Intermediate_Casing()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolAlphaCloudShellOldOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"foo\", \"cloud-shell\", \"old\")] "
+                + "public record ToolAlphaCloudShellOldOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolAlphaCloudshell.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolAlphaCloudshell { "
+                + "public Task OldAsync(ToolAlphaCloudShellOldOptions? options = null) => Task.CompletedTask; }");
+            var tool = Tool(Command(
+                "ToolBetaCurrentOptions",
+                "ToolOptions",
+                ["foo", "beta"],
+                subDomainGroup: "beta-key",
+                commandGroupIdentifierOverride: "Beta"));
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(tool, root);
+
+            var restored = preserved.Commands.Single(command => command.ClassName == "ToolAlphaCloudShellOldOptions");
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored.SubDomainGroup).IsEqualTo("Alpha");
+                await Assert.That(restored.CommandGroupIdentifierOverride).IsEqualTo("Alpha");
+                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["beta-key", "Alpha"]);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Uses_One_Root_For_Removed_Parent_And_Child()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2117,6 +2117,47 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Restores_Missing_Group_Alongside_Other_Live_Group()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolAlphaOldOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"foo\", \"old\")] "
+                + "public record ToolAlphaOldOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolAlpha.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolAlpha { "
+                + "public Task OldAsync(ToolAlphaOldOptions? options = null) => Task.CompletedTask; }");
+            var tool = Tool(Command(
+                "ToolBetaCurrentOptions",
+                "ToolOptions",
+                ["foo", "beta"],
+                subDomainGroup: "beta-key",
+                commandGroupIdentifierOverride: "Beta"));
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(tool, root);
+
+            var restored = preserved.Commands.Single(command => command.ClassName == "ToolAlphaOldOptions");
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored.SubDomainGroup).IsEqualTo("Alpha");
+                await Assert.That(restored.CommandGroupIdentifierOverride).IsEqualTo("Alpha");
+                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["beta-key", "Alpha"]);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Uses_One_Root_For_Removed_Parent_And_Child()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1852,17 +1852,24 @@ public class GeneratorHardeningTests
                 + "public Task ChildAsync(ToolGroupNestedChildOptions? options = null) => Task.CompletedTask; }");
 
             var preserved = GeneratedApiCompatibilityPreserver.Preserve(
-                Tool(Command("ToolCurrentOptions", "ToolOptions", ["current"])),
+                Tool(Command(
+                    "ToolGroupCurrentOptions",
+                    "ToolOptions",
+                    ["group", "current"],
+                    subDomainGroup: "Group")),
                 root);
 
             var restored = preserved.Commands
-                .Where(command => command.SubDomainGroup == "group")
+                .Where(command => command.ClassName != "ToolGroupCurrentOptions")
                 .ToArray();
             using (Assert.Multiple())
             {
                 await Assert.That(restored).Count().IsEqualTo(2);
+                await Assert.That(restored.Select(command => command.SubDomainGroup!))
+                    .IsEquivalentTo(["Group", "Group"]);
                 await Assert.That(restored.Select(command => command.CommandGroupIdentifierOverride!))
                     .IsEquivalentTo(["Group", "Group"]);
+                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["Group"]);
                 await Assert.That(GeneratorUtils.GetSubDomainIdentifier(preserved, "group"))
                     .IsEqualTo("Group");
             }
@@ -1896,8 +1903,12 @@ public class GeneratorHardeningTests
                 Tool(Command("ToolCurrentOptions", "ToolOptions", ["current"])),
                 root);
 
-            var restored = preserved.Commands.Single(command => command.SubDomainGroup == "appset");
-            await Assert.That(restored.CommandGroupIdentifierOverride).IsEqualTo("ApplicationSet");
+            var restored = preserved.Commands.Single(command => command.SubDomainGroup == "ApplicationSet");
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored.CommandGroupIdentifierOverride).IsEqualTo("ApplicationSet");
+                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["ApplicationSet"]);
+            }
         }
         finally
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1856,7 +1856,8 @@ public class GeneratorHardeningTests
                     "ToolGroupCurrentOptions",
                     "ToolOptions",
                     ["group", "current"],
-                    subDomainGroup: "Group")),
+                    subDomainGroup: "group",
+                    commandGroupIdentifierOverride: "Group")),
                 root);
 
             var restored = preserved.Commands
@@ -1866,10 +1867,10 @@ public class GeneratorHardeningTests
             {
                 await Assert.That(restored).Count().IsEqualTo(2);
                 await Assert.That(restored.Select(command => command.SubDomainGroup!))
-                    .IsEquivalentTo(["Group", "Group"]);
+                    .IsEquivalentTo(["group", "group"]);
                 await Assert.That(restored.Select(command => command.CommandGroupIdentifierOverride!))
                     .IsEquivalentTo(["Group", "Group"]);
-                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["Group"]);
+                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["group"]);
                 await Assert.That(GeneratorUtils.GetSubDomainIdentifier(preserved, "group"))
                     .IsEqualTo("Group");
             }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1955,6 +1955,43 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Distinguishes_Literal_Execute_From_Parent_Facade()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolCloudShellExecuteOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"cloud-shell\", \"execute\")] "
+                + "public record ToolCloudShellExecuteOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolCloudshell.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolCloudshell { "
+                + "public Task ExecuteAsync(ToolCloudShellExecuteOptions? options = null) => Task.CompletedTask; }");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+                Tool(Command("ToolCurrentOptions", "ToolOptions", ["current"])),
+                root);
+
+            var restored = preserved.Commands.Single(command => command.ClassName == "ToolCloudShellExecuteOptions");
+            using (Assert.Multiple())
+            {
+                await Assert.That(restored.SubDomainGroup).IsEqualTo("Cloudshell");
+                await Assert.That(restored.CommandGroupIdentifierOverride).IsEqualTo("Cloudshell");
+                await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["Cloudshell"]);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Uses_One_Root_For_Removed_Parent_And_Child()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -120,7 +120,7 @@ internal static class GeneratedApiCompatibilityPreserver
         IReadOnlyList<GeneratedFacadeMethod> facadeMethods)
     {
         var commandParts = baseline.CommandParts!;
-        var groupIdentifier = GetRestoredCommandGroupIdentifier(tool, facadeMethods[0]);
+        var groupIdentifier = GetRestoredCommandGroupIdentifier(tool, baseline);
 
         return new CliCommandDefinition
         {
@@ -145,11 +145,37 @@ internal static class GeneratedApiCompatibilityPreserver
 
     private static string? GetRestoredCommandGroupIdentifier(
         CliToolDefinition tool,
-        GeneratedFacadeMethod facade) =>
-        facade.DeclaringType.Length > tool.NamespacePrefix.Length
-        && facade.DeclaringType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
-            ? facade.DeclaringType[tool.NamespacePrefix.Length..]
-            : null;
+        GeneratedApiBaseline baseline)
+    {
+        var rootCommand = baseline.CommandParts?[0];
+        if (rootCommand is null)
+        {
+            return null;
+        }
+
+        var defaultIdentifier = GeneratorUtils.ToPascalCase(rootCommand);
+        var currentIdentifiers = tool.Commands
+            .Where(command => command.CommandParts.Length > 0
+                              && command.CommandParts[0].Equals(
+                                  rootCommand,
+                                  StringComparison.OrdinalIgnoreCase))
+            .Select(command => command.CommandGroupIdentifierOverride ?? defaultIdentifier)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (currentIdentifiers.Length == 1)
+        {
+            return currentIdentifiers[0];
+        }
+
+        if (baseline.ClassName.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
+            && baseline.ClassName.AsSpan(tool.NamespacePrefix.Length)
+                .StartsWith(defaultIdentifier, StringComparison.OrdinalIgnoreCase))
+        {
+            return baseline.ClassName.Substring(tool.NamespacePrefix.Length, defaultIdentifier.Length);
+        }
+
+        return defaultIdentifier;
+    }
 
     private static CliOptionDefinition[] RestoreRemovedOptions(
         IEnumerable<GeneratedApiProperty> properties) =>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -220,15 +220,19 @@ internal static class GeneratedApiCompatibilityPreserver
         IReadOnlyList<string> commandParts,
         GeneratedFacadeMethod facadeMethod)
     {
-        var facadeCommandParts = facadeMethod.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)
-            ? commandParts.Skip(1)
-            : commandParts.Skip(1).SkipLast(1);
-        var facadeSuffix = string.Concat(facadeCommandParts.Select(GeneratorUtils.ToPascalCase));
         var implementationType = facadeMethod.DeclaringType.StartsWith(
             $"I{tool.NamespacePrefix}",
             StringComparison.Ordinal)
             ? facadeMethod.DeclaringType[1..]
             : facadeMethod.DeclaringType;
+        var commandTail = commandParts.Skip(1).ToArray();
+        var commandTailSuffix = string.Concat(commandTail.Select(GeneratorUtils.ToPascalCase));
+        var isParentExecuteFacade = facadeMethod.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)
+                                    && implementationType.EndsWith(commandTailSuffix, StringComparison.Ordinal)
+                                    && implementationType.Length
+                                    > tool.NamespacePrefix.Length + commandTailSuffix.Length;
+        var facadeCommandParts = isParentExecuteFacade ? commandTail : commandTail.SkipLast(1);
+        var facadeSuffix = string.Concat(facadeCommandParts.Select(GeneratorUtils.ToPascalCase));
         if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
             || !implementationType.EndsWith(facadeSuffix, StringComparison.Ordinal)
             || implementationType.Length <= tool.NamespacePrefix.Length + facadeSuffix.Length)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -157,11 +157,20 @@ internal static class GeneratedApiCompatibilityPreserver
                                   rootCommand,
                                   StringComparison.OrdinalIgnoreCase))
             .Select(command => command.SubDomainGroup)
-            .Where(static group => group is not null)
+            .OfType<string>()
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        return currentGroups.Length == 1 ? currentGroups[0] : fallbackIdentifier;
+        if (currentGroups.Length == 1)
+        {
+            return currentGroups[0];
+        }
+
+        var matchingGroups = currentGroups
+            .Where(group => GeneratorUtils.GetSubDomainIdentifier(tool, group)
+                .Equals(fallbackIdentifier, StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        return matchingGroups.Length == 1 ? matchingGroups[0] : fallbackIdentifier;
     }
 
     private static string? GetRestoredCommandGroupIdentifier(
@@ -226,11 +235,13 @@ internal static class GeneratedApiCompatibilityPreserver
             ? facadeMethod.DeclaringType[1..]
             : facadeMethod.DeclaringType;
         var commandTail = commandParts.Skip(1).ToArray();
-        var commandTailSuffix = string.Concat(commandTail.Select(GeneratorUtils.ToPascalCase));
+        var optionsImplementationType = facadeMethod.OptionsType.EndsWith("Options", StringComparison.Ordinal)
+            ? facadeMethod.OptionsType[..^"Options".Length]
+            : facadeMethod.OptionsType;
         var isParentExecuteFacade = facadeMethod.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)
-                                    && implementationType.EndsWith(commandTailSuffix, StringComparison.Ordinal)
-                                    && implementationType.Length
-                                    > tool.NamespacePrefix.Length + commandTailSuffix.Length;
+                                    && implementationType.Equals(
+                                        optionsImplementationType,
+                                        StringComparison.OrdinalIgnoreCase);
         var facadeCommandParts = isParentExecuteFacade ? commandTail : commandTail.SkipLast(1);
         var facadeSuffix = string.Concat(facadeCommandParts.Select(GeneratorUtils.ToPascalCase));
         if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -235,17 +235,19 @@ internal static class GeneratedApiCompatibilityPreserver
         var commandTail = commandParts.Skip(1).ToArray();
         var isParentExecuteFacade = IsParentExecuteFacade(implementationType, facadeMethod);
         var facadeCommandParts = isParentExecuteFacade ? commandTail : commandTail.SkipLast(1);
-        var facadeSuffix = string.Concat(facadeCommandParts.Select(GeneratorUtils.ToPascalCase));
-        if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
-            || !implementationType.EndsWith(facadeSuffix, StringComparison.OrdinalIgnoreCase)
-            || implementationType.Length <= tool.NamespacePrefix.Length + facadeSuffix.Length)
+        if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal))
         {
             return null;
         }
 
-        return implementationType.Substring(
-            tool.NamespacePrefix.Length,
-            implementationType.Length - tool.NamespacePrefix.Length - facadeSuffix.Length);
+        var defaultIdentifiers = commandParts
+            .Take(1)
+            .Concat(facadeCommandParts)
+            .Select(GeneratorUtils.ToPascalCase)
+            .ToArray();
+        return SplitRecoveredIdentifiers(
+            implementationType[tool.NamespacePrefix.Length..],
+            defaultIdentifiers)?[0];
     }
 
     private static IReadOnlyDictionary<int, string> GetRestoredCommandPartIdentifierOverrides(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -210,17 +210,18 @@ internal static class GeneratedApiCompatibilityPreserver
             return currentIdentifiers[0];
         }
 
-        var commandSuffix = string.Concat(
-            baseline.CommandParts!
-                .Skip(1)
-                .Select(GeneratorUtils.ToPascalCase)) + "Options";
         if (baseline.ClassName.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
-            && baseline.ClassName.EndsWith(commandSuffix, StringComparison.Ordinal)
-            && baseline.ClassName.Length > tool.NamespacePrefix.Length + commandSuffix.Length)
+            && baseline.ClassName.EndsWith("Options", StringComparison.Ordinal))
         {
-            return baseline.ClassName.Substring(
-                tool.NamespacePrefix.Length,
-                baseline.ClassName.Length - tool.NamespacePrefix.Length - commandSuffix.Length);
+            var recoveredIdentifiers = SplitRecoveredIdentifiers(
+                baseline.ClassName[tool.NamespacePrefix.Length..^"Options".Length],
+                baseline.CommandParts!
+                    .Select(GeneratorUtils.ToPascalCase)
+                    .ToArray());
+            if (recoveredIdentifiers is not null)
+            {
+                return recoveredIdentifiers[0];
+            }
         }
 
         return defaultIdentifier;

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -167,11 +167,17 @@ internal static class GeneratedApiCompatibilityPreserver
             return currentIdentifiers[0];
         }
 
+        var commandSuffix = string.Concat(
+            baseline.CommandParts!
+                .Skip(1)
+                .Select(GeneratorUtils.ToPascalCase)) + "Options";
         if (baseline.ClassName.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
-            && baseline.ClassName.AsSpan(tool.NamespacePrefix.Length)
-                .StartsWith(defaultIdentifier, StringComparison.OrdinalIgnoreCase))
+            && baseline.ClassName.EndsWith(commandSuffix, StringComparison.Ordinal)
+            && baseline.ClassName.Length > tool.NamespacePrefix.Length + commandSuffix.Length)
         {
-            return baseline.ClassName.Substring(tool.NamespacePrefix.Length, defaultIdentifier.Length);
+            return baseline.ClassName.Substring(
+                tool.NamespacePrefix.Length,
+                baseline.ClassName.Length - tool.NamespacePrefix.Length - commandSuffix.Length);
         }
 
         return defaultIdentifier;

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -262,44 +262,14 @@ internal static class GeneratedApiCompatibilityPreserver
         Dictionary<int, string>? recoveredOverrides = null;
         foreach (var facadeMethod in facadeMethods)
         {
-            var implementationType = GetFacadeImplementationType(tool, facadeMethod);
-            var isParentExecuteFacade = IsParentExecuteFacade(implementationType, facadeMethod);
-            var facadePartCount = commandParts.Count - (isParentExecuteFacade ? 1 : 2);
-            if (facadePartCount <= 0)
+            var candidate = GetRecoveredCommandPartIdentifierOverrides(
+                tool,
+                commandParts,
+                groupIdentifier,
+                facadeMethod);
+            if (candidate is null)
             {
                 continue;
-            }
-
-            var identifiers = commandParts
-                .Skip(1)
-                .Take(facadePartCount)
-                .Select(GeneratorUtils.ToPascalCase)
-                .ToArray();
-            var suffixLength = identifiers.Sum(static identifier => identifier.Length);
-            if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
-                || implementationType.Length <= tool.NamespacePrefix.Length + suffixLength
-                || !implementationType.EndsWith(
-                    string.Concat(identifiers),
-                    StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            var suffixStart = implementationType.Length - suffixLength;
-            var recoveredGroup = implementationType.Substring(
-                tool.NamespacePrefix.Length,
-                suffixStart - tool.NamespacePrefix.Length);
-            if (!recoveredGroup.Equals(groupIdentifier, StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            var candidate = new Dictionary<int, string>();
-            var offset = suffixStart;
-            for (var index = 0; index < identifiers.Length; index++)
-            {
-                candidate[index + 1] = implementationType.Substring(offset, identifiers[index].Length);
-                offset += identifiers[index].Length;
             }
 
             if (recoveredOverrides is not null
@@ -313,6 +283,55 @@ internal static class GeneratedApiCompatibilityPreserver
         }
 
         return recoveredOverrides ?? new Dictionary<int, string>();
+    }
+
+    private static Dictionary<int, string>? GetRecoveredCommandPartIdentifierOverrides(
+        CliToolDefinition tool,
+        IReadOnlyList<string> commandParts,
+        string groupIdentifier,
+        GeneratedFacadeMethod facadeMethod)
+    {
+        var implementationType = GetFacadeImplementationType(tool, facadeMethod);
+        var isParentExecuteFacade = IsParentExecuteFacade(implementationType, facadeMethod);
+        var facadePartCount = commandParts.Count - (isParentExecuteFacade ? 1 : 2);
+        if (facadePartCount <= 0)
+        {
+            return null;
+        }
+
+        var identifiers = commandParts
+            .Skip(1)
+            .Take(facadePartCount)
+            .Select(GeneratorUtils.ToPascalCase)
+            .ToArray();
+        var suffixLength = identifiers.Sum(static identifier => identifier.Length);
+        if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
+            || implementationType.Length <= tool.NamespacePrefix.Length + suffixLength
+            || !implementationType.EndsWith(
+                string.Concat(identifiers),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var suffixStart = implementationType.Length - suffixLength;
+        var recoveredGroup = implementationType.Substring(
+            tool.NamespacePrefix.Length,
+            suffixStart - tool.NamespacePrefix.Length);
+        if (!recoveredGroup.Equals(groupIdentifier, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var recoveredOverrides = new Dictionary<int, string>();
+        var offset = suffixStart;
+        for (var index = 0; index < identifiers.Length; index++)
+        {
+            recoveredOverrides[index + 1] = implementationType.Substring(offset, identifiers[index].Length);
+            offset += identifiers[index].Length;
+        }
+
+        return recoveredOverrides;
     }
 
     private static string GetFacadeImplementationType(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -189,13 +189,8 @@ internal static class GeneratedApiCompatibilityPreserver
             return currentIdentifiers[0];
         }
 
-        var facadeSuffix = string.Concat(
-            baseline.CommandParts!
-                .Skip(1)
-                .SkipLast(1)
-                .Select(GeneratorUtils.ToPascalCase));
         var facadeIdentifiers = facadeMethods
-            .Select(method => GetRootIdentifierFromFacade(tool, method.DeclaringType, facadeSuffix))
+            .Select(method => GetRootIdentifierFromFacade(tool, baseline.CommandParts!, method))
             .Where(static identifier => identifier is not null)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
@@ -222,12 +217,18 @@ internal static class GeneratedApiCompatibilityPreserver
 
     private static string? GetRootIdentifierFromFacade(
         CliToolDefinition tool,
-        string declaringType,
-        string facadeSuffix)
+        IReadOnlyList<string> commandParts,
+        GeneratedFacadeMethod facadeMethod)
     {
-        var implementationType = declaringType.StartsWith($"I{tool.NamespacePrefix}", StringComparison.Ordinal)
-            ? declaringType[1..]
-            : declaringType;
+        var facadeCommandParts = facadeMethod.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)
+            ? commandParts.Skip(1)
+            : commandParts.Skip(1).SkipLast(1);
+        var facadeSuffix = string.Concat(facadeCommandParts.Select(GeneratorUtils.ToPascalCase));
+        var implementationType = facadeMethod.DeclaringType.StartsWith(
+            $"I{tool.NamespacePrefix}",
+            StringComparison.Ordinal)
+            ? facadeMethod.DeclaringType[1..]
+            : facadeMethod.DeclaringType;
         if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
             || !implementationType.EndsWith(facadeSuffix, StringComparison.Ordinal)
             || implementationType.Length <= tool.NamespacePrefix.Length + facadeSuffix.Length)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -121,6 +121,9 @@ internal static class GeneratedApiCompatibilityPreserver
     {
         var commandParts = baseline.CommandParts!;
         var groupIdentifier = GetRestoredCommandGroupIdentifier(tool, baseline, facadeMethods);
+        var subDomainGroup = commandParts.Length > 1
+            ? GetRestoredSubDomainGroup(tool, commandParts[0], groupIdentifier)
+            : null;
 
         return new CliCommandDefinition
         {
@@ -133,7 +136,7 @@ internal static class GeneratedApiCompatibilityPreserver
             PositionalArguments = RestoreRemovedPositionalArguments(baseline.Properties),
             CompatibilityProperties = RestoreRemovedCompatibilityProperties(baseline.Properties),
             CompatibilityConstructors = baseline.Constructors,
-            SubDomainGroup = commandParts.Length > 1 ? groupIdentifier : null,
+            SubDomainGroup = subDomainGroup,
             CommandGroupIdentifierOverride = commandParts.Length > 1 ? groupIdentifier : null,
             PreserveExecuteFacade = facadeMethods.Any(static method =>
                 method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)),
@@ -141,6 +144,24 @@ internal static class GeneratedApiCompatibilityPreserver
                 !method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)),
             PreserveOptionalOptionsParameter = facadeMethods.Any(static method => method.IsOptionsOptional),
         };
+    }
+
+    private static string? GetRestoredSubDomainGroup(
+        CliToolDefinition tool,
+        string rootCommand,
+        string? fallbackIdentifier)
+    {
+        var currentGroups = tool.Commands
+            .Where(command => command.CommandParts.Length > 0
+                              && command.CommandParts[0].Equals(
+                                  rootCommand,
+                                  StringComparison.OrdinalIgnoreCase))
+            .Select(command => command.SubDomainGroup)
+            .Where(static group => group is not null)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return currentGroups.Length == 1 ? currentGroups[0] : fallbackIdentifier;
     }
 
     private static string? GetRestoredCommandGroupIdentifier(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -120,7 +120,7 @@ internal static class GeneratedApiCompatibilityPreserver
         IReadOnlyList<GeneratedFacadeMethod> facadeMethods)
     {
         var commandParts = baseline.CommandParts!;
-        var groupIdentifier = GetRestoredCommandGroupIdentifier(tool, baseline);
+        var groupIdentifier = GetRestoredCommandGroupIdentifier(tool, baseline, facadeMethods);
 
         return new CliCommandDefinition
         {
@@ -145,7 +145,8 @@ internal static class GeneratedApiCompatibilityPreserver
 
     private static string? GetRestoredCommandGroupIdentifier(
         CliToolDefinition tool,
-        GeneratedApiBaseline baseline)
+        GeneratedApiBaseline baseline,
+        IReadOnlyList<GeneratedFacadeMethod> facadeMethods)
     {
         var rootCommand = baseline.CommandParts?[0];
         if (rootCommand is null)
@@ -167,6 +168,21 @@ internal static class GeneratedApiCompatibilityPreserver
             return currentIdentifiers[0];
         }
 
+        var facadeSuffix = string.Concat(
+            baseline.CommandParts!
+                .Skip(1)
+                .SkipLast(1)
+                .Select(GeneratorUtils.ToPascalCase));
+        var facadeIdentifiers = facadeMethods
+            .Select(method => GetRootIdentifierFromFacade(tool, method.DeclaringType, facadeSuffix))
+            .Where(static identifier => identifier is not null)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (facadeIdentifiers.Length == 1)
+        {
+            return facadeIdentifiers[0];
+        }
+
         var commandSuffix = string.Concat(
             baseline.CommandParts!
                 .Skip(1)
@@ -181,6 +197,26 @@ internal static class GeneratedApiCompatibilityPreserver
         }
 
         return defaultIdentifier;
+    }
+
+    private static string? GetRootIdentifierFromFacade(
+        CliToolDefinition tool,
+        string declaringType,
+        string facadeSuffix)
+    {
+        var implementationType = declaringType.StartsWith($"I{tool.NamespacePrefix}", StringComparison.Ordinal)
+            ? declaringType[1..]
+            : declaringType;
+        if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
+            || !implementationType.EndsWith(facadeSuffix, StringComparison.Ordinal)
+            || implementationType.Length <= tool.NamespacePrefix.Length + facadeSuffix.Length)
+        {
+            return null;
+        }
+
+        return implementationType.Substring(
+            tool.NamespacePrefix.Length,
+            implementationType.Length - tool.NamespacePrefix.Length - facadeSuffix.Length);
     }
 
     private static CliOptionDefinition[] RestoreRemovedOptions(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -307,34 +307,80 @@ internal static class GeneratedApiCompatibilityPreserver
             .Take(facadePartCount)
             .Select(GeneratorUtils.ToPascalCase)
             .ToArray();
-        var suffixLength = identifiers.Sum(static identifier => identifier.Length);
-        if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
-            || implementationType.Length <= tool.NamespacePrefix.Length + suffixLength
-            || !implementationType.EndsWith(
-                string.Concat(identifiers),
-                StringComparison.OrdinalIgnoreCase))
+        if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal))
         {
             return null;
         }
 
-        var suffixStart = implementationType.Length - suffixLength;
-        var recoveredGroup = implementationType.Substring(
-            tool.NamespacePrefix.Length,
-            suffixStart - tool.NamespacePrefix.Length);
-        if (!recoveredGroup.Equals(groupIdentifier, StringComparison.OrdinalIgnoreCase))
+        var implementationSuffix = implementationType[tool.NamespacePrefix.Length..];
+        if (!implementationSuffix.StartsWith(groupIdentifier, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var recoveredIdentifiers = SplitRecoveredIdentifiers(
+            implementationSuffix[groupIdentifier.Length..],
+            identifiers);
+        if (recoveredIdentifiers is null)
         {
             return null;
         }
 
         var recoveredOverrides = new Dictionary<int, string>();
-        var offset = suffixStart;
-        for (var index = 0; index < identifiers.Length; index++)
+        for (var index = 0; index < recoveredIdentifiers.Length; index++)
         {
-            recoveredOverrides[index + 1] = implementationType.Substring(offset, identifiers[index].Length);
-            offset += identifiers[index].Length;
+            recoveredOverrides[index + 1] = recoveredIdentifiers[index];
         }
 
         return recoveredOverrides;
+    }
+
+    private static string[]? SplitRecoveredIdentifiers(
+        string recoveredSuffix,
+        IReadOnlyList<string> defaultIdentifiers)
+    {
+        if (recoveredSuffix.Length < defaultIdentifiers.Count)
+        {
+            return null;
+        }
+
+        var candidates = new Dictionary<int, (int Cost, string[] Identifiers, bool IsUnique)>
+        {
+            [0] = (0, [], true),
+        };
+        for (var partIndex = 0; partIndex < defaultIdentifiers.Count; partIndex++)
+        {
+            var nextCandidates = new Dictionary<int, (int Cost, string[] Identifiers, bool IsUnique)>();
+            var remainingPartCount = defaultIdentifiers.Count - partIndex - 1;
+            foreach (var (offset, candidate) in candidates)
+            {
+                for (var end = offset + 1; end <= recoveredSuffix.Length - remainingPartCount; end++)
+                {
+                    var identifier = recoveredSuffix[offset..end];
+                    var cost = candidate.Cost
+                               + (identifier.Equals(
+                                   defaultIdentifiers[partIndex],
+                                   StringComparison.OrdinalIgnoreCase)
+                                   ? 0
+                                   : 1);
+                    var identifiers = candidate.Identifiers.Append(identifier).ToArray();
+                    if (!nextCandidates.TryGetValue(end, out var current) || cost < current.Cost)
+                    {
+                        nextCandidates[end] = (cost, identifiers, candidate.IsUnique);
+                    }
+                    else if (cost == current.Cost)
+                    {
+                        nextCandidates[end] = (cost, current.Identifiers, false);
+                    }
+                }
+            }
+
+            candidates = nextCandidates;
+        }
+
+        return candidates.TryGetValue(recoveredSuffix.Length, out var result) && result.IsUnique
+            ? result.Identifiers
+            : null;
     }
 
     private static string GetFacadeImplementationType(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -272,14 +272,17 @@ internal static class GeneratedApiCompatibilityPreserver
                 continue;
             }
 
-            if (recoveredOverrides is not null
-                && !recoveredOverrides.OrderBy(static pair => pair.Key)
-                    .SequenceEqual(candidate.OrderBy(static pair => pair.Key)))
+            recoveredOverrides ??= new Dictionary<int, string>();
+            foreach (var (partIndex, identifier) in candidate)
             {
-                return new Dictionary<int, string>();
-            }
+                if (recoveredOverrides.TryGetValue(partIndex, out var recoveredIdentifier)
+                    && !recoveredIdentifier.Equals(identifier, StringComparison.Ordinal))
+                {
+                    return new Dictionary<int, string>();
+                }
 
-            recoveredOverrides = candidate;
+                recoveredOverrides[partIndex] = identifier;
+            }
         }
 
         return recoveredOverrides ?? new Dictionary<int, string>();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -190,7 +190,9 @@ internal static class GeneratedApiCompatibilityPreserver
                               && command.CommandParts[0].Equals(
                                   rootCommand,
                                   StringComparison.OrdinalIgnoreCase))
-            .Select(command => command.CommandGroupIdentifierOverride ?? defaultIdentifier)
+            .Select(command => command.SubDomainGroup is { } group
+                ? GeneratorUtils.GetSubDomainIdentifier(tool, group)
+                : command.CommandGroupIdentifierOverride ?? defaultIdentifier)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
         if (currentIdentifiers.Length == 1)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -138,6 +138,11 @@ internal static class GeneratedApiCompatibilityPreserver
             CompatibilityConstructors = baseline.Constructors,
             SubDomainGroup = subDomainGroup,
             CommandGroupIdentifierOverride = commandParts.Length > 1 ? groupIdentifier : null,
+            CommandPartIdentifierOverrides = GetRestoredCommandPartIdentifierOverrides(
+                tool,
+                commandParts,
+                groupIdentifier,
+                facadeMethods),
             PreserveExecuteFacade = facadeMethods.Any(static method =>
                 method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)),
             PreserveNamedFacade = facadeMethods.Any(static method =>
@@ -226,23 +231,13 @@ internal static class GeneratedApiCompatibilityPreserver
         IReadOnlyList<string> commandParts,
         GeneratedFacadeMethod facadeMethod)
     {
-        var implementationType = facadeMethod.DeclaringType.StartsWith(
-            $"I{tool.NamespacePrefix}",
-            StringComparison.Ordinal)
-            ? facadeMethod.DeclaringType[1..]
-            : facadeMethod.DeclaringType;
+        var implementationType = GetFacadeImplementationType(tool, facadeMethod);
         var commandTail = commandParts.Skip(1).ToArray();
-        var optionsImplementationType = facadeMethod.OptionsType.EndsWith("Options", StringComparison.Ordinal)
-            ? facadeMethod.OptionsType[..^"Options".Length]
-            : facadeMethod.OptionsType;
-        var isParentExecuteFacade = facadeMethod.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)
-                                    && implementationType.Equals(
-                                        optionsImplementationType,
-                                        StringComparison.OrdinalIgnoreCase);
+        var isParentExecuteFacade = IsParentExecuteFacade(implementationType, facadeMethod);
         var facadeCommandParts = isParentExecuteFacade ? commandTail : commandTail.SkipLast(1);
         var facadeSuffix = string.Concat(facadeCommandParts.Select(GeneratorUtils.ToPascalCase));
         if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
-            || !implementationType.EndsWith(facadeSuffix, StringComparison.Ordinal)
+            || !implementationType.EndsWith(facadeSuffix, StringComparison.OrdinalIgnoreCase)
             || implementationType.Length <= tool.NamespacePrefix.Length + facadeSuffix.Length)
         {
             return null;
@@ -251,6 +246,91 @@ internal static class GeneratedApiCompatibilityPreserver
         return implementationType.Substring(
             tool.NamespacePrefix.Length,
             implementationType.Length - tool.NamespacePrefix.Length - facadeSuffix.Length);
+    }
+
+    private static IReadOnlyDictionary<int, string> GetRestoredCommandPartIdentifierOverrides(
+        CliToolDefinition tool,
+        IReadOnlyList<string> commandParts,
+        string? groupIdentifier,
+        IReadOnlyList<GeneratedFacadeMethod> facadeMethods)
+    {
+        if (groupIdentifier is null)
+        {
+            return new Dictionary<int, string>();
+        }
+
+        Dictionary<int, string>? recoveredOverrides = null;
+        foreach (var facadeMethod in facadeMethods)
+        {
+            var implementationType = GetFacadeImplementationType(tool, facadeMethod);
+            var isParentExecuteFacade = IsParentExecuteFacade(implementationType, facadeMethod);
+            var facadePartCount = commandParts.Count - (isParentExecuteFacade ? 1 : 2);
+            if (facadePartCount <= 0)
+            {
+                continue;
+            }
+
+            var identifiers = commandParts
+                .Skip(1)
+                .Take(facadePartCount)
+                .Select(GeneratorUtils.ToPascalCase)
+                .ToArray();
+            var suffixLength = identifiers.Sum(static identifier => identifier.Length);
+            if (!implementationType.StartsWith(tool.NamespacePrefix, StringComparison.Ordinal)
+                || implementationType.Length <= tool.NamespacePrefix.Length + suffixLength
+                || !implementationType.EndsWith(
+                    string.Concat(identifiers),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var suffixStart = implementationType.Length - suffixLength;
+            var recoveredGroup = implementationType.Substring(
+                tool.NamespacePrefix.Length,
+                suffixStart - tool.NamespacePrefix.Length);
+            if (!recoveredGroup.Equals(groupIdentifier, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var candidate = new Dictionary<int, string>();
+            var offset = suffixStart;
+            for (var index = 0; index < identifiers.Length; index++)
+            {
+                candidate[index + 1] = implementationType.Substring(offset, identifiers[index].Length);
+                offset += identifiers[index].Length;
+            }
+
+            if (recoveredOverrides is not null
+                && !recoveredOverrides.OrderBy(static pair => pair.Key)
+                    .SequenceEqual(candidate.OrderBy(static pair => pair.Key)))
+            {
+                return new Dictionary<int, string>();
+            }
+
+            recoveredOverrides = candidate;
+        }
+
+        return recoveredOverrides ?? new Dictionary<int, string>();
+    }
+
+    private static string GetFacadeImplementationType(
+        CliToolDefinition tool,
+        GeneratedFacadeMethod facadeMethod) =>
+        facadeMethod.DeclaringType.StartsWith($"I{tool.NamespacePrefix}", StringComparison.Ordinal)
+            ? facadeMethod.DeclaringType[1..]
+            : facadeMethod.DeclaringType;
+
+    private static bool IsParentExecuteFacade(
+        string implementationType,
+        GeneratedFacadeMethod facadeMethod)
+    {
+        var optionsImplementationType = facadeMethod.OptionsType.EndsWith("Options", StringComparison.Ordinal)
+            ? facadeMethod.OptionsType[..^"Options".Length]
+            : facadeMethod.OptionsType;
+        return facadeMethod.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)
+               && implementationType.Equals(optionsImplementationType, StringComparison.OrdinalIgnoreCase);
     }
 
     private static CliOptionDefinition[] RestoreRemovedOptions(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -161,11 +161,6 @@ internal static class GeneratedApiCompatibilityPreserver
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        if (currentGroups.Length == 1)
-        {
-            return currentGroups[0];
-        }
-
         var matchingGroups = currentGroups
             .Where(group => GeneratorUtils.GetSubDomainIdentifier(tool, group)
                 .Equals(fallbackIdentifier, StringComparison.OrdinalIgnoreCase))
@@ -185,6 +180,16 @@ internal static class GeneratedApiCompatibilityPreserver
         }
 
         var defaultIdentifier = GeneratorUtils.ToPascalCase(rootCommand);
+        var facadeIdentifiers = facadeMethods
+            .Select(method => GetRootIdentifierFromFacade(tool, baseline.CommandParts!, method))
+            .Where(static identifier => identifier is not null)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (facadeIdentifiers.Length == 1)
+        {
+            return facadeIdentifiers[0];
+        }
+
         var currentIdentifiers = tool.Commands
             .Where(command => command.CommandParts.Length > 0
                               && command.CommandParts[0].Equals(
@@ -198,16 +203,6 @@ internal static class GeneratedApiCompatibilityPreserver
         if (currentIdentifiers.Length == 1)
         {
             return currentIdentifiers[0];
-        }
-
-        var facadeIdentifiers = facadeMethods
-            .Select(method => GetRootIdentifierFromFacade(tool, baseline.CommandParts!, method))
-            .Where(static identifier => identifier is not null)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-        if (facadeIdentifiers.Length == 1)
-        {
-            return facadeIdentifiers[0];
         }
 
         var commandSuffix = string.Concat(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -133,7 +133,7 @@ internal static class GeneratedApiCompatibilityPreserver
             PositionalArguments = RestoreRemovedPositionalArguments(baseline.Properties),
             CompatibilityProperties = RestoreRemovedCompatibilityProperties(baseline.Properties),
             CompatibilityConstructors = baseline.Constructors,
-            SubDomainGroup = commandParts.Length > 1 ? commandParts[0] : null,
+            SubDomainGroup = commandParts.Length > 1 ? groupIdentifier : null,
             CommandGroupIdentifierOverride = commandParts.Length > 1 ? groupIdentifier : null,
             PreserveExecuteFacade = facadeMethods.Any(static method =>
                 method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -88,6 +88,13 @@ public record CliCommandDefinition
     public string? CommandGroupIdentifierOverride { get; init; }
 
     /// <summary>
+    /// Optional generated identifiers for nested command parts, keyed by their zero-based
+    /// position in <see cref="CommandParts"/>. Used to retain historical facade casing.
+    /// </summary>
+    public IReadOnlyDictionary<int, string> CommandPartIdentifierOverrides { get; init; }
+        = new Dictionary<int, string>();
+
+    /// <summary>
     /// Enums that need to be generated for this command's options.
     /// </summary>
     public IReadOnlyList<CliEnumDefinition> Enums { get; init; } = [];

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
@@ -66,38 +66,46 @@ public class CommandTreeNode
             Depth = 0
         };
 
-        foreach (var command in commands)
-        {
-            InsertCommand(root, command, toolPrefix, 1);
-        }
+        PopulateNode(root, commands, 1);
 
         return root;
     }
 
-    private static void InsertCommand(CommandTreeNode node, CliCommandDefinition command, string toolPrefix, int partIndex)
+    private static void PopulateNode(
+        CommandTreeNode node,
+        IReadOnlyList<CliCommandDefinition> commands,
+        int partIndex)
     {
-        // CommandParts are the parts after the tool name
-        // e.g., for "gcloud workspace-add-ons deployments create", parts are ["workspace-add-ons", "deployments", "create"]
-        var parts = command.CommandParts;
-
-        // If we're at the last part, this command belongs to the CURRENT node (not a child)
-        // The method name will be the last segment
-        if (partIndex >= parts.Length - 1)
+        foreach (var command in commands.Where(command => partIndex >= command.CommandParts.Length - 1))
         {
-            // We're at the parent of the leaf command
             node.Commands.Add(command);
-            return;
         }
 
-        // Create child nodes for intermediate segments
-        var segment = parts[partIndex];
-        var pascalSegment = command.CommandPartIdentifierOverrides.TryGetValue(partIndex, out var identifierOverride)
-            ? identifierOverride
-            : ToPascalCase(segment);
-
-        if (!node.Children.TryGetValue(segment, out var child))
+        var childCommandGroups = commands
+            .Where(command => partIndex < command.CommandParts.Length - 1)
+            .GroupBy(command => command.CommandParts[partIndex], StringComparer.OrdinalIgnoreCase);
+        foreach (var childCommandGroup in childCommandGroups)
         {
-            child = new CommandTreeNode
+            var segment = childCommandGroup.Key;
+            var childCommands = childCommandGroup.ToArray();
+            var identifierOverrides = childCommands
+                .Select(command => command.CommandPartIdentifierOverrides.TryGetValue(
+                    partIndex,
+                    out var identifierOverride)
+                        ? identifierOverride
+                        : null)
+                .OfType<string>()
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            if (identifierOverrides.Length > 1)
+            {
+                throw new InvalidOperationException(
+                    $"Command part '{segment}' has conflicting generated identifiers: "
+                    + $"{string.Join(", ", identifierOverrides)}.");
+            }
+
+            var pascalSegment = identifierOverrides.SingleOrDefault() ?? ToPascalCase(segment);
+            var child = new CommandTreeNode
             {
                 Segment = segment,
                 PascalSegment = pascalSegment,
@@ -105,15 +113,8 @@ public class CommandTreeNode
                 Depth = partIndex
             };
             node.Children[segment] = child;
+            PopulateNode(child, childCommands, partIndex + 1);
         }
-        else if (!child.PascalSegment.Equals(pascalSegment, StringComparison.Ordinal))
-        {
-            throw new InvalidOperationException(
-                $"Command part '{segment}' has conflicting generated identifiers: "
-                + $"{child.PascalSegment}, {pascalSegment}.");
-        }
-
-        InsertCommand(child, command, toolPrefix, partIndex + 1);
     }
 
     private static string ToPascalCase(string input) => GeneratorUtils.ToPascalCase(input);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
@@ -91,7 +91,9 @@ public class CommandTreeNode
 
         // Create child nodes for intermediate segments
         var segment = parts[partIndex];
-        var pascalSegment = ToPascalCase(segment);
+        var pascalSegment = command.CommandPartIdentifierOverrides.TryGetValue(partIndex, out var identifierOverride)
+            ? identifierOverride
+            : ToPascalCase(segment);
 
         if (!node.Children.TryGetValue(segment, out var child))
         {
@@ -103,6 +105,12 @@ public class CommandTreeNode
                 Depth = partIndex
             };
             node.Children[segment] = child;
+        }
+        else if (!child.PascalSegment.Equals(pascalSegment, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Command part '{segment}' has conflicting generated identifiers: "
+                + $"{child.PascalSegment}, {pascalSegment}.");
         }
 
         InsertCommand(child, command, toolPrefix, partIndex + 1);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
@@ -88,7 +88,11 @@ public class CommandTreeNode
         {
             var segment = childCommandGroup.Key;
             var childCommands = childCommandGroup.ToArray();
-            var identifierOverrides = childCommands
+            var identifierOverrides = commands
+                .Where(command => partIndex < command.CommandParts.Length
+                                  && command.CommandParts[partIndex].Equals(
+                                      segment,
+                                      StringComparison.OrdinalIgnoreCase))
                 .Select(command => command.CommandPartIdentifierOverrides.TryGetValue(
                     partIndex,
                     out var identifierOverride)


### PR DESCRIPTION
## Summary
- keep restored nested command facades on their root sub-domain identifier
- preserve current explicit identifiers and baseline root casing
- prevent Terraform `stacks` restoration from producing conflicting `Stacks`, `StacksConfiguration`, `StacksDeploymentGroup`, and `StacksDeploymentRun` identifiers
- add a nested-facade restoration regression

## Validation
- focused regression: 1/1 passed
- full OptionsGenerator tests: 987/987 passed with coverage
- OptionsGenerator Release build: 0 warnings, 0 errors
- diff check clean

This is stacked on #4006 because Terraform reaches this path only after repeatable-option generation succeeds. Rebase onto `main` after #4006 merges.

Refs #3996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when restoring nested or aliased commands.
  - Preserved established command identifiers, including custom names and historical casing.
  - Correctly distinguishes literal `execute` commands from parent command facades.
  - Consolidates removed parent and child commands under a consistent restored root.
  - Rejects conflicting command identifiers to prevent ambiguous command hierarchies.

- **Tests**
  - Added coverage for command restoration scenarios to help prevent future compatibility regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->