### PR TITLE
Preserve generated CLI operands

### DIFF
--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -3732,6 +3732,60 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Prefers_Historical_Facade_Group_Casing_For_Normalized_Subdomains()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolAccessApprovalRequestsOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"access-approval\", \"requests\")] "
+                + "public record ToolAccessApprovalRequestsOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolAccessApprovalRequestsApproveOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"access-approval\", \"requests\", \"approve\")] "
+                + "public record ToolAccessApprovalRequestsApproveOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolAccessapprovalRequests.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; "
+                + "public class ToolAccessapprovalRequests { "
+                + "public Task ApproveAsync(ToolAccessApprovalRequestsApproveOptions? options = null) "
+                + "=> Task.CompletedTask; }");
+            var parent = Command(
+                "ToolAccessApprovalRequestsOptions",
+                "ToolOptions",
+                ["access-approval", "requests"],
+                subDomainGroup: "AccessApproval");
+            var current = Command(
+                "ToolAccessApprovalRequestsApproveOptions",
+                "ToolOptions",
+                ["access-approval", "requests", "approve"],
+                subDomainGroup: "AccessApproval");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(Tool(parent, current), root);
+            var generated = (await new SubDomainClassGenerator().GenerateAsync(preserved))
+                .Single(file => Path.GetFileName(file.RelativePath)
+                    .Equals("ToolAccessapprovalRequests.Generated.cs", StringComparison.Ordinal));
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(preserved.Commands.Select(command => command.CommandGroupIdentifierOverride!))
+                    .IsEquivalentTo(["Accessapproval", "Accessapproval"]);
+                await Assert.That(generated.Content).Contains("ApproveAsync(");
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Ignores_Other_Tool_Facades_In_Shared_Package()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Generators/GeneratorHardeningTests.cs
@@ -3786,6 +3786,49 @@ public class GeneratorHardeningTests
     }
 
     [Test]
+    public async Task ApiCompatibilityPreserver_Does_Not_Inherit_Group_Identifier_From_Sibling_Branch()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");
+        var packageDirectory = Path.Combine(root, "src", "ModularPipelines.Tool");
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Options"));
+        Directory.CreateDirectory(Path.Combine(packageDirectory, "Services"));
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolAccessApprovalRequestsApproveOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"access-approval\", \"requests\", \"approve\")] "
+                + "public record ToolAccessApprovalRequestsApproveOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Options", "ToolAccessApprovalSettingsOptions.Generated.cs"),
+                "using ModularPipelines.Attributes; "
+                + "[CliSubCommand(\"access-approval\", \"settings\")] "
+                + "public record ToolAccessApprovalSettingsOptions : ToolOptions;");
+            await File.WriteAllTextAsync(
+                Path.Combine(packageDirectory, "Services", "ToolLegacyRequests.Generated.cs"),
+                "namespace ModularPipelines.Tool.Services; "
+                + "public class ToolLegacyRequests { "
+                + "public Task ApproveAsync(ToolAccessApprovalRequestsApproveOptions? options = null) "
+                + "=> Task.CompletedTask; }");
+            var settings = Command(
+                "ToolAccessApprovalSettingsOptions",
+                "ToolOptions",
+                ["access-approval", "settings"],
+                subDomainGroup: "AccessApproval");
+
+            var preserved = GeneratedApiCompatibilityPreserver.Preserve(Tool(settings), root);
+            var preservedSettings = preserved.Commands.Single(command =>
+                command.CommandParts.SequenceEqual(["access-approval", "settings"]));
+
+            await Assert.That(preservedSettings.CommandGroupIdentifierOverride).IsEqualTo("AccessApproval");
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Test]
     public async Task ApiCompatibilityPreserver_Ignores_Other_Tool_Facades_In_Shared_Package()
     {
         var root = Path.Combine(Path.GetTempPath(), $"service-api-{Guid.NewGuid():N}");

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AwsCliScraperTests.cs
@@ -93,6 +93,29 @@ public class AwsCliScraperTests
         }
     }
 
+    [Test]
+    public async Task List_Options_Do_Not_Mine_Nested_Enum_Values()
+    {
+        var scraper = new AwsCliScraper(
+            new AwsListHelpExecutor(),
+            new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+            NullLogger<AwsCliScraper>.Instance);
+        var commands = new List<CliCommandDefinition>();
+
+        await foreach (var command in scraper.ScrapeAsync())
+        {
+            commands.Add(command);
+        }
+
+        var option = commands.Single().Options.Single();
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.CSharpType).IsEqualTo("IEnumerable<string>?");
+            await Assert.That(option.AcceptsMultipleValues).IsTrue();
+            await Assert.That(option.EnumDefinition).IsNull();
+        }
+    }
+
     private sealed class AwsHelpExecutor : ICliCommandExecutor
     {
         public Task<CliCommandResult> ExecuteAsync(
@@ -168,6 +191,41 @@ public class AwsCliScraperTests
                     OPTIONS
                            --traffic-routing-config (structure)
                             Possible values: TimeBasedCanary TimeBasedLinear AllAtOnce timeBasedCanary
+                    """,
+                _ => string.Empty,
+            };
+
+            return Task.FromResult(new CliCommandResult
+            {
+                StandardOutput = output,
+                StandardError = string.Empty,
+                ExitCode = string.IsNullOrEmpty(output) ? 1 : 0,
+            });
+        }
+
+        public Task<bool> IsAvailableAsync(
+            string command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(true);
+    }
+
+    private sealed class AwsListHelpExecutor : ICliCommandExecutor
+    {
+        public Task<CliCommandResult> ExecuteAsync(
+            string command,
+            string arguments,
+            CancellationToken cancellationToken = default,
+            string? workingDirectory = null)
+        {
+            var output = arguments switch
+            {
+                "help" => "AVAILABLE SERVICES\n       o ec2",
+                "ec2 help" => "AVAILABLE COMMANDS\n       o create-ipam-prefix-list-resolver",
+                "ec2 create-ipam-prefix-list-resolver help" => """
+                    OPTIONS
+                           --rules (list)
+                            CIDR selection rules. Possible values: static-cidr ipam-resource-cidr
+                            ipam-pool-cidr StaticCidr is the fixed CIDR value.
                     """,
                 _ => string.Empty,
             };

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/AzCliScraperTests.cs
@@ -156,6 +156,43 @@ public class AzCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Description_Only_Value_Arguments_Are_Not_Flags()
+    {
+        const string helpText = """
+            Command
+                az stack-whatif group create : Create a deployment stack what-if result.
+
+            Optional Arguments
+                --description     : The description of deployment stack.
+                --no-color        : Disable color in pretty-printed results.
+                --parameters -p   : Parameters may be supplied from a file or as KEY=VALUE pairs.
+                --tags            : Space-separated tags: key[=value] [key[=value] ...].
+                --template-file -f: A path to a template file or Bicep file.
+                --template-uri -u : A uri to a remote template file.
+            """;
+
+        var command = await new TestAzCliScraper().Parse(
+            ["az", "stack-whatif", "group", "create"],
+            helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Single(option => option.PropertyName == "Description").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.PropertyName == "Parameters").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.PropertyName == "Tags").CSharpType)
+                .IsEqualTo("IEnumerable<string>?");
+            await Assert.That(command.Options.Single(option => option.PropertyName == "TemplateFile").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.PropertyName == "TemplateUri").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.PropertyName == "NoColor").IsFlag)
+                .IsTrue();
+        }
+    }
+
     private sealed class TestAzCliScraper()
         : AzCliScraper(
             new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/Cli/CliScraperTraversalTests.cs
@@ -54,6 +54,9 @@ public class CliScraperTraversalTests
             .IsEquivalentTo(["fake parent", "fake parent child"]);
         await Assert.That(commands.Single(command => command.FullCommand == "fake parent").Options)
             .Contains(option => option.SwitchName == "--scope");
+        await Assert.That(commands.Single(command => command.FullCommand == "fake parent")
+                .PositionalArguments.Single().PropertyName)
+            .IsEqualTo("Command");
         await Assert.That(executor.Arguments)
             .IsEquivalentTo(["--help", "parent --help", "parent child --help"]);
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DotNetCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/DotNetCliScraperTests.cs
@@ -2,11 +2,32 @@ using System.Net;
 using Microsoft.Extensions.Logging.Abstractions;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers;
+using ModularPipelines.OptionsGenerator.Scrapers.Cli;
+using ModularPipelines.OptionsGenerator.TypeDetection;
 
 namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
 
 public class DotNetCliScraperTests
 {
+    [Test]
+    public async Task Subcommands_With_Positional_Signatures_Are_Discovered()
+    {
+        const string helpText = """
+                                Commands:
+                                  add                                      Add a package or reference.
+                                  delete <PackageId> <PackageVersion>      Delete a package.
+                                  source <PackageSourcePath>               Add a package source.
+                                  why <PROJECT | SOLUTION | FILE> <PACKAGE>    Show dependency paths.
+
+                                Options:
+                                  -h, --help  Show command line help.
+                                """;
+
+        var subcommands = new TestDotNetCliScraper().Extract(helpText);
+
+        await Assert.That(subcommands).IsEquivalentTo(["add", "delete", "source", "why"]);
+    }
+
     [Test]
     [Arguments("--nologo", "Nologo")]
     [Arguments("--no-logo", "NoLogo")]
@@ -88,6 +109,19 @@ public class DotNetCliScraperTests
         CSharpType = "bool?",
         IsFlag = true,
     };
+
+    private sealed class TestDotNetCliScraper : DotNetCliScraper
+    {
+        public TestDotNetCliScraper()
+            : base(
+                new ProcessCliCommandExecutor(NullLogger<ProcessCliCommandExecutor>.Instance),
+                new HelpTextCache(NullLogger<HelpTextCache>.Instance),
+                NullLogger<DotNetCliScraper>.Instance)
+        {
+        }
+
+        public IReadOnlyList<string> Extract(string helpText) => [.. ExtractSubcommands(helpText)];
+    }
 
     private sealed class StaticHtmlHandler(string html) : HttpMessageHandler
     {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -296,6 +296,24 @@ public class GitCliScraperTests
     }
 
     [Test]
+    public async Task Parses_Short_Only_Value_Options()
+    {
+        const string helpText = "    -C <n>                ensure at least <n> lines of context match";
+        using var scraper = new TestGitCliScraper();
+        var command = await scraper.Parse(["git", "apply"], helpText);
+        var option = command!.Options.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.SwitchName).IsEqualTo("-C");
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.CSharpType).IsEqualTo("int?");
+            await Assert.That(option.ValueArity).IsEqualTo(CliOptionValueArity.Required);
+            await Assert.That(option.ValueSeparator).IsEqualTo(" ");
+        }
+    }
+
+    [Test]
     public async Task Parses_Options_With_Wrapped_Descriptions()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -262,6 +262,31 @@ public class GitCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Parses_Options_With_Wrapped_Descriptions()
+    {
+        const string helpText = """
+            usage: git add [<options>]
+
+                -N, --[no-]intent-to-add
+                                    record only the fact that the path will be added later
+            """;
+        using var scraper = new TestGitCliScraper();
+        var command = await scraper.Parse(["git", "add"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Select(option => option.SwitchName))
+                .IsEquivalentTo(["--intent-to-add", "--no-intent-to-add"]);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--intent-to-add").Description)
+                .IsEqualTo("record only the fact that the path will be added later");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--no-intent-to-add").Description)
+                .Contains("record only the fact that the path will be added later");
+            await Assert.That(command.Options.All(option => option is { IsFlag: true, CSharpType: "bool?" }))
+                .IsTrue();
+        }
+    }
+
     private static CliCommandResult Result(
         string standardOutput,
         string standardError = "",

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
@@ -223,6 +224,7 @@ public class GitCliScraperTests
                 --[no-]upload-pack <path>                       path to upload pack
                 --[no-]recurse-submodules[=<on-demand>]         control recursive fetching
                 --[no-]signed[=(yes|no|if-asked)]               GPG sign the request
+                --[no-]chmod (+|-)x                             override the executable bit
             """;
         using var scraper = new TestGitCliScraper();
         var command = await scraper.Parse(["git", "fetch"], helpText);
@@ -235,9 +237,31 @@ public class GitCliScraperTests
                 .IsFalse();
             await Assert.That(command.Options.Single(option => option.SwitchName == "--signed").IsFlag)
                 .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--chmod").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--chmod").CSharpType)
+                .IsEqualTo("string?");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--chmod").ValueArity)
+                .IsEqualTo(CliOptionValueArity.Required);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--chmod").ValueSeparator)
+                .IsEqualTo(" ");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--recurse-submodules").ValueArity)
+                .IsEqualTo(CliOptionValueArity.Optional);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--recurse-submodules").ValueSeparator)
+                .IsEqualTo("=");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--signed").ValueArity)
+                .IsEqualTo(CliOptionValueArity.Optional);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--signed").ValueSeparator)
+                .IsEqualTo("=");
             await Assert.That(command.Options
-                    .Where(option => option.SwitchName is "--no-upload-pack" or "--no-recurse-submodules" or "--no-signed")
-                    .All(option => option.IsFlag && option.CSharpType == "bool?"))
+                    .Where(option => option.SwitchName is "--no-upload-pack" or "--no-recurse-submodules" or "--no-signed" or "--no-chmod")
+                    .All(option => option is
+                    {
+                        IsFlag: true,
+                        CSharpType: "bool?",
+                        ValueArity: CliOptionValueArity.Required,
+                        ValueSeparator: " ",
+                    }))
                 .IsTrue();
         }
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -185,6 +186,31 @@ public class GitCliScraperTests
         await Assert.That(subcommands).IsEquivalentTo(["add"]);
     }
 
+    [Test]
+    public async Task Parses_Negatable_Option_Without_Colliding_With_Operand()
+    {
+        const string helpText = """
+            usage: git merge [<options>] [<commit>...]
+
+                --[no-]commit       perform a commit if the merge succeeds (default)
+            """;
+        using var scraper = new TestGitCliScraper();
+        var command = await scraper.Parse(["git", "merge"], helpText);
+        var resolved = InheritedPropertyCollisionResolver.Resolve(
+                scraper.CreateToolDefinition() with { Commands = [command!] })
+            .Commands.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolved.Options.Single().SwitchName).IsEqualTo("--commit");
+            await Assert.That(resolved.Options.Single().PropertyName).IsEqualTo("Commit");
+            await Assert.That(resolved.Options.Single().IsFlag).IsTrue();
+            await Assert.That(resolved.PositionalArguments.Single().PropertyName)
+                .IsEqualTo("CommitArgument");
+            await Assert.That(resolved.PositionalArguments.Single().IsVariadic).IsTrue();
+        }
+    }
+
     private static CliCommandResult Result(
         string standardOutput,
         string standardError = "",
@@ -218,6 +244,24 @@ public class GitCliScraperTests
             string command,
             CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
+    }
+
+    private sealed class TestGitCliScraper : GitCliScraper
+    {
+        public TestGitCliScraper()
+            : base(
+                new StubExecutor(),
+                new StubHelpTextCache(),
+                NullLogger<GitCliScraper>.Instance)
+        {
+        }
+
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                UsageSynopsisParser.Parse(helpText, commandPath),
+                CancellationToken.None);
     }
 
     private sealed class StdoutHelpExecutor : ICliCommandExecutor

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -314,6 +314,23 @@ public class GitCliScraperTests
     }
 
     [Test]
