### PR TITLE
Disambiguate async-suffixed CLI commands

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -4283,6 +4283,44 @@ public class GeneratorHardeningTests
             .Contains("InvokeDataAutomationAsyncCommandAsync(");
     }
 
+    [Test]
+    public async Task SubDomainClassGenerator_Selects_Unique_Async_Disambiguator()
+    {
+        var tool = Tool(
+            Command(
+                "ToolAppFooOptions",
+                "ToolOptions",
+                ["app", "foo"],
+                subDomainGroup: "app") with
+            {
+                FullCommand = "tool app foo",
+            },
+            Command(
+                "ToolAppFooAsyncOptions",
+                "ToolOptions",
+                ["app", "foo-async"],
+                subDomainGroup: "app") with
+            {
+                FullCommand = "tool app foo-async",
+            },
+            Command(
+                "ToolAppFooAsyncCommandOptions",
+                "ToolOptions",
+                ["app", "foo-async-command"],
+                subDomainGroup: "app") with
+            {
+                FullCommand = "tool app foo-async-command",
+            });
+
+        var service = (await new SubDomainClassGenerator().GenerateAsync(tool))
+            .Single(file => Path.GetFileName(file.RelativePath) == "ToolApp.Generated.cs")
+            .Content;
+
+        await Assert.That(service).Contains("FooAsync(");
+        await Assert.That(service).Contains("FooAsyncCommandAsync(");
+        await Assert.That(service).Contains("FooAsyncCommand2Async(");
+    }
+
     #endregion
 
     #region Root command collision filter

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -4219,6 +4219,37 @@ public class GeneratorHardeningTests
             .And.HasMessageContaining("FooBar");
     }
 
