### PR TITLE
[Automated] Update yarn CLI Options

### DIFF
--- a/docs/docs/mp-packages/cli/yarn.md
+++ b/docs/docs/mp-packages/cli/yarn.md
@@ -44,6 +44,7 @@ var yarn = context.Tools.Yarn;
 | `yarn constraints query` | `YarnConstraintsQueryOptions` |
 | `yarn constraints source` | `YarnConstraintsSourceOptions` |
 | `yarn dedupe` | `YarnDedupeOptions` |
+| `yarn dlx` | `YarnDlxOptions` |
 | `yarn exec` | `YarnExecOptions` |
 | `yarn explain` | `YarnExplainOptions` |
 | `yarn info` | `YarnInfoOptions` |
@@ -80,6 +81,7 @@ var yarn = context.Tools.Yarn;
 | `yarn version apply` | `YarnVersionApplyOptions` |
 | `yarn version check` | `YarnVersionCheckOptions` |
 | `yarn why` | `YarnWhyOptions` |
+| `yarn workspace` | `YarnWorkspaceOptions` |
 | `yarn workspaces focus` | `YarnWorkspacesFocusOptions` |
 | `yarn workspaces foreach` | `YarnWorkspacesForeachOptions` |
 | `yarn workspaces list` | `YarnWorkspacesListOptions` |

--- a/src/ModularPipelines.Yarn/Generated/Yarn.CommandCoverage.json
+++ b/src/ModularPipelines.Yarn/Generated/Yarn.CommandCoverage.json
@@ -2,8 +2,8 @@
   "formatVersion": 1,
   "toolName": "yarn",
   "toolVersion": "4.18.0",
-  "commandCount": 50,
-  "commandTreeSha256": "aadb75ed7e1625f7f996663f7fc8c86f99b87dcd4eb8731744b656f494da6aa3",
+  "commandCount": 52,
+  "commandTreeSha256": "e257eecd91b494ea27b85879a1fe8297c96a2747f7308e7455a4d7479c2a0132",
   "commands": [
     "yarn add",
     "yarn bin",
@@ -16,6 +16,7 @@
     "yarn constraints query",
     "yarn constraints source",
     "yarn dedupe",
+    "yarn dlx",
     "yarn exec",
     "yarn explain",
     "yarn info",
@@ -52,6 +53,7 @@
     "yarn version apply",
     "yarn version check",
     "yarn why",
+    "yarn workspace",
     "yarn workspaces focus",
     "yarn workspaces foreach",
     "yarn workspaces list"

--- a/src/ModularPipelines.Yarn/Options/YarnBinOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnBinOptions.Generated.cs
@@ -17,4 +17,10 @@ namespace ModularPipelines.Yarn.Options;
 [CliSubCommand("bin")]
 public record YarnBinOptions : YarnOptions
 {
+    /// <summary>
+    /// The name operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Name { get; set; }
+
 }

--- a/src/ModularPipelines.Yarn/Options/YarnDlxOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnDlxOptions.Generated.cs
@@ -14,14 +14,9 @@ namespace ModularPipelines.Yarn.Options;
 
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("patch")]
-public record YarnPatchOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Package
+[CliSubCommand("dlx")]
+public record YarnDlxOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] IEnumerable<string> Command
 ) : YarnOptions
 {
-    public YarnPatchOptions()
-        : this(default(string)!)
-    {
-    }
-
 }

--- a/src/ModularPipelines.Yarn/Options/YarnExecOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnExecOptions.Generated.cs
@@ -15,6 +15,13 @@ namespace ModularPipelines.Yarn.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("exec")]
-public record YarnExecOptions : YarnOptions
+public record YarnExecOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] IEnumerable<string> CommandName
+) : YarnOptions
 {
+    public YarnExecOptions()
+        : this(default(IEnumerable<string>)!)
+    {
+    }
+
 }

--- a/src/ModularPipelines.Yarn/Options/YarnExplainOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnExplainOptions.Generated.cs
@@ -17,4 +17,10 @@ namespace ModularPipelines.Yarn.Options;
 [CliSubCommand("explain")]
 public record YarnExplainOptions : YarnOptions
 {
+    /// <summary>
+    /// The code operand.
+    /// </summary>
+    [CliArgument(0, Phase = CommandLinePhase.EarlyOperand)]
+    public string? Code { get; set; }
+
 }

--- a/src/ModularPipelines.Yarn/Options/YarnPatchCommitOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnPatchCommitOptions.Generated.cs
@@ -15,6 +15,13 @@ namespace ModularPipelines.Yarn.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("patch-commit")]
-public record YarnPatchCommitOptions : YarnOptions
+public record YarnPatchCommitOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string PatchFolder
+) : YarnOptions
 {
+    public YarnPatchCommitOptions()
+        : this(default(string)!)
+    {
+    }
+
 }

--- a/src/ModularPipelines.Yarn/Options/YarnWhyOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnWhyOptions.Generated.cs
@@ -15,6 +15,13 @@ namespace ModularPipelines.Yarn.Options;
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
 [CliSubCommand("why")]
-public record YarnWhyOptions : YarnOptions
+public record YarnWhyOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Package
+) : YarnOptions
 {
+    public YarnWhyOptions()
+        : this(default(string)!)
+    {
+    }
+
 }

--- a/src/ModularPipelines.Yarn/Options/YarnWorkspaceOptions.Generated.cs
+++ b/src/ModularPipelines.Yarn/Options/YarnWorkspaceOptions.Generated.cs
@@ -14,14 +14,10 @@ namespace ModularPipelines.Yarn.Options;
 
 [GeneratedCode("ModularPipelines.OptionsGenerator", "2.0.0")]
 [ExcludeFromCodeCoverage]
