### PR TITLE
[Automated] Update kustomize CLI Options

### DIFF
--- a/src/ModularPipelines.Kubernetes/Extensions/KustomizeExtensions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Extensions/KustomizeExtensions.Generated.cs
@@ -36,7 +36,7 @@ public static class KustomizeExtensions
     }
 
     /// <summary>
-    /// Gets the kustomize service from the pipeline context.
+    /// Gets the kustomize service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IKustomize"/> service for executing kustomize commands.</returns>

--- a/src/ModularPipelines.Kubernetes/Generated/Kustomize.CommandCoverage.json
+++ b/src/ModularPipelines.Kubernetes/Generated/Kustomize.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "kustomize",
+  "toolVersion": "v5.8.1",
   "commandCount": 45,
   "commandTreeSha256": "0ae36cae52a7633cdaf6161528ae7819e41d2855a07443c9b69a53279326fb08",
   "commands": [

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeCfgCatOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeCfgCatOptions.Generated.cs
@@ -22,10 +22,8 @@ public record KustomizeCfgCatOptions(
     [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Dir
 ) : KustomizeOptions
 {
-    /// <summary>
-    /// Creates compatibility options without the newly required directory operand.
-    /// </summary>
-    public KustomizeCfgCatOptions() : this(string.Empty)
+    public KustomizeCfgCatOptions()
+        : this(string.Empty)
     {
     }
 

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeCfgCountOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeCfgCountOptions.Generated.cs
@@ -44,6 +44,9 @@ public record KustomizeCfgCountOptions : KustomizeOptions
     [CliFlag("--stack-trace")]
     public bool? StackTrace { get; set; }
 
+    /// <summary>
+    /// The DIR operand.
+    /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? Dir { get; set; }
 

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeCfgTreeOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeCfgTreeOptions.Generated.cs
@@ -110,6 +110,9 @@ public record KustomizeCfgTreeOptions : KustomizeOptions
     [CliFlag("--stack-trace")]
     public bool? StackTrace { get; set; }
 
+    /// <summary>
+    /// The DIR operand.
+    /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? Dir { get; set; }
 

--- a/src/ModularPipelines.Kubernetes/Options/KustomizeFnRunOptions.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Options/KustomizeFnRunOptions.Generated.cs
@@ -110,6 +110,9 @@ public record KustomizeFnRunOptions : KustomizeOptions
     [CliFlag("--stack-trace")]
     public bool? StackTrace { get; set; }
 
+    /// <summary>
+    /// The DIR operand.
+    /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public string? Dir { get; set; }
 

--- a/src/ModularPipelines.Kubernetes/Services/IKustomize.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/IKustomize.Generated.cs
@@ -23,17 +23,17 @@ public partial interface IKustomize
     /// <summary>
     /// Gets the cfg sub-domain service.
     /// </summary>
-    IKustomizeCfg Cfg { get; }
+    IKustomizeCfg Cfg => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the edit sub-domain service.
     /// </summary>
-    IKustomizeEdit Edit { get; }
+    IKustomizeEdit Edit => throw new System.NotSupportedException();
 
     /// <summary>
     /// Gets the fn sub-domain service.
     /// </summary>
-    IKustomizeFn Fn { get; }
+    IKustomizeFn Fn => throw new System.NotSupportedException();
 
     #endregion
 
@@ -46,7 +46,7 @@ public partial interface IKustomize
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> BuildAsync(KustomizeBuildOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> BuildAsync(KustomizeBuildOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -56,7 +56,7 @@ public partial interface IKustomize
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> CreateAsync(KustomizeCreateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CreateAsync(KustomizeCreateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -66,7 +66,7 @@ public partial interface IKustomize
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> LocalizeAsync(KustomizeLocalizeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> LocalizeAsync(KustomizeLocalizeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     #endregion

--- a/src/ModularPipelines.Kubernetes/Services/IKustomizeCfg.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/IKustomizeCfg.Generated.cs
@@ -28,7 +28,7 @@ public interface IKustomizeCfg
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(KustomizeCfgOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ExecuteAsync(KustomizeCfgOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -38,7 +38,7 @@ public interface IKustomizeCfg
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> CatAsync(KustomizeCfgCatOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CatAsync(KustomizeCfgCatOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -48,7 +48,7 @@ public interface IKustomizeCfg
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> CountAsync(KustomizeCfgCountOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CountAsync(KustomizeCfgCountOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -58,7 +58,7 @@ public interface IKustomizeCfg
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> GrepAsync(KustomizeCfgGrepOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> GrepAsync(KustomizeCfgGrepOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -68,7 +68,7 @@ public interface IKustomizeCfg
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> TreeAsync(KustomizeCfgTreeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> TreeAsync(KustomizeCfgTreeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Kubernetes/Services/IKustomizeEdit.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/IKustomizeEdit.Generated.cs
@@ -24,17 +24,17 @@ public interface IKustomizeEdit
     /// <summary>
     /// kustomize add sub-commands.
     /// </summary>
-    KustomizeEditAdd Add { get; }
+    KustomizeEditAdd Add => throw new System.NotSupportedException();
 
     /// <summary>
     /// kustomize remove sub-commands.
     /// </summary>
-    KustomizeEditRemove Remove { get; }
+    KustomizeEditRemove Remove => throw new System.NotSupportedException();
 
     /// <summary>
     /// kustomize set sub-commands.
     /// </summary>
-    KustomizeEditSet Set { get; }
+    KustomizeEditSet Set => throw new System.NotSupportedException();
 
     /// <summary>
     /// Edits a kustomization file
@@ -43,7 +43,7 @@ public interface IKustomizeEdit
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(KustomizeEditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ExecuteAsync(KustomizeEditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -53,7 +53,7 @@ public interface IKustomizeEdit
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> AlphaListBuiltinPluginAsync(KustomizeEditAlphaListBuiltinPluginOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> AlphaListBuiltinPluginAsync(KustomizeEditAlphaListBuiltinPluginOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -63,7 +63,7 @@ public interface IKustomizeEdit
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FixAsync(KustomizeEditFixOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> FixAsync(KustomizeEditFixOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }

--- a/src/ModularPipelines.Kubernetes/Services/IKustomizeFn.Generated.cs
+++ b/src/ModularPipelines.Kubernetes/Services/IKustomizeFn.Generated.cs
@@ -28,7 +28,7 @@ public interface IKustomizeFn
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> ExecuteAsync(KustomizeFnOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ExecuteAsync(KustomizeFnOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     /// <summary>
@@ -38,7 +38,7 @@ public interface IKustomizeFn
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RunAsync(KustomizeFnRunOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RunAsync(KustomizeFnRunOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **kustomize** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- kustomize (v5.8.1): 45 commands, tree 0ae36cae52a7633cdaf6161528ae7819e41d2855a07443c9b69a53279326fb08

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator