### PR TITLE
Update Azure Network SDK and pin AppService

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Azure.ResourceManager.AlertsManagement" Version="1.1.2" />
     <PackageVersion Include="Azure.ResourceManager.AppConfiguration" Version="1.4.1" />
     <PackageVersion Include="Azure.ResourceManager.ApplicationInsights" Version="1.1.0" />
-    <PackageVersion Include="Azure.ResourceManager.AppService" Version="1.4.1" />
+    <PackageVersion Include="Azure.ResourceManager.AppService" Version="1.5.0" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.7" />
     <PackageVersion Include="Azure.ResourceManager.Compute" Version="1.16.0" />
     <PackageVersion Include="Azure.ResourceManager.ContainerRegistry" Version="1.4.0" />
@@ -21,7 +21,7 @@
     <PackageVersion Include="Azure.ResourceManager.KeyVault" Version="1.4.0" />
     <PackageVersion Include="Azure.ResourceManager.KubernetesConfiguration" Version="1.2.1" />
     <PackageVersion Include="Azure.ResourceManager.ManagedServiceIdentities" Version="1.4.1" />
-    <PackageVersion Include="Azure.ResourceManager.Network" Version="1.16.0" />
+    <PackageVersion Include="Azure.ResourceManager.Network" Version="1.17.0" />
     <PackageVersion Include="Azure.ResourceManager.OperationalInsights" Version="1.3.2" />
     <PackageVersion Include="Azure.ResourceManager.Redis" Version="1.5.1" />
     <PackageVersion Include="Azure.ResourceManager.SecurityCenter" Version="1.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Azure.ResourceManager.AlertsManagement" Version="1.1.2" />
     <PackageVersion Include="Azure.ResourceManager.AppConfiguration" Version="1.4.1" />
     <PackageVersion Include="Azure.ResourceManager.ApplicationInsights" Version="1.1.0" />
-    <PackageVersion Include="Azure.ResourceManager.AppService" Version="1.5.0" />
+    <PackageVersion Include="Azure.ResourceManager.AppService" Version="1.4.1" />
     <PackageVersion Include="Azure.ResourceManager.Authorization" Version="1.1.7" />
     <PackageVersion Include="Azure.ResourceManager.Compute" Version="1.16.0" />
     <PackageVersion Include="Azure.ResourceManager.ContainerRegistry" Version="1.4.0" />

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-      "config:recommended"
-   ]
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Preserve the public AppService domain-provisioning contract until DomainRegistration is stable",
+      "matchPackageNames": [
+        "Azure.ResourceManager.AppService"
+      ],
+      "allowedVersions": "<=1.4.1"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- update `Azure.ResourceManager.Network` from 1.16.0 to 1.17.0
- retain `Azure.ResourceManager.AppService` 1.4.1 because 1.5.0 obsoletes the public domain-provisioning types preserved by #3118
- add a Renovate `allowedVersions` rule so the incompatible AppService bump is not reopened

## Validation

- Renovate JSON parses successfully
- exact-head CI is authoritative; the initial local Azure build reached the mandated 2 GB agent guard and was not retried
- dotnet-inspect confirmed the replacement surface is currently only in `Azure.ResourceManager.DomainRegistration` 1.0.0-beta.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Azure networking package to version 1.17.0.
  * Restricted automatic updates for the Azure App Service package to version 1.4.1 or earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->