### PR TITLE
[Automated] Update pnpm CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/pnpm.md
+++ b/docs/docs/mp-packages/cli/pnpm.md
@@ -7,7 +7,13 @@ title: pnpm CLI reference
 
 `ModularPipelines.Node` provides strongly typed access to the `pnpm` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `pnpm` executable. Install it separately and ensure `pnpm` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Node
@@ -30,7 +36,7 @@ public class RunCommandModule : Module<CommandResult>
         CancellationToken cancellationToken)
     {
         return await context.Tools.Pnpm.AuditAsync(
-            new PnpmAuditOptions
+            new PnpmAuditOptions()
             {
                 AuditLevel = "high",
             },

--- a/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
+++ b/src/ModularPipelines.Node/Extensions/PnpmExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class PnpmExtensions
     }
 
     /// <summary>
-    /// Gets the pnpm service from the pipeline context.
+    /// Gets the pnpm service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IPnpm"/> service for executing pnpm commands.</returns>

--- a/src/ModularPipelines.Node/Generated/Pnpm.CommandCoverage.json
+++ b/src/ModularPipelines.Node/Generated/Pnpm.CommandCoverage.json
@@ -1,6 +1,7 @@
 {
   "formatVersion": 1,
   "toolName": "pnpm",
+  "toolVersion": "11.23.0",
   "commandCount": 10,
   "commandTreeSha256": "cb939fe929bf55ab34691b42cc4b86072d72586b984937e4c3c43dc8b6c6be56",
   "commands": [

--- a/src/ModularPipelines.Node/Options/PnpmAddOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmAddOptions.Generated.cs
@@ -39,7 +39,7 @@ public record PnpmAddOptions : PnpmOptions
     public string? Config { get; set; }
 
     /// <summary>
-    /// Change to directory &lt;dir&gt; (default: ~/work/ModularPipelines/ ModularPipelines/tools/ModularPipelines. OptionsGenerator/src/ModularPipelines. OptionsGenerator)
+    /// Change to directory &lt;dir&gt; (default: ~/work/_temp/generator-work)
     /// </summary>
     [CliOption("--dir", ShortForm = "-C")]
     public string? Dir { get; set; }
@@ -199,5 +199,11 @@ public record PnpmAddOptions : PnpmOptions
     /// </summary>
     [CliOption("--test-pattern")]
     public string? TestPattern { get; set; }
+
+    /// <summary>
+    /// The name operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Name { get; set; }
 
 }

--- a/src/ModularPipelines.Node/Options/PnpmAuditOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmAuditOptions.Generated.cs
@@ -80,4 +80,10 @@ public record PnpmAuditOptions : PnpmOptions
     [CliOption("--prod", ShortForm = "-P")]
     public string? Prod { get; set; }
 
+    /// <summary>
+    /// The signatures operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Signatures { get; set; }
+
 }

--- a/src/ModularPipelines.Node/Options/PnpmCreateOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmCreateOptions.Generated.cs
@@ -26,4 +26,10 @@ public record PnpmCreateOptions : PnpmOptions
     [CliOption("--allow-build")]
     public string? AllowBuild { get; set; }
 
+    /// <summary>
+    /// The name operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Name { get; set; }
+
 }

--- a/src/ModularPipelines.Node/Options/PnpmDlxOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmDlxOptions.Generated.cs
@@ -18,8 +18,15 @@ namespace ModularPipelines.Node.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("dlx")]
-public record PnpmDlxOptions : PnpmOptions
+public record PnpmDlxOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Command
+) : PnpmOptions
 {
+    public PnpmDlxOptions()
+        : this(default(string)!)
+    {
+    }
+
     /// <summary>
     /// A list of package names that are allowed to run postinstall scripts during installation
     /// </summary>
@@ -37,5 +44,11 @@ public record PnpmDlxOptions : PnpmOptions
     /// </summary>
     [CliOption("--shell-mode", ShortForm = "-c")]
     public string? ShellMode { get; set; }
+
+    /// <summary>
+    /// The args operand.
+    /// </summary>
+    [CliArgument(1, Phase = CommandLinePhase.EarlyOperand)]
+    public IEnumerable<string>? Args { get; set; }
 
 }

