### PR TITLE
Fix refreshed CLI generation compatibility

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -109,7 +109,8 @@ public class GeneratorHardeningTests
         bool isRequired = false,
         bool isCompatibility = false,
         string? forwardToPropertyName = null,
-        bool useInitAccessor = false) =>
+        bool useInitAccessor = false,
+        CommandLinePhase? phase = null) =>
         new(
             propertyName,
             cSharpType,
@@ -119,7 +120,8 @@ public class GeneratorHardeningTests
             isCompatibility,
             forwardToPropertyName,
             null,
-            useInitAccessor);
+            useInitAccessor,
+            Phase: phase);
 
     private static CliOptionDefinition RequiredOption(string switchName, string propertyName) =>
         new()
@@ -1789,7 +1791,7 @@ public class GeneratorHardeningTests
     }
 
     [Test]
-    public async Task ApiCompatibilityPreserver_Rejects_Old_Deconstruct_Arity_For_New_Required_Members()
+    public async Task ApiCompatibilityPreserver_Retains_Old_Deconstruct_Arity_For_New_Required_Members()
     {
         var command = Command("ToolMoveOptions", "ToolOptions", ["move"]) with
         {
@@ -1812,12 +1814,17 @@ public class GeneratorHardeningTests
             ],
         };
 
-        var exception = Assert.Throws<InvalidOperationException>(() =>
-            GeneratedApiCompatibilityPreserver.Preserve(
-                command,
-                [BaselineProperty("Source", "string", switchName: "--source", isRequired: true)]));
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [BaselineProperty("Source", "string", switchName: "--source", isRequired: true)]);
+        var generated = (await new OptionsClassGenerator().GenerateAsync(Tool(preserved))).Single().Content;
 
-        await Assert.That(exception.Message).Contains("newly required member(s) Destination have no baseline value");
+        using (Assert.Multiple())
+        {
+            await Assert.That(generated).Contains("public ToolMoveOptions(string Source)");
+            await Assert.That(generated).Contains(": this(Source, default(string)!)");
+            await Assert.That(generated).Contains("public void Deconstruct(out string Source)");
+        }
     }
 
     [Test]
@@ -2034,7 +2041,7 @@ public class GeneratorHardeningTests
     }
 
     [Test]
-    public async Task ApiCompatibilityPreserver_Rejects_Deconstruct_Preservation_For_New_Required_Members()
+    public async Task ApiCompatibilityPreserver_Extends_Deconstruct_Preservation_For_New_Required_Members()
     {
         var root = Path.Combine(Path.GetTempPath(), $"options-api-{Guid.NewGuid():N}");
         var optionsDirectory = Path.Combine(root, "src", "ModularPipelines.Tool", "Options");
@@ -2057,10 +2064,17 @@ public class GeneratorHardeningTests
                 ],
             };
 
-            var exception = Assert.Throws<InvalidOperationException>(() =>
-                GeneratedApiCompatibilityPreserver.Preserve(Tool(command), root));
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(Tool(command), root);
+            var generated = (await new OptionsClassGenerator().GenerateAsync(preserved)).Single().Content;
 
-            await Assert.That(exception.Message).Contains("newly required member(s) Force have no baseline value");
+            using (Assert.Multiple())
+            {
+                await Assert.That(generated).Contains("public ToolMoveOptions(string Source, string Destination)");
+                await Assert.That(generated).Contains(": this(Source, Destination, default(string)!)");
+                await Assert.That(generated)
+                    .Contains("public void Deconstruct(out string Source, out string Destination)");
+                await Assert.That(generated).Contains("public ToolMoveOptions(string Source)");
+            }
         }
         finally
         {
@@ -3480,6 +3494,121 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Restores_Removed_Flat_Nested_Facades()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolSourceEditOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"source\", \"edit\")] "
+                + "public record ToolSourceEditOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "Tool.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class Tool { "
+                + "public Task SourceEditAsync(ToolSourceEditOptions? options = null) => Task.CompletedTask; }");
+            var current = Command(
+                "ToolSourceListOptions",
+                "ToolOptions",
+                ["source", "list"],
+                subDomainGroup: "source");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(Tool(current), root);
+            var generated = (await new ServiceInterfaceGenerator().GenerateAsync(preserved))
+                .Single().Content;
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(preserved.Commands.Select(static command => command.ClassName))
+                    .Contains("ToolSourceEditOptions");
+                await Assert.That(generated)
+                    .Contains("SourceEditAsync(ToolSourceEditOptions? options = null");
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Restores_Live_Command_Class_Name_By_Command_Path()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolBundleOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"bundle\")] "
+                + "public record ToolBundleOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "Tool.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class Tool { "
+                + "public Task BundleAsync(ToolBundleOptions? options = null) => Task.CompletedTask; }");
+            var tool = Tool(Command(
+                "ToolBundleBundleOptions",
+                "ToolOptions",
+                ["bundle"]));
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(tool, root);
+
+            await Assert.That(preserved.Commands).HasSingleItem();
+            await Assert.That(preserved.Commands.Single().ClassName).IsEqualTo("ToolBundleOptions");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Distinguishes_Positional_Argument_Phases()
+    {
+        var command = Command("ToolRunOptions", "ToolOptions", ["run"]) with
+        {
+            PositionalArguments =
+            [
+                new CliPositionalArgument
+                {
+                    PropertyName = "Prefix",
+                    CSharpType = "string",
+                    IsRequired = true,
+                    PositionIndex = 0,
+                    Phase = CommandLinePhase.Passthrough,
+                },
+            ],
+        };
+
+        var preserved = GeneratedApiCompatibilityPreserver.Preserve(
+            command,
+            [
+                BaselineProperty(
+                    "CommandOptions",
+                    "IEnumerable<string>?",
+                    argumentPosition: 0,
+                    phase: CommandLinePhase.EarlyOperand),
+            ]);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(preserved.PositionalArguments.Single().PropertyName)
+                .IsEqualTo("Prefix");
+            await Assert.That(preserved.CompatibilityProperties.Single().PropertyName)
+                .IsEqualTo("CommandOptions");
+            await Assert.That(preserved.CompatibilityProperties.Single().ForwardToPropertyName)
+                .IsNull();
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Retains_Removed_Global_Options()
     {
         var preserved = GeneratedApiCompatibilityPreserver.PreserveGlobalOptions(
@@ -3598,6 +3727,29 @@ public class GeneratorHardeningTests
             await Assert.That(resolvedCommand.PositionalArguments.Single().PropertyName)
                 .IsEqualTo("FilenameArgument");
         }
+    }
+
+    [Test]
+    public async Task Record_Reserved_Property_Names_Are_Disambiguated()
+    {
+        var command = Command("ToolCreateOptions", "ToolOptions", ["create"]) with
+        {
+            Options =
+            [
+                new CliOptionDefinition
+                {
+                    SwitchName = "--clone",
+                    PropertyName = "Clone",
+                    CSharpType = "bool?",
+                    IsFlag = true,
+                },
+            ],
+        };
+
+        var resolved = InheritedPropertyCollisionResolver.Resolve(Tool(command));
+
+        await Assert.That(resolved.Commands.Single().Options.Single().PropertyName)
+            .IsEqualTo("CliClone");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -539,7 +539,7 @@ public class GeneratorHardeningTests
             await Assert.That(rootClass.Content)
                 .Contains("public ToolParentImageTools ImageTools =>");
             await Assert.That(rootInterface.Content)
-                .Contains("ToolParentImageTools ImageTools { get; }");
+                .Contains("ToolParentImageTools ImageTools => throw new System.NotSupportedException();");
             await Assert.That(rootInterface.Content)
                 .Contains("only this top-level facade is interface-backed");
             await Assert.That(childClass.Content)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -2074,6 +2074,8 @@ public class GeneratorHardeningTests
                 await Assert.That(generated)
                     .Contains("public void Deconstruct(out string Source, out string Destination)");
                 await Assert.That(generated).Contains("public ToolMoveOptions(string Source)");
+                await Assert.That(generated)
+                    .Contains(": this(Source, default(string)!, default(string)!)");
             }
         }
         finally

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -3538,6 +3538,78 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Leaves_Nested_Named_Facades_Nested()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolSourceEditOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"source\", \"edit\")] "
+                + "public record ToolSourceEditOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolSource.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; public class ToolSource { "
+                + "public Task EditAsync(ToolSourceEditOptions? options = null) => Task.CompletedTask; }");
+            var current = Command(
+                "ToolSourceEditOptions",
+                "ToolOptions",
+                ["source", "edit"],
+                subDomainGroup: "source");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(Tool(current), root);
+            var rootFacade = (await new ServiceInterfaceGenerator().GenerateAsync(preserved))
+                .Single().Content;
+            var nestedFacade = (await new SubDomainClassGenerator().GenerateAsync(preserved))
+                .Single(file => Path.GetFileName(file.RelativePath)
+                    .Equals("ToolSource.Generated.cs", StringComparison.Ordinal))
+                .Content;
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(rootFacade).DoesNotContain("SourceEditAsync(");
+                await Assert.That(nestedFacade).Contains("EditAsync(");
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
+    public async Task ApiCompatibilityPreserver_Rejects_Live_Class_Name_Collisions()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolOldAOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"a\")] "
+                + "public record ToolOldAOptions : ToolOptions;");
+            var tool = Tool(
+                Command("ToolNewAOptions", "ToolOptions", ["a"]),
+                Command("ToolOldAOptions", "ToolOptions", ["b"]));
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                Task.FromResult(GeneratedApiCompatibilityPreserver.Preserve(tool, root)));
+
+            await Assert.That(exception!.Message).Contains("ToolOldAOptions (tool, tool)");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Restores_Live_Command_Class_Name_By_Command_Path()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -200,6 +200,28 @@ public class CliScraperTraversalTests
     }
 
     [Test]
+    public async Task CobraTraversal_Does_Not_Treat_Title_Cased_Prose_As_Command_Section()
+    {
+        var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["--help"] = """
+                Usage:
+                  fake [command]
+
+                List Installed Commands
+                Use "fake [command] --help" for more information.
+                guidance    Read the CLI reference.
+                """,
+        });
+        var scraper = new TestCobraScraper(executor);
+
+        var commands = await ScrapeAsync(scraper);
+
+        await Assert.That(commands).IsEmpty();
+        await Assert.That(executor.Arguments).IsEquivalentTo(["--help"]);
+    }
+
+    [Test]
     public async Task CobraTraversal_Stops_When_Nested_Command_Reprints_Parent_Help()
     {
         var executor = new StubExecutor(new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CosignCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/CosignCliScraperTests.cs
@@ -57,6 +57,24 @@ public class CosignCliScraperTests
     }
 
     [Test]
+    public async Task Does_Not_Treat_Description_Ending_In_Commands_As_Command_Section()
+    {
+        const string helpText = """
+            List installed extension commands
+
+            USAGE
+              cosign extension list [flags]
+
+            LEARN MORE
+              Use `cosign <command> <subcommand> --help` for more information.
+            """;
+
+        var subcommands = new TestCosignCliScraper().Extract(helpText);
+
+        await Assert.That(subcommands).IsEmpty();
+    }
+
+    [Test]
     [Arguments("signing-config", "signing config")]
     [Arguments("trusted-root", "trusted root")]
     public async Task Extracts_Cosign_V3_Single_Row_All_Word_Command_Tables(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/VaultCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/VaultCliScraperTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes;
+using ModularPipelines.OptionsGenerator.Models;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
+
+namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
+
+public class VaultCliScraperTests
+{
+    [Test]
+    public async Task Command_Group_Args_Remain_Optional_After_Placeholder_Removal()
+    {
+        const string helpText = """
+            Usage: vault audit <subcommand> [options] [args]
+
+              This command groups subcommands for interacting with Vault's audit devices.
+
+            Subcommands:
+                disable    Disables an audit device
+                enable     Enables an audit device
+                list       Lists enabled audit devices
+            """;
+        var command = await new TestVaultCliScraper().ParseGroup(
+            ["vault", "audit"],
+            helpText);
+
+        var argument = command!.PositionalArguments.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(argument.PropertyName).IsEqualTo("Args");
+            await Assert.That(argument.CSharpType).IsEqualTo("string?");
+            await Assert.That(argument.IsRequired).IsFalse();
+            await Assert.That(argument.Phase).IsEqualTo(CommandLinePhase.Passthrough);
+        }
+    }
+
+    private sealed class TestVaultCliScraper : VaultCliScraper
+    {
+        public TestVaultCliScraper()
+            : base(
+                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<VaultCliScraper>.Instance)
+        {
+        }
+
+        public Task<CliCommandDefinition?> ParseGroup(string[] commandPath, string helpText)
+        {
+            var usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(
+                ParseUsageSynopsis(commandPath, helpText));
+            return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
+        }
+    }
+}

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -2014,11 +2014,7 @@ internal static class GeneratedApiCompatibilityPreserver
     {
         if (left.ArgumentPosition is not null || right.ArgumentPosition is not null)
         {
-            return left.ArgumentPosition == right.ArgumentPosition
-                   && (left.Phase is null || right.Phase is null || left.Phase == right.Phase)
-                   && left.PrependOptionTerminator == right.PrependOptionTerminator
-                   && left.PrependOptionTerminatorIfValueStartsWithDash
-                   == right.PrependOptionTerminatorIfValueStartsWithDash;
+            return HasSamePositionalIdentity(left, right);
         }
 
         if (left.SwitchName is not null || right.SwitchName is not null)
@@ -2027,6 +2023,20 @@ internal static class GeneratedApiCompatibilityPreserver
         }
 
         return true;
+    }
+
+    private static bool HasSamePositionalIdentity(
+        GeneratedApiProperty left,
+        GeneratedApiProperty right)
+    {
+        var phasesMatch = left.Phase is null
+                          || right.Phase is null
+                          || left.Phase == right.Phase;
+        return left.ArgumentPosition == right.ArgumentPosition
+               && phasesMatch
+               && left.PrependOptionTerminator == right.PrependOptionTerminator
+               && left.PrependOptionTerminatorIfValueStartsWithDash
+               == right.PrependOptionTerminatorIfValueStartsWithDash;
     }
 
     private static Dictionary<string, GeneratedApiBaseline> ReadBaseline(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -65,13 +65,18 @@ internal static class GeneratedApiCompatibilityPreserver
             .Where(static method => method.IsOptionsOptional)
             .Select(static method => method.OptionsType)
             .ToHashSet(StringComparer.Ordinal);
-        var commands = compatibleTool.Commands
+        var liveCommands = compatibleTool.Commands
             .Select(command => PreserveIdentifierCasing(
                 compatibleTool,
                 command,
                 baseline,
                 facadeMethods))
-            .Concat(RestoreRemovedCommands(compatibleTool, baseline, facadeMethods))
+            .ToArray();
+        var commands = liveCommands
+            .Concat(RestoreRemovedCommands(
+                compatibleTool with { Commands = liveCommands },
+                baseline,
+                facadeMethods))
             .DistinctBy(static command => command.ClassName, StringComparer.Ordinal)
             .ToArray();
         var preservedTool = compatibleTool with
@@ -476,9 +481,11 @@ internal static class GeneratedApiCompatibilityPreserver
         IReadOnlyDictionary<string, GeneratedApiBaseline> baseline,
         IReadOnlyList<GeneratedFacadeMethod> facadeMethods)
     {
+        var matchingBaseline = FindCommandBaseline(command, baseline);
         var preserved = command with
         {
-            ClassName = FindBaselineIdentifier(command.ClassName, baseline.Keys),
+            ClassName = matchingBaseline?.ClassName
+                        ?? FindBaselineIdentifier(command.ClassName, baseline.Keys),
             ParentClassName = FindBaselineIdentifier(command.ParentClassName, baseline.Keys),
         };
         if (!baseline.TryGetValue(preserved.ClassName, out var commandBaseline)
@@ -512,6 +519,29 @@ internal static class GeneratedApiCompatibilityPreserver
                                                  : null),
             CommandPartIdentifierOverrides = mergedOverrides,
         };