+    [Test]
+    public async Task SubDomainClassGenerator_Disambiguates_Literal_Async_Command()
+    {
+        var tool = Tool(
+            Command(
+                "ToolBedrockInvokeDataAutomationOptions",
+                "ToolOptions",
+                ["bedrock", "invoke-data-automation"],
+                subDomainGroup: "bedrock") with
+            {
+                FullCommand = "tool bedrock invoke-data-automation",
+            },
+            Command(
+                "ToolBedrockInvokeDataAutomationAsyncOptions",
+                "ToolOptions",
+                ["bedrock", "invoke-data-automation-async"],
+                subDomainGroup: "bedrock") with
+            {
+                FullCommand = "tool bedrock invoke-data-automation-async",
+            });
+
+        var service = (await new SubDomainClassGenerator().GenerateAsync(tool))
+            .Single(file => Path.GetFileName(file.RelativePath) == "ToolBedrock.Generated.cs")
+            .Content;
+
+        await Assert.That(service)
+            .Contains("InvokeDataAutomationAsync(");
+        await Assert.That(service)
+            .Contains("InvokeDataAutomationAsyncCommandAsync(");
+    }
+
     #endregion
 
     #region Root command collision filter

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -4220,6 +4220,39 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task SubDomainClassGenerator_Throws_When_Parents_Normalize_To_Same_Child()
+    {
+        var tool = Tool(
+            Command(
+                "ToolAppFooBarOptions",
+                "ToolOptions",
+                ["app", "foo-bar"],
+                subDomainGroup: "app") with
+            {
+                FullCommand = "tool app foo-bar",
+            },
+            Command(
+                "ToolAppFooBar2Options",
+                "ToolOptions",
+                ["app", "foo_bar"],
+                subDomainGroup: "app") with
+            {
+                FullCommand = "tool app foo_bar",
+            },
+            Command(
+                "ToolAppFooBarChildOptions",
+                "ToolOptions",
+                ["app", "foo-bar", "child"],
+                subDomainGroup: "app"));
+
+        void Generate() => _ = new SubDomainClassGenerator().GenerateAsync(tool);
+
+        await Assert.That(Generate)
+            .Throws<InvalidOperationException>()
+            .And.HasMessageContaining("tool app foo-bar, tool app foo_bar");
+    }
+
+    [Test]
     public async Task SubDomainClassGenerator_Disambiguates_Literal_Async_Command()
     {
         var tool = Tool(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -290,6 +290,43 @@ public class MarkdownDocumentationGeneratorTests
     }
 
     [Test]
+    public async Task GenerateAsync_Ignores_Siblings_Moved_To_Execute()
+    {
+        var asyncCommand = Command(
+            "fake app foo-async",
+            "FakeAppFooAsyncOptions",
+            ["app", "foo-async"],
+            "app") with
+        {
+            IsSafeForDocumentation = true,
+        };
+        var tool = Tool(
+            "fake",
+            Command("fake app foo", "FakeAppFooOptions", ["app", "foo"], "app"),
+            Command(
+                "fake app foo child",
+                "FakeAppFooChildOptions",
+                ["app", "foo", "child"],
+                "app"),
+            asyncCommand) with
+        {
+            PreferredDocumentationExampleCommand = asyncCommand.FullCommand,
+        };
+
+        var documentation = await GenerateDocumentation(tool);
+        var service = (await new SubDomainClassGenerator().GenerateAsync(tool))
+            .Single(file => Path.GetFileName(file.RelativePath) == "FakeApp.Generated.cs")
+            .Content;
+
+        await Assert.That(documentation)
+            .Contains("context.Tools.Fake.App.FooAsync(");
+        await Assert.That(documentation)
+            .DoesNotContain("FooAsyncCommandAsync(");
+        await Assert.That(service)
+            .Contains("Task<CommandResult> FooAsync(");
+    }
+
+    [Test]
     public async Task GenerateAsync_UsesTheGeneratedConstructorParameterList()
     {
         var command = Command("fake run", "FakeRunOptions", ["run"]) with

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/MarkdownDocumentationGeneratorTests.cs
@@ -293,20 +293,20 @@ public class MarkdownDocumentationGeneratorTests
     public async Task GenerateAsync_Ignores_Siblings_Moved_To_Execute()
     {
         var asyncCommand = Command(
-            "fake app foo-async",
-            "FakeAppFooAsyncOptions",
-            ["app", "foo-async"],
+            "fake app foo-bar-async",
+            "FakeAppFooBarAsyncOptions",
+            ["app", "foo-bar-async"],
             "app") with
         {
             IsSafeForDocumentation = true,
         };
         var tool = Tool(
             "fake",
-            Command("fake app foo", "FakeAppFooOptions", ["app", "foo"], "app"),
+            Command("fake app foo-bar", "FakeAppFooBarOptions", ["app", "foo-bar"], "app"),
             Command(
-                "fake app foo child",
+                "fake app foo_bar child",
                 "FakeAppFooChildOptions",
-                ["app", "foo", "child"],
+                ["app", "foo_bar", "child"],
                 "app"),
             asyncCommand) with
         {
@@ -319,11 +319,11 @@ public class MarkdownDocumentationGeneratorTests
             .Content;
 
         await Assert.That(documentation)
-            .Contains("context.Tools.Fake.App.FooAsync(");
+            .Contains("context.Tools.Fake.App.FooBarAsync(");
         await Assert.That(documentation)
-            .DoesNotContain("FooAsyncCommandAsync(");
+            .DoesNotContain("FooBarAsyncCommandAsync(");
         await Assert.That(service)
-            .Contains("Task<CommandResult> FooAsync(");
+            .Contains("Task<CommandResult> FooBarAsync(");
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -609,9 +609,32 @@ public static partial class GeneratorUtils
     /// <summary>
     /// Generates a method name for a command emitted on a sub-domain service.
     /// A literal <c>execute</c> child is disambiguated from the parent command's
-    /// reserved <c>ExecuteAsync</c> method.
+    /// reserved <c>ExecuteAsync</c> method. A literal <c>*-async</c> command is
+    /// disambiguated when adding the standard async suffix would collide with a sibling.
     /// </summary>
     public static string GenerateSubDomainMethodName(
+        CliCommandDefinition command,
+        bool hasParentCommand,
+        IEnumerable<CliCommandDefinition>? siblingCommands = null)
+    {
+        var methodName = GenerateSubDomainBaseMethodName(command, hasParentCommand);
+
+        if (!methodName.EndsWith("Async", StringComparison.OrdinalIgnoreCase)
+            || siblingCommands is null)
+        {
+            return methodName;
+        }
+
+        var publicMethodName = EnsureAsyncSuffix(methodName);
+        var hasAsyncSuffixCollision = siblingCommands.Any(candidate =>
+            !candidate.FullCommand.Equals(command.FullCommand, StringComparison.OrdinalIgnoreCase)
+            && EnsureAsyncSuffix(GenerateSubDomainBaseMethodName(candidate, hasParentCommand))
+                .Equals(publicMethodName, StringComparison.OrdinalIgnoreCase));
+
+        return hasAsyncSuffixCollision ? $"{methodName}Command" : methodName;
+    }
+
+    private static string GenerateSubDomainBaseMethodName(
         CliCommandDefinition command,
         bool hasParentCommand)
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratorUtils.cs
@@ -625,13 +625,27 @@ public static partial class GeneratorUtils
             return methodName;
         }
 
-        var publicMethodName = EnsureAsyncSuffix(methodName);
-        var hasAsyncSuffixCollision = siblingCommands.Any(candidate =>
-            !candidate.FullCommand.Equals(command.FullCommand, StringComparison.OrdinalIgnoreCase)
-            && EnsureAsyncSuffix(GenerateSubDomainBaseMethodName(candidate, hasParentCommand))
-                .Equals(publicMethodName, StringComparison.OrdinalIgnoreCase));
+        var siblingPublicMethodNames = siblingCommands
+            .Where(candidate => !candidate.FullCommand.Equals(
+                command.FullCommand,
+                StringComparison.OrdinalIgnoreCase))
+            .Select(candidate => EnsureAsyncSuffix(
+                GenerateSubDomainBaseMethodName(candidate, hasParentCommand)))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (!siblingPublicMethodNames.Contains(EnsureAsyncSuffix(methodName)))
+        {
+            return methodName;
+        }
 
-        return hasAsyncSuffixCollision ? $"{methodName}Command" : methodName;
+        var disambiguatedMethodName = $"{methodName}Command";
+        for (var suffix = 2;
+             siblingPublicMethodNames.Contains(EnsureAsyncSuffix(disambiguatedMethodName));
+             suffix++)
+        {
+            disambiguatedMethodName = $"{methodName}Command{suffix}";
+        }
+
+        return disambiguatedMethodName;
     }
 
     private static string GenerateSubDomainBaseMethodName(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -336,7 +336,9 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
                 .SkipLast(1)
                 .SequenceEqual(
                     command.CommandParts.SkipLast(1),
-                    StringComparer.OrdinalIgnoreCase));
+                    StringComparer.OrdinalIgnoreCase)
+            && (candidate.PreserveNamedFacade
+                || !tool.Commands.Any(descendant => IsCommandPrefix(candidate, descendant))));
 
     private static bool HasExecutableParentCommand(
         CliToolDefinition tool,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -318,9 +318,25 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
 
         var methodName = GeneratorUtils.GenerateSubDomainMethodName(
             command,
-            HasExecutableParentCommand(tool, command));
+            HasExecutableParentCommand(tool, command),
+            GetSiblingCommands(tool, command));
         return $"context.Tools.{tool.NamespacePrefix}.{string.Join('.', navigationSegments)}.{GeneratorUtils.EnsureAsyncSuffix(methodName)}";
     }
