### PR TITLE
[Automated] Update go CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/go.md
+++ b/docs/docs/mp-packages/cli/go.md
@@ -7,7 +7,13 @@ title: go CLI reference
 
 `ModularPipelines.Go` provides strongly typed access to the `go` CLI.
 
-## Installation
+## Executable prerequisite
+
+This package does not install the `go` executable. Install it separately and ensure `go` is available on `PATH`.
+
+Follow the executable's official documentation for installation instructions.
+
+## Package installation
 
 ```shell
 dotnet add package ModularPipelines.Go
@@ -41,7 +47,25 @@ public class RunCommandModule : Module<CommandResult>
 | CLI command | Options record |
 | --- | --- |
 | `go build` | `GoBuildOptions` |
+| `go clean` | `GoCleanOptions` |
+| `go env` | `GoEnvOptions` |
 | `go fix` | `GoFixOptions` |
+| `go fmt` | `GoFmtOptions` |
 | `go generate` | `GoGenerateOptions` |
+| `go get` | `GoGetOptions` |
+| `go install` | `GoInstallOptions` |
+| `go list` | `GoListOptions` |
+| `go mod` | `GoModOptions` |
+| `go mod download` | `GoModDownloadOptions` |
+| `go mod edit` | `GoModEditOptions` |
+| `go mod init` | `GoModInitOptions` |
+| `go mod why` | `GoModWhyOptions` |
+| `go run` | `GoRunOptions` |
+| `go telemetry` | `GoTelemetryOptions` |
 | `go test` | `GoTestOptions` |
+| `go tool` | `GoToolOptions` |
 | `go vet` | `GoVetOptions` |
+| `go work` | `GoWorkOptions` |
+| `go work edit` | `GoWorkEditOptions` |
+| `go work init` | `GoWorkInitOptions` |
+| `go work use` | `GoWorkUseOptions` |

--- a/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
+++ b/src/ModularPipelines.Go/Extensions/GoExtensions.Generated.cs
@@ -33,7 +33,7 @@ public static class GoExtensions
     }
 
     /// <summary>
-    /// Gets the go service from the pipeline context.
+    /// Gets the go service from the pipeline context for compatibility.
     /// </summary>
     /// <param name="context">The pipeline context.</param>
     /// <returns>The <see cref="IGo"/> service for executing go commands.</returns>

--- a/src/ModularPipelines.Go/Generated/Go.CommandCoverage.json
+++ b/src/ModularPipelines.Go/Generated/Go.CommandCoverage.json
@@ -1,15 +1,37 @@
 {
   "formatVersion": 1,
   "toolName": "go",
-  "commandCount": 5,
-  "commandTreeSha256": "d91b6c355f88c3e297ae0e96351ad5c316d2d369a2330c61a3a3c715e9996129",
+  "toolVersion": "go version go1.27.0 linux/amd64",
+  "commandCount": 23,
+  "commandTreeSha256": "93c8759ef56e6f27c819ff7e849e2156e7837444f7311267b71d63d48ea78f5d",
   "commands": [
     "go build",
+    "go clean",
+    "go env",
     "go fix",
+    "go fmt",
     "go generate",
+    "go get",
+    "go install",
+    "go list",
+    "go mod",
+    "go mod download",
+    "go mod edit",
+    "go mod init",
+    "go mod why",
+    "go run",
+    "go telemetry",
     "go test",
-    "go vet"
+    "go tool",
+    "go vet",
+    "go work",
+    "go work edit",
+    "go work init",
+    "go work use"
   ],
-  "commandGroups": [],
+  "commandGroups": [
+    "go mod",
+    "go work"
+  ],
   "exclusions": []
 }

--- a/src/ModularPipelines.Go/Options/GoCleanOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoCleanOptions.Generated.cs
@@ -13,12 +13,12 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Clean removes object files from package source directories.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("clean")]
+public record GoCleanOptions : GoOptions
 {
     /// <summary>
     /// The packages operand.

--- a/src/ModularPipelines.Go/Options/GoEnvOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoEnvOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Env prints Go environment information.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("env")]
+public record GoEnvOptions : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The var operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    public IEnumerable<string>? Var { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoFixOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoFixOptions.Generated.cs
@@ -20,4 +20,10 @@ namespace ModularPipelines.Go.Options;
 [CliSubCommand("fix")]
 public record GoFixOptions : GoOptions
 {
+    /// <summary>
+    /// The packages operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? Packages { get; set; }
+
 }

--- a/src/ModularPipelines.Go/Options/GoFmtOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoFmtOptions.Generated.cs
@@ -13,12 +13,12 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Fmt runs the command 'gofmt -l -w' on the packages named
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("fmt")]
+public record GoFmtOptions : GoOptions
 {
     /// <summary>
     /// The packages operand.

--- a/src/ModularPipelines.Go/Options/GoGenerateOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoGenerateOptions.Generated.cs
@@ -20,4 +20,10 @@ namespace ModularPipelines.Go.Options;
 [CliSubCommand("generate")]
 public record GoGenerateOptions : GoOptions
 {
+    /// <summary>
+    /// The file or package targets.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? Targets { get; set; }
+
 }

--- a/src/ModularPipelines.Go/Options/GoGetOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoGetOptions.Generated.cs
@@ -13,12 +13,12 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Get resolves its command-line arguments to packages at specific module versions,
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("get")]
+public record GoGetOptions : GoOptions
 {
     /// <summary>
     /// The packages operand.

--- a/src/ModularPipelines.Go/Options/GoInstallOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoInstallOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Install compiles and installs the packages named by the import paths.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("install")]
+public record GoInstallOptions : GoOptions
 {
     /// <summary>
     /// The packages operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
     public IEnumerable<string>? Packages { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoListOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoListOptions.Generated.cs
@@ -13,12 +13,12 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// List lists the named packages, one per line.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("list")]
+public record GoListOptions : GoOptions
 {
     /// <summary>
     /// The packages operand.

--- a/src/ModularPipelines.Go/Options/GoModDownloadOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoModDownloadOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Download downloads the named modules, which can be module patterns selecting
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("mod", "download")]
+public record GoModDownloadOptions : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The modules operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    public IEnumerable<string>? Modules { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoModEditOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoModEditOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Edit provides a command-line interface for editing go.mod,
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("mod", "edit")]
+public record GoModEditOptions : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The go.mod operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    public string? GoMod { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoModInitOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoModInitOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Init initializes and writes a new go.mod file in the current directory, in
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("mod", "init")]
+public record GoModInitOptions : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The module-path operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? ModulePath { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoModOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoModOptions.Generated.cs
@@ -13,17 +13,19 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// go mod &lt;command&gt; [arguments]
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("mod")]
+public record GoModOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Command
+) : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The arguments operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    [CliArgument(1, Phase = CommandLinePhase.EarlyOperand)]
+    public string? CliArguments { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoModWhyOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoModWhyOptions.Generated.cs
@@ -13,17 +13,13 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Why shows a shortest path in the import graph from the main module to
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("mod", "why")]
+public record GoModWhyOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] IEnumerable<string> Packages
+) : GoOptions
 {
-    /// <summary>
-    /// The packages operand.
-    /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
-
 }

--- a/src/ModularPipelines.Go/Options/GoRunOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoRunOptions.Generated.cs
@@ -13,17 +13,19 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Run compiles and runs the named main Go package.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("run")]
+public record GoRunOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Package
+) : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The arguments operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? CliArguments { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoTelemetryOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoTelemetryOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Telemetry is used to manage Go telemetry data and settings.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("telemetry")]
+public record GoTelemetryOptions : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The telemetry mode: off, local, or on.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Mode { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoTestOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoTestOptions.Generated.cs
@@ -20,4 +20,10 @@ namespace ModularPipelines.Go.Options;
 [CliSubCommand("test")]
 public record GoTestOptions : GoOptions
 {
+    /// <summary>
+    /// The packages operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public IEnumerable<string>? Packages { get; set; }
+
 }

--- a/src/ModularPipelines.Go/Options/GoToolOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoToolOptions.Generated.cs
@@ -13,17 +13,19 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Tool runs the go tool command identified by the arguments.
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("tool")]
+public record GoToolOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.Passthrough, Required = true)] string Command
+) : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The args operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    [CliArgument(1, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? Args { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoVetOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoVetOptions.Generated.cs
@@ -20,4 +20,10 @@ namespace ModularPipelines.Go.Options;
 [CliSubCommand("vet")]
 public record GoVetOptions : GoOptions
 {
+    /// <summary>
+    /// The packages operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
+    public IEnumerable<string>? Packages { get; set; }
+
 }

--- a/src/ModularPipelines.Go/Options/GoWorkEditOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoWorkEditOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Edit provides a command-line interface for editing go.work,
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("work", "edit")]
+public record GoWorkEditOptions : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The go.work operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? GoWork { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoWorkInitOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoWorkInitOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Init initializes and writes a new go.work file in the
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("work", "init")]
+public record GoWorkInitOptions : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The moddirs operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public IEnumerable<string>? Moddirs { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoWorkOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoWorkOptions.Generated.cs
@@ -13,17 +13,19 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// go work &lt;command&gt; [arguments]
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("work")]
+public record GoWorkOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Command
+) : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The arguments operand.
     /// </summary>
-    [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    [CliArgument(1, Phase = CommandLinePhase.EarlyOperand)]
+    public string? CliArguments { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Options/GoWorkUseOptions.Generated.cs
+++ b/src/ModularPipelines.Go/Options/GoWorkUseOptions.Generated.cs
@@ -13,17 +13,17 @@ using ModularPipelines.Go.Options;
 namespace ModularPipelines.Go.Options;
 
 /// <summary>
-/// Build compiles the packages named by the import paths,
+/// Use provides a command-line interface for adding
 /// </summary>
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("build")]
-public record GoBuildOptions : GoOptions
+[CliSubCommand("work", "use")]
+public record GoWorkUseOptions : GoOptions
 {
     /// <summary>
-    /// The packages operand.
+    /// The moddirs operand.
     /// </summary>
     [CliArgument(0, Phase = CommandLinePhase.Passthrough)]
-    public IEnumerable<string>? Packages { get; set; }
+    public IEnumerable<string>? Moddirs { get; set; }
 
 }

--- a/src/ModularPipelines.Go/Services/Go.Generated.cs
+++ b/src/ModularPipelines.Go/Services/Go.Generated.cs
@@ -41,12 +41,39 @@ internal partial class Go : IGo
     }
 
     /// <inheritdoc />
+    public virtual async Task<CommandResult> CleanAsync(
+        GoCleanOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoCleanOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> EnvAsync(
+        GoEnvOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoEnvOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<CommandResult> FixAsync(
         GoFixOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
         return await _command.ExecuteCommandLineToolAsync(options ?? new GoFixOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> FmtAsync(
+        GoFmtOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoFmtOptions(), executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />
@@ -59,6 +86,96 @@ internal partial class Go : IGo
     }
 
     /// <inheritdoc />
+    public virtual async Task<CommandResult> GetAsync(
+        GoGetOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoGetOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> InstallAsync(
+        GoInstallOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoInstallOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> ListAsync(
+        GoListOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoListOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> ModDownloadAsync(
+        GoModDownloadOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoModDownloadOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> ModEditAsync(
+        GoModEditOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoModEditOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> ModInitAsync(
+        GoModInitOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoModInitOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> ModAsync(
+        GoModOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> ModWhyAsync(
+        GoModWhyOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> RunAsync(
+        GoRunOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> TelemetryAsync(
+        GoTelemetryOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoTelemetryOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<CommandResult> TestAsync(
         GoTestOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
@@ -68,12 +185,57 @@ internal partial class Go : IGo
     }
 
     /// <inheritdoc />
+    public virtual async Task<CommandResult> ToolAsync(
+        GoToolOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<CommandResult> VetAsync(
         GoVetOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
         CancellationToken cancellationToken = default)
     {
         return await _command.ExecuteCommandLineToolAsync(options ?? new GoVetOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> WorkEditAsync(
+        GoWorkEditOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoWorkEditOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> WorkInitAsync(
+        GoWorkInitOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoWorkInitOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> WorkAsync(
+        GoWorkOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> WorkUseAsync(
+        GoWorkUseOptions? options = null,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options ?? new GoWorkUseOptions(), executionOptions, cancellationToken);
     }
 
     #endregion

--- a/src/ModularPipelines.Go/Services/IGo.Generated.cs
+++ b/src/ModularPipelines.Go/Services/IGo.Generated.cs
@@ -27,7 +27,28 @@ public partial interface IGo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> BuildAsync(GoBuildOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> BuildAsync(GoBuildOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Clean removes object files from package source directories.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> CleanAsync(GoCleanOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Env prints Go environment information.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> EnvAsync(GoEnvOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Fix runs the Go fix tool (cmd/fix) on the named packages
@@ -36,7 +57,18 @@ public partial interface IGo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> FixAsync(GoFixOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> FixAsync(GoFixOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Fmt runs the command 'gofmt -l -w' on the packages named
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> FmtAsync(GoFmtOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Generate runs commands described by directives within existing
@@ -45,7 +77,108 @@ public partial interface IGo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> GenerateAsync(GoGenerateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> GenerateAsync(GoGenerateOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Get resolves its command-line arguments to packages at specific module versions,
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> GetAsync(GoGetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Install compiles and installs the packages named by the import paths.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> InstallAsync(GoInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// List lists the named packages, one per line.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> ListAsync(GoListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Download downloads the named modules, which can be module patterns selecting
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> ModDownloadAsync(GoModDownloadOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Edit provides a command-line interface for editing go.mod,
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> ModEditAsync(GoModEditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Init initializes and writes a new go.mod file in the current directory, in
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> ModInitAsync(GoModInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// go mod &lt;command&gt; [arguments]
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> ModAsync(GoModOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Why shows a shortest path in the import graph from the main module to
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> ModWhyAsync(GoModWhyOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Run compiles and runs the named main Go package.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> RunAsync(GoRunOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Telemetry is used to manage Go telemetry data and settings.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> TelemetryAsync(GoTelemetryOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// 'Go test' automates testing the packages named by the import paths.
@@ -54,7 +187,18 @@ public partial interface IGo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> TestAsync(GoTestOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> TestAsync(GoTestOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Tool runs the go tool command identified by the arguments.
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> ToolAsync(GoToolOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     /// <summary>
     /// Vet runs the Go vet tool (cmd/vet) on the named packages
@@ -63,7 +207,48 @@ public partial interface IGo
     /// <param name="executionOptions">The execution configuration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The command result.</returns>
-    Task<CommandResult> VetAsync(GoVetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default);
+    public Task<CommandResult> VetAsync(GoVetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Edit provides a command-line interface for editing go.work,
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> WorkEditAsync(GoWorkEditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Init initializes and writes a new go.work file in the
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> WorkInitAsync(GoWorkInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// go work &lt;command&gt; [arguments]
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> WorkAsync(GoWorkOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    /// <summary>
+    /// Use provides a command-line interface for adding
+    /// </summary>
+    /// <param name="options">The command options.</param>
+    /// <param name="executionOptions">The execution configuration options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The command result.</returns>
+    public Task<CommandResult> WorkUseAsync(GoWorkUseOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
 
     #endregion
 }


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **go** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- go (go version go1.27.0 linux/amd64): 23 commands, tree 93c8759ef56e6f27c819ff7e849e2156e7837444f7311267b71d63d48ea78f5d
  - Added: go clean, go env, go fmt, go get, go install, go list, go mod, go mod download, go mod edit, go mod init, go mod why, go run, go telemetry, go tool, go work, go work edit, go work init, go work use

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the Go executable must be installed separately and available on `PATH`.
  * Renamed the installation section to “Package installation.”
  * Expanded the CLI reference with additional Go commands, options, and subcommands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->