--- a/src/ModularPipelines.Node/Options/PnpmInitOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmInitOptions.Generated.cs
@@ -27,13 +27,13 @@ public record PnpmInitOptions : PnpmOptions
     public string? Bare { get; set; }
 
     /// <summary>
-    /// Declare a pnpm version range via "devEngines.packageManager" in package.json and auto-download pnpm when it is missing
+    /// Pin the pnpm version in package.json, through "devEngines.packageManager" and "packageManager", and auto-download pnpm when it is missing
     /// </summary>
     [CliOption("--init-package-manager")]
     public string? InitPackageManager { get; set; }
 
     /// <summary>
-    /// Set the module system for the package. Defaults to "commonjs".
+    /// Set the module system for the package. Defaults to "module".
     /// </summary>
     [CliOption("--init-type")]
     public string? InitType { get; set; }

--- a/src/ModularPipelines.Node/Options/PnpmPublishOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmPublishOptions.Generated.cs
@@ -129,4 +129,10 @@ public record PnpmPublishOptions : PnpmOptions
     [CliOption("--test-pattern")]
     public string? TestPattern { get; set; }
 
+    /// <summary>
+    /// The &lt;tarball&gt; operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Tarball { get; set; }
+
 }

--- a/src/ModularPipelines.Node/Options/PnpmRunOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmRunOptions.Generated.cs
@@ -18,8 +18,15 @@ namespace ModularPipelines.Node.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("run")]
-public record PnpmRunOptions : PnpmOptions
+public record PnpmRunOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Command
+) : PnpmOptions
 {
+    public PnpmRunOptions()
+        : this(default(string)!)
+    {
+    }
+
     /// <summary>
     /// Aggregate output from child processes that are run in parallel, and only print output when child process is finished. It makes reading large logs after running `pnpm recursive` with `--parallel` or with `--workspace-concurrency` much easier (especially on CI). Only `--reporter=append-only` is supported.
     /// </summary>
@@ -27,7 +34,7 @@ public record PnpmRunOptions : PnpmOptions
     public string? AggregateOutput { get; set; }
 
     /// <summary>
-    /// Change to directory &lt;dir&gt; (default: ~/work/ModularPipelines/ ModularPipelines/tools/ModularPipelines. OptionsGenerator/src/ModularPipelines. OptionsGenerator)
+    /// Change to directory &lt;dir&gt; (default: ~/work/_temp/generator-work)
     /// </summary>
     [CliOption("--dir", ShortForm = "-C")]
     public string? Dir { get; set; }
@@ -145,5 +152,11 @@ public record PnpmRunOptions : PnpmOptions
     /// </summary>
     [CliOption("--test-pattern")]
     public string? TestPattern { get; set; }
+
+    /// <summary>
+    /// The &lt;args&gt; operand.
+    /// </summary>
+    [CliArgument(1, Phase = CommandLinePhase.EarlyOperand)]
+    public IEnumerable<string>? Args { get; set; }
 
 }

--- a/src/ModularPipelines.Node/Options/PnpmUnlinkOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmUnlinkOptions.Generated.cs
@@ -27,7 +27,7 @@ public record PnpmUnlinkOptions : PnpmOptions
     public string? AggregateOutput { get; set; }
 
     /// <summary>
-    /// Change to directory &lt;dir&gt; (default: ~/work/ModularPipelines/ModularPipelines/ tools/ModularPipelines.OptionsGenerator/src/ ModularPipelines.OptionsGenerator)
+    /// Change to directory &lt;dir&gt; (default: ~/work/_temp/generator-work)
     /// </summary>
     [CliOption("--dir", ShortForm = "-C")]
     public string? Dir { get; set; }
@@ -73,5 +73,11 @@ public record PnpmUnlinkOptions : PnpmOptions
     /// </summary>
     [CliOption("--yes", ShortForm = "-y")]
     public string? Yes { get; set; }
+
+    /// <summary>
+    /// The &lt;pkg&gt; operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public IEnumerable<string>? Pkg { get; set; }
 
 }

--- a/src/ModularPipelines.Node/Options/PnpmWhyOptions.Generated.cs
+++ b/src/ModularPipelines.Node/Options/PnpmWhyOptions.Generated.cs
@@ -18,8 +18,15 @@ namespace ModularPipelines.Node.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("why")]
-public record PnpmWhyOptions : PnpmOptions
+public record PnpmWhyOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] IEnumerable<string> Pkg
+) : PnpmOptions
 {
+    public PnpmWhyOptions()
+        : this(default(IEnumerable<string>)!)
+    {
+    }
+
     /// <summary>
     /// Aggregate output from child processes that are run in parallel, and only print output when child process is finished. It makes reading large logs after running `pnpm recursive` with `--parallel` or with `--workspace-concurrency` much easier (especially on CI). Only `--reporter=append-only` is supported.
     /// </summary>
@@ -39,7 +46,7 @@ public record PnpmWhyOptions : PnpmOptions
     public string? Dev { get; set; }
 
     /// <summary>
-    /// Change to directory &lt;dir&gt; (default: ~/work/ModularPipelines/ModularPipelines/ tools/ModularPipelines.OptionsGenerator/src/ ModularPipelines.OptionsGenerator)
+    /// Change to directory &lt;dir&gt; (default: ~/work/_temp/generator-work)
     /// </summary>
     [CliOption("--dir", ShortForm = "-C")]
     public string? Dir { get; set; }

--- a/src/ModularPipelines.Node/Services/IPnpm.Generated.cs
+++ b/src/ModularPipelines.Node/Services/IPnpm.Generated.cs
@@ -27,7 +27,8 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> AddAsync(PnpmAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> AddAsync(PnpmAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Checks for known security issues with the installed packages.
@@ -36,7 +37,8 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> AuditAsync(PnpmAuditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> AuditAsync(PnpmAuditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Creates a project from a `create-*` starter kit.
@@ -45,7 +47,8 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> CreateAsync(PnpmCreateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> CreateAsync(PnpmCreateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Run a package in a temporary environment.
@@ -54,7 +57,8 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> DlxAsync(PnpmDlxOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> DlxAsync(PnpmDlxOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Create a package.json file
@@ -63,7 +67,8 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> InitAsync(PnpmInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> InitAsync(PnpmInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Publishes a package to the npm registry.
@@ -72,7 +77,8 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> PublishAsync(PnpmPublishOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> PublishAsync(PnpmPublishOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Alias: run-script
@@ -81,7 +87,8 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> RunAsync(PnpmRunOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> RunAsync(PnpmRunOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Stage packages for publishing, deferring proof-of-presence (2FA) to a later point in time.
@@ -90,7 +97,8 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> StageAsync(PnpmStageOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> StageAsync(PnpmStageOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Alias: dislink
@@ -99,7 +107,8 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> UnlinkAsync(PnpmUnlinkOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> UnlinkAsync(PnpmUnlinkOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Shows the packages that depend on &lt;pkg&gt;
@@ -108,7 +117,8 @@ public partial interface IPnpm
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> WhyAsync(PnpmWhyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> WhyAsync(PnpmWhyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     #endregion
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **pnpm** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- pnpm (11.23.0): 10 commands, tree cb939fe929bf55ab34691b42cc4b86072d72586b984937e4c3c43dc8b6c6be56

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the `pnpm` executable must be installed separately and available on the system `PATH`.
  * Added guidance to consult the official `pnpm` documentation for installation instructions.
  * Updated the usage example for improved syntax consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->