+
+    private static IEnumerable<CliCommandDefinition> GetSiblingCommands(
+        CliToolDefinition tool,
+        CliCommandDefinition command) =>
+        tool.Commands.Where(candidate =>
+            string.Equals(
+                candidate.SubDomainGroup,
+                command.SubDomainGroup,
+                StringComparison.OrdinalIgnoreCase)
+            && candidate.CommandParts.Length == command.CommandParts.Length
+            && candidate.CommandParts
+                .SkipLast(1)
+                .SequenceEqual(
+                    command.CommandParts.SkipLast(1),
+                    StringComparer.OrdinalIgnoreCase));
 
     private static bool HasExecutableParentCommand(
         CliToolDefinition tool,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -323,22 +323,33 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
         return $"context.Tools.{tool.NamespacePrefix}.{string.Join('.', navigationSegments)}.{GeneratorUtils.EnsureAsyncSuffix(methodName)}";
     }
 
-    private static IEnumerable<CliCommandDefinition> GetSiblingCommands(
+    private static IReadOnlyList<CliCommandDefinition> GetSiblingCommands(
         CliToolDefinition tool,
-        CliCommandDefinition command) =>
-        tool.Commands.Where(candidate =>
-            string.Equals(
+        CliCommandDefinition command)
+    {
+        var subDomainCommands = tool.Commands
+            .Where(candidate => string.Equals(
                 candidate.SubDomainGroup,
                 command.SubDomainGroup,
-                StringComparison.OrdinalIgnoreCase)
-            && candidate.CommandParts.Length == command.CommandParts.Length
-            && candidate.CommandParts
-                .SkipLast(1)
-                .SequenceEqual(
-                    command.CommandParts.SkipLast(1),
-                    StringComparer.OrdinalIgnoreCase)
-            && (candidate.PreserveNamedFacade
-                || !tool.Commands.Any(descendant => IsCommandPrefix(candidate, descendant))));
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var node = CommandTreeNode.BuildTree(
+            tool.NamespacePrefix,
+            GeneratorUtils.GetSubDomainIdentifier(tool, command.SubDomainGroup!),
+            subDomainCommands);
+
+        for (var partIndex = 1; partIndex < command.CommandParts.Length - 1; partIndex++)
+        {
+            if (!node.Children.TryGetValue(command.CommandParts[partIndex], out node))
+            {
+                return [];
+            }
+        }
+
+        return node.Commands
+            .Where(node.EmitsNamedFacade)
+            .ToList();
+    }
 
     private static bool HasExecutableParentCommand(
         CliToolDefinition tool,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/MarkdownDocumentationGenerator.cs
@@ -346,9 +346,7 @@ public partial class MarkdownDocumentationGenerator : ICodeGenerator, IGenerated
             }
         }
 
-        return node.Commands
-            .Where(node.EmitsNamedFacade)
-            .ToList();
+        return node.GetNamedFacadeCommands();
     }
 
     private static bool HasExecutableParentCommand(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
@@ -338,15 +338,20 @@ public class SubDomainClassGenerator : ICodeGenerator
     private static IEnumerable<(CliCommandDefinition Command, string MethodName)> GetCompatibilityCommands(
         CommandTreeNode node,
         CliCommandDefinition? parentCommand,
-        HashSet<CliCommandDefinition> excludedCommands) =>
-        node.Commands
+        HashSet<CliCommandDefinition> excludedCommands)
+    {
+        var commands = node.Commands
             .Where(command => !excludedCommands.Contains(command))
+            .ToList();
+        return commands
             .OrderBy(command => command.ClassName)
             .Select(command => (
                 command,
                 GeneratorUtils.GenerateSubDomainMethodName(
                     command,
-                    parentCommand is not null)));
+                    parentCommand is not null,
+                    commands)));
+    }
 
     private static void GenerateCompatibilityMethodSignature(
         StringBuilder sb,
@@ -485,7 +490,8 @@ public class SubDomainClassGenerator : ICodeGenerator
         {
             var methodName = GeneratorUtils.GenerateSubDomainMethodName(
                 command,
-                parentCommand is not null);
+                parentCommand is not null,
+                commands);
             GeneratorUtils.GenerateServiceMethodSignature(sb, methodName, command);
             sb.AppendLine();
         }
@@ -607,7 +613,10 @@ public class SubDomainClassGenerator : ICodeGenerator
 
         foreach (var command in commands.OrderBy(c => c.ClassName))
         {
-            var methodName = GeneratorUtils.GenerateSubDomainMethodName(command, parentCommand is not null);
+            var methodName = GeneratorUtils.GenerateSubDomainMethodName(
+                command,
+                parentCommand is not null,
+                commands);
             GeneratorUtils.GenerateServiceMethod(sb, methodName, command);
             sb.AppendLine();
         }
@@ -626,7 +635,8 @@ public class SubDomainClassGenerator : ICodeGenerator
             .Concat(commands
                 .Select(command => GeneratorUtils.GenerateSubDomainMethodName(
                     command,
-                    parentCommand is not null))
+                    parentCommand is not null,
+                    commands))
                 .Select(GeneratorUtils.EnsureAsyncSuffix));
         if (parentCommand is not null)
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
@@ -87,21 +87,9 @@ public class SubDomainClassGenerator : ICodeGenerator
 
         // Build map of commands that collide with child property names
         // These will become ExecuteAsync() methods on the child classes instead
-        var collidingCommands = new Dictionary<string, CliCommandDefinition>(StringComparer.OrdinalIgnoreCase);
-        foreach (var command in node.Commands)
-        {
-            var methodName = GeneratorUtils.GenerateMethodNameFromLastCommandPart(command);
-            var matchingChild = node.Children.Values
-                .FirstOrDefault(c => c.PascalSegment.Equals(methodName, StringComparison.OrdinalIgnoreCase));
-
-            if (matchingChild != null)
-            {
-                collidingCommands[matchingChild.Segment] = command;
-            }
-        }
-
-        var excludedCommands = node.Commands
-            .Where(command => !node.EmitsNamedFacade(command))
+        var collidingCommands = node.GetChildParentCommands();
+        var excludedCommands = collidingCommands.Values
+            .Where(command => !command.PreserveNamedFacade)
             .ToHashSet();
 
         // Generate the command represented by this node as ExecuteAsync(). Root nodes receive

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/SubDomainClassGenerator.cs
@@ -100,8 +100,8 @@ public class SubDomainClassGenerator : ICodeGenerator
             }
         }
 
