### PR TITLE
[Automated] Update newman CLI Options

### DIFF
--- a/src/ModularPipelines.Newman/Services/INewman.Generated.cs
+++ b/src/ModularPipelines.Newman/Services/INewman.Generated.cs
@@ -27,7 +27,7 @@ public partial interface INewman
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RunAsync(NewmanRunOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RunAsync(NewmanRunOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     #endregion


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **newman** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- newman (6.2.2): 1 commands, tree ced9ddeba1af07157ce673dfef4b2f598ce1042109b01550b39b5f7ea93e9c38

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator