### PR TITLE
Restore full CLI generation matrix

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -197,10 +197,9 @@ jobs:
             remove_legacy_file "$PKG_DIR/I${PREFIX}.cs"
             remove_legacy_file "$PKG_DIR/${PREFIX}.cs"
 
-            # Delete only this tool's generated service files. Packages such as
-            # ModularPipelines.Java contain services for multiple CLI tools.
-            remove_legacy_file "$PKG_DIR/Services/I${PREFIX}.Generated.cs"
-            remove_legacy_file "$PKG_DIR/Services/${PREFIX}.Generated.cs"
+            # Keep generated service files until generation succeeds. They are the API
+            # baseline used to restore commands that disappeared from newer CLI help,
+            # and successful generation overwrites these exact paths atomically.
           fi
 
           echo "Cleanup complete for $PACKAGE"
@@ -810,13 +809,9 @@ jobs:
             Remove-LegacyFile $interfaceFile
             Remove-LegacyFile $implFile
 
-            # Delete only this tool's generated service files. A package may
-            # contain services for multiple CLI tools.
-            $servicesDir = Join-Path $pkgDir "Services"
-            if (Test-Path $servicesDir) {
-              Remove-LegacyFile (Join-Path $servicesDir "I$prefix.Generated.cs")
-              Remove-LegacyFile (Join-Path $servicesDir "$prefix.Generated.cs")
-            }
+            # Keep generated service files until generation succeeds. They are the API
+            # baseline used to restore commands that disappeared from newer CLI help,
+            # and successful generation overwrites these exact paths atomically.
           }
 
           Write-Host "Cleanup complete for $package"

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1088,6 +1088,64 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Keeps_Historical_Alias_On_Restored_Collision_Target()
+    {
+        var command = Command("ToolLoginOptions", "ToolOptions", ["login"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--server",
+                    PropertyName = "Server",
+                    CSharpType = "string?",
+                },
+            ],
+            PositionalArguments =
+            [
+                new CliPositionalArgument
+                {
+                    PropertyName = "Server",
+                    CSharpType = "string",
+                    IsRequired = true,
+                    PositionIndex = 0,
+                },
+            ],
+            CompatibilityProperties =
+            [
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "LegacyServer",
+                    CSharpType = "string?",
+                    ForwardToPropertyName = "Server",
+                    ObsoleteMessage = "Use Server instead.",
+                },
+            ],
+        };
+        var collisionResolved = InheritedPropertyCollisionResolver.Resolve(Tool(command))
+            .Commands.Single();
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            collisionResolved,
+            [
+                BaselineProperty("Server", "string", argumentPosition: 0, isRequired: true),
+                BaselineProperty(
+                    "LegacyServer",
+                    "string?",
+                    isCompatibility: true,
+                    forwardToPropertyName: "Server"),
+            ]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(preserved.Options.Single().PropertyName).IsEqualTo("ServerOption");
+            await Assert.That(preserved.PositionalArguments.Single().PropertyName).IsEqualTo("Server");
+            await Assert.That(preserved.CompatibilityProperties.Single().ForwardToPropertyName)
+                .IsEqualTo("Server");
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Retargets_Transitive_Compatibility_Aliases()
     {
         var command = Command("ToolChecksumOptions", "ToolOptions", ["checksum"]) with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -419,6 +419,27 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task SubDomain_Generators_Deduplicate_Identical_Executable_Parents()
+    {
+        var parent = Command("ToolGroupOptions", "ToolOptions", ["group"]);
+        var tool = Tool(
+            parent,
+            parent,
+            Command(
+                "ToolGroupChildOptions",
+                "ToolOptions",
+                ["group", "child"],
+                subDomainGroup: "group"));
+
+        var groupService = (await new SubDomainClassGenerator().GenerateAsync(tool))
+            .Single(file => Path.GetFileName(file.RelativePath).Equals(
+                "ToolGroup.Generated.cs",
+                StringComparison.Ordinal));
+
+        await Assert.That(groupService.Content.Split("ExecuteAsync(")).Count().IsEqualTo(2);
+    }
+
+    [Test]
     public async Task SubDomain_Parent_Requires_Options_When_It_Has_Required_Operands()
     {
         var parent = Command("ToolServiceOptions", "ToolOptions", ["service"]) with
@@ -980,6 +1001,137 @@ public class GeneratorHardeningTests
             await Assert.That(generated).Contains("get => DepVersion;");
             await Assert.That(generated).Contains("init => DepVersion = value;");
         }
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Prefers_Matching_Cli_Identity_For_Duplicate_Names()
+    {
+        var command = Command("ToolLoginOptions", "ToolOptions", ["login"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--server",
+                    PropertyName = "Server",
+                    CSharpType = "string?",
+                },
+            ],
+            PositionalArguments =
+            [
+                new CliPositionalArgument
+                {
+                    PropertyName = "Server",
+                    CSharpType = "string?",
+                    PositionIndex = 0,
+                },
+            ],
+        };
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [BaselineProperty("Server", "string", argumentPosition: 0, isRequired: true)]);
+
+        await Assert.That(preserved.PositionalArguments.Single().CSharpType).IsEqualTo("string");
+        await Assert.That(preserved.PositionalArguments.Single().IsRequired).IsTrue();
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Retargets_Transitive_Compatibility_Aliases()
+    {
+        var command = Command("ToolChecksumOptions", "ToolOptions", ["checksum"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--changeset-author",
+                    PropertyName = "ChangesetAuthor",
+                    CSharpType = "string?",
+                },
+            ],
+            CompatibilityProperties =
+            [
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "LegacyAuthor",
+                    CSharpType = "string?",
+                    ForwardToPropertyName = "ChangeSetAuthor",
+                    ObsoleteMessage = "Use ChangeSetAuthor instead.",
+                },
+            ],
+        };
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [
+                BaselineProperty(
+                    "ChangeSetAuthor",
+                    "string?",
+                    switchName: "--changeset-author"),
+                BaselineProperty(
+                    "LegacyAuthor",
+                    "string?",
+                    isCompatibility: true,
+                    forwardToPropertyName: "ChangeSetAuthor"),
+            ]);
+
+        var aliases = preserved.CompatibilityProperties.ToDictionary(
+            static property => property.PropertyName,
+            StringComparer.Ordinal);
+        using (Assert.Multiple())
+        {
+            await Assert.That(aliases["ChangeSetAuthor"].ForwardToPropertyName)
+                .IsEqualTo("ChangesetAuthor");
+            await Assert.That(aliases["LegacyAuthor"].ForwardToPropertyName)
+                .IsEqualTo("ChangesetAuthor");
+        }
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Drops_Alias_Shadowed_By_Live_Property()
+    {
+        var command = Command("ToolChecksumOptions", "ToolOptions", ["checksum"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--changeset-author",
+                    PropertyName = "ChangesetAuthor",
+                    CSharpType = "string?",
+                },
+            ],
+            CompatibilityProperties =
+            [
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "ChangesetAuthor",
+                    CSharpType = "string?",
+                    ForwardToPropertyName = "ChangeSetAuthor",
+                    ObsoleteMessage = "Use ChangeSetAuthor instead.",
+                },
+            ],
+        };
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [
+                BaselineProperty(
+                    "ChangeSetAuthor",
+                    "string?",
+                    switchName: "--changeset-author"),
+                BaselineProperty(
+                    "ChangesetAuthor",
+                    "string?",
+                    isCompatibility: true,
+                    forwardToPropertyName: "ChangeSetAuthor"),
+            ]);
+
+        await Assert.That(preserved.CompatibilityProperties).HasSingleItem();
+        var alias = preserved.CompatibilityProperties.Single();
+        await Assert.That(alias.PropertyName).IsEqualTo("ChangeSetAuthor");
+        await Assert.That(alias.ForwardToPropertyName).IsEqualTo("ChangesetAuthor");
     }
 
     [Test]
@@ -1946,6 +2098,49 @@ public class GeneratorHardeningTests
                 await Assert.That(restored.SubDomainGroup).IsEqualTo("Cloudshell");
                 await Assert.That(restored.CommandGroupIdentifierOverride).IsEqualTo("Cloudshell");
                 await Assert.That(preserved.SubDomainGroups).IsEquivalentTo(["Cloudshell"]);
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Preserves_Historical_Facade_Casing_For_Live_Command()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolAgentTaskCreateOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"agent-task\", \"create\")] "
+                + "public record ToolAgentTaskCreateOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolAgenttask.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolAgenttask { "
+                + "public Task CreateAsync(ToolAgentTaskCreateOptions? options = null) => Task.CompletedTask; }");
+            var tool = Tool(Command(
+                "ToolAgentTaskCreateOptions",
+                "ToolOptions",
+                ["agent-task", "create"],
+                subDomainGroup: "agent-task"));
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(tool, root);
+            var command = preserved.Commands.Single();
+            var generated = (await new SubDomainClassGenerator().GenerateAsync(preserved))
+                .Single(file => Path.GetFileName(file.RelativePath).Equals(
+                    "ToolAgenttask.Generated.cs",
+                    StringComparison.Ordinal));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(command.CommandGroupIdentifierOverride).IsEqualTo("Agenttask");
+                await Assert.That(generated.Content).Contains("CreateAsync(");
             }
         }
         finally
@@ -3123,6 +3318,43 @@ public class GeneratorHardeningTests
             await Assert.That(generated).Contains("set => LegacyArguments = value;");
             await Assert.That(generated)
                 .Contains("public virtual IEnumerable<string>? LegacyArguments { get; set; }");
+        }
+    }
+
+    [Test]
+    public async Task Local_Option_And_Argument_Name_Collisions_Are_Disambiguated()
+    {
+        var command = Command("ToolCreateOptions", "ToolOptions", ["create"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--filename",
+                    PropertyName = "Filename",
+                    CSharpType = "string?",
+                },
+            ],
+            PositionalArguments =
+            [
+                new CliPositionalArgument
+                {
+                    PropertyName = "Filename",
+                    CSharpType = "IEnumerable<string>?",
+                    PositionIndex = 0,
+                },
+            ],
+        };
+
+        var resolved = InheritedPropertyCollisionResolver.Resolve(Tool(command));
+        var resolvedCommand = resolved.Commands.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolvedCommand.Options.Single().PropertyName)
+                .IsEqualTo("Filename");
+            await Assert.That(resolvedCommand.PositionalArguments.Single().PropertyName)
+                .IsEqualTo("FilenameArgument");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2071,8 +2071,10 @@ public class GeneratorHardeningTests
                 + "[CliOption(\"--pull\", ShortForm = \"-p\", PreferShortForm = true, "
                 + "Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)] "
                 + "public CliOptionValue? Pull { get; set; } "
+                + "[SecretValue(\"password\", \"token\")] "
                 + "[CliOption(\"--arguments\", GroupValues = true)] "
                 + "public IEnumerable<string>? Arguments { get; set; } "
+                + "[SecretValue] "
                 + "[CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true, "
                 + "PrependOptionTerminatorIfValueStartsWithDash = true)] "
                 + "public string? Operand { get; set; } }");
