### PR TITLE
Deduplicate case-variant AWS enum values

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
@@ -52,6 +52,47 @@ public class AwsCliScraperTests
             .IsEquivalentTo(["aws ec2 describe-instances"]);
     }
 
+    [Test]
+    public async Task Enum_Detection_Deduplicates_Case_Variant_Values()
+    {
+        var definition = AwsCliScraper.TryDetectEnum(
+            "TrafficRoutingConfig",
+            "AwsDeployCreateDeploymentConfigOptions",
+            "Possible values: TimeBasedCanary TimeBasedLinear AllAtOnce timeBasedCanary timeBasedLinear");
+        var values = definition!.Values;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(values.Select(value => value.CliValue))
+                .IsEquivalentTo(["TimeBasedCanary", "TimeBasedLinear", "AllAtOnce"]);
+            await Assert.That(values.Select(value => value.MemberName).Distinct().Count())
+                .IsEqualTo(values.Count);
+        }
+    }
+
+    [Test]
+    public async Task Structure_Options_Are_Rendered_As_A_Single_Value()
+    {
+        var scraper = new AwsCliScraper(
+            new AwsStructureHelpExecutor(),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<AwsCliScraper>.Instance);
+        var commands = new List<CliCommandDefinition>();
+
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        var option = commands.Single().Options.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.IsKeyValue).IsFalse();
+            await Assert.That(option.CSharpType).IsEqualTo("string?");
+            await Assert.That(option.EnumDefinition).IsNull();
+        }
+    }
+
     private sealed class AwsHelpExecutor : ICliCommandExecutor
     {
         public Task<CliCommandResult> ExecuteAsync(
@@ -104,6 +145,40 @@ public class AwsCliScraperTests
                 StandardError = string.Empty,
                 ExitCode = 0,
             });
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+
+    private sealed class AwsStructureHelpExecutor : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            var output = arguments switch
+            {
+                "help" => "AVAILABLE SERVICES\n       o deploy",
+                "deploy help" => "AVAILABLE COMMANDS\n       o create-deployment-config",
+                "deploy create-deployment-config help" => """
+                    OPTIONS
+                           --traffic-routing-config (structure)
+                            Possible values: TimeBasedCanary TimeBasedLinear AllAtOnce timeBasedCanary
+                    """,
+                _ => string.Empty,
+            };
+
+            return Task.FromResult(new CliCommandResult
+            {
+                StandardOutput = output,
+                StandardError = string.Empty,
+                ExitCode = string.IsNullOrEmpty(output) ? 1 : 0,
+            });
+        }
 
         public Task<bool> IsAvailableAsync(
             string command,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
@@ -355,9 +355,13 @@ public partial class AwsCliScraper : CliScraperBase
             var isFlag = IsAwsBooleanType(typeHint);
             var isArray = typeHint.Contains("list") || typeHint.Contains("...") || (description?.Contains("multiple values") ?? false);
             var isNumeric = IsNumericType(typeHint);
-            var isKeyValue = typeHint.Contains("map") || typeHint.Contains("structure") || (description?.Contains("key=value") ?? false);
+            var isStructure = typeHint.Contains("structure");
+            var isKeyValue = !isStructure
+                             && (typeHint.Contains("map") || (description?.Contains("key=value") ?? false));
 
-            var enumDef = TryDetectEnum(propertyName, className, description);
+            var enumDef = isStructure || isKeyValue
+                ? null
+                : TryDetectEnum(propertyName, className, description);
             var csharpType = DetermineCSharpType(isFlag, isArray, isKeyValue, isNumeric, enumDef);
 
             options.Add(new CliOptionDefinition
@@ -405,7 +409,7 @@ public partial class AwsCliScraper : CliScraperBase
         return lower.Contains("integer") || lower.Contains("long") || lower.Contains("float") || lower.Contains("double");
     }
 
-    private static CliEnumDefinition? TryDetectEnum(string propertyName, string className, string? description)
+    internal static CliEnumDefinition? TryDetectEnum(string propertyName, string className, string? description)
     {
         if (string.IsNullOrEmpty(description))
         {
@@ -420,7 +424,7 @@ public partial class AwsCliScraper : CliScraperBase
                 .Split([',', ' '], StringSplitOptions.RemoveEmptyEntries)
                 .Select(v => v.Trim().TrimEnd('.'))
                 .Where(v => v.Length > 0 && v.Length < 30 && IsValidEnumValue(v))
-                .Distinct()
+                .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
 
             if (values.Length >= 2 && values.Length <= 15)


### PR DESCRIPTION
## Summary

- model AWS structure shorthand options as a single string argument
- keep AWS map/key-value options as typed key-value collections
- deduplicate scalar AWS enum values case-insensitively during scraping
- prevent `TimeBasedCanary` and `timeBasedCanary` from generating the same C# member twice
- add focused regression coverage for both cases

## Validation

- AWS scraper regressions: 4/4
- OptionsGenerator full suite: 1,065/1,065

## Evidence

All-tool proof run 32786853097 failed AWS with duplicate member `TimeBasedCanary` in `AwsDeployCreateDeploymentConfigTrafficRoutingConfig`. AWS `(structure)` shorthand must also remain one process argument, such as `type=TimeBasedCanary,waitTimeInMinutes=5`; representing it as `string?` provides that exact rendering while map options retain `IReadOnlyList<KeyValue>?`.

Refs #3996
Refs #3910


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS option detection so key-value options retain their correct structure.
  * Prevented duplicate enum values that differ only by letter casing.
  * Ensured structure options render as a single nullable value without incorrect metadata.

* **Tests**
  * Added coverage for case-insensitive enum deduplication and structure-option rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->