### PR TITLE
Serialize process environment tests

### DIFF
--- a/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
+++ b/test/ModularPipelines.UnitTests/Engine/RunReportTests.cs
@@ -2448,6 +2448,7 @@ public class RunReportTests
     }
 
     [Test]
+    [TUnit.Core.NotInParallel("ProcessEnvironment")]
     public async Task DistributedWorkerDoesNotPersistRunReportOrHistory()
     {
         var directory = CreateTemporaryDirectory();
@@ -2727,6 +2728,7 @@ public class RunReportTests
     }
 
     [Test]
+    [TUnit.Core.NotInParallel("ProcessEnvironment")]
     public async Task DistributedWorkerMetricsTimeoutWhenCoordinatorIgnoresCancellation()
     {
         var coordinator = new Mock<IDistributedCoordinator>();
@@ -2983,6 +2985,7 @@ public class RunReportTests
     }
 
     [Test]
+    [TUnit.Core.NotInParallel("ProcessEnvironment")]
     public async Task DistributedMasterAggregatesWorkerUnattributedCommands()
     {
         var runStartedAt = DateTimeOffset.UtcNow;
@@ -3180,6 +3183,7 @@ public class RunReportTests
     }
 
     [Test]
+    [TUnit.Core.NotInParallel("ProcessEnvironment")]
     [Arguments(3, 1, 3, 0)]
     [Arguments(1, 1, 3, 2)]
     [Arguments(3, 2, 6, 3)]
@@ -3259,6 +3263,7 @@ public class RunReportTests
     }
 
     [Test]
+    [TUnit.Core.NotInParallel("ProcessEnvironment")]
     public async Task DistributedMasterReconcilesMatchedMetricsPerWorker()
     {
         var firstContext = new DuplicateAssemblyLoadContext();
@@ -3346,6 +3351,7 @@ public class RunReportTests
     }
 
     [Test]
+    [TUnit.Core.NotInParallel("ProcessEnvironment")]
     public async Task DistributedMasterWaitsForParticipatingWorkerFinalMetrics()
     {
         var runStartedAt = DateTimeOffset.UtcNow;
@@ -3407,6 +3413,7 @@ public class RunReportTests
     }
 
     [Test]
+    [TUnit.Core.NotInParallel("ProcessEnvironment")]
     public async Task DistributedMasterMetricsTimeoutWhenCoordinatorIgnoresCancellation()
     {
         var queryCompletion = new TaskCompletionSource<IReadOnlyList<WorkerRegistration>>(
@@ -3455,6 +3462,7 @@ public class RunReportTests
     }
 
     [Test]
+    [TUnit.Core.NotInParallel("ProcessEnvironment")]
     public async Task DistributedMasterDoesNotWaitForWorkersMissingFromThisRun()
     {
         var runStartedAt = DateTimeOffset.UtcNow;
@@ -3506,6 +3514,7 @@ public class RunReportTests
     }
 
     [Test]
+    [TUnit.Core.NotInParallel("ProcessEnvironment")]
     public async Task DistributedMasterUsesExecutionIdentifierInsteadOfWorkerClock()
     {
         var runStartedAt = DateTimeOffset.UtcNow;


### PR DESCRIPTION
## Summary
- serialize RunReport tests that mutate MODULAR_PIPELINES_INSTANCE
- share the existing ProcessEnvironment TUnit constraint with other environment-mutating tests
- prevent master/worker role races that can leave worker-metrics waits pending

## Validation
- focused TUnit filter: 3/3 passed

Refs #3997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by preventing environment-sensitive distributed run-report tests from executing concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->