+    public async Task Parses_Optional_Attached_Short_Only_Values()
+    {
+        const string helpText = "    -C[<score>]           find copies as well as moves";
+        using var scraper = new TestGitCliScraper();
+        var command = await scraper.Parse(["git", "blame"], helpText);
+        var option = command!.Options.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.SwitchName).IsEqualTo("-C");
+            await Assert.That(option.IsFlag).IsFalse();
+            await Assert.That(option.ValueArity).IsEqualTo(CliOptionValueArity.Optional);
+            await Assert.That(option.ValueSeparator).IsEmpty();
+        }
+    }
+
+    [Test]
     public async Task Parses_Options_With_Wrapped_Descriptions()
     {
         const string helpText = """

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -294,6 +294,8 @@ public class GitCliScraperTests
 
                 -N, --[no-]intent-to-add
                                     record only the fact that the path will be added later
+                -W, --[no-]function-context
+                                    generate diffs with <n> lines context
             """;
         using var scraper = new TestGitCliScraper();
         var command = await scraper.Parse(["git", "add"], helpText);
@@ -301,11 +303,18 @@ public class GitCliScraperTests
         using (Assert.Multiple())
         {
             await Assert.That(command!.Options.Select(option => option.SwitchName))
-                .IsEquivalentTo(["--intent-to-add", "--no-intent-to-add"]);
+                .IsEquivalentTo([
+                    "--intent-to-add",
+                    "--no-intent-to-add",
+                    "--function-context",
+                    "--no-function-context",
+                ]);
             await Assert.That(command.Options.Single(option => option.SwitchName == "--intent-to-add").Description)
                 .IsEqualTo("record only the fact that the path will be added later");
             await Assert.That(command.Options.Single(option => option.SwitchName == "--no-intent-to-add").Description)
                 .Contains("record only the fact that the path will be added later");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--function-context").Description)
+                .IsEqualTo("generate diffs with <n> lines context");
             await Assert.That(command.Options.All(option => option is { IsFlag: true, CSharpType: "bool?" }))
                 .IsTrue();
         }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -225,6 +225,7 @@ public class GitCliScraperTests
                 --[no-]recurse-submodules[=<on-demand>]         control recursive fetching
                 --[no-]signed[=(yes|no|if-asked)]               GPG sign the request
                 --[no-]chmod (+|-)x                             override the executable bit
+                --[no-]resolvemsg ...                           override error message
             """;
         using var scraper = new TestGitCliScraper();
         var command = await scraper.Parse(["git", "fetch"], helpText);
@@ -245,6 +246,14 @@ public class GitCliScraperTests
                 .IsEqualTo(CliOptionValueArity.Required);
             await Assert.That(command.Options.Single(option => option.SwitchName == "--chmod").ValueSeparator)
                 .IsEqualTo(" ");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--resolvemsg").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--resolvemsg").CSharpType)
+                .IsEqualTo("string?");
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--resolvemsg").ValueArity)
+                .IsEqualTo(CliOptionValueArity.Required);
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--resolvemsg").ValueSeparator)
+                .IsEqualTo(" ");
             await Assert.That(command.Options.Single(option => option.SwitchName == "--recurse-submodules").ValueArity)
                 .IsEqualTo(CliOptionValueArity.Optional);
             await Assert.That(command.Options.Single(option => option.SwitchName == "--recurse-submodules").ValueSeparator)
@@ -254,7 +263,7 @@ public class GitCliScraperTests
             await Assert.That(command.Options.Single(option => option.SwitchName == "--signed").ValueSeparator)
                 .IsEqualTo("=");
             await Assert.That(command.Options
-                    .Where(option => option.SwitchName is "--no-upload-pack" or "--no-recurse-submodules" or "--no-signed" or "--no-chmod")
+                    .Where(option => option.SwitchName is "--no-upload-pack" or "--no-recurse-submodules" or "--no-signed" or "--no-chmod" or "--no-resolvemsg")
                     .All(option => option is
                     {
                         IsFlag: true,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -214,6 +214,34 @@ public class GitCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Parses_Value_Taking_And_Alternative_Valued_Negatable_Options()
+    {
+        const string helpText = """
+            usage: git fetch [<options>]
+
+                --[no-]upload-pack <path>                       path to upload pack
+                --[no-]recurse-submodules[=<on-demand>]         control recursive fetching
+                --[no-]signed[=(yes|no|if-asked)]               GPG sign the request
+            """;
+        using var scraper = new TestGitCliScraper();
+        var command = await scraper.Parse(["git", "fetch"], helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.Options.Single(option => option.SwitchName == "--upload-pack").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--recurse-submodules").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.SwitchName == "--signed").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options
+                    .Where(option => option.SwitchName is "--no-upload-pack" or "--no-recurse-submodules" or "--no-signed")
+                    .All(option => option.IsFlag && option.CSharpType == "bool?"))
+                .IsTrue();
+        }
+    }
+
     private static CliCommandResult Result(
         string standardOutput,
         string standardError = "",

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -202,9 +202,12 @@ public class GitCliScraperTests
 
         using (Assert.Multiple())
         {
-            await Assert.That(resolved.Options.Single().SwitchName).IsEqualTo("--commit");
-            await Assert.That(resolved.Options.Single().PropertyName).IsEqualTo("Commit");
-            await Assert.That(resolved.Options.Single().IsFlag).IsTrue();
+            var commit = resolved.Options.Single(option => option.SwitchName == "--commit");
+            var noCommit = resolved.Options.Single(option => option.SwitchName == "--no-commit");
+            await Assert.That(commit.PropertyName).IsEqualTo("Commit");
+            await Assert.That(commit.IsFlag).IsTrue();
+            await Assert.That(noCommit.PropertyName).IsEqualTo("NoCommit");
+            await Assert.That(noCommit.IsFlag).IsTrue();
             await Assert.That(resolved.PositionalArguments.Single().PropertyName)
                 .IsEqualTo("CommitArgument");
             await Assert.That(resolved.PositionalArguments.Single().IsVariadic).IsTrue();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/GitCliScraperTests.cs
@@ -242,6 +242,26 @@ public class GitCliScraperTests
         }
     }
 
+    [Test]
+    public async Task Parses_Short_Only_Options()
+    {
+        const string helpText = """
+            usage: git add [<options>]
+
+                -p                  interactively choose hunks
+            """;
+        using var scraper = new TestGitCliScraper();
+        var command = await scraper.Parse(["git", "add"], helpText);
+        var option = command!.Options.Single();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(option.SwitchName).IsEqualTo("-p");
+            await Assert.That(option.ShortForm).IsEqualTo("-p");
+            await Assert.That(option.Description).IsEqualTo("interactively choose hunks");
+        }
+    }
+
     private static CliCommandResult Result(
         string standardOutput,
         string standardError = "",

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -90,6 +90,19 @@ public class PositionalOperandAdapterTests
     }
 
     [Test]
+    [Arguments("cache", "Usage: pip cache list [<pattern>]\n  pip cache purge")]
+    [Arguments("config", "Usage: pip config [<file-option>] list\n  pip config get command.option")]
+    [Arguments("index", "Usage: pip index versions <package>")]
+    public async Task Pip_Parent_Groups_Do_Not_Treat_Child_Syntax_As_Operands(
+        string commandName,
+        string helpText)
+    {
+        var command = await new TestPipCliScraper().Parse(["pip", commandName], helpText);
+
+        await Assert.That(command!.PositionalArguments).IsEmpty();
+    }
+
+    [Test]
     public async Task Pnpm_Add_Preserves_Name_Operand()
     {
         var command = await new TestPnpmCliScraper().Parse(
@@ -97,6 +110,28 @@ public class PositionalOperandAdapterTests
             "Usage: pnpm add <name>");
 
         await AssertArgument(command, "Name", isRequired: true, isVariadic: false);
+    }
+
+    [Test]
+    public async Task Pnpm_Stage_Does_Not_Treat_Child_Syntax_As_Operands()
+    {
+        const string helpText = "Usage: pnpm stage publish [<tarball>|<dir>]\n"
+                                + "       pnpm stage list [<package-spec>]";
+
+        var command = await new TestPnpmCliScraper().Parse(["pnpm", "stage"], helpText);
+
+        await Assert.That(command!.PositionalArguments).IsEmpty();
+    }
+
+    [Test]
+    public async Task Pnpm_Unlink_Ignores_Parenthetical_Explanation()
+    {
+        const string helpText = "Usage: pnpm unlink (in package dir)\n"
+                                + "       pnpm unlink <pkg>...";
+
+        var command = await new TestPnpmCliScraper().Parse(["pnpm", "unlink"], helpText);
+
+        await AssertArgument(command, "Pkg", isRequired: false, isVariadic: true);
     }
 
     private static async Task AssertArgument(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -134,6 +134,21 @@ public class PositionalOperandAdapterTests
         await AssertArgument(command, "Pkg", isRequired: false, isVariadic: true);
     }
 
+    [Test]
+    [Arguments("metadata")]
+    [Arguments("stacks")]
+    [Arguments("state")]
+    public async Task Terraform_Command_Group_Args_Are_Variadic(string commandName)
+    {
+        var command = await new TestTerraformCliScraper().Parse(
+            ["terraform", commandName],
+            $"Usage: terraform {commandName} [args]");
+
+        await AssertArgument(command, "Args", isRequired: false, isVariadic: true);
+        await Assert.That(command!.PositionalArguments.Single().CSharpType)
+            .IsEqualTo("IEnumerable<string>?");
+    }
+
     private static async Task AssertArgument(
         CliCommandDefinition? command,
         string propertyName,
@@ -209,6 +224,20 @@ public class PositionalOperandAdapterTests
             PositionalOperandAdapterTests.Executor,
             PositionalOperandAdapterTests.Cache,
             NullLogger<PnpmCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
+    }
+
+    private sealed class TestTerraformCliScraper()
+        : TerraformCliScraper(
+            PositionalOperandAdapterTests.Executor,
+            PositionalOperandAdapterTests.Cache,
+            NullLogger<TerraformCliScraper>.Instance)
     {
         public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
             ParseCommandAsync(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -45,17 +45,17 @@ public class PositionalOperandAdapterTests
     }
 
     [Test]
-    public async Task Liquibase_Help_Option_Description_Is_Not_An_Operand()
+    public async Task Liquibase_Command_Group_Preserves_Executable_Command_Operand()
     {
         const string helpText = "Usage: liquibase init [OPTIONS] [COMMAND]\n  -h, --help   Show this help message and exit";
 
-        var usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(
-            UsageSynopsisParser.Parse(helpText, ["liquibase", "init"]));
+        var usage = UsageSynopsisParser.Parse(helpText, ["liquibase", "init"]);
 
         using (Assert.Multiple())
         {
-            await Assert.That(usage.HasOperandTokens).IsFalse();
-            await Assert.That(usage.PositionalArguments).IsEmpty();
+            await Assert.That(usage.HasOperandTokens).IsTrue();
+            await Assert.That(usage.PositionalArguments.Single().PropertyName)
+                .IsEqualTo("Command");
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -149,6 +150,34 @@ public class PositionalOperandAdapterTests
             .IsEqualTo("IEnumerable<string>?");
     }
 
+    [Test]
+    [Arguments("eval")]
+    [Arguments("eval-all")]
+    public async Task Yq_Expressions_And_Files_Render_After_Options(string commandName)
+    {
+        var command = await new TestYqCliScraper().Parse(
+            ["yq", commandName],
+            $"Usage: yq {commandName} [expression] [yaml_file1]...");
+
+        await Assert.That(command!.PositionalArguments).Count().IsEqualTo(2);
+        await Assert.That(command.PositionalArguments.All(argument =>
+                argument.Phase == CommandLinePhase.Passthrough
+                && argument.PrependOptionTerminatorIfValueStartsWithDash))
+            .IsTrue();
+    }
+
+    [Test]
+    public async Task Packer_Inspect_Template_Renders_After_Options()
+    {
+        var command = await new TestPackerCliScraper().Parse(
+            ["packer", "inspect"],
+            "Usage: packer inspect TEMPLATE");
+
+        await Assert.That(command!.PositionalArguments.Single().PropertyName).IsEqualTo("Template");
+        await Assert.That(command.PositionalArguments.Single().Phase)
+            .IsEqualTo(CommandLinePhase.Passthrough);
+    }
+
     private static async Task AssertArgument(
         CliCommandDefinition? command,
         string propertyName,
@@ -238,6 +267,34 @@ public class PositionalOperandAdapterTests
             PositionalOperandAdapterTests.Executor,
             PositionalOperandAdapterTests.Cache,
             NullLogger<TerraformCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
+    }
+
+    private sealed class TestYqCliScraper()
+        : YqCliScraper(
+            PositionalOperandAdapterTests.Executor,
+            PositionalOperandAdapterTests.Cache,
+            NullLogger<YqCliScraper>.Instance)
+    {
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                ParseUsageSynopsis(commandPath, helpText),
+                CancellationToken.None);
+    }
+
+    private sealed class TestPackerCliScraper()
+        : PackerCliScraper(
+            PositionalOperandAdapterTests.Executor,
+            PositionalOperandAdapterTests.Cache,
+            NullLogger<PackerCliScraper>.Instance)
     {
         public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
             ParseCommandAsync(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PositionalOperandAdapterTests.cs
@@ -39,9 +39,29 @@ public class PositionalOperandAdapterTests
         const string helpText = "usage: go fix [build flags] [-fixtool prog] [fix flags] [packages]";
         var command = await new TestGoCliScraper().Parse(["go", "fix"], helpText);
 
-        await AssertArgument(command, "Packages", isRequired: false, isVariadic: false);
+        await AssertArgument(command, "Packages", isRequired: false, isVariadic: true);
         await Assert.That(command!.PositionalArguments.Select(argument => argument.PropertyName))
             .IsEquivalentTo(["Packages"]);
+    }
+
+    [Test]
+    public async Task Go_Telemetry_Models_Choice_As_Mode()
+    {
+        var command = await new TestGoCliScraper().Parse(
+            ["go", "telemetry"],
+            "usage: go telemetry [off|local|on]");
+
+        await AssertArgument(command, "Mode", isRequired: false, isVariadic: false);
+    }
+
+    [Test]
+    public async Task Go_Generate_Models_File_Or_Package_Targets()
+    {
+        var command = await new TestGoCliScraper().Parse(
+            ["go", "generate"],
+            "usage: go generate [build flags] [file.go... | packages]");
+
+        await AssertArgument(command, "Targets", isRequired: false, isVariadic: true);
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PulumiCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PulumiCliScraperTests.cs
@@ -27,8 +27,15 @@ public class PulumiCliScraperTests
         await Assert.That(scraper.DeclaresCommandGroup(helpText)).IsFalse();
         await Assert.That(command!.PositionalArguments.Select(argument => argument.PropertyName))
             .IsEquivalentTo(["EnvironmentName", "Command", "Args"]);
-        await Assert.That(command.PositionalArguments.Single(argument => argument.PropertyName == "Command").IsRequired)
-            .IsTrue();
+        var commandArgument = command.PositionalArguments.Single(argument => argument.PropertyName == "Command");
+        using (Assert.Multiple())
+        {
+            await Assert.That(commandArgument.IsRequired).IsTrue();
+            await Assert.That(commandArgument.Phase).IsEqualTo(CommandLinePhase.Passthrough);
+            await Assert.That(commandArgument.PositionIndex).IsEqualTo(0);
+            await Assert.That(commandArgument.PrependOptionTerminator).IsTrue();
+        }
+
         var args = command.PositionalArguments.Single(argument => argument.PropertyName == "Args");
         await Assert.That(args.CSharpType).IsEqualTo("IEnumerable<string>?");
         await Assert.That(args.IsVariadic).IsTrue();

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PulumiCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/PulumiCliScraperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -20,7 +21,18 @@ public class PulumiCliScraperTests
               The command receives the environment variables.
             """;
 
-        await Assert.That(new TestPulumiCliScraper().DeclaresCommandGroup(helpText)).IsFalse();
+        var scraper = new TestPulumiCliScraper();
+        var command = await scraper.Parse(["pulumi", "env", "run"], helpText);
+
+        await Assert.That(scraper.DeclaresCommandGroup(helpText)).IsFalse();
+        await Assert.That(command!.PositionalArguments.Select(argument => argument.PropertyName))
+            .IsEquivalentTo(["EnvironmentName", "Command", "Args"]);
+        await Assert.That(command.PositionalArguments.Single(argument => argument.PropertyName == "Command").IsRequired)
+            .IsTrue();
+        var args = command.PositionalArguments.Single(argument => argument.PropertyName == "Args");
+        await Assert.That(args.CSharpType).IsEqualTo("IEnumerable<string>?");
+        await Assert.That(args.IsVariadic).IsTrue();
+        await Assert.That(args.Phase).IsEqualTo(CommandLinePhase.Passthrough);
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/SnykCliScraperTests.cs
@@ -348,19 +348,13 @@ public class SnykCliScraperTests
     }
 
     [Test]
-    public async Task Iac_Group_Models_Optional_Path_From_Usage()
+    public async Task Iac_Group_Does_Not_Model_Child_Path_On_Parent()
     {
         var command = await new TestSnykCliScraper().Parse(
             ["snyk", "iac"],
             "Usage: snyk iac <COMMAND> [<OPTIONS>] [<PATH>]");
 
-        var path = command!.PositionalArguments.Single();
-        using (Assert.Multiple())
-        {
-            await Assert.That(path.PropertyName).IsEqualTo("Path");
-            await Assert.That(path.IsRequired).IsFalse();
-            await Assert.That(path.CSharpType).IsEqualTo("string?");
-        }
+        await Assert.That(command!.PositionalArguments).IsEmpty();
     }
 
     [Test]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/UsageSynopsisParserTests.cs
@@ -83,7 +83,7 @@ public class UsageSynopsisParserTests
     }
 
     [Test]
