### PR TITLE
Allow manual generation without auto-merge

### DIFF
--- a/.github/workflows/generate-cli-options.yml
+++ b/.github/workflows/generate-cli-options.yml
@@ -17,6 +17,11 @@ on:
         required: false
         default: true
         type: boolean
+      enable-auto-merge:
+        description: 'Enable auto-merge for created pull requests'
+        required: false
+        default: true
+        type: boolean
       approve-command-coverage-shrinkage:
         description: 'Explicitly approve removed commands for this run'
         required: false
@@ -680,7 +685,7 @@ jobs:
           committer: thomhurst <9139608+thomhurst@users.noreply.github.com>
 
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pull-request-number && steps.api-compat.outcome == 'success'
+        if: steps.create-pr.outputs.pull-request-number && steps.api-compat.outcome == 'success' && (github.event_name != 'workflow_dispatch' || inputs['enable-auto-merge'])
         run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --auto --squash
         env:
           GH_TOKEN: ${{ secrets.CLI_SCRAPER_PAT_TOKEN }}
@@ -972,7 +977,7 @@ jobs:
           committer: thomhurst <9139608+thomhurst@users.noreply.github.com>
 
       - name: Enable auto-merge
-        if: steps.create-pr.outputs.pull-request-number && steps.api-compat.outcome == 'success'
+        if: steps.create-pr.outputs.pull-request-number && steps.api-compat.outcome == 'success' && (github.event_name != 'workflow_dispatch' || inputs['enable-auto-merge'])
         shell: pwsh
         run: gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --auto --squash
         env:


### PR DESCRIPTION
## Summary

- add an `enable-auto-merge` manual-dispatch input
- preserve auto-merge for scheduled generation and default manual runs
- allow an explicit manual run to create PRs without merging them automatically
- apply the same guard to Linux and Windows generation jobs

## Validation

- `git diff --check`
- local `actionlint` unavailable; GitHub fast-fail validates workflow syntax

This lets the issue/PR loop inspect and merge generated PRs through `scripts/Merge-Pr.ps1`.

Refs #3996
Refs #3910