+    }
+
+    private static GeneratedApiBaseline? FindCommandBaseline(
+        CliCommandDefinition command,
+        IReadOnlyDictionary<string, GeneratedApiBaseline> baseline)
+    {
+        if (baseline.TryGetValue(command.ClassName, out var exact))
+        {
+            return exact;
+        }
+
+        var matches = baseline.Values
+            .Where(candidate => candidate.CommandParts is not null
+                                && string.Equals(
+                                    candidate.ParentClassName,
+                                    command.ParentClassName,
+                                    StringComparison.OrdinalIgnoreCase)
+                                && candidate.CommandParts.SequenceEqual(
+                                    command.CommandParts,
+                                    StringComparer.OrdinalIgnoreCase))
+            .Take(2)
+            .ToArray();
+        return matches.Length == 1 ? matches[0] : null;
     }
 
     private static string FindBaselineIdentifier(
@@ -1790,8 +1820,7 @@ internal static class GeneratedApiCompatibilityPreserver
                 && baseline.CSharpType.Equals(current.CSharpType, StringComparison.Ordinal)))
             .Select(static property => property.PropertyName)
             .ToArray();
-        if (addedRequired.Length > 0
-            && (!allowNewRequiredMembers || baselineRequired.Length > 0))
+        if (addedRequired.Length > 0 && !allowNewRequiredMembers)
         {
             throw new InvalidOperationException(
                 "Cannot retain generated constructors because newly required member(s) "
@@ -1961,7 +1990,11 @@ internal static class GeneratedApiCompatibilityPreserver
             false,
             null,
             null,
-            argument.IsRequired);
+            UseInitAccessor: argument.IsRequired,
+            Phase: argument.Phase,
+            PrependOptionTerminator: argument.PrependOptionTerminator,
+            PrependOptionTerminatorIfValueStartsWithDash:
+                argument.PrependOptionTerminatorIfValueStartsWithDash);
 
     private static GeneratedApiProperty ToGeneratedProperty(CliOptionDefinition option) =>
         new(
@@ -1981,7 +2014,11 @@ internal static class GeneratedApiCompatibilityPreserver
     {
         if (left.ArgumentPosition is not null || right.ArgumentPosition is not null)
         {
-            return left.ArgumentPosition == right.ArgumentPosition;
+            return left.ArgumentPosition == right.ArgumentPosition
+                   && (left.Phase is null || right.Phase is null || left.Phase == right.Phase)
+                   && left.PrependOptionTerminator == right.PrependOptionTerminator
+                   && left.PrependOptionTerminatorIfValueStartsWithDash
+                   == right.PrependOptionTerminatorIfValueStartsWithDash;
         }
 
         if (left.SwitchName is not null || right.SwitchName is not null)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -1829,7 +1829,13 @@ internal static class GeneratedApiCompatibilityPreserver
 
         foreach (var constructor in baselineConstructors)
         {
-            AddCompatibilityConstructor(compatibilityConstructors, constructor, currentRequired);
+            AddCompatibilityConstructor(
+                compatibilityConstructors,
+                RemapPrimaryConstructorArguments(
+                    constructor,
+                    baselineRequired,
+                    currentRequired),
+                currentRequired);
         }
 
         if (HasSameConstructorContract(baselineRequired, currentRequired))
@@ -1858,6 +1864,41 @@ internal static class GeneratedApiCompatibilityPreserver
                 PreserveDeconstruct = baselineParameters.Length > 0,
             },
             currentRequired);