-[CliSubCommand("patch")]
-public record YarnPatchOptions(
-    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string Package
+[CliSubCommand("workspace")]
+public record YarnWorkspaceOptions(
+    [property: CliArgument(0, Phase = CommandLinePhase.EarlyOperand, Required = true)] string WorkspaceName,
+    [property: CliArgument(1, Phase = CommandLinePhase.EarlyOperand, Required = true)] IEnumerable<string> CommandName
 ) : YarnOptions
 {
-    public YarnPatchOptions()
-        : this(default(string)!)
-    {
-    }
-
 }

--- a/src/ModularPipelines.Yarn/Services/IYarn.Generated.cs
+++ b/src/ModularPipelines.Yarn/Services/IYarn.Generated.cs
@@ -20,154 +20,160 @@ public partial interface IYarn
 {
     #region Commands
 
-    Task<CommandResult> AddAsync(YarnAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> AddAsync(YarnAddOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> BinAsync(YarnBinOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> BinAsync(YarnBinOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> CacheCleanAsync(YarnCacheCleanOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> CacheCleanAsync(YarnCacheCleanOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> ConfigGetAsync(YarnConfigGetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConfigGetAsync(YarnConfigGetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> ConfigAsync(YarnConfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConfigAsync(YarnConfigOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> ConfigSetAsync(YarnConfigSetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConfigSetAsync(YarnConfigSetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> ConfigUnsetAsync(YarnConfigUnsetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConfigUnsetAsync(YarnConfigUnsetOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> ConstraintsAsync(YarnConstraintsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConstraintsAsync(YarnConstraintsOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> ConstraintsQueryAsync(YarnConstraintsQueryOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConstraintsQueryAsync(YarnConstraintsQueryOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> ConstraintsSourceAsync(YarnConstraintsSourceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ConstraintsSourceAsync(YarnConstraintsSourceOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> DedupeAsync(YarnDedupeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DedupeAsync(YarnDedupeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> ExecAsync(YarnExecOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> DlxAsync(YarnDlxOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> ExplainAsync(YarnExplainOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ExecAsync(YarnExecOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> InfoAsync(YarnInfoOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> ExplainAsync(YarnExplainOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> InitAsync(YarnInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> InfoAsync(YarnInfoOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> InstallAsync(YarnInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> InitAsync(YarnInitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> LinkAsync(YarnLinkOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> InstallAsync(YarnInstallOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> NpmAuditAsync(YarnNpmAuditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> LinkAsync(YarnLinkOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> NpmInfoAsync(YarnNpmInfoOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NpmAuditAsync(YarnNpmAuditOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> NpmLoginAsync(YarnNpmLoginOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NpmInfoAsync(YarnNpmInfoOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> NpmLogoutAsync(YarnNpmLogoutOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NpmLoginAsync(YarnNpmLoginOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> NpmPublishAsync(YarnNpmPublishOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NpmLogoutAsync(YarnNpmLogoutOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> NpmStageApproveAsync(YarnNpmStageApproveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NpmPublishAsync(YarnNpmPublishOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> NpmStageListAsync(YarnNpmStageListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NpmStageApproveAsync(YarnNpmStageApproveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> NpmStageRejectAsync(YarnNpmStageRejectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NpmStageListAsync(YarnNpmStageListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> NpmTagListAsync(YarnNpmTagListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NpmStageRejectAsync(YarnNpmStageRejectOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> NpmWhoamiAsync(YarnNpmWhoamiOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NpmTagListAsync(YarnNpmTagListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> PackAsync(YarnPackOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> NpmWhoamiAsync(YarnNpmWhoamiOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> PatchCommitAsync(YarnPatchCommitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PackAsync(YarnPackOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> PatchAsync(YarnPatchOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PatchCommitAsync(YarnPatchCommitOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> PluginCheckAsync(YarnPluginCheckOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PatchAsync(YarnPatchOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> PluginImportFromSourcesAsync(YarnPluginImportFromSourcesOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PluginCheckAsync(YarnPluginCheckOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> PluginImportAsync(YarnPluginImportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PluginImportFromSourcesAsync(YarnPluginImportFromSourcesOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> PluginListAsync(YarnPluginListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PluginImportAsync(YarnPluginImportOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> PluginRuntimeAsync(YarnPluginRuntimeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PluginListAsync(YarnPluginListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> RemoveAsync(YarnRemoveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> PluginRuntimeAsync(YarnPluginRuntimeOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> RunAsync(YarnRunOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RemoveAsync(YarnRemoveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> SetVersionFromSourcesAsync(YarnSetVersionFromSourcesOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> RunAsync(YarnRunOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> SetVersionAsync(YarnSetVersionOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SetVersionFromSourcesAsync(YarnSetVersionFromSourcesOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> StageAsync(YarnStageOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> SetVersionAsync(YarnSetVersionOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> UnlinkAsync(YarnUnlinkOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> StageAsync(YarnStageOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> UnplugAsync(YarnUnplugOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UnlinkAsync(YarnUnlinkOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> UpgradeInteractiveAsync(YarnUpgradeInteractiveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UnplugAsync(YarnUnplugOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> UpAsync(YarnUpOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UpgradeInteractiveAsync(YarnUpgradeInteractiveOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> VersionApplyAsync(YarnVersionApplyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> UpAsync(YarnUpOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> VersionCheckAsync(YarnVersionCheckOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> VersionApplyAsync(YarnVersionApplyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> WhyAsync(YarnWhyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> VersionCheckAsync(YarnVersionCheckOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> WorkspacesFocusAsync(YarnWorkspacesFocusOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> WhyAsync(YarnWhyOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> WorkspacesForeachAsync(YarnWorkspacesForeachOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> WorkspaceAsync(YarnWorkspaceOptions options, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
-    Task<CommandResult> WorkspacesListAsync(YarnWorkspacesListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+    public Task<CommandResult> WorkspacesFocusAsync(YarnWorkspacesFocusOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    public Task<CommandResult> WorkspacesForeachAsync(YarnWorkspacesForeachOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
+        => throw new System.NotSupportedException();
+
+    public Task<CommandResult> WorkspacesListAsync(YarnWorkspacesListOptions? options = null, CommandExecutionOptions? executionOptions = null, CancellationToken cancellationToken = default)
         => throw new System.NotSupportedException();
 
     #endregion

--- a/src/ModularPipelines.Yarn/Services/Yarn.Generated.cs
+++ b/src/ModularPipelines.Yarn/Services/Yarn.Generated.cs
@@ -131,6 +131,15 @@ internal partial class Yarn : IYarn
     }
 
     /// <inheritdoc />
+    public virtual async Task<CommandResult> DlxAsync(
+        YarnDlxOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
     public virtual async Task<CommandResult> ExecAsync(
         YarnExecOptions? options = null,
         CommandExecutionOptions? executionOptions = null,
@@ -452,6 +461,15 @@ internal partial class Yarn : IYarn
         CancellationToken cancellationToken = default)
     {
         return await _command.ExecuteCommandLineToolAsync(options ?? new YarnWhyOptions(), executionOptions, cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public virtual async Task<CommandResult> WorkspaceAsync(
+        YarnWorkspaceOptions options,
+        CommandExecutionOptions? executionOptions = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await _command.ExecuteCommandLineToolAsync(options, executionOptions, cancellationToken);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## Summary
This PR contains automatically generated updates to **yarn** CLI options classes.

The generator scraped the latest CLI help output from the installed tool.

## Changes
- Updated options classes to reflect latest CLI documentation
- Added new commands if any were detected
- Updated option types and descriptions

## Command coverage
Command coverage report:
- yarn (4.18.0): 52 commands, tree e257eecd91b494ea27b85879a1fe8297c96a2747f7308e7455a4d7479c2a0132
  - Added: yarn dlx, yarn workspace

## Verification
- [x] Solution builds successfully
- API compatibility gate: **success**

---
🤖 Generated with ModularPipelines.OptionsGenerator