@@ -2110,13 +2112,17 @@ public class GeneratorHardeningTests
                 await Assert.That(pull.ValueSeparator).IsEqualTo("=");
                 await Assert.That(pull.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
                 await Assert.That(arguments.GroupValues).IsTrue();
+                await Assert.That(arguments.IsSecret).IsTrue();
+                await Assert.That(arguments.SecretValueKeys).IsEquivalentTo(["password", "token"]);
                 await Assert.That(operand.Phase).IsEqualTo(CommandLinePhase.Passthrough);
+                await Assert.That(operand.IsSecret).IsTrue();
                 await Assert.That(operand.PrependOptionTerminator).IsTrue();
                 await Assert.That(operand.PrependOptionTerminatorIfValueStartsWithDash).IsTrue();
                 await Assert.That(generatedOptions)
                     .Contains("[CliOption(\"--pull\", ShortForm = \"-p\", PreferShortForm = true, Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]");
                 await Assert.That(generatedOptions)
                     .Contains("[CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true, PrependOptionTerminatorIfValueStartsWithDash = true)]");
+                await Assert.That(generatedOptions).Contains("[SecretValue(\"password\", \"token\")]");
                 await Assert.That(generated).Contains("RemovedAsync(ToolRemovedOptions? options = null");
             }
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1404,7 +1404,7 @@ public class GeneratorHardeningTests
     }
 
     [Test]
-    public async Task ApiCompatibilityPreserver_Rejects_Reused_Compatibility_Property_With_Cli_Identity()
+    public async Task ApiCompatibilityPreserver_Allows_Reintroduced_Compatibility_Property()
     {
         var command = Command("ToolCopyOptions", "ToolOptions", ["copy"]) with
         {
@@ -1419,13 +1419,15 @@ public class GeneratorHardeningTests
             ],
         };
 
-        var exception = Assert.Throws<InvalidOperationException>(() =>
-            GeneratedApiCompatibilityPreserver.Preserve(
-                command,
-                [BaselineProperty("RemovedFlag", "bool?", isCompatibility: true)]));
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [BaselineProperty("RemovedFlag", "bool?", isCompatibility: true)]);
 
-        await Assert.That(exception.Message)
-            .Contains("ToolCopyOptions.RemovedFlag changed CLI switch or argument position");
+        using (Assert.Multiple())
+        {
+            await Assert.That(preserved.Options.Single().PropertyName).IsEqualTo("RemovedFlag");
+            await Assert.That(preserved.CompatibilityProperties).IsEmpty();
+        }
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1037,6 +1037,45 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Restores_Name_After_Local_Collision_Rename()
+    {
+        var command = Command("ToolLoginOptions", "ToolOptions", ["login"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--server",
+                    PropertyName = "Server",
+                    CSharpType = "string?",
+                },
+            ],
+            PositionalArguments =
+            [
+                new CliPositionalArgument
+                {
+                    PropertyName = "Server",
+                    CSharpType = "string",
+                    IsRequired = true,
+                    PositionIndex = 0,
+                },
+            ],
+        };
+        var collisionResolved = InheritedPropertyCollisionResolver.Resolve(Tool(command))
+            .Commands.Single();
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            collisionResolved,
+            [BaselineProperty("Server", "string", argumentPosition: 0, isRequired: true)]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(preserved.Options.Single().PropertyName).IsEqualTo("ServerOption");
+            await Assert.That(preserved.PositionalArguments.Single().PropertyName).IsEqualTo("Server");
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Retargets_Transitive_Compatibility_Aliases()
     {
         var command = Command("ToolChecksumOptions", "ToolOptions", ["checksum"]) with
@@ -2128,7 +2167,13 @@ public class GeneratorHardeningTests
                 "ToolAgentTaskCreateOptions",
                 "ToolOptions",
                 ["agent-task", "create"],
-                subDomainGroup: "agent-task"));
+                subDomainGroup: "agent-task") with
+            {
+                CommandPartIdentifierOverrides = new Dictionary<int, string>
+                {
+                    [0] = "AgentTask",
+                },
+            });
 
             var preserved = GeneratedApiCompatibilityPreserver.Preserve(tool, root);
             var command = preserved.Commands.Single();
@@ -2140,6 +2185,7 @@ public class GeneratorHardeningTests
             using (Assert.Multiple())
             {
                 await Assert.That(command.CommandGroupIdentifierOverride).IsEqualTo("Agenttask");
+                await Assert.That(command.CommandPartIdentifierOverrides[0]).IsEqualTo("AgentTask");
                 await Assert.That(generated.Content).Contains("CreateAsync(");
             }
         }
@@ -3204,7 +3250,7 @@ public class GeneratorHardeningTests
     }
 
     [Test]
-    public async Task ApiCompatibilityPreserver_Rejects_Required_Rename_Collisions()
+    public async Task ApiCompatibilityPreserver_Resolves_Required_Rename_Collisions()
     {
         var command = Command("ToolAddOptions", "ToolOptions", ["add"]) with
         {
@@ -3229,12 +3275,17 @@ public class GeneratorHardeningTests
             ],
         };
 
-        var exception = Assert.Throws<InvalidOperationException>(() =>
-            GeneratedApiCompatibilityPreserver.Preserve(
-                command,
-                [BaselineProperty("StableName", "string", argumentPosition: 0, isRequired: true)]));
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [BaselineProperty("StableName", "string", argumentPosition: 0, isRequired: true)]);
 
-        await Assert.That(exception.Message).Contains("would duplicate a member name");
+        using (Assert.Multiple())
+        {
+            await Assert.That(preserved.PositionalArguments.Single().PropertyName)
+                .IsEqualTo("StableName");
+            await Assert.That(preserved.Options.Single().PropertyName)
+                .IsEqualTo("StableNameOption");
+        }
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2066,8 +2066,12 @@ public class GeneratorHardeningTests
                 "using ModularPipelines.Attributes; "
                 + "[CliSubCommand(\"removed\")] "
                 + "public record ToolRemovedOptions : ToolOptions { "
+                + "[Range(0, 6)] "
+                + "[RegularExpression(\"^[0-6]$\")] "
                 + "[CliFlag(\"--force\", ShortForm = \"-f\", PreferShortForm = true, Phase = CommandLinePhase.Terminal)] "
                 + "public int? Force { get; set; } "
+                + "[CliOptionValueRange(1, 3)] "
+                + "[CliOptionValueRegularExpression(\"^[1-3]$\")] "
                 + "[CliOption(\"--pull\", ShortForm = \"-p\", PreferShortForm = true, "
                 + "Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)] "
                 + "public CliOptionValue? Pull { get; set; } "
@@ -2106,11 +2110,17 @@ public class GeneratorHardeningTests
                 await Assert.That(force.ShortForm).IsEqualTo("-f");
                 await Assert.That(force.PreferShortForm).IsTrue();
                 await Assert.That(force.Phase).IsEqualTo(CommandLinePhase.Terminal);
+                await Assert.That(force.ValidationConstraints!.MinValue).IsEqualTo(0);
+                await Assert.That(force.ValidationConstraints.MaxValue).IsEqualTo(6);
+                await Assert.That(force.ValidationConstraints.Pattern).IsEqualTo("^[0-6]$");
                 await Assert.That(pull.IsFlag).IsFalse();
                 await Assert.That(pull.ShortForm).IsEqualTo("-p");
                 await Assert.That(pull.PreferShortForm).IsTrue();
                 await Assert.That(pull.ValueSeparator).IsEqualTo("=");
                 await Assert.That(pull.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+                await Assert.That(pull.ValidationConstraints!.MinValue).IsEqualTo(1);
+                await Assert.That(pull.ValidationConstraints.MaxValue).IsEqualTo(3);
+                await Assert.That(pull.ValidationConstraints.Pattern).IsEqualTo("^[1-3]$");
                 await Assert.That(arguments.GroupValues).IsTrue();
                 await Assert.That(arguments.IsSecret).IsTrue();
                 await Assert.That(arguments.SecretValueKeys).IsEquivalentTo(["password", "token"]);
@@ -2120,6 +2130,11 @@ public class GeneratorHardeningTests
                 await Assert.That(operand.PrependOptionTerminatorIfValueStartsWithDash).IsTrue();
                 await Assert.That(generatedOptions)
                     .Contains("[CliOption(\"--pull\", ShortForm = \"-p\", PreferShortForm = true, Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]");
+                await Assert.That(generatedOptions).Contains("[Range(0, 6)]");
+                await Assert.That(generatedOptions).Contains("[RegularExpression(\"^[0-6]$\")]");
+                await Assert.That(generatedOptions).Contains("[CliOptionValueRange(1, 3)]");
+                await Assert.That(generatedOptions)
+                    .Contains("[CliOptionValueRegularExpression(\"^[1-3]$\")]");
                 await Assert.That(generatedOptions)
                     .Contains("[CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true, PrependOptionTerminatorIfValueStartsWithDash = true)]");
                 await Assert.That(generatedOptions).Contains("[SecretValue(\"password\", \"token\")]");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1186,6 +1186,72 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Renames_Live_Property_Shadowing_Forwarded_Alias()
+    {
+        var command = Command("ToolPushOptions", "ToolOptions", ["push"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--output",
+                    PropertyName = "Output",
+                    CSharpType = "string?",
+                },
+                new CliOptionDefinition
+                {
+                    SwitchName = "--legacy-output",
+                    PropertyName = "LegacyOutput",
+                    CSharpType = "string?",
+                },
+            ],
+            CompatibilityProperties =
+            [
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "ScrapedLegacyOutput",
+                    CSharpType = "string?",
+                    ForwardToPropertyName = "LegacyOutput",
+                    ObsoleteMessage = "Use LegacyOutput instead.",
+                },
+            ],
+        };
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [
+                BaselineProperty("Output", "string?", switchName: "--output"),
+                BaselineProperty(
+                    "LegacyOutput",
+                    "string?",
+                    isCompatibility: true,
+                    forwardToPropertyName: "Output"),
+                BaselineProperty(
+                    "VeryLegacyOutput",
+                    "string?",
+                    isCompatibility: true,
+                    forwardToPropertyName: "LegacyOutput"),
+            ]);
+
+        var options = preserved.Options.ToDictionary(
+            static option => option.PropertyName,
+            StringComparer.Ordinal);
+        var aliases = preserved.CompatibilityProperties.ToDictionary(
+            static property => property.PropertyName,
+            StringComparer.Ordinal);
+        using (Assert.Multiple())
+        {
+            await Assert.That(options["Output"].SwitchName).IsEqualTo("--output");
+            await Assert.That(options["LegacyOutputOption"].SwitchName).IsEqualTo("--legacy-output");
+            await Assert.That(aliases["LegacyOutput"].ForwardToPropertyName).IsEqualTo("Output");
+            await Assert.That(aliases["VeryLegacyOutput"].ForwardToPropertyName)
+                .IsEqualTo("LegacyOutput");
+            await Assert.That(aliases["ScrapedLegacyOutput"].ForwardToPropertyName)
+                .IsEqualTo("LegacyOutputOption");
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Retains_Scalar_To_Collection_Changes()
     {
         var command = Command("ToolCopyOptions", "ToolOptions", ["copy"]) with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2000,7 +2000,16 @@ public class GeneratorHardeningTests
                 "using ModularPipelines.Attributes; "
                 + "[CliSubCommand(\"removed\")] "
                 + "public record ToolRemovedOptions : ToolOptions { "
-                + "[CliFlag(\"--force\")] public bool? Force { get; set; } }");
+                + "[CliFlag(\"--force\", ShortForm = \"-f\", PreferShortForm = true, Phase = CommandLinePhase.Terminal)] "
+                + "public int? Force { get; set; } "
+                + "[CliOption(\"--pull\", ShortForm = \"-p\", PreferShortForm = true, "
+                + "Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)] "
+                + "public CliOptionValue? Pull { get; set; } "
+                + "[CliOption(\"--arguments\", GroupValues = true)] "
+                + "public IEnumerable<string>? Arguments { get; set; } "
+                + "[CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true, "
+                + "PrependOptionTerminatorIfValueStartsWithDash = true)] "
+                + "public string? Operand { get; set; } }");
             await File.WriteAllTextAsync(
                 Path.Combine(packageDirectory, "Services", "Tool.Generated.cs"),
                 "namespace ModularPipelines.Tool.Services; "
@@ -2011,14 +2020,37 @@ public class GeneratorHardeningTests
                 root);
             var restored = preserved.Commands.Single(command =>
                 command.ClassName.Equals("ToolRemovedOptions", StringComparison.Ordinal));