+    }
+
+    private static CliCompatibilityConstructor RemapPrimaryConstructorArguments(
+        CliCompatibilityConstructor constructor,
+        IReadOnlyList<GeneratedApiProperty> baselineRequired,
+        IReadOnlyList<GeneratedApiProperty> currentRequired) =>
+        constructor with
+        {
+            PrimaryConstructorArguments = currentRequired
+                .Select(current => GetPreservedPrimaryConstructorArgument(
+                    constructor,
+                    baselineRequired,
+                    current))
+                .ToArray(),
+        };
+
+    private static string GetPreservedPrimaryConstructorArgument(
+        CliCompatibilityConstructor constructor,
+        IReadOnlyList<GeneratedApiProperty> baselineRequired,
+        GeneratedApiProperty current)
+    {
+        var currentContract = GetConstructorParameterContract(current);
+        var baselineIndex = -1;
+        for (var index = 0; index < baselineRequired.Count; index++)
+        {
+            if (GetConstructorParameterContract(baselineRequired[index]) == currentContract)
+            {
+                baselineIndex = index;
+                break;
+            }
+        }
+
+        return baselineIndex >= 0 && baselineIndex < constructor.PrimaryConstructorArguments.Count
+            ? constructor.PrimaryConstructorArguments[baselineIndex]
+            : GetTypedDefault(current.CSharpType);
     }
 
     private static void AddCompatibilityConstructor(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -61,6 +61,11 @@ internal static class GeneratedApiCompatibilityPreserver
             .Where(static method => !method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal))
             .Select(static method => method.OptionsType)
             .ToHashSet(StringComparer.Ordinal);
+        var rootNamedFacadeOptionTypes = facadeMethods
+            .Where(method => IsRootFacadeMethod(compatibleTool, method)
+                             && !method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal))
+            .Select(static method => method.OptionsType)
+            .ToHashSet(StringComparer.Ordinal);
         var optionalFacadeOptionTypes = facadeMethods
             .Where(static method => method.IsOptionsOptional)
             .Select(static method => method.OptionsType)
@@ -72,6 +77,7 @@ internal static class GeneratedApiCompatibilityPreserver
                 baseline,
                 facadeMethods))
             .ToArray();