-    public async Task Command_Group_Placeholders_Are_Not_Operands()
+    public async Task Command_Group_Placeholders_Remain_Executable_Operands()
     {
         var parsed = UsageSynopsisParser.Parse(
             "Usage: docker buildx [OPTIONS] COMMAND",
@@ -92,15 +92,14 @@ public class UsageSynopsisParserTests
             "Usage: winget source [<command>] [<options>]",
             ["winget", "source"]);
 
-        var result = UsageSynopsisParser.RemoveCommandGroupPlaceholders(parsed);
-        var nestedResult = UsageSynopsisParser.RemoveCommandGroupPlaceholders(nested);
-
         using (Assert.Multiple())
         {
-            await Assert.That(result.PositionalArguments).IsEmpty();
-            await Assert.That(result.HasOperandTokens).IsFalse();
-            await Assert.That(nestedResult.PositionalArguments).IsEmpty();
-            await Assert.That(nestedResult.HasOperandTokens).IsFalse();
+            await Assert.That(parsed.PositionalArguments.Single().PropertyName)
+                .IsEqualTo("Command");
+            await Assert.That(parsed.HasOperandTokens).IsTrue();
+            await Assert.That(nested.PositionalArguments.Single().PropertyName)
+                .IsEqualTo("Command");
+            await Assert.That(nested.HasOperandTokens).IsTrue();
         }
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/VaultCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/VaultCliScraperTests.cs
@@ -9,7 +9,7 @@ namespace ModularPipelines.OptionsGenerator.Tests.Scrapers;
 public class VaultCliScraperTests
 {
     [Test]
-    public async Task Command_Group_Args_Remain_Optional_After_Placeholder_Removal()
+    public async Task Command_Group_Preserves_Subcommand_And_Optional_Args()
     {
         const string helpText = """
             Usage: vault audit <subcommand> [options] [args]
@@ -25,9 +25,12 @@ public class VaultCliScraperTests
             ["vault", "audit"],
             helpText);
 
-        var argument = command!.PositionalArguments.Single();
+        var subcommand = command!.PositionalArguments[0];
+        var argument = command.PositionalArguments[1];
         using (Assert.Multiple())
         {
+            await Assert.That(subcommand.PropertyName).IsEqualTo("Subcommand");
+            await Assert.That(subcommand.IsRequired).IsTrue();
             await Assert.That(argument.PropertyName).IsEqualTo("Args");
             await Assert.That(argument.CSharpType).IsEqualTo("string?");
             await Assert.That(argument.IsRequired).IsFalse();
@@ -47,8 +50,7 @@ public class VaultCliScraperTests
 
         public Task<CliCommandDefinition?> ParseGroup(string[] commandPath, string helpText)
         {
-            var usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(
-                ParseUsageSynopsis(commandPath, helpText));
+            var usage = ParseUsageSynopsis(commandPath, helpText);
             return ParseCommandAsync(commandPath, helpText, usage, CancellationToken.None);
         }
     }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator.Tests/Scrapers/YarnCliScraperTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.Scrapers.Cli;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
@@ -46,6 +47,36 @@ public class YarnCliScraperTests
             ["add", "bin", "workspace", "workspaces focus", "cache clean", "rebuild", "node"]);
     }
 
+    [Test]
+    public async Task Parses_Clipanion_Usage_Operands_And_Numbered_Option_Values()
+    {
+        const string helpText = """
+            ━━━ Usage ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+              $ yarn dlx [-p,--package #0] [-q,--quiet] <command>
+
+            ━━━ Options ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+              -p,--package #0    The package to install before running the command
+              -q,--quiet         Only report critical errors
+            """;
+
+        var command = await new TestYarnCliScraper().Parse(
+            ["yarn", "dlx"],
+            helpText);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(command!.PositionalArguments.Single().PropertyName)
+                .IsEqualTo("Command");
+            await Assert.That(command.PositionalArguments.Single().IsRequired).IsTrue();
+            await Assert.That(command.Options.Single(option => option.PropertyName == "Package").IsFlag)
+                .IsFalse();
+            await Assert.That(command.Options.Single(option => option.PropertyName == "Quiet").IsFlag)
+                .IsTrue();
+        }
+    }
+
     private sealed class TestYarnCliScraper : YarnCliScraper
     {
         public TestYarnCliScraper()
@@ -57,5 +88,12 @@ public class YarnCliScraperTests
         }
 
         public List<string> Extract(string helpText) => ExtractSubcommands(helpText).ToList();
+
+        public Task<CliCommandDefinition?> Parse(string[] commandPath, string helpText) =>
+            ParseCommandAsync(
+                commandPath,
+                helpText,
+                UsageSynopsisParser.Parse(helpText, commandPath),
+                CancellationToken.None);
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -615,6 +615,16 @@ internal static class GeneratedApiCompatibilityPreserver
             tool,
             commandBaseline,
             commandFacadeMethods);
+        if (commandFacadeMethods.Length == 0)
+        {
+            groupIdentifier = GetHistoricalSiblingRootIdentifier(
+                                  tool,
+                                  commandBaseline,
+                                  baseline,
+                                  facadeMethods)
+                              ?? groupIdentifier;
+        }
+
         var recoveredOverrides = GetRestoredCommandPartIdentifierOverrides(
             tool,
             commandBaseline.CommandParts,
@@ -637,6 +647,37 @@ internal static class GeneratedApiCompatibilityPreserver
             CommandGroupIdentifierOverride = commandGroupIdentifierOverride,
             CommandPartIdentifierOverrides = mergedOverrides,
         };
+    }
+
+    private static string? GetHistoricalSiblingRootIdentifier(
+        CliToolDefinition tool,
+        GeneratedApiBaseline commandBaseline,
+        IReadOnlyDictionary<string, GeneratedApiBaseline> baseline,
+        IReadOnlyList<GeneratedFacadeMethod> facadeMethods)
+    {
+        var rootCommand = commandBaseline.CommandParts?[0];
+        if (rootCommand is null)
+        {
+            return null;
+        }
+
+        var identifiers = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var method in facadeMethods)
+        {
+            if (!baseline.TryGetValue(method.OptionsType, out var methodBaseline)
+                || methodBaseline.CommandParts is not { Length: > 0 } commandParts
+                || !commandParts[0].Equals(rootCommand, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (GetRootIdentifierFromFacade(tool, commandParts, method) is { } identifier)
+            {
+                identifiers.Add(identifier);
+            }
+        }
+
+        return identifiers.Count == 1 ? identifiers.Single() : null;
     }
 
     private static CliCommandDefinition PreserveCommandScopedEnumCasing(

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Generators/GeneratedApiCompatibilityPreserver.cs
@@ -655,18 +655,21 @@ internal static class GeneratedApiCompatibilityPreserver
         IReadOnlyDictionary<string, GeneratedApiBaseline> baseline,
         IReadOnlyList<GeneratedFacadeMethod> facadeMethods)
     {
-        var rootCommand = commandBaseline.CommandParts?[0];
-        if (rootCommand is null)
+        if (commandBaseline.CommandParts is not { Length: > 1 } targetCommandParts)
         {
             return null;
         }
+
+        var rootCommand = targetCommandParts[0];
+        var branchCommand = targetCommandParts[1];
 
         var identifiers = new HashSet<string>(StringComparer.Ordinal);
         foreach (var method in facadeMethods)
         {
             if (!baseline.TryGetValue(method.OptionsType, out var methodBaseline)
-                || methodBaseline.CommandParts is not { Length: > 0 } commandParts
-                || !commandParts[0].Equals(rootCommand, StringComparison.OrdinalIgnoreCase))
+                || methodBaseline.CommandParts is not { Length: > 1 } commandParts
+                || !commandParts[0].Equals(rootCommand, StringComparison.OrdinalIgnoreCase)
+                || !commandParts[1].Equals(branchCommand, StringComparison.OrdinalIgnoreCase))
             {
                 continue;
             }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AwsCliScraper.cs
@@ -359,7 +359,7 @@ public partial class AwsCliScraper : CliScraperBase
             var isKeyValue = !isStructure
                              && (typeHint.Contains("map") || (description?.Contains("key=value") ?? false));
 
-            var enumDef = isStructure || isKeyValue
+            var enumDef = isStructure || isKeyValue || isArray
                 ? null
                 : TryDetectEnum(propertyName, className, description);
             var csharpType = DetermineCSharpType(isFlag, isArray, isKeyValue, isNumeric, enumDef);

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/AzCliScraper.cs
@@ -297,7 +297,7 @@ public partial class AzCliScraper : CliScraperBase
 
                 // Determine type based on value hint
                 var explicitBooleanValue = HelpDeclaresExplicitBooleanValue(description);
-                var isFlag = IsPresenceOnlyFlag(valueHint, explicitBooleanValue);
+                var isFlag = IsPresenceOnlyFlag(valueHint, description, explicitBooleanValue);
 
                 var isRequired = sectionName.Equals("Required Arguments", StringComparison.OrdinalIgnoreCase);
 
@@ -328,9 +328,12 @@ public partial class AzCliScraper : CliScraperBase
     /// <summary>
     /// Determines whether an option is rendered without a value.
     /// </summary>
-    private static bool IsPresenceOnlyFlag(string valueHint, bool explicitBooleanValue)
+    private static bool IsPresenceOnlyFlag(
+        string valueHint,
+        string description,
+        bool explicitBooleanValue)
     {
-        if (explicitBooleanValue)
+        if (explicitBooleanValue || HelpDeclaresOptionValue(description))
         {
             return false;
         }
@@ -339,6 +342,12 @@ public partial class AzCliScraper : CliScraperBase
                valueHint.Equals("true", StringComparison.OrdinalIgnoreCase) ||
                valueHint.Equals("false", StringComparison.OrdinalIgnoreCase);
     }
+
+    private static bool HelpDeclaresOptionValue(string description) =>
+        AzValueDescriptionPattern().IsMatch(description)
+        || description.Contains("may be supplied", StringComparison.OrdinalIgnoreCase)
+        || description.Contains("space-separated", StringComparison.OrdinalIgnoreCase)
+        || description.Contains("key=value", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Determines the C# type based on value hint and description.
@@ -499,6 +508,9 @@ public partial class AzCliScraper : CliScraperBase
     /// </summary>
     [GeneratedRegex(@"^\s+--(?<long>[\w-]+)(?:\s+-(?<short>\w))?(?:\s+(?<value>[A-Z_]+))?\s*:\s*(?<desc>.*)$", RegexOptions.Multiline)]
     private static partial Regex AzOptionPattern();
+
+    [GeneratedRegex(@"^(?:(?:a|an|the)\s+)?(?:path|uri|url|name|id|identifier|description|query|string|value|template|resource|parameters?|managed identity|subnet|virtual network)\b", RegexOptions.IgnoreCase)]
+    private static partial Regex AzValueDescriptionPattern();
 
     #endregion
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/CliScraperBase.cs
@@ -460,11 +460,6 @@ public abstract partial class CliScraperBase : ICliScraper
         CancellationToken cancellationToken)
     {
         var usage = ParseUsageSynopsis(path, helpText);
-        if (subcommands.Count > 0)
-        {
-            usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage);
-        }
-
         LogUsageSynopsisSelection(path, usage);
         if (ShouldSkipCommand(path, helpText, subcommands, usage))
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/DotNetCliScraper.cs
@@ -671,9 +671,10 @@ public partial class DotNetCliScraper : CliScraperBase
     private static partial Regex SectionHeaderPattern();
 
     /// <summary>
-    /// Matches subcommand lines: "  command    description"
+    /// Matches subcommand lines, including positional placeholders before the description:
+    /// "  command &lt;ARGUMENT&gt;    description"
     /// </summary>
-    [GeneratedRegex(@"^\s{2,}(?<name>[\w-]+)\s{2,}", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^\s{2,}(?<name>[\w-]+)(?:\s+(?:<[^>]+>|\[[^\]]+\]))*\s{2,}", RegexOptions.Multiline)]
     private static partial Regex SubcommandLinePattern();
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -561,13 +561,13 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             CSharpType = csharpType,
             IsRequired = false,
             IsFlag = isFlag,
-            ValueArity = valueSyntax?.StartsWith("[", StringComparison.Ordinal) == true
+            ValueArity = valueSyntax?.StartsWith('[') == true
                 ? CliOptionValueArity.Optional
                 : CliOptionValueArity.Required,
             ValueSeparator = valueSyntax switch
             {
                 { } value when value.Contains('=') => "=",
-                { } value when value.StartsWith("[", StringComparison.Ordinal) => string.Empty,
+                { } value when value.StartsWith('[') => string.Empty,
                 _ => " ",
             },
             IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -561,10 +561,15 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             CSharpType = csharpType,
             IsRequired = false,
             IsFlag = isFlag,
-            ValueArity = valueSyntax?.StartsWith("[=", StringComparison.Ordinal) == true
+            ValueArity = valueSyntax?.StartsWith("[", StringComparison.Ordinal) == true
                 ? CliOptionValueArity.Optional
                 : CliOptionValueArity.Required,
-            ValueSeparator = valueSyntax?.Contains('=') == true ? "=" : " ",
+            ValueSeparator = valueSyntax switch
+            {
+                { } value when value.Contains('=') => "=",
+                { } value when value.StartsWith("[", StringComparison.Ordinal) => string.Empty,
+                _ => " ",
+            },
             IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
         };
         return true;
@@ -834,7 +839,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
     /// --xxx   description
     /// -x   description
     /// </summary>
-    [GeneratedRegex(@"^\s+(?:(?<short>-\w),\s+)?(?<long>--(?:\[no-\])?[\w-]+)(?<value>\[?=\S+\]?|\s+(?:<[^>]+>|\.{3}|\([^\s|)]+(?:\|[^\s|)]+)+\)\S*))?(?:\s+(?<description>.*))?$|^\s+(?<shortOnly>-\w)(?<value>\[?=\S+\]?|\s+(?:<[^>]+>|\.{3}|\([^\s|)]+(?:\|[^\s|)]+)+\)\S*))?(?:\s+(?<shortDescription>.*))?$")]
+    [GeneratedRegex(@"^\s+(?:(?<short>-\w),\s+)?(?<long>--(?:\[no-\])?[\w-]+)(?<value>\[?=\S+\]?|\s+(?:<[^>]+>|\.{3}|\([^\s|)]+(?:\|[^\s|)]+)+\)\S*))?(?:\s+(?<description>.*))?$|^\s+(?<shortOnly>-\w)(?<value>\[?=\S+\]?|\[<[^>]+>\]|\s+(?:<[^>]+>|\.{3}|\([^\s|)]+(?:\|[^\s|)]+)+\)\S*))?(?:\s+(?<shortDescription>.*))?$")]
     private static partial Regex OptionLineRegex();
 
     [GeneratedRegex(@"^\s*(?:usage:|or:)\s+(.+)$", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -834,7 +834,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
     /// --xxx   description
     /// -x   description
     /// </summary>
-    [GeneratedRegex(@"^\s+(?:(?<short>-\w),\s+)?(?<long>--(?:\[no-\])?[\w-]+)(?<value>\[?=\S+\]?|\s+(?:<[^>]+>|\.{3}|\([^\s|)]+(?:\|[^\s|)]+)+\)\S*))?(?:\s+(?<description>.*))?$|^\s+(?<shortOnly>-\w)(?:\s+(?<shortDescription>.*))?$")]
+    [GeneratedRegex(@"^\s+(?:(?<short>-\w),\s+)?(?<long>--(?:\[no-\])?[\w-]+)(?<value>\[?=\S+\]?|\s+(?:<[^>]+>|\.{3}|\([^\s|)]+(?:\|[^\s|)]+)+\)\S*))?(?:\s+(?<description>.*))?$|^\s+(?<shortOnly>-\w)(?<value>\[?=\S+\]?|\s+(?:<[^>]+>|\.{3}|\([^\s|)]+(?:\|[^\s|)]+)+\)\S*))?(?:\s+(?<shortDescription>.*))?$")]
     private static partial Regex OptionLineRegex();
 
     [GeneratedRegex(@"^\s*(?:usage:|or:)\s+(.+)$", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -490,7 +490,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             // Long flag
             if (match.Groups[2].Success)
             {
-                longFlag = match.Groups[2].Value.Trim();
+                longFlag = NormalizeNegatableLongFlag(match.Groups[2].Value.Trim());
             }
 
             // Description
@@ -641,6 +641,11 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         return result;
     }
 
+    private static string NormalizeNegatableLongFlag(string optionName) =>
+        optionName.StartsWith("--[no-]", StringComparison.Ordinal)
+            ? "--" + optionName[7..]
+            : optionName;
+
     /// <summary>
     /// Converts a leading digit to a word (e.g., "3way" -> "ThreeWay").
     /// </summary>
@@ -730,7 +735,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
     /// --xxx   description
     /// -x   description
     /// </summary>
-    [GeneratedRegex(@"^\s+(?:(-\w),\s+)?(--[\w-]+(?:\[?=[\w<>\[\]]+\]?)?)\s+(.*)$|^\s+(-\w)\s+(.*)$")]
+    [GeneratedRegex(@"^\s+(?:(-\w),\s+)?(--(?:\[no-\])?[\w-]+(?:\[?=[\w<>\[\]]+\]?)?)\s+(.*)$|^\s+(-\w)\s+(.*)$")]
     private static partial Regex OptionLineRegex();
 
     [GeneratedRegex(@"^\s*(?:usage:|or:)\s+(.+)$", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -465,13 +465,22 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
     {
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var lines = helpText.Split('\n');
 
-        foreach (var line in helpText.Split('\n'))
+        for (var index = 0; index < lines.Length; index++)
         {
+            var line = lines[index];
             if (!TryParseOption(line, out var option, out var negatedLongFlag)
                 || !seenOptions.Add(option.SwitchName))
             {
                 continue;
+            }
+
+            if (string.IsNullOrEmpty(option.Description)
+                && TryGetWrappedDescription(lines, index, out var description))
+            {
+                option = AddDescription(option, line, description);
+                index++;
             }
 
             options.Add(option);
@@ -482,6 +491,46 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         }
 
         return options;
+    }
+
+    private static bool TryGetWrappedDescription(
+        IReadOnlyList<string> lines,
+        int declarationIndex,
+        out string description)
+    {
+        description = "";
+        if (declarationIndex + 1 >= lines.Count)
+        {
+            return false;
+        }
+
+        var declaration = lines[declarationIndex];
+        var candidate = lines[declarationIndex + 1];
+        description = candidate.Trim();
+        return description.Length > 0
+               && !description.StartsWith('-')
+               && GetIndentation(candidate) > GetIndentation(declaration);
+    }
+
+    private static int GetIndentation(string value) =>
+        value.TakeWhile(char.IsWhiteSpace).Count();
+
+    private static CliOptionDefinition AddDescription(
+        CliOptionDefinition option,
+        string declaration,
+        string description)
+    {
+        var (csharpType, isFlag) = InferType(
+            option.SwitchName,
+            description,
+            $"{declaration} {description}");
+        return option with
+        {
+            Description = description,
+            CSharpType = csharpType,
+            IsFlag = isFlag,
+            IsSecret = GeneratorUtils.IsSecretOption(option.PropertyName, isFlag),
+        };
     }
 
     private static bool TryParseOption(
@@ -603,7 +652,8 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         }
 
         // Check for common boolean patterns
-        if (lowerOpt.StartsWith("no-") ||
+        if (fullLine.Contains("--[no-]", StringComparison.Ordinal) ||
+            lowerOpt.StartsWith("no-") ||
             lowerDesc.Contains("disable") ||
             lowerDesc.Contains("enable") ||
             lowerDesc.Contains("toggle") ||
@@ -754,7 +804,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
     /// --xxx   description
     /// -x   description
     /// </summary>
-    [GeneratedRegex(@"^\s+(?:(-\w),\s+)?(--(?:\[no-\])?[\w-]+)(?:\[?=\S+\]?)?\s+(.*)$|^\s+(-\w)\s+(.*)$")]
+    [GeneratedRegex(@"^\s+(?:(-\w),\s+)?(--(?:\[no-\])?[\w-]+)(?:\[?=\S+\]?)?(?:\s+(.*))?$|^\s+(-\w)(?:\s+(.*))?$")]
     private static partial Regex OptionLineRegex();
 
     [GeneratedRegex(@"^\s*(?:usage:|or:)\s+(.+)$", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -520,10 +521,9 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         string declaration,
         string description)
     {
-        var (csharpType, isFlag) = InferType(
-            option.SwitchName,
-            description,
-            $"{declaration} {description}");
+        var (csharpType, isFlag) = option.IsFlag
+            ? InferType(option.SwitchName, description, $"{declaration} {description}")
+            : (option.CSharpType, false);
         return option with
         {
             Description = description,
@@ -547,7 +547,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         }
 
         var shortFlag = GetShortFlag(match);
-        var advertisedLongFlag = GetGroupValue(match, 2);
+        var advertisedLongFlag = GetGroupValue(match, "long");
         var longFlag = advertisedLongFlag is null
             ? null
             : NormalizeNegatableLongFlag(advertisedLongFlag);
@@ -563,6 +563,13 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
 
         var description = GetDescription(match);
         var (csharpType, isFlag) = InferType(primaryFlag, description, line);
+        var valueSyntax = GetGroupValue(match, "value");
+        if (valueSyntax is not null)
+        {
+            csharpType = isFlag ? "string?" : csharpType;
+            isFlag = false;
+        }
+
         option = new CliOptionDefinition
         {
             SwitchName = primaryFlag,
@@ -572,21 +579,25 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             CSharpType = csharpType,
             IsRequired = false,
             IsFlag = isFlag,
+            ValueArity = valueSyntax?.StartsWith("[=", StringComparison.Ordinal) == true
+                ? CliOptionValueArity.Optional
+                : CliOptionValueArity.Required,
+            ValueSeparator = valueSyntax?.Contains('=') == true ? "=" : " ",
             IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
         };
         return true;
     }
 
-    private static string? GetGroupValue(Match match, int index) =>
-        match.Groups[index] is { Success: true, Value.Length: > 0 } group
+    private static string? GetGroupValue(Match match, string name) =>
+        match.Groups[name] is { Success: true, Value.Length: > 0 } group
             ? group.Value.Trim()
             : null;
 
     private static string? GetShortFlag(Match match) =>
-        GetGroupValue(match, 1) ?? GetGroupValue(match, 4);
+        GetGroupValue(match, "short") ?? GetGroupValue(match, "shortOnly");
 
     private static string GetDescription(Match match) =>
-        GetGroupValue(match, 3) ?? GetGroupValue(match, 5) ?? "";
+        GetGroupValue(match, "description") ?? GetGroupValue(match, "shortDescription") ?? "";
 
     private static CliOptionDefinition CreateNegatedOption(
         CliOptionDefinition option,
@@ -601,6 +612,8 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             CSharpType = "bool?",
             Description = $"Negates {option.SwitchName}. {option.Description}",
             IsFlag = true,
+            ValueArity = CliOptionValueArity.Required,
+            ValueSeparator = " ",
             IsSecret = GeneratorUtils.IsSecretOption(negatedPropertyName, isFlag: true),
         };
     }
@@ -804,7 +817,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
     /// --xxx   description
     /// -x   description
     /// </summary>
-    [GeneratedRegex(@"^\s+(?:(-\w),\s+)?(--(?:\[no-\])?[\w-]+)(?:\[?=\S+\]?)?(?:\s+(.*))?$|^\s+(-\w)(?:\s+(.*))?$")]
+    [GeneratedRegex(@"^\s+(?:(?<short>-\w),\s+)?(?<long>--(?:\[no-\])?[\w-]+)(?<value>\[?=\S+\]?|\s+(?:<[^>]+>|\([^\s|)]+(?:\|[^\s|)]+)+\)\S*))?(?:\s+(?<description>.*))?$|^\s+(?<shortOnly>-\w)(?:\s+(?<shortDescription>.*))?$")]
     private static partial Regex OptionLineRegex();
 
     [GeneratedRegex(@"^\s*(?:usage:|or:)\s+(.+)$", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -497,7 +497,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             return false;
         }
 
-        var shortFlag = GetGroupValue(match, 1) ?? GetGroupValue(match, 4);
+        var shortFlag = GetShortFlag(match);
         var advertisedLongFlag = GetGroupValue(match, 2);
         var longFlag = advertisedLongFlag is null
             ? null
@@ -512,7 +512,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             return false;
         }
 
-        var description = GetGroupValue(match, 3) ?? GetGroupValue(match, 5) ?? "";
+        var description = GetDescription(match);
         var (csharpType, isFlag) = InferType(primaryFlag, description, line);
         option = new CliOptionDefinition
         {
@@ -532,6 +532,12 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         match.Groups[index] is { Success: true, Value.Length: > 0 } group
             ? group.Value.Trim()
             : null;
+
+    private static string? GetShortFlag(Match match) =>
+        GetGroupValue(match, 1) ?? GetGroupValue(match, 4);
+
+    private static string GetDescription(Match match) =>
+        GetGroupValue(match, 3) ?? GetGroupValue(match, 5) ?? "";
 
     private static CliOptionDefinition CreateNegatedOption(
         CliOptionDefinition option,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -834,7 +834,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
     /// --xxx   description
     /// -x   description
     /// </summary>
-    [GeneratedRegex(@"^\s+(?:(?<short>-\w),\s+)?(?<long>--(?:\[no-\])?[\w-]+)(?<value>\[?=\S+\]?|\s+(?:<[^>]+>|\([^\s|)]+(?:\|[^\s|)]+)+\)\S*))?(?:\s+(?<description>.*))?$|^\s+(?<shortOnly>-\w)(?:\s+(?<shortDescription>.*))?$")]
+    [GeneratedRegex(@"^\s+(?:(?<short>-\w),\s+)?(?<long>--(?:\[no-\])?[\w-]+)(?<value>\[?=\S+\]?|\s+(?:<[^>]+>|\.{3}|\([^\s|)]+(?:\|[^\s|)]+)+\)\S*))?(?:\s+(?<description>.*))?$|^\s+(?<shortOnly>-\w)(?:\s+(?<shortDescription>.*))?$")]
     private static partial Regex OptionLineRegex();
 
     [GeneratedRegex(@"^\s*(?:usage:|or:)\s+(.+)$", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -497,7 +497,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             return false;
         }
 
-        var shortFlag = GetGroupValue(match, 1);
+        var shortFlag = GetGroupValue(match, 1) ?? GetGroupValue(match, 4);
         var advertisedLongFlag = GetGroupValue(match, 2);
         var longFlag = advertisedLongFlag is null
             ? null
@@ -512,7 +512,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             return false;
         }
 
-        var description = GetGroupValue(match, 3) ?? "";
+        var description = GetGroupValue(match, 3) ?? GetGroupValue(match, 5) ?? "";
         var (csharpType, isFlag) = InferType(primaryFlag, description, line);
         option = new CliOptionDefinition
         {

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -479,6 +479,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
 
             string? shortFlag = null;
             string? longFlag = null;
+            string? negatedLongFlag = null;
             var description = "";
 
             // Check if we have a short flag
@@ -490,7 +491,9 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             // Long flag
             if (match.Groups[2].Success)
             {
-                longFlag = NormalizeNegatableLongFlag(match.Groups[2].Value.Trim());
+                var advertisedLongFlag = match.Groups[2].Value.Trim();
+                longFlag = NormalizeNegatableLongFlag(advertisedLongFlag);
+                negatedLongFlag = GetNegatedLongFlag(advertisedLongFlag);
             }
 
             // Description
@@ -526,7 +529,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             // SwitchName should be the full flag with dashes (--long-flag)
             var switchName = longFlag ?? shortFlag;
 
-            options.Add(new CliOptionDefinition
+            var option = new CliOptionDefinition
             {
                 SwitchName = switchName!,
                 ShortForm = shortFlag,
@@ -536,7 +539,21 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
                 IsRequired = false,
                 IsFlag = isFlag,
                 IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
-            });
+            };
+            options.Add(option);
+
+            if (isFlag && negatedLongFlag is not null && seenOptions.Add(negatedLongFlag))
+            {
+                var negatedPropertyName = NormalizeGitPropertyName(negatedLongFlag)!;
+                options.Add(option with
+                {
+                    SwitchName = negatedLongFlag,
+                    ShortForm = null,
+                    PropertyName = negatedPropertyName,
+                    Description = $"Negates {longFlag}. {description}",
+                    IsSecret = GeneratorUtils.IsSecretOption(negatedPropertyName, isFlag: true),
+                });
+            }
         }
 
         return options;
@@ -645,6 +662,11 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         optionName.StartsWith("--[no-]", StringComparison.Ordinal)
             ? "--" + optionName[7..]
             : optionName;
+
+    private static string? GetNegatedLongFlag(string optionName) =>
+        optionName.StartsWith("--[no-]", StringComparison.Ordinal)
+            ? "--no-" + optionName[7..]
+            : null;
 
     /// <summary>
     /// Converts a leading digit to a word (e.g., "3way" -> "ThreeWay").

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -546,29 +546,17 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             return false;
         }
 
-        var shortFlag = GetShortFlag(match);
-        var advertisedLongFlag = GetGroupValue(match, "long");
-        var longFlag = advertisedLongFlag is null
-            ? null
-            : NormalizeNegatableLongFlag(advertisedLongFlag);
-        negatedLongFlag = advertisedLongFlag is null
-            ? null
-            : GetNegatedLongFlag(advertisedLongFlag);
-        var primaryFlag = longFlag ?? shortFlag;
-        var propertyName = primaryFlag is null ? null : NormalizeGitPropertyName(primaryFlag);
-        if (primaryFlag is null || propertyName is null)
+        var identity = GetOptionIdentity(match);
+        if (identity is null)
         {
             return false;
         }
 
+        var (shortFlag, primaryFlag, propertyName, negatedFlag) = identity.Value;
+        negatedLongFlag = negatedFlag;
         var description = GetDescription(match);
-        var (csharpType, isFlag) = InferType(primaryFlag, description, line);
         var valueSyntax = GetGroupValue(match, "value");
-        if (valueSyntax is not null)
-        {
-            csharpType = isFlag ? "string?" : csharpType;
-            isFlag = false;
-        }
+        var (csharpType, isFlag) = InferOptionType(primaryFlag, description, line, valueSyntax);
 
         option = new CliOptionDefinition
         {
@@ -588,6 +576,35 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         return true;
     }
 
+    private static OptionIdentity? GetOptionIdentity(Match match)
+    {
+        var shortFlag = GetShortFlag(match);
+        var advertisedLongFlag = GetGroupValue(match, "long");
+        var primaryFlag = advertisedLongFlag is null
+            ? shortFlag
+            : NormalizeNegatableLongFlag(advertisedLongFlag);
+        var propertyName = primaryFlag is null ? null : NormalizeGitPropertyName(primaryFlag);
+        return primaryFlag is null || propertyName is null
+            ? null
+            : new OptionIdentity(
+                shortFlag,
+                primaryFlag,
+                propertyName,
+                advertisedLongFlag is null ? null : GetNegatedLongFlag(advertisedLongFlag));
+    }
+
+    private static (string CSharpType, bool IsFlag) InferOptionType(
+        string primaryFlag,
+        string description,
+        string line,
+        string? valueSyntax)
+    {
+        var (csharpType, isFlag) = InferType(primaryFlag, description, line);
+        return valueSyntax is null
+            ? (csharpType, isFlag)
+            : (isFlag ? "string?" : csharpType, false);
+    }
+
     private static string? GetGroupValue(Match match, string name) =>
         match.Groups[name] is { Success: true, Value.Length: > 0 } group
             ? group.Value.Trim()
@@ -598,6 +615,12 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
 
     private static string GetDescription(Match match) =>
         GetGroupValue(match, "description") ?? GetGroupValue(match, "shortDescription") ?? "";
+
+    private readonly record struct OptionIdentity(
+        string? ShortFlag,
+        string PrimaryFlag,
+        string PropertyName,
+        string? NegatedFlag);
 
     private static CliOptionDefinition CreateNegatedOption(
         CliOptionDefinition option,

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -466,99 +466,88 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
         var options = new List<CliOptionDefinition>();
         var seenOptions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        var lines = helpText.Split('\n');
-
-        foreach (var line in lines)
+        foreach (var line in helpText.Split('\n'))
         {
-            // Match option lines: -x, --xxx or just --xxx
-            var match = OptionLineRegex().Match(line);
-            if (!match.Success)
+            if (!TryParseOption(line, out var option, out var negatedLongFlag)
+                || !seenOptions.Add(option.SwitchName))
             {
                 continue;
             }
 
-            string? shortFlag = null;
-            string? longFlag = null;
-            string? negatedLongFlag = null;
-            var description = "";
-
-            // Check if we have a short flag
-            if (match.Groups[1].Success && !string.IsNullOrEmpty(match.Groups[1].Value))
-            {
-                shortFlag = match.Groups[1].Value.Trim();
-            }
-
-            // Long flag
-            if (match.Groups[2].Success)
-            {
-                var advertisedLongFlag = match.Groups[2].Value.Trim();
-                longFlag = NormalizeNegatableLongFlag(advertisedLongFlag);
-                negatedLongFlag = GetNegatedLongFlag(advertisedLongFlag);
-            }
-
-            // Description
-            if (match.Groups[3].Success)
-            {
-                description = match.Groups[3].Value.Trim();
-            }
-
-            // Use long flag preferably, fall back to short
-            var primaryFlag = longFlag ?? shortFlag;
-            if (string.IsNullOrEmpty(primaryFlag))
-            {
-                continue;
-            }
-
-            // Skip duplicates
-            if (seenOptions.Contains(primaryFlag))
-            {
-                continue;
-            }
-            seenOptions.Add(primaryFlag);
-
-            // Generate property name
-            var propertyName = NormalizeGitPropertyName(primaryFlag);
-            if (string.IsNullOrEmpty(propertyName))
-            {
-                continue;
-            }
-
-            // Determine type based on the option
-            var (csharpType, isFlag) = InferType(primaryFlag, description, line);
-
-            // SwitchName should be the full flag with dashes (--long-flag)
-            var switchName = longFlag ?? shortFlag;
-
-            var option = new CliOptionDefinition
-            {
-                SwitchName = switchName!,
-                ShortForm = shortFlag,
-                Description = description,
-                PropertyName = propertyName,
-                CSharpType = csharpType,
-                IsRequired = false,
-                IsFlag = isFlag,
-                IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
-            };
             options.Add(option);
-
             if (negatedLongFlag is not null && seenOptions.Add(negatedLongFlag))
             {
-                var negatedPropertyName = NormalizeGitPropertyName(negatedLongFlag)!;
-                options.Add(option with
-                {
-                    SwitchName = negatedLongFlag,
-                    ShortForm = null,
-                    PropertyName = negatedPropertyName,
-                    CSharpType = "bool?",
-                    Description = $"Negates {longFlag}. {description}",
-                    IsFlag = true,
-                    IsSecret = GeneratorUtils.IsSecretOption(negatedPropertyName, isFlag: true),
-                });
+                options.Add(CreateNegatedOption(option, negatedLongFlag));
             }
         }
 
         return options;
+    }
+
+    private static bool TryParseOption(
+        string line,
+        out CliOptionDefinition option,
+        out string? negatedLongFlag)
+    {
+        option = null!;
+        negatedLongFlag = null;
+        var match = OptionLineRegex().Match(line);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        var shortFlag = GetGroupValue(match, 1);
+        var advertisedLongFlag = GetGroupValue(match, 2);
+        var longFlag = advertisedLongFlag is null
+            ? null
+            : NormalizeNegatableLongFlag(advertisedLongFlag);
+        negatedLongFlag = advertisedLongFlag is null
+            ? null
+            : GetNegatedLongFlag(advertisedLongFlag);
+        var primaryFlag = longFlag ?? shortFlag;
+        var propertyName = primaryFlag is null ? null : NormalizeGitPropertyName(primaryFlag);
+        if (primaryFlag is null || propertyName is null)
+        {
+            return false;
+        }
+
+        var description = GetGroupValue(match, 3) ?? "";
+        var (csharpType, isFlag) = InferType(primaryFlag, description, line);
+        option = new CliOptionDefinition
+        {
+            SwitchName = primaryFlag,
+            ShortForm = shortFlag,
+            Description = description,
+            PropertyName = propertyName,
+            CSharpType = csharpType,
+            IsRequired = false,
+            IsFlag = isFlag,
+            IsSecret = GeneratorUtils.IsSecretOption(propertyName, isFlag)
+        };
+        return true;
+    }
+
+    private static string? GetGroupValue(Match match, int index) =>
+        match.Groups[index] is { Success: true, Value.Length: > 0 } group
+            ? group.Value.Trim()
+            : null;
+
+    private static CliOptionDefinition CreateNegatedOption(
+        CliOptionDefinition option,
+        string negatedLongFlag)
+    {
+        var negatedPropertyName = NormalizeGitPropertyName(negatedLongFlag)!;
+        return option with
+        {
+            SwitchName = negatedLongFlag,
+            ShortForm = null,
+            PropertyName = negatedPropertyName,
+            CSharpType = "bool?",
+            Description = $"Negates {option.SwitchName}. {option.Description}",
+            IsFlag = true,
+            IsSecret = GeneratorUtils.IsSecretOption(negatedPropertyName, isFlag: true),
+        };
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -542,7 +542,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             };
             options.Add(option);
 
-            if (isFlag && negatedLongFlag is not null && seenOptions.Add(negatedLongFlag))
+            if (negatedLongFlag is not null && seenOptions.Add(negatedLongFlag))
             {
                 var negatedPropertyName = NormalizeGitPropertyName(negatedLongFlag)!;
                 options.Add(option with
@@ -550,7 +550,9 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
                     SwitchName = negatedLongFlag,
                     ShortForm = null,
                     PropertyName = negatedPropertyName,
+                    CSharpType = "bool?",
                     Description = $"Negates {longFlag}. {description}",
+                    IsFlag = true,
                     IsSecret = GeneratorUtils.IsSecretOption(negatedPropertyName, isFlag: true),
                 });
             }
@@ -757,7 +759,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
     /// --xxx   description
     /// -x   description
     /// </summary>
-    [GeneratedRegex(@"^\s+(?:(-\w),\s+)?(--(?:\[no-\])?[\w-]+(?:\[?=[\w<>\[\]]+\]?)?)\s+(.*)$|^\s+(-\w)\s+(.*)$")]
+    [GeneratedRegex(@"^\s+(?:(-\w),\s+)?(--(?:\[no-\])?[\w-]+)(?:\[?=\S+\]?)?\s+(.*)$|^\s+(-\w)\s+(.*)$")]
     private static partial Regex OptionLineRegex();
 
     [GeneratedRegex(@"^\s*(?:usage:|or:)\s+(.+)$", RegexOptions.IgnoreCase)]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GitCliScraper.cs
@@ -480,7 +480,7 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
             if (string.IsNullOrEmpty(option.Description)
                 && TryGetWrappedDescription(lines, index, out var description))
             {
-                option = AddDescription(option, line, description);
+                option = AddDescription(option, description);
                 index++;
             }
 
@@ -518,18 +518,12 @@ public partial class GitCliScraper : CliScraperBase, IDisposable
 
     private static CliOptionDefinition AddDescription(
         CliOptionDefinition option,
-        string declaration,
         string description)
     {
-        var (csharpType, isFlag) = option.IsFlag
-            ? InferType(option.SwitchName, description, $"{declaration} {description}")
-            : (option.CSharpType, false);
         return option with
         {
             Description = description,
-            CSharpType = csharpType,
-            IsFlag = isFlag,
-            IsSecret = GeneratorUtils.IsSecretOption(option.PropertyName, isFlag),
+            IsSecret = GeneratorUtils.IsSecretOption(option.PropertyName, option.IsFlag),
         };
     }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/GoCliScraper.cs
@@ -176,7 +176,9 @@ public partial class GoCliScraper : CliScraperBase
             .Where(o => o.EnumDefinition is not null)
             .Select(o => o.EnumDefinition!)
             .ToList();
-        var positionalArguments = GetPositionalArguments(usage);
+        var positionalArguments = NormalizePositionalArguments(
+            commandParts,
+            GetPositionalArguments(usage));
 
         var className = GenerateClassName(commandPath);
 
@@ -198,6 +200,45 @@ public partial class GoCliScraper : CliScraperBase
         };
 
         return Task.FromResult<CliCommandDefinition?>(command);
+    }
+
+    private static IReadOnlyList<CliPositionalArgument> NormalizePositionalArguments(
+        IReadOnlyList<string> commandParts,
+        IReadOnlyList<CliPositionalArgument> arguments) =>
+        arguments.Select(argument => NormalizePositionalArgument(commandParts, argument)).ToArray();
+
+    private static CliPositionalArgument NormalizePositionalArgument(
+        IReadOnlyList<string> commandParts,
+        CliPositionalArgument argument)
+    {
+        if (commandParts is ["telemetry"] && argument.PropertyName == "Off")
+        {
+            return argument with
+            {
+                PropertyName = "Mode",
+                Description = "The telemetry mode: off, local, or on.",
+            };
+        }
+
+        if (commandParts is ["generate"] && argument.PropertyName == "FileGo")
+        {
+            argument = argument with
+            {
+                PropertyName = "Targets",
+                Description = "The file or package targets.",
+            };
+        }
+
+        if (argument.PropertyName is not ("Packages" or "Modules" or "Moddirs" or "Targets"))
+        {
+            return argument;
+        }
+
+        return argument with
+        {
+            CSharpType = argument.IsRequired ? "IEnumerable<string>" : "IEnumerable<string>?",
+            IsVariadic = true,
+        };
     }
 
     /// <summary>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PackerCliScraper.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Generators;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
@@ -99,6 +100,8 @@ public partial class PackerCliScraper : CliScraperBase
             return Task.FromResult<CliCommandDefinition?>(null);
         }
 
+        usage = NormalizeInspectUsage(commandParts, usage);
+
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
 
@@ -123,6 +126,24 @@ public partial class PackerCliScraper : CliScraperBase
 
         return Task.FromResult<CliCommandDefinition?>(command);
     }
+
+    private static UsageSynopsisParseResult NormalizeInspectUsage(
+        IReadOnlyList<string> commandParts,
+        UsageSynopsisParseResult usage) =>
+        commandParts is ["inspect"]
+            ? usage with
+            {
+                PositionalArguments = usage.PositionalArguments
+                    .Select(argument => argument with { Phase = CommandLinePhase.Passthrough })
+                    .ToArray(),
+            }
+            : usage;
+
+    /// <inheritdoc />
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage) =>
+        NormalizeInspectUsage(command.CommandParts, usage);
 
     /// <summary>
     /// Extracts description from help text.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PipCliScraper.cs
@@ -140,6 +140,7 @@ public partial class PipCliScraper : CliScraperBase
             return Task.FromResult<CliCommandDefinition?>(null);
         }
 
+        usage = NormalizeParentGroupUsage(commandParts, usage);
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText, commandParts);
         var enums = options
@@ -169,6 +170,24 @@ public partial class PipCliScraper : CliScraperBase
 
         return Task.FromResult<CliCommandDefinition?>(command);
     }
+
+    private static UsageSynopsisParseResult NormalizeParentGroupUsage(
+        IReadOnlyList<string> commandParts,
+        UsageSynopsisParseResult usage) =>
+        commandParts is ["cache" or "config" or "index"]
+            ? usage with
+            {
+                HasOperandTokens = false,
+                PositionalArguments = [],
+                UnparsedOperandTokens = [],
+            }
+            : usage;
+
+    /// <inheritdoc />
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage) =>
+        NormalizeParentGroupUsage(command.CommandParts, usage);
 
     /// <summary>
     /// Extracts description from help text.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PnpmCliScraper.cs
@@ -160,6 +160,8 @@ public partial class PnpmCliScraper : CliScraperBase
             return Task.FromResult<CliCommandDefinition?>(null);
         }
 
+        usage = NormalizeParentGroupUsage(commandParts, usage);
+
         // Parse description from help text
         var description = ExtractDescription(helpText);
 
@@ -194,6 +196,24 @@ public partial class PnpmCliScraper : CliScraperBase
 
         return Task.FromResult<CliCommandDefinition?>(command);
     }
+
+    private static UsageSynopsisParseResult NormalizeParentGroupUsage(
+        IReadOnlyList<string> commandParts,
+        UsageSynopsisParseResult usage) =>
+        commandParts is ["stage"]
+            ? usage with
+            {
+                HasOperandTokens = false,
+                PositionalArguments = [],
+                UnparsedOperandTokens = [],
+            }
+            : usage;
+
+    /// <inheritdoc />
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage) =>
+        NormalizeParentGroupUsage(command.CommandParts, usage);
 
     /// <summary>
     /// Extracts description from help text.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PulumiCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PulumiCliScraper.cs
@@ -110,6 +110,8 @@ public partial class PulumiCliScraper : CobraCliScraper
             {
                 CSharpType = "string",
                 IsRequired = true,
+                Phase = CommandLinePhase.Passthrough,
+                PositionIndex = 0,
             };
         }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PulumiCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/PulumiCliScraper.cs
@@ -1,4 +1,6 @@
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
+using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
 namespace ModularPipelines.OptionsGenerator.Scrapers.Cli;
@@ -60,5 +62,65 @@ public partial class PulumiCliScraper : CobraCliScraper
         {
             yield return "pulumi env get [<org-name>/][<project-name>/]<environment-name>[@<version>] [path]";
         }
+    }
+
+    /// <inheritdoc />
+    protected override IReadOnlyList<CliPositionalArgument> ApplyPositionalArgumentFixes(
+        string[] commandParts,
+        IReadOnlyList<CliPositionalArgument> positionalArguments) =>
+        commandParts is ["env", "run"]
+            ? NormalizeEnvRunArguments(positionalArguments)
+            : positionalArguments;
+
+    /// <inheritdoc />
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage) =>
+        command.CommandParts is ["env", "run"]
+            ? usage with { PositionalArguments = NormalizeEnvRunArguments(usage.PositionalArguments) }
+            : usage;
+
+    private static IReadOnlyList<CliPositionalArgument> NormalizeEnvRunArguments(
+        IReadOnlyList<CliPositionalArgument> positionalArguments)
+    {
+        var arguments = positionalArguments
+            .Select(NormalizeEnvRunArgument)
+            .ToList();
+        if (arguments.All(argument => !argument.PropertyName.Equals("Args", StringComparison.OrdinalIgnoreCase)))
+        {
+            arguments.Add(new CliPositionalArgument
+            {
+                PropertyName = "Args",
+                CSharpType = "IEnumerable<string>?",
+                Description = "Arguments passed to the command.",
+                Phase = CommandLinePhase.Passthrough,
+                PositionIndex = 1,
+                IsVariadic = true,
+            });
+        }
+
+        return arguments;
+    }
+
+    private static CliPositionalArgument NormalizeEnvRunArgument(CliPositionalArgument argument)
+    {
+        if (argument.PropertyName.Equals("Command", StringComparison.OrdinalIgnoreCase))
+        {
+            return argument with
+            {
+                CSharpType = "string",
+                IsRequired = true,
+            };
+        }
+
+        return argument.PropertyName.Equals("Args", StringComparison.OrdinalIgnoreCase)
+            ? argument with
+            {
+                CSharpType = "IEnumerable<string>?",
+                Phase = CommandLinePhase.Passthrough,
+                PositionIndex = 1,
+                IsVariadic = true,
+            }
+            : argument;
     }
 }

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/SnykCliScraper.cs
@@ -155,14 +155,14 @@ public partial class SnykCliScraper : CliScraperBase
         UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
-        usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage);
-
         var commandParts = commandPath.Skip(1).ToArray();
 
         if (commandParts.Length == 0)
         {
             return Task.FromResult<CliCommandDefinition?>(null);
         }
+
+        usage = NormalizeCommandGroupUsage(commandParts, usage);
 
         var description = ExtractDescription(helpText);
         var options = ParseOptions(helpText);
@@ -198,6 +198,27 @@ public partial class SnykCliScraper : CliScraperBase
 
         return Task.FromResult<CliCommandDefinition?>(command);
     }
+
+    private static UsageSynopsisParseResult NormalizeCommandGroupUsage(
+        IReadOnlyList<string> commandParts,
+        UsageSynopsisParseResult usage)
+    {
+        usage = UsageSynopsisParser.RemoveCommandGroupPlaceholders(usage);
+        return commandParts is ["iac"]
+            ? usage with
+            {
+                HasOperandTokens = false,
+                PositionalArguments = [],
+                UnparsedOperandTokens = [],
+            }
+            : usage;
+    }
+
+    /// <inheritdoc />
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage) =>
+        NormalizeCommandGroupUsage(command.CommandParts, usage);
 
     /// <summary>
     /// Extracts description from help text.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/TerraformCliScraper.cs
@@ -158,6 +158,8 @@ public partial class TerraformCliScraper : CliScraperBase
             return Task.FromResult<CliCommandDefinition?>(null);
         }
 
+        usage = NormalizeCommandGroupUsage(commandParts, usage);
+
         // Get the first subcommand for grouping (e.g., "workspace" for "workspace list")
         var subDomain = commandParts.Length > 1 ? ToPascalCase(commandParts[0]) : null;
 
@@ -194,6 +196,30 @@ public partial class TerraformCliScraper : CliScraperBase
 
         return Task.FromResult<CliCommandDefinition?>(command);
     }
+
+    private static UsageSynopsisParseResult NormalizeCommandGroupUsage(
+        IReadOnlyList<string> commandParts,
+        UsageSynopsisParseResult usage) =>
+        commandParts is ["metadata" or "stacks" or "state"]
+            ? usage with
+            {
+                PositionalArguments = usage.PositionalArguments
+                    .Select(argument => argument.PropertyName.Equals("Args", StringComparison.OrdinalIgnoreCase)
+                        ? argument with
+                        {
+                            CSharpType = "IEnumerable<string>?",
+                            IsVariadic = true,
+                        }
+                        : argument)
+                    .ToArray(),
+            }
+            : usage;
+
+    /// <inheritdoc />
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage) =>
+        NormalizeCommandGroupUsage(command.CommandParts, usage);
 
     /// <summary>
     /// Extracts description from help text.

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -330,11 +330,23 @@ public static class UsageSynopsisParser
         List<string> synopses)
     {
         var parts = new List<string> { inlineSynopsis };
+        var commandToken = inlineSynopsis.Split(' ', 2)[0];
         var index = startIndex;
         for (; index < lines.Length; index++)
         {
             var line = lines[index];
             var trimmed = line.Trim();
+            if (line.Length != trimmed.Length
+                && trimmed.Split(' ', 2)[0].Equals(
+                    commandToken,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                synopses.Add(string.Join(' ', parts));
+                parts.Clear();
+                parts.Add(trimmed);
+                continue;
+            }
+
             if (!IsSynopsisContinuation(line, trimmed))
             {
                 break;
@@ -823,11 +835,23 @@ public static class UsageSynopsisParser
 
     private static bool IsNonOperandSyntax(string token)
     {
+        if (IsParentheticalExplanation(token))
+        {
+            return true;
+        }
+
         var content = TrimControlWrappers(token);
         return string.IsNullOrWhiteSpace(content)
                || content.StartsWith('-')
                || IsOptionControlLabel(content)
                || content.All(character => !char.IsLetterOrDigit(character));
+    }
+
+    private static bool IsParentheticalExplanation(string token)
+    {
+        var trimmed = token.Trim();
+        return trimmed.StartsWith("(in ", StringComparison.OrdinalIgnoreCase)
+               && trimmed.EndsWith(')');
     }
 
     private static bool IsOptionControlLabel(string content) =>

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/UsageSynopsisParser.cs
@@ -373,6 +373,13 @@ public static class UsageSynopsisParser
     private static bool TryReadUsageHeading(string line, out string synopsis)
     {
         synopsis = "";
+        if (line.Trim(' ', '\t', '━', '─').Equals(
+                "Usage",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
         if (!line.StartsWith("usage", StringComparison.OrdinalIgnoreCase))
         {
             return false;
@@ -397,6 +404,7 @@ public static class UsageSynopsisParser
 
     private static int ReadIndentedSynopses(string[] lines, int startIndex, List<string> synopses)
     {
+        var initialSynopsisCount = synopses.Count;
         var index = startIndex;
         for (; index < lines.Length; index++)
         {
@@ -404,6 +412,11 @@ public static class UsageSynopsisParser
             var trimmed = line.Trim();
             if (string.IsNullOrWhiteSpace(trimmed))
             {
+                if (synopses.Count == initialSynopsisCount)
+                {
+                    continue;
+                }
+
                 break;
             }
 

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YarnCliScraper.cs
@@ -301,6 +301,13 @@ public partial class YarnCliScraper : CliScraperBase
     protected override Task<CliCommandDefinition?> ParseCommandAsync(
         string[] commandPath,
         string helpText,
+        CancellationToken cancellationToken) =>
+        throw new InvalidOperationException("Shared traversal must pass its parsed synopsis.");
+
+    protected override Task<CliCommandDefinition?> ParseCommandAsync(
+        string[] commandPath,
+        string helpText,
+        UsageSynopsisParseResult usage,
         CancellationToken cancellationToken)
     {
         var commandParts = commandPath.Skip(1).ToArray(); // Skip tool name
@@ -338,7 +345,9 @@ public partial class YarnCliScraper : CliScraperBase
             Description = description,
             DocumentationUrl = null,
             Options = options,
-            PositionalArguments = [],
+            PositionalArguments = usage.PositionalArguments,
+            UsageSynopsis = usage.Synopsis,
+            HasOperandTakingUsage = usage.HasOperandTokens,
             SubDomainGroup = subDomain,
             Enums = enums
         };
@@ -537,7 +546,8 @@ public partial class YarnCliScraper : CliScraperBase
             }
 
             // Determine if this is a flag (boolean) or takes a value
-            var isFlag = IsBooleanOption(longForm, description);
+            var isFlag = !match.Groups["value"].Success
+                         && IsBooleanOption(longForm, description);
             var csharpType = isFlag ? "bool?" : "string?";
 
             options.Add(new CliOptionDefinition
@@ -586,6 +596,7 @@ public partial class YarnCliScraper : CliScraperBase
         // Common boolean option patterns
         if (cleanName.StartsWith("no-") ||
             cleanName == "json" ||
+            cleanName == "quiet" ||
             cleanName == "verbose" ||
             cleanName == "silent" ||
             cleanName == "offline" ||
@@ -772,7 +783,7 @@ public partial class YarnCliScraper : CliScraperBase
     /// --json                     Description
     /// -F,--fixed                 Description
     /// </summary>
-    [GeneratedRegex(@"^\s*(?:(?<short>-\w),)?(?<long>--[\w-]+)\s{2,}(?<desc>.*)$", RegexOptions.Multiline)]
+    [GeneratedRegex(@"^\s*(?:(?<short>-\w),)?(?<long>--[\w-]+)(?:\s+(?<value>#\d+|<[^>]+>))?\s{2,}(?<desc>.*)$", RegexOptions.Multiline)]
     private static partial Regex YarnOptionPattern();
 
     [GeneratedRegex(@"^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$")]

--- a/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YqCliScraper.cs
+++ b/tools/ModularPipelines.OptionsGenerator/src/ModularPipelines.OptionsGenerator/Scrapers/Cli/YqCliScraper.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
+using ModularPipelines.Attributes;
 using ModularPipelines.OptionsGenerator.Models;
 using ModularPipelines.OptionsGenerator.TypeDetection;
 
@@ -47,4 +48,32 @@ public partial class YqCliScraper : CobraCliScraper
     {
         "--help", "-h", "--version", "help", "completion", "shell-completion"
     };
+
+    /// <inheritdoc />
+    protected override IReadOnlyList<CliPositionalArgument> ApplyPositionalArgumentFixes(
+        string[] commandParts,
+        IReadOnlyList<CliPositionalArgument> positionalArguments) =>
+        NormalizeEvalArguments(commandParts, positionalArguments);
+
+    /// <inheritdoc />
+    protected override UsageSynopsisParseResult NormalizeUsageSynopsis(
+        CliCommandDefinition command,
+        UsageSynopsisParseResult usage) =>
+        usage with
+        {
+            PositionalArguments = NormalizeEvalArguments(command.CommandParts, usage.PositionalArguments),
+        };
+
+    private static IReadOnlyList<CliPositionalArgument> NormalizeEvalArguments(
+        IReadOnlyList<string> commandParts,
+        IReadOnlyList<CliPositionalArgument> positionalArguments) =>
+        commandParts is ["eval" or "eval-all"]
+            ? positionalArguments
+                .Select(argument => argument with
+                {
+                    Phase = CommandLinePhase.Passthrough,
+                    PrependOptionTerminatorIfValueStartsWithDash = true,
+                })
+                .ToArray()
+            : positionalArguments;
 }


### PR DESCRIPTION
## Summary - retain command-group operands on executable parent commands - parse Yarn Clipanion usage headings and numbered option values - expand Git negatable help entries into positive and negative flags - model Go telemetry choices and plural targets accurately - infer description-only Azure value arguments without changing presence flags  ## Validation - OptionsGenerator solution Release build - 47 CliScraperTraversalTests - 35 UsageSynopsisParserTests - 11 GitCliScraperTests - 8 PositionalOperandAdapterTests - 7 AzCliScraperTests - 2 YarnCliScraperTests - 1 VaultCliScraperTests - 19 SnykCliScraperTests  Supports #3996. - 157 GeneratorHardeningTests passed, including normalized subdomain sibling casing recovery. - Release solution build reached the repository 2 GB agent memory guard (2.78 GB); not retried per policy.  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line parsing across Azure CLI, Git, Go, Yarn, Pip, Pnpm, Vault, and other tools.
  * More accurately recognizes value-taking options, negatable flags, positional arguments, variadic operands, and command subgroups.
  * Preserves historical command naming and casing for API compatibility.
  * Improved handling of usage sections, command syntax, and passthrough arguments.

* **Tests**
  * Added regression coverage for parsing, positional operands, option types, command traversal, and compatibility preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai --> - Pip parent groups no longer absorb child command syntax as operands. - pnpm repeated usage alternatives and parenthetical annotations parse without duplicate command operands. - 35 UsageSynopsisParserTests and 13 PositionalOperandAdapterTests passed. - Snyk IaC parent groups no longer render child PATH operands without the required command. - 19 SnykCliScraperTests passed.  - .NET subcommands with positional signatures are now discovered; 8 DotNetCliScraperTests passed. - Git value-taking and alternative-valued negations are modeled; 12 GitCliScraperTests passed. - Historical facade recovery is branch-scoped; 158 GeneratorHardeningTests passed.  - Terraform metadata/stacks/state command tails now emit variadic argv; 16 PositionalOperandAdapterTests passed.  - Pulumi env run now preserves required command plus variadic argv tail; 4 PulumiCliScraperTests passed. 
- Yq dash-leading expressions are terminator-safe and Packer inspect operands render after options; 19 PositionalOperandAdapterTests passed.
- Git option parsing complexity split into focused helpers; 12 GitCliScraperTests passed.
- AWS list-option regression: 5/5 AwsCliScraperTests pass; nested structure enums no longer override collection types.
- Git short-only options: 13/13 GitCliScraperTests pass; regex fallback retains short flag and description.
- Wrapped Git option help: 14/14 GitCliScraperTests pass; declaration-only lines retain following descriptions and negated boolean forms.