+            var force = restored.Options.Single(option => option.PropertyName == "Force");
+            var pull = restored.Options.Single(option => option.PropertyName == "Pull");
+            var arguments = restored.Options.Single(option => option.PropertyName == "Arguments");
+            var operand = restored.PositionalArguments.Single();
             var generated = (await new ServiceInterfaceGenerator().GenerateAsync(preserved))
                 .Single(file => file.RelativePath.EndsWith("ITool.Generated.cs", StringComparison.Ordinal))
+                .Content;
+            var generatedOptions = (await new OptionsClassGenerator().GenerateAsync(preserved))
+                .Single(file => file.RelativePath.EndsWith("ToolRemovedOptions.Generated.cs", StringComparison.Ordinal))
                 .Content;
 
             using (Assert.Multiple())
             {
                 await Assert.That(restored.CommandParts).IsEquivalentTo(["removed"]);
-                await Assert.That(restored.Options.Single().PropertyName).IsEqualTo("Force");
+                await Assert.That(force.IsFlag).IsTrue();
+                await Assert.That(force.ShortForm).IsEqualTo("-f");
+                await Assert.That(force.PreferShortForm).IsTrue();
+                await Assert.That(force.Phase).IsEqualTo(CommandLinePhase.Terminal);
+                await Assert.That(pull.IsFlag).IsFalse();
+                await Assert.That(pull.ShortForm).IsEqualTo("-p");
+                await Assert.That(pull.PreferShortForm).IsTrue();
+                await Assert.That(pull.ValueSeparator).IsEqualTo("=");
+                await Assert.That(pull.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+                await Assert.That(arguments.GroupValues).IsTrue();
+                await Assert.That(operand.Phase).IsEqualTo(CommandLinePhase.Passthrough);
+                await Assert.That(operand.PrependOptionTerminator).IsTrue();
+                await Assert.That(operand.PrependOptionTerminatorIfValueStartsWithDash).IsTrue();
+                await Assert.That(generatedOptions)
+                    .Contains("[CliOption(\"--pull\", ShortForm = \"-p\", PreferShortForm = true, Format = OptionFormat.EqualsSeparated, ValueArity = CliOptionValueArity.Optional)]");
+                await Assert.That(generatedOptions)
+                    .Contains("[CliArgument(0, Phase = CommandLinePhase.Passthrough, PrependOptionTerminator = true, PrependOptionTerminatorIfValueStartsWithDash = true)]");
                 await Assert.That(generated).Contains("RemovedAsync(ToolRemovedOptions? options = null");
             }
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -1060,6 +1060,16 @@ public class GeneratorHardeningTests
                     PositionIndex = 0,
                 },
             ],
+            CompatibilityProperties =
+            [
+                new CliCompatibilityProperty
+                {
+                    PropertyName = "LegacyServer",
+                    CSharpType = "string?",
+                    ForwardToPropertyName = "Server",
+                    ObsoleteMessage = "Use Server instead.",
+                },
+            ],
         };
         var collisionResolved = InheritedPropertyCollisionResolver.Resolve(Tool(command))
             .Commands.Single();
@@ -1072,6 +1082,8 @@ public class GeneratorHardeningTests
         {
             await Assert.That(preserved.Options.Single().PropertyName).IsEqualTo("ServerOption");
             await Assert.That(preserved.PositionalArguments.Single().PropertyName).IsEqualTo("Server");
+            await Assert.That(preserved.CompatibilityProperties.Single().ForwardToPropertyName)
+                .IsEqualTo("ServerOption");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -75,6 +75,40 @@ public class GitCliScraperTests
     }
 
     [Test]