+        RejectLiveCommandClassNameCollisions(liveCommands);
         var commands = liveCommands
             .Concat(RestoreRemovedCommands(
                 compatibleTool with { Commands = liveCommands },
@@ -95,6 +101,9 @@ internal static class GeneratedApiCompatibilityPreserver
                     : command)
                 .Select(command => namedFacadeOptionTypes.Contains(command.ClassName)
                     ? command with { PreserveNamedFacade = true }
+                    : command)
+                .Select(command => rootNamedFacadeOptionTypes.Contains(command.ClassName)
+                    ? command with { PreserveRootNamedFacade = true }
                     : command)
                 .Select(command => optionalFacadeOptionTypes.Contains(command.ClassName)
                     ? command with { PreserveOptionalOptionsParameter = true }
@@ -161,6 +170,9 @@ internal static class GeneratedApiCompatibilityPreserver
                 method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)),
             PreserveNamedFacade = facadeMethods.Any(static method =>
                 !method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)),
+            PreserveRootNamedFacade = facadeMethods.Any(method =>
+                IsRootFacadeMethod(tool, method)
+                && !method.MethodName.Equals("ExecuteAsync", StringComparison.Ordinal)),
             PreserveOptionalOptionsParameter = facadeMethods.Any(static method => method.IsOptionsOptional),
         };
     }
@@ -406,6 +418,32 @@ internal static class GeneratedApiCompatibilityPreserver
         facadeMethod.DeclaringType.StartsWith($"I{tool.NamespacePrefix}", StringComparison.Ordinal)
             ? facadeMethod.DeclaringType[1..]
             : facadeMethod.DeclaringType;