-        var excludedCommands = collidingCommands.Values
-            .Where(static command => !command.PreserveNamedFacade)
+        var excludedCommands = node.Commands
+            .Where(command => !node.EmitsNamedFacade(command))
             .ToHashSet();
 
         // Generate the command represented by this node as ExecuteAsync(). Root nodes receive

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
@@ -43,6 +43,16 @@ public class CommandTreeNode
     public bool HasChildren => Children.Count > 0;
 
     /// <summary>
+    /// Whether a direct command remains a named facade on this node instead of moving
+    /// to <c>ExecuteAsync</c> on a matching child command group.
+    /// </summary>
+    internal bool EmitsNamedFacade(CliCommandDefinition command) =>
+        command.PreserveNamedFacade
+        || Children.Values.All(child => !child.PascalSegment.Equals(
+            GeneratorUtils.GenerateMethodNameFromLastCommandPart(command),
+            StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
     /// Depth in the tree (0 = root).
     /// </summary>
     public int Depth { get; set; }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Models/CommandTreeNode.cs
@@ -43,14 +43,46 @@ public class CommandTreeNode
     public bool HasChildren => Children.Count > 0;
 
     /// <summary>
-    /// Whether a direct command remains a named facade on this node instead of moving
-    /// to <c>ExecuteAsync</c> on a matching child command group.
+    /// Commands that move to <c>ExecuteAsync</c> on matching child command groups.
     /// </summary>
-    internal bool EmitsNamedFacade(CliCommandDefinition command) =>
-        command.PreserveNamedFacade
-        || Children.Values.All(child => !child.PascalSegment.Equals(
-            GeneratorUtils.GenerateMethodNameFromLastCommandPart(command),
-            StringComparison.OrdinalIgnoreCase));
+    internal IReadOnlyDictionary<string, CliCommandDefinition> GetChildParentCommands()
+    {
+        var collisions = Commands
+            .Select(command => new
+            {
+                Command = command,
+                Child = Children.Values.FirstOrDefault(child => child.PascalSegment.Equals(
+                    GeneratorUtils.GenerateMethodNameFromLastCommandPart(command),
+                    StringComparison.OrdinalIgnoreCase)),
+            })
+            .Where(collision => collision.Child is not null)
+            .ToList();
+        var ambiguousCollision = collisions
+            .GroupBy(collision => collision.Child!.Segment, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(group => group.Skip(1).Any());
+        if (ambiguousCollision is not null)
+        {
+            throw new InvalidOperationException(
+                $"Command group '{ambiguousCollision.Key}' has multiple executable parent commands: "
+                + $"{string.Join(", ", ambiguousCollision.Select(collision => collision.Command.FullCommand))}.");
+        }
+
+        return collisions.ToDictionary(
+            collision => collision.Child!.Segment,
+            collision => collision.Command,
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Direct commands that remain named facades on this node.
+    /// </summary>
+    internal IReadOnlyList<CliCommandDefinition> GetNamedFacadeCommands()
+    {
+        var movedCommands = GetChildParentCommands().Values
+            .Where(command => !command.PreserveNamedFacade)
+            .ToHashSet();
+        return Commands.Where(command => !movedCommands.Contains(command)).ToList();
+    }
 
     /// <summary>
     /// Depth in the tree (0 = root).


### PR DESCRIPTION
Fixes the AWS Bedrock generation failure discovered by the full CLI matrix. A literal *-async command now receives a scoped Command disambiguator only when the standard async suffix collides with a sibling, preserving the existing command facade. Generated documentation uses the same resolved name. Added regression coverage.\n\nRefs #3996\nRefs #3910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented ambiguous generated command names when commands normalize to the same parent or when multiple asynchronous commands collide.
  - Added unique suffixes to conflicting asynchronous command names.
  - Excluded redirected sibling commands from generated documentation examples while retaining the valid asynchronous command.
- **Documentation**
  - Improved generated command documentation accuracy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->