### PR TITLE
Give AWS generation additional timeout

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -82,7 +82,8 @@ jobs:
                 package: .packageName,
                 prefix: .namespacePrefix,
                 outputDirectory: .outputDirectory,
-                generateCommandFacade: .generateCommandFacade
+                generateCommandFacade: .generateCommandFacade,
+                timeoutMinutes: (if .toolName == "aws" then 150 else 60 end)
               }]}' \
               "$RUNNER_TEMP/tool-catalog.json"
           }
@@ -100,7 +101,7 @@ jobs:
       - validate-generation-safety
       - tool-catalog
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: ${{ matrix.timeoutMinutes }}
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- emit a per-tool timeout in the generated workflow matrix
- allow AWS generation 150 minutes while every other tool remains at 60
- preserve the Windows matrix timeout at 60 minutes

## Test plan
- [x] `actionlint .github/workflows/generate-cli-options.yml`
- [x] official `jq` 1.8.2 fixture assertions for AWS, other Linux tools, and Windows tools
- [x] PyYAML syntax parse

GitHub job timeout behavior has no local runtime unit-test seam; scheduled/manual workflow runs provide end-to-end evidence.

Closes #4048

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tool catalog generation now applies tool-specific time limits.
  * AWS tools can run for up to 150 minutes, while other tools retain a 60-minute limit.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->