+
+    private static bool IsRootFacadeMethod(
+        CliToolDefinition tool,
+        GeneratedFacadeMethod facadeMethod) =>
+        facadeMethod.DeclaringType.Equals(tool.NamespacePrefix, StringComparison.Ordinal)
+        || facadeMethod.DeclaringType.Equals($"I{tool.NamespacePrefix}", StringComparison.Ordinal);
+
+    private static void RejectLiveCommandClassNameCollisions(
+        IReadOnlyList<CliCommandDefinition> commands)
+    {
+        var collisions = commands
+            .GroupBy(static command => command.ClassName, StringComparer.Ordinal)
+            .Where(static group => group.Skip(1).Any())
+            .ToArray();
+        if (collisions.Length == 0)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "Generated API compatibility restoration produced duplicate command class name(s): "
+            + string.Join(
+                "; ",
+                collisions.Select(group =>
+                    $"{group.Key} ({string.Join(", ", group.Select(static command => command.FullCommand))})")));
+    }
 
     private static bool IsParentExecuteFacade(
         string implementationType,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -1075,8 +1075,8 @@ public static partial class GeneratorUtils
         var subDomainNames = GetSubDomainIdentifiers(tool);
 
         var rootCommands = tool.Commands
-            .Where(c => c.SubDomainGroup is null || c.PreserveNamedFacade)
-            .Where(c => c.PreserveNamedFacade
+            .Where(c => c.SubDomainGroup is null || c.PreserveRootNamedFacade)
+            .Where(c => c.PreserveRootNamedFacade
                         || !subDomainNames.Contains(GetCommandGroupIdentifier(c)))
             .ToList();
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -1075,7 +1075,7 @@ public static partial class GeneratorUtils
         var subDomainNames = GetSubDomainIdentifiers(tool);
 
         var rootCommands = tool.Commands
-            .Where(c => c.SubDomainGroup is null)
+            .Where(c => c.SubDomainGroup is null || c.PreserveNamedFacade)
             .Where(c => c.PreserveNamedFacade
                         || !subDomainNames.Contains(GetCommandGroupIdentifier(c)))
             .ToList();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/InheritedPropertyCollisionResolver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/InheritedPropertyCollisionResolver.cs
@@ -11,6 +11,11 @@ internal static class InheritedPropertyCollisionResolver
             .Select(property => property.Name)
             .ToHashSet(StringComparer.Ordinal);
 
+    private static readonly HashSet<string> RecordReservedPropertyNames =
+    [
+        "Clone",
+    ];
+
     public static bool IsInheritedPropertyName(string propertyName) =>
         InheritedPropertyNames.Contains(propertyName);
 
@@ -216,7 +221,8 @@ internal static class InheritedPropertyCollisionResolver
             return existingRename;
         }
 
-        if (!IsInheritedPropertyName(propertyName))
+        if (!IsInheritedPropertyName(propertyName)
+            && !RecordReservedPropertyNames.Contains(propertyName))
         {
             return propertyName;
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
@@ -465,7 +465,8 @@ public class SubDomainClassGenerator : ICodeGenerator
             sb.AppendLine("    /// <summary>");
             sb.AppendLine($"    /// {tool.ToolName} {child.Segment.ToLowerInvariant()} sub-commands.");
             sb.AppendLine("    /// </summary>");
-            sb.AppendLine($"    {child.ClassName} {child.PascalSegment} {{ get; }}");
+            sb.AppendLine(
+                $"    {child.ClassName} {child.PascalSegment} => throw new System.NotSupportedException();");
             sb.AppendLine();
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CliCommandDefinition.cs
@@ -132,6 +132,11 @@ public record CliCommandDefinition
     public bool PreserveNamedFacade { get; init; }
 
     /// <summary>
+    /// Whether an existing named command facade was declared directly on the root service.
+    /// </summary>
+    public bool PreserveRootNamedFacade { get; init; }
+
+    /// <summary>
     /// Whether an existing facade allowed its options argument to be omitted.
     /// </summary>
     public bool PreserveOptionalOptionsParameter { get; init; }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -557,7 +557,7 @@ public abstract partial class CliScraperBase : ICliScraper
     {
         foreach (var subcommand in subcommands)
         {
-            if (IsSkippableSubcommand(subcommand))
+            if (!IsValidDiscoveredSubcommand(subcommand) || IsSkippableSubcommand(subcommand))
             {
                 continue;
             }
@@ -574,6 +574,12 @@ public abstract partial class CliScraperBase : ICliScraper
             await workChannel.Writer.WriteAsync(childPath, cancellationToken);
         }
     }
+
+    /// <summary>
+    /// Validates a subcommand name before traversal queues its command path.
+    /// </summary>
+    protected virtual bool IsValidDiscoveredSubcommand(string subcommand) =>
+        !string.IsNullOrWhiteSpace(subcommand);
 
     private static async Task CompleteCommandChannelAsync(
         IReadOnlyCollection<Task> workerTasks,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -975,7 +975,9 @@ public abstract partial class CobraCliScraper : CliScraperBase
     /// "Common Commands:", "Management Commands:", "Swarm Commands:", "Scanning Commands:",
     /// "Utility Commands:", etc. Uses a flexible pattern to match any word prefix.
     /// </summary>
-    [GeneratedRegex(@"^(?:[A-Z][\w ]*\s+)?Commands:?\s*$", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
+    [GeneratedRegex(
+        @"^(?:[A-Z][\w-]*(?:[ \t]+[A-Z][\w-]*)*[ \t]+)?(?:Commands|COMMANDS):?[ \t]*$",
+        RegexOptions.Multiline)]
     private static partial Regex CommandsSectionPattern();
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -82,6 +82,14 @@ public abstract partial class CobraCliScraper : CliScraperBase
 
             var section = normalizedText.Substring(sectionStart, sectionEnd - sectionStart);
 
+            // Some CLIs omit the colon on real section headings. For those headings,
+            // require an indented command row so title-cased prose cannot open a section.
+            if (!commandsSectionMatch.Value.TrimEnd().EndsWith(':')
+                && !ContainsIndentedCommandRow(section))
+            {
+                continue;
+            }
+
             // Parse command lines: "  command    description"
             var lines = section.Split('\n');
             var sectionCommandCount = 0;
@@ -99,7 +107,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
                 if (match.Success)
                 {
                     var commandName = match.Groups["name"].Value.Trim();
-                    if (!string.IsNullOrEmpty(commandName) && !commandName.Contains(' ') &&
+                    if (IsValidCommandPart(commandName) && !commandName.Contains(' ') &&
                         seenCommands.Add(commandName))
                     {
                         subcommands.Add(commandName);
@@ -124,6 +132,16 @@ public abstract partial class CobraCliScraper : CliScraperBase
 
         return subcommands;
     }
+
+    protected override bool IsValidDiscoveredSubcommand(string subcommand) =>
+        IsValidCommandPart(subcommand);
+
+    private static bool ContainsIndentedCommandRow(string section) =>
+        section.Split('\n')
+            .Where(static line => line.Length > 0 && char.IsWhiteSpace(line[0]))
+            .Select(line => SubcommandLinePattern().Match(line))
+            .Any(match => match.Success
+                          && IsValidCommandPart(match.Groups["name"].Value.Trim()));
 
     /// <summary>
     /// Parses a Cobra command from its help text.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CobraCliScraper.cs
@@ -70,17 +70,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
 
         foreach (Match commandsSectionMatch in commandsSectionMatches)
         {
-            var sectionStart = commandsSectionMatch.Index + commandsSectionMatch.Length;
-
-            // Find where this section ends (next section header or end of text)
-            var sectionEnd = normalizedText.Length;
-            var nextSectionMatch = SectionHeaderPattern().Match(normalizedText, sectionStart);
-            if (nextSectionMatch.Success)
-            {
-                sectionEnd = nextSectionMatch.Index;
-            }
-
-            var section = normalizedText.Substring(sectionStart, sectionEnd - sectionStart);
+            var section = GetCommandSection(normalizedText, commandsSectionMatch);
 
             // Some CLIs omit the colon on real section headings. For those headings,
             // require an indented command row so title-cased prose cannot open a section.
@@ -90,31 +80,7 @@ public abstract partial class CobraCliScraper : CliScraperBase
                 continue;
             }
 
-            // Parse command lines: "  command    description"
-            var lines = section.Split('\n');
-            var sectionCommandCount = 0;
-            foreach (var line in lines)
-            {
-                // Cobra separates its command table from trailing guidance with a blank line.
-                // Stop there so prose such as `Use ...` and `Learn More` cannot become
-                // recursive command paths when an unrecognised command prints parent help.
-                if (sectionCommandCount > 0 && string.IsNullOrWhiteSpace(line))
-                {
-                    break;
-                }
-
-                var match = SubcommandLinePattern().Match(line);
-                if (match.Success)
-                {
-                    var commandName = match.Groups["name"].Value.Trim();
-                    if (IsValidCommandPart(commandName) && !commandName.Contains(' ') &&
-                        seenCommands.Add(commandName))
-                    {
-                        subcommands.Add(commandName);
-                        sectionCommandCount++;
-                    }
-                }
-            }
+            var sectionCommandCount = AddSectionSubcommands(section, seenCommands, subcommands);
 
             Logger.LogDebug("[{Tool}] Extracted {Count} commands from section '{Section}'",
                 ToolName, sectionCommandCount, commandsSectionMatch.Value.Trim());
@@ -131,6 +97,49 @@ public abstract partial class CobraCliScraper : CliScraperBase
         }
 
         return subcommands;
+    }
+
+    private static string GetCommandSection(string helpText, Match header)
+    {
+        var sectionStart = header.Index + header.Length;
+        var nextSection = SectionHeaderPattern().Match(helpText, sectionStart);
+        var sectionEnd = nextSection.Success ? nextSection.Index : helpText.Length;
+        return helpText.Substring(sectionStart, sectionEnd - sectionStart);
+    }
+
+    private static int AddSectionSubcommands(
+        string section,
+        HashSet<string> seenCommands,
+        ICollection<string> subcommands)
+    {
+        var count = 0;
+        foreach (var line in section.Split('\n'))
+        {
+            // Cobra separates its command table from trailing guidance with a blank line.
+            if (count > 0 && string.IsNullOrWhiteSpace(line))
+            {
+                break;
+            }
+
+            var match = SubcommandLinePattern().Match(line);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var commandName = match.Groups["name"].Value.Trim();
+            if (!IsValidCommandPart(commandName)
+                || commandName.Contains(' ')
+                || !seenCommands.Add(commandName))
+            {
+                continue;
+            }
+
+            subcommands.Add(commandName);
+            count++;
+        }
+
+        return count;
     }
 
     protected override bool IsValidDiscoveredSubcommand(string subcommand) =>


### PR DESCRIPTION
Fixes failures exposed by the full validation-only CLI generation matrix after #4047.

Changes:
- distinguish positional arguments by command-line phase and terminator behavior
- preserve historical command class names by command path
- restore flat named facades for removed nested commands
- preserve old constructors/deconstructors when CLIs add required operands
- disambiguate record-reserved Clone properties
- reject prose ending in "commands" as a Cobra command section
- cover Vault command-group [args] parsing

Validation:
- OptionsGenerator tests: 1,046 passed
- Release OptionsGenerator solution build: 0 warnings, 0 errors
- Liquibase 5.0.3 generation: 43 commands, 0 errors
- GitHub CLI 2.98.0 generation: 229 commands, 0 errors
- Vault 2.0.4 full local scrape reached the mandatory 2 GB agent guard; focused parsing regression passes

Refs #3996
Refs #3910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated CLI compatibility when new required options are introduced, preserving older constructors and deconstruction patterns.
  - Restored removed command facades and improved command matching across renamed or reorganized command paths.
  - Correctly distinguishes positional argument phases and option terminators.
  - Prevents reserved record property names, such as `Clone`, from causing naming conflicts.
  - Improved detection of command sections across supported CLI help formats.
  - Preserved explicitly configured root command facades in grouped command structures.
  - Fixed grouped command arguments being incorrectly marked as required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->