+    public async Task Dispose_Waits_For_InFlight_Repository_Initialization()
+    {
+        var executor = new BlockingInitExecutor();
+        var scraper = new GitCliScraper(
+            executor,
+            new StubHelpTextCache(),
+            NullLogger<GitCliScraper>.Instance);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var scrapeTask = DrainAsync(scraper, cancellationTokenSource.Token);
+        await executor.InitializationStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        cancellationTokenSource.Cancel();
+        var disposalStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var disposeTask = Task.Run(() =>
+        {
+            disposalStarted.SetResult();
+            scraper.Dispose();
+        });
+        await disposalStarted.Task;
+        await Task.Delay(50);
+
+        await Assert.That(disposeTask.IsCompleted).IsFalse();
+        executor.AllowInitialization.SetResult();
+        await Assert.That(async () => await scrapeTask).Throws<OperationCanceledException>();
+        await disposeTask;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(executor.RepositoryExistedAfterInitialization).IsTrue();
+            await Assert.That(Directory.Exists(executor.RepositoryDirectory!)).IsFalse();
+        }
+    }
+
+    [Test]
     public async Task ExtractSubcommands_Skips_Global_Options_Before_Command_Name()
     {
         const string help = """
@@ -148,6 +182,15 @@ public class GitCliScraperTests
             StandardError = standardError,
             ExitCode = exitCode,
         };
+
+    private static async Task DrainAsync(
+        GitCliScraper scraper,
+        CancellationToken cancellationToken)
+    {
+        await foreach (var _ in scraper.ScrapeAsync(cancellationToken))
+        {
+        }
+    }
 
     private sealed class StubExecutor : ICliCommandExecutor
     {
@@ -227,6 +270,49 @@ public class GitCliScraperTests
                 "status -h" => Result("usage: git status [<options>]"),
                 _ => Result(string.Empty, "unexpected invocation", exitCode: 1),
             });
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+
+    private sealed class BlockingInitExecutor : ICliCommandExecutor
+    {
+        public TaskCompletionSource InitializationStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowInitialization { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string? RepositoryDirectory { get; private set; }
+
+        public bool RepositoryExistedAfterInitialization { get; private set; }
+
+        public async Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            if (arguments == "init --quiet")
+            {
+                RepositoryDirectory = workingDirectory;
+                InitializationStarted.SetResult();
+                await AllowInitialization.Task;
+                RepositoryExistedAfterInitialization = Directory.Exists(workingDirectory);
+                return Result(string.Empty);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            return arguments switch
+            {
+                "help -a" => Result("Main Porcelain Commands\n   stash                   Stash changes"),
+                "stash -h" => Result("usage: git stash\n   or: git stash pop [--index]"),
+                "stash pop -h" => Result("usage: git stash pop [--index]"),
+                _ => Result(string.Empty, "unexpected invocation", exitCode: 1),
+            };
         }
 
         public Task<bool> IsAvailableAsync(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -25,28 +25,31 @@ public class GitCliScraperTests
     public async Task ScrapeAsync_Discovers_Generic_Groups_Without_Repeating_Parent_Help()
     {
         var executor = new GroupedHelpExecutor();
-        var scraper = new GitCliScraper(
-            executor,
-            new StubHelpTextCache(),
-            NullLogger<GitCliScraper>.Instance);
-        var commands = new List<CliCommandDefinition>();
-
-        await foreach (var command in scraper.ScrapeAsync())
+        string helpRepository;
+        using (var scraper = new GitCliScraper(
+                   executor,
+                   new StubHelpTextCache(),
+                   NullLogger<GitCliScraper>.Instance))
         {
-            commands.Add(command);
+            var commands = new List<CliCommandDefinition>();
+            await foreach (var command in scraper.ScrapeAsync())
+            {
+                commands.Add(command);
+            }
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(commands.Select(command => command.FullCommand))
+                    .IsEquivalentTo(["git stash", "git stash pop", "git status"]);
+                await Assert.That(executor.StashHelpInvocations).IsEqualTo(1);
+                await Assert.That(executor.StatusHelpInvocations).IsEqualTo(1);
+                await Assert.That(executor.NestedHelpWorkingDirectory).IsNotNull();
+            }
+
+            helpRepository = executor.NestedHelpWorkingDirectory!;
         }
 
-        using (Assert.Multiple())
-        {
-            await Assert.That(commands.Select(command => command.FullCommand))
-                .IsEquivalentTo(["git stash", "git stash pop", "git status"]);
-            await Assert.That(executor.StashHelpInvocations).IsEqualTo(1);
-            await Assert.That(executor.StatusHelpInvocations).IsEqualTo(1);
-            await Assert.That(executor.NestedHelpWorkingDirectory).IsNotNull();
-        }
-
-        scraper.Dispose();
-        await Assert.That(Directory.Exists(executor.NestedHelpWorkingDirectory!)).IsFalse();
+        await Assert.That(Directory.Exists(helpRepository)).IsFalse();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -44,6 +44,9 @@ public class GitCliScraperTests
             await Assert.That(executor.StatusHelpInvocations).IsEqualTo(1);
             await Assert.That(executor.NestedHelpWorkingDirectory).IsNotNull();
         }
+
+        scraper.Dispose();
+        await Assert.That(Directory.Exists(executor.NestedHelpWorkingDirectory!)).IsFalse();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -109,6 +109,19 @@ public class GitCliScraperTests
     }
 
     [Test]
+    public async Task ScrapeAsync_Throws_After_Disposal()
+    {
+        var scraper = new GitCliScraper(
+            new StubExecutor(),
+            new StubHelpTextCache(),
+            NullLogger<GitCliScraper>.Instance);
+        scraper.Dispose();
+
+        await Assert.That(async () => await DrainAsync(scraper, CancellationToken.None))
+            .Throws<ObjectDisposedException>();
+    }
+
+    [Test]
     public async Task ExtractSubcommands_Skips_Global_Options_Before_Command_Name()
     {
         const string help = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -42,6 +42,7 @@ public class GitCliScraperTests
                 .IsEquivalentTo(["git stash", "git stash pop", "git status"]);
             await Assert.That(executor.StashHelpInvocations).IsEqualTo(1);
             await Assert.That(executor.StatusHelpInvocations).IsEqualTo(1);
+            await Assert.That(executor.NestedHelpWorkingDirectory).IsNotNull();
         }
     }
 
@@ -186,6 +187,8 @@ public class GitCliScraperTests
 
         public int StatusHelpInvocations { get; private set; }
 
+        public string? NestedHelpWorkingDirectory { get; private set; }
+
         public Task<CliCommandResult> ExecuteAsync(
             string command,
             string arguments,
@@ -200,9 +203,14 @@ public class GitCliScraperTests
             {
                 StatusHelpInvocations++;
             }
+            else if (arguments == "stash pop -h")
+            {
+                NestedHelpWorkingDirectory = workingDirectory;
+            }
 
             return Task.FromResult(arguments switch
             {
+                "init --quiet" => Result(string.Empty),
                 "help -a" => Result(
                     "Main Porcelain Commands\n"
                     + "   stash                   Stash changes\n"

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -61,7 +61,11 @@ internal static class GeneratedApiCompatibilityPreserver
             .Select(static method => method.OptionsType)
             .ToHashSet(StringComparer.Ordinal);
         var commands = compatibleTool.Commands
-            .Select(command => PreserveIdentifierCasing(command, baseline))
+            .Select(command => PreserveIdentifierCasing(
+                compatibleTool,
+                command,
+                baseline,
+                facadeMethods))
             .Concat(RestoreRemovedCommands(compatibleTool, baseline, facadeMethods))
             .DistinctBy(static command => command.ClassName, StringComparer.Ordinal)
             .ToArray();
@@ -448,13 +452,46 @@ internal static class GeneratedApiCompatibilityPreserver
             .ToArray();
 
     private static CliCommandDefinition PreserveIdentifierCasing(
+        CliToolDefinition tool,
         CliCommandDefinition command,
-        IReadOnlyDictionary<string, GeneratedApiBaseline> baseline)
+        IReadOnlyDictionary<string, GeneratedApiBaseline> baseline,
+        IReadOnlyList<GeneratedFacadeMethod> facadeMethods)
     {
-        return command with
+        var preserved = command with
         {
             ClassName = FindBaselineIdentifier(command.ClassName, baseline.Keys),
             ParentClassName = FindBaselineIdentifier(command.ParentClassName, baseline.Keys),
+        };
+        if (!baseline.TryGetValue(preserved.ClassName, out var commandBaseline)
+            || commandBaseline.CommandParts is not { Length: > 0 })
+        {
+            return preserved;
+        }
+
+        var commandFacadeMethods = facadeMethods
+            .Where(method => method.OptionsType.Equals(preserved.ClassName, StringComparison.Ordinal))
+            .ToArray();
+        var groupIdentifier = GetRestoredCommandGroupIdentifier(
+            tool,
+            commandBaseline,
+            commandFacadeMethods);
+        var recoveredOverrides = GetRestoredCommandPartIdentifierOverrides(
+            tool,
+            commandBaseline.CommandParts,
+            groupIdentifier,
+            commandFacadeMethods);
+        var mergedOverrides = recoveredOverrides
+            .Concat(preserved.CommandPartIdentifierOverrides)
+            .DistinctBy(static pair => pair.Key)
+            .ToDictionary(static pair => pair.Key, static pair => pair.Value);
+
+        return preserved with
+        {
+            CommandGroupIdentifierOverride = preserved.CommandGroupIdentifierOverride
+                                             ?? (preserved.CommandParts.Length > 1
+                                                 ? groupIdentifier
+                                                 : null),
+            CommandPartIdentifierOverrides = mergedOverrides,
         };
     }
 
@@ -779,7 +816,13 @@ internal static class GeneratedApiCompatibilityPreserver
         IReadOnlyList<GeneratedApiProperty> baselineProperties,
         IReadOnlyList<CliCompatibilityConstructor> baselineConstructors)
     {
-        var compatibilityProperties = command.CompatibilityProperties.ToList();
+        var livePropertyNames = command.Options
+            .Select(static option => option.PropertyName)
+            .Concat(command.PositionalArguments.Select(static argument => argument.PropertyName))
+            .ToHashSet(StringComparer.Ordinal);
+        var compatibilityProperties = command.CompatibilityProperties
+            .Where(property => !livePropertyNames.Contains(property.PropertyName))
+            .ToList();
         var compatibilityConstructors = command.CompatibilityConstructors.ToList();
         var positionalArguments = command.PositionalArguments.ToArray();
         var options = command.Options.ToArray();
@@ -821,8 +864,11 @@ internal static class GeneratedApiCompatibilityPreserver
                 baseline,
                 currentProperties,
                 compatibilityProperties,
+                renamedProperties,
                 violations);
         }
+
+        RetargetCompatibilityProperties(compatibilityProperties, renamedProperties);
 
         if (violations.Count > 0)
         {
@@ -976,13 +1022,28 @@ internal static class GeneratedApiCompatibilityPreserver
         GeneratedApiProperty baseline,
         IReadOnlyList<GeneratedApiProperty> currentProperties,
         ICollection<CliCompatibilityProperty> compatibilityProperties,
+        IDictionary<string, string> renamedProperties,
         List<string> violations)
     {
-        var sameName = currentProperties.FirstOrDefault(property =>
-            property.PropertyName.Equals(baseline.PropertyName, StringComparison.Ordinal));
+        var sameNameCandidates = currentProperties
+            .Where(property => property.PropertyName.Equals(
+                baseline.PropertyName,
+                StringComparison.Ordinal))
+            .ToArray();
+        var sameName = sameNameCandidates.FirstOrDefault(property =>
+                           HasSameCliIdentity(property, baseline))
+                       ?? sameNameCandidates.FirstOrDefault();
         if (sameName is not null)
         {
-            ValidateMatchingProperty(command, baseline, sameName, violations);
+            if (baseline is { IsCompatibility: true, ForwardToPropertyName: not null })
+            {
+                ValidateMatchingPropertyShape(command, baseline, sameName, violations);
+            }
+            else
+            {
+                ValidateMatchingProperty(command, baseline, sameName, violations);
+            }
+
             return;
         }
 
@@ -1024,6 +1085,28 @@ internal static class GeneratedApiCompatibilityPreserver
             },
             compatibilityProperties,
             violations);
+        if (replacement is not null)
+        {
+            renamedProperties[baseline.PropertyName] = replacement.PropertyName;
+        }
+    }
+
+    private static void RetargetCompatibilityProperties(
+        IList<CliCompatibilityProperty> compatibilityProperties,
+        IReadOnlyDictionary<string, string> renamedProperties)
+    {
+        for (var index = 0; index < compatibilityProperties.Count; index++)
+        {
+            var property = compatibilityProperties[index];
+            if (property.ForwardToPropertyName is { } target
+                && renamedProperties.TryGetValue(target, out var replacement))
+            {
+                compatibilityProperties[index] = property with
+                {
+                    ForwardToPropertyName = replacement,
+                };
+            }
+        }
     }
 
     private static bool TryRecordRemovedPropertyViolation(
@@ -1148,28 +1231,48 @@ internal static class GeneratedApiCompatibilityPreserver
         GeneratedApiProperty current,
         List<string> violations)
     {
+        if (!ValidateMatchingPropertyShape(command, baseline, current, violations))
+        {
+            return;
+        }
+
+        if (!HasSameCliIdentity(current, baseline))
+        {
+            violations.Add(
+                $"{command.ClassName}.{baseline.PropertyName} changed CLI switch or argument position");
+        }
+    }
+
+    private static bool ValidateMatchingPropertyShape(
+        CliCommandDefinition command,
+        GeneratedApiProperty baseline,
+        GeneratedApiProperty current,
+        ICollection<string> violations)
+    {
         if (!current.CSharpType.Equals(baseline.CSharpType, StringComparison.Ordinal))
         {
             violations.Add(
                 $"{command.ClassName}.{baseline.PropertyName} changed type from "
                 + $"{baseline.CSharpType} to {current.CSharpType}");
+            return false;
         }
-        else if (baseline.IsRequired && !current.IsRequired)
+
+        if (baseline.IsRequired && !current.IsRequired)
         {
             violations.Add(
                 $"{command.ClassName}.{baseline.PropertyName} changed from required to optional");
+            return false;
         }
-        else if (!baseline.IsRequired && current.IsRequired)
+
+        if (!baseline.IsRequired && current.IsRequired)
         {
             violations.Add(
                 $"{command.ClassName}.{baseline.PropertyName} changed from optional to required "
                 + "and would remove its public setter");
+            return false;
         }
-        else if (!HasSameCliIdentity(current, baseline))
-        {
-            violations.Add(
-                $"{command.ClassName}.{baseline.PropertyName} changed CLI switch or argument position");
-        }
+
+        return true;
     }
 
     private static void RestoreRequiredMemberNames(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -430,6 +430,8 @@ internal static class GeneratedApiCompatibilityPreserver
                 Phase = property.Phase ?? CommandLinePhase.Normal,
                 GroupValues = property.GroupValues,
                 ValueSeparator = property.ValueSeparator,
+                IsSecret = property.IsSecret,
+                SecretValueKeys = property.SecretValueKeys ?? [],
             })
             .ToArray();
 
@@ -447,6 +449,7 @@ internal static class GeneratedApiCompatibilityPreserver
                 PrependOptionTerminator = property.PrependOptionTerminator,
                 PrependOptionTerminatorIfValueStartsWithDash =
                     property.PrependOptionTerminatorIfValueStartsWithDash,
+                IsSecret = property.IsSecret,
             })
             .ToArray();
 
@@ -2338,6 +2341,7 @@ internal static class GeneratedApiCompatibilityPreserver
         var cliOption = FindAttribute(attributes, "CliOption");
         var cliFlag = FindAttribute(attributes, "CliFlag");
         var cliSwitch = cliOption ?? cliFlag;
+        var secretValue = FindAttribute(attributes, "SecretValue");
         var obsolete = FindAttribute(attributes, "Obsolete");
         var (targetPropertyName, forwardingKind) = GetForwarding(accessorList);
         bool? isFlag = cliSwitch is null ? null : cliFlag is not null;
@@ -2364,7 +2368,9 @@ internal static class GeneratedApiCompatibilityPreserver
             GetNullableEnumNamedArgument<CommandLinePhase>(cliSwitch, "Phase")
             ?? GetNullableEnumNamedArgument<CommandLinePhase>(cliArgument, "Phase"),
             GetBooleanNamedArgument(cliArgument, "PrependOptionTerminator"),
-            GetBooleanNamedArgument(cliArgument, "PrependOptionTerminatorIfValueStartsWithDash"));
+            GetBooleanNamedArgument(cliArgument, "PrependOptionTerminatorIfValueStartsWithDash"),
+            secretValue is not null,
+            GetStringArguments(secretValue));
     }
 
     private static AttributeSyntax? FindAttribute(
@@ -2386,6 +2392,24 @@ internal static class GeneratedApiCompatibilityPreserver
             && literal.Token.Value is int value
                 ? value
                 : null;
+
+    private static string[]? GetStringArguments(AttributeSyntax? attribute)
+    {
+        if (attribute is null)
+        {
+            return null;
+        }
+
+        return
+        [
+            .. attribute.ArgumentList?.Arguments
+                .Select(static argument => argument.Expression)
+                .OfType<LiteralExpressionSyntax>()
+                .Where(static literal => literal.IsKind(SyntaxKind.StringLiteralExpression))
+                .Select(static literal => literal.Token.ValueText)
+                ?? [],
+        ];
+    }
 
     private static string? GetStringNamedArgument(AttributeSyntax? attribute, string name) =>
         FindNamedArgument(attribute, name)?.Expression is LiteralExpressionSyntax literal
@@ -2534,7 +2558,9 @@ internal sealed record GeneratedApiProperty(
     bool GroupValues = false,
     CommandLinePhase? Phase = null,
     bool PrependOptionTerminator = false,
-    bool PrependOptionTerminatorIfValueStartsWithDash = false);
+    bool PrependOptionTerminatorIfValueStartsWithDash = false,
+    bool IsSecret = false,
+    string[]? SecretValueKeys = null);
 
 internal sealed record GeneratedApiBaseline(
     string ClassName,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -841,13 +841,18 @@ internal static class GeneratedApiCompatibilityPreserver
         var compatibilityConstructors = command.CompatibilityConstructors.ToList();
         var positionalArguments = command.PositionalArguments.ToArray();
         var options = command.Options.ToArray();
+        var renamedProperties = new Dictionary<string, string>(StringComparer.Ordinal);
         RestoreNamesChangedByLocalCollisions(
             baselineProperties,
             positionalArguments,
             options,
             compatibilityProperties);
+        RestoreForwardedAliasCollisions(
+            baselineProperties,
+            positionalArguments,
+            options,
+            compatibilityProperties);
         var violations = new List<string>();
-        var renamedProperties = new Dictionary<string, string>(StringComparer.Ordinal);
         var preservedTypeChanges = PreserveScalarToCollectionChanges(
             command,
             baselineProperties,
@@ -882,6 +887,7 @@ internal static class GeneratedApiCompatibilityPreserver
             PreserveBaselineProperty(
                 command,
                 baseline,
+                baselineProperties,
                 currentProperties,
                 compatibilityProperties,
                 renamedProperties,
@@ -969,6 +975,86 @@ internal static class GeneratedApiCompatibilityPreserver
             propertyNames.Add(baseline.PropertyName);
         }
     }
+
+    private static void RestoreForwardedAliasCollisions(
+        IReadOnlyList<GeneratedApiProperty> baselineProperties,
+        CliPositionalArgument[] positionalArguments,
+        CliOptionDefinition[] options,
+        IList<CliCompatibilityProperty> compatibilityProperties)
+    {
+        var propertyNames = options.Select(static option => option.PropertyName)
+            .Concat(positionalArguments.Select(static argument => argument.PropertyName))
+            .Concat(compatibilityProperties.Select(static property => property.PropertyName))
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var alias in baselineProperties.Where(static property =>
+                     property is { IsCompatibility: true, ForwardToPropertyName: not null }))
+        {
+            var aliasMember = FindLocalMember(
+                positionalArguments,
+                options,
+                property => property.PropertyName.Equals(alias.PropertyName, StringComparison.Ordinal));
+            var targetBaseline = FindForwardingTargetBaseline(baselineProperties, alias);
+            if (aliasMember is null
+                || targetBaseline is null
+                || HasSameCliIdentity(GetLocalMember(aliasMember.Value, positionalArguments, options), targetBaseline))
+            {
+                continue;
+            }
+
+            var targetMember = FindLocalMember(
+                positionalArguments,
+                options,
+                property => HasSameCliIdentity(property, targetBaseline));
+            if (targetMember is null)
+            {
+                continue;
+            }
+
+            propertyNames.Remove(alias.PropertyName);
+            var replacementName = GetUniquePropertyName(
+                alias.PropertyName + (aliasMember.Value.IsOption ? "Option" : "Argument"),
+                propertyNames);
+            RenameLocalMember(aliasMember.Value, replacementName, positionalArguments, options);
+            RetargetCompatibilityProperties(
+                compatibilityProperties,
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [alias.PropertyName] = replacementName,
+                });
+            compatibilityProperties.Add(ToCompatibilityProperty(alias));
+            propertyNames.Add(alias.PropertyName);
+        }
+    }
+
+    private static GeneratedApiProperty? FindForwardingTargetBaseline(
+        IReadOnlyList<GeneratedApiProperty> baselineProperties,
+        GeneratedApiProperty alias)
+    {
+        var targetName = alias.ForwardToPropertyName;
+        var visited = new HashSet<string>(StringComparer.Ordinal);
+        while (targetName is not null && visited.Add(targetName))
+        {
+            var target = baselineProperties.FirstOrDefault(property =>
+                property.PropertyName.Equals(targetName, StringComparison.Ordinal));
+            if (target is null || !target.IsCompatibility)
+            {
+                return target;
+            }
+
+            targetName = target.ForwardToPropertyName;
+        }
+
+        return null;
+    }
+
+    private static GeneratedApiProperty GetLocalMember(
+        LocalMemberLocation location,
+        IReadOnlyList<CliPositionalArgument> positionalArguments,
+        IReadOnlyList<CliOptionDefinition> options) =>
+        location.IsOption
+            ? ToGeneratedProperty(options[location.Index])
+            : ToGeneratedProperty(positionalArguments[location.Index]);
 
     private static LocalMemberLocation? FindLocalMember(
         IReadOnlyList<CliPositionalArgument> positionalArguments,
@@ -1148,6 +1234,7 @@ internal static class GeneratedApiCompatibilityPreserver
     private static void PreserveBaselineProperty(
         CliCommandDefinition command,
         GeneratedApiProperty baseline,
+        IReadOnlyList<GeneratedApiProperty> baselineProperties,
         IReadOnlyList<GeneratedApiProperty> currentProperties,
         ICollection<CliCompatibilityProperty> compatibilityProperties,
         IDictionary<string, string> renamedProperties,
@@ -1156,6 +1243,7 @@ internal static class GeneratedApiCompatibilityPreserver
         if (TryValidateSameNameProperty(
                 command,
                 baseline,
+                baselineProperties,
                 currentProperties,
                 violations))
         {
@@ -1209,6 +1297,7 @@ internal static class GeneratedApiCompatibilityPreserver
     private static bool TryValidateSameNameProperty(
         CliCommandDefinition command,
         GeneratedApiProperty baseline,
+        IReadOnlyList<GeneratedApiProperty> baselineProperties,
         IReadOnlyList<GeneratedApiProperty> currentProperties,
         List<string> violations)
     {
@@ -1224,7 +1313,15 @@ internal static class GeneratedApiCompatibilityPreserver
             return false;
         }
 
-        if (baseline.IsCompatibility)
+        var forwardingTarget = FindForwardingTargetBaseline(baselineProperties, baseline);
+        if (baseline.IsCompatibility
+            && baseline.ForwardToPropertyName is not null
+            && (forwardingTarget is null || !HasSameCliIdentity(match, forwardingTarget)))
+        {
+            violations.Add(
+                $"{command.ClassName}.{baseline.PropertyName} compatibility alias now resolves to a different CLI switch or argument position");
+        }
+        else if (baseline.IsCompatibility)
         {
             ValidateMatchingPropertyShape(command, baseline, match, violations);
         }
@@ -1314,18 +1411,21 @@ internal static class GeneratedApiCompatibilityPreserver
         ICollection<string> violations) =>
         PreserveCompatibilityProperty(
             command,
-            new CliCompatibilityProperty
-            {
-                PropertyName = baseline.PropertyName,
-                CSharpType = baseline.CSharpType,
-                ForwardToPropertyName = baseline.ForwardToPropertyName,
-                UseInitAccessor = baseline.UseInitAccessor,
-                ForwardingKind = baseline.ForwardingKind,
-                ObsoleteMessage = baseline.ObsoleteMessage
-                    ?? $"{baseline.PropertyName} is retained for compatibility.",
-            },
+            ToCompatibilityProperty(baseline),
             compatibilityProperties,
             violations);
+
+    private static CliCompatibilityProperty ToCompatibilityProperty(GeneratedApiProperty baseline) =>
+        new()
+        {
+            PropertyName = baseline.PropertyName,
+            CSharpType = baseline.CSharpType,
+            ForwardToPropertyName = baseline.ForwardToPropertyName,
+            UseInitAccessor = baseline.UseInitAccessor,
+            ForwardingKind = baseline.ForwardingKind,
+            ObsoleteMessage = baseline.ObsoleteMessage
+                ?? $"{baseline.PropertyName} is retained for compatibility.",
+        };
 
     private static void PreserveCompatibilityProperty(
         CliCommandDefinition command,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -1208,7 +1208,7 @@ internal static class GeneratedApiCompatibilityPreserver
             return false;
         }
 
-        if (baseline is { IsCompatibility: true, ForwardToPropertyName: not null })
+        if (baseline.IsCompatibility)
         {
             ValidateMatchingPropertyShape(command, baseline, match, violations);
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -15,6 +15,11 @@ internal static class GeneratedApiCompatibilityPreserver
         Rejected,
     }
 
+    private readonly record struct LocalMemberLocation(
+        bool IsOption,
+        int Index,
+        string PropertyName);
+
     public static CliToolDefinition Preserve(CliToolDefinition tool, string outputDirectory)
     {
         var optionsDirectory = Path.Combine(
@@ -480,8 +485,8 @@ internal static class GeneratedApiCompatibilityPreserver
             commandBaseline.CommandParts,
             groupIdentifier,
             commandFacadeMethods);
-        var mergedOverrides = recoveredOverrides
-            .Concat(preserved.CommandPartIdentifierOverrides)
+        var mergedOverrides = preserved.CommandPartIdentifierOverrides
+            .Concat(recoveredOverrides)
             .DistinctBy(static pair => pair.Key)
             .ToDictionary(static pair => pair.Key, static pair => pair.Value);
 
@@ -826,6 +831,11 @@ internal static class GeneratedApiCompatibilityPreserver
         var compatibilityConstructors = command.CompatibilityConstructors.ToList();
         var positionalArguments = command.PositionalArguments.ToArray();
         var options = command.Options.ToArray();
+        RestoreNamesChangedByLocalCollisions(
+            baselineProperties,
+            positionalArguments,
+            options,
+            command.CompatibilityProperties);
         var violations = new List<string>();
         var renamedProperties = new Dictionary<string, string>(StringComparer.Ordinal);
         var preservedTypeChanges = PreserveScalarToCollectionChanges(
@@ -895,6 +905,108 @@ internal static class GeneratedApiCompatibilityPreserver
                 command.DocumentationExampleValues,
                 renamedProperties),
         };
+    }
+
+    private static void RestoreNamesChangedByLocalCollisions(
+        IReadOnlyList<GeneratedApiProperty> baselineProperties,
+        CliPositionalArgument[] positionalArguments,
+        CliOptionDefinition[] options,
+        IReadOnlyList<CliCompatibilityProperty> compatibilityProperties)
+    {
+        var propertyNames = options.Select(static option => option.PropertyName)
+            .Concat(positionalArguments.Select(static argument => argument.PropertyName))
+            .Concat(compatibilityProperties.Select(static property => property.PropertyName))
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var baseline in baselineProperties.Where(static property => !property.IsCompatibility))
+        {
+            var historicalMember = FindLocalMember(
+                positionalArguments,
+                options,
+                property => HasSameCliIdentity(property, baseline));
+            if (historicalMember is null
+                || historicalMember.Value.PropertyName.Equals(
+                    baseline.PropertyName,
+                    StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var conflictingMember = FindLocalMember(
+                positionalArguments,
+                options,
+                property => property.PropertyName.Equals(
+                    baseline.PropertyName,
+                    StringComparison.Ordinal));
+            if (conflictingMember is null)
+            {
+                continue;
+            }
+
+            propertyNames.Remove(historicalMember.Value.PropertyName);
+            propertyNames.Remove(conflictingMember.Value.PropertyName);
+            var conflictingName = GetUniquePropertyName(
+                baseline.PropertyName + (conflictingMember.Value.IsOption ? "Option" : "Argument"),
+                propertyNames);
+            RenameLocalMember(conflictingMember.Value, conflictingName, positionalArguments, options);
+            RenameLocalMember(historicalMember.Value, baseline.PropertyName, positionalArguments, options);
+            propertyNames.Add(baseline.PropertyName);
+        }
+    }
+
+    private static LocalMemberLocation? FindLocalMember(
+        IReadOnlyList<CliPositionalArgument> positionalArguments,
+        IReadOnlyList<CliOptionDefinition> options,
+        Func<GeneratedApiProperty, bool> predicate)
+    {
+        for (var index = 0; index < options.Count; index++)
+        {
+            if (predicate(ToGeneratedProperty(options[index])))
+            {
+                return new LocalMemberLocation(true, index, options[index].PropertyName);
+            }
+        }
+
+        for (var index = 0; index < positionalArguments.Count; index++)
+        {
+            if (predicate(ToGeneratedProperty(positionalArguments[index])))
+            {
+                return new LocalMemberLocation(false, index, positionalArguments[index].PropertyName);
+            }
+        }
+
+        return null;
+    }
+
+    private static void RenameLocalMember(
+        LocalMemberLocation location,
+        string propertyName,
+        CliPositionalArgument[] positionalArguments,
+        CliOptionDefinition[] options)
+    {
+        if (location.IsOption)
+        {
+            options[location.Index] = options[location.Index] with { PropertyName = propertyName };
+            return;
+        }
+
+        positionalArguments[location.Index] = positionalArguments[location.Index] with
+        {
+            PropertyName = propertyName,
+        };
+    }
+
+    private static string GetUniquePropertyName(
+        string candidate,
+        HashSet<string> propertyNames)
+    {
+        var root = candidate;
+        for (var suffix = 2; !propertyNames.Add(candidate); suffix++)
+        {
+            candidate = root + suffix;
+        }
+
+        return candidate;
     }
 
     private static HashSet<string> PreserveScalarToCollectionChanges(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -432,6 +432,7 @@ internal static class GeneratedApiCompatibilityPreserver
                 ValueSeparator = property.ValueSeparator,
                 IsSecret = property.IsSecret,
                 SecretValueKeys = property.SecretValueKeys ?? [],
+                ValidationConstraints = property.ValidationConstraints,
             })
             .ToArray();
 
@@ -2342,6 +2343,10 @@ internal static class GeneratedApiCompatibilityPreserver
         var cliFlag = FindAttribute(attributes, "CliFlag");
         var cliSwitch = cliOption ?? cliFlag;
         var secretValue = FindAttribute(attributes, "SecretValue");
+        var range = FindAttribute(attributes, "Range")
+                    ?? FindAttribute(attributes, "CliOptionValueRange");
+        var regularExpression = FindAttribute(attributes, "RegularExpression")
+                                ?? FindAttribute(attributes, "CliOptionValueRegularExpression");
         var obsolete = FindAttribute(attributes, "Obsolete");
         var (targetPropertyName, forwardingKind) = GetForwarding(accessorList);
         bool? isFlag = cliSwitch is null ? null : cliFlag is not null;
@@ -2370,7 +2375,25 @@ internal static class GeneratedApiCompatibilityPreserver
             GetBooleanNamedArgument(cliArgument, "PrependOptionTerminator"),
             GetBooleanNamedArgument(cliArgument, "PrependOptionTerminatorIfValueStartsWithDash"),
             secretValue is not null,
-            GetStringArguments(secretValue));
+            GetStringArguments(secretValue),
+            GetValidationConstraints(range, regularExpression));
+    }
+
+    private static CliValidationConstraints? GetValidationConstraints(
+        AttributeSyntax? range,
+        AttributeSyntax? regularExpression)
+    {
+        var minValue = GetIntegerArgument(range);
+        var maxValue = GetIntegerArgument(range, 1);
+        var pattern = GetStringArgument(regularExpression);
+        return minValue is null && maxValue is null && pattern is null
+            ? null
+            : new CliValidationConstraints
+            {
+                MinValue = minValue,
+                MaxValue = maxValue,
+                Pattern = pattern,
+            };
     }
 
     private static AttributeSyntax? FindAttribute(
@@ -2386,8 +2409,8 @@ internal static class GeneratedApiCompatibilityPreserver
                 ? literal.Token.ValueText
                 : null;
 
-    private static int? GetIntegerArgument(AttributeSyntax? attribute) =>
-        attribute?.ArgumentList?.Arguments.FirstOrDefault()?.Expression is LiteralExpressionSyntax literal
+    private static int? GetIntegerArgument(AttributeSyntax? attribute, int index = 0) =>
+        attribute?.ArgumentList?.Arguments.ElementAtOrDefault(index)?.Expression is LiteralExpressionSyntax literal
             && literal.IsKind(SyntaxKind.NumericLiteralExpression)
             && literal.Token.Value is int value
                 ? value
@@ -2560,7 +2583,8 @@ internal sealed record GeneratedApiProperty(
     bool PrependOptionTerminator = false,
     bool PrependOptionTerminatorIfValueStartsWithDash = false,
     bool IsSecret = false,
-    string[]? SecretValueKeys = null);
+    string[]? SecretValueKeys = null,
+    CliValidationConstraints? ValidationConstraints = null);
 
 internal sealed record GeneratedApiBaseline(
     string ClassName,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -835,7 +835,7 @@ internal static class GeneratedApiCompatibilityPreserver
             baselineProperties,
             positionalArguments,
             options,
-            command.CompatibilityProperties);
+            compatibilityProperties);
         var violations = new List<string>();
         var renamedProperties = new Dictionary<string, string>(StringComparer.Ordinal);
         var preservedTypeChanges = PreserveScalarToCollectionChanges(
@@ -911,7 +911,7 @@ internal static class GeneratedApiCompatibilityPreserver
         IReadOnlyList<GeneratedApiProperty> baselineProperties,
         CliPositionalArgument[] positionalArguments,
         CliOptionDefinition[] options,
-        IReadOnlyList<CliCompatibilityProperty> compatibilityProperties)
+        IList<CliCompatibilityProperty> compatibilityProperties)
     {
         var propertyNames = options.Select(static option => option.PropertyName)
             .Concat(positionalArguments.Select(static argument => argument.PropertyName))
@@ -950,6 +950,12 @@ internal static class GeneratedApiCompatibilityPreserver
                 propertyNames);
             RenameLocalMember(conflictingMember.Value, conflictingName, positionalArguments, options);
             RenameLocalMember(historicalMember.Value, baseline.PropertyName, positionalArguments, options);
+            RetargetCompatibilityProperties(
+                compatibilityProperties,
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [baseline.PropertyName] = conflictingName,
+                });
             propertyNames.Add(baseline.PropertyName);
         }
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -970,12 +970,20 @@ internal static class GeneratedApiCompatibilityPreserver
                 propertyNames);
             RenameLocalMember(conflictingMember.Value, conflictingName, positionalArguments, options);
             RenameLocalMember(historicalMember.Value, baseline.PropertyName, positionalArguments, options);
+            var historicalForwarders = baselineProperties
+                .Where(property => property is { IsCompatibility: true, ForwardToPropertyName: not null }
+                    && property.ForwardToPropertyName.Equals(
+                        baseline.PropertyName,
+                        StringComparison.Ordinal))
+                .Select(static property => property.PropertyName)
+                .ToHashSet(StringComparer.Ordinal);
             RetargetCompatibilityProperties(
                 compatibilityProperties,
                 new Dictionary<string, string>(StringComparer.Ordinal)
                 {
                     [baseline.PropertyName] = conflictingName,
-                });
+                },
+                historicalForwarders);
             propertyNames.Add(baseline.PropertyName);
         }
     }
@@ -1339,12 +1347,14 @@ internal static class GeneratedApiCompatibilityPreserver
 
     private static void RetargetCompatibilityProperties(
         IList<CliCompatibilityProperty> compatibilityProperties,
-        IReadOnlyDictionary<string, string> renamedProperties)
+        IReadOnlyDictionary<string, string> renamedProperties,
+        IReadOnlySet<string>? excludedProperties = null)
     {
         for (var index = 0; index < compatibilityProperties.Count; index++)
         {
             var property = compatibilityProperties[index];
-            if (property.ForwardToPropertyName is { } target
+            if (excludedProperties?.Contains(property.PropertyName) != true
+                && property.ForwardToPropertyName is { } target
                 && renamedProperties.TryGetValue(target, out var replacement))
             {
                 compatibilityProperties[index] = property with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -1025,25 +1025,12 @@ internal static class GeneratedApiCompatibilityPreserver
         IDictionary<string, string> renamedProperties,
         List<string> violations)
     {
-        var sameNameCandidates = currentProperties
-            .Where(property => property.PropertyName.Equals(
-                baseline.PropertyName,
-                StringComparison.Ordinal))
-            .ToArray();
-        var sameName = sameNameCandidates.FirstOrDefault(property =>
-                           HasSameCliIdentity(property, baseline))
-                       ?? sameNameCandidates.FirstOrDefault();
-        if (sameName is not null)
+        if (TryValidateSameNameProperty(
+                command,
+                baseline,
+                currentProperties,
+                violations))
         {
-            if (baseline is { IsCompatibility: true, ForwardToPropertyName: not null })
-            {
-                ValidateMatchingPropertyShape(command, baseline, sameName, violations);
-            }
-            else
-            {
-                ValidateMatchingProperty(command, baseline, sameName, violations);
-            }
-
             return;
         }
 
@@ -1089,6 +1076,36 @@ internal static class GeneratedApiCompatibilityPreserver
         {
             renamedProperties[baseline.PropertyName] = replacement.PropertyName;
         }
+    }
+
+    private static bool TryValidateSameNameProperty(
+        CliCommandDefinition command,
+        GeneratedApiProperty baseline,
+        IReadOnlyList<GeneratedApiProperty> currentProperties,
+        List<string> violations)
+    {
+        var candidates = currentProperties
+            .Where(property => property.PropertyName.Equals(
+                baseline.PropertyName,
+                StringComparison.Ordinal))
+            .ToArray();
+        var match = candidates.FirstOrDefault(property => HasSameCliIdentity(property, baseline))
+                    ?? candidates.FirstOrDefault();
+        if (match is null)
+        {
+            return false;
+        }
+
+        if (baseline is { IsCompatibility: true, ForwardToPropertyName: not null })
+        {
+            ValidateMatchingPropertyShape(command, baseline, match, violations);
+        }
+        else
+        {
+            ValidateMatchingProperty(command, baseline, match, violations);
+        }
+
+        return true;
     }
 
     private static void RetargetCompatibilityProperties(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -420,10 +420,16 @@ internal static class GeneratedApiCompatibilityPreserver
             .Select(static property => new CliOptionDefinition
             {
                 SwitchName = property.SwitchName!,
+                ShortForm = property.ShortForm,
+                PreferShortForm = property.PreferShortForm,
                 PropertyName = property.PropertyName,
                 CSharpType = property.CSharpType,
                 IsRequired = property.IsRequired,
-                IsFlag = property.CSharpType is "bool" or "bool?",
+                IsFlag = property.IsFlag ?? property.CSharpType is "bool" or "bool?",
+                ValueArity = property.ValueArity,
+                Phase = property.Phase ?? CommandLinePhase.Normal,
+                GroupValues = property.GroupValues,
+                ValueSeparator = property.ValueSeparator,
             })
             .ToArray();
 
@@ -437,6 +443,10 @@ internal static class GeneratedApiCompatibilityPreserver
                 CSharpType = property.CSharpType,
                 PositionIndex = property.ArgumentPosition!.Value,
                 IsRequired = property.IsRequired,
+                Phase = property.Phase ?? CommandLinePhase.Passthrough,
+                PrependOptionTerminator = property.PrependOptionTerminator,
+                PrependOptionTerminatorIfValueStartsWithDash =
+                    property.PrependOptionTerminatorIfValueStartsWithDash,
             })
             .ToArray();
 
@@ -2225,24 +2235,36 @@ internal static class GeneratedApiCompatibilityPreserver
     {
         var attributes = attributeLists.SelectMany(list => list.Attributes).ToArray();
         var cliArgument = FindAttribute(attributes, "CliArgument");
-        var cliOption = FindAttribute(attributes, "CliOption")
-                        ?? FindAttribute(attributes, "CliFlag");
+        var cliOption = FindAttribute(attributes, "CliOption");
+        var cliFlag = FindAttribute(attributes, "CliFlag");
+        var cliSwitch = cliOption ?? cliFlag;
         var obsolete = FindAttribute(attributes, "Obsolete");
-        var forwarding = GetForwarding(accessorList);
+        var (targetPropertyName, forwardingKind) = GetForwarding(accessorList);
+        bool? isFlag = cliSwitch is null ? null : cliFlag is not null;
 
         return new GeneratedApiProperty(
             propertyName,
             cSharpType,
-            GetStringArgument(cliOption),
+            GetStringArgument(cliSwitch),
             GetIntegerArgument(cliArgument),
-            isRequired,
+            isRequired || GetBooleanNamedArgument(cliArgument, "Required"),
             obsolete is not null,
-            forwarding.TargetPropertyName,
+            targetPropertyName,
             GetStringArgument(obsolete),
             isRequired
             || accessorList?.Accessors.Any(static accessor =>
                 accessor.IsKind(SyntaxKind.InitAccessorDeclaration)) == true,
-            forwarding.Kind);
+            forwardingKind,
+            isFlag,
+            GetStringNamedArgument(cliSwitch, "ShortForm"),
+            GetBooleanNamedArgument(cliSwitch, "PreferShortForm"),
+            GetOptionValueSeparator(cliOption),
+            GetEnumNamedArgument(cliOption, "ValueArity", CliOptionValueArity.Required),
+            GetBooleanNamedArgument(cliOption, "GroupValues"),
+            GetNullableEnumNamedArgument<CommandLinePhase>(cliSwitch, "Phase")
+            ?? GetNullableEnumNamedArgument<CommandLinePhase>(cliArgument, "Phase"),
+            GetBooleanNamedArgument(cliArgument, "PrependOptionTerminator"),
+            GetBooleanNamedArgument(cliArgument, "PrependOptionTerminatorIfValueStartsWithDash"));
     }
 
     private static AttributeSyntax? FindAttribute(
@@ -2264,6 +2286,57 @@ internal static class GeneratedApiCompatibilityPreserver
             && literal.Token.Value is int value
                 ? value
                 : null;
+
+    private static string? GetStringNamedArgument(AttributeSyntax? attribute, string name) =>
+        FindNamedArgument(attribute, name)?.Expression is LiteralExpressionSyntax literal
+        && literal.IsKind(SyntaxKind.StringLiteralExpression)
+            ? literal.Token.ValueText
+            : null;
+
+    private static bool GetBooleanNamedArgument(AttributeSyntax? attribute, string name) =>
+        FindNamedArgument(attribute, name)?.Expression.Kind() == SyntaxKind.TrueLiteralExpression;
+
+    private static TEnum GetEnumNamedArgument<TEnum>(
+        AttributeSyntax? attribute,
+        string name,
+        TEnum defaultValue)
+        where TEnum : struct, Enum =>
+        GetNullableEnumNamedArgument<TEnum>(attribute, name) ?? defaultValue;
+
+    private static string GetOptionValueSeparator(AttributeSyntax? attribute) =>
+        GetNamedEnumMember(attribute, "Format") switch
+        {
+            "EqualsSeparated" => "=",
+            "ColonSeparated" => ":",
+            "NoSeparator" => string.Empty,
+            _ => " ",
+        };
+
+    private static TEnum? GetNullableEnumNamedArgument<TEnum>(
+        AttributeSyntax? attribute,
+        string name)
+        where TEnum : struct, Enum
+    {
+        var memberName = GetNamedEnumMember(attribute, name);
+        return Enum.TryParse<TEnum>(memberName, out var value) ? value : null;
+    }
+
+    private static string? GetNamedEnumMember(AttributeSyntax? attribute, string name)
+    {
+        var expression = FindNamedArgument(attribute, name)?.Expression;
+        return expression switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name.Identifier.ValueText,
+            IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+            _ => null,
+        };
+    }
+
+    private static AttributeArgumentSyntax? FindNamedArgument(
+        AttributeSyntax? attribute,
+        string name) =>
+        attribute?.ArgumentList?.Arguments.FirstOrDefault(argument =>
+            argument.NameEquals?.Name.Identifier.ValueText.Equals(name, StringComparison.Ordinal) == true);
 
     private static (string? TargetPropertyName, CliCompatibilityForwardingKind Kind) GetForwarding(
         AccessorListSyntax? accessorList)
@@ -2352,7 +2425,16 @@ internal sealed record GeneratedApiProperty(
     string? ForwardToPropertyName,
     string? ObsoleteMessage,
     bool UseInitAccessor = false,
-    CliCompatibilityForwardingKind ForwardingKind = CliCompatibilityForwardingKind.Direct);
+    CliCompatibilityForwardingKind ForwardingKind = CliCompatibilityForwardingKind.Direct,
+    bool? IsFlag = null,
+    string? ShortForm = null,
+    bool PreferShortForm = false,
+    string ValueSeparator = " ",
+    CliOptionValueArity ValueArity = CliOptionValueArity.Required,
+    bool GroupValues = false,
+    CommandLinePhase? Phase = null,
+    bool PrependOptionTerminator = false,
+    bool PrependOptionTerminatorIfValueStartsWithDash = false);
 
 internal sealed record GeneratedApiBaseline(
     string ClassName,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -1112,6 +1112,9 @@ public static partial class GeneratorUtils
             .Where(command => command.SubDomainGroup is null)
             .Where(command => command.CommandParts.Length == 1)
             .Where(command => subDomainNames.Contains(GetCommandGroupIdentifier(command)))
+            .DistinctBy(
+                command => $"{GetCommandGroupIdentifier(command)}\u001F{command.ClassName}",
+                StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         var duplicateParentGroups = GetDuplicateCommandGroups(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/InheritedPropertyCollisionResolver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/InheritedPropertyCollisionResolver.cs
@@ -76,6 +76,9 @@ internal static class InheritedPropertyCollisionResolver
             command.CommandParts,
             occupiedNames,
             renamedProperties);
+        var usedLocalNames = new HashSet<string>(StringComparer.Ordinal);
+        options = ResolveDuplicateOptionNames(options, usedLocalNames);
+        var renamedArgumentNames = new Dictionary<string, string>(StringComparer.Ordinal);
         var positionalArguments = command.PositionalArguments
             .Select(argument => argument with
             {
@@ -85,6 +88,15 @@ internal static class InheritedPropertyCollisionResolver
                     occupiedNames,
                     renamedProperties),
             })
+            .Select(argument => !usedLocalNames.Contains(argument.PropertyName)
+                ? argument
+                : argument with
+                {
+                    PropertyName = GetOrCreateArgumentName(
+                        argument.PropertyName,
+                        renamedArgumentNames,
+                        usedLocalNames),
+                })
             .ToArray();
 
         return command with
@@ -113,6 +125,60 @@ internal static class InheritedPropertyCollisionResolver
                     pair => pair.Value,
                     StringComparer.Ordinal),
         };
+    }
+
+    private static IReadOnlyList<CliOptionDefinition> ResolveDuplicateOptionNames(
+        IReadOnlyList<CliOptionDefinition> options,
+        HashSet<string> usedLocalNames) =>
+        options
+            .Select(option => usedLocalNames.Add(option.PropertyName)
+                ? option
+                : option with
+                {
+                    PropertyName = CreateUniqueLocalName(
+                        option.PropertyName,
+                        "Option",
+                        usedLocalNames),
+                })
+            .ToArray();
+
+    private static string GetOrCreateArgumentName(
+        string propertyName,
+        IDictionary<string, string> renamedArgumentNames,
+        HashSet<string> usedLocalNames)
+    {
+        if (renamedArgumentNames.TryGetValue(propertyName, out var renamedPropertyName))
+        {
+            return renamedPropertyName;
+        }
+
+        renamedPropertyName = CreateUniqueLocalName(
+            propertyName,
+            "Argument",
+            usedLocalNames);
+        renamedArgumentNames.Add(propertyName, renamedPropertyName);
+        return renamedPropertyName;
+    }
+
+    private static string CreateUniqueLocalName(
+        string propertyName,
+        string suffix,
+        HashSet<string> usedLocalNames)
+    {
+        var candidate = propertyName + suffix;
+        if (usedLocalNames.Add(candidate))
+        {
+            return candidate;
+        }
+
+        for (var index = 2; ; index++)
+        {
+            candidate = propertyName + suffix + index;
+            if (usedLocalNames.Add(candidate))
+            {
+                return candidate;
+            }
+        }
     }
 
     private static bool TryGetRename(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -16,7 +16,7 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 public partial class GitCliScraper : CliScraperBase, IDisposable
 {
     private readonly object _helpRepositoryLock = new();
-    private readonly SemaphoreSlim _helpRepositoryUsage = new(1, 1);
+    private readonly SemaphoreSlim _helpCommandUsage = new(1, 1);
     private string? _helpRepositoryDirectory;
     private Task<string>? _helpRepositoryTask;
     private bool _disposed;
@@ -43,10 +43,17 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             GenerateCode = false,
         };
 
+    public override Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        return base.IsAvailableAsync(cancellationToken);
+    }
+
     protected override async Task<string?> GetHelpTextAsync(
         string[] commandPath,
         CancellationToken cancellationToken)
     {
+        ThrowIfDisposed();
         var cacheKey = string.Join(' ', commandPath);
         if (HelpCache.TryGet(cacheKey, out var cached))
         {
@@ -57,14 +64,12 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             ? "help -a"
             : $"{string.Join(' ', commandPath.Skip(1))} -h";
         var usesHelpRepository = commandPath.Length > 2;
-        if (usesHelpRepository)
-        {
-            await _helpRepositoryUsage.WaitAsync(cancellationToken);
-        }
+        await _helpCommandUsage.WaitAsync(cancellationToken);
 
         CliCommandResult result;
         try
         {
+            ThrowIfDisposed();
             var workingDirectory = usesHelpRepository
                 ? await GetHelpRepositoryAsync()
                 : null;
@@ -76,10 +81,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         }
         finally
         {
-            if (usesHelpRepository)
-            {
-                _helpRepositoryUsage.Release();
-            }
+            _helpCommandUsage.Release();
         }
 
         // Git sends short help to either stream and commonly exits with its usage code.
@@ -92,6 +94,14 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
 
         HelpCache.Set(cacheKey, helpText);
         return helpText;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        lock (_helpRepositoryLock)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+        }
     }
 
     private Task<string> GetHelpRepositoryAsync()
@@ -137,7 +147,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             initialization = _helpRepositoryTask;
         }
 
-        _helpRepositoryUsage.Wait();
+        _helpCommandUsage.Wait();
         string? directory;
         try
         {
@@ -159,7 +169,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         }
         finally
         {
-            _helpRepositoryUsage.Release();
+            _helpCommandUsage.Release();
         }
 
         if (directory is null || !Directory.Exists(directory))

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -15,6 +15,9 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 /// </summary>
 public partial class GitCliScraper : CliScraperBase
 {
+    private readonly object _helpRepositoryLock = new();
+    private Task<string>? _helpRepositoryTask;
+
     public override string ToolName => "git";
     public override string NamespacePrefix => "Git";
     public override string TargetNamespace => "ModularPipelines.Git";
@@ -50,7 +53,14 @@ public partial class GitCliScraper : CliScraperBase
         var arguments = commandPath.Length == 1
             ? "help -a"
             : $"{string.Join(' ', commandPath.Skip(1))} -h";
-        var result = await Executor.ExecuteAsync(ToolName, arguments, cancellationToken);
+        var workingDirectory = commandPath.Length > 2
+            ? await GetHelpRepositoryAsync(cancellationToken)
+            : null;
+        var result = await Executor.ExecuteAsync(
+            ToolName,
+            arguments,
+            cancellationToken,
+            workingDirectory);
 
         // Git sends short help to either stream and commonly exits with its usage code.
         var helpText = result.CombinedOutput;
@@ -62,6 +72,32 @@ public partial class GitCliScraper : CliScraperBase
 
         HelpCache.Set(cacheKey, helpText);
         return helpText;
+    }
+
+    private Task<string> GetHelpRepositoryAsync(CancellationToken cancellationToken)
+    {
+        lock (_helpRepositoryLock)
+        {
+            return _helpRepositoryTask ??= CreateHelpRepositoryAsync(cancellationToken);
+        }
+    }
+
+    private async Task<string> CreateHelpRepositoryAsync(CancellationToken cancellationToken)
+    {
+        var directory = Path.Combine(Path.GetTempPath(), $"git-scraper-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var result = await Executor.ExecuteAsync(
+            ToolName,
+            "init --quiet",
+            cancellationToken,
+            directory);
+        if (!result.Success)
+        {
+            throw new InvalidOperationException(
+                $"Could not initialize the temporary Git help repository: {result.CombinedOutput}");
+        }
+
+        return directory;
     }
 
     protected override IEnumerable<string> ExtractSubcommands(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -13,9 +13,10 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 /// - Options via 'git <command> -h' with format: -short, --long   description
 /// - Mostly flat command structure, with usage-derived child commands
 /// </summary>
-public partial class GitCliScraper : CliScraperBase
+public partial class GitCliScraper : CliScraperBase, IDisposable
 {
     private readonly object _helpRepositoryLock = new();
+    private string? _helpRepositoryDirectory;
     private Task<string>? _helpRepositoryTask;
 
     public override string ToolName => "git";
@@ -85,6 +86,7 @@ public partial class GitCliScraper : CliScraperBase
     private async Task<string> CreateHelpRepositoryAsync()
     {
         var directory = Path.Combine(Path.GetTempPath(), $"git-scraper-{Guid.NewGuid():N}");
+        _helpRepositoryDirectory = directory;
         Directory.CreateDirectory(directory);
         var result = await Executor.ExecuteAsync(
             ToolName,
@@ -98,6 +100,35 @@ public partial class GitCliScraper : CliScraperBase
         }
 
         return directory;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        string? directory;
+        lock (_helpRepositoryLock)
+        {
+            directory = _helpRepositoryDirectory;
+            _helpRepositoryDirectory = null;
+            _helpRepositoryTask = null;
+        }
+
+        if (directory is null || !Directory.Exists(directory))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            Logger.LogWarning(
+                exception,
+                "Could not delete temporary Git help repository: {Directory}",
+                directory);
+        }
     }
 
     protected override IEnumerable<string> ExtractSubcommands(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -16,8 +16,10 @@ namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
 public partial class GitCliScraper : CliScraperBase, IDisposable
 {
     private readonly object _helpRepositoryLock = new();
+    private readonly SemaphoreSlim _helpRepositoryUsage = new(1, 1);
     private string? _helpRepositoryDirectory;
     private Task<string>? _helpRepositoryTask;
+    private bool _disposed;
 
     public override string ToolName => "git";
     public override string NamespacePrefix => "Git";
@@ -54,14 +56,31 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         var arguments = commandPath.Length == 1
             ? "help -a"
             : $"{string.Join(' ', commandPath.Skip(1))} -h";
-        var workingDirectory = commandPath.Length > 2
-            ? await GetHelpRepositoryAsync()
-            : null;
-        var result = await Executor.ExecuteAsync(
-            ToolName,
-            arguments,
-            cancellationToken,
-            workingDirectory);
+        var usesHelpRepository = commandPath.Length > 2;
+        if (usesHelpRepository)
+        {
+            await _helpRepositoryUsage.WaitAsync(cancellationToken);
+        }
+
+        CliCommandResult result;
+        try
+        {
+            var workingDirectory = usesHelpRepository
+                ? await GetHelpRepositoryAsync()
+                : null;
+            result = await Executor.ExecuteAsync(
+                ToolName,
+                arguments,
+                cancellationToken,
+                workingDirectory);
+        }
+        finally
+        {
+            if (usesHelpRepository)
+            {
+                _helpRepositoryUsage.Release();
+            }
+        }
 
         // Git sends short help to either stream and commonly exits with its usage code.
         var helpText = result.CombinedOutput;
@@ -79,6 +98,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
     {
         lock (_helpRepositoryLock)
         {
+            ObjectDisposedException.ThrowIf(_disposed, this);
             return _helpRepositoryTask ??= CreateHelpRepositoryAsync();
         }
     }
@@ -92,7 +112,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             ToolName,
             "init --quiet",
             CancellationToken.None,
-            directory);
+            directory).ConfigureAwait(false);
         if (!result.Success)
         {
             throw new InvalidOperationException(
@@ -105,12 +125,41 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
     /// <inheritdoc />
     public void Dispose()
     {
-        string? directory;
+        Task<string>? initialization;
         lock (_helpRepositoryLock)
         {
-            directory = _helpRepositoryDirectory;
-            _helpRepositoryDirectory = null;
-            _helpRepositoryTask = null;
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            initialization = _helpRepositoryTask;
+        }
+
+        _helpRepositoryUsage.Wait();
+        string? directory;
+        try
+        {
+            try
+            {
+                initialization?.GetAwaiter().GetResult();
+            }
+            catch
+            {
+                // The caller observes initialization failures; disposal still owns cleanup.
+            }
+
+            lock (_helpRepositoryLock)
+            {
+                directory = _helpRepositoryDirectory;
+                _helpRepositoryDirectory = null;
+                _helpRepositoryTask = null;
+            }
+        }
+        finally
+        {
+            _helpRepositoryUsage.Release();
         }
 
         if (directory is null || !Directory.Exists(directory))
@@ -129,6 +178,8 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
                 "Could not delete temporary Git help repository: {Directory}",
                 directory);
         }
+
+        GC.SuppressFinalize(this);
     }
 
     protected override IEnumerable<string> ExtractSubcommands(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -54,7 +54,7 @@ public partial class GitCliScraper : CliScraperBase
             ? "help -a"
             : $"{string.Join(' ', commandPath.Skip(1))} -h";
         var workingDirectory = commandPath.Length > 2
-            ? await GetHelpRepositoryAsync(cancellationToken)
+            ? await GetHelpRepositoryAsync()
             : null;
         var result = await Executor.ExecuteAsync(
             ToolName,
@@ -74,22 +74,22 @@ public partial class GitCliScraper : CliScraperBase
         return helpText;
     }
 
-    private Task<string> GetHelpRepositoryAsync(CancellationToken cancellationToken)
+    private Task<string> GetHelpRepositoryAsync()
     {
         lock (_helpRepositoryLock)
         {
-            return _helpRepositoryTask ??= CreateHelpRepositoryAsync(cancellationToken);
+            return _helpRepositoryTask ??= CreateHelpRepositoryAsync();
         }
     }
 
-    private async Task<string> CreateHelpRepositoryAsync(CancellationToken cancellationToken)
+    private async Task<string> CreateHelpRepositoryAsync()
     {
         var directory = Path.Combine(Path.GetTempPath(), $"git-scraper-{Guid.NewGuid():N}");
         Directory.CreateDirectory(directory);
         var result = await Executor.ExecuteAsync(
             ToolName,
             "init --quiet",
-            cancellationToken,
+            CancellationToken.None,
             directory);
         if (!result.Success)
         {


### PR DESCRIPTION
Refs #3996 Refs #3910  ## Summary - retain generated facade baselines so removed root commands can be restored - preserve historical facade identifiers and compatibility aliases across CLI changes - deduplicate identical command parents and local option/operand names - preserve CLI rendering metadata for restored commands - run nested Git help inside an initialized, disposable temporary repository  ## Validation - complete OptionsGenerator test project: 1,040 passed - OptionsGenerator Release build: 0 warnings, 0 errors - local gh generation: 229 commands, 301 files, 0 errors - local WinGet generation: 42 commands, 49 files, 0 errors  Full Git scraping exceeded the mandatory 2 GB local agent guard; CI owns that full-matrix check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility restoration for generated APIs, including option metadata, aliases, renamed properties, and required members.
  * Prevented naming conflicts between inherited options and positional arguments.
  * Removed duplicate command definitions during generation.
  * Improved Git-based help processing, including safe cleanup and cancellation handling.

* **Reliability**
  * Generated service files are now preserved as the API baseline